### PR TITLE
doc: fix linting command for vcbuild

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,9 @@ Running `make test`/`vcbuild test` will run the linter as well unless one or
 more tests fail.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild lint`.
+`make lint`/`vcbuild jslint`. At this time, only JavaScript linting is
+available on Windows. `make lint` on POSIX will run both JavaScript linting and
+C++ linting.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:


### PR DESCRIPTION
Currently, `vcbuild` only supports `jslint`. `vcbuild lint` will not
work because there is no `lint` task specified in `vcbuild.bat`. Update
documentation to use `vcbuild jslint` instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc