### PR TITLE
test: add common.mustNotCall()

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -497,6 +497,12 @@ function fail(msg) {
 }
 exports.fail = fail;
 
+exports.mustNotCall = function(msg) {
+  return function mustNotCall() {
+    fail(msg || 'function should not have been called');
+  };
+};
+
 exports.skip = function(msg) {
   console.log(`1..0 # Skipped: ${msg}`);
 };

--- a/test/debugger/test-debugger-remote.js
+++ b/test/debugger/test-debugger-remote.js
@@ -15,8 +15,8 @@ const interfacer = spawn(process.execPath, ['debug', `localhost:${PORT}`]);
 interfacer.stdout.setEncoding('utf-8');
 
 // fail the test if either of the processes exit normally
-const debugBreakExit = common.fail.bind(null, 'child should not exit normally');
-const debugExit = common.fail.bind(null, 'interfacer should not exit normally');
+const debugBreakExit = common.mustNotCall('child should not exit normally');
+const debugExit = common.mustNotCall('interfacer should not exit normally');
 child.on('exit', debugBreakExit);
 interfacer.on('exit', debugExit);
 

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -116,7 +116,8 @@ function makeBufferingDataCallback(dataCallback) {
 }
 
 function timeout(message, multiplicator) {
-  return setTimeout(() => common.fail(message), TIMEOUT * (multiplicator || 1));
+  return setTimeout(common.mustNotCall(message),
+                    TIMEOUT * (multiplicator || 1));
 }
 
 const TestSession = function(socket, harness) {
@@ -398,7 +399,7 @@ Harness.prototype.wsHandshake = function(devtoolsUrl, tests, readyCallback) {
       });
     }
     enqueue(tests);
