### PR TITLE
test: make module testing stricter

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -1,8 +1,6 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-
-console.error('load test-module-loading-error.js');
 
 const error_desc = {
   win32: ['%1 is not a valid Win32 application'],
@@ -12,27 +10,23 @@ const error_desc = {
 };
 const dlerror_msg = error_desc[process.platform];
 
-if (!dlerror_msg) {
-  common.skip('platform not supported.');
-  return;
-}
+assert.throws(
+  () => { require('../fixtures/module-loading-error.node'); },
+  (e) => {
+    if (dlerror_msg && !dlerror_msg.some((msg) => e.message.includes(msg)))
+      return false;
+    if (e.name !== 'Error')
+      return false;
+    return true;
+  }
+);
 
-try {
-  require('../fixtures/module-loading-error.node');
-} catch (e) {
-  assert.strictEqual(dlerror_msg.some((errMsgCase) => {
-    return e.toString().indexOf(errMsgCase) !== -1;
-  }), true);
-}
+assert.throws(
+  require,
+  /^AssertionError: missing path$/
+);
 
-try {
-  require();
-} catch (e) {
-  assert.ok(e.toString().includes('missing path'));
-}
-
-try {
-  require({});
-} catch (e) {
-  assert.ok(e.toString().includes('path must be a string'));
-}
+assert.throws(
+  () => { require({}); },
+  /^AssertionError: path must be a string$/
+);


### PR DESCRIPTION
In test-module-loading-error:

* Do not skip the rest of the test just because we are running on a
  platform for which the test does not know the expected system error
  message. Simply skip the message validation but run the remainder of
  the test.
* Use assert.throws() in place of try/catch
* Make checks more strict. Instead of partial string matches, match the
  entire string. Add check for Error name to at least do some validation
  in situations where we do not have the system error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test module