### PR TITLE
tools: enable no-else-return ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -34,6 +34,7 @@ rules:
   # Best Practices
   # http://eslint.org/docs/rules/#best-practices
   dot-location: [2, property]
+  no-else-return: 2
   no-fallthrough: 2
   no-global-assign: 2
   no-multi-spaces: 2

--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -35,9 +35,8 @@ AutocannonBenchmarker.prototype.processResults = function(output) {
   }
   if (!result || !result.requests || !result.requests.average) {
     return undefined;
-  } else {
-    return result.requests.average;
   }
+  return result.requests.average;
 };
 
 function WrkBenchmarker() {
@@ -63,9 +62,8 @@ WrkBenchmarker.prototype.processResults = function(output) {
   const result = match && +match[1];
   if (!isFinite(result)) {
     return undefined;
-  } else {
-    return result;
   }
+  return result;
 };
 
 const http_benchmarkers = [new WrkBenchmarker(), new AutocannonBenchmarker()];

--- a/benchmark/scatter.js
+++ b/benchmark/scatter.js
@@ -33,9 +33,8 @@ let printHeader = true;
 function csvEncodeValue(value) {
   if (typeof value === 'number') {
     return value.toString();
-  } else {
-    return '"' + value.replace(/"/g, '""') + '"';
   }
+  return '"' + value.replace(/"/g, '""') + '"';
 }
 
 (function recursive(i) {

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -101,8 +101,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
 
   if (typeof skipBody !== 'number')
     return skipBody ? 1 : 0;
-  else
-    return skipBody;
+  return skipBody;
 }
 
 // XXX This is a mess.

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -18,18 +18,17 @@ function prependListener(emitter, event, fn) {
   // event emitter implementation with them.
   if (typeof emitter.prependListener === 'function') {
     return emitter.prependListener(event, fn);
-  } else {
-    // This is a hack to make sure that our error handler is attached before any
-    // userland ones.  NEVER DO THIS. This is here only because this code needs
-    // to continue to work with older versions of Node.js that do not include
-    // the prependListener() method. The goal is to eventually remove this hack.
-    if (!emitter._events || !emitter._events[event])
-      emitter.on(event, fn);
-    else if (Array.isArray(emitter._events[event]))
-      emitter._events[event].unshift(fn);
-    else
-      emitter._events[event] = [fn, emitter._events[event]];
   }
+  // This is a hack to make sure that our error handler is attached before any
+  // userland ones.  NEVER DO THIS. This is here only because this code needs
+  // to continue to work with older versions of Node.js that do not include
+  // the prependListener() method. The goal is to eventually remove this hack.
+  if (!emitter._events || !emitter._events[event])
+    emitter.on(event, fn);
+  else if (Array.isArray(emitter._events[event]))
+    emitter._events[event].unshift(fn);
+  else
+    emitter._events[event] = [fn, emitter._events[event]];
 }
 
 function ReadableState(options, stream) {
@@ -251,8 +250,7 @@ function howMuchToRead(n, state) {
     // Only flow one buffer at a time
     if (state.flowing && state.length)
       return state.buffer.head.data.length;
-    else
-      return state.length;
+    return state.length;
   }
   // If we're asking for more than the current hwm, then raise the hwm.
   if (n > state.highWaterMark)

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -386,9 +386,8 @@ CryptoStream.prototype.isSessionReused = function() {
 CryptoStream.prototype.getCipher = function(err) {
   if (this.pair.ssl) {
     return this.pair.ssl.getCurrentCipher();
-  } else {
-    return null;
   }
+  return null;
 };
 
 
@@ -490,9 +489,8 @@ Object.defineProperty(CryptoStream.prototype, 'readyState', {
       return 'readOnly';
     } else if (!this.readable && this.writable) {
       return 'writeOnly';
-    } else {
-      return 'closed';
     }
+    return 'closed';
   }
 });
 
@@ -521,9 +519,8 @@ util.inherits(CleartextStream, CryptoStream);
 CleartextStream.prototype._internallyPendingBytes = function() {
   if (this.pair.ssl) {
     return this.pair.ssl.clearPending();
-  } else {
-    return 0;
   }
+  return 0;
 };
 
 
@@ -581,9 +578,8 @@ util.inherits(EncryptedStream, CryptoStream);
 EncryptedStream.prototype._internallyPendingBytes = function() {
   if (this.pair.ssl) {
     return this.pair.ssl.encPending();
-  } else {
-    return 0;
   }
+  return 0;
 };
 
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -115,12 +115,11 @@ function requestOCSP(self, hello, ctx, cb) {
 
   if (self.server.listenerCount('OCSPRequest') === 0) {
     return cb(null);
-  } else {
-    self.server.emit('OCSPRequest',
-                     ctx.getCertificate(),
-                     ctx.getIssuer(),
-                     onOCSP);
   }
+  self.server.emit('OCSPRequest',
+                   ctx.getCertificate(),
+                   ctx.getIssuer(),
+                   onOCSP);
 
   var once = false;
   function onOCSP(err, response) {
@@ -655,9 +654,8 @@ TLSSocket.prototype.isSessionReused = function() {
 TLSSocket.prototype.getCipher = function(err) {
   if (this._handle) {
     return this._handle.getCurrentCipher();
-  } else {
-    return null;
   }
+  return null;
 };
 
 TLSSocket.prototype.getEphemeralKeyInfo = function() {
@@ -1090,9 +1088,8 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
       if (options.rejectUnauthorized) {
         socket.destroy(verifyError);
         return;
-      } else {
-        socket.emit('secureConnect');
       }
+      socket.emit('secureConnect');
     } else {
       socket.authorized = true;
       socket.emit('secureConnect');

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -195,21 +195,20 @@ function _deepEqual(actual, expected, strict, memos) {
   // (although not necessarily the same order), equivalent values for every
   // corresponding key, and an identical 'prototype' property. Note: this
   // accounts for both named and indexed properties on Arrays.
-  } else {
-    memos = memos || {actual: [], expected: []};
-
-    const actualIndex = memos.actual.indexOf(actual);
-    if (actualIndex !== -1) {
-      if (actualIndex === memos.expected.indexOf(expected)) {
-        return true;
-      }
-    }
-
-    memos.actual.push(actual);
-    memos.expected.push(expected);
-
-    return objEquiv(actual, expected, strict, memos);
   }
+  memos = memos || {actual: [], expected: []};
+
+  const actualIndex = memos.actual.indexOf(actual);
+  if (actualIndex !== -1) {
+    if (actualIndex === memos.expected.indexOf(expected)) {
+      return true;
+    }
+  }
+
+  memos.actual.push(actual);
+  memos.expected.push(expected);
+
+  return objEquiv(actual, expected, strict, memos);
 }
 
 function isArguments(object) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -191,9 +191,8 @@ function allocate(size) {
     poolOffset += size;
     alignPool();
     return b;
-  } else {
-    return createUnsafeBuffer(size);
   }
+  return createUnsafeBuffer(size);
 }
 
 
@@ -817,9 +816,8 @@ Buffer.prototype.toJSON = function() {
     for (var i = 0; i < this.length; ++i)
       data[i] = this[i];
     return { type: 'Buffer', data };
-  } else {
-    return { type: 'Buffer', data: [] };
   }
+  return { type: 'Buffer', data: [] };
 };
 
 
@@ -832,9 +830,8 @@ function adjustOffset(offset, length) {
   } else if (offset < 0) {
     offset += length;
     return offset > 0 ? offset : 0;
-  } else {
-    return offset < length ? offset : length;
   }
+  return offset < length ? offset : length;
 }
 
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -278,9 +278,8 @@ exports.resolve = function resolve(hostname, type_, callback_) {
 
   if (typeof resolver === 'function') {
     return resolver(hostname, callback);
-  } else {
-    throw new Error(`Unknown type "${type_}"`);
   }
+  throw new Error(`Unknown type "${type_}"`);
 };
 
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -358,9 +358,8 @@ EventEmitter.prototype.removeListener =
           if (--this._eventsCount === 0) {
             this._events = new EventHandlers();
             return this;
-          } else {
-            delete events[type];
           }
+          delete events[type];
         } else if (position === 0) {
           list.shift();
         } else {
@@ -447,9 +446,8 @@ EventEmitter.prototype.listeners = function listeners(type) {
 EventEmitter.listenerCount = function(emitter, type) {
   if (typeof emitter.listenerCount === 'function') {
     return emitter.listenerCount(type);
-  } else {
-    return listenerCount.call(emitter, type);
   }
+  return listenerCount.call(emitter, type);
 };
 
 EventEmitter.prototype.listenerCount = listenerCount;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -899,10 +899,9 @@ function preprocessSymlinkDestination(path, type, linkPath) {
     // A relative target is relative to the link's parent directory.
     path = pathModule.resolve(linkPath, '..', path);
     return pathModule._makeLong(path);
-  } else {
-    // Windows symlinks don't tolerate forward slashes.
-    return ('' + path).replace(/\//g, '\\');
   }
+  // Windows symlinks don't tolerate forward slashes.
+  return ('' + path).replace(/\//g, '\\');
 }
 
 fs.symlink = function(target, path, type_, callback_) {
@@ -1460,9 +1459,8 @@ function encodeRealpathResult(result, options) {
   const asBuffer = Buffer.from(result);
   if (options.encoding === 'buffer') {
     return asBuffer;
-  } else {
-    return asBuffer.toString(options.encoding);
   }
+  return asBuffer.toString(options.encoding);
 }
 
 fs.realpathSync = function realpathSync(p, options) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -699,9 +699,8 @@ class URLSearchParams {
       return `${this.constructor.name} {\n  ${output.join(',\n  ')} }`;
     } else if (output.length) {
       return `${this.constructor.name} { ${output.join(separator)} }`;
-    } else {
-      return `${this.constructor.name} {}`;
     }
+    return `${this.constructor.name} {}`;
   }
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -393,9 +393,8 @@ Object.defineProperty(Socket.prototype, 'readyState', {
       return 'readOnly';
     } else if (!this.readable && this.writable) {
       return 'writeOnly';
-    } else {
-      return 'closed';
     }
+    return 'closed';
   }
 });
 
@@ -1415,9 +1414,8 @@ Server.prototype.address = function() {
     return out;
   } else if (this._pipeName) {
     return this._pipeName;
-  } else {
-    return null;
   }
+  return null;
 };
 
 function onconnection(err, clientHandle) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -413,25 +413,20 @@ const win32 = {
       if (isAbsolute) {
         if (tail.length > 0)
           return '\\' + tail;
-        else
-          return '\\';
+        return '\\';
       } else if (tail.length > 0) {
         return tail;
-      } else {
-        return '';
       }
-    } else {
-      if (isAbsolute) {
-        if (tail.length > 0)
-          return device + '\\' + tail;
-        else
-          return device + '\\';
-      } else if (tail.length > 0) {
-        return device + tail;
-      } else {
-        return device;
-      }
+      return '';
     }
+    if (isAbsolute) {
+      if (tail.length > 0)
+        return device + '\\' + tail;
+      return device + '\\';
+    } else if (tail.length > 0) {
+      return device + tail;
+    }
+    return device;
   },
 
 
@@ -643,12 +638,11 @@ const win32 = {
     // the common path parts
     if (out.length > 0)
       return out + toOrig.slice(toStart + lastCommonSep, toEnd);
-    else {
-      toStart += lastCommonSep;
-      if (toOrig.charCodeAt(toStart) === 92/*\*/)
-        ++toStart;
-      return toOrig.slice(toStart, toEnd);
-    }
+
+    toStart += lastCommonSep;
+    if (toOrig.charCodeAt(toStart) === 92/*\*/)
+      ++toStart;
+    return toOrig.slice(toStart, toEnd);
   },
 
 
@@ -786,8 +780,7 @@ const win32 = {
     if (end === -1) {
       if (rootEnd === -1)
         return '.';
-      else
-        end = rootEnd;
+      end = rootEnd;
     }
     return path.slice(0, end);
   },
@@ -858,28 +851,27 @@ const win32 = {
       else if (end === -1)
         end = path.length;
       return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= start; --i) {
-        const code = path.charCodeAt(i);
-        if (code === 47/*/*/ || code === 92/*\*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
     }
+    for (i = path.length - 1; i >= start; --i) {
+      const code = path.charCodeAt(i);
+      if (code === 47/*/*/ || code === 92/*\*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1)
+      return '';
+    return path.slice(start, end);
   },
 
 
@@ -1163,13 +1155,11 @@ const posix = {
     if (resolvedAbsolute) {
       if (resolvedPath.length > 0)
         return '/' + resolvedPath;
-      else
-        return '/';
+      return '/';
     } else if (resolvedPath.length > 0) {
       return resolvedPath;
-    } else {
-      return '.';
     }
+    return '.';
   },
 
 
@@ -1306,12 +1296,11 @@ const posix = {
     // the common path parts
     if (out.length > 0)
       return out + to.slice(toStart + lastCommonSep);
-    else {
-      toStart += lastCommonSep;
-      if (to.charCodeAt(toStart) === 47/*/*/)
-        ++toStart;
-      return to.slice(toStart);
-    }
+
+    toStart += lastCommonSep;
+    if (to.charCodeAt(toStart) === 47/*/*/)
+      ++toStart;
+    return to.slice(toStart);
   },
 
 
@@ -1403,27 +1392,26 @@ const posix = {
       else if (end === -1)
         end = path.length;
       return path.slice(start, end);
-    } else {
-      for (i = path.length - 1; i >= 0; --i) {
-        if (path.charCodeAt(i) === 47/*/*/) {
-          // If we reached a path separator that was not part of a set of path
-          // separators at the end of the string, stop now
-          if (!matchedSlash) {
-            start = i + 1;
-            break;
-          }
-        } else if (end === -1) {
-          // We saw the first non-path separator, mark this as the end of our
-          // path component
-          matchedSlash = false;
-          end = i + 1;
-        }
-      }
-
-      if (end === -1)
-        return '';
-      return path.slice(start, end);
     }
+    for (i = path.length - 1; i >= 0; --i) {
+      if (path.charCodeAt(i) === 47/*/*/) {
+        // If we reached a path separator that was not part of a set of path
+        // separators at the end of the string, stop now
+        if (!matchedSlash) {
+          start = i + 1;
+          break;
+        }
+      } else if (end === -1) {
+        // We saw the first non-path separator, mark this as the end of our
+        // path component
+        matchedSlash = false;
+        end = i + 1;
+      }
+    }
+
+    if (end === -1)
+      return '';
+    return path.slice(start, end);
   },
 
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -556,9 +556,8 @@ function REPLServer(prompt,
           self.bufferedCommand += cmd + '\n';
           self.displayPrompt();
           return;
-        } else {
-          self._domain.emit('error', e.err || e);
         }
+        self._domain.emit('error', e.err || e);
       }
 
       // Clear buffer if no SyntaxErrors

--- a/lib/url.js
+++ b/lib/url.js
@@ -527,8 +527,9 @@ function autoEscapeStr(rest) {
   // There are ordinary characters at the end.
   if (lastEscapedPos < rest.length)
     return escaped + rest.slice(lastEscapedPos);
-  else  // The last character is escaped.
-    return escaped;
+
+  // The last character is escaped.
+  return escaped;
 }
 
 // format a parsed object into a url string

--- a/lib/util.js
+++ b/lib/util.js
@@ -207,9 +207,8 @@ function stylizeWithColor(str, styleType) {
   if (style) {
     return `\u001b[${inspect.colors[style][0]}m${str}` +
            `\u001b[${inspect.colors[style][1]}m`;
-  } else {
-    return str;
   }
+  return str;
 }
 
 
@@ -380,9 +379,8 @@ function formatValue(ctx, value, recurseTimes) {
     if (isDate(value)) {
       if (Number.isNaN(value.getTime())) {
         return ctx.stylize(value.toString(), 'date');
-      } else {
-        return ctx.stylize(Date.prototype.toISOString.call(value), 'date');
       }
+      return ctx.stylize(Date.prototype.toISOString.call(value), 'date');
     }
     if (isError(value)) {
       return formatError(value);
@@ -545,9 +543,8 @@ function formatValue(ctx, value, recurseTimes) {
   if (recurseTimes < 0) {
     if (isRegExp(value)) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
-    } else {
-      return ctx.stylize('[Object]', 'special');
     }
+    return ctx.stylize('[Object]', 'special');
   }
 
   ctx.seen.push(value);

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -19,18 +19,16 @@ const realRunInContext = Script.prototype.runInContext;
 Script.prototype.runInThisContext = function(options) {
   if (options && options.breakOnSigint && process._events.SIGINT) {
     return sigintHandlersWrap(realRunInThisContext, this, [options]);
-  } else {
-    return realRunInThisContext.call(this, options);
   }
+  return realRunInThisContext.call(this, options);
 };
 
 Script.prototype.runInContext = function(contextifiedSandbox, options) {
   if (options && options.breakOnSigint && process._events.SIGINT) {
     return sigintHandlersWrap(realRunInContext, this,
                               [contextifiedSandbox, options]);
-  } else {
-    return realRunInContext.call(this, contextifiedSandbox, options);
   }
+  return realRunInContext.call(this, contextifiedSandbox, options);
 };
 
 Script.prototype.runInNewContext = function(sandbox, options) {

--- a/test/common.js
+++ b/test/common.js
@@ -234,9 +234,8 @@ exports.ddCommand = function(filename, kilobytes) {
     const p = path.resolve(exports.fixturesDir, 'create-file.js');
     return '"' + process.argv[0] + '" "' + p + '" "' +
            filename + '" ' + (kilobytes * 1024);
-  } else {
-    return 'dd if=/dev/zero of="' + filename + '" bs=1024 count=' + kilobytes;
   }
+  return 'dd if=/dev/zero of="' + filename + '" bs=1024 count=' + kilobytes;
 };
 
 
@@ -245,9 +244,8 @@ exports.spawnCat = function(options) {
 
   if (exports.isWindows) {
     return spawn('more', [], options);
-  } else {
-    return spawn('cat', [], options);
   }
+  return spawn('cat', [], options);
 };
 
 
@@ -256,9 +254,8 @@ exports.spawnSyncCat = function(options) {
 
   if (exports.isWindows) {
     return spawnSync('more', [], options);
-  } else {
-    return spawnSync('cat', [], options);
   }
+  return spawnSync('cat', [], options);
 };
 
 
@@ -267,9 +264,8 @@ exports.spawnPwd = function(options) {
 
   if (exports.isWindows) {
     return spawn('cmd.exe', ['/d', '/c', 'cd'], options);
-  } else {
-    return spawn('pwd', [], options);
   }
+  return spawn('pwd', [], options);
 };
 
 
@@ -278,9 +274,8 @@ exports.spawnSyncPwd = function(options) {
 
   if (exports.isWindows) {
     return spawnSync('cmd.exe', ['/d', '/c', 'cd'], options);
-  } else {
-    return spawnSync('pwd', [], options);
   }
+  return spawnSync('pwd', [], options);
 };
 
 exports.platformTimeout = function(ms) {
@@ -560,9 +555,8 @@ exports.nodeProcessAborted = function nodeProcessAborted(exitCode, signal) {
   // the expected exit codes or signals.
   if (signal !== null) {
     return expectedSignals.includes(signal);
-  } else {
-    return expectedExitCodes.includes(exitCode);
   }
+  return expectedExitCodes.includes(exitCode);
 };
 
 exports.busyLoop = function busyLoop(time) {

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -332,11 +332,10 @@ Buffer.alloc(8, '');
           elseWasLast = false;
           ctr = ctr + 1;
           return 0;
-        } else {
-          elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
-          return -1;
         }
+        elseWasLast = true;
+        // Once buffer.js calls the C++ implemenation of fill, return -1
+        return -1;
       }
     };
     Buffer.alloc(1).fill(Buffer.alloc(1), start, 1);
@@ -365,11 +364,10 @@ assert.throws(() => {
           elseWasLast = false;
           ctr = ctr + 1;
           return 1;
-        } else {
-          elseWasLast = true;
-          // Once buffer.js calls the C++ implemenation of fill, return -1
-          return -1;
         }
+        elseWasLast = true;
+        // Once buffer.js calls the C++ implemenation of fill, return -1
+        return -1;
       }
     };
     Buffer.alloc(1).fill(Buffer.alloc(1), 0, end);

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -10,11 +10,10 @@ let tests_run = 0;
 function stat_resource(resource) {
   if (typeof resource === 'string') {
     return fs.statSync(resource);
-  } else {
-    // ensure mtime has been written to disk
-    fs.fsyncSync(resource);
-    return fs.fstatSync(resource);
   }
+  // ensure mtime has been written to disk
+  fs.fsyncSync(resource);
+  return fs.fstatSync(resource);
 }
 
 function check_mtime(resource, mtime) {

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -79,10 +79,9 @@ function pingPongTest(port, host) {
         assert.strictEqual(client.writable, false);
         assert.strictEqual(client.readable, true);
         return;
-      } else {
-        assert.strictEqual(client.writable, true);
-        assert.strictEqual(client.readable, true);
       }
+      assert.strictEqual(client.writable, true);
+      assert.strictEqual(client.readable, true);
 
       if (count < N) {
         client.write('PING');

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -30,9 +30,8 @@ if (common.isWindows) {
     if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
       common.skip('insufficient privileges');
       return;
-    } else {
-      test();
     }
+    test();
   });
 } else {
   test();

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -74,8 +74,7 @@ function test2() {
   r._read = function(n) {
     if (!reads--)
       return r.push(null); // EOF
-    else
-      return r.push(Buffer.from('x'));
+    return r.push(Buffer.from('x'));
   };
 
   const results = [];

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -67,9 +67,8 @@ function pingPongTest(port, host, on_complete) {
       if (sent_final_ping) {
         assert.strictEqual('readOnly', client.readyState);
         return;
-      } else {
-        assert.strictEqual('open', client.readyState);
       }
+      assert.strictEqual('open', client.readyState);
 
       if (count < N) {
         client.write('PING');

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -294,10 +294,9 @@ function linkManPages(text) {
     if (BSD_ONLY_SYSCALLS.has(name)) {
       return ' <a href="https://www.freebsd.org/cgi/man.cgi?query=' + name +
              '&sektion=' + number + '">' + displayAs + '</a>';
-    } else {
-      return ' <a href="http://man7.org/linux/man-pages/man' + number +
-             '/' + name + '.' + number + '.html">' + displayAs + '</a>';
     }
+    return ' <a href="http://man7.org/linux/man-pages/man' + number +
+             '/' + name + '.' + number + '.html">' + displayAs + '</a>';
   });
 }
 


### PR DESCRIPTION
If an if block contains a return statement, the else block becomes unnecessary. Its contents can be placed outside of the block.

Refs: http://eslint.org/docs/rules/no-else-return

Inspired by https://github.com/nodejs/node/pull/11148

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test lib benchmark