### PR TITLE
url: fix error message of url.format

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -547,7 +547,7 @@ function urlFormat(obj, options) {
     obj = urlParse(obj);
   } else if (typeof obj !== 'object' || obj === null) {
     throw new TypeError('Parameter "urlObj" must be an object, not ' +
-                        obj === null ? 'null' : typeof obj);
+                        (obj === null ? 'null' : typeof obj));
   } else if (!(obj instanceof Url)) {
     var format = obj[internalUrl.formatSymbol];
     return format ?

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -3,17 +3,20 @@ require('../common');
 const assert = require('assert');
 const url = require('url');
 
-// https://github.com/nodejs/node/pull/1036
-const throws = [
-  undefined,
-  null,
-  true,
-  false,
-  0,
-  function() {}
-];
-for (let i = 0; i < throws.length; i++) {
-  assert.throws(function() { url.format(throws[i]); }, TypeError);
+const throwsObjsAndReportTypes = new Map([
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  [false, 'boolean'],
+  [0, 'number'],
+  [function() {}, 'function'],
+  [Symbol('foo'), 'symbol']
+]);
+
+for (const [obj, type] of throwsObjsAndReportTypes) {
+  const error = new RegExp('^TypeError: Parameter "urlObj" must be an object' +
+                           `, not ${type}$`);
+  assert.throws(function() { url.format(obj); }, error);
 }
 assert.strictEqual(url.format(''), '');
 assert.strictEqual(url.format({}), '');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
The previous code: `'Parameter "urlObj" must be an object, not ' + obj === null ? 'null' : typeof obj` actually equals `('Parameter "urlObj" must be an object, not ' + obj) === null ? 'null' : typeof obj` and its former test did not check the error message. 

So the eventual error message we got is very weird, like: `TypeError: undefined`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url