### PR TITLE
url, test: synchronize web-platform-test url tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -585,3 +585,28 @@ Object.defineProperty(exports, 'hasIntl', {
     return process.binding('config').hasIntl;
   }
 });
+
+// https://github.com/w3c/testharness.js/blob/master/testharness.js
+exports.WPT = {
+  test: (fn, desc) => {
+    try {
+      fn();
+    } catch (err) {
+      if (err instanceof Error)
+        err.message = `In ${desc}:\n  ${err.message}`;
+      throw err;
+    }
+  },
+  assert_equals: assert.strictEqual,
+  assert_true: (value, message) => assert.strictEqual(value, true, message),
+  assert_false: (value, message) => assert.strictEqual(value, false, message),
+  assert_throws: (code, func, desc) => {
+    assert.throws(func, (err) => {
+      return typeof err === 'object' && 'name' in err && err.name === code.name;
+    }, desc);
+  },
+  assert_array_equals: assert.deepStrictEqual,
+  assert_unreached(desc) {
+    assert.fail(undefined, undefined, `Reached unreachable code: ${desc}`);
+  }
+};

--- a/test/fixtures/url-setter-tests.json
+++ b/test/fixtures/url-setter-tests.json
@@ -1,5 +1,6 @@
 {
     "comment": [
+        "License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html",
         "## Tests for setters of https://url.spec.whatwg.org/#urlutils-members",
         "",
         "This file contains a JSON object.",

--- a/test/fixtures/url-setter-tests.json
+++ b/test/fixtures/url-setter-tests.json
@@ -20,8 +20,7 @@
         "  get the attribute `key` (invoke its getter).",
         "  The returned string must be equal to `value`.",
         "",
-        "Note: the 'href' setter is already covered by urltestdata.json.",
-        "Source: https://github.com/w3c/web-platform-tests/tree/master/url"
+        "Note: the 'href' setter is already covered by urltestdata.json."
     ],
     "protocol": [
         {
@@ -104,12 +103,28 @@
             }
         },
         {
-            "comment": "Can’t switch from special scheme to non-special. Note: this may change, see https://github.com/whatwg/url/issues/104",
+            "comment": "Can’t switch from special scheme to non-special",
             "href": "http://example.net",
             "new_value": "b",
             "expected": {
                 "href": "http://example.net/",
                 "protocol": "http:"
+            }
+        },
+        {
+            "href": "https://example.net",
+            "new_value": "s",
+            "expected": {
+                "href": "https://example.net/",
+                "protocol": "https:"
+            }
+        },
+        {
+            "href": "ftp://example.net",
+            "new_value": "test",
+            "expected": {
+                "href": "ftp://example.net/",
+                "protocol": "ftp:"
             }
         },
         {
@@ -122,12 +137,36 @@
             }
         },
         {
-            "comment": "Can’t switch from non-special scheme to special. Note: this may change, see https://github.com/whatwg/url/issues/104",
+            "comment": "Can’t switch from non-special scheme to special",
             "href": "ssh://me@example.net",
             "new_value": "http",
             "expected": {
                 "href": "ssh://me@example.net/",
                 "protocol": "ssh:"
+            }
+        },
+        {
+            "href": "ssh://me@example.net",
+            "new_value": "gopher",
+            "expected": {
+                "href": "ssh://me@example.net/",
+                "protocol": "ssh:"
+            }
+        },
+        {
+            "href": "ssh://me@example.net",
+            "new_value": "file",
+            "expected": {
+                "href": "ssh://me@example.net/",
+                "protocol": "ssh:"
+            }
+        },
+        {
+            "href": "nonsense:///test",
+            "new_value": "https",
+            "expected": {
+                "href": "nonsense:///test",
+                "protocol": "nonsense:"
             }
         },
         {

--- a/test/fixtures/url-tests-additional.js
+++ b/test/fixtures/url-tests-additional.js
@@ -1,0 +1,87 @@
+module.exports = [
+  {
+    'url': 'tftp://foobar.com/someconfig;mode=netascii',
+    'protocol': 'tftp:',
+    'hostname': 'foobar.com',
+    'pathname': '/someconfig;mode=netascii'
+  },
+  {
+    'url': 'telnet://user:pass@foobar.com:23/',
+    'protocol': 'telnet:',
+    'username': 'user',
+    'password': 'pass',
+    'hostname': 'foobar.com',
+    'port': '23',
+    'pathname': '/'
+  },
+  {
+    'url': 'ut2004://10.10.10.10:7777/Index.ut2',
+    'protocol': 'ut2004:',
+    'hostname': '10.10.10.10',
+    'port': '7777',
+    'pathname': '/Index.ut2'
+  },
+  {
+    'url': 'redis://foo:bar@somehost:6379/0?baz=bam&qux=baz',
+    'protocol': 'redis:',
+    'username': 'foo',
+    'password': 'bar',
+    'hostname': 'somehost',
+    'port': '6379',
+    'pathname': '/0',
+    'search': '?baz=bam&qux=baz'
+  },
+  {
+    'url': 'rsync://foo@host:911/sup',
+    'protocol': 'rsync:',
+    'username': 'foo',
+    'hostname': 'host',
+    'port': '911',
+    'pathname': '/sup'
+  },
+  {
+    'url': 'git://github.com/foo/bar.git',
+    'protocol': 'git:',
+    'hostname': 'github.com',
+    'pathname': '/foo/bar.git'
+  },
+  {
+    'url': 'irc://myserver.com:6999/channel?passwd',
+    'protocol': 'irc:',
+    'hostname': 'myserver.com',
+    'port': '6999',
+    'pathname': '/channel',
+    'search': '?passwd'
+  },
+  {
+    'url': 'dns://fw.example.org:9999/foo.bar.org?type=TXT',
+    'protocol': 'dns:',
+    'hostname': 'fw.example.org',
+    'port': '9999',
+    'pathname': '/foo.bar.org',
+    'search': '?type=TXT'
+  },
+  {
+    'url': 'ldap://localhost:389/ou=People,o=JNDITutorial',
+    'protocol': 'ldap:',
+    'hostname': 'localhost',
+    'port': '389',
+    'pathname': '/ou=People,o=JNDITutorial'
+  },
+  {
+    'url': 'git+https://github.com/foo/bar',
+    'protocol': 'git+https:',
+    'hostname': 'github.com',
+    'pathname': '/foo/bar'
+  },
+  {
+    'url': 'urn:ietf:rfc:2648',
+    'protocol': 'urn:',
+    'pathname': 'ietf:rfc:2648'
+  },
+  {
+    'url': 'tag:joe@example.org,2001:foo/bar',
+    'protocol': 'tag:',
+    'pathname': 'joe@example.org,2001:foo/bar'
+  }
+];

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -1,0 +1,142 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const { URL, URLSearchParams } = require('url');
+const { test, assert_equals, assert_true, assert_throws } = common.WPT;
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl');
+  return;
+}
+
+const request = {
+  response: require(path.join(common.fixturesDir, 'url-tests.json'))
+};
+
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+function runURLConstructorTests() {
+  // var setup = async_test("Loading data…")
+  // setup.step(function() {
+  //   var request = new XMLHttpRequest()
+  //   request.open("GET", "urltestdata.json")
+  //   request.send()
+  //   request.responseType = "json"
+  //   request.onload = setup.step_func(function() {
+         runURLTests(request.response)
+  //     setup.done()
+  //   })
+  // })
+}
+
+function bURL(url, base) {
+  return new URL(url, base || "about:blank")
+}
+
+
+function runURLTests(urltests) {
+  for(var i = 0, l = urltests.length; i < l; i++) {
+    var expected = urltests[i]
+    if (typeof expected === "string") continue // skip comments
+
+    test(function() {
+      if (expected.failure) {
+        assert_throws(new TypeError(), function() {
+          bURL(expected.input, expected.base)
+        })
+        return
+      }
+
+      var url = bURL(expected.input, expected.base)
+      assert_equals(url.href, expected.href, "href")
+      assert_equals(url.protocol, expected.protocol, "protocol")
+      assert_equals(url.username, expected.username, "username")
+      assert_equals(url.password, expected.password, "password")
+      assert_equals(url.host, expected.host, "host")
+      assert_equals(url.hostname, expected.hostname, "hostname")
+      assert_equals(url.port, expected.port, "port")
+      assert_equals(url.pathname, expected.pathname, "pathname")
+      assert_equals(url.search, expected.search, "search")
+      if ("searchParams" in expected) {
+        assert_true("searchParams" in url)
+      //   assert_equals(url.searchParams.toString(), expected.searchParams, "searchParams")
+      }
+      assert_equals(url.hash, expected.hash, "hash")
+    }, "Parsing: <" + expected.input + "> against <" + expected.base + ">")
+  }
+}
+
+function runURLSearchParamTests() {
+  test(function() {
+    var url = bURL('http://example.org/?a=b')
+    assert_true("searchParams" in url)
+    var searchParams = url.searchParams
+    assert_true(url.searchParams === searchParams, 'Object identity should hold.')
+  }, 'URL.searchParams getter')
+
+  test(function() {
+    var url = bURL('http://example.org/?a=b')
+    assert_true("searchParams" in url)
+    var searchParams = url.searchParams
+    assert_equals(searchParams.toString(), 'a=b')
+
+    searchParams.set('a', 'b')
+    assert_equals(url.searchParams.toString(), 'a=b')
+    assert_equals(url.search, '?a=b')
+    url.search = ''
+    assert_equals(url.searchParams.toString(), '')
+    assert_equals(url.search, '')
+    assert_equals(searchParams.toString(), '')
+  }, 'URL.searchParams updating, clearing')
+
+  test(function() {
+    'use strict'
+    var urlString = 'http://example.org'
+    var url = bURL(urlString)
+    assert_throws(TypeError(), function() { url.searchParams = new URLSearchParams(urlString) })
+  }, 'URL.searchParams setter, invalid values')
+
+  test(function() {
+    var url = bURL('http://example.org/file?a=b&c=d')
+    assert_true("searchParams" in url)
+    var searchParams = url.searchParams
+    assert_equals(url.search, '?a=b&c=d')
+    assert_equals(searchParams.toString(), 'a=b&c=d')
+
+    // Test that setting 'search' propagates to the URL object's query object.
+    url.search = 'e=f&g=h'
+    assert_equals(url.search, '?e=f&g=h')
+    assert_equals(searchParams.toString(), 'e=f&g=h')
+
+    // ..and same but with a leading '?'.
+    url.search = '?e=f&g=h'
+    assert_equals(url.search, '?e=f&g=h')
+    assert_equals(searchParams.toString(), 'e=f&g=h')
+
+    // And in the other direction, altering searchParams propagates
+    // back to 'search'.
+    // searchParams.append('i', ' j ')
+    // assert_equals(url.search, '?e=f&g=h&i=+j+')
+    // assert_equals(url.searchParams.toString(), 'e=f&g=h&i=+j+')
+    // assert_equals(searchParams.get('i'), ' j ')
+
+    // searchParams.set('e', 'updated')
+    // assert_equals(url.search, '?e=updated&g=h&i=+j+')
+    // assert_equals(searchParams.get('e'), 'updated')
+
+    // var url2 = bURL('http://example.org/file??a=b&c=d')
+    // assert_equals(url2.search, '??a=b&c=d')
+    // assert_equals(url2.searchParams.toString(), '%3Fa=b&c=d')
+
+    // url2.href = 'http://example.org/file??a=b'
+    // assert_equals(url2.search, '??a=b')
+    // assert_equals(url2.searchParams.toString(), '%3Fa=b')
+  }, 'URL.searchParams and URL.search setters, update propagation')
+}
+runURLSearchParamTests()
+runURLConstructorTests()
+/* eslint-enable */

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+const URL = require('url').URL;
+const { test, assert_equals, assert_throws } = common.WPT;
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl');
+  return;
+}
+
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/historical.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+// var objects = [
+//   [function() { return window.location }, "location object"],
+//   [function() { return document.createElement("a") }, "a element"],
+//   [function() { return document.createElement("area") }, "area element"],
+// ];
+
+// objects.forEach(function(o) {
+//   test(function() {
+//     var object = o[0]();
+//     assert_false("searchParams" in object,
+//                  o[1] + " should not have a searchParams attribute");
+//   }, "searchParams on " + o[1]);
+// });
+
+test(function() {
+  var url = new URL("./foo", "http://www.example.org");
+  assert_equals(url.href, "http://www.example.org/foo");
+  assert_throws(new TypeError(), function() {
+    url.href = "./bar";
+  });
+}, "Setting URL's href attribute and base URLs");
+
+test(function() {
+  assert_equals(URL.domainToASCII, undefined);
+}, "URL.domainToASCII should be undefined");
+
+test(function() {
+  assert_equals(URL.domainToUnicode, undefined);
+}, "URL.domainToUnicode should be undefined");
+/* eslint-enable */

--- a/test/parallel/test-whatwg-url-inspect.js
+++ b/test/parallel/test-whatwg-url-inspect.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const common = require('../common');
+const util = require('util');
+const URL = require('url').URL;
+const path = require('path');
+const assert = require('assert');
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl');
+  return;
+}
+
+// Tests below are not from WPT.
+const tests = require(path.join(common.fixturesDir, 'url-tests.json'));
+const additional_tests = require(
+  path.join(common.fixturesDir, 'url-tests-additional.js'));
+
+const allTests = additional_tests.slice();
+for (const test of tests) {
+  if (test.failure || typeof test === 'string') continue;
+  allTests.push(test);
+}
+
+for (const test of allTests) {
+  const url = test.url ? new URL(test.url) : new URL(test.input, test.base);
+
+  for (const showHidden of [true, false]) {
+    const res = util.inspect(url, {
+      showHidden
+    });
+
+    const lines = res.split('\n');
+
+    const firstLine = lines[0];
+    assert.strictEqual(firstLine, 'URL {');
+
+    const lastLine = lines[lines.length - 1];
+    assert.strictEqual(lastLine, '}');
+
+    const innerLines = lines.slice(1, lines.length - 1);
+    const keys = new Set();
+    for (const line of innerLines) {
+      const i = line.indexOf(': ');
+      const k = line.slice(0, i).trim();
+      const v = line.slice(i + 2);
+      assert.strictEqual(keys.has(k), false, 'duplicate key found: ' + k);
+      keys.add(k);
+
+      const hidden = new Set([
+        'password',
+        'cannot-be-base',
+        'special'
+      ]);
+      if (showHidden) {
+        if (!hidden.has(k)) {
+          assert.strictEqual(v, url[k], k);
+          continue;
+        }
+
+        if (k === 'password') {
+          assert.strictEqual(v, url[k], k);
+        }
+        if (k === 'cannot-be-base') {
+          assert.ok(v.match(/^true$|^false$/), k + ' is Boolean');
+        }
+        if (k === 'special') {
+          assert.ok(v.match(/^true$|^false$/), k + ' is Boolean');
+        }
+        continue;
+      }
+
+      // showHidden is false
+      if (k === 'password') {
+        assert.strictEqual(v, '--------', k);
+        continue;
+      }
+      assert.strictEqual(hidden.has(k), false, 'no hidden keys: ' + k);
+      assert.strictEqual(v, url[k], k);
+    }
+  }
+}

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -1,0 +1,52 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const URL = require('url').URL;
+const { test, assert_equals } = common.WPT;
+
+if (!common.hasIntl) {
+  // A handful of the tests fail when ICU is not included.
+  common.skip('missing Intl');
+  return;
+}
+
+const request = {
+  response: require(path.join(common.fixturesDir, 'url-tests.json'))
+};
+
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+function runURLOriginTests() {
+  // var setup = async_test("Loading data…")
+  // setup.step(function() {
+  //   var request = new XMLHttpRequest()
+  //   request.open("GET", "urltestdata.json")
+  //   request.send()
+  //   request.responseType = "json"
+  //   request.onload = setup.step_func(function() {
+         runURLTests(request.response)
+  //     setup.done()
+  //   })
+  // })
+}
+
+function bURL(url, base) {
+  return new URL(url, base || "about:blank")
+}
+
+function runURLTests(urltests) {
+  for(var i = 0, l = urltests.length; i < l; i++) {
+    var expected = urltests[i]
+    if (typeof expected === "string" || !("origin" in expected)) continue
+    test(function() {
+      var url = bURL(expected.input, expected.base)
+      assert_equals(url.origin, expected.origin, "origin")
+    }, "Origin parsing: <" + expected.input + "> against <" + expected.base + ">")
+  }
+}
+
+runURLOriginTests()
+/* eslint-enable */

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const common = require('../common');
-const util = require('util');
+const URL = require('url').URL;
+const path = require('path');
+const assert = require('assert');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.
@@ -9,12 +11,9 @@ if (!common.hasIntl) {
   return;
 }
 
-const URL = require('url').URL;
-const path = require('path');
-const assert = require('assert');
+// Tests below are not from WPT.
 const tests = require(path.join(common.fixturesDir, 'url-tests.json'));
 
-// Tests below are not from WPT.
 for (const test of tests) {
   if (typeof test === 'string')
     continue;
@@ -25,7 +24,11 @@ for (const test of tests) {
   }
 }
 
