### PR TITLE
net: use actual Timeout instances on Sockets

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const async_wrap = process.binding('async_wrap');
+// Two arrays that share state between C++ and JS.
+const { async_hook_fields, async_id_fields } = async_wrap;
+const {
+  initTriggerId,
+  // The needed emit*() functions.
+  emitInit
+} = require('internal/async_hooks');
+// Grab the constants necessary for working with internal arrays.
+const { kInit, kAsyncIdCounter } = async_wrap.constants;
+// Symbols for storing async id state.
+const async_id_symbol = Symbol('asyncId');
+const trigger_async_id_symbol = Symbol('triggerId');
+
+const errors = require('internal/errors');
+
+// Timeout values > TIMEOUT_MAX are set to 1.
+const TIMEOUT_MAX = 2147483647; // 2^31-1
+
+module.exports = {
+  TIMEOUT_MAX,
+  kTimeout: Symbol('timeout'), // For hiding Timeouts on other internals.
+  async_id_symbol,
+  trigger_async_id_symbol,
+  Timeout,
+  setUnrefTimeout,
+};
+
+// Timer constructor function.
+// The entire prototype is defined in lib/timers.js
+function Timeout(after, callback, args) {
+  this._called = false;
+  this._idleTimeout = after;
+  this._idlePrev = this;
+  this._idleNext = this;
+  this._idleStart = null;
+  this._onTimeout = callback;
+  this._timerArgs = args;
+  this._repeat = null;
+  this._destroyed = false;
+  this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
+  this[trigger_async_id_symbol] = initTriggerId();
+  if (async_hook_fields[kInit] > 0)
+    emitInit(
+      this[async_id_symbol], 'Timeout', this[trigger_async_id_symbol], this
+    );
+}
+
+var timers;
+function getTimers() {
+  if (timers === undefined) {
+    timers = require('timers');
+  }
+  return timers;
+}
+
+function setUnrefTimeout(callback, after) {
+  // Type checking identical to setTimeout()
+  if (typeof callback !== 'function') {
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
+  }
+
+  after *= 1; // coalesce to number or NaN
+  if (!(after >= 1 && after <= TIMEOUT_MAX)) {
+    if (after > TIMEOUT_MAX) {
+      process.emitWarning(`${after} does not fit into` +
+                          ' a 32-bit signed integer.' +
+                          '\nTimeout duration was set to 1.',
+                          'TimeoutOverflowWarning');
+    }
+    after = 1; // schedule on next tick, follows browser behavior
+  }
+
+  const timer = new Timeout(after, callback, null);
+  if (process.domain)
+    timer.domain = process.domain;
+
+  getTimers()._unrefActive(timer);
+
+  return timer;
+}

--- a/lib/net.js
+++ b/lib/net.js
@@ -55,6 +55,8 @@ var cluster = null;
 const errnoException = util._errnoException;
 const exceptionWithHostPort = util._exceptionWithHostPort;
 
