### PR TITLE
child_process: charify the usage of 'else'

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -35,9 +35,9 @@ exports.fork = function(modulePath /*, args, options*/) {
   if (pos < arguments.length && arguments[pos] != null) {
     if (typeof arguments[pos] !== 'object') {
       throw new TypeError('Incorrect value of args option');
-    } else {
-      options = util._extend({}, arguments[pos++]);
     }
+
+    options = util._extend({}, arguments[pos++]);
   }
 
   // Prepare arguments for fork:
@@ -581,8 +581,8 @@ function execFileSync(/*command, args, options*/) {
 
   if (err)
     throw err;
-  else
-    return ret.stdout;
+
+  return ret.stdout;
 }
 exports.execFileSync = execFileSync;
 
@@ -601,8 +601,8 @@ function execSync(command /*, options*/) {
 
   if (err)
     throw err;
-  else
-    return ret.stdout;
+
+  return ret.stdout;
 }
 exports.execSync = execSync;
 


### PR DESCRIPTION
the keyword 'else' is unnecessary after 'throw' statements.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process