### PR TITLE
src: don't overwrite non-writable vm globals

### DIFF
--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -75,3 +75,16 @@ assert.throws(function() {
 // https://github.com/nodejs/node/issues/6158
 ctx = new Proxy({}, {});
 assert.strictEqual(typeof vm.runInNewContext('String', ctx), 'function');
+
+// https://github.com/nodejs/node/issues/10223
+ctx = vm.createContext();
+vm.runInContext('Object.defineProperty(this, "x", { value: 42 })', ctx);
+assert.strictEqual(ctx.x, 42);
+assert.strictEqual(vm.runInContext('x', ctx), 42);
+
+vm.runInContext('x = 0', ctx);                      // Does not throw but x...
+assert.strictEqual(vm.runInContext('x', ctx), 42);  // ...should be unaltered.
+
+assert.throws(() => vm.runInContext('"use strict"; x = 0', ctx),
+              /Cannot assign to read only property 'x'/);
+assert.strictEqual(vm.runInContext('x', ctx), 42);


### PR DESCRIPTION
Another try for https://github.com/nodejs/node/issues/10223. 

This is @bnoordhuis reverted commit, without removing `is_contextual_store`.  

Now `defineProperty(this, ..., {value: })` is intercepted and copied by the SetterCallback and global assignment succeeds the first time. The callback does not overwrite read-only values. 

The first assert in the test is different from the reverted commit, because `defineProperty(..., {value: })` is intercepted and copied by the SetterCallback. 

https://github.com/nodejs/node/blob/master/test/known_issues/test-vm-data-property-writable.js is still a known issue, because the property descriptor is taken from the sandbox not the vm context. The test is not testing that read-only properties are not overwritten, but that defineProperty works.