### PR TITLE
test, url: updated assertions in url-searchparams-getall tests

### DIFF
--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -25,17 +25,22 @@ test(function() {
 
 test(function() {
     var params = new URLSearchParams('a=1&a=2&a=3&a');
-    assert_true(params.has('a'), `Search params object doesn't have name "a"`);
+    assert_true(params.has('a'), 'Search params object doesn\'t have name "a"');
     var matches = params.getAll('a');
     assert(matches);
-    assert_equals(matches.length, 4, `Unexpected length of name "a" values in search params object: ${matches.length}`);
-    assert_array_equals(matches, ['1', '2', '3', ''], `Unexpected name "a" values: ${matches}`);
+    assert_equals(matches.length, 4, `Unexpected length of name "a" values in 
+      search params object: ${matches.length}`);
+    assert_array_equals(matches, ['1', '2', '3', ''], `Unexpected name "a" 
+      values: ${matches}`);
     params.set('a', 'one');
-    assert_equals(params.get('a'), 'one', `Search params object doesn't have name "a" with value "one"`);
+    assert_equals(params.get('a'), 'one', 'Search params object doesn\'t ' +
+      'have name "a" with value "one"');
     matches = params.getAll('a');
     assert(matches);
-    assert_equals(matches.length, 1, `Unexpected length of name "a" values in search params object: ${matches.length}`);
-    assert_array_equals(matches, ['one'], `Unexpected name "a" values: ${matches}`);
+    assert_equals(matches.length, 1, `Unexpected length of name "a" values in 
+      search params object: ${matches.length}`);
+    assert_array_equals(matches, ['one'], `Unexpected name "a" values: 
+      ${matches}`);
 }, 'getAll() multiples');
 /* eslint-enable */
 

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -25,15 +25,17 @@ test(function() {
 
 test(function() {
     var params = new URLSearchParams('a=1&a=2&a=3&a');
-    assert_true(params.has('a'), 'Search params object has name "a"');
+    assert_true(params.has('a'), `Search params object doesn't have name "a"`);
     var matches = params.getAll('a');
-    assert_true(matches && matches.length == 4, 'Search params object has values for name "a"');
-    assert_array_equals(matches, ['1', '2', '3', ''], 'Search params object has expected name "a" values');
+    assert(matches);
+    assert_equals(matches.length, 4, `Unexpected length of name "a" values in search params object: ${matches.length}`);
+    assert_array_equals(matches, ['1', '2', '3', ''], `Unexpected name "a" values: ${matches}`);
     params.set('a', 'one');
-    assert_equals(params.get('a'), 'one', 'Search params object has name "a" with value "one"');
-    var matches = params.getAll('a');
-    assert_true(matches && matches.length == 1, 'Search params object has values for name "a"');
-    assert_array_equals(matches, ['one'], 'Search params object has expected name "a" values');
+    assert_equals(params.get('a'), 'one', `Search params object doesn't have name "a" with value "one"`);
+    matches = params.getAll('a');
+    assert(matches);
+    assert_equals(matches.length, 1, `Unexpected length of name "a" values in search params object: ${matches.length}`);
+    assert_array_equals(matches, ['one'], `Unexpected name "a" values: ${matches}`);
 }, 'getAll() multiples');
 /* eslint-enable */
 


### PR DESCRIPTION
I have updated assertions in url-searchparams-getall tests, made them more clear
for debugging and improved test messages.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
no
