### PR TITLE
test: improve punycode test coverage

### DIFF
--- a/test/parallel/test-punycode.js
+++ b/test/parallel/test-punycode.js
@@ -237,3 +237,9 @@ assert.strictEqual(punycode.ucs2.encode([0xDC00]), '\uDC00');
 assert.strictEqual(punycode.ucs2.encode([0xDC00, 0x61, 0x62]), '\uDC00ab');
 
 assert.strictEqual(errors, 0);
+
+// test map domain
+assert.strictEqual(punycode.toASCII('Bücher@日本語.com'),
+                   'Bücher@xn--wgv71a119e.com');
+assert.strictEqual(punycode.toUnicode('Bücher@xn--wgv71a119e.com'),
+                   'Bücher@日本語.com');


### PR DESCRIPTION
Adds two additional tests for mapDomain function in punycode.js.

When an email address is given to the toASCII() and toUnicode() functions, only the parts before the '@' character should be encoded/decoded.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A
