### PR TITLE
src: fix building --without-v8-platform

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -228,7 +228,6 @@ static struct {
   }
 #endif  // HAVE_INSPECTOR
 
-  v8::Platform* platform_;
 #else  // !NODE_USE_V8_PLATFORM
   void Initialize(int thread_pool_size) {}
   void PumpMessageLoop(Isolate* isolate) {}
@@ -239,6 +238,8 @@ static struct {
     return false;  // make compiler happy
   }
 #endif  // !NODE_USE_V8_PLATFORM
+
+  v8::Platform* platform_;
 } v8_platform;
 
 #ifdef __POSIX__

--- a/src/node.cc
+++ b/src/node.cc
@@ -233,7 +233,7 @@ static struct {
   void PumpMessageLoop(Isolate* isolate) {}
   void Dispose() {}
   bool StartInspector(Environment *env, const char* script_path,
-                      int port, bool wait) {
+                      const node::DebugOptions& options) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
     return false;  // make compiler happy
   }


### PR DESCRIPTION
Node fails to compile when configured `--without-v8-platform` because of two issues with the implementation in src/node.cc when !NODE_USE_V8_PLATFORM. This branch fixes those two issues.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (Note: `make -j4 test` passes with these changes when I build with the default configure options. It fails when I build `--without-v8-platform`, but since previously it didn't even compile with that option, these changes are still an improvement.)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

The affected core subsystem appears to be "src", or possibly "build." The only file that is changed is src/node.cc.
