### PR TITLE
url: fix surrogate handling in encodeAuth()

### DIFF
--- a/lib/internal/querystring.js
+++ b/lib/internal/querystring.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const hexTable = new Array(256);
+for (var i = 0; i < 256; ++i)
+  hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
+
+// Instantiating this is faster than explicitly calling `Object.create(null)`
+// to get a "clean" empty object (tested with v8 v4.9).
+function StorageObject() {}
+StorageObject.prototype = Object.create(null);
+
+module.exports = {
+  hexTable,
+  StorageObject
+};

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const { StorageObject } = require('internal/querystring');
 const binding = process.binding('url');
 const context = Symbol('context');
 const cannotBeBase = Symbol('cannot-be-base');
@@ -21,9 +22,6 @@ const kFormat = Symbol('format');
 const IteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf([][Symbol.iterator]())
 );
-
-function StorageObject() {}
-StorageObject.prototype = Object.create(null);
 
 class OpaqueOrigin {
   toString() {
@@ -527,74 +525,6 @@ Object.defineProperties(URL.prototype, {
     }
   }
 });
-
-const hexTable = new Array(256);
-
-for (var i = 0; i < 256; ++i)
-  hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
-function encodeAuth(str) {
-  // faster encodeURIComponent alternative for encoding auth uri components
-  var out = '';
-  var lastPos = 0;
-  for (var i = 0; i < str.length; ++i) {
-    var c = str.charCodeAt(i);
-
-    // These characters do not need escaping:
-    // ! - . _ ~
-    // ' ( ) * :
-    // digits
-    // alpha (uppercase)
-    // alpha (lowercase)
-    if (c === 0x21 || c === 0x2D || c === 0x2E || c === 0x5F || c === 0x7E ||
-        (c >= 0x27 && c <= 0x2A) ||
-        (c >= 0x30 && c <= 0x3A) ||
-        (c >= 0x41 && c <= 0x5A) ||
-        (c >= 0x61 && c <= 0x7A)) {
-      continue;
-    }
-
-    if (i - lastPos > 0)
-      out += str.slice(lastPos, i);
-
-    lastPos = i + 1;
-
-    // Other ASCII characters
-    if (c < 0x80) {
-      out += hexTable[c];
-      continue;
-    }
-
-    // Multi-byte characters ...
-    if (c < 0x800) {
-      out += hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    if (c < 0xD800 || c >= 0xE000) {
-      out += hexTable[0xE0 | (c >> 12)] +
-             hexTable[0x80 | ((c >> 6) & 0x3F)] +
-             hexTable[0x80 | (c & 0x3F)];
-      continue;
-    }
-    // Surrogate pair
-    ++i;
-    ++lastPos;
-    var c2;
-    if (i < str.length)
-      c2 = str.charCodeAt(i) & 0x3FF;
-    else
-      c2 = 0;
-    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
-    out += hexTable[0xF0 | (c >> 18)] +
-           hexTable[0x80 | ((c >> 12) & 0x3F)] +
-           hexTable[0x80 | ((c >> 6) & 0x3F)] +
-           hexTable[0x80 | (c & 0x3F)];
-  }
-  if (lastPos === 0)
-    return str;
-  if (lastPos < str.length)
-    return out + str.slice(lastPos);
-  return out;
-}
 
 function update(url, params) {
   if (!url)
@@ -1181,6 +1111,5 @@ exports.URL = URL;
 exports.URLSearchParams = URLSearchParams;
 exports.domainToASCII = domainToASCII;
 exports.domainToUnicode = domainToUnicode;
-exports.encodeAuth = encodeAuth;
 exports.urlToOptions = urlToOptions;
 exports.formatSymbol = kFormat;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -577,6 +577,7 @@ function encodeAuth(str) {
     }
     // Surrogate pair
     ++i;
+    ++lastPos;
     var c2;
     if (i < str.length)
       c2 = str.charCodeAt(i) & 0x3FF;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Buffer } = require('buffer');
+const { StorageObject, hexTable } = require('internal/querystring');
 const QueryString = module.exports = {
   unescapeBuffer,
   // `unescape()` is a JS global, so we need to use a different local name
@@ -14,13 +16,6 @@ const QueryString = module.exports = {
   parse,
   decode: parse
 };
-const Buffer = require('buffer').Buffer;
-
-// This constructor is used to store parsed query string values. Instantiating
-// this is faster than explicitly calling `Object.create(null)` to get a
-// "clean" empty object (tested with v8 v4.9).
-function ParsedQueryString() {}
-ParsedQueryString.prototype = Object.create(null);
 
 const unhexTable = [
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0 - 15
@@ -115,10 +110,6 @@ function qsUnescape(s, decodeSpaces) {
   }
 }
 
-
-const hexTable = [];
-for (var i = 0; i < 256; ++i)
-  hexTable[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
 
 // These characters do not need escaping when generating query strings:
 // ! - . _ ~
@@ -263,7 +254,7 @@ const defEqCodes = [61]; // =
 
 // Parse a key/val string.
 function parse(qs, sep, eq, options) {
-  const obj = new ParsedQueryString();
+  const obj = new StorageObject();
 
   if (typeof qs !== 'string' || qs.length === 0) {
     return obj;

--- a/lib/url.js
+++ b/lib/url.js
@@ -10,8 +10,8 @@ function importPunycode() {
 
 const { toASCII } = importPunycode();
 
+const { StorageObject, hexTable } = require('internal/querystring');
 const internalUrl = require('internal/url');
-const encodeAuth = internalUrl.encodeAuth;
 exports.parse = urlParse;
 exports.resolve = urlResolve;
 exports.resolveObject = urlResolveObject;
@@ -75,12 +75,6 @@ const slashedProtocol = {
   'file:': true
 };
 const querystring = require('querystring');
-
-// This constructor is used to store parsed query string values. Instantiating
-// this is faster than explicitly calling `Object.create(null)` to get a
-// "clean" empty object (tested with v8 v4.9).
-function ParsedQueryString() {}
-ParsedQueryString.prototype = Object.create(null);
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url instanceof Url) return url;
@@ -190,7 +184,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         }
       } else if (parseQueryString) {
         this.search = '';
-        this.query = new ParsedQueryString();
+        this.query = new StorageObject();
       }
       return this;
     }
@@ -380,7 +374,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   } else if (parseQueryString) {
     // no query string, but parseQueryString still requested
     this.search = '';
-    this.query = new ParsedQueryString();
+    this.query = new StorageObject();
   }
 
   var firstIdx = (questionIdx !== -1 &&
@@ -947,4 +941,76 @@ function spliceOne(list, index) {
   for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
     list[i] = list[k];
   list.pop();
+}
+
+// These characters do not need escaping:
+// ! - . _ ~
+// ' ( ) * :
+// digits
+// alpha (uppercase)
+// alpha (lowercase)
+const noEscapeAuth = [
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00 - 0x0F
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10 - 0x1F
+  0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, // 0x20 - 0x2F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, // 0x30 - 0x3F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40 - 0x4F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0  // 0x70 - 0x7F
+];
+
+function encodeAuth(str) {
+  // faster encodeURIComponent alternative for encoding auth uri components
+  var out = '';
+  var lastPos = 0;
+  for (var i = 0; i < str.length; ++i) {
+    var c = str.charCodeAt(i);
+
+    // ASCII
+    if (c < 0x80) {
+      if (noEscapeAuth[c] === 1)
+        continue;
+      if (lastPos < i)
+        out += str.slice(lastPos, i);
+      lastPos = i + 1;
+      out += hexTable[c];
+      continue;
+    }
+
+    if (lastPos < i)
+      out += str.slice(lastPos, i);
+
+    // Multi-byte characters ...
+    if (c < 0x800) {
+      lastPos = i + 1;
+      out += hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    if (c < 0xD800 || c >= 0xE000) {
+      lastPos = i + 1;
+      out += hexTable[0xE0 | (c >> 12)] +
+             hexTable[0x80 | ((c >> 6) & 0x3F)] +
+             hexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    // Surrogate pair
+    ++i;
+    var c2;
+    if (i < str.length)
+      c2 = str.charCodeAt(i) & 0x3FF;
+    else
+      c2 = 0;
+    lastPos = i + 1;
+    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
+    out += hexTable[0xF0 | (c >> 18)] +
+           hexTable[0x80 | ((c >> 12) & 0x3F)] +
+           hexTable[0x80 | ((c >> 6) & 0x3F)] +
+           hexTable[0x80 | (c & 0x3F)];
+  }
+  if (lastPos === 0)
+    return str;
+  if (lastPos < str.length)
+    return out + str.slice(lastPos);
+  return out;
 }

--- a/node.gyp
+++ b/node.gyp
@@ -93,6 +93,7 @@
       'lib/internal/process/stdio.js',
       'lib/internal/process/warning.js',
       'lib/internal/process.js',
+      'lib/internal/querystring.js',
       'lib/internal/readline.js',
       'lib/internal/repl.js',
       'lib/internal/socket_list.js',

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -235,6 +235,15 @@ const formatTests = {
     protocol: 'file',
     pathname: '/home/user',
     path: '/home/user'
+  },
+
+  // surrogate in auth
+  'http://%F0%9F%98%80@www.example.com/': {
+    href: 'http://%F0%9F%98%80@www.example.com/',
+    protocol: 'http:',
+    auth: '\uD83D\uDE00',
+    hostname: 'www.example.com',
+    pathname: '/'
   }
 };
 for (const u in formatTests) {


### PR DESCRIPTION
Currently, the legacy URL stringifier miscalculates the offset of an extra surrogate, causing the high surrogate to be included unescaped:

```js
> url.format({ auth: '\uD83D\uDE00', hostname: 'a' })
'%F0%9F%98%80�@a'
> Array.from(url.format({ auth: '\uD83D\uDE00', hostname: 'a' })).map(ch => ch.charCodeAt(0).toString(16)).join(' ')
'25 46 30 25 39 46 25 39 38 25 38 30 de00 40 61'
//%  F  0  %  9  F  %  9  8  %  8  0    �  @  a
```

Also included in the PR is a commit that moves the function, which is only used in the legacy `url` module, to that file. Certain generic percent encoding handling functions and tables are also moved to a separate lib/internal/querystring.js.

<s>CI: https://ci.nodejs.org/job/node-test-pull-request/6212/</s>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url, querystring