+const { kTimeout, TIMEOUT_MAX, setUnrefTimeout } = require('internal/timers');
+
 function noop() {}
 
 function createHandle(fd) {
@@ -188,6 +190,7 @@ function Socket(options) {
   this._handle = null;
   this._parent = null;
   this._host = null;
+  this[kTimeout] = null;
 
   if (typeof options === 'number')
     options = { fd: options }; // Legacy interface.
@@ -259,9 +262,12 @@ function Socket(options) {
 }
 util.inherits(Socket, stream.Duplex);
 
+// Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
-  for (var s = this; s !== null; s = s._parent)
-    timers._unrefActive(s);
+  for (var s = this; s !== null; s = s._parent) {
+    if (s[kTimeout])
+      timers._unrefActive(s[kTimeout]);
+  }
 };
 
 // the user has called .end(), and all the bytes have been
@@ -380,14 +386,36 @@ Socket.prototype.listen = function() {
 
 
 Socket.prototype.setTimeout = function(msecs, callback) {
+  // Type checking identical to timers.enroll()
+  if (typeof msecs !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'msecs',
+                               'number', msecs);
+  }
+
+  if (msecs < 0 || !isFinite(msecs)) {
+    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE', 'msecs',
+                                'a non-negative finite number', msecs);
+  }
+
+  // Ensure that msecs fits into signed int32
+  if (msecs > TIMEOUT_MAX) {
+    process.emitWarning(`${msecs} does not fit into a 32-bit signed integer.` +
+                        `\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
+                        'TimeoutOverflowWarning');
+    msecs = TIMEOUT_MAX;
+  }
+
   if (msecs === 0) {
-    timers.unenroll(this);
+    clearTimeout(this[kTimeout]);
+
     if (callback) {
       this.removeListener('timeout', callback);
     }
   } else {
-    timers.enroll(this, msecs);
-    timers._unrefActive(this);
+    this[kTimeout] = setUnrefTimeout(() => {
+      this._onTimeout();
+    }, msecs);
+
     if (callback) {
       this.once('timeout', callback);
     }
@@ -542,8 +570,9 @@ Socket.prototype._destroy = function(exception, cb) {
 
   this.readable = this.writable = false;
 
-  for (var s = this; s !== null; s = s._parent)
-    timers.unenroll(s);
+  for (var s = this; s !== null; s = s._parent) {
+    clearTimeout(s[kTimeout]);
+  }
 
   debug('close');
   if (this._handle) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -24,6 +24,7 @@
 const async_wrap = process.binding('async_wrap');
 const TimerWrap = process.binding('timer_wrap').Timer;
 const L = require('internal/linkedlist');
+const timerInternals = require('internal/timers');
 const internalUtil = require('internal/util');
 const { createPromise, promiseResolve } = process.binding('util');
 const assert = require('assert');
@@ -44,8 +45,8 @@ const {
 // Grab the constants necessary for working with internal arrays.
 const { kInit, kDestroy, kAsyncIdCounter } = async_wrap.constants;
 // Symbols for storing async id state.
-const async_id_symbol = Symbol('asyncId');
-const trigger_async_id_symbol = Symbol('triggerAsyncId');
+const async_id_symbol = timerInternals.async_id_symbol;
+const trigger_async_id_symbol = timerInternals.trigger_async_id_symbol;
 
 /* This is an Uint32Array for easier sharing with C++ land. */
 const scheduledImmediateCount = process._scheduledImmediateCount;
@@ -55,7 +56,10 @@ const activateImmediateCheck = process._activateImmediateCheck;
 delete process._activateImmediateCheck;
 
 // Timeout values > TIMEOUT_MAX are set to 1.
-const TIMEOUT_MAX = 2147483647; // 2^31-1
+const TIMEOUT_MAX = timerInternals.TIMEOUT_MAX; // 2^31-1
+
+// The Timeout class
+const Timeout = timerInternals.Timeout;
 
 
 // HOW and WHY the timers implementation works the way it does.
@@ -578,25 +582,6 @@ exports.clearInterval = function(timer) {
     clearTimeout(timer);
   }
 };
-
-
-function Timeout(after, callback, args) {
-  this._called = false;
-  this._idleTimeout = after;
-  this._idlePrev = this;
-  this._idleNext = this;
-  this._idleStart = null;
-  this._onTimeout = callback;
-  this._timerArgs = args;
-  this._repeat = null;
-  this._destroyed = false;
-  this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
-  this[trigger_async_id_symbol] = initTriggerId();
-  if (async_hook_fields[kInit] > 0)
-    emitInit(
-      this[async_id_symbol], 'Timeout', this[trigger_async_id_symbol], this
-    );
-}
 
 
 function unrefdHandle() {

--- a/node.gyp
+++ b/node.gyp
@@ -123,6 +123,7 @@
       'lib/internal/repl/await.js',
       'lib/internal/socket_list.js',
       'lib/internal/test/unicode.js',
+      'lib/internal/timers.js',
       'lib/internal/tls.js',
       'lib/internal/trace_events_async_hooks.js',
       'lib/internal/url.js',

--- a/test/parallel/test-http-client-timeout-on-connect.js
+++ b/test/parallel/test-http-client-timeout-on-connect.js
@@ -1,7 +1,11 @@
+// Flags: --expose-internals
+
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
+const { kTimeout } = require('internal/timers');
 
 const server = http.createServer((req, res) => {
   // This space is intentionally left blank.
@@ -13,9 +17,9 @@ server.listen(0, common.localhostIPv4, common.mustCall(() => {
 
   req.setTimeout(1);
   req.on('socket', common.mustCall((socket) => {
-    assert.strictEqual(socket._idleTimeout, undefined);
+    assert.strictEqual(socket[kTimeout], null);
     socket.on('connect', common.mustCall(() => {
-      assert.strictEqual(socket._idleTimeout, 1);
+      assert.strictEqual(socket[kTimeout]._idleTimeout, 1);
     }));
   }));
   req.on('timeout', common.mustCall(() => req.abort()));

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -36,13 +36,13 @@ const validDelays = [0, 0.001, 1, 1e6];
 for (let i = 0; i < nonNumericDelays.length; i++) {
   assert.throws(function() {
     s.setTimeout(nonNumericDelays[i], () => {});
-  }, TypeError);
+  }, TypeError, nonNumericDelays[i]);
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
   assert.throws(function() {
     s.setTimeout(badRangeDelays[i], () => {});
-  }, RangeError);
+  }, RangeError, badRangeDelays[i]);
 }
 
 for (let i = 0; i < validDelays.length; i++) {

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -1,5 +1,8 @@
+// Flags: --expose_internals
+
 'use strict';
 const common = require('../common');
+const { kTimeout, TIMEOUT_MAX } = require('internal/timers');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -30,13 +33,13 @@ let lastIdleStart;
 
 server.listen(0, () => {
   socket = net.connect(server.address().port, function() {
-    const s = socket.setTimeout(Number.MAX_VALUE, function() {
+    const s = socket.setTimeout(TIMEOUT_MAX, function() {
       throw new Error('timeout');
     });
     assert.ok(s instanceof net.Socket);
 
-    assert.notStrictEqual(socket._idleTimeout, -1);
-    lastIdleStart = socket._idleStart;
+    assert.notStrictEqual(socket[kTimeout]._idleTimeout, -1);
+    lastIdleStart = socket[kTimeout]._idleStart;
 
     const tsocket = tls.connect({
       socket: socket,
@@ -47,6 +50,6 @@ server.listen(0, () => {
 });
 
 process.on('exit', () => {
-  assert.strictEqual(socket._idleTimeout, -1);
-  assert(lastIdleStart < socket._idleStart);
+  assert.strictEqual(socket[kTimeout]._idleTimeout, -1);
+  assert(lastIdleStart < socket[kTimeout]._idleStart);
 });

--- a/test/sequential/test-http-server-keep-alive-timeout-slow-client-headers.js
+++ b/test/sequential/test-http-server-keep-alive-timeout-slow-client-headers.js
@@ -26,6 +26,8 @@ server.listen(0, common.mustCall(() => {
     server.close();
   }));
 
+  server.on('clientError', (e) => console.error(e));
+
   function request(callback) {
     socket.setEncoding('utf8');
     socket.on('data', onData);
@@ -49,6 +51,7 @@ server.listen(0, common.mustCall(() => {
     }
 
     function onHeaders() {
+      console.log(require('util').inspect(response));
       assert.ok(response.includes('HTTP/1.1 200 OK\r\n'));
       assert.ok(response.includes('Connection: keep-alive\r\n'));
       callback();


### PR DESCRIPTION
This makes `net.Socket`s use actual `Timeout` objects in a `_timeout` property, rather than making the socket itself a timer and appending properties to it directly.

This should make the code generally easier to understand, and might also prevent some deopts from properties being changes on the socket itself.

It is possible this could effect performance either better or worse, but I highly doubt it would be a significant difference. I'll try to run benchmarks on it in the coming days, but if anyone else would like to that would also be appreciated.

This also exposes `timers.Timeout` so as to avoid a circular dependency with the new `lib/internal/timers.js`, but we might not want that so I should be able to refactor more of timers into the internals file if necessary. Tagging as `semver-minor` for now due to this. I could also split that into separate commits.

_Made live on https://twitch.tv/nodesource_

CI: https://ci.nodejs.org/job/node-test-pull-request/6202/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net, timers