-function verifyURL(url, test) {
+const additional_tests = require(
+  path.join(common.fixturesDir, 'url-tests-additional.js'));
+
+for (const test of additional_tests) {
+  const url = new URL(test.url);
   if (test.href) assert.strictEqual(url.href, test.href);
   if (test.origin) assert.strictEqual(url.origin, test.origin);
   if (test.protocol) assert.strictEqual(url.protocol, test.protocol);
@@ -37,163 +40,4 @@ function verifyURL(url, test) {
   if (test.pathname) assert.strictEqual(url.pathname, test.pathname);
   if (test.search) assert.strictEqual(url.search, test.search);
   if (test.hash) assert.strictEqual(url.hash, test.hash);
-}
-
-const additional_tests = [
-  {
-    'url': 'tftp://foobar.com/someconfig;mode=netascii',
-    'protocol': 'tftp:',
-    'hostname': 'foobar.com',
-    'pathname': '/someconfig;mode=netascii'
-  },
-  {
-    'url': 'telnet://user:pass@foobar.com:23/',
-    'protocol': 'telnet:',
-    'username': 'user',
-    'password': 'pass',
-    'hostname': 'foobar.com',
-    'port': '23',
-    'pathname': '/'
-  },
-  {
-    'url': 'ut2004://10.10.10.10:7777/Index.ut2',
-    'protocol': 'ut2004:',
-    'hostname': '10.10.10.10',
-    'port': '7777',
-    'pathname': '/Index.ut2'
-  },
-  {
-    'url': 'redis://foo:bar@somehost:6379/0?baz=bam&qux=baz',
-    'protocol': 'redis:',
-    'username': 'foo',
-    'password': 'bar',
-    'hostname': 'somehost',
-    'port': '6379',
-    'pathname': '/0',
-    'search': '?baz=bam&qux=baz'
-  },
-  {
-    'url': 'rsync://foo@host:911/sup',
-    'protocol': 'rsync:',
-    'username': 'foo',
-    'hostname': 'host',
-    'port': '911',
-    'pathname': '/sup'
-  },
-  {
-    'url': 'git://github.com/foo/bar.git',
-    'protocol': 'git:',
-    'hostname': 'github.com',
-    'pathname': '/foo/bar.git'
-  },
-  {
-    'url': 'irc://myserver.com:6999/channel?passwd',
-    'protocol': 'irc:',
-    'hostname': 'myserver.com',
-    'port': '6999',
-    'pathname': '/channel',
-    'search': '?passwd'
-  },
-  {
-    'url': 'dns://fw.example.org:9999/foo.bar.org?type=TXT',
-    'protocol': 'dns:',
-    'hostname': 'fw.example.org',
-    'port': '9999',
-    'pathname': '/foo.bar.org',
-    'search': '?type=TXT'
-  },
-  {
-    'url': 'ldap://localhost:389/ou=People,o=JNDITutorial',
-    'protocol': 'ldap:',
-    'hostname': 'localhost',
-    'port': '389',
-    'pathname': '/ou=People,o=JNDITutorial'
-  },
-  {
-    'url': 'git+https://github.com/foo/bar',
-    'protocol': 'git+https:',
-    'hostname': 'github.com',
-    'pathname': '/foo/bar'
-  },
-  {
-    'url': 'urn:ietf:rfc:2648',
-    'protocol': 'urn:',
-    'pathname': 'ietf:rfc:2648'
-  },
-  {
-    'url': 'tag:joe@example.org,2001:foo/bar',
-    'protocol': 'tag:',
-    'pathname': 'joe@example.org,2001:foo/bar'
-  }
-];
-
-for (const test of additional_tests) {
-  const url = new URL(test.url);
-  verifyURL(url, test);
-}
-
-// test inspect
-const allTests = additional_tests.slice();
-for (const test of tests) {
-  if (test.failure || typeof test === 'string') continue;
-  allTests.push(test);
-}
-
-for (const test of allTests) {
-  const url = test.url ? new URL(test.url) : new URL(test.input, test.base);
-
-  for (const showHidden of [true, false]) {
-    const res = util.inspect(url, {
-      showHidden
-    });
-
-    const lines = res.split('\n');
-
-    const firstLine = lines[0];
-    assert.strictEqual(firstLine, 'URL {');
-
-    const lastLine = lines[lines.length - 1];
-    assert.strictEqual(lastLine, '}');
-
-    const innerLines = lines.slice(1, lines.length - 1);
-    const keys = new Set();
-    for (const line of innerLines) {
-      const i = line.indexOf(': ');
-      const k = line.slice(0, i).trim();
-      const v = line.slice(i + 2);
-      assert.strictEqual(keys.has(k), false, 'duplicate key found: ' + k);
-      keys.add(k);
-
-      const hidden = new Set([
-        'password',
-        'cannot-be-base',
-        'special'
-      ]);
-      if (showHidden) {
-        if (!hidden.has(k)) {
-          assert.strictEqual(v, url[k], k);
-          continue;
-        }
-
-        if (k === 'password') {
-          assert.strictEqual(v, url[k], k);
-        }
-        if (k === 'cannot-be-base') {
-          assert.ok(v.match(/^true$|^false$/), k + ' is Boolean');
-        }
-        if (k === 'special') {
-          assert.ok(v.match(/^true$|^false$/), k + ' is Boolean');
-        }
-        continue;
-      }
-
-      // showHidden is false
-      if (k === 'password') {
-        assert.strictEqual(v, '--------', k);
-        continue;
-      }
-      assert.strictEqual(hidden.has(k), false, 'no hidden keys: ' + k);
-      assert.strictEqual(v, url[k], k);
-    }
-  }
 }

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -14,6 +14,17 @@ const path = require('path');
 const assert = require('assert');
 const tests = require(path.join(common.fixturesDir, 'url-tests.json'));
 
+// Tests below are not from WPT.
+for (const test of tests) {
+  if (typeof test === 'string')
+    continue;
+
+  if (test.failure) {
+    assert.throws(() => new URL(test.input, test.base),
+                  /^TypeError: Invalid URL$/);
+  }
+}
+
 function verifyURL(url, test) {
   if (test.href) assert.strictEqual(url.href, test.href);
   if (test.origin) assert.strictEqual(url.origin, test.origin);
@@ -26,19 +37,6 @@ function verifyURL(url, test) {
   if (test.pathname) assert.strictEqual(url.pathname, test.pathname);
   if (test.search) assert.strictEqual(url.search, test.search);
   if (test.hash) assert.strictEqual(url.hash, test.hash);
-}
-
-for (const test of tests) {
-  if (typeof test === 'string')
-    continue;
-
-  if (test.failure) {
-    assert.throws(() => new URL(test.input, test.base),
-                  /^TypeError: Invalid URL$/);
-  } else {
-    const url = new URL(test.input, test.base);
-    verifyURL(url, test);
-  }
 }
 
 const additional_tests = [

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -2,11 +2,11 @@
 'use strict';
 
 require('../common');
-
 const URL = require('url').URL;
 const assert = require('assert');
 const urlToOptions = require('internal/url').urlToOptions;
 
+// Tests below are not from WPT.
 const url = new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test');
 const oldParams = url.searchParams;  // for test of [SameObject]
 

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -1,55 +1,60 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_equals, assert_true } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b');
+    assert_equals(params + '', 'a=b');
+    params.append('a', 'b');
+    assert_equals(params + '', 'a=b&a=b');
+    params.append('a', 'c');
+    assert_equals(params + '', 'a=b&a=b&a=c');
+}, 'Append same name');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('', '');
+    assert_equals(params + '', '=');
+    params.append('', '');
+    assert_equals(params + '', '=&=');
+}, 'Append empty strings');
+test(function() {
+    var params = new URLSearchParams();
+    params.append(null, null);
+    assert_equals(params + '', 'null=null');
+    params.append(null, null);
+    assert_equals(params + '', 'null=null&null=null');
+}, 'Append null');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('first', 1);
+    params.append('second', 2);
+    params.append('third', '');
+    params.append('first', 10);
+    assert_true(params.has('first'), 'Search params object has name "first"');
+    assert_equals(params.get('first'), '1', 'Search params object has name "first" with value "1"');
+    assert_equals(params.get('second'), '2', 'Search params object has name "second" with value "2"');
+    assert_equals(params.get('third'), '', 'Search params object has name "third" with value ""');
+    params.append('first', 10);
+    assert_equals(params.get('first'), '1', 'Search params object has name "first" with value "1"');
+}, 'Append multiple');
+/* eslint-enable */
 
-// Append same name
-params = new URLSearchParams();
-params.append('a', 'b');
-assert.strictEqual(params + '', 'a=b');
-params.append('a', 'b');
-assert.strictEqual(params + '', 'a=b&a=b');
-params.append('a', 'c');
-assert.strictEqual(params + '', 'a=b&a=b&a=c');
-
-// Append empty strings
-params = new URLSearchParams();
-params.append('', '');
-assert.strictEqual(params + '', '=');
-params.append('', '');
-assert.strictEqual(params + '', '=&=');
-
-// Append null
-params = new URLSearchParams();
-params.append(null, null);
-assert.strictEqual(params + '', 'null=null');
-params.append(null, null);
-assert.strictEqual(params + '', 'null=null&null=null');
-
-// Append multiple
-params = new URLSearchParams();
-params.append('first', 1);
-params.append('second', 2);
-params.append('third', '');
-params.append('first', 10);
-assert.strictEqual(true, params.has('first'),
-                   'Search params object has name "first"');
-assert.strictEqual(params.get('first'), '1',
-                   'Search params object has name "first" with value "1"');
-assert.strictEqual(params.get('second'), '2',
-                   'Search params object has name "second" with value "2"');
-assert.strictEqual(params.get('third'), '',
-                   'Search params object has name "third" with value ""');
-params.append('first', 10);
-assert.strictEqual(params.get('first'), '1',
-                   'Search params object has name "first" with value "1"');
-
-assert.throws(() => {
-  params.append.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.set('a');
-}, /^TypeError: "name" and "value" arguments must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.append.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.set('a');
+  }, /^TypeError: "name" and "value" arguments must be specified$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -1,190 +1,209 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const {
+  test, assert_equals, assert_true,
+  assert_false, assert_throws, assert_array_equals
+} = common.WPT;
 
-let params;
+/* eslint-disable */
+var params;  // Strict mode fix for WPT.
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/405394a/url/urlsearchparams-constructor.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams();
+    assert_equals(params + '', '');
+    params = new URLSearchParams('');
+    assert_equals(params + '', '');
+    params = new URLSearchParams('a=b');
+    assert_equals(params + '', 'a=b');
+    params = new URLSearchParams(params);
+    assert_equals(params + '', 'a=b');
+}, 'Basic URLSearchParams construction');
 
-// Basic URLSearchParams construction
-params = new URLSearchParams();
-assert.strictEqual(params + '', '');
-params = new URLSearchParams('');
-assert.strictEqual(params + '', '');
-params = new URLSearchParams('a=b');
-assert.strictEqual(params + '', 'a=b');
-params = new URLSearchParams(params);
-assert.strictEqual(params + '', 'a=b');
+test(function() {
+    var params = new URLSearchParams()
+    assert_equals(params.toString(), "")
+}, "URLSearchParams constructor, no arguments")
 
-// URLSearchParams constructor, no arguments
-params = new URLSearchParams();
-assert.strictEqual(params.toString(), '');
+// test(() => {
+//     params = new URLSearchParams(DOMException.prototype);
+//     assert_equals(params.toString(), "INDEX_SIZE_ERR=1&DOMSTRING_SIZE_ERR=2&HIERARCHY_REQUEST_ERR=3&WRONG_DOCUMENT_ERR=4&INVALID_CHARACTER_ERR=5&NO_DATA_ALLOWED_ERR=6&NO_MODIFICATION_ALLOWED_ERR=7&NOT_FOUND_ERR=8&NOT_SUPPORTED_ERR=9&INUSE_ATTRIBUTE_ERR=10&INVALID_STATE_ERR=11&SYNTAX_ERR=12&INVALID_MODIFICATION_ERR=13&NAMESPACE_ERR=14&INVALID_ACCESS_ERR=15&VALIDATION_ERR=16&TYPE_MISMATCH_ERR=17&SECURITY_ERR=18&NETWORK_ERR=19&ABORT_ERR=20&URL_MISMATCH_ERR=21&QUOTA_EXCEEDED_ERR=22&TIMEOUT_ERR=23&INVALID_NODE_TYPE_ERR=24&DATA_CLONE_ERR=25")
+// }, "URLSearchParams constructor, DOMException.prototype as argument")
 
-assert.throws(() => URLSearchParams(), TypeError,
-              'Calling \'URLSearchParams\' without \'new\' should throw.');
+test(() => {
+    params = new URLSearchParams('');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_equals(params.__proto__, URLSearchParams.prototype, 'expected URLSearchParams.prototype as prototype.');
+}, "URLSearchParams constructor, empty string as argument")
 
-// URLSearchParams constructor, undefined and null as argument
-params = new URLSearchParams(undefined);
-assert.strictEqual(params.toString(), '');
-params = new URLSearchParams(null);
-assert.strictEqual(params.toString(), '');
+test(() => {
+    params = new URLSearchParams({});
+    assert_equals(params + '', "");
+}, 'URLSearchParams constructor, {} as argument');
 
-// URLSearchParams constructor, empty string as argument
-params = new URLSearchParams('');
-// eslint-disable-next-line no-restricted-properties
-assert.notEqual(params, null, 'constructor returned non-null value.');
-// eslint-disable-next-line no-proto
-assert.strictEqual(params.__proto__, URLSearchParams.prototype,
-                   'expected URLSearchParams.prototype as prototype.');
+test(function() {
+    var params = new URLSearchParams('a=b');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_false(params.has('b'), 'Search params object has not got name "b"');
+    var params = new URLSearchParams('a=b&c');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_true(params.has('c'), 'Search params object has name "c"');
+    var params = new URLSearchParams('&a&&& &&&&&a+b=& c&m%c3%b8%c3%b8');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_true(params.has('a b'), 'Search params object has name "a b"');
+    assert_true(params.has(' '), 'Search params object has name " "');
+    assert_false(params.has('c'), 'Search params object did not have the name "c"');
+    assert_true(params.has(' c'), 'Search params object has name " c"');
+    assert_true(params.has('møø'), 'Search params object has name "møø"');
+}, 'URLSearchParams constructor, string.');
 
-// URLSearchParams constructor, {} as argument
-params = new URLSearchParams({});
-assert.strictEqual(params + '', '');
+test(function() {
+    var seed = new URLSearchParams('a=b&c=d');
+    var params = new URLSearchParams(seed);
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_equals(params.get('a'), 'b');
+    assert_equals(params.get('c'), 'd');
+    assert_false(params.has('d'));
+    // The name-value pairs are copied when created; later updates
+    // should not be observable.
+    seed.append('e', 'f');
+    assert_false(params.has('e'));
+    params.append('g', 'h');
+    assert_false(seed.has('g'));
+}, 'URLSearchParams constructor, object.');
 
-// URLSearchParams constructor, string.
-params = new URLSearchParams('a=b');
-assert.notStrictEqual(params, null, 'constructor returned non-null value.');
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(false, params.has('b'),
-                   'Search params object has not got name "b"');
-params = new URLSearchParams('a=b&c');
-assert.notStrictEqual(params, null, 'constructor returned non-null value.');
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(true, params.has('c'),
-                   'Search params object has name "c"');
-params = new URLSearchParams('&a&&& &&&&&a+b=& c&m%c3%b8%c3%b8');
-assert.notStrictEqual(params, null, 'constructor returned non-null value.');
-assert.strictEqual(true, params.has('a'), 'Search params object has name "a"');
-assert.strictEqual(true, params.has('a b'),
-                   'Search params object has name "a b"');
-assert.strictEqual(true, params.has(' '),
-                   'Search params object has name " "');
-assert.strictEqual(false, params.has('c'),
-                   'Search params object did not have the name "c"');
-assert.strictEqual(true, params.has(' c'),
-                   'Search params object has name " c"');
-assert.strictEqual(true, params.has('møø'),
-                   'Search params object has name "møø"');
+test(function() {
+    var params = new URLSearchParams('a=b+c');
+    assert_equals(params.get('a'), 'b c');
+    params = new URLSearchParams('a+b=c');
+    assert_equals(params.get('a b'), 'c');
+}, 'Parse +');
 
-// URLSearchParams constructor, object.
-const seed = new URLSearchParams('a=b&c=d');
-params = new URLSearchParams(seed);
-assert.notStrictEqual(params, null, 'constructor returned non-null value.');
-assert.strictEqual(params.get('a'), 'b');
-assert.strictEqual(params.get('c'), 'd');
-assert.strictEqual(false, params.has('d'));
-// The name-value pairs are copied when created; later updates
-// should not be observable.
-seed.append('e', 'f');
-assert.strictEqual(false, params.has('e'));
-params.append('g', 'h');
-assert.strictEqual(false, seed.has('g'));
+test(function() {
+    var params = new URLSearchParams('a=b c');
+    assert_equals(params.get('a'), 'b c');
+    params = new URLSearchParams('a b=c');
+    assert_equals(params.get('a b'), 'c');
+}, 'Parse space');
 
-// Parse +
-params = new URLSearchParams('a=b+c');
-assert.strictEqual(params.get('a'), 'b c');
-params = new URLSearchParams('a+b=c');
-assert.strictEqual(params.get('a b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b%20c');
+    assert_equals(params.get('a'), 'b c');
+    params = new URLSearchParams('a%20b=c');
+    assert_equals(params.get('a b'), 'c');
+}, 'Parse %20');
 
-// Parse space
-params = new URLSearchParams('a=b c');
-assert.strictEqual(params.get('a'), 'b c');
-params = new URLSearchParams('a b=c');
-assert.strictEqual(params.get('a b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b\0c');
+    assert_equals(params.get('a'), 'b\0c');
+    params = new URLSearchParams('a\0b=c');
+    assert_equals(params.get('a\0b'), 'c');
+}, 'Parse \\0');
 
-// Parse %20
-params = new URLSearchParams('a=b%20c');
-assert.strictEqual(params.get('a'), 'b c');
-params = new URLSearchParams('a%20b=c');
-assert.strictEqual(params.get('a b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b%00c');
+    assert_equals(params.get('a'), 'b\0c');
+    params = new URLSearchParams('a%00b=c');
+    assert_equals(params.get('a\0b'), 'c');
+}, 'Parse %00');
 
-// Parse \0
-params = new URLSearchParams('a=b\0c');
-assert.strictEqual(params.get('a'), 'b\0c');
-params = new URLSearchParams('a\0b=c');
-assert.strictEqual(params.get('a\0b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b\u2384');
+    assert_equals(params.get('a'), 'b\u2384');
+    params = new URLSearchParams('a\u2384b=c');
+    assert_equals(params.get('a\u2384b'), 'c');
+}, 'Parse \u2384');  // Unicode Character 'COMPOSITION SYMBOL' (U+2384)
 
-// Parse %00
-params = new URLSearchParams('a=b%00c');
-assert.strictEqual(params.get('a'), 'b\0c');
-params = new URLSearchParams('a%00b=c');
-assert.strictEqual(params.get('a\0b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b%e2%8e%84');
+    assert_equals(params.get('a'), 'b\u2384');
+    params = new URLSearchParams('a%e2%8e%84b=c');
+    assert_equals(params.get('a\u2384b'), 'c');
+}, 'Parse %e2%8e%84');  // Unicode Character 'COMPOSITION SYMBOL' (U+2384)
 
-// Parse \u2384 (Unicode Character 'COMPOSITION SYMBOL' (U+2384))
-params = new URLSearchParams('a=b\u2384');
-assert.strictEqual(params.get('a'), 'b\u2384');
-params = new URLSearchParams('a\u2384b=c');
-assert.strictEqual(params.get('a\u2384b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b\uD83D\uDCA9c');
+    assert_equals(params.get('a'), 'b\uD83D\uDCA9c');
+    params = new URLSearchParams('a\uD83D\uDCA9b=c');
+    assert_equals(params.get('a\uD83D\uDCA9b'), 'c');
+}, 'Parse \uD83D\uDCA9');  // Unicode Character 'PILE OF POO' (U+1F4A9)
 
-// Parse %e2%8e%84 (Unicode Character 'COMPOSITION SYMBOL' (U+2384))
-params = new URLSearchParams('a=b%e2%8e%84');
-assert.strictEqual(params.get('a'), 'b\u2384');
-params = new URLSearchParams('a%e2%8e%84b=c');
-assert.strictEqual(params.get('a\u2384b'), 'c');
+test(function() {
+    var params = new URLSearchParams('a=b%f0%9f%92%a9c');
+    assert_equals(params.get('a'), 'b\uD83D\uDCA9c');
+    params = new URLSearchParams('a%f0%9f%92%a9b=c');
+    assert_equals(params.get('a\uD83D\uDCA9b'), 'c');
+}, 'Parse %f0%9f%92%a9');  // Unicode Character 'PILE OF POO' (U+1F4A9)
 
-// Parse \uD83D\uDCA9 (Unicode Character 'PILE OF POO' (U+1F4A9))
-params = new URLSearchParams('a=b\uD83D\uDCA9c');
-assert.strictEqual(params.get('a'), 'b\uD83D\uDCA9c');
-params = new URLSearchParams('a\uD83D\uDCA9b=c');
-assert.strictEqual(params.get('a\uD83D\uDCA9b'), 'c');
-
-// Parse %f0%9f%92%a9 (Unicode Character 'PILE OF POO' (U+1F4A9))
-params = new URLSearchParams('a=b%f0%9f%92%a9c');
-assert.strictEqual(params.get('a'), 'b\uD83D\uDCA9c');
-params = new URLSearchParams('a%f0%9f%92%a9b=c');
-assert.strictEqual(params.get('a\uD83D\uDCA9b'), 'c');
-
-// Constructor with sequence of sequences of strings
-params = new URLSearchParams([]);
-// eslint-disable-next-line no-restricted-properties
-assert.notEqual(params, null, 'constructor returned non-null value.');
-params = new URLSearchParams([['a', 'b'], ['c', 'd']]);
-assert.strictEqual(params.get('a'), 'b');
-assert.strictEqual(params.get('c'), 'd');
-assert.throws(() => new URLSearchParams([[1]]),
-              /^TypeError: Each query pair must be a name\/value tuple$/);
-assert.throws(() => new URLSearchParams([[1, 2, 3]]),
-              /^TypeError: Each query pair must be a name\/value tuple$/);
+test(function() {
+    var params = new URLSearchParams([]);
+    assert_true(params != null, 'constructor returned non-null value.');
+    params = new URLSearchParams([['a', 'b'], ['c', 'd']]);
+    assert_equals(params.get("a"), "b");
+    assert_equals(params.get("c"), "d");
+    assert_throws(new TypeError(), function() { new URLSearchParams([[1]]); });
+    assert_throws(new TypeError(), function() { new URLSearchParams([[1,2,3]]); });
+}, "Constructor with sequence of sequences of strings");
 
 [
-  // Further confirmation needed
-  // https://github.com/w3c/web-platform-tests/pull/4523#discussion_r98337513
-  // {
-  //   input: {'+': '%C2'},
-  //   output: [[' ', '\uFFFD']],
-  //   name: 'object with +'
-  // },
-  {
-    input: {c: 'x', a: '?'},
-    output: [['c', 'x'], ['a', '?']],
-    name: 'object with two keys'
-  },
-  {
-    input: [['c', 'x'], ['a', '?']],
-    output: [['c', 'x'], ['a', '?']],
-    name: 'array with two keys'
-  }
+//   { "input": {"+": "%C2"}, "output": [[" ", "\uFFFD"]], "name": "object with +" },
+  { "input": {c: "x", a: "?"}, "output": [["c", "x"], ["a", "?"]], "name": "object with two keys" },
+  { "input": [["c", "x"], ["a", "?"]], "output": [["c", "x"], ["a", "?"]], "name": "array with two keys" }
 ].forEach((val) => {
-  const params = new URLSearchParams(val.input);
-  assert.deepStrictEqual(Array.from(params), val.output,
-                         `Construct with ${val.name}`);
-});
+    test(() => {
+        let params = new URLSearchParams(val.input),
+            i = 0
+        for (let param of params) {
+            assert_array_equals(param, val.output[i])
+            i++
+        }
+    }, "Construct with " + val.name)
+})
 
-// Custom [Symbol.iterator]
-params = new URLSearchParams();
-params[Symbol.iterator] = function *() {
-  yield ['a', 'b'];
-};
-const params2 = new URLSearchParams(params);
-assert.strictEqual(params2.get('a'), 'b');
+test(() => {
+  params = new URLSearchParams()
+  params[Symbol.iterator] = function *() {
+    yield ["a", "b"]
+  }
+  let params2 = new URLSearchParams(params)
+  assert_equals(params2.get("a"), "b")
+}, "Custom [Symbol.iterator]")
+/* eslint-enable */
 
-assert.throws(() => new URLSearchParams({ [Symbol.iterator]: 42 }),
-              /^TypeError: Query pairs must be iterable$/);
-assert.throws(() => new URLSearchParams([{}]),
-              /^TypeError: Each query pair must be iterable$/);
-assert.throws(() => new URLSearchParams(['a']),
-              /^TypeError: Each query pair must be iterable$/);
-assert.throws(() => new URLSearchParams([{ [Symbol.iterator]: 42 }]),
-              /^TypeError: Each query pair must be iterable$/);
+// Tests below are not from WPT.
+{
+//   assert.throws(() => {
+//     new URLSearchParams({
+//         toString() { throw new TypeError('Illegal invocation'); }
+//     });
+//   }, TypeError);
+}
+
+{
+  let params;
+  // URLSearchParams constructor, undefined and null as argument
+  params = new URLSearchParams(undefined);
+  assert.strictEqual(params.toString(), '');
+  params = new URLSearchParams(null);
+  assert.strictEqual(params.toString(), '');
+  assert.throws(() => new URLSearchParams([[1]]),
+                /^TypeError: Each query pair must be a name\/value tuple$/);
+  assert.throws(() => new URLSearchParams([[1, 2, 3]]),
+                /^TypeError: Each query pair must be a name\/value tuple$/);
+  assert.throws(() => new URLSearchParams({ [Symbol.iterator]: 42 }),
+                /^TypeError: Query pairs must be iterable$/);
+  assert.throws(() => new URLSearchParams([{}]),
+                /^TypeError: Each query pair must be iterable$/);
+  assert.throws(() => new URLSearchParams(['a']),
+                /^TypeError: Each query pair must be iterable$/);
+  assert.throws(() => new URLSearchParams([{ [Symbol.iterator]: 42 }]),
+                /^TypeError: Each query pair must be iterable$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -1,52 +1,57 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
-const url = require('url');
-const URL = url.URL;
-const URLSearchParams = url.URLSearchParams;
+const { URL, URLSearchParams } = require('url');
+const { test, assert_equals, assert_true, assert_false } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-delete.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=b&c=d');
+    params.delete('a');
+    assert_equals(params + '', 'c=d');
+    params = new URLSearchParams('a=a&b=b&a=a&c=c');
+    params.delete('a');
+    assert_equals(params + '', 'b=b&c=c');
+    params = new URLSearchParams('a=a&=&b=b&c=c');
+    params.delete('');
+    assert_equals(params + '', 'a=a&b=b&c=c');
+    params = new URLSearchParams('a=a&null=null&b=b');
+    params.delete(null);
+    assert_equals(params + '', 'a=a&b=b');
+    params = new URLSearchParams('a=a&undefined=undefined&b=b');
+    params.delete(undefined);
+    assert_equals(params + '', 'a=a&b=b');
+}, 'Delete basics');
 
-// Delete basics
-params = new URLSearchParams('a=b&c=d');
-params.delete('a');
-assert.strictEqual(params + '', 'c=d');
-params = new URLSearchParams('a=a&b=b&a=a&c=c');
-params.delete('a');
-assert.strictEqual(params + '', 'b=b&c=c');
-params = new URLSearchParams('a=a&=&b=b&c=c');
-params.delete('');
-assert.strictEqual(params + '', 'a=a&b=b&c=c');
-params = new URLSearchParams('a=a&null=null&b=b');
-params.delete(null);
-assert.strictEqual(params + '', 'a=a&b=b');
-params = new URLSearchParams('a=a&undefined=undefined&b=b');
-params.delete(undefined);
-assert.strictEqual(params + '', 'a=a&b=b');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('first', 1);
+    assert_true(params.has('first'), 'Search params object has name "first"');
+    assert_equals(params.get('first'), '1', 'Search params object has name "first" with value "1"');
+    params.delete('first');
+    assert_false(params.has('first'), 'Search params object has no "first" name');
+    params.append('first', 1);
+    params.append('first', 10);
+    params.delete('first');
+    assert_false(params.has('first'), 'Search params object has no "first" name');
+}, 'Deleting appended multiple');
+/* eslint-enable */
 
