### PR TITLE
test: improve readline coverage to check end and clear keys

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -175,6 +175,14 @@ addTest('\x1b[D\x1b[C\x1b[D\x1b[C'.split(''), [
   { name: 'right', sequence: '\x1b[C', code: '[C' },
 ]);
 
+// end clear end clear
+addTest('\x1b[F\x1b[E\x1b[F\x1b[E', [
+  { name: 'end', sequence: '\x1b[F', code: '[F' },
+  { name: 'clear', sequence: '\x1b[E', code: '[E' },
+  { name: 'end', sequence: '\x1b[F', code: '[F' },
+  { name: 'clear', sequence: '\x1b[E', code: '[E' },
+]);
+
 // escape sequences mixed with regular ones
 addTest('\x1b[DD\x1b[2DD\x1b[2^D', [
   { name: 'left', sequence: '\x1b[D', code: '[D' },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I improved test coverage for readline. I found some key tests are missing. This PR will improve [coverage](https://coverage.nodejs.org/)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
N/A