### PR TITLE
fs: avoid out-of-bounds arguments index access

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -251,7 +251,11 @@ fs.existsSync = function(path) {
 };
 
 fs.readFile = function(path, options, callback) {
-  callback = maybeCallback(arguments[arguments.length - 1]);
+  if (arguments.length) {
+    callback = maybeCallback(arguments[arguments.length - 1]);
+  } else {
+    callback = rethrow();
+  }
   options = getOptions(options, { flag: 'r' });
 
   if (!nullCheck(path, callback))
@@ -534,7 +538,13 @@ function modeNum(m, def) {
 }
 
 fs.open = function(path, flags, mode, callback_) {
-  var callback = makeCallback(arguments[arguments.length - 1]);
+  var callback;
+
+  if (arguments.length) {
+    callback = makeCallback(arguments[arguments.length - 1]);
+  } else {
+    callback = rethrow();
+  }
   mode = modeNum(mode, 0o666);
 
   if (!nullCheck(path, callback)) return;
@@ -857,7 +867,13 @@ function preprocessSymlinkDestination(path, type, linkPath) {
 
 fs.symlink = function(target, path, type_, callback_) {
   var type = (typeof type_ === 'string' ? type_ : null);
-  var callback = makeCallback(arguments[arguments.length - 1]);
+  var callback;
+
+  if (arguments.length) {
+    callback = makeCallback(arguments[arguments.length - 1]);
+  } else {
+    callback = rethrow();
+  }
 
   if (!nullCheck(target, callback)) return;
   if (!nullCheck(path, callback)) return;
@@ -1074,8 +1090,7 @@ fs.futimesSync = function(fd, atime, mtime) {
   binding.futimes(fd, atime, mtime);
 };
 
-function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
+function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {
 
   // write(fd, buffer, offset, length, position, callback)
   fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
@@ -1107,7 +1122,11 @@ function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
 }
 
 fs.writeFile = function(path, data, options, callback) {
-  callback = maybeCallback(arguments[arguments.length - 1]);
+  if (arguments.length) {
+    callback = maybeCallback(arguments[arguments.length - 1]);
+  } else {
+    callback = rethrow();
+  }
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'w' });
   const flag = options.flag || 'w';
 
@@ -1161,7 +1180,12 @@ fs.writeFileSync = function(path, data, options) {
 };
 
 fs.appendFile = function(path, data, options, callback) {
-  callback = maybeCallback(arguments[arguments.length - 1]);
+  if (arguments.length) {
+    callback = maybeCallback(arguments[arguments.length - 1]);
+  } else {
+    callback = rethrow();
+  }
+
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'a' });
 
   // Don't make changes directly on options object


### PR DESCRIPTION
This updates fs to prevent accessing out-of-range indices on the arguments object, which is known to cause V8 optimization bailout.

Related to issues discussed here: https://github.com/nodejs/node/issues/10323

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs