### PR TITLE
doc: replace newlines in deprecation with space

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -208,7 +208,7 @@ function parseLists(input) {
           headingIndex = -1;
           heading = null;
         }
-        tok.text = parseAPIHeader(tok.text);
+        tok.text = parseAPIHeader(tok.text).replace(/\n/g, ' ');
         output.push({ type: 'html', text: tok.text });
         return;
       } else if (state === 'MAYBE_STABILITY_BQ') {


### PR DESCRIPTION
As it is, each line in the deprecation heading which are wrapped at 80
characters in the *.md files, are shown in different lines. For example

    > Stability: 0 - Deprecated: Use
    > `Buffer.from(arrayBuffer[, byteOffset [, length]])`
    > instead.

is shown in three different lines. This patch replaces the newlines
with space characters, so that the output will be in single line.

---

**Before this patch:**

https://nodejs.org/api/buffer.html#buffer_new_buffer_arraybuffer_byteoffset_length

<img width="698" alt="screen shot 2017-01-31 at 12 13 59 am" src="https://cloud.githubusercontent.com/assets/696611/22436717/45b32030-e74b-11e6-8dd1-6be80ed2562f.png">

**After this patch:**

<img width="885" alt="screen shot 2017-01-31 at 12 22 41 am" src="https://cloud.githubusercontent.com/assets/696611/22436756/6cef9598-e74b-11e6-92aa-77130e7e19ad.png">


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

tools

---

cc @nodejs/documentation 
