### PR TITLE
internal/child_process: move anonymous class out of setupChannel

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -407,6 +407,24 @@ ChildProcess.prototype.unref = function() {
   if (this._handle) this._handle.unref();
 };
 
+class Control extends EventEmitter {
+  constructor(channel) {
+    super();
+    this.channel = channel;
+    this.refs = 0;
+  }
+  ref() {
+    if (++this.refs === 1) {
+      this.channel.ref();
+    }
+  }
+  unref() {
+    if (--this.refs === 0) {
+      this.channel.unref();
+      this.emit('unref');
+    }
+  }
+}
 
 function setupChannel(target, channel) {
   target.channel = channel;
@@ -421,24 +439,7 @@ function setupChannel(target, channel) {
   target._handleQueue = null;
   target._pendingHandle = null;
 
-  const control = new class extends EventEmitter {
-    constructor() {
-      super();
-      this.channel = channel;
-      this.refs = 0;
-    }
-    ref() {
-      if (++this.refs === 1) {
-        this.channel.ref();
-      }
-    }
-    unref() {
-      if (--this.refs === 0) {
-        this.channel.unref();
-        this.emit('unref');
-      }
-    }
-  }();
+  const control = new Control(channel);
 
   var decoder = new StringDecoder('utf8');
   var jsonBuffer = '';


### PR DESCRIPTION
Move the anonymous class out of setupChannel to clarify code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
internal/child_process