### PR TITLE
test: improve events coverage to check removeListeners functions

### DIFF
--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -82,3 +82,9 @@ function listener() {}
   const ee = new events.EventEmitter();
   assert.deepStrictEqual(ee, ee.removeAllListeners());
 }
+
+{
+  const ee = new events.EventEmitter();
+  ee._events = undefined;
+  assert.strictEqual(ee, ee.removeAllListeners());
+}

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -128,3 +128,11 @@ assert.throws(() => {
 
   ee.removeListener('foo', null);
 }, /^TypeError: "listener" argument must be a function$/);
+
+{
+  const ee = new EventEmitter();
+  const listener = () => {};
+  ee._events = undefined;
+  const e = ee.removeListener('foo', listener);
+  assert.strictEqual(e, ee);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I improved test coverage for events. I found removeListerers , removeAllListerers tests. However remove(All)Listener(s) function does not pass some points. This PR will improve [coverage](https://coverage.nodejs.org/).

I found [this commit](https://github.com/nodejs/node/commit/bee83e0bbc4f61c3bef3bb18043e3f39ea40a336), but it seems to need to add tests when _events is undefined.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
N/A