### PR TITLE
util: add inspectTag template literal tag

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -371,6 +371,27 @@ added: v6.6.0
 A Symbol that can be used to declare custom inspect functions, see
 [Custom inspection functions on Objects][].
 
+## util.inspectTag
+<!-- YAML
+added: REPLACEME
+-->
+
+A template literal tag that ensures each replacement in a template string is
+passed through `util.inspect()`.
+
+```js
+const inspectTag = require('util').inspectTag;
+const obj = {a: 1};
+
+// Without the tag:
+console.log(`${obj}`);
+  // Prints: '[object Object]'
+
+// With the tag:
+console.log(inspectTag`${obj}`);
+  // Prints: '{ a : 1 }'
+```
+
 ## Deprecated APIs
 
 The following APIs have been deprecated and should no longer be used. Existing

--- a/lib/util.js
+++ b/lib/util.js
@@ -1054,3 +1054,18 @@ exports._exceptionWithHostPort = function(err,
 // process.versions needs a custom function as some values are lazy-evaluated.
 process.versions[exports.inspect.custom] =
   (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));
+
+// A template literal tag that ensures that string literal elements
+// are passed through the util.format mechanism.
+// Example use:
+//   inspectTag`This is object ${obj}`
+function inspectTag(strings, ...keys) {
+  var ret = '';
+  for (var n = 0; n < strings.length; n++) {
+    ret += strings[n];
+    if (n < keys.length)
+      ret += exports.inspect(keys[n]);
+  }
+  return ret;
+}
+exports.inspectTag = inspectTag;

--- a/test/parallel/test-util-inspecttag.js
+++ b/test/parallel/test-util-inspecttag.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+const inspectTag = util.inspectTag;
+
+const obj = {a: 1};
+
+assert.strictEqual(`${obj}`, '[object Object]');
+assert.strictEqual(inspectTag`${obj}`, '{ a: 1 }');
+assert.strictEqual(inspectTag`${obj}-${obj}`, '{ a: 1 }-{ a: 1 }');


### PR DESCRIPTION
Introduces a simple template literal tag that ensures that each constituent part of the template literal passes through `util.inspect()` using the default options.

This is inspired by recent changes in tests that have tried to convert `console.log('message', a, b)` to something like:

```js
`message ${a} ${b}`
```

```js
const inspectTag = require('util').inspectTag;
const m = {a: 1};

console.log(`${m}`);
// Prints: '[object Object]'

console.log(inspectTag`${m}`);
// Prints: '{ a : 1 }'
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util