-// Deleting appended multiple
-params = new URLSearchParams();
-params.append('first', 1);
-assert.strictEqual(true, params.has('first'),
-                   'Search params object has name "first"');
-assert.strictEqual(params.get('first'), '1',
-                   'Search params object has name "first" with value "1"');
-params.delete('first');
-assert.strictEqual(false, params.has('first'),
-                   'Search params object has no "first" name');
-params.append('first', 1);
-params.append('first', 10);
-params.delete('first');
-assert.strictEqual(false, params.has('first'),
-                   'Search params object has no "first" name');
-
-assert.throws(() => {
-  params.delete.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.delete();
-}, /^TypeError: "name" argument must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.delete.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.delete();
+  }, /^TypeError: "name" argument must be specified$/);
+}
 
 // https://github.com/nodejs/node/issues/10480
 // Emptying searchParams should correctly update url's query

--- a/test/parallel/test-whatwg-url-searchparams-entries.js
+++ b/test/parallel/test-whatwg-url-searchparams-entries.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 
+// Tests below are not from WPT.
 const params = new URLSearchParams('a=b&c=d');
 const entries = params.entries();
 assert.strictEqual(typeof entries[Symbol.iterator], 'function');

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -2,42 +2,53 @@
 
 const common = require('../common');
 const assert = require('assert');
-const url = require('url');
-const URL = url.URL;
-const URLSearchParams = url.URLSearchParams;
+const { URL, URLSearchParams } = require('url');
+const { test, assert_array_equals, assert_unreached } = common.WPT;
 
-let a, b, i;
+/* eslint-disable */
+var i;  // Strict mode fix for WPT.
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/a8b2b1e/url/urlsearchparams-foreach.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=1&b=2&c=3');
+    var keys = [];
+    var values = [];
+    params.forEach(function(value, key) {
+        keys.push(key);
+        values.push(value);
+    });
+    assert_array_equals(keys, ['a', 'b', 'c']);
+    assert_array_equals(values, ['1', '2', '3']);
+}, "ForEach Check");
 
-// ForEach Check
-const params = new URLSearchParams('a=1&b=2&c=3');
-const keys = [];
-const values = [];
-params.forEach((value, key) => {
-  keys.push(key);
-  values.push(value);
-});
-assert.deepStrictEqual(keys, ['a', 'b', 'c']);
-assert.deepStrictEqual(values, ['1', '2', '3']);
+test(function() {
+    let a = new URL("http://a.b/c?a=1&b=2&c=3&d=4");
+    let b = a.searchParams;
+    var c = [];
+    for (i of b) {
+        a.search = "x=1&y=2&z=3";
+        c.push(i);
+    }
+    assert_array_equals(c[0], ["a","1"]);
+    assert_array_equals(c[1], ["y","2"]);
+    assert_array_equals(c[2], ["z","3"]);
+}, "For-of Check");
 
-// For-of Check
-a = new URL('http://a.b/c?a=1&b=2&c=3&d=4');
-b = a.searchParams;
-const c = [];
-for (i of b) {
-  a.search = 'x=1&y=2&z=3';
-  c.push(i);
+test(function() {
+    let a = new URL("http://a.b/c");
+    let b = a.searchParams;
+    for (i of b) {
+        assert_unreached(i);
+    }
+}, "empty");
+/* eslint-enable */
+
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.forEach.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
 }
-assert.deepStrictEqual(c[0], ['a', '1']);
-assert.deepStrictEqual(c[1], ['y', '2']);
-assert.deepStrictEqual(c[2], ['z', '3']);
-
-// empty
-a = new URL('http://a.b/c');
-b = a.searchParams;
-for (i of b) {
-  common.fail('should not be reached');
-}
-
-assert.throws(() => {
-  params.forEach.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -1,38 +1,45 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_equals, assert_true } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-get.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=b&c=d');
+    assert_equals(params.get('a'), 'b');
+    assert_equals(params.get('c'), 'd');
+    assert_equals(params.get('e'), null);
+    params = new URLSearchParams('a=b&c=d&a=e');
+    assert_equals(params.get('a'), 'b');
+    params = new URLSearchParams('=b&c=d');
+    assert_equals(params.get(''), 'b');
+    params = new URLSearchParams('a=&c=d&a=e');
+    assert_equals(params.get('a'), '');
+}, 'Get basics');
 
-// Get basics
-params = new URLSearchParams('a=b&c=d');
-assert.strictEqual(params.get('a'), 'b');
-assert.strictEqual(params.get('c'), 'd');
-assert.strictEqual(params.get('e'), null);
-params = new URLSearchParams('a=b&c=d&a=e');
-assert.strictEqual(params.get('a'), 'b');
-params = new URLSearchParams('=b&c=d');
-assert.strictEqual(params.get(''), 'b');
-params = new URLSearchParams('a=&c=d&a=e');
-assert.strictEqual(params.get('a'), '');
+test(function() {
+    var params = new URLSearchParams('first=second&third&&');
+    assert_true(params != null, 'constructor returned non-null value.');
+    assert_true(params.has('first'), 'Search params object has name "first"');
+    assert_equals(params.get('first'), 'second', 'Search params object has name "first" with value "second"');
+    assert_equals(params.get('third'), '', 'Search params object has name "third" with the empty value.');
+    assert_equals(params.get('fourth'), null, 'Search params object has no "fourth" name and value.');
+}, 'More get() basics');
+/* eslint-enable */
 
-// More get() basics
-params = new URLSearchParams('first=second&third&&');
-assert.notStrictEqual(params, null, 'constructor returned non-null value.');
-assert.strictEqual(true, params.has('first'),
-                   'Search params object has name "first"');
-assert.strictEqual(params.get('first'), 'second',
-                   'Search params object has name "first" with value "second"');
-assert.strictEqual(params.get('third'), '',
-                   'Search params object has name "third" with empty value.');
-assert.strictEqual(params.get('fourth'), null,
-                   'Search params object has no "fourth" name and value.');
-
-assert.throws(() => {
-  params.get.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.get();
-}, /^TypeError: "name" argument must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.get.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.get();
+  }, /^TypeError: "name" argument must be specified$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -1,45 +1,49 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_equals, assert_true, assert_array_equals } = common.WPT;
 
-let params;
-let matches;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-getall.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=b&c=d');
+    assert_array_equals(params.getAll('a'), ['b']);
+    assert_array_equals(params.getAll('c'), ['d']);
+    assert_array_equals(params.getAll('e'), []);
+    params = new URLSearchParams('a=b&c=d&a=e');
+    assert_array_equals(params.getAll('a'), ['b', 'e']);
+    params = new URLSearchParams('=b&c=d');
+    assert_array_equals(params.getAll(''), ['b']);
+    params = new URLSearchParams('a=&c=d&a=e');
+    assert_array_equals(params.getAll('a'), ['', 'e']);
+}, 'getAll() basics');
 
-// getAll() basics
-params = new URLSearchParams('a=b&c=d');
-assert.deepStrictEqual(params.getAll('a'), ['b']);
-assert.deepStrictEqual(params.getAll('c'), ['d']);
-assert.deepStrictEqual(params.getAll('e'), []);
-params = new URLSearchParams('a=b&c=d&a=e');
-assert.deepStrictEqual(params.getAll('a'), ['b', 'e']);
-params = new URLSearchParams('=b&c=d');
-assert.deepStrictEqual(params.getAll(''), ['b']);
-params = new URLSearchParams('a=&c=d&a=e');
-assert.deepStrictEqual(params.getAll('a'), ['', 'e']);
+test(function() {
+    var params = new URLSearchParams('a=1&a=2&a=3&a');
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    var matches = params.getAll('a');
+    assert_true(matches && matches.length == 4, 'Search params object has values for name "a"');
+    assert_array_equals(matches, ['1', '2', '3', ''], 'Search params object has expected name "a" values');
+    params.set('a', 'one');
+    assert_equals(params.get('a'), 'one', 'Search params object has name "a" with value "one"');
+    var matches = params.getAll('a');
+    assert_true(matches && matches.length == 1, 'Search params object has values for name "a"');
+    assert_array_equals(matches, ['one'], 'Search params object has expected name "a" values');
+}, 'getAll() multiples');
+/* eslint-enable */
 
-// getAll() multiples
-params = new URLSearchParams('a=1&a=2&a=3&a');
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-matches = params.getAll('a');
-assert(matches && matches.length == 4,
-       'Search params object has values for name "a"');
-assert.deepStrictEqual(matches, ['1', '2', '3', ''],
-                       'Search params object has expected name "a" values');
-params.set('a', 'one');
-assert.strictEqual(params.get('a'), 'one',
-                   'Search params object has name "a" with value "one"');
-matches = params.getAll('a');
-assert(matches && matches.length == 1,
-       'Search params object has values for name "a"');
-assert.deepStrictEqual(matches, ['one'],
-                       'Search params object has expected name "a" values');
-
-assert.throws(() => {
-  params.getAll.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.getAll();
-}, /^TypeError: "name" argument must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.getAll.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.getAll();
+  }, /^TypeError: "name" argument must be specified$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -1,42 +1,48 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_false, assert_true } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-has.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=b&c=d');
+    assert_true(params.has('a'));
+    assert_true(params.has('c'));
+    assert_false(params.has('e'));
+    params = new URLSearchParams('a=b&c=d&a=e');
+    assert_true(params.has('a'));
+    params = new URLSearchParams('=b&c=d');
+    assert_true(params.has(''));
+    params = new URLSearchParams('null=a');
+    assert_true(params.has(null));
+}, 'Has basics');
 
-// Has basics
-params = new URLSearchParams('a=b&c=d');
-assert.strictEqual(true, params.has('a'));
-assert.strictEqual(true, params.has('c'));
-assert.strictEqual(false, params.has('e'));
-params = new URLSearchParams('a=b&c=d&a=e');
-assert.strictEqual(true, params.has('a'));
-params = new URLSearchParams('=b&c=d');
-assert.strictEqual(true, params.has(''));
-params = new URLSearchParams('null=a');
-assert.strictEqual(true, params.has(null));
+test(function() {
+    var params = new URLSearchParams('a=b&c=d&&');
+    params.append('first', 1);
+    params.append('first', 2);
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_true(params.has('c'), 'Search params object has name "c"');
+    assert_true(params.has('first'), 'Search params object has name "first"');
+    assert_false(params.has('d'), 'Search params object has no name "d"');
+    params.delete('first');
+    assert_false(params.has('first'), 'Search params object has no name "first"');
+}, 'has() following delete()');
+/* eslint-enable */
 
-// has() following delete()
-params = new URLSearchParams('a=b&c=d&&');
-params.append('first', 1);
-params.append('first', 2);
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(true, params.has('c'),
-                   'Search params object has name "c"');
-assert.strictEqual(true, params.has('first'),
-                   'Search params object has name "first"');
-assert.strictEqual(false, params.has('d'),
-                   'Search params object has no name "d"');
-params.delete('first');
-assert.strictEqual(false, params.has('first'),
-                   'Search params object has no name "first"');
-
-assert.throws(() => {
-  params.has.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.has();
-}, /^TypeError: "name" argument must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.has.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.has();
+  }, /^TypeError: "name" argument must be specified$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-inspect.js
+++ b/test/parallel/test-whatwg-url-searchparams-inspect.js
@@ -3,12 +3,9 @@
 require('../common');
 const assert = require('assert');
 const util = require('util');
-const URL = require('url').URL;
+const URLSearchParams = require('url').URLSearchParams;
 
-// Until we export URLSearchParams
-const m = new URL('http://example.org');
-const URLSearchParams = m.searchParams.constructor;
-
+// Tests below are not from WPT.
 const sp = new URLSearchParams('?a=a&b=b&b=c');
 assert.strictEqual(util.inspect(sp),
                    "URLSearchParams { 'a' => 'a', 'b' => 'b', 'b' => 'c' }");

--- a/test/parallel/test-whatwg-url-searchparams-keys.js
+++ b/test/parallel/test-whatwg-url-searchparams-keys.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 
+// Tests below are not from WPT.
 const params = new URLSearchParams('a=b&c=d');
 const keys = params.keys();
 

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -1,41 +1,46 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_equals, assert_true } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-set.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+test(function() {
+    var params = new URLSearchParams('a=b&c=d');
+    params.set('a', 'B');
+    assert_equals(params + '', 'a=B&c=d');
+    params = new URLSearchParams('a=b&c=d&a=e');
+    params.set('a', 'B');
+    assert_equals(params + '', 'a=B&c=d')
+    params.set('e', 'f');
+    assert_equals(params + '', 'a=B&c=d&e=f')
+}, 'Set basics');
 
-// Set basics
-params = new URLSearchParams('a=b&c=d');
-params.set('a', 'B');
-assert.strictEqual(params + '', 'a=B&c=d');
-params = new URLSearchParams('a=b&c=d&a=e');
-params.set('a', 'B');
-assert.strictEqual(params + '', 'a=B&c=d');
-params.set('e', 'f');
-assert.strictEqual(params + '', 'a=B&c=d&e=f');
+test(function() {
+    var params = new URLSearchParams('a=1&a=2&a=3');
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_equals(params.get('a'), '1', 'Search params object has name "a" with value "1"');
+    params.set('first', 4);
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_equals(params.get('a'), '1', 'Search params object has name "a" with value "1"');
+    params.set('a', 4);
+    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_equals(params.get('a'), '4', 'Search params object has name "a" with value "4"');
+}, 'URLSearchParams.set');
+/* eslint-enable */
 
-// URLSearchParams.set
-params = new URLSearchParams('a=1&a=2&a=3');
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(params.get('a'), '1',
-                   'Search params object has name "a" with value "1"');
-params.set('first', 4);
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(params.get('a'), '1',
-                   'Search params object has name "a" with value "1"');
-params.set('a', 4);
-assert.strictEqual(true, params.has('a'),
-                   'Search params object has name "a"');
-assert.strictEqual(params.get('a'), '4',
-                   'Search params object has name "a" with value "4"');
-
-assert.throws(() => {
-  params.set.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
-assert.throws(() => {
-  params.set('a');
-}, /^TypeError: "name" and "value" arguments must be specified$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.set.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+  assert.throws(() => {
+    params.set('a');
+  }, /^TypeError: "name" and "value" arguments must be specified$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -1,115 +1,131 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
+const { test, assert_equals } = common.WPT;
 
-let params;
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+// test(function() {
+//     var params = new URLSearchParams();
+//     params.append('a', 'b c');
+//     assert_equals(params + '', 'a=b+c');
+//     params.delete('a');
+//     params.append('a b', 'c');
+//     assert_equals(params + '', 'a+b=c');
+// }, 'Serialize space');
 
-// Serialize space
-// querystring does not currently handle spaces intelligently
-// params = new URLSearchParams();
-// params.append('a', 'b c');
-// assert.strictEqual(params + '', 'a=b+c');
-// params.delete('a');
-// params.append('a b', 'c');
-// assert.strictEqual(params + '', 'a+b=c');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', '');
+    assert_equals(params + '', 'a=');
+    params.append('a', '');
+    assert_equals(params + '', 'a=&a=');
+    params.append('', 'b');
+    assert_equals(params + '', 'a=&a=&=b');
+    params.append('', '');
+    assert_equals(params + '', 'a=&a=&=b&=');
+    params.append('', '');
+    assert_equals(params + '', 'a=&a=&=b&=&=');
+}, 'Serialize empty value');
 
-// Serialize empty value
-params = new URLSearchParams();
-params.append('a', '');
-assert.strictEqual(params + '', 'a=');
-params.append('a', '');
-assert.strictEqual(params + '', 'a=&a=');
-params.append('', 'b');
-assert.strictEqual(params + '', 'a=&a=&=b');
-params.append('', '');
-assert.strictEqual(params + '', 'a=&a=&=b&=');
-params.append('', '');
-assert.strictEqual(params + '', 'a=&a=&=b&=&=');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('', 'b');
+    assert_equals(params + '', '=b');
+    params.append('', 'b');
+    assert_equals(params + '', '=b&=b');
+}, 'Serialize empty name');
 
-// Serialize empty name
-params = new URLSearchParams();
-params.append('', 'b');
-assert.strictEqual(params + '', '=b');
-params.append('', 'b');
-assert.strictEqual(params + '', '=b&=b');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('', '');
+    assert_equals(params + '', '=');
+    params.append('', '');
+    assert_equals(params + '', '=&=');
+}, 'Serialize empty name and value');
 
-// Serialize empty name and value
-params = new URLSearchParams();
-params.append('', '');
-assert.strictEqual(params + '', '=');
-params.append('', '');
-assert.strictEqual(params + '', '=&=');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b+c');
+    assert_equals(params + '', 'a=b%2Bc');
+    params.delete('a');
+    params.append('a+b', 'c');
+    assert_equals(params + '', 'a%2Bb=c');
+}, 'Serialize +');
 
-// Serialize +
-params = new URLSearchParams();
-params.append('a', 'b+c');
-assert.strictEqual(params + '', 'a=b%2Bc');
-params.delete('a');
-params.append('a+b', 'c');
-assert.strictEqual(params + '', 'a%2Bb=c');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('=', 'a');
+    assert_equals(params + '', '%3D=a');
+    params.append('b', '=');
+    assert_equals(params + '', '%3D=a&b=%3D');
+}, 'Serialize =');
 
-// Serialize =
-params = new URLSearchParams();
-params.append('=', 'a');
-assert.strictEqual(params + '', '%3D=a');
-params.append('b', '=');
-assert.strictEqual(params + '', '%3D=a&b=%3D');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('&', 'a');
+    assert_equals(params + '', '%26=a');
+    params.append('b', '&');
+    assert_equals(params + '', '%26=a&b=%26');
+}, 'Serialize &');
 
-// Serialize &
-params = new URLSearchParams();
-params.append('&', 'a');
-assert.strictEqual(params + '', '%26=a');
-params.append('b', '&');
-assert.strictEqual(params + '', '%26=a&b=%26');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', '*-._');
+    assert_equals(params + '', 'a=*-._');
+    params.delete('a');
+    params.append('*-._', 'c');
+    assert_equals(params + '', '*-._=c');
+}, 'Serialize *-._');
 
-// Serialize *-._
-params = new URLSearchParams();
-params.append('a', '*-._');
-assert.strictEqual(params + '', 'a=*-._');
-params.delete('a');
-params.append('*-._', 'c');
-assert.strictEqual(params + '', '*-._=c');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b%c');
+    assert_equals(params + '', 'a=b%25c');
+    params.delete('a');
+    params.append('a%b', 'c');
+    assert_equals(params + '', 'a%25b=c');
+}, 'Serialize %');
 
-// Serialize %
-params = new URLSearchParams();
-params.append('a', 'b%c');
-assert.strictEqual(params + '', 'a=b%25c');
-params.delete('a');
-params.append('a%b', 'c');
-assert.strictEqual(params + '', 'a%25b=c');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b\0c');
+    assert_equals(params + '', 'a=b%00c');
+    params.delete('a');
+    params.append('a\0b', 'c');
+    assert_equals(params + '', 'a%00b=c');
+}, 'Serialize \\0');
 
-// Serialize \\0
-params = new URLSearchParams();
-params.append('a', 'b\0c');
-assert.strictEqual(params + '', 'a=b%00c');
-params.delete('a');
-params.append('a\0b', 'c');
-assert.strictEqual(params + '', 'a%00b=c');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b\uD83D\uDCA9c');
+    assert_equals(params + '', 'a=b%F0%9F%92%A9c');
+    params.delete('a');
+    params.append('a\uD83D\uDCA9b', 'c');
+    assert_equals(params + '', 'a%F0%9F%92%A9b=c');
+}, 'Serialize \uD83D\uDCA9');  // Unicode Character 'PILE OF POO' (U+1F4A9)
 
-// Serialize \uD83D\uDCA9
-// Unicode Character 'PILE OF POO' (U+1F4A9)
-params = new URLSearchParams();
-params.append('a', 'b\uD83D\uDCA9c');
-assert.strictEqual(params + '', 'a=b%F0%9F%92%A9c');
-params.delete('a');
-params.append('a\uD83D\uDCA9b', 'c');
-assert.strictEqual(params + '', 'a%F0%9F%92%A9b=c');
+test(function() {
+    var params;
+    // params = new URLSearchParams('a=b&c=d&&e&&');
+    // assert_equals(params.toString(), 'a=b&c=d&e=');
+    // params = new URLSearchParams('a = b &a=b&c=d%20');
+    // assert_equals(params.toString(), 'a+=+b+&a=b&c=d+');
+    // The lone '=' _does_ survive the roundtrip.
+    params = new URLSearchParams('a=&a=b');
+    assert_equals(params.toString(), 'a=&a=b');
+}, 'URLSearchParams.toString');
+/* eslint-enable */
 
-// URLSearchParams.toString
-
-// querystring parses `&&` as {'': ''}
-// params = new URLSearchParams('a=b&c=d&&e&&');
-// assert.strictEqual(params.toString(), 'a=b&c=d&e=');
-
-// querystring does not currently handle spaces intelligently
-// params = new URLSearchParams('a = b &a=b&c=d%20');
-// assert.strictEqual(params.toString(), 'a+=+b+&a=b&c=d+');
-
-// The lone '=' _does_ survive the roundtrip.
-params = new URLSearchParams('a=&a=b');
-assert.strictEqual(params.toString(), 'a=&a=b');
-assert.throws(() => {
-  params.toString.call(undefined);
-}, /^TypeError: Value of `this` is not a URLSearchParams$/);
+// Tests below are not from WPT.
+{
+  const params = new URLSearchParams();
+  assert.throws(() => {
+    params.toString.call(undefined);
+  }, /^TypeError: Value of `this` is not a URLSearchParams$/);
+}

--- a/test/parallel/test-whatwg-url-searchparams-values.js
+++ b/test/parallel/test-whatwg-url-searchparams-values.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 
+// Tests below are not from WPT.
 const params = new URLSearchParams('a=b&c=d');
 const values = params.values();
 

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -4,6 +4,7 @@ require('../common');
 const assert = require('assert');
 const URL = require('url').URL;
 
+// Tests below are not from WPT.
 const serialized = 'a=a&a=1&a=true&a=undefined&a=null&a=%5Bobject%20Object%5D';
 const values = ['a', 1, true, undefined, null, {}];
 

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const common = require('../common');
+const path = require('path');
+const URL = require('url').URL;
+const { test, assert_equals } = common.WPT;
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.
@@ -8,25 +11,68 @@ if (!common.hasIntl) {
   return;
 }
 
-const path = require('path');
-const URL = require('url').URL;
-const assert = require('assert');
-const attrs = require(path.join(common.fixturesDir, 'url-setter-tests.json'));
+const request = {
+  response: require(path.join(common.fixturesDir, 'url-setter-tests.json'))
+};
 
-for (const attr in attrs) {
-  if (attr === 'comment')
-    continue;
-  const tests = attrs[attr];
-  let n = 0;
-  for (const test of tests) {
-    if (test.skip) continue;
-    n++;
-    const url = new URL(test.href);
-    url[attr] = test.new_value;
-    for (const test_attr in test.expected) {
-      assert.strictEqual(test.expected[test_attr], url[test_attr],
-                         `${n} ${attr} ${test_attr} ` +
-                         `${test.href} ${test.comment}`);
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+function startURLSettersTests() {
+//   var setup = async_test("Loading data…")
+//   setup.step(function() {
+//     var request = new XMLHttpRequest()
+//     request.open("GET", "setters_tests.json")
+//     request.send()
+//     request.responseType = "json"
+//     request.onload = setup.step_func(function() {
+         runURLSettersTests(request.response)
+//       setup.done()
+//     })
+//   })
+}
+
+function runURLSettersTests(all_test_cases) {
+  for (var attribute_to_be_set in all_test_cases) {
+    if (attribute_to_be_set == "comment") {
+      continue;
+    }
+    var test_cases = all_test_cases[attribute_to_be_set];
+    for(var i = 0, l = test_cases.length; i < l; i++) {
+      var test_case = test_cases[i];
+      var name = "Setting <" + test_case.href + ">." + attribute_to_be_set +
+                 " = '" + test_case.new_value + "'";
+      if ("comment" in test_case) {
+        name += " " + test_case.comment;
+      }
+      test(function() {
+        var url = new URL(test_case.href);
+        url[attribute_to_be_set] = test_case.new_value;
+        for (var attribute in test_case.expected) {
+          assert_equals(url[attribute], test_case.expected[attribute])
+        }
+      }, "URL: " + name)
+      // test(function() {
+      //   var url = document.createElement("a");
+      //   url.href = test_case.href;
+      //   url[attribute_to_be_set] = test_case.new_value;
+      //   for (var attribute in test_case.expected) {
+      //     assert_equals(url[attribute], test_case.expected[attribute])
+      //   }
+      // }, "<a>: " + name)
+      // test(function() {
+      //   var url = document.createElement("area");
+      //   url.href = test_case.href;
+      //   url[attribute_to_be_set] = test_case.new_value;
+      //   for (var attribute in test_case.expected) {
+      //     assert_equals(url[attribute], test_case.expected[attribute])
+      //   }
+      // }, "<area>: " + name)
     }
   }
 }
+
+startURLSettersTests()
+/* eslint-enable */

--- a/test/parallel/test-whatwg-url-tostringtag.js
+++ b/test/parallel/test-whatwg-url-tostringtag.js
@@ -3,6 +3,8 @@
 require('../common');
 const assert = require('assert');
 const URL = require('url').URL;
+
+// Tests below are not from WPT.
 const toString = Object.prototype.toString;
 
 const url = new URL('http://example.org');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

<del>This is still a WIP, I'll update all the URLSearchParams tests first, then see how we can synchronize other tests. But I would like to get some feedback from @nodejs/url just to make sure I'm on the right direction.</del>

This is an attempt to synchronize the tests of our WHATWG URL implementation with the tests in https://github.com/w3c/web-platform-tests/tree/master/url. https://github.com/nodejs/node/pull/9484 ported some of the URLSearchParams tests into our code base, but it is somewhat hard to see how up-to-date we are compared with the upstream tests.

In this PR, the upstream tests are placed like this

```js
'use strict';

const common = require('../common');
const assert = require('assert');
const URLSearchParams = require('url').URLSearchParams;

const { test, assert_equals, assert_true } = common.WPT;  // port WPT test utilities

/* eslint-disable */
// Disable eslint because WPT tests have different styles
/* WPT Refs:
   https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
*/
// The last version of this test suite identified as compatible

// Pure copy-paste of the WPT test
// with incompatible/non-appliable tests comment out

/* eslint-enable */

// Tests below are not from WPT.
// We can also identify tests that can be merged upstream here.
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, url-whatwg