### PR TITLE
deps: hide zlib internal symbols

### DIFF
--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -48,13 +48,10 @@
               '.',
             ],
           },
-          'defines': [
-            'HAVE_HIDDEN',
-          ],
           'conditions': [
             ['OS!="win"', {
               'cflags!': [ '-ansi' ],
-              'defines': [ 'Z_HAVE_UNISTD_H' ],
+              'defines': [ 'Z_HAVE_UNISTD_H', 'HAVE_HIDDEN' ],
             }],
             ['OS=="mac" or OS=="ios" or OS=="freebsd" or OS=="android"', {
               # Mac, Android and the BSDs don't have fopen64, ftello64, or

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -48,6 +48,9 @@
               '.',
             ],
           },
+          'defines': [
+            'HAVE_HIDDEN',
+          ],
           'conditions': [
             ['OS!="win"', {
               'cflags!': [ '-ansi' ],


### PR DESCRIPTION
Use HAVE_HIDDEN when compiling zlib so it's internal symbols
have __attribute__((visibility ("hidden"))).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps
