### PR TITLE
test: use repeat() instead of new Array().join()

### DIFF
--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -15,7 +15,7 @@ const flatLongLen = Buffer.concat(long, 40);
 assert.strictEqual(flatZero.length, 0);
 assert.strictEqual(flatOne.toString(), 'asdf');
 
-const check = new Array(10 + 1).join('asdf');
+const check = 'asdf'.repeat(10);
 
 // A special case where concat used to return the first item,
 // if the length is one. This check is to make sure that we don't do that.

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -11,7 +11,7 @@ if (!common.isWindows) {
 
 // make a path that will be at least 260 chars long.
 const fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-const fileName = path.join(common.tmpDir, new Array(fileNameLen + 1).join('x'));
+const fileName = path.join(common.tmpDir, 'x'.repeat(fileNameLen));
 const fullPath = path.resolve(fileName);
 
 common.refreshTmpDir();

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -21,7 +21,7 @@ if (process.argv[2] === 'child') {
 }
 
 const filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
-const dataExpected = new Array(1000000).join('a');
+const dataExpected = 'a'.repeat(999999);
 common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -18,7 +18,7 @@ if (process.argv[2] === 'child') {
 }
 
 const filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
-const dataExpected = new Array(1000000).join('a');
+const dataExpected = 'a'.repeat(999999);
 common.refreshTmpDir();
 fs.writeFileSync(filename, dataExpected);
 

--- a/test/parallel/test-http-byteswritten.js
+++ b/test/parallel/test-http-byteswritten.js
@@ -16,7 +16,7 @@ const httpServer = http.createServer(common.mustCall(function(req, res) {
 
   // Write 1.5mb to cause some requests to buffer
   // Also, mix up the encodings a bit.
-  const chunk = new Array(1024 + 1).join('7');
+  const chunk = '7'.repeat(1024);
   const bchunk = Buffer.from(chunk);
   for (let i = 0; i < 1024; i++) {
     res.write(chunk);

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -70,7 +70,7 @@ function child() {
 
   let req = `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nAccept: */*\r\n\r\n`;
 
-  req = new Array(10241).join(req);
+  req = req.repeat(10240);
 
   conn.on('connect', write);
 

--- a/test/parallel/test-http-pipeline-regr-3332.js
+++ b/test/parallel/test-http-pipeline-regr-3332.js
@@ -19,7 +19,7 @@ const server = http.createServer(function(req, res) {
     }
   });
 }).listen(0, function() {
-  const req = new Array(COUNT + 1).join('GET / HTTP/1.1\r\n\r\n');
+  const req = 'GET / HTTP/1.1\r\n\r\n'.repeat(COUNT);
   client = net.connect(this.address().port, function() {
     client.write(req);
   });

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -24,7 +24,7 @@ TestWriter.prototype._write = function(chunk, encoding, cb) {
 
 const chunks = new Array(50);
 for (let i = 0; i < chunks.length; i++) {
-  chunks[i] = new Array(i + 1).join('x');
+  chunks[i] = 'x'.repeat(i);
 }
 
 // tiny node-tap lookalike.

--- a/test/parallel/test-string-decoder-end.js
+++ b/test/parallel/test-string-decoder-end.js
@@ -12,7 +12,7 @@ const bufs = [ '☃💩', 'asdf' ].map((b) => Buffer.from(b));
 
 // also test just arbitrary bytes from 0-15.
 for (let i = 1; i <= 16; i++) {
-  const bytes = new Array(i).join('.').split('.').map((_, j) => j + 0x78);
+  const bytes = '.'.repeat(i - 1).split('.').map((_, j) => j + 0x78);
   bufs.push(Buffer.from(bytes));
 }
 

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 const stream = require('stream');
 const util = require('util');
 
-const request = Buffer.from(new Array(1024 * 256).join('ABCD')); // 1mb
+const request = Buffer.from('ABCD'.repeat(1024 * 256 - 1)); // 1mb
 
 const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),


### PR DESCRIPTION
The usage of `new Array(length + 1).join(str)` is strange.
Change to `str.repeat(length)` is more clearly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test