### PR TITLE
url: fix setting `url.search` to the empty string

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -195,12 +195,7 @@ function onParseSearchComplete(flags, protocol, username, password,
   if (flags & binding.URL_FLAGS_FAILED)
     return;
   const ctx = this[context];
-  if (query) {
-    ctx.query = query;
-    ctx.flags |= binding.URL_FLAGS_HAS_QUERY;
-  } else {
-    ctx.flags &= ~binding.URL_FLAGS_HAS_QUERY;
-  }
+  ctx.query = query;
 }
 
 function onParseHashComplete(flags, protocol, username, password,
@@ -487,13 +482,15 @@ Object.defineProperties(URL.prototype, {
       if (!search) {
         ctx.query = null;
         ctx.flags &= ~binding.URL_FLAGS_HAS_QUERY;
-        this[searchParams][searchParams] = [];
-        return;
+      } else {
+        if (search[0] === '?') search = search.slice(1);
+        ctx.query = '';
+        ctx.flags |= binding.URL_FLAGS_HAS_QUERY;
+        if (search) {
+          binding.parse(search, binding.kQuery, null, ctx,
+                        onParseSearchComplete.bind(this));
+        }
       }
-      if (search[0] === '?') search = search.slice(1);
-      ctx.query = '';
-      binding.parse(search, binding.kQuery, null, ctx,
-                    onParseSearchComplete.bind(this));
       initSearchParams(this[searchParams], search);
     }
   },
@@ -614,6 +611,10 @@ function update(url, params) {
 // Reused by the URL parse function invoked by
 // the href setter, and the URLSearchParams constructor
 function initSearchParams(url, init) {
+  if (!init) {
+    url[searchParams] = [];
+    return;
+  }
   url[searchParams] = getParamsFromObject(querystring.parse(init));
 }
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -487,7 +487,7 @@ Object.defineProperties(URL.prototype, {
       if (!search) {
         ctx.query = null;
         ctx.flags &= ~binding.URL_FLAGS_HAS_QUERY;
-        this[searchParams][searchParams] = {};
+        this[searchParams][searchParams] = [];
         return;
       }
       if (search[0] === '?') search = search.slice(1);

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -608,8 +608,6 @@ function update(url, params) {
   }
 }
 
-// Reused by the URL parse function invoked by
-// the href setter, and the URLSearchParams constructor
 function initSearchParams(url, init) {
   if (!init) {
     url[searchParams] = [];

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -20,6 +20,10 @@ assert(sp.has('a'));
 assert.strictEqual(sp.get('a'), '[object Object]');
 sp.delete('a');
 assert(!sp.has('a'));
+
+m.search = '';
+assert.strictEqual(sp.toString(), '');
+
 values.forEach((i) => sp.append('a', i));
 assert(sp.has('a'));
 assert.strictEqual(sp.getAll('a').length, 6);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/11101
Fixes: 98bb65f641 "url: improving URLSearchParams"

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url