### PR TITLE
buffer, test: add tests for buffer.toJSON (backport v7.x)

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -767,30 +767,6 @@ assert.strictEqual(Buffer.from('13.37').length, 5);
 // issue GH-3416
 Buffer.from(Buffer.allocUnsafe(0), 0, 0);
 
-// GH-5110
-{
-  const buffer = Buffer.from('test');
-  const string = JSON.stringify(buffer);
-
-  assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
-
-  assert.deepStrictEqual(buffer, JSON.parse(string, (key, value) => {
-    return value && value.type === 'Buffer' ?
-      Buffer.from(value.data) :
-      value;
-  }));
-}
-
-// issue GH-7849
-{
-  const buf = Buffer.from('test');
-  const json = JSON.stringify(buf);
-  const obj = JSON.parse(json);
-  const copy = Buffer.from(obj);
-
-  assert(buf.equals(copy));
-}
-
 // issue GH-4331
 assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFF), RangeError);
 assert.throws(() => Buffer.allocUnsafe(0xFFFFFFFFF), RangeError);

--- a/test/parallel/test-buffer-tojson.js
+++ b/test/parallel/test-buffer-tojson.js
@@ -1,0 +1,36 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const Buffer = require('buffer').Buffer;
+
+{
+  assert.strictEqual(JSON.stringify(Buffer.alloc(0)),
+                     '{"type":"Buffer","data":[]}');
+  assert.strictEqual(JSON.stringify(Buffer.from([1, 2, 3, 4])),
+                     '{"type":"Buffer","data":[1,2,3,4]}');
+}
+
+// issue GH-7849
+{
+  const buf = Buffer.from('test');
+  const json = JSON.stringify(buf);
+  const obj = JSON.parse(json);
+  const copy = Buffer.from(obj);
+
+  assert.deepStrictEqual(buf, copy);
+}
+
+// GH-5110
+{
+  const buffer = Buffer.from('test');
+  const string = JSON.stringify(buffer);
+
+  assert.strictEqual(string, '{"type":"Buffer","data":[116,101,115,116]}');
+
+  function receiver(key, value) {
+    return value && value.type === 'Buffer' ? Buffer.from(value.data) : value;
+  }
+
+  assert.deepStrictEqual(buffer, JSON.parse(string, receiver));
+}


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/10979

* Pull out the tests for buffer.toJSON from test-buffer-alloc
* Add tests for serializing a 0-length buffer

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test buffer