### PR TITLE
url: add urlSearchParams.sort()

### DIFF
--- a/benchmark/url/url-searchparams-sort.js
+++ b/benchmark/url/url-searchparams-sort.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common.js');
+const URLSearchParams = require('url').URLSearchParams;
+
+const inputs = {
+  empty: '',
+  sorted: 'a&b&c&d&e&f&g&h&i&j&k&l&m&n&o&p&q&r&s&t&u&v&w&x&y&z',
+  almostsorted: 'a&b&c&d&e&f&g&i&h&j&k&l&m&n&o&p&q&r&s&t&u&w&v&x&y&z',
+  reversed: 'z&y&x&w&v&u&t&s&r&q&p&o&n&m&l&k&j&i&h&g&f&e&d&c&b&a',
+  random: 'm&t&d&c&z&v&a&n&p&y&u&o&h&l&f&j&e&q&b&i&s&x&k&w&r&g',
+  // 8 parameters
+  short: 'm&t&d&c&z&v&a&n',
+  // 88 parameters
+  long: 'g&r&t&h&s&r&d&w&b&n&h&k&x&m&k&h&o&e&x&c&c&g&e&b&p&p&s&n&j&b&y&z&' +
+        'u&l&o&r&w&a&u&l&m&f&j&q&p&f&e&y&e&n&e&l&m&w&u&w&t&n&t&q&v&y&c&o&' +
+        'k&f&j&i&l&m&g&j&d&i&z&q&p&x&q&q&d&n&y&w&g&i&v&r'
+};
+
+function getParams(str) {
+  const out = [];
+  for (const key of str.split('&')) {
+    out.push(key, '');
+  }
+  return out;
+}
+
+const bench = common.createBenchmark(main, {
+  type: Object.keys(inputs),
+  n: [1e6]
+}, {
+  flags: ['--expose-internals']
+});
+
+function main(conf) {
+  const searchParams = require('internal/url').searchParamsSymbol;
+  const input = inputs[conf.type];
+  const n = conf.n | 0;
+  const params = new URLSearchParams();
+  const array = getParams(input);
+
+  var i;
+  bench.start();
+  for (i = 0; i < n; i++) {
+    params[searchParams] = array.slice();
+    params.sort();
+  }
+  bench.end(n);
+}

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -777,6 +777,21 @@ Returns an ES6 Iterator over the names of each name-value pair.
 Remove any existing name-value pairs whose name is `name` and append a new
 name-value pair.
 
+#### urlSearchParams.sort()
+
+Sort all existing name-value pairs in-place by their names. Sorting is done
+with a [stable sorting algorithm][], so relative order between name-value pairs
+with the same name is preserved.
+
+This method can be used, in particular, to increase cache hits.
+
+```js
+const params = new URLSearchParams('query[]=abc&type=search&query[]=123');
+params.sort();
+console.log(params.toString());
+  // Prints query%5B%5D=abc&query%5B%5D=123&type=search
+```
+
 #### urlSearchParams.toString()
 
 * Returns: {String}