-  }).on('response', () => common.fail('Upgrade was not received'));
+  }).on('response', common.mustNotCall('Upgrade was not received'));
 };
 
 Harness.prototype.runFrontendSession = function(tests) {

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -45,7 +45,7 @@ function checkWrap(req) {
 
 TEST(function test_reverse_bogus(done) {
   assert.throws(() => {
-    dns.reverse('bogus ip', common.fail);
+    dns.reverse('bogus ip', common.mustNotCall());
   }, /^Error: getHostByAddr EINVAL$/);
   done();
 });

--- a/test/internet/test-http-dns-fail.js
+++ b/test/internet/test-http-dns-fail.js
@@ -16,7 +16,7 @@ function httpreq(count) {
     port: 80,
     path: '/',
     method: 'GET'
-  }, common.fail);
+  }, common.mustNotCall());
 
   req.on('error', common.mustCall((e) => {
     assert.strictEqual(e.code, 'ENOTFOUND');

--- a/test/internet/test-net-connect-timeout.js
+++ b/test/internet/test-net-connect-timeout.js
@@ -26,4 +26,4 @@ socket.on('timeout', common.mustCall(function() {
   socket.destroy();
 }));
 
-socket.on('connect', common.fail);
+socket.on('connect', common.mustNotCall());

--- a/test/internet/test-net-connect-unref.js
+++ b/test/internet/test-net-connect-unref.js
@@ -8,6 +8,6 @@ const client = net.createConnection(53, '8.8.8.8', function() {
   client.unref();
 });
 
-client.on('close', common.fail);
+client.on('close', common.mustNotCall());
 
-setTimeout(common.fail, TIMEOUT).unref();
+setTimeout(common.mustNotCall(), TIMEOUT).unref();

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -37,10 +37,10 @@ if (typeof process.argv[2] === 'string') {
   async_wrap.setupHooks({ init, pre, post, destroy });
   async_wrap.enable();
 
-  process.on('uncaughtException', common.fail);
+  process.on('uncaughtException', common.mustNotCall());
 
   const d = domain.create();
-  d.on('error', common.fail);
+  d.on('error', common.mustNotCall());
   d.run(() => {
     // Using randomBytes because timers are not yet supported.
     crypto.randomBytes(0, () => { });

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -5,7 +5,7 @@ const spawn = require('child_process').spawn;
 const cat = spawn(common.isWindows ? 'cmd' : 'cat');
 
 cat.stdout.on('end', common.mustCall(function() {}));
-cat.stderr.on('data', common.fail);
+cat.stderr.on('data', common.mustNotCall());
 cat.stderr.on('end', common.mustCall(function() {}));
 
 cat.on('exit', common.mustCall(function(code, signal) {

--- a/test/parallel/test-child-process-recv-handle.js
+++ b/test/parallel/test-child-process-recv-handle.js
@@ -24,7 +24,7 @@ function master() {
   });
   proc.stdout.on('data', common.mustCall((data) => {
     assert.strictEqual(data.toString(), 'ok\r\n');
-    net.createServer(common.fail).listen(0, function() {
+    net.createServer(common.mustNotCall()).listen(0, function() {
       handle = this._handle;
       proc.send('one');
       proc.send('two', handle);

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -20,7 +20,7 @@ s.on('exit', function() {
   handle.close();
 });
 
-net.createServer(common.fail).listen(0, function() {
+net.createServer(common.mustNotCall()).listen(0, function() {
   handle = this._handle;
   assert.strictEqual(s.send('one', handle), true);
   assert.strictEqual(s.send('two', handle), true);

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -7,7 +7,7 @@ const cp = require('child_process');
 const doesNotExist = cp.spawn('does-not-exist', {shell: true});
 
 assert.notStrictEqual(doesNotExist.spawnfile, 'does-not-exist');
-doesNotExist.on('error', common.fail);
+doesNotExist.on('error', common.mustNotCall());
 doesNotExist.on('exit', common.mustCall((code, signal) => {
   assert.strictEqual(signal, null);
 

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -15,7 +15,7 @@ const empty = common.fixturesDir + '/empty.js';
 
 assert.throws(function() {
   const child = spawn(invalidcmd, 'this is not an array');
-  child.on('error', common.fail);
+  child.on('error', common.mustNotCall());
 }, TypeError);
 
 // verify that valid argument combinations do not throw

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -24,7 +24,7 @@ cat.stdout.on('data', function(chunk) {
 
 cat.stdout.on('end', common.mustCall(function() {}));
 
-cat.stderr.on('data', common.fail);
+cat.stderr.on('data', common.mustNotCall());
 
 cat.stderr.on('end', common.mustCall(function() {}));
 

--- a/test/parallel/test-child-process-stdout-flush.js
+++ b/test/parallel/test-child-process-stdout-flush.js
@@ -12,7 +12,7 @@ const child = spawn(process.argv[0], [sub, n]);
 let count = 0;
 
 child.stderr.setEncoding('utf8');
-child.stderr.on('data', common.fail);
+child.stderr.on('data', common.mustNotCall());
 
 child.stdout.setEncoding('utf8');
 child.stdout.on('data', (data) => {

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -19,8 +19,8 @@ if (cluster.isMaster) {
     assert.strictEqual(exitCode, 0);
   }));
 } else {
-  const s = net.createServer(common.fail);
-  s.listen(42, common.fail.bind(null, 'listen should have failed'));
+  const s = net.createServer(common.mustNotCall());
+  s.listen(42, common.mustNotCall('listen should have failed'));
   s.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'EACCES');
     process.disconnect();

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -60,9 +60,10 @@ if (!id) {
 } else if (id === 'one') {
   if (cluster.isMaster) return startWorker();
 
-  http.createServer(common.fail).listen(common.PORT, common.mustCall(() => {
-    process.send('READY');
-  }));
+  http.createServer(common.mustNotCall())
+    .listen(common.PORT, common.mustCall(() => {
+      process.send('READY');
+    }));
 
   process.on('message', common.mustCall((m) => {
     if (m === 'QUIT') process.exit();
@@ -70,11 +71,11 @@ if (!id) {
 } else if (id === 'two') {
   if (cluster.isMaster) return startWorker();
 
-  const server = http.createServer(common.fail);
+  const server = http.createServer(common.mustNotCall());
   process.on('message', common.mustCall((m) => {
     if (m === 'QUIT') process.exit();
     assert.strictEqual(m, 'START');
-    server.listen(common.PORT, common.fail);
+    server.listen(common.PORT, common.mustNotCall());
     server.on('error', common.mustCall((e) => {
       assert.strictEqual(e.code, 'EADDRINUSE');
       process.send(e.code);

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -11,7 +11,7 @@ const net = require('net');
 const id = '' + process.argv[2];
 
 if (id === 'undefined') {
-  const server = net.createServer(common.fail);
+  const server = net.createServer(common.mustNotCall());
   server.listen(common.PORT, function() {
     const worker = fork(__filename, ['worker']);
     worker.on('message', function(msg) {
@@ -22,14 +22,14 @@ if (id === 'undefined') {
     });
   });
 } else if (id === 'worker') {
-  let server = net.createServer(common.fail);
-  server.listen(common.PORT, common.fail);
+  let server = net.createServer(common.mustNotCall());
+  server.listen(common.PORT, common.mustNotCall());
   server.on('error', common.mustCall(function(e) {
     assert(e.code, 'EADDRINUSE');
     process.send('stop-listening');
     process.once('message', function(msg) {
       if (msg !== 'stopped-listening') return;
-      server = net.createServer(common.fail);
+      server = net.createServer(common.mustNotCall());
       server.listen(common.PORT, common.mustCall(function() {
         server.close();
       }));

--- a/test/parallel/test-cluster-listening-port.js
+++ b/test/parallel/test-cluster-listening-port.js
@@ -15,5 +15,5 @@ if (cluster.isMaster) {
     worker.kill();
   }));
 } else {
-  net.createServer(common.fail).listen(0);
+  net.createServer(common.mustNotCall()).listen(0);
 }

--- a/test/parallel/test-cluster-net-listen.js
+++ b/test/parallel/test-cluster-net-listen.js
@@ -11,5 +11,5 @@ if (cluster.isMaster) {
   }));
 } else {
   // listen() without port should not trigger a libuv assert
-  net.createServer(common.fail).listen(process.exit);
+  net.createServer(common.mustNotCall()).listen(process.exit);
 }

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -9,7 +9,7 @@ if (cluster.isMaster) {
     if (msg === 'done') this.kill();
   });
 } else {
-  const server = net.createServer(common.fail);
+  const server = net.createServer(common.mustNotCall());
   server.listen(common.PORT, function() {
     server.unref();
     server.ref();

--- a/test/parallel/test-cluster-setup-master-argv.js
+++ b/test/parallel/test-cluster-setup-master-argv.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
-setTimeout(common.fail.bind(assert, 'setup not emitted'), 1000).unref();
+setTimeout(common.mustNotCall('setup not emitted'), 1000).unref();
 
 cluster.on('setup', common.mustCall(function() {
   const clusterArgs = cluster.settings.args;

--- a/test/parallel/test-cluster-shared-handle-bind-error.js
+++ b/test/parallel/test-cluster-shared-handle-bind-error.js
@@ -8,7 +8,7 @@ if (cluster.isMaster) {
   // Master opens and binds the socket and shares it with the worker.
   cluster.schedulingPolicy = cluster.SCHED_NONE;
   // Hog the TCP port so that when the worker tries to bind, it'll fail.
-  const server = net.createServer(common.fail);
+  const server = net.createServer(common.mustNotCall());
 
   server.listen(common.PORT, common.mustCall(() => {
     const worker = cluster.fork();
@@ -18,8 +18,8 @@ if (cluster.isMaster) {
     }));
   }));
 } else {
-  const s = net.createServer(common.fail);
-  s.listen(common.PORT, common.fail.bind(null, 'listen should have failed'));
+  const s = net.createServer(common.mustNotCall());
+  s.listen(common.PORT, common.mustNotCall('listen should have failed'));
   s.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'EADDRINUSE');
     process.disconnect();

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -21,8 +21,8 @@ if (cluster.isMaster) {
     assert.strictEqual(exitCode, 0);
   }));
 } else {
-  const s = net.createServer(common.fail);
-  s.listen(42, common.fail.bind(null, 'listen should have failed'));
+  const s = net.createServer(common.mustNotCall());
+  s.listen(42, common.mustNotCall('listen should have failed'));
   s.on('error', common.mustCall(function(err) {
     assert.strictEqual(err.code, 'EACCES');
     process.disconnect();

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -9,7 +9,7 @@ const err = new Stream();
 
 // ensure the Console instance doesn't write to the
 // process' "stdout" or "stderr" streams
-process.stdout.write = process.stderr.write = common.fail;
+process.stdout.write = process.stderr.write = common.mustNotCall();
 
 // make sure that the "Console" function exists
 assert.strictEqual('function', typeof Console);

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -63,27 +63,30 @@ assert.throws(function() {
 
 // Should not work with Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, Infinity, 'sha256', common.fail);
+  crypto.pbkdf2('password', 'salt', 1, Infinity, 'sha256',
+                common.mustNotCall());
 }, /^TypeError: Bad key length$/);
 
 // Should not work with negative Infinity key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -Infinity, 'sha256', common.fail);
+  crypto.pbkdf2('password', 'salt', 1, -Infinity, 'sha256',
+                common.mustNotCall());
 }, /^TypeError: Bad key length$/);
 
 // Should not work with NaN key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, NaN, 'sha256', common.fail);
+  crypto.pbkdf2('password', 'salt', 1, NaN, 'sha256', common.mustNotCall());
 }, /^TypeError: Bad key length$/);
 
 // Should not work with negative key length
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, -1, 'sha256', common.fail);
+  crypto.pbkdf2('password', 'salt', 1, -1, 'sha256', common.mustNotCall());
 }, /^TypeError: Bad key length$/);
 
 // Should not work with key length that does not fit into 32 signed bits
 assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, 4073741824, 'sha256', common.fail);
+  crypto.pbkdf2('password', 'salt', 1, 4073741824, 'sha256',
+                common.mustNotCall());
 }, /^TypeError: Bad key length$/);
 
 // Should not get FATAL ERROR with empty password and salt

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -41,7 +41,7 @@ server.listen(0, common.mustCall(() => {
   }, common.mustCall(() => {
     verify();
   }))
-    .on('error', common.fail)
+    .on('error', common.mustNotCall())
     .on('close', common.mustCall(() => {
       server.close();
     })).resume();

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -6,7 +6,7 @@ const dgram = require('dgram');
 // IPv4 Test
 const socket_ipv4 = dgram.createSocket('udp4');
 
-socket_ipv4.on('listening', common.fail);
+socket_ipv4.on('listening', common.mustNotCall());
 
 socket_ipv4.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.port, undefined);
@@ -21,7 +21,7 @@ socket_ipv4.bind(0, '1.1.1.1');
 // IPv6 Test
 const socket_ipv6 = dgram.createSocket('udp6');
 
-socket_ipv6.on('listening', common.fail);
+socket_ipv6.on('listening', common.mustNotCall());
 
 socket_ipv6.on('error', common.mustCall(function(e) {
   // EAFNOSUPPORT or EPROTONOSUPPORT means IPv6 is disabled on this system.

--- a/test/parallel/test-dgram-unref.js
+++ b/test/parallel/test-dgram-unref.js
@@ -6,4 +6,4 @@ const s = dgram.createSocket('udp4');
 s.bind();
 s.unref();
 
-setTimeout(common.fail, 1000).unref();
+setTimeout(common.mustNotCall(), 1000).unref();

--- a/test/parallel/test-domain-multi.js
+++ b/test/parallel/test-domain-multi.js
@@ -8,7 +8,7 @@ const http = require('http');
 const a = domain.create();
 a.enter(); // this will be our "root" domain
 
-a.on('error', common.fail);
+a.on('error', common.mustNotCall());
 
 const server = http.createServer((req, res) => {
   // child domain of a.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -20,7 +20,7 @@ function listener2() {}
 {
   const ee = new EventEmitter();
   ee.on('hello', listener1);
-  ee.on('removeListener', common.fail);
+  ee.on('removeListener', common.mustNotCall());
   ee.removeListener('hello', listener2);
   assert.deepStrictEqual([listener1], ee.listeners('hello'));
 }

--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -5,9 +5,9 @@ const spawn = require('child_process').spawn;
 
 // spawn a node child process in "interactive" mode (force the repl)
 const cp = spawn(process.execPath, ['-i']);
-const timeoutId = setTimeout(function() {
-  common.fail('timeout!');
-}, common.platformTimeout(5000)); // give node + the repl 5 seconds to start
+// give node + the repl 5 seconds to start
+const timeoutId = setTimeout(common.mustNotCall(),
+                             common.platformTimeout(5000));
 
 cp.stdout.setEncoding('utf8');
 

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -82,7 +82,7 @@ fs.access(readOnlyFile, fs.W_OK, common.mustCall((err) => {
 }));
 
 assert.throws(() => {
-  fs.access(100, fs.F_OK, () => { common.fail('callback should not run'); });
+  fs.access(100, fs.F_OK, common.mustNotCall());
 }, /^TypeError: path must be a string or Buffer$/);
 
 assert.throws(() => {

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -43,10 +43,10 @@ check(fs.symlink, fs.symlinkSync, 'foo\u0000bar', 'foobar');
 check(fs.symlink, fs.symlinkSync, 'foobar', 'foo\u0000bar');
 check(fs.truncate, fs.truncateSync, 'foo\u0000bar');
 check(fs.unlink, fs.unlinkSync, 'foo\u0000bar');
-check(null, fs.unwatchFile, 'foo\u0000bar', common.fail);
+check(null, fs.unwatchFile, 'foo\u0000bar', common.mustNotCall());
 check(fs.utimes, fs.utimesSync, 'foo\u0000bar', 0, 0);
-check(null, fs.watch, 'foo\u0000bar', common.fail);
-check(null, fs.watchFile, 'foo\u0000bar', common.fail);
+check(null, fs.watch, 'foo\u0000bar', common.mustNotCall());
+check(null, fs.watchFile, 'foo\u0000bar', common.mustNotCall());
 check(fs.writeFile, fs.writeFileSync, 'foo\u0000bar');
 
 const fileUrl = new URL('file:///C:/foo\u0000bar');

--- a/test/parallel/test-fs-read-stream-err.js
+++ b/test/parallel/test-fs-read-stream-err.js
@@ -38,5 +38,5 @@ fs.read = function() {
 };
 
 stream.on('data', (buf) => {
-  stream.on('data', () => common.fail("no more 'data' events should follow"));
+  stream.on('data', common.mustNotCall("no more 'data' events should follow"));
 });

--- a/test/parallel/test-http-abort-before-end.js
+++ b/test/parallel/test-http-abort-before-end.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const http = require('http');
 const assert = require('assert');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 
 server.listen(0, function() {
   const req = http.request({

--- a/test/parallel/test-http-abort-queued-2.js
+++ b/test/parallel/test-http-abort-queued-2.js
@@ -24,7 +24,7 @@ server.listen(0, common.mustCall(() => {
 
   http.get({agent, port}, (res) => res.resume());
 
-  const req = http.get({agent, port}, common.fail);
+  const req = http.get({agent, port}, common.mustNotCall());
   req.abort();
 
   http.get({agent, port}, common.mustCall((res) => {

--- a/test/parallel/test-http-bind-twice.js
+++ b/test/parallel/test-http-bind-twice.js
@@ -3,10 +3,10 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-const server1 = http.createServer(common.fail);
+const server1 = http.createServer(common.mustNotCall());
 server1.listen(0, '127.0.0.1', common.mustCall(function() {
-  const server2 = http.createServer(common.fail);
-  server2.listen(this.address().port, '127.0.0.1', common.fail);
+  const server2 = http.createServer(common.mustNotCall());
+  server2.listen(this.address().port, '127.0.0.1', common.mustNotCall());
 
   server2.on('error', common.mustCall(function(e) {
     assert.strictEqual(e.code, 'EADDRINUSE');

--- a/test/parallel/test-http-client-abort-event.js
+++ b/test/parallel/test-http-client-abort-event.js
@@ -8,7 +8,7 @@ const server = http.createServer(function(req, res) {
 server.listen(0, common.mustCall(function() {
   const req = http.request({
     port: this.address().port
-  }, common.fail);
+  }, common.mustNotCall());
 
   req.on('abort', common.mustCall(function() {
     server.close();

--- a/test/parallel/test-http-client-abort-no-agent.js
+++ b/test/parallel/test-http-client-abort-no-agent.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const http = require('http');
 const net = require('net');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 
 server.listen(0, common.mustCall(() => {
   const req = http.get({

--- a/test/parallel/test-http-client-abort-unix-socket.js
+++ b/test/parallel/test-http-client-abort-unix-socket.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const http = require('http');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 
 class Agent extends http.Agent {
   createConnection(options, oncreate) {

--- a/test/parallel/test-http-client-check-http-token.js
+++ b/test/parallel/test-http-client-check-http-token.js
@@ -18,7 +18,7 @@ const server = http.createServer((req, res) => {
 function test() {
   function fail(input) {
     assert.throws(() => {
-      http.request({ method: input, path: '/' }, common.fail);
+      http.request({ method: input, path: '/' }, common.mustNotCall());
     }, /^TypeError: Method must be a string$/);
   }
 

--- a/test/parallel/test-http-client-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-client-reject-chunked-with-content-length.js
@@ -17,9 +17,7 @@ server.listen(0, () => {
   // The callback should not be called because the server is sending
   // both a Content-Length header and a Transfer-Encoding: chunked
   // header, which is a violation of the HTTP spec.
-  const req = http.get({port: server.address().port}, (res) => {
-    common.fail('callback should not be called');
-  });
+  const req = http.get({port: server.address().port}, common.mustNotCall());
   req.on('error', common.mustCall((err) => {
     assert(/^Parse Error/.test(err.message));
     assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');

--- a/test/parallel/test-http-client-reject-cr-no-lf.js
+++ b/test/parallel/test-http-client-reject-cr-no-lf.js
@@ -16,9 +16,7 @@ const server = net.createServer((socket) => {
 server.listen(0, () => {
   // The callback should not be called because the server is sending a
   // header field that ends only in \r with no following \n
-  const req = http.get({port: server.address().port}, (res) => {
-    common.fail('callback should not be called');
-  });
+  const req = http.get({port: server.address().port}, common.mustNotCall());
   req.on('error', common.mustCall((err) => {
     assert(/^Parse Error/.test(err.message));
     assert.strictEqual(err.code, 'HPE_LF_EXPECTED');

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -5,6 +5,6 @@ const http = require('http');
 
 for (let i = 0; i <= 32; i += 1) {
   const path = 'bad' + String.fromCharCode(i) + 'path';
-  assert.throws(() => http.get({ path }, common.fail),
+  assert.throws(() => http.get({ path }, common.mustNotCall()),
                 /contains unescaped characters/);
 }

--- a/test/parallel/test-http-conn-reset.js
+++ b/test/parallel/test-http-conn-reset.js
@@ -19,7 +19,7 @@ server.listen(0, options.host, common.mustCall(onListen));
 // do a GET request, expect it to fail
 function onListen() {
   options.port = this.address().port;
-  const req = http.request(options, common.fail);
+  const req = http.request(options, common.mustNotCall());
   req.on('error', common.mustCall(function(err) {
     assert.strictEqual(err.code, 'ECONNRESET');
   }));

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 server.on('connect', common.mustCall(function(req, socket, firstBodyChunk) {
   assert.strictEqual(req.method, 'CONNECT');
   assert.strictEqual(req.url, 'example.com:443');
@@ -31,7 +31,7 @@ server.listen(0, common.mustCall(function() {
     port: this.address().port,
     method: 'CONNECT',
     path: 'example.com:443'
-  }, common.fail);
+  }, common.mustNotCall());
 
   req.on('close', common.mustCall(function() { }));
 

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 
 server.on('connect', common.mustCall((req, socket, firstBodyChunk) => {
   assert.strictEqual(req.method, 'CONNECT');
@@ -26,7 +26,7 @@ server.listen(0, common.mustCall(function() {
     port: this.address().port,
     method: 'CONNECT',
     path: 'google.com:443'
-  }, common.fail);
+  }, common.mustNotCall());
 
   req.on('close', common.mustCall(() => {}));
 

--- a/test/parallel/test-http-destroyed-socket-write2.js
+++ b/test/parallel/test-http-destroyed-socket-write2.js
@@ -53,12 +53,8 @@ server.listen(0, function() {
   }));
 
   req.on('response', function(res) {
-    res.on('data', function(chunk) {
-      common.fail('Should not receive response data');
-    });
-    res.on('end', function() {
-      common.fail('Should not receive response end');
-    });
+    res.on('data', common.mustNotCall('Should not receive response data'));
+    res.on('end', common.mustNotCall('Should not receive response end'));
   });
 
   write();

--- a/test/parallel/test-http-double-content-length.js
+++ b/test/parallel/test-http-double-content-length.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 // The callback should never be invoked because the server
 // should respond with a 400 Client Error when a double
 // Content-Length header is received.
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 server.on('clientError', common.mustCall((err, socket) => {
   assert(/^Parse Error/.test(err.message));
   assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
@@ -18,11 +18,8 @@ server.listen(0, () => {
   const req = http.get({
     port: server.address().port,
     // Send two content-length header values.
-    headers: {'Content-Length': [1, 2]}},
-                       (res) => {
-                         common.fail('an error should have occurred');
-                       }
-  );
+    headers: {'Content-Length': [1, 2]}
+  }, common.mustNotCall('an error should have occurred'));
   req.on('error', common.mustCall(() => {
     server.close();
   }));

--- a/test/parallel/test-http-host-headers.js
+++ b/test/parallel/test-http-host-headers.js
@@ -38,7 +38,7 @@ function testHttp() {
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
-    }, cb).on('error', common.fail);
+    }, cb).on('error', common.mustNotCall());
 
     http.request({
       method: 'GET',
@@ -46,7 +46,7 @@ function testHttp() {
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
-    }, cb).on('error', common.fail).end();
+    }, cb).on('error', common.mustNotCall()).end();
 
     http.request({
       method: 'POST',
@@ -54,7 +54,7 @@ function testHttp() {
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
-    }, cb).on('error', common.fail).end();
+    }, cb).on('error', common.mustNotCall()).end();
 
     http.request({
       method: 'PUT',
@@ -62,7 +62,7 @@ function testHttp() {
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
-    }, cb).on('error', common.fail).end();
+    }, cb).on('error', common.mustNotCall()).end();
 
     http.request({
       method: 'DELETE',
@@ -70,6 +70,6 @@ function testHttp() {
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
-    }, cb).on('error', common.fail).end();
+    }, cb).on('error', common.mustNotCall()).end();
   });
 }

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -35,7 +35,7 @@ function newParser(type) {
   parser[kOnHeadersComplete] = function(info) {
   };
 
-  parser[kOnBody] = common.fail;
+  parser[kOnBody] = common.mustNotCall('kOnBody should not be called');
 
   parser[kOnMessageComplete] = function() {
   };

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -38,7 +38,7 @@ function parent() {
         // may still be asked to process more requests if they were read before
         // the flood-prevention mechanism activated.
         setImmediate(() => {
-          req.socket.on('data', () => common.fail('Unexpected data received'));
+          req.socket.on('data', common.mustNotCall('Unexpected data received'));
         });
       }
       backloggedReqs++;

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -9,9 +9,7 @@ const reqstr = 'POST / HTTP/1.1\r\n' +
                'Content-Length: 1\r\n' +
                'Transfer-Encoding: chunked\r\n\r\n';
 
-const server = http.createServer((req, res) => {
-  common.fail('callback should not be invoked');
-});
+const server = http.createServer(common.mustNotCall());
 server.on('clientError', common.mustCall((err) => {
   assert(/^Parse Error/.test(err.message));
   assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');

--- a/test/parallel/test-http-server-reject-cr-no-lf.js
+++ b/test/parallel/test-http-server-reject-cr-no-lf.js
@@ -11,9 +11,7 @@ const str = 'GET / HTTP/1.1\r\n' +
             '\r\n';
 
 
-const server = http.createServer((req, res) => {
-  common.fail('this should not be called');
-});
+const server = http.createServer(common.mustNotCall());
 server.on('clientError', common.mustCall((err) => {
   assert(/^Parse Error/.test(err.message));
   assert.strictEqual(err.code, 'HPE_LF_EXPECTED');
@@ -21,9 +19,7 @@ server.on('clientError', common.mustCall((err) => {
 }));
 server.listen(0, () => {
   const client = net.connect({port: server.address().port}, () => {
-    client.on('data', (chunk) => {
-      common.fail('this should not be called');
-    });
+    client.on('data', common.mustNotCall());
     client.on('end', common.mustCall(() => {
       server.close();
     }));

--- a/test/parallel/test-http-server-unconsume-consume.js
+++ b/test/parallel/test-http-server-unconsume-consume.js
@@ -2,10 +2,7 @@
 const common = require('../common');
 const http = require('http');
 
-const testServer = http.createServer((req, res) => {
-  common.fail('Should not be called');
-  res.end();
-});
+const testServer = http.createServer(common.mustNotCall());
 testServer.on('connect', common.mustCall((req, socket, head) => {
   socket.write('HTTP/1.1 200 Connection Established' + '\r\n' +
       'Proxy-agent: Node-Proxy' + '\r\n' +

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -53,7 +53,7 @@ server.on('listening', function() {
   c.on('connect', function() {
     outstanding_reqs++;
     c.write('GET / HTTP/1.1\r\n\r\n');
-    tid = setTimeout(common.fail, 2000, 'Couldn\'t find last chunk.');
+    tid = setTimeout(common.mustNotCall(), 2000, 'Couldn\'t find last chunk.');
   });
 
   c.on('data', function(chunk) {

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -81,6 +81,6 @@ function third(server) {
     assert(!req.socket.isSessionReused());
     server.close();
   });
-  req.on('error', common.fail);
+  req.on('error', common.mustNotCall());
   req.end();
 }

--- a/test/parallel/test-https-client-checkServerIdentity.js
+++ b/test/parallel/test-https-client-checkServerIdentity.js
@@ -29,7 +29,7 @@ function authorized() {
     port: server.address().port,
     rejectUnauthorized: true,
     ca: [fs.readFileSync(path.join(common.fixturesDir, 'keys/ca2-cert.pem'))]
-  }, common.fail);
+  }, common.mustNotCall());
   req.on('error', function(err) {
     override();
   });

--- a/test/parallel/test-https-client-reject.js
+++ b/test/parallel/test-https-client-reject.js
@@ -44,7 +44,7 @@ function rejectUnauthorized() {
     port: server.address().port
   };
   options.agent = new https.Agent(options);
-  const req = https.request(options, common.fail);
+  const req = https.request(options, common.mustNotCall());
   req.on('error', function(err) {
     authorized();
   });
@@ -62,6 +62,6 @@ function authorized() {
     assert(req.socket.authorized);
     server.close();
   });
-  req.on('error', common.fail);
+  req.on('error', common.mustNotCall());
   req.end();
 }

--- a/test/parallel/test-https-connecting-to-http.js
+++ b/test/parallel/test-https-connecting-to-http.js
@@ -10,10 +10,10 @@ if (!common.hasCrypto) {
 }
 const https = require('https');
 
-const server = http.createServer(common.fail);
+const server = http.createServer(common.mustNotCall());
 
 server.listen(0, common.mustCall(function() {
-  const req = https.get({ port: this.address().port }, common.fail);
+  const req = https.get({ port: this.address().port }, common.mustNotCall());
 
   req.on('error', common.mustCall(function(e) {
     console.log('Got expected error: ', e.message);

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -97,7 +97,7 @@ test(function serverResponseTimeout(cb) {
 test(function serverRequestNotTimeoutAfterEnd(cb) {
   function handler(req, res) {
     // just do nothing, we should get a timeout event.
-    req.setTimeout(50, common.fail);
+    req.setTimeout(50, common.mustNotCall());
     res.on('timeout', common.mustCall(function(socket) {}));
   }
   const server = https.createServer(serverOptions, common.mustCall(handler));
@@ -147,8 +147,8 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 test(function idleTimeout(cb) {
   const server = https.createServer(serverOptions,
                                     common.mustCall(function(req, res) {
-                                      req.on('timeout', common.fail);
-                                      res.on('timeout', common.fail);
+                                      req.on('timeout', common.mustNotCall());
+                                      res.on('timeout', common.mustNotCall());
                                       res.end();
                                     }));
   server.setTimeout(50, common.mustCall(function(socket) {

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -17,7 +17,7 @@ const options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-const server = https.createServer(options, common.fail);
+const server = https.createServer(options, common.mustNotCall());
 
 server.on('secureConnection', function(cleartext) {
   const s = cleartext.setTimeout(50, function() {

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -17,7 +17,7 @@ const options = {
   handshakeTimeout: 50
 };
 
-const server = https.createServer(options, common.fail);
+const server = https.createServer(options, common.mustNotCall());
 
 server.on('clientError', common.mustCall(function(err, conn) {
   // Don't hesitate to update the asserts if the internal structure of

--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -3,9 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-net.createServer(common.fail).listen({fd: 2})
+net.createServer(common.mustNotCall()).listen({fd: 2})
   .on('error', common.mustCall(onError));
-net.createServer(common.fail).listen({fd: 42})
+net.createServer(common.mustNotCall()).listen({fd: 42})
   .on('error', common.mustCall(onError));
 
 function onError(ex) {

--- a/test/parallel/test-net-better-error-messages-listen-path.js
+++ b/test/parallel/test-net-better-error-messages-listen-path.js
@@ -3,8 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const fp = '/blah/fadfa';
-const server = net.createServer(common.fail);
-server.listen(fp, common.fail);
+const server = net.createServer(common.mustNotCall());
+server.listen(fp, common.mustNotCall());
 server.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.address, fp);
 }));

--- a/test/parallel/test-net-better-error-messages-listen.js
+++ b/test/parallel/test-net-better-error-messages-listen.js
@@ -3,8 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server = net.createServer(common.fail);
-server.listen(1, '1.1.1.1', common.fail);
+const server = net.createServer(common.mustNotCall());
+server.listen(1, '1.1.1.1', common.mustNotCall());
 server.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.address, '1.1.1.1');
   assert.strictEqual(e.port, 1);

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fp = '/tmp/fadagagsdfgsdf';
 const c = net.connect(fp);
 
-c.on('connect', common.fail);
+c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ENOENT');

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 const c = net.createConnection(common.PORT, '***');
 
-c.on('connect', common.fail);
+c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ENOTFOUND');

--- a/test/parallel/test-net-better-error-messages-port.js
+++ b/test/parallel/test-net-better-error-messages-port.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 const c = net.createConnection(common.PORT);
 
-c.on('connect', common.fail);
+c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ECONNREFUSED');

--- a/test/parallel/test-net-bind-twice.js
+++ b/test/parallel/test-net-bind-twice.js
@@ -3,10 +3,10 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server1 = net.createServer(common.fail);
+const server1 = net.createServer(common.mustNotCall());
 server1.listen(0, '127.0.0.1', common.mustCall(function() {
-  const server2 = net.createServer(common.fail);
-  server2.listen(this.address().port, '127.0.0.1', common.fail);
+  const server2 = net.createServer(common.mustNotCall());
+  server2.listen(this.address().port, '127.0.0.1', common.mustNotCall());
 
   server2.on('error', common.mustCall(function(e) {
     assert.strictEqual(e.code, 'EADDRINUSE');

--- a/test/parallel/test-net-connect-handle-econnrefused.js
+++ b/test/parallel/test-net-connect-handle-econnrefused.js
@@ -7,9 +7,7 @@ const assert = require('assert');
 // Hopefully nothing is running on common.PORT
 const c = net.createConnection(common.PORT);
 
-c.on('connect', function() {
-  common.fail('connected?!');
-});
+c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   console.error('couldn\'t connect.');

--- a/test/parallel/test-net-connect-immediate-destroy.js
+++ b/test/parallel/test-net-connect-immediate-destroy.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const net = require('net');
 
-const socket = net.connect(common.PORT, common.localhostIPv4, common.fail);
-socket.on('error', common.fail);
+const socket = net.connect(common.PORT, common.localhostIPv4,
+                           common.mustNotCall());
+socket.on('error', common.mustNotCall());
 socket.destroy();

--- a/test/parallel/test-net-connect-paused-connection.js
+++ b/test/parallel/test-net-connect-paused-connection.js
@@ -8,7 +8,5 @@ net.createServer(function(conn) {
 }).listen(0, function() {
   net.connect(this.address().port, 'localhost').pause();
 
-  setTimeout(function() {
-    common.fail('expected to exit');
-  }, 1000).unref();
+  setTimeout(common.mustNotCall('expected to exit'), 1000).unref();
 }).unref();

--- a/test/parallel/test-net-dns-lookup-skip.js
+++ b/test/parallel/test-net-dns-lookup-skip.js
@@ -10,7 +10,8 @@ function check(addressType) {
 
   const address = addressType === 4 ? '127.0.0.1' : '::1';
   server.listen(0, address, function() {
-    net.connect(this.address().port, address).on('lookup', common.fail);
+    net.connect(this.address().port, address)
+      .on('lookup', common.mustNotCall());
   });
 }
 

--- a/test/parallel/test-net-listen-close-server-callback-is-not-function.js
+++ b/test/parallel/test-net-listen-close-server-callback-is-not-function.js
@@ -2,10 +2,10 @@
 const common = require('../common');
 const net = require('net');
 
-const server = net.createServer(common.fail);
+const server = net.createServer(common.mustNotCall());
 
 server.on('close', common.mustCall(function() {}));
 
-server.listen(0, common.fail);
+server.listen(0, common.mustNotCall());
 
 server.close('bad argument');

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -4,6 +4,6 @@ const net = require('net');
 
 const server = net.createServer(function(socket) {
 });
-server.listen(0, common.fail);
-server.on('error', common.fail);
+server.listen(0, common.mustNotCall());
+server.on('error', common.mustNotCall());
 server.close();

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -4,5 +4,5 @@ const net = require('net');
 
 const server = net.createServer(function(socket) {
 });
-server.listen(1, '1.1.1.1', common.fail); // EACCESS or EADDRNOTAVAIL
+server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCESS or EADDRNOTAVAIL
 server.on('error', common.mustCall(function(error) {}));

--- a/test/parallel/test-net-listen-fd0.js
+++ b/test/parallel/test-net-listen-fd0.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const net = require('net');
 
 // This should fail with an async EINVAL error, not throw an exception
-net.createServer(common.fail)
+net.createServer(common.mustNotCall())
   .listen({fd: 0})
   .on('error', common.mustCall(function(e) {
     assert(e instanceof Error);

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -35,11 +35,11 @@ listenVariants.forEach((listenVariant, i) => {
       // skip this, because listen(port) can also be listen(path)
       return;
     }
-    assert.throws(() => listenVariant(port, common.fail),
+    assert.throws(() => listenVariant(port, common.mustNotCall()),
                   /"port" argument must be >= 0 and < 65536/i);
   });
 
   [null, true, false].forEach((port) =>
-    assert.throws(() => listenVariant(port, common.fail),
+    assert.throws(() => listenVariant(port, common.mustNotCall()),
                   /invalid listen argument/i));
 });

--- a/test/parallel/test-net-pause-resume-connecting.js
+++ b/test/parallel/test-net-pause-resume-connecting.js
@@ -34,7 +34,7 @@ server.listen(0, function() {
   // Client 3
   conn = require('net').createConnection(this.address().port, 'localhost');
   conn.pause();
-  conn.on('data', common.fail);
+  conn.on('data', common.mustNotCall());
   scheduleTearDown(conn);
 
 
@@ -51,7 +51,7 @@ server.listen(0, function() {
   conn.resume();
   conn.resume();
   conn.pause();
-  conn.on('data', common.fail);
+  conn.on('data', common.mustNotCall());
   scheduleTearDown(conn);
 
   function onDataOk() {

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -48,7 +48,7 @@ function pingPongTest(port, host) {
       socket.end();
     }));
 
-    socket.on('error', common.fail);
+    socket.on('error', common.mustNotCall());
 
     socket.on('close', common.mustCall(function() {
       assert.strictEqual(socket.writable, false);
@@ -99,7 +99,7 @@ function pingPongTest(port, host) {
       assert.strictEqual(sent_final_ping, true);
     }));
 
-    client.on('error', common.fail);
+    client.on('error', common.mustNotCall());
   }));
 }
 

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -57,9 +57,8 @@ noEntSocketClient.on('error', common.mustCall(function(err) {
 // On Windows or when running as root, a chmod has no effect on named pipes
 if (!common.isWindows && process.getuid() !== 0) {
   // Trying to connect to a socket one has no access to should result in EACCES
-  const accessServer = net.createServer(function() {
-    common.fail('server callback should not run');
-  });
+  const accessServer = net.createServer(
+    common.mustNotCall('server callback should not run'));
   accessServer.listen(common.PIPE, common.mustCall(function() {
     fs.chmodSync(common.PIPE, 0);
 

--- a/test/parallel/test-net-reconnect-error.js
+++ b/test/parallel/test-net-reconnect-error.js
@@ -9,9 +9,7 @@ let disconnect_count = 0;
 // Hopefully nothing is running on common.PORT
 const c = net.createConnection(common.PORT);
 
-c.on('connect', function() {
-  common.fail('client should not have connected');
-});
+c.on('connect', common.mustNotCall('client should not have connected'));
 
 c.on('error', function(e) {
   console.error('CLIENT error: ' + e.code);

--- a/test/parallel/test-net-server-unref-persistent.js
+++ b/test/parallel/test-net-server-unref-persistent.js
@@ -9,4 +9,4 @@ server.listen();
 
 // If the timeout fires, that means the server held the event loop open
 // and the unref() was not persistent. Close the server and fail the test.
-setTimeout(common.fail, 1000).unref();
+setTimeout(common.mustNotCall(), 1000).unref();

--- a/test/parallel/test-net-server-unref.js
+++ b/test/parallel/test-net-server-unref.js
@@ -6,4 +6,4 @@ const s = net.createServer();
 s.listen(0);
 s.unref();
 
-setTimeout(common.fail, 1000).unref();
+setTimeout(common.mustNotCall(), 1000).unref();

--- a/test/parallel/test-net-settimeout.js
+++ b/test/parallel/test-net-settimeout.js
@@ -15,9 +15,7 @@ const server = net.createServer(common.mustCall((c) => {
 server.listen(0, function() {
   const socket = net.createConnection(this.address().port, 'localhost');
 
-  const s = socket.setTimeout(T, () => {
-    common.fail('Socket timeout event is not expected to fire');
-  });
+  const s = socket.setTimeout(T, common.mustNotCall());
   assert.ok(s instanceof net.Socket);
 
   socket.on('data', common.mustCall(() => {

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -22,5 +22,5 @@ process.nextTick(function(a, b) {
 }, 42, obj);
 
 process.on('exit', function() {
-  process.nextTick(common.fail);
+  process.nextTick(common.mustNotCall());
 });

--- a/test/parallel/test-pipe-address.js
+++ b/test/parallel/test-pipe-address.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const net = require('net');
-const server = net.createServer(common.fail);
+const server = net.createServer(common.mustNotCall());
 
 common.refreshTmpDir();
 

--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -8,4 +8,4 @@ const s = net.Server();
 s.listen(common.PIPE);
 s.unref();
 
-setTimeout(common.fail, 1000).unref();
+setTimeout(common.mustNotCall(), 1000).unref();

--- a/test/parallel/test-process-exit-from-before-exit.js
+++ b/test/parallel/test-process-exit-from-before-exit.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 
 process.on('beforeExit', common.mustCall(function() {
-  setTimeout(common.fail, 5);
+  setTimeout(common.mustNotCall(), 5);
   process.exit(0);  // Should execute immediately even if we schedule new work.
   common.fail();
 }));

--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -16,15 +16,15 @@ net.Server().listen(common.PORT, function() {
 
 // The first argument is a configuration object
 assert.throws(() => {
-  net.Server().listen({ port: invalidPort }, common.fail);
+  net.Server().listen({ port: invalidPort }, common.mustNotCall());
 }, errorMessage);
 
 // The first argument is the port, no IP given.
 assert.throws(() => {
-  net.Server().listen(invalidPort, common.fail);
+  net.Server().listen(invalidPort, common.mustNotCall());
 }, errorMessage);
 
 // The first argument is the port, the second an IP.
 assert.throws(() => {
-  net.Server().listen(invalidPort, '0.0.0.0', common.fail);
+  net.Server().listen(invalidPort, '0.0.0.0', common.mustNotCall());
 }, errorMessage);

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -11,7 +11,7 @@ const testMe = repl.start('', putIn, function(cmd, context, filename,
   callback(null, cmd);
 });
 
-testMe._domain.on('error', common.fail);
+testMe._domain.on('error', common.mustNotCall());
 
 testMe.complete('', function(err, results) {
   assert.strictEqual(err, null);

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -29,7 +29,7 @@ setInterval(function() {
 
 // Test on condition where a watcher for SIGNAL
 // has been previously registered, and `process.listeners(SIGNAL).length === 1`
-process.on('SIGHUP', function() { common.fail('should not run'); });
+process.on('SIGHUP', common.mustNotCall());
 process.removeAllListeners('SIGHUP');
 process.on('SIGHUP', common.mustCall(function() {}));
 process.kill(process.pid, 'SIGHUP');

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -25,7 +25,7 @@ source.unpipe(dest2);
 assert.strictEqual(source._readableState.pipes, dest1);
 assert.notStrictEqual(source._readableState.pipes, dest2);
 
-dest2.on('unpipe', common.fail);
+dest2.on('unpipe', common.mustNotCall());
 source.unpipe(dest2);
 
 source.unpipe(dest1);

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -11,7 +11,7 @@ const Readable = require('stream').Readable;
     highWaterMark: 3
   });
 
-  r._read = common.fail;
+  r._read = common.mustNotCall();
 
   // This triggers a 'readable' event, which is lost.
   r.push(Buffer.from('blerg'));
@@ -50,7 +50,7 @@ const Readable = require('stream').Readable;
     highWaterMark: 30
   });
 
-  r._read = common.fail;
+  r._read = common.mustNotCall();
 
   // This triggers a 'readable' event, which is lost.
   r.push(Buffer.from('blerg'));

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -38,9 +38,7 @@ function test(decode, uncork, multi, next) {
   }
 
   const w = new stream.Writable({ decodeStrings: decode });
-  w._write = function(chunk, e, cb) {
-    common.fail('Should not call _write');
-  };
+  w._write = common.mustNotCall('Should not call _write');
 
   const expectChunks = decode ? [
     { encoding: 'buffer',

--- a/test/parallel/test-timer-close.js
+++ b/test/parallel/test-timer-close.js
@@ -8,4 +8,4 @@ const Timer = process.binding('timer_wrap').Timer;
 const t = new Timer();
 
 t.close(common.mustCall(function() {}));
-t.close(() => common.fail('This should never be called'));
+t.close(common.mustNotCall());

--- a/test/parallel/test-timers-immediate.js
+++ b/test/parallel/test-timers-immediate.js
@@ -12,9 +12,7 @@ setImmediate(common.mustCall(function() {
   clearImmediate(immediateB);
 }));
 
-const immediateB = setImmediate(function() {
-  common.fail('this immediate should not run');
-});
+const immediateB = setImmediate(common.mustNotCall());
 
 setImmediate(function(x, y, z) {
   immediateC = [x, y, z];

--- a/test/parallel/test-timers-regress-GH-9765.js
+++ b/test/parallel/test-timers-regress-GH-9765.js
@@ -14,10 +14,6 @@ setImmediate(common.mustCall(function() {
   clearImmediate(i3);
 }));
 
-const i2 = setImmediate(function() {
-  common.fail('immediate callback should not have fired');
-});
+const i2 = setImmediate(common.mustNotCall());
 
-const i3 = setImmediate(function() {
-  common.fail('immediate callback should not have fired');
-});
+const i3 = setImmediate(common.mustNotCall());

--- a/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
+++ b/test/parallel/test-timers-same-timeout-wrong-list-deleted.js
@@ -22,9 +22,7 @@ const handle1 = setTimeout(common.mustCall(function() {
   clearTimeout(handle1);
 
   // Cause a new list with the same key (TIMEOUT) to be created for this timer
-  const handle2 = setTimeout(function() {
-    common.fail('Inner callback is not called');
-  }, TIMEOUT);
+  const handle2 = setTimeout(common.mustNotCall(), TIMEOUT);
 
   setTimeout(common.mustCall(function() {
     // Attempt to cancel the second timer. Fix for this bug will keep the

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -10,7 +10,7 @@ const common = require('../common');
 const timers = require('timers');
 
 const foo = {
-  _onTimeout: common.fail
+  _onTimeout: common.mustNotCall('_onTimeout should not be called')
 };
 
 const bar = {

--- a/test/parallel/test-tls-cipher-list.js
+++ b/test/parallel/test-tls-cipher-list.js
@@ -17,12 +17,12 @@ function doCheck(arg, check) {
     'require("crypto").constants.defaultCipherList'
   ]);
   spawn(process.execPath, arg, {})
-    .on('error', common.fail)
+    .on('error', common.mustNotCall())
     .stdout.on('data', function(chunk) {
       out += chunk;
     }).on('end', function() {
       assert.strictEqual(out.trim(), check);
-    }).on('error', common.fail);
+    }).on('error', common.mustNotCall());
 }
 
 // test the default unmodified version

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -14,7 +14,7 @@ const path = require('path');
 const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-const conn = tls.connect({cert, key, port: common.PORT}, common.fail);
+const conn = tls.connect({cert, key, port: common.PORT}, common.mustNotCall());
 conn.on('error', function() {
 });
 assert.doesNotThrow(function() {

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -8,7 +8,7 @@ if (!common.hasCrypto) {
 }
 const tls = require('tls');
 
-const conn = tls.connect(common.PORT, common.fail);
+const conn = tls.connect(common.PORT, common.mustNotCall());
 conn.on('error', common.mustCall(function() {
   assert.doesNotThrow(function() {
     conn.destroy();

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -75,7 +75,7 @@ function testDHE2048() {
 
 testDHE1024();
 
-assert.throws(() => test(512, true, common.fail),
+assert.throws(() => test(512, true, common.mustNotCall()),
               /DH parameter is less than 1024 bits/);
 
 [0, -1, -Infinity, NaN].forEach((minDHSize) => {

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -35,14 +35,14 @@ function unauthorized() {
     socket.end();
     rejectUnauthorized();
   }));
-  socket.on('error', common.fail);
+  socket.on('error', common.mustNotCall());
   socket.write('ok');
 }
 
 function rejectUnauthorized() {
   const socket = tls.connect(server.address().port, {
     servername: 'localhost'
-  }, common.fail);
+  }, common.mustNotCall());
   socket.on('error', common.mustCall(function(err) {
     console.error(err);
     authorized();
@@ -59,6 +59,6 @@ function authorized() {
     socket.end();
     server.close();
   }));
-  socket.on('error', common.fail);
+  socket.on('error', common.mustNotCall());
   socket.write('ok');
 }

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -16,7 +16,7 @@ const server = tls.createServer({
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 }, function(c) {
 }).listen(0, common.mustCall(function() {
-  const c = tls.connect(this.address().port, common.fail);
+  const c = tls.connect(this.address().port, common.mustNotCall());
 
   c.on('error', common.mustCall(function(err) {}));
 

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -17,7 +17,7 @@ const path = require('path');
   const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
   const options = {cert: cert, key: key, port: common.PORT};
-  const conn = tls.connect(options, common.fail);
+  const conn = tls.connect(options, common.mustNotCall());
 
   conn.on('error', common.mustCall(function() {}));
 }
@@ -32,7 +32,7 @@ const path = require('path');
     key: key,
     port: common.PORT,
     ciphers: 'rick-128-roll'
-  }, common.fail);
+  }, common.mustNotCall());
 
   conn.on('error', common.mustCall(function() {}));
 }

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -18,7 +18,7 @@ const options = {
   ecdhCurve: false
 };
 
-const server = tls.createServer(options, common.fail);
+const server = tls.createServer(options, common.mustNotCall());
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
   let cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -33,9 +33,7 @@ const server = tls.createServer(options, (c) => {
     port: server.address().port,
     rejectUnauthorized: false,
     servername: 'any.name'
-  }, () => {
-    common.fail('Should not be called');
-  });
+  }, common.mustNotCall());
 
   c.on('error', common.mustCall((err) => {
     assert(/socket hang up/.test(err.message));

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -20,7 +20,7 @@ const server = tls.createServer({
   const c = tls.connect({
     port: this.address().port,
     ciphers: 'RC4'
-  }, common.fail);
+  }, common.mustNotCall());
 
   c.on('error', common.mustCall(function(err) {
     assert.notStrictEqual(err.code, 'ECONNRESET');

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -15,7 +15,7 @@ const options = {
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
 };
 
-const server = tls.createServer(options, common.fail);
+const server = tls.createServer(options, common.mustNotCall());
 
 server.listen(0, common.mustCall(function() {
   const c = net.createConnection(this.address().port);

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -18,7 +18,7 @@ if (common.opensslCli === false) {
 
 const cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');
 const key = fs.readFileSync(common.fixturesDir + '/test_key.pem');
-const server = tls.createServer({ cert: cert, key: key }, common.fail);
+const server = tls.createServer({ cert: cert, key: key }, common.mustNotCall());
 const errors = [];
 let stderr = '';
 

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -16,7 +16,7 @@ const options = {
   handshakeTimeout: 50
 };
 
-const server = tls.createServer(options, common.fail);
+const server = tls.createServer(options, common.mustNotCall());
 
 server.on('tlsClientError', common.mustCall(function(err, conn) {
   conn.destroy();

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -38,5 +38,5 @@ const server = tls.createServer({
   // treated as error.
   conn.end('');
 
-  conn.on('error', common.fail);
+  conn.on('error', common.mustNotCall());
 }));

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -76,7 +76,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 const script = common.fixturesDir + '/vm-run-in-debug-context.js';
 let proc = spawn(process.execPath, [script]);
 const data = [];
-proc.stdout.on('data', common.fail);
+proc.stdout.on('data', common.mustNotCall());
 proc.stderr.on('data', data.push.bind(data));
 proc.stderr.once('end', common.mustCall(function() {
   const haystack = Buffer.concat(data).toString('utf8');
@@ -88,8 +88,8 @@ proc.once('exit', common.mustCall(function(exitCode, signalCode) {
 }));
 
 proc = spawn(process.execPath, [script, 'handle-fatal-exception']);
-proc.stdout.on('data', common.fail);
-proc.stderr.on('data', common.fail);
+proc.stdout.on('data', common.mustNotCall());
+proc.stderr.on('data', common.mustNotCall());
 proc.once('exit', common.mustCall(function(exitCode, signalCode) {
   assert.strictEqual(exitCode, 42);
   assert.strictEqual(signalCode, null);

--- a/test/parallel/test-zerolengthbufferbug.js
+++ b/test/parallel/test-zerolengthbufferbug.js
@@ -15,7 +15,7 @@ const server = http.createServer(function(req, res) {
 server.listen(0, common.mustCall(function() {
   http.get({ port: this.address().port }, common.mustCall(function(res) {
 
-    res.on('data', common.fail);
+    res.on('data', common.mustNotCall());
 
     res.on('end', function(d) {
       server.close();

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -97,9 +97,9 @@ assert.doesNotThrow(
         fs.unwatchFile(filenameThree, b);
         ++watchSeenThree;
       }
-      fs.watchFile(filenameThree, common.fail);
+      fs.watchFile(filenameThree, common.mustNotCall());
       fs.watchFile(filenameThree, b);
-      fs.unwatchFile(filenameThree, common.fail);
+      fs.unwatchFile(filenameThree, common.mustNotCall());
     }
 );
 

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -18,7 +18,7 @@ try { fs.mkdirSync(testsubdir, 0o700); } catch (e) {}
 
 // Need a grace period, else the mkdirSync() above fires off an event.
 setTimeout(function() {
-  const watcher = fs.watch(testDir, { persistent: true }, common.fail);
+  const watcher = fs.watch(testDir, { persistent: true }, common.mustNotCall());
   setTimeout(function() {
     fs.writeFileSync(filepath, 'test');
   }, 100);

--- a/test/pummel/test-net-timeout2.js
+++ b/test/pummel/test-net-timeout2.js
@@ -9,7 +9,7 @@ const seconds = 5;
 let counter = 0;
 
 const server = net.createServer(function(socket) {
-  socket.setTimeout((seconds / 2) * 1000, common.fail);
+  socket.setTimeout((seconds / 2) * 1000, common.mustNotCall());
 
   const interval = setInterval(function() {
     counter++;

--- a/test/sequential/test-child-process-emfile.js
+++ b/test/sequential/test-child-process-emfile.js
@@ -43,9 +43,7 @@ proc.on('error', common.mustCall(function(err) {
   assert.strictEqual(err.code, 'EMFILE');
 }));
 
-proc.on('exit', function() {
-  common.fail('"exit" should not be emitted (the process never spawned!)');
-});
+proc.on('exit', common.mustNotCall('"exit" event should not be emitted'));
 
 // close one fd for LSan
 if (openFds.length >= 1) {

--- a/test/sequential/test-http-server-consumed-timeout.js
+++ b/test/sequential/test-http-server-consumed-timeout.js
@@ -9,9 +9,8 @@ const server = http.createServer((req, res) => {
   res.writeHead(200);
   res.flushHeaders();
 
-  req.setTimeout(common.platformTimeout(200), () => {
-    common.fail('Request timeout should not fire');
-  });
+  req.setTimeout(common.platformTimeout(200),
+                 common.mustNotCall('Request timeout should not fire'));
   req.resume();
   req.once('end', common.mustCall(() => {
     res.end();

--- a/test/sequential/test-net-server-address.js
+++ b/test/sequential/test-net-server-address.js
@@ -7,7 +7,7 @@ const net = require('net');
 const family_ipv4 = 'IPv4';
 const server_ipv4 = net.createServer();
 
-server_ipv4.on('error', common.fail);
+server_ipv4.on('error', common.mustNotCall());
 
 server_ipv4
   .listen(common.PORT + 1, common.localhostIPv4, common.mustCall(() => {
@@ -28,7 +28,7 @@ const localhost_ipv6 = '::1';
 const family_ipv6 = 'IPv6';
 const server_ipv6 = net.createServer();
 
-server_ipv6.on('error', common.fail);
+server_ipv6.on('error', common.mustNotCall());
 
 server_ipv6.listen(common.PORT + 2, localhost_ipv6, common.mustCall(() => {
   const address_ipv6 = server_ipv6.address();
@@ -42,7 +42,7 @@ server_ipv6.listen(common.PORT + 2, localhost_ipv6, common.mustCall(() => {
 const anycast_ipv6 = '::';
 const server1 = net.createServer();
 
-server1.on('error', common.fail);
+server1.on('error', common.mustNotCall());
 
 // Specify the port number
 server1.listen(common.PORT + 3, common.mustCall(() => {
@@ -56,7 +56,7 @@ server1.listen(common.PORT + 3, common.mustCall(() => {
 // Test without hostname or port
 const server2 = net.createServer();
 
-server2.on('error', common.fail);
+server2.on('error', common.mustNotCall());
 
 // Don't specify the port number
 server2.listen(common.mustCall(() => {
@@ -69,7 +69,7 @@ server2.listen(common.mustCall(() => {
 // Test without hostname, but with a false-y port
 const server3 = net.createServer();
 
-server3.on('error', common.fail);
+server3.on('error', common.mustNotCall());
 
 // Specify a false-y port number
 server3.listen(0, common.mustCall(() => {


### PR DESCRIPTION
This commit adds a `mustNotCall()` helper for testing. This provides an alternative to using `common.fail()` as a callback, or creating a callback function for the sole purpose of calling `common.fail()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
