### PR TITLE
test: simplify output handling in repl tests

### DIFF
--- a/test/known_issues/test-repl-require-context.js
+++ b/test/known_issues/test-repl-require-context.js
@@ -19,9 +19,7 @@ outputStream.setEncoding('utf8');
 outputStream.on('data', (data) => output += data);
 
 r.on('exit', common.mustCall(() => {
-  const results = output.split('\n').map((line) => {
-    return line.replace(/\w*>\w*/, '').trim();
-  });
+  const results = output.replace(/^> /mg, '').split('\n');
 
   assert.deepStrictEqual(results, ['undefined', 'true', 'true', '']);
 }));

--- a/test/parallel/test-repl-require-context.js
+++ b/test/parallel/test-repl-require-context.js
@@ -14,10 +14,7 @@ child.stdout.on('data', (data) => {
 });
 
 child.on('exit', common.mustCall(() => {
-  const results = output.split('\n').map((line) => {
-    return line.replace(/\w*>\w*/, '').trim();
-  });
-
+  const results = output.replace(/^> /mg, '').split('\n');
   assert.deepStrictEqual(results, ['undefined', 'true', 'true', '']);
 }));
 


### PR DESCRIPTION
Replace .map() + .replace().trim() with a single .replace().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl