### PR TITLE
test: make test-fs-access stricter

### DIFF
--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -7,16 +7,7 @@ const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
 const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
 const readWriteFile = path.join(common.tmpDir, 'read_write_file');
 
-const removeFile = function(file) {
-  try {
-    fs.unlinkSync(file);
-  } catch (err) {
-    // Ignore error
-  }
-};
-
 const createFileWithPerms = function(file, mode) {
-  removeFile(file);
   fs.writeFileSync(file, '');
   fs.chmodSync(file, mode);
 };
@@ -91,16 +82,16 @@ fs.access(readOnlyFile, fs.W_OK, common.mustCall((err) => {
 }));
 
 assert.throws(() => {
-  fs.access(100, fs.F_OK, (err) => {});
-}, /path must be a string or Buffer/);
+  fs.access(100, fs.F_OK, () => { common.fail('callback should not run'); });
+}, /^TypeError: path must be a string or Buffer$/);
 
 assert.throws(() => {
   fs.access(__filename, fs.F_OK);
-}, /"callback" argument must be a function/);
+}, /^TypeError: "callback" argument must be a function$/);
 
 assert.throws(() => {
   fs.access(__filename, fs.F_OK, {});
-}, /"callback" argument must be a function/);
+}, /^TypeError: "callback" argument must be a function$/);
 
 assert.doesNotThrow(() => {
   fs.accessSync(__filename);
@@ -112,13 +103,16 @@ assert.doesNotThrow(() => {
   fs.accessSync(readWriteFile, mode);
 });
 
-assert.throws(() => {
-  fs.accessSync(doesNotExist);
-}, (err) => {
-  return err.code === 'ENOENT' && err.path === doesNotExist;
-});
-
-process.on('exit', () => {
-  removeFile(readOnlyFile);
-  removeFile(readWriteFile);
-});
+assert.throws(
+  () => { fs.accessSync(doesNotExist); },
+  (err) => {
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.path, doesNotExist);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, access '${doesNotExist}'`
+    );
+    assert.strictEqual(err.constructor, Error);
+    return true;
+  }
+);


### PR DESCRIPTION
Change regular expression matching in `assert.throws()` to match the
entire error message. In `assert.throws()` that uses a function for
matching rather than a regular expression, add checks for the `message`
property and the error's constructor.

Also, refactored to remove unnecessary temp file handling. No need to
remove temp files after the test. Each test is responsible for clearing
the temp directory if it needs to use it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs