### PR TITLE
test: fix test.py command line options processing

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1399,7 +1399,7 @@ def BuildOptions():
       default=1, type="int")
   result.add_option('--abort-on-timeout',
       help='Send SIGABRT instead of SIGTERM to kill processes that time out',
-      default=False, dest="abort_on_timeout")
+      default=False, action="store_true", dest="abort_on_timeout")
   return result
 
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/11086 had introduced a regression
that broke command line options processing for tools/test.py.

Basically, it made tools/test.py discard the command line argument that
would be passed after `--abort-on-timeout`. For instance, when running:

```
$ python tools/test.py --abort-on-timeout path/to/some-test
```

all tests would be run because the last command line argument
(`/path/to/some-test`) would be discarded.

This change fixes this regression.

Refs: https://github.com/nodejs/node/pull/11086

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test