### PR TITLE
benchmark: add assert.deep[Strict]Equal benchmarks

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -2,22 +2,21 @@
 const common = require('../common.js');
 const assert = require('assert');
 const bench = common.createBenchmark(main, {
-  type: ('Int8Array Uint8Array Int16Array Uint16Array Int32Array Uint32Array ' +
-    'Float32Array Float64Array Uint8ClampedArray').split(' '),
-  n: [1],
-  method: ['strict', 'nonstrict'],
-  len: [1e6]
+  n: [1e3],
+  len: [1e2],
+  method: ['strict', 'nonstrict']
 });
 
 function main(conf) {
-  const type = conf.type;
-  const clazz = global[type];
   const n = +conf.n;
   const len = +conf.len;
-
-  const actual = new clazz(len);
-  const expected = new clazz(len);
   var i;
+
+  const data = Buffer.allocUnsafe(len);
+  const actual = Buffer.alloc(len);
+  const expected = Buffer.alloc(len);
+  data.copy(actual);
+  data.copy(expected);
 
   switch (conf.method) {
     case 'strict':

--- a/benchmark/assert/deepequal-prims-and-objs-big-array.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common.js');
-var assert = require('assert');
+const common = require('../common.js');
+const assert = require('assert');
 
 const primValues = {
   'null': null,
@@ -13,29 +13,43 @@ const primValues = {
   'new-array': new Array([1, 2, 3])
 };
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   prim: Object.keys(primValues),
-  n: [25]
+  n: [25],
+  len: [1e5],
+  method: ['strict', 'nonstrict']
 });
 
 function main(conf) {
-  var prim = primValues[conf.prim];
-  var n = +conf.n;
-  var primArray;
-  var primArrayCompare;
-  var x;
+  const prim = primValues[conf.prim];
+  const n = +conf.n;
+  const len = +conf.len;
+  const actual = [];
+  const expected = [];
+  var i;
 
-  primArray = new Array();
-  primArrayCompare = new Array();
-  for (x = 0; x < (1e5); x++) {
-    primArray.push(prim);
-    primArrayCompare.push(prim);
+  for (var x = 0; x < len; x++) {
+    actual.push(prim);
+    expected.push(prim);
   }
 
-  bench.start();
-  for (x = 0; x < n; x++) {
-    // eslint-disable-next-line no-restricted-properties
-    assert.deepEqual(primArray, primArrayCompare);
+  switch (conf.method) {
+    case 'strict':
+      bench.start();
+      for (i = 0; i < n; ++i) {
+        // eslint-disable-next-line no-restricted-properties
+        assert.deepEqual(actual, expected);
+      }
+      bench.end(n);
+      break;
+    case 'nonstrict':
+      bench.start();
+      for (i = 0; i < n; ++i) {
+        assert.deepStrictEqual(actual, expected);
+      }
+      bench.end(n);
+      break;
+    default:
+      throw new Error('Unsupported method');
   }
-  bench.end(n);
 }

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common.js');
-var assert = require('assert');
+const common = require('../common.js');
+const assert = require('assert');
 
 const primValues = {
   'null': null,
@@ -13,22 +13,37 @@ const primValues = {
   'new-array': new Array([1, 2, 3])
 };
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   prim: Object.keys(primValues),
-  n: [1e5]
+  n: [1e6],
+  method: ['strict', 'nonstrict']
 });
 
 function main(conf) {
-  var prim = primValues[conf.prim];
-  var n = +conf.n;
-  var x;
+  const prim = primValues[conf.prim];
+  const n = +conf.n;
+  const actual = prim;
+  const expected = prim;
+  var i;
 
-  bench.start();
-
-  for (x = 0; x < n; x++) {
-    // eslint-disable-next-line no-restricted-properties
-    assert.deepEqual(new Array([prim]), new Array([prim]));
+  // Creates new array to avoid loop invariant code motion
+  switch (conf.method) {
+    case 'strict':
+      bench.start();
+      for (i = 0; i < n; ++i) {
+        // eslint-disable-next-line no-restricted-properties
+        assert.deepEqual([actual], [expected]);
+      }
+      bench.end(n);
+      break;
+    case 'nonstrict':
+      bench.start();
+      for (i = 0; i < n; ++i) {
+        assert.deepStrictEqual([actual], [expected]);
+      }
+      bench.end(n);
+      break;
+    default:
+      throw new Error('Unsupported method');
   }
-
-  bench.end(n);
 }


### PR DESCRIPTION
* Move numbers into configuration
* Add buffer comparison benchmark
* Add assert.deepStrictEqual benchmarks

Refs: https://github.com/nodejs/node/pull/10282#pullrequestreview-18438073

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark, assert