### PR TITLE
http: add debug message for invalid header value

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -315,6 +315,7 @@ function storeHeader(self, state, field, value) {
       'Header name must be a valid HTTP Token ["' + field + '"]');
   }
   if (common._checkInvalidHeaderChar(value) === true) {
+    debug('Header "%s" contains invalid characters', field);
     throw new TypeError('The header content contains invalid characters');
   }
   state.messageHeader += field + ': ' + escapeHeaderValue(value) + CRLF;
@@ -355,6 +356,7 @@ OutgoingMessage.prototype.setHeader = function(name, value) {
   if (this._header)
     throw new Error('Can\'t set headers after they are sent.');
   if (common._checkInvalidHeaderChar(value) === true) {
+    debug('Header "%s" contains invalid characters', name);
     throw new TypeError('The header content contains invalid characters');
   }
   if (this._headers === null)
@@ -532,6 +534,7 @@ OutgoingMessage.prototype.addTrailers = function(headers) {
         'Trailer name must be a valid HTTP Token ["' + field + '"]');
     }
     if (common._checkInvalidHeaderChar(value) === true) {
+      debug('Trailer "%s" contains invalid characters', field);
       throw new TypeError('The header content contains invalid characters');
     }
     this._trailer += field + ': ' + escapeHeaderValue(value) + CRLF;


### PR DESCRIPTION
This makes it easier to see what header has an invalid value.

PR-URL: #9195
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
Reviewed-By: Brian White <mscdex@mscdex.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http

This is a backport of https://github.com/nodejs/node/pull/9195 to v6.x.

/cc @MylesBorins 