### PR TITLE
test: refactor test-fs-error-messages.js

### DIFF
--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -9,202 +9,156 @@ const existingFile2 = path.join(common.fixturesDir, 'create-file.js');
 const existingDir = path.join(common.fixturesDir, 'empty');
 const existingDir2 = path.join(common.fixturesDir, 'keys');
 
-// ASYNC_CALL
+// Test all operations failing with ENOENT errors
+function testEnoentError(file, endMessage, syscal, err) {
+  const sufix = (endMessage) ? endMessage : '';
 
-fs.stat(fn, function(err) {
+  assert(err instanceof Error);
   assert.strictEqual(fn, err.path);
-  assert.ok(0 <= err.message.indexOf(fn));
+  assert.strictEqual(
+    err.message,
+    `ENOENT: no such file or directory, ${syscal} '${file}'${sufix}`
+  );
+
+  return true;
+}
+
+// Test all operations failing with EEXIST errors
+function testEexistError(source, dest, syscal, err) {
+  const sufix = (dest) ? ` -> '${dest}'` : '';
+
+  assert(err instanceof Error);
+  assert.strictEqual(source, err.path);
+  assert.strictEqual(
+    err.message,
+    `EEXIST: file already exists, ${syscal} '${source}'${sufix}`
+  );
+
+  return true;
+}
+
+// Test all operations failing with ENOTEMPTY errors
+function testEnoemptyError(source, dest, err) {
+  assert(err instanceof Error);
+  assert.strictEqual(source, err.path);
+  assert.strictEqual(
+    err.message,
+    `ENOTEMPTY: directory not empty, rename '${source}' ` +
+    `-> '${dest}'`
+  );
+
+  return true;
+}
+
+// Test all operations failing with ENOTDIR errors
+function testEnotdirError(dir, err) {
+  assert(err instanceof Error);
+  assert.strictEqual(dir, err.path);
+  assert.strictEqual(
+    err.message,
+    `ENOTDIR: not a directory, rmdir '${dir}'`
+  );
+
+  return true;
+}
+
+// Generating ENOENTS errors
+fs.stat(fn, (err) => testEnoentError(fn, '', 'stat', err));
+fs.lstat(fn, (err) => testEnoentError(fn, '', 'lstat', err));
+fs.readlink(fn, (err) => testEnoentError(fn, '', 'readlink', err));
+fs.link(fn, 'foo', (err) => testEnoentError(fn, ' -> \'foo\'', 'link', err));
+fs.unlink(fn, (err) => testEnoentError(fn, '', 'unlink', err));
+fs.rmdir(fn, (err) => testEnoentError(fn, '', 'rmdir', err));
+fs.chmod(fn, 0o666, (err) => testEnoentError(fn, '', 'chmod', err));
+fs.open(fn, 'r', 0o666, (err) => testEnoentError(fn, '', 'open', err));
+fs.readFile(fn, (err) => testEnoentError(fn, '', 'open', err));
+fs.readdir(fn, (err) => testEnoentError(fn, '', 'scandir', err));
+
+fs.rename(fn, 'foo', (err) => {
+  testEnoentError(fn, ' -> \'foo\'', 'rename', err);
 });
 
-fs.lstat(fn, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.readlink(fn, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.link(fn, 'foo', function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.link(existingFile, existingFile2, function(err) {
-  assert.ok(0 <= err.message.indexOf(existingFile));
-  assert.ok(0 <= err.message.indexOf(existingFile2));
-});
-
-fs.symlink(existingFile, existingFile2, function(err) {
-  assert.ok(0 <= err.message.indexOf(existingFile));
-  assert.ok(0 <= err.message.indexOf(existingFile2));
-});
-
-fs.unlink(fn, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.rename(fn, 'foo', function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.rename(existingDir, existingDir2, function(err) {
-  assert.ok(0 <= err.message.indexOf(existingDir));
-  assert.ok(0 <= err.message.indexOf(existingDir2));
-});
-
-fs.rmdir(fn, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.mkdir(existingFile, 0o666, function(err) {
-  assert.ok(0 <= err.message.indexOf(existingFile));
-});
-
-fs.rmdir(existingFile, function(err) {
-  assert.ok(0 <= err.message.indexOf(existingFile));
-});
-
-fs.chmod(fn, 0o666, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.open(fn, 'r', 0o666, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-fs.readFile(fn, function(err) {
-  assert.ok(0 <= err.message.indexOf(fn));
-});
-
-// Sync
-
-const errors = [];
-let expected = 0;
-
-try {
-  ++expected;
+assert.throws(() => {
   fs.statSync(fn);
-} catch (err) {
-  errors.push('stat');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'stat', err));
 
-try {
-  ++expected;
-  fs.mkdirSync(existingFile, 0o666);
-} catch (err) {
-  errors.push('mkdir');
-  assert.ok(0 <= err.message.indexOf(existingFile));
-}
-
-try {
-  ++expected;
-  fs.chmodSync(fn, 0o666);
-} catch (err) {
-  errors.push('chmod');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
-
-try {
-  ++expected;
+assert.throws(() => {
   fs.lstatSync(fn);
-} catch (err) {
-  errors.push('lstat');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'lstat', err));
 
-try {
-  ++expected;
+assert.throws(() => {
   fs.readlinkSync(fn);
-} catch (err) {
-  errors.push('readlink');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'readlink', err));
 
-try {
-  ++expected;
+assert.throws(() => {
   fs.linkSync(fn, 'foo');
-} catch (err) {
-  errors.push('link');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, ' -> \'foo\'', 'link', err));
 
-try {
-  ++expected;
-  fs.linkSync(existingFile, existingFile2);
-} catch (err) {
-  errors.push('link');
-  assert.ok(0 <= err.message.indexOf(existingFile));
-  assert.ok(0 <= err.message.indexOf(existingFile2));
-}
-
-try {
-  ++expected;
-  fs.symlinkSync(existingFile, existingFile2);
-} catch (err) {
-  errors.push('symlink');
-  assert.ok(0 <= err.message.indexOf(existingFile));
-  assert.ok(0 <= err.message.indexOf(existingFile2));
-}
-
-try {
-  ++expected;
+assert.throws(() => {
   fs.unlinkSync(fn);
-} catch (err) {
-  errors.push('unlink');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'unlink', err));
 
-try {
-  ++expected;
+assert.throws(() => {
   fs.rmdirSync(fn);
-} catch (err) {
-  errors.push('rmdir');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'rmdir', err));
 
-try {
-  ++expected;
-  fs.rmdirSync(existingFile);
-} catch (err) {
-  errors.push('rmdir');
-  assert.ok(0 <= err.message.indexOf(existingFile));
-}
+assert.throws(() => {
+  fs.chmodSync(fn, 0o666);
+}, (err) => testEnoentError(fn, '', 'chmod', err));
 
-try {
-  ++expected;
+assert.throws(() => {
   fs.openSync(fn, 'r');
-} catch (err) {
-  errors.push('opens');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'open', err));
 
-try {
-  ++expected;
-  fs.renameSync(fn, 'foo');
-} catch (err) {
-  errors.push('rename');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+assert.throws(() => {
+  fs.readFileSync(fn);
+}, (err) => testEnoentError(fn, '', 'open', err));
 
-try {
-  ++expected;
-  fs.renameSync(existingDir, existingDir2);
-} catch (err) {
-  errors.push('rename');
-  assert.ok(0 <= err.message.indexOf(existingDir));
-  assert.ok(0 <= err.message.indexOf(existingDir2));
-}
-
-try {
-  ++expected;
+assert.throws(() => {
   fs.readdirSync(fn);
-} catch (err) {
-  errors.push('readdir');
-  assert.ok(0 <= err.message.indexOf(fn));
-}
+}, (err) => testEnoentError(fn, '', 'scandir', err));
 
-process.on('exit', function() {
-  assert.strictEqual(expected, errors.length,
-                     'Test fs sync exceptions raised, got ' + errors.length +
-               ' expected ' + expected);
+assert.throws(() => {
+  fs.renameSync(fn, 'foo');
+}, (err) => testEnoentError(fn, ' -> \'foo\'', 'rename', err));
+
+// Generating EEXIST errors
+fs.link(existingFile, existingFile2, (err) => {
+  testEexistError(existingFile, existingFile2, 'link', err);
 });
+
+fs.symlink(existingFile, existingFile2, (err) => {
+  testEexistError(existingFile, existingFile2, 'symlink', err);
+});
+
+fs.mkdir(existingFile, 0o666, (err) => {
+  testEexistError(existingFile, null, 'mkdir', err);
+});
+
+assert.throws(() => {
+  fs.linkSync(existingFile, existingFile2);
+}, (err) => testEexistError(existingFile, existingFile2, 'link', err));
+
+assert.throws(() => {
+  fs.symlinkSync(existingFile, existingFile2);
+}, (err) => testEexistError(existingFile, existingFile2, 'symlink', err));
+
+assert.throws(() => {
+  fs.mkdirSync(existingFile, 0o666);
+}, (err) => testEexistError(existingFile, null, 'mkdir', err));
+
+// Generating ENOTEMPTY errors
+fs.rename(existingDir, existingDir2, (err) => {
+  testEnoemptyError(existingDir, existingDir2, err);
+});
+
+assert.throws(() => {
+  fs.renameSync(existingDir, existingDir2);
+}, (err) => testEnoemptyError(existingDir, existingDir2, err));
+
+// Generating ENOTDIR errors
+fs.rmdir(existingFile, (err) => testEnotdirError(existingFile, err));
+
+assert.throws(() => {
+  fs.rmdirSync(existingFile);
+}, (err) => testEnotdirError(existingFile, err));


### PR DESCRIPTION
* group tests by error type
* improve error validation for all messages
* use assert.throws instead of try and catch
* use arrow functions
* add missing test for readdir
* add missing test for readFileSync
* remove unnecessary variables

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