@@ -872,3 +887,4 @@ console.log(myURL.origin);
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 [`array.toString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
 [WHATWG URL]: #url_the_whatwg_url_api
+[stable sorting algorithm]: https://en.wikipedia.org/wiki/Sorting_algorithm#Stability

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -766,6 +766,35 @@ class URLSearchParams {
   }
 }
 
+// for merge sort
+function merge(out, start, mid, end, lBuffer, rBuffer) {
+  const sizeLeft = mid - start;
+  const sizeRight = end - mid;
+  var l, r, o;
+
+  for (l = 0; l < sizeLeft; l++)
+    lBuffer[l] = out[start + l];
+  for (r = 0; r < sizeRight; r++)
+    rBuffer[r] = out[mid + r];
+
+  l = 0;
+  r = 0;
+  o = start;
+  while (l < sizeLeft && r < sizeRight) {
+    if (lBuffer[l] <= rBuffer[r]) {
+      out[o++] = lBuffer[l++];
+      out[o++] = lBuffer[l++];
+    } else {
+      out[o++] = rBuffer[r++];
+      out[o++] = rBuffer[r++];
+    }
+  }
+  while (l < sizeLeft)
+    out[o++] = lBuffer[l++];
+  while (r < sizeRight)
+    out[o++] = rBuffer[r++];
+}
+
 defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   append(name, value) {
     if (!this || !(this instanceof URLSearchParams)) {
@@ -892,6 +921,51 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
     // is `value`, to `list`.
     if (!found) {
       list.push(name, value);
+    }
+
+    update(this[context], this);
+  },
+
+  sort() {
+    const a = this[searchParams];
+    const len = a.length;
+    if (len <= 2) {
+      return;
+    }
+
+    // arbitrary number found through testing
+    if (len < 100) {
+      // Simple stable in-place insertion sort
+      // Derived from v8/src/js/array.js
+      for (var i = 2; i < len; i += 2) {
+        var curKey = a[i];
+        var curVal = a[i + 1];
+        var j;
+        for (j = i - 2; j >= 0; j -= 2) {
+          if (a[j] > curKey) {
+            a[j + 2] = a[j];
+            a[j + 3] = a[j + 1];
+          } else {
+            break;
+          }
+        }
+        a[j + 2] = curKey;
+        a[j + 3] = curVal;
+      }
+    } else {
+      // Bottom-up iterative stable merge sort
+      const lBuffer = new Array(len);
+      const rBuffer = new Array(len);
+      for (var step = 2; step < len; step *= 2) {
+        for (var start = 0; start < len - 2; start += 2 * step) {
+          var mid = start + step;
+          var end = mid + step;
+          end = end < len ? end : len;
+          if (mid > end)
+            continue;
+          merge(a, start, mid, end, lBuffer, rBuffer);
+        }
+      }
     }
 
     update(this[context], this);

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1257,3 +1257,4 @@ exports.domainToUnicode = domainToUnicode;
 exports.encodeAuth = encodeAuth;
 exports.urlToOptions = urlToOptions;
 exports.formatSymbol = kFormat;
+exports.searchParamsSymbol = searchParams;

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const common = require('../common');
+const {URL, URLSearchParams} = require('url');
+const { test, assert_array_equals } = common.WPT;
+
+/* eslint-disable */
+/* WPT Refs:
+   https://github.com/w3c/web-platform-tests/blob/5903e00e77e85f8bcb21c73d1d7819fcd04763bd/url/urlsearchparams-sort.html
+   License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
+*/
+[
+  {
+    "input": "z=b&a=b&z=a&a=a",
+    "output": [["a", "b"], ["a", "a"], ["z", "b"], ["z", "a"]]
+  },
+  {
+    "input": "\uFFFD=x&\uFFFC&\uFFFD=a",
+    "output": [["\uFFFC", ""], ["\uFFFD", "x"], ["\uFFFD", "a"]]
+  },
+  {
+    "input": "ﬃ&🌈", // 🌈 > code point, but < code unit because two code units
+    "output": [["🌈", ""], ["ﬃ", ""]]
+  },
+  {
+    "input": "é&e\uFFFD&e\u0301",
+    "output": [["e\u0301", ""], ["e\uFFFD", ""], ["é", ""]]
+  },
+  {
+    "input": "z=z&a=a&z=y&a=b&z=x&a=c&z=w&a=d&z=v&a=e&z=u&a=f&z=t&a=g",
+    "output": [["a", "a"], ["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"], ["a", "f"], ["a", "g"], ["z", "z"], ["z", "y"], ["z", "x"], ["z", "w"], ["z", "v"], ["z", "u"], ["z", "t"]]
+  }
+].forEach((val) => {
+  test(() => {
+    let params = new URLSearchParams(val.input),
+        i = 0
+    params.sort()
+    for(let param of params) {
+      assert_array_equals(param, val.output[i])
+      i++
+    }
+  }, "Parse and sort: " + val.input)
+
+  test(() => {
+    let url = new URL("?" + val.input, "https://example/")
+    url.searchParams.sort()
+    let params = new URLSearchParams(url.search),
+        i = 0
+    for(let param of params) {
+      assert_array_equals(param, val.output[i])
+      i++
+    }
+  }, "URL parse and sort: " + val.input)
+})
+/* eslint-enable */
+
+// Tests below are not from WPT.
+;[
+  {
+    'input': 'z=a&=b&c=d',
+    'output': [['', 'b'], ['c', 'd'], ['z', 'a']]
+  }
+].forEach((val) => {
+  test(() => {
+    const params = new URLSearchParams(val.input);
+    let i = 0;
+    params.sort();
+    for (const param of params) {
+      assert_array_equals(param, val.output[i]);
+      i++;
+    }
+  }, 'Parse and sort: ' + val.input);
+
+  test(() => {
+    const url = new URL(`?${val.input}`, 'https://example/');
+    url.searchParams.sort();
+    const params = new URLSearchParams(url.search);
+    let i = 0;
+    for (const param of params) {
+      assert_array_equals(param, val.output[i]);
+      i++;
+    }
+  }, 'URL parse and sort: ' + val.input);
+});


### PR DESCRIPTION
The URL Standard requires `sort()` to be stable, which precludes us from using the V8-native `sort()` function.

I originally wanted to make the function a simple insertion sort only, but I realized it had the potential for a DoS attack because of its nature of being <var>O</var>(<var>n</var><sup>2</sup>).

The algorithm for the function follows the norm: insertion sort for small arrays, divide-and-conquer (in this case, a stable merge sort) for larger arrays. In this specific case, the cutoff is set at 59 items, though if performance improvements are made to either sort the cutoff may be adjusted.

Fixes: #10760
Ref: whatwg/url#26
Ref: whatwg/url#199
Ref: w3c/web-platform-tests#4531

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url