### PR TITLE
buffer: stricter argument checking in toString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -463,7 +463,7 @@ function slowToString(encoding, start, end) {
   if (end <= start)
     return '';
 
-  if (!encoding) encoding = 'utf8';
+  if (encoding === undefined) encoding = 'utf8';
 
   while (true) {
     switch (encoding) {

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -82,3 +82,6 @@ assert.strictEqual(rangeBuffer.toString('ascii', 0, true), 'a');
 assert.strictEqual(rangeBuffer.toString({toString: function() {
   return 'ascii';
 }}), 'abc');
+
+// try toString() with 0 as the encoding
+assert.throws(() => rangeBuffer.toString(0, 1, 2), /Unknown encoding/);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -83,5 +83,6 @@ assert.strictEqual(rangeBuffer.toString({toString: function() {
   return 'ascii';
 }}), 'abc');
 
-// try toString() with 0 as the encoding
-assert.throws(() => rangeBuffer.toString(0, 1, 2), /Unknown encoding/);
+// try toString() with 0 and null as the encoding
+assert.throws(() => rangeBuffer.toString(0, 1, 2), /^TypeError: Unknown encoding: 0$/);
+assert.throws(() => rangeBuffer.toString(null, 1, 2), /^TypeError: Unknown encoding: null$/);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -84,5 +84,9 @@ assert.strictEqual(rangeBuffer.toString({toString: function() {
 }}), 'abc');
 
 // try toString() with 0 and null as the encoding
-assert.throws(() => rangeBuffer.toString(0, 1, 2), /^TypeError: Unknown encoding: 0$/);
-assert.throws(() => rangeBuffer.toString(null, 1, 2), /^TypeError: Unknown encoding: null$/);
+assert.throws(() => {
+  rangeBuffer.toString(0, 1, 2);
+}, /^TypeError: Unknown encoding: 0$/);
+assert.throws(() => {
+  rangeBuffer.toString(null, 1, 2);
+}, /^TypeError: Unknown encoding: null$/);


### PR DESCRIPTION
Currently, `Buffer.from('hello').toString(0, 1)` returns `ello`, which is confusing. On the other hand, `Buffer.from('hello').toString(1, 2)` throws an expected error. This PR disallows passing anything other than `undefined` or a valid encoding as `encoding`.

I would love to remove the check altogether thereby also disallowing `undefined`, but the [documentation](https://github.com/nodejs/node/blob/39f65e66562835dfb09b610cd5322794d10bbe12/doc/api/buffer.md#buftostringencoding-start-end) mentions this feature and there is a [test](https://github.com/nodejs/node/blob/58dc229d9aac29132cf038ed07b3b7e13b671dca/test/parallel/test-stream2-writable.js#L151) for it, so I guess it's not happening, although I can hardly imagine anyone doing this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer