### PR TITLE
test: improve crypto.setEngine coverage to check for errors

### DIFF
--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+assert.throws(function() {
+  crypto.setEngine(true);
+}, /^TypeError: "id" argument should be a string$/);
+
+assert.throws(function() {
+  crypto.setEngine('/path/to/engine', 'notANumber');
+}, /^TypeError: "flags" argument should be a number, if present$/);


### PR DESCRIPTION
test: improve crypto.setEngine test coverage to check for errors

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A
