### PR TITLE
tools/doc: improvements for types

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -478,8 +478,8 @@ changes:
 > Stability: 0 - Deprecated:
 > Use [`Buffer.from(string[, encoding])`][`Buffer.from(string)`] instead.
 
-* `string` {String} String to encode
-* `encoding` {String} The encoding of `string`. **Default:** `'utf8'`
+* `string` {string} String to encode
+* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
 Creates a new `Buffer` containing the given JavaScript string `string`. If
 provided, the `encoding` parameter identifies the character encoding of `string`.
@@ -508,9 +508,9 @@ added: v5.10.0
 -->
 
 * `size` {Integer} The desired length of the new `Buffer`
-* `fill` {String | Buffer | Integer} A value to pre-fill the new `Buffer` with.
+* `fill` {string | Buffer | Integer} A value to pre-fill the new `Buffer` with.
   **Default:** `0`
-* `encoding` {String} If `fill` is a string, this is its encoding.
+* `encoding` {string} If `fill` is a string, this is its encoding.
   **Default:** `'utf8'`
 
 Allocates a new `Buffer` of `size` bytes. If `fill` is `undefined`, the
@@ -674,9 +674,9 @@ changes:
                  or `ArrayBuffer`.
 -->
 
-* `string` {String | Buffer | TypedArray | DataView | ArrayBuffer} A value to
+* `string` {string | Buffer | TypedArray | DataView | ArrayBuffer} A value to
   calculate the length of
-* `encoding` {String} If `string` is a string, this is its encoding.
+* `encoding` {string} If `string` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Integer} The number of bytes contained within `string`
 
@@ -876,8 +876,8 @@ A `TypeError` will be thrown if `buffer` is not a `Buffer`.
 added: v5.10.0
 -->
 
-* `string` {String} A string to encode.
-* `encoding` {String} The encoding of `string`. **Default:** `'utf8'`
+* `string` {string} A string to encode.
+* `encoding` {string} The encoding of `string`. **Default:** `'utf8'`
 
 Creates a new `Buffer` containing the given JavaScript string `string`. If
 provided, the `encoding` parameter identifies the character encoding of `string`.
@@ -917,7 +917,7 @@ Returns `true` if `obj` is a `Buffer`, `false` otherwise.
 added: v0.9.1
 -->
 
-* `encoding` {String} A character encoding name to check
+* `encoding` {string} A character encoding name to check
 * Returns: {Boolean}
 
 Returns `true` if `encoding` contains a supported character encoding, or `false`
@@ -1170,10 +1170,10 @@ changes:
     description: The `encoding` parameter is supported now.
 -->
 
-* `value` {String | Buffer | Integer} The value to fill `buf` with
+* `value` {string | Buffer | Integer} The value to fill `buf` with
 * `offset` {Integer} Where to start filling `buf`. **Default:** `0`
 * `end` {Integer} Where to stop filling `buf` (not inclusive). **Default:** [`buf.length`]
-* `encoding` {String} If `value` is a string, this is its encoding.
+* `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Buffer} A reference to `buf`
 
@@ -1207,9 +1207,9 @@ console.log(Buffer.allocUnsafe(3).fill('\u0222'));
 added: v5.3.0
 -->
 
-* `value` {String | Buffer | Integer} What to search for
+* `value` {string | Buffer | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`. **Default:** `0`
-* `encoding` {String} If `value` is a string, this is its encoding.
+* `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Boolean} `true` if `value` was found in `buf`, `false` otherwise
 
@@ -1256,9 +1256,9 @@ changes:
                  is no longer required.
 -->
 
-* `value` {String | Buffer | Uint8Array | Integer} What to search for
+* `value` {string | Buffer | Uint8Array | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`. **Default:** `0`
-* `encoding` {String} If `value` is a string, this is its encoding.
+* `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Integer} The index of the first occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`
@@ -1365,10 +1365,10 @@ changes:
     description: The `value` can now be a `Uint8Array`.
 -->
 
-* `value` {String | Buffer | Uint8Array | Integer} What to search for
+* `value` {string | Buffer | Uint8Array | Integer} What to search for
 * `byteOffset` {Integer} Where to begin searching in `buf`.
   **Default:** [`buf.length`]` - 1`
-* `encoding` {String} If `value` is a string, this is its encoding.
+* `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`
 * Returns: {Integer} The index of the last occurrence of `value` in `buf` or `-1`
   if `buf` does not contain `value`
@@ -1501,7 +1501,7 @@ added: v0.11.15
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Number}
 
 Reads a 64-bit double from `buf` at the specified `offset` with specified
@@ -1537,7 +1537,7 @@ added: v0.11.15
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Number}
 
 Reads a 32-bit float from `buf` at the specified `offset` with specified
@@ -1572,7 +1572,7 @@ added: v0.5.0
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 1`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads a signed 8-bit integer from `buf` at the specified `offset`.
@@ -1604,7 +1604,7 @@ added: v0.5.5
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 2`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads a signed 16-bit integer from `buf` at the specified `offset` with
@@ -1638,7 +1638,7 @@ added: v0.5.5
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads a signed 32-bit integer from `buf` at the specified `offset` with
@@ -1673,7 +1673,7 @@ added: v0.11.15
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to read. Must satisfy: `0 < byteLength <= 6`
-* `noAssert` {Boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
@@ -1704,7 +1704,7 @@ added: v0.5.0
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 1`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads an unsigned 8-bit integer from `buf` at the specified `offset`.
@@ -1734,7 +1734,7 @@ added: v0.5.5
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 2`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads an unsigned 16-bit integer from `buf` at the specified `offset` with
@@ -1772,7 +1772,7 @@ added: v0.5.5
 -->
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads an unsigned 32-bit integer from `buf` at the specified `offset` with
@@ -1805,7 +1805,7 @@ added: v0.11.15
 
 * `offset` {Integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to read. Must satisfy: `0 < byteLength <= 6`
-* `noAssert` {Boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `offset` and `byteLength` validation? **Default:** `false`
 * Returns: {Integer}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
@@ -2025,7 +2025,7 @@ console.log(copy);
 added: v0.1.90
 -->
 
-* `encoding` {String} The character encoding to decode to. **Default:** `'utf8'`
+* `encoding` {string} The character encoding to decode to. **Default:** `'utf8'`
 * `start` {Integer} The byte offset to start decoding at. **Default:** `0`
 * `end` {Integer} The byte offset to stop decoding at (not inclusive).
   **Default:** [`buf.length`]
@@ -2106,10 +2106,10 @@ for (const value of buf) {
 added: v0.1.90
 -->
 
-* `string` {String} String to be written to `buf`
+* `string` {string} String to be written to `buf`
 * `offset` {Integer} Where to start writing `string`. **Default:** `0`
 * `length` {Integer} How many bytes to write. **Default:** `buf.length - offset`
-* `encoding` {String} The character encoding of `string`. **Default:** `'utf8'`
+* `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`
 * Returns: {Integer} Number of bytes written
 
 Writes `string` to `buf` at `offset` according to the character encoding in `encoding`.
@@ -2134,9 +2134,9 @@ console.log(`${len} bytes: ${buf.toString('utf8', 0, len)}`);
 added: v0.11.15
 -->
 
-* `value` {Number} Number to be written to `buf`
+* `value` {number} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2169,9 +2169,9 @@ console.log(buf);
 added: v0.11.15
 -->
 
-* `value` {Number} Number to be written to `buf`
+* `value` {number} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2205,7 +2205,7 @@ added: v0.5.0
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 1`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset`. `value` *should* be a valid
@@ -2237,7 +2237,7 @@ added: v0.5.5
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 2`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2270,7 +2270,7 @@ added: v0.5.5
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2304,7 +2304,7 @@ added: v0.11.15
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to write. Must satisfy: `0 < byteLength <= 6`
-* `noAssert` {Boolean} Skip `value`, `offset`, and `byteLength` validation?
+* `noAssert` {boolean} Skip `value`, `offset`, and `byteLength` validation?
   **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
@@ -2338,7 +2338,7 @@ added: v0.5.0
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 1`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset`. `value` *should* be a
@@ -2370,7 +2370,7 @@ added: v0.5.5
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 2`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2407,7 +2407,7 @@ added: v0.5.5
 
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 4`
-* `noAssert` {Boolean} Skip `value` and `offset` validation? **Default:** `false`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
 Writes `value` to `buf` at the specified `offset` with specified endian
@@ -2443,7 +2443,7 @@ added: v0.5.5
 * `value` {Integer} Number to be written to `buf`
 * `offset` {Integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - byteLength`
 * `byteLength` {Integer} How many bytes to write. Must satisfy: `0 < byteLength <= 6`
-* `noAssert` {Boolean} Skip `value`, `offset`, and `byteLength` validation?
+* `noAssert` {boolean} Skip `value`, `offset`, and `byteLength` validation?
   **Default:** `false`
 * Returns: {Integer} `offset` plus the number of bytes written
 
@@ -2507,8 +2507,8 @@ changes:
 -->
 
 * `source` {Buffer|Uint8Array} A `Buffer` or `Uint8Array` instance
-* `fromEnc` {String} The current encoding
-* `toEnc` {String} To target encoding
+* `fromEnc` {string} The current encoding
+* `toEnc` {string} To target encoding
 
 Re-encodes the given `Buffer` or `Uint8Array` instance from one character
 encoding to another. Returns a new `Buffer` instance.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -125,25 +125,25 @@ exec('"my script.cmd" a b', (err, stdout, stderr) => {
 added: v0.1.90
 -->
 
-* `command` {String} The command to run, with space-separated arguments
+* `command` {string} The command to run, with space-separated arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
+  * `cwd` {string} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
-  * `encoding` {String} (Default: `'utf8'`)
-  * `shell` {String} Shell to execute the command with
+  * `encoding` {string} (Default: `'utf8'`)
+  * `shell` {string} Shell to execute the command with
     (Default: `'/bin/sh'` on UNIX, `'cmd.exe'` on Windows, The shell should
      understand the `-c` switch on UNIX or `/d /s /c` on Windows. On Windows,
      command line parsing should be compatible with `cmd.exe`.)
-  * `timeout` {Number} (Default: `0`)
+  * `timeout` {number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
-  * `killSignal` {String|Integer} (Default: `'SIGTERM'`)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `killSignal` {string|Integer} (Default: `'SIGTERM'`)
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
 * `callback` {Function} called with the output when process terminates
   * `error` {Error}
-  * `stdout` {String|Buffer}
-  * `stderr` {String|Buffer}
+  * `stdout` {string|Buffer}
+  * `stderr` {string|Buffer}
 * Returns: {ChildProcess}
 
 Spawns a shell then executes the `command` within that shell, buffering any
@@ -205,22 +205,22 @@ replace the existing process and uses a shell to execute the command.*
 added: v0.1.91
 -->
 
-* `file` {String} The name or path of the executable file to run
+* `file` {string} The name or path of the executable file to run
 * `args` {Array} List of string arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
+  * `cwd` {string} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
-  * `encoding` {String} (Default: `'utf8'`)
-  * `timeout` {Number} (Default: `0`)
+  * `encoding` {string} (Default: `'utf8'`)
+  * `timeout` {number} (Default: `0`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed (Default: `200*1024`)
-  * `killSignal` {String|Integer} (Default: `'SIGTERM'`)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `killSignal` {string|Integer} (Default: `'SIGTERM'`)
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
 * `callback` {Function} called with the output when process terminates
   * `error` {Error}
-  * `stdout` {String|Buffer}
-  * `stderr` {String|Buffer}
+  * `stdout` {string|Buffer}
+  * `stderr` {string|Buffer}
 * Returns: {ChildProcess}
 
 The `child_process.execFile()` function is similar to [`child_process.exec()`][]
@@ -260,24 +260,24 @@ changes:
     description: The `stdio` option is supported now.
 -->
 
-* `modulePath` {String} The module to run in the child
+* `modulePath` {string} The module to run in the child
 * `args` {Array} List of string arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
+  * `cwd` {string} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
-  * `execPath` {String} Executable used to create the child process
+  * `execPath` {string} Executable used to create the child process
   * `execArgv` {Array} List of string arguments passed to the executable
     (Default: `process.execArgv`)
-  * `silent` {Boolean} If `true`, stdin, stdout, and stderr of the child will be
+  * `silent` {boolean} If `true`, stdin, stdout, and stderr of the child will be
     piped to the parent, otherwise they will be inherited from the parent, see
     the `'pipe'` and `'inherit'` options for [`child_process.spawn()`][]'s
     [`stdio`][] for more details (Default: `false`)
-  * `stdio` {Array|String} See [`child_process.spawn()`][]'s [`stdio`][].
+  * `stdio` {Array|string} See [`child_process.spawn()`][]'s [`stdio`][].
     When this option is provided, it overrides `silent`. If the array variant
     is used, it must contain exactly one item with value `'ipc'` or an error
     will be thrown. For instance `[0, 1, 2, 'ipc']`.
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
 * Returns: {ChildProcess}
 
 The `child_process.fork()` method is a special case of
@@ -318,21 +318,21 @@ changes:
     description: The `shell` option is supported now.
 -->
 
-* `command` {String} The command to run
+* `command` {string} The command to run
 * `args` {Array} List of string arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
+  * `cwd` {string} Current working directory of the child process
   * `env` {Object} Environment key-value pairs
-  * `argv0` {String} Explicitly set the value of `argv[0]` sent to the child
+  * `argv0` {string} Explicitly set the value of `argv[0]` sent to the child
     process. This will be set to `command` if not specified.
-  * `stdio` {Array|String} Child's stdio configuration. (See
+  * `stdio` {Array|string} Child's stdio configuration. (See
     [`options.stdio`][`stdio`])
-  * `detached` {Boolean} Prepare child to run independently of its parent
+  * `detached` {boolean} Prepare child to run independently of its parent
     process. Specific behavior depends on the platform, see
     [`options.detached`][])
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
+  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. A different shell can be
     specified as a string. The shell should understand the `-c` switch on UNIX,
     or `/d /s /c` on Windows. Defaults to `false` (no shell).
@@ -601,27 +601,27 @@ changes:
     description: The `encoding` option can now explicitly be set to `buffer`.
 -->
 
-* `file` {String} The name or path of the executable file to run
+* `file` {string} The name or path of the executable file to run
 * `args` {Array} List of string arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer|Uint8Array} The value which will be passed as stdin
+  * `cwd` {string} Current working directory of the child process
+  * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
     to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {String | Array} Child's stdio configuration. (Default: `'pipe'`)
+  * `stdio` {string | Array} Child's stdio configuration. (Default: `'pipe'`)
     - `stderr` by default will be output to the parent process' stderr unless
       `stdio` is specified
   * `env` {Object} Environment key-value pairs
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `timeout` {Number} In milliseconds the maximum amount of time the process
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
+  * `timeout` {number} In milliseconds the maximum amount of time the process
     is allowed to run. (Default: `undefined`)
-  * `killSignal` {String|Integer} The signal value to be used when the spawned
+  * `killSignal` {string|Integer} The signal value to be used when the spawned
     process will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed
-  * `encoding` {String} The encoding used for all stdio inputs and outputs. (Default: `'buffer'`)
-* Returns: {Buffer|String} The stdout from the command
+  * `encoding` {string} The encoding used for all stdio inputs and outputs. (Default: `'buffer'`)
+* Returns: {Buffer|string} The stdout from the command
 
 The `child_process.execFileSync()` method is generally identical to
 [`child_process.execFile()`][] with the exception that the method will not return
@@ -644,31 +644,31 @@ changes:
     description: The `input` option can now be a `Uint8Array`.
 -->
 
-* `command` {String} The command to run
+* `command` {string} The command to run
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer|Uint8Array} The value which will be passed as stdin
+  * `cwd` {string} Current working directory of the child process
+  * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
     to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {String | Array} Child's stdio configuration. (Default: `'pipe'`)
+  * `stdio` {string | Array} Child's stdio configuration. (Default: `'pipe'`)
     - `stderr` by default will be output to the parent process' stderr unless
       `stdio` is specified
   * `env` {Object} Environment key-value pairs
-  * `shell` {String} Shell to execute the command with
+  * `shell` {string} Shell to execute the command with
     (Default: `'/bin/sh'` on UNIX, `'cmd.exe'` on Windows, The shell should
      understand the `-c` switch on UNIX or `/d /s /c` on Windows. On Windows,
      command line parsing should be compatible with `cmd.exe`.)
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `timeout` {Number} In milliseconds the maximum amount of time the process
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
+  * `timeout` {number} In milliseconds the maximum amount of time the process
     is allowed to run. (Default: `undefined`)
-  * `killSignal` {String|Integer} The signal value to be used when the spawned
+  * `killSignal` {string|Integer} The signal value to be used when the spawned
     process will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed
-  * `encoding` {String} The encoding used for all stdio inputs and outputs.
+  * `encoding` {string} The encoding used for all stdio inputs and outputs.
     (Default: `'buffer'`)
-* Returns: {Buffer|String} The stdout from the command
+* Returns: {Buffer|string} The stdout from the command
 
 The `child_process.execSync()` method is generally identical to
 [`child_process.exec()`][] with the exception that the method will not return until
@@ -701,36 +701,36 @@ changes:
     description: The `shell` option is supported now.
 -->
 
-* `command` {String} The command to run
+* `command` {string} The command to run
 * `args` {Array} List of string arguments
 * `options` {Object}
-  * `cwd` {String} Current working directory of the child process
-  * `input` {String|Buffer|Uint8Array} The value which will be passed as stdin
+  * `cwd` {string} Current working directory of the child process
+  * `input` {string|Buffer|Uint8Array} The value which will be passed as stdin
     to the spawned process
     - supplying this value will override `stdio[0]`
-  * `stdio` {String | Array} Child's stdio configuration.
+  * `stdio` {string | Array} Child's stdio configuration.
   * `env` {Object} Environment key-value pairs
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
-  * `timeout` {Number} In milliseconds the maximum amount of time the process
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
+  * `timeout` {number} In milliseconds the maximum amount of time the process
     is allowed to run. (Default: `undefined`)
-  * `killSignal` {String|Integer} The signal value to be used when the spawned
+  * `killSignal` {string|Integer} The signal value to be used when the spawned
     process will be killed. (Default: `'SIGTERM'`)
   * [`maxBuffer`][] {Number} largest amount of data (in bytes) allowed on
     stdout or stderr - if exceeded child process is killed
-  * `encoding` {String} The encoding used for all stdio inputs and outputs.
+  * `encoding` {string} The encoding used for all stdio inputs and outputs.
     (Default: `'buffer'`)
-  * `shell` {Boolean|String} If `true`, runs `command` inside of a shell. Uses
+  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
     `'/bin/sh'` on UNIX, and `'cmd.exe'` on Windows. A different shell can be
     specified as a string. The shell should understand the `-c` switch on UNIX,
     or `/d /s /c` on Windows. Defaults to `false` (no shell).
 * Returns: {Object}
-  * `pid` {Number} Pid of the child process
+  * `pid` {number} Pid of the child process
   * `output` {Array} Array of results from stdio output
-  * `stdout` {Buffer|String} The contents of `output[1]`
-  * `stderr` {Buffer|String} The contents of `output[2]`
-  * `status` {Number} The exit code of the child process
-  * `signal` {String} The signal used to kill the child process
+  * `stdout` {Buffer|string} The contents of `output[1]`
+  * `stderr` {Buffer|string} The contents of `output[2]`
+  * `status` {number} The exit code of the child process
+  * `signal` {string} The signal used to kill the child process
   * `error` {Error} The error object if the child process failed or timed out
 
 The `child_process.spawnSync()` method is generally identical to
@@ -763,8 +763,8 @@ instances of `ChildProcess`.
 added: v0.7.7
 -->
 
-* `code` {Number} the exit code if the child exited on its own.
-* `signal` {String} the signal by which the child process was terminated.
+* `code` {number} the exit code if the child exited on its own.
+* `signal` {string} the signal by which the child process was terminated.
 
 The `'close'` event is emitted when the stdio streams of a child process have
 been closed. This is distinct from the [`'exit'`][] event, since multiple
@@ -801,8 +801,8 @@ See also [`child.kill()`][] and [`child.send()`][].
 added: v0.1.90
 -->
 
-* `code` {Number} the exit code if the child exited on its own.
-* `signal` {String} the signal by which the child process was terminated.
+* `code` {number} the exit code if the child exited on its own.
+* `signal` {string} the signal by which the child process was terminated.
 
 The `'exit'` event is emitted after the child process ends. If the process
 exited, `code` is the final exit code of the process, otherwise `null`. If the
@@ -876,7 +876,7 @@ within the child process to close the IPC channel as well.
 added: v0.1.90
 -->
 
-* `signal` {String}
+* `signal` {string}
 
 The `child.kill()` methods sends a signal to the child process. If no argument
 is given, the process will be sent the `'SIGTERM'` signal. See signal(7) for

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -148,8 +148,8 @@ In a worker you can also use `process.on('error')`.
 added: v0.11.2
 -->
 
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the name of the signal (e.g. `'SIGHUP'`) that caused
+* `code` {number} the exit code, if it exited normally.
+* `signal` {string} the name of the signal (e.g. `'SIGHUP'`) that caused
   the process to be killed.
 
 Similar to the `cluster.on('exit')` event, but specific to this worker.
@@ -386,7 +386,7 @@ because of exiting or being signaled). Otherwise, it returns `false`.
 added: v0.9.12
 -->
 
-* `signal` {String} Name of the kill signal to send to the worker
+* `signal` {string} Name of the kill signal to send to the worker
   process.
 
 This function will kill the worker. In the master, it does this by disconnecting
@@ -514,8 +514,8 @@ added: v0.7.9
 -->
 
 * `worker` {cluster.Worker}
-* `code` {Number} the exit code, if it exited normally.
-* `signal` {String} the name of the signal (e.g. `'SIGHUP'`) that caused
+* `code` {number} the exit code, if it exited normally.
+* `signal` {string} the name of the signal (e.g. `'SIGHUP'`) that caused
   the process to be killed.
 
 When any of the workers die the cluster module will emit the `'exit'` event.
@@ -736,16 +736,16 @@ changes:
 * {Object}
   * `execArgv` {Array} list of string arguments passed to the Node.js
     executable. (Default=`process.execArgv`)
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `exec` {string} file path to worker file.  (Default=`process.argv[1]`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
+  * `silent` {boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
   * `stdio` {Array} Configures the stdio of forked processes. Because the
     cluster module relies on IPC to function, this configuration must contain an
     `'ipc'` entry. When this option is provided, it overrides `silent`.
-  * `uid` {Number} Sets the user identity of the process. (See setuid(2).)
-  * `gid` {Number} Sets the group identity of the process. (See setgid(2).)
+  * `uid` {number} Sets the user identity of the process. (See setuid(2).)
+  * `gid` {number} Sets the group identity of the process. (See setgid(2).)
 
 After calling `.setupMaster()` (or `.fork()`) this settings object will contain
 the settings, including the default values.
@@ -762,10 +762,10 @@ changes:
 -->
 
 * `settings` {Object}
-  * `exec` {String} file path to worker file.  (Default=`process.argv[1]`)
+  * `exec` {string} file path to worker file.  (Default=`process.argv[1]`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
-  * `silent` {Boolean} whether or not to send output to parent's stdio.
+  * `silent` {boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
   * `stdio` {Array} Configures the stdio of forked processes. When this option
     is provided, it overrides `silent`.

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -74,18 +74,18 @@ The `'message'` event is emitted when a new datagram is available on a socket.
 The event handler function is passed two arguments: `msg` and `rinfo`.
 * `msg` {Buffer} - The message
 * `rinfo` {Object} - Remote address information
-  * `address` {String} The sender address
-  * `family` {String} The address family (`'IPv4'` or `'IPv6'`)
-  * `port` {Number} The sender port
-  * `size` {Number} The message size
+  * `address` {string} The sender address
+  * `family` {string} The address family (`'IPv4'` or `'IPv6'`)
+  * `port` {number} The sender port
+  * `size` {number} The message size
 
 ### socket.addMembership(multicastAddress[, multicastInterface])
 <!-- YAML
 added: v0.6.9
 -->
 
-* `multicastAddress` {String}
-* `multicastInterface` {String}, Optional
+* `multicastAddress` {string}
+* `multicastInterface` {string}, Optional
 
 Tells the kernel to join a multicast group at the given `multicastAddress` and
 `multicastInterface` using the `IP_ADD_MEMBERSHIP` socket option. If the
@@ -107,8 +107,8 @@ properties.
 added: v0.1.99
 -->
 
-* `port` {Number} - Integer, Optional
-* `address` {String}, Optional
+* `port` {number} - Integer, Optional
+* `address` {string}, Optional
 * `callback` {Function} with no parameters, Optional. Called when
   binding is complete.
 
@@ -160,9 +160,9 @@ added: v0.11.14
 -->
 
 * `options` {Object} - Required. Supports the following properties:
-  * `port` {Number} - Optional.
-  * `address` {String} - Optional.
-  * `exclusive` {Boolean} - Optional.
+  * `port` {number} - Optional.
+  * `address` {string} - Optional.
+  * `exclusive` {boolean} - Optional.
 * `callback` {Function} - Optional.
 
 For UDP sockets, causes the `dgram.Socket` to listen for datagram
@@ -214,8 +214,8 @@ provided, it is added as a listener for the [`'close'`][] event.
 added: v0.6.9
 -->
 
-* `multicastAddress` {String}
-* `multicastInterface` {String}, Optional
+* `multicastAddress` {string}
+* `multicastInterface` {string}, Optional
 
 Instructs the kernel to leave a multicast group at `multicastAddress` using the
 `IP_DROP_MEMBERSHIP` socket option. This method is automatically called by the
@@ -258,11 +258,11 @@ changes:
                  and `length` parameters are optional now.
 -->
 
-* `msg` {Buffer|String|Array} Message to be sent
-* `offset` {Number} Integer. Optional. Offset in the buffer where the message starts.
-* `length` {Number} Integer. Optional. Number of bytes in the message.
-* `port` {Number} Integer. Destination port.
-* `address` {String} Destination hostname or IP address. Optional.
+* `msg` {Buffer|string|array} Message to be sent
+* `offset` {number} Integer. Optional. Offset in the buffer where the message starts.
+* `length` {number} Integer. Optional. Number of bytes in the message.
+* `port` {number} Integer. Destination port.
+* `address` {string} Destination hostname or IP address. Optional.
 * `callback` {Function} Called when the message has been sent. Optional.
 
 Broadcasts a datagram on the socket. The destination `port` and `address` must
@@ -360,7 +360,7 @@ source that the data did not reach its intended recipient.
 added: v0.6.9
 -->
 
-* `flag` {Boolean}
+* `flag` {boolean}
 
 Sets or clears the `SO_BROADCAST` socket option.  When set to `true`, UDP
 packets may be sent to a local interface's broadcast address.
@@ -370,7 +370,7 @@ packets may be sent to a local interface's broadcast address.
 added: v0.3.8
 -->
 
-* `flag` {Boolean}
+* `flag` {boolean}
 
 Sets or clears the `IP_MULTICAST_LOOP` socket option.  When set to `true`,
 multicast packets will also be received on the local interface.
@@ -380,7 +380,7 @@ multicast packets will also be received on the local interface.
 added: v0.3.8
 -->
 
-* `ttl` {Number} Integer
+* `ttl` {number} Integer
 
 Sets the `IP_MULTICAST_TTL` socket option.  While TTL generally stands for
 "Time to Live", in this context it specifies the number of IP hops that a
@@ -396,7 +396,7 @@ between 0 and 255. The default on most systems is `1` but can vary.
 added: v0.1.101
 -->
 
-* `ttl` {Number} Integer
+* `ttl` {number} Integer
 
 Sets the `IP_TTL` socket option. While TTL generally stands for "Time to Live",
 in this context it specifies the number of IP hops that a packet is allowed to
@@ -477,7 +477,7 @@ and `udp6` sockets). The bound address and port can be retrieved using
 added: v0.1.99
 -->
 
-* `type` {String} - Either 'udp4' or 'udp6'
+* `type` {string} - Either 'udp4' or 'udp6'
 * `callback` {Function} - Attached as a listener to `'message'` events.
   Optional
 * Returns: {dgram.Socket}

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -78,7 +78,7 @@ an integer, then it must be `4` or `6`.
 
 Alternatively, `options` can be an object containing these properties:
 
-* `family` {Number} - The record family. If present, must be the integer
+* `family` {number} - The record family. If present, must be the integer
   `4` or `6`. If not provided, both IP v4 and v6 addresses are accepted.
 * `hints`: {Number} - If present, it should be one or more of the supported
   `getaddrinfo` flags. If `hints` is not provided, then no flags are passed to
@@ -214,9 +214,9 @@ Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the
 will contain an array of IPv4 addresses (e.g.
 `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
 
-* `hostname` {String} Hostname to resolve.
+* `hostname` {string} Hostname to resolve.
 * `options` {Object}
-  * `ttl` {Boolean} Retrieve the Time-To-Live value (TTL) of each record.
+  * `ttl` {boolean} Retrieve the Time-To-Live value (TTL) of each record.
     The callback receives an array of `{ address: '1.2.3.4', ttl: 60 }` objects
     rather than an array of strings.  The TTL is expressed in seconds.
 * `callback` {Function} An `(err, result)` callback function.
@@ -235,9 +235,9 @@ Uses the DNS protocol to resolve a IPv6 addresses (`AAAA` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function
 will contain an array of IPv6 addresses.
 
-* `hostname` {String} Hostname to resolve.
+* `hostname` {string} Hostname to resolve.
 * `options` {Object}
-  * `ttl` {Boolean} Retrieve the Time-To-Live value (TTL) of each record.
+  * `ttl` {boolean} Retrieve the Time-To-Live value (TTL) of each record.
     The callback receives an array of `{ address: '0:1:2:3:4:5:6:7', ttl: 60 }`
     objects rather than an array of strings.  The TTL is expressed in seconds.
 * `callback` {Function} An `(err, result)` callback function.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -195,7 +195,7 @@ will either be instances of, or inherit from, the `Error` class.
 
 ### new Error(message)
 
-* `message` {String}
+* `message` {string}
 
 Creates a new `Error` object and sets the `error.message` property to the
 provided text message. If an object is passed as `message`, the text message

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -185,7 +185,7 @@ added and `'removeListener'` when existing listeners are removed.
 added: v0.1.26
 -->
 
-* `eventName` {String|Symbol} The name of the event being listened for
+* `eventName` {string|symbol} The name of the event being listened for
 * `listener` {Function} The event handler function
 
 The `EventEmitter` instance will emit its own `'newListener'` event *before*
@@ -229,7 +229,7 @@ changes:
                  now yields the original listener function.
 -->
 
-* `eventName` {String|Symbol} The event name
+* `eventName` {string|symbol} The event name
 * `listener` {Function} The event handler function
 
 The `'removeListener'` event is emitted *after* the `listener` is removed.
@@ -345,7 +345,7 @@ set by [`emitter.setMaxListeners(n)`][] or defaults to
 added: v3.2.0
 -->
 
-* `eventName` {String|Symbol} The name of the event being listened for
+* `eventName` {string|symbol} The name of the event being listened for
 
 Returns the number of listeners listening to the event named `eventName`.
 
@@ -374,7 +374,7 @@ console.log(util.inspect(server.listeners('connection')));
 added: v0.1.101
 -->
 
-* `eventName` {String|Symbol} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds the `listener` function to the end of the listeners array for the
@@ -410,7 +410,7 @@ myEE.emit('foo');
 added: v0.3.0
 -->
 
-* `eventName` {String|Symbol} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds a **one time** `listener` function for the event named `eventName`. The
@@ -443,7 +443,7 @@ myEE.emit('foo');
 added: v6.0.0
 -->
 
-* `eventName` {String|Symbol} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds the `listener` function to the *beginning* of the listeners array for the
@@ -465,7 +465,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 added: v6.0.0
 -->
 
-* `eventName` {String|Symbol} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds a **one time** `listener` function for the event named `eventName` to the

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -121,8 +121,8 @@ The object itself emits these events:
 added: v0.5.8
 -->
 
-* `eventType` {String} The type of fs change
-* `filename` {String | Buffer} The filename that changed (if relevant/available)
+* `eventType` {string} The type of fs change
+* `filename` {string | Buffer} The filename that changed (if relevant/available)
 
 Emitted when something changes in a watched directory or file.
 See more details in [`fs.watch()`][].
@@ -318,7 +318,7 @@ argument to `fs.createWriteStream()`. If `path` is passed as a string, then
 added: v0.11.15
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -439,7 +439,7 @@ process.
 added: v0.11.15
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 
 Synchronous version of [`fs.access()`][]. This throws if any accessibility
@@ -461,12 +461,12 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Number} filename or file descriptor
-* `data` {String | Buffer}
+* `file` {string | Buffer | Number} filename or file descriptor
+* `data` {string | Buffer}
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `'utf8'`
+  * `encoding` {string | Null} default = `'utf8'`
   * `mode` {Integer} default = `0o666`
-  * `flag` {String} default = `'a'`
+  * `flag` {string} default = `'a'`
 * `callback` {Function}
 
 Asynchronously append data to a file, creating the file if it does not yet exist.
@@ -504,12 +504,12 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Number} filename or file descriptor
-* `data` {String | Buffer}
+* `file` {string | Buffer | Number} filename or file descriptor
+* `data` {string | Buffer}
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `'utf8'`
+  * `encoding` {string | Null} default = `'utf8'`
   * `mode` {Integer} default = `0o666`
-  * `flag` {String} default = `'a'`
+  * `flag` {string} default = `'a'`
 
 The synchronous version of [`fs.appendFile()`][]. Returns `undefined`.
 
@@ -523,7 +523,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -535,7 +535,7 @@ to the completion callback.
 added: v0.6.7
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 
 Synchronous chmod(2). Returns `undefined`.
@@ -550,7 +550,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 * `callback` {Function}
@@ -563,7 +563,7 @@ to the completion callback.
 added: v0.1.97
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 
@@ -612,13 +612,13 @@ changes:
     description: The passed `options` object can be a string now.
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `flags` {String}
-  * `encoding` {String}
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `flags` {string}
+  * `encoding` {string}
   * `fd` {Integer}
   * `mode` {Integer}
-  * `autoClose` {Boolean}
+  * `autoClose` {boolean}
   * `start` {Integer}
   * `end` {Integer}
 
@@ -683,13 +683,13 @@ changes:
     description: The passed `options` object can be a string now.
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `flags` {String}
-  * `defaultEncoding` {String}
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `flags` {string}
+  * `defaultEncoding` {string}
   * `fd` {Integer}
   * `mode` {Integer}
-  * `autoClose` {Boolean}
+  * `autoClose` {boolean}
   * `start` {Integer}
 
 Returns a new [`WriteStream`][] object. (See [Writable Stream][]).
@@ -733,7 +733,7 @@ deprecated: v1.0.0
 
 > Stability: 0 - Deprecated: Use [`fs.stat()`][] or [`fs.access()`][] instead.
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `callback` {Function}
 
 Test whether or not the given path exists by checking with the file system.
@@ -834,7 +834,7 @@ process.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 
 Synchronous version of [`fs.exists()`][].
 Returns `true` if the file exists, `false` otherwise.
@@ -1092,7 +1092,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -1106,7 +1106,7 @@ Only available on Mac OS X.
 deprecated: v0.4.7
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 
 Synchronous lchmod(2). Returns `undefined`.
@@ -1121,7 +1121,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 * `callback` {Function}
@@ -1134,7 +1134,7 @@ to the completion callback.
 deprecated: v0.4.7
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `uid` {Integer}
 * `gid` {Integer}
 
@@ -1150,8 +1150,8 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `existingPath` {String | Buffer}
-* `newPath` {String | Buffer}
+* `existingPath` {string | Buffer}
+* `newPath` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous link(2). No arguments other than a possible exception are given to
@@ -1162,8 +1162,8 @@ the completion callback.
 added: v0.1.31
 -->
 
-* `existingPath` {String | Buffer}
-* `newPath` {String | Buffer}
+* `existingPath` {string | Buffer}
+* `newPath` {string | Buffer}
 
 Synchronous link(2). Returns `undefined`.
 
@@ -1177,7 +1177,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous lstat(2). The callback gets two arguments `(err, stats)` where
@@ -1190,7 +1190,7 @@ not the file that it refers to.
 added: v0.1.30
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 
 Synchronous lstat(2). Returns an instance of [`fs.Stats`][].
 
@@ -1204,7 +1204,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -1216,7 +1216,7 @@ to the completion callback. `mode` defaults to `0o777`.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `mode` {Integer}
 
 Synchronous mkdir(2). Returns `undefined`.
@@ -1234,9 +1234,9 @@ changes:
     description: The `callback` parameter is optional now.
 -->
 
-* `prefix` {String}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `prefix` {string}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 * `callback` {Function}
 
 Creates a unique temporary directory.
@@ -1296,9 +1296,9 @@ fs.mkdtemp(tmpDir + path.sep, (err, folder) => {
 added: v5.10.0
 -->
 
-* `prefix` {String}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `prefix` {string}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 
 The synchronous version of [`fs.mkdtemp()`][]. Returns the created
 folder path.
@@ -1311,8 +1311,8 @@ object with an `encoding` property specifying the character encoding to use.
 added: v0.0.2
 -->
 
-* `path` {String | Buffer}
-* `flags` {String | Number}
+* `path` {string | Buffer}
+* `flags` {string | Number}
 * `mode` {Integer}
 * `callback` {Function}
 
@@ -1395,8 +1395,8 @@ fs.open('<directory>', 'a+', (err, fd) => {
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
-* `flags` {String | Number}
+* `path` {string | Buffer}
+* `flags` {string | Number}
 * `mode` {Integer}
 
 Synchronous version of [`fs.open()`][]. Returns an integer representing the file
@@ -1415,7 +1415,7 @@ changes:
 -->
 
 * `fd` {Integer}
-* `buffer` {String | Buffer | Uint8Array}
+* `buffer` {string | Buffer | Uint8Array}
 * `offset` {Integer}
 * `length` {Integer}
 * `position` {Integer}
@@ -1444,9 +1444,9 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 * `callback` {Function}
 
 Asynchronous readdir(3).  Reads the contents of a directory.
@@ -1463,9 +1463,9 @@ the filenames returned will be passed as `Buffer` objects.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 
 Synchronous readdir(3). Returns an array of filenames excluding `'.'` and
 `'..'`.
@@ -1492,10 +1492,10 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Integer} filename or file descriptor
+* `file` {string | Buffer | Integer} filename or file descriptor
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `null`
-  * `flag` {String} default = `'r'`
+  * `encoding` {string | Null} default = `null`
+  * `flag` {string} default = `'r'`
 * `callback` {Function}
 
 Asynchronously reads the entire contents of a file. Example:
@@ -1532,10 +1532,10 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Integer} filename or file descriptor
+* `file` {string | Buffer | Integer} filename or file descriptor
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `null`
-  * `flag` {String} default = `'r'`
+  * `encoding` {string | Null} default = `null`
+  * `flag` {string} default = `'r'`
 
 Synchronous version of [`fs.readFile`][]. Returns the contents of the `file`.
 
@@ -1552,9 +1552,9 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 * `callback` {Function}
 
 Asynchronous readlink(2). The callback gets two arguments `(err,
@@ -1570,9 +1570,9 @@ the link path returned will be passed as a `Buffer` object.
 added: v0.1.31
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 
 Synchronous readlink(2). Returns the symbolic link's string value.
 
@@ -1591,7 +1591,7 @@ changes:
 -->
 
 * `fd` {Integer}
-* `buffer` {String | Buffer | Uint8Array}
+* `buffer` {string | Buffer | Uint8Array}
 * `offset` {Integer}
 * `length` {Integer}
 * `position` {Integer}
@@ -1615,9 +1615,9 @@ changes:
     description: The `cache` parameter was removed.
 -->
 
-* `path` {String | Buffer}
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer}
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 * `callback` {Function}
 
 Asynchronous realpath(3). The `callback` gets two arguments `(err,
@@ -1643,9 +1643,9 @@ changes:
     description: The `cache` parameter was removed.
 -->
 
-* `path` {String | Buffer};
-* `options` {String | Object}
-  * `encoding` {String} default = `'utf8'`
+* `path` {string | Buffer};
+* `options` {string | Object}
+  * `encoding` {string} default = `'utf8'`
 
 Synchronous realpath(3). Returns the resolved path.
 
@@ -1666,8 +1666,8 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `oldPath` {String | Buffer}
-* `newPath` {String | Buffer}
+* `oldPath` {string | Buffer}
+* `newPath` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous rename(2). No arguments other than a possible exception are given
@@ -1678,8 +1678,8 @@ to the completion callback.
 added: v0.1.21
 -->
 
-* `oldPath` {String | Buffer}
-* `newPath` {String | Buffer}
+* `oldPath` {string | Buffer}
+* `newPath` {string | Buffer}
 
 Synchronous rename(2). Returns `undefined`.
 
@@ -1693,7 +1693,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous rmdir(2). No arguments other than a possible exception are given
@@ -1704,7 +1704,7 @@ to the completion callback.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 
 Synchronous rmdir(2). Returns `undefined`.
 
@@ -1718,7 +1718,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous stat(2). The callback gets two arguments `(err, stats)` where
@@ -1739,7 +1739,7 @@ is recommended.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 
 Synchronous stat(2). Returns an instance of [`fs.Stats`][].
 
@@ -1748,9 +1748,9 @@ Synchronous stat(2). Returns an instance of [`fs.Stats`][].
 added: v0.1.31
 -->
 
-* `target` {String | Buffer}
-* `path` {String | Buffer}
-* `type` {String}
+* `target` {string | Buffer}
+* `path` {string | Buffer}
+* `type` {string}
 * `callback` {Function}
 
 Asynchronous symlink(2). No arguments other than a possible exception are given
@@ -1773,9 +1773,9 @@ It creates a symbolic link named "new-port" that points to "foo".
 added: v0.1.31
 -->
 
-* `target` {String | Buffer}
-* `path` {String | Buffer}
-* `type` {String}
+* `target` {string | Buffer}
+* `path` {string | Buffer}
+* `type` {string}
 
 Synchronous symlink(2). Returns `undefined`.
 
@@ -1789,7 +1789,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `len` {Integer} default = `0`
 * `callback` {Function}
 
@@ -1802,7 +1802,7 @@ first argument. In this case, `fs.ftruncate()` is called.
 added: v0.8.6
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `len` {Integer} default = `0`
 
 Synchronous truncate(2). Returns `undefined`. A file descriptor can also be
@@ -1818,7 +1818,7 @@ changes:
                  it will emit a deprecation warning.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `callback` {Function}
 
 Asynchronous unlink(2). No arguments other than a possible exception are given
@@ -1829,7 +1829,7 @@ to the completion callback.
 added: v0.1.21
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 
 Synchronous unlink(2). Returns `undefined`.
 
@@ -1838,7 +1838,7 @@ Synchronous unlink(2). Returns `undefined`.
 added: v0.1.31
 -->
 
-* `filename` {String | Buffer}
+* `filename` {string | Buffer}
 * `listener` {Function}
 
 Stop watching for changes on `filename`. If `listener` is specified, only that
@@ -1866,7 +1866,7 @@ changes:
                  time specifiers.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `atime` {Integer}
 * `mtime` {Integer}
 * `callback` {Function}
@@ -1893,7 +1893,7 @@ changes:
                  time specifiers.
 -->
 
-* `path` {String | Buffer}
+* `path` {string | Buffer}
 * `atime` {Integer}
 * `mtime` {Integer}
 
@@ -1908,15 +1908,15 @@ changes:
     description: The passed `options` object will never be modified.
 -->
 
-* `filename` {String | Buffer}
-* `options` {String | Object}
-  * `persistent` {Boolean} Indicates whether the process should continue to run
+* `filename` {string | Buffer}
+* `options` {string | Object}
+  * `persistent` {boolean} Indicates whether the process should continue to run
     as long as files are being watched. default = `true`
-  * `recursive` {Boolean} Indicates whether all subdirectories should be
+  * `recursive` {boolean} Indicates whether all subdirectories should be
     watched, or only the current directory. The applies when a directory is
     specified, and only on supported platforms (See [Caveats][]). default =
     `false`
-  * `encoding` {String} Specifies the character encoding to be used for the
+  * `encoding` {string} Specifies the character encoding to be used for the
      filename passed to the listener. default = `'utf8'`
 * `listener` {Function}
 
@@ -2011,9 +2011,9 @@ fs.watch('somedir', (eventType, filename) => {
 added: v0.1.31
 -->
 
-* `filename` {String | Buffer}
+* `filename` {string | Buffer}
 * `options` {Object}
-  * `persistent` {Boolean}
+  * `persistent` {boolean}
   * `interval` {Integer}
 * `listener` {Function}
 
@@ -2109,9 +2109,9 @@ changes:
 -->
 
 * `fd` {Integer}
-* `string` {String}
+* `string` {string}
 * `position` {Integer}
-* `encoding` {String}
+* `encoding` {string}
 * `callback` {Function}
 
 Write `string` to the file specified by `fd`.  If `string` is not a string, then
@@ -2155,12 +2155,12 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Integer} filename or file descriptor
-* `data` {String | Buffer | Uint8Array}
+* `file` {string | Buffer | Integer} filename or file descriptor
+* `data` {string | Buffer | Uint8Array}
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `'utf8'`
+  * `encoding` {string | Null} default = `'utf8'`
   * `mode` {Integer} default = `0o666`
-  * `flag` {String} default = `'w'`
+  * `flag` {string} default = `'w'`
 * `callback` {Function}
 
 Asynchronously writes data to a file, replacing the file if it already exists.
@@ -2205,12 +2205,12 @@ changes:
     description: The `file` parameter can be a file descriptor now.
 -->
 
-* `file` {String | Buffer | Integer} filename or file descriptor
-* `data` {String | Buffer | Uint8Array}
+* `file` {string | Buffer | Integer} filename or file descriptor
+* `data` {string | Buffer | Uint8Array}
 * `options` {Object | String}
-  * `encoding` {String | Null} default = `'utf8'`
+  * `encoding` {string | Null} default = `'utf8'`
   * `mode` {Integer} default = `0o666`
-  * `flag` {String} default = `'w'`
+  * `flag` {string} default = `'w'`
 
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 
@@ -2242,9 +2242,9 @@ changes:
 -->
 
 * `fd` {Integer}
-* `string` {String}
+* `string` {string}
 * `position` {Integer}
-* `encoding` {String}
+* `encoding` {string}
 
 Synchronous versions of [`fs.write()`][]. Returns the number of bytes written.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -110,16 +110,16 @@ added: v0.3.4
 
 * `options` {Object} Set of configurable options to set on the agent.
   Can have the following fields:
-  * `keepAlive` {Boolean} Keep sockets around even when there are no
+  * `keepAlive` {boolean} Keep sockets around even when there are no
     outstanding requests, so they can be used for future requests without
     having to reestablish a TCP connection. Default = `false`
   * `keepAliveMsecs` {Integer} When using the `keepAlive` option, specifies
     the [initial delay](net.html#net_socket_setkeepalive_enable_initialdelay)
     for TCP Keep-Alive packets. Ignored when the
     `keepAlive` option is `false` or `undefined`. Default = `1000`.
-  * `maxSockets` {Number} Maximum number of sockets to allow per
+  * `maxSockets` {number} Maximum number of sockets to allow per
     host.  Default = `Infinity`.
-  * `maxFreeSockets` {Number} Maximum number of sockets to leave open
+  * `maxFreeSockets` {number} Maximum number of sockets to leave open
     in a free state.  Only relevant if `keepAlive` is set to `true`.
     Default = `256`.
 
@@ -184,9 +184,9 @@ added: v0.11.4
 -->
 
 * `options` {Object} A set of options providing information for name generation
-  * `host` {String} A domain name or IP address of the server to issue the request to
-  * `port` {Number} Port of remote server
-  * `localAddress` {String} Local interface to bind for network connections
+  * `host` {string} A domain name or IP address of the server to issue the request to
+  * `port` {number} Port of remote server
+  * `localAddress` {string} Local interface to bind for network connections
     when issuing the request
 * Returns: {String}
 
@@ -463,8 +463,8 @@ aborted, in milliseconds since 1 January 1970 00:00:00 UTC.
 added: v0.1.90
 -->
 
-* `data` {String | Buffer}
-* `encoding` {String}
+* `data` {string | Buffer}
+* `encoding` {string}
 * `callback` {Function}
 
 Finishes sending the request. If any parts of the body are
@@ -497,7 +497,7 @@ the optimization and kickstart the request.
 added: v0.5.9
 -->
 
-* `noDelay` {Boolean}
+* `noDelay` {boolean}
 
 Once a socket is assigned to this request and is connected
 [`socket.setNoDelay()`][] will be called.
@@ -507,8 +507,8 @@ Once a socket is assigned to this request and is connected
 added: v0.5.9
 -->
 
-* `enable` {Boolean}
-* `initialDelay` {Number}
+* `enable` {boolean}
+* `initialDelay` {number}
 
 Once a socket is assigned to this request and is connected
 [`socket.setKeepAlive()`][] will be called.
@@ -518,7 +518,7 @@ Once a socket is assigned to this request and is connected
 added: v0.5.9
 -->
 
-* `timeout` {Number} Milliseconds before a request is considered to be timed out.
+* `timeout` {number} Milliseconds before a request is considered to be timed out.
 * `callback` {Function} Optional function to be called when a timeout occurs. Same as binding to the `timeout` event.
 
 Once a socket is assigned to this request and is connected
@@ -531,8 +531,8 @@ Returns `request`.
 added: v0.1.29
 -->
 
-* `chunk` {String | Buffer}
-* `encoding` {String}
+* `chunk` {string | Buffer}
+* `encoding` {string}
 * `callback` {Function}
 
 Sends a chunk of the body.  By calling this method
@@ -737,7 +737,7 @@ subsequent call will *re-open* the server using the provided options.
 added: v0.1.90
 -->
 
-* `path` {String}
+* `path` {string}
 * `callback` {Function}
 
 Start a UNIX socket server listening for connections on the given `path`.
@@ -753,9 +753,9 @@ subsequent call will *re-open* the server using the provided options.
 added: v0.1.90
 -->
 
-* `port` {Number}
-* `hostname` {String}
-* `backlog` {Number}
+* `port` {number}
+* `hostname` {string}
+* `backlog` {number}
 * `callback` {Function}
 
 Begin accepting connections on the specified `port` and `hostname`. If the
@@ -809,7 +809,7 @@ no limit will be applied.
 added: v0.9.12
 -->
 
-* `msecs` {Number}
+* `msecs` {number}
 * `callback` {Function}
 
 Sets the timeout value for sockets, and emits a `'timeout'` event on
@@ -907,8 +907,8 @@ will result in a [`TypeError`][] being thrown.
 added: v0.1.90
 -->
 
-* `data` {String | Buffer}
-* `encoding` {String}
+* `data` {string | Buffer}
+* `encoding` {string}
 * `callback` {Function}
 
 This method signals to the server that all of the response headers and body
@@ -936,7 +936,7 @@ as `false`. After [`response.end()`][] executes, the value will be `true`.
 added: v0.4.0
 -->
 
-* `name` {String}
+* `name` {string}
 * Returns: {String}
 
 Reads out a header that's already been queued but not sent to the client.
@@ -1022,7 +1022,7 @@ Boolean (read-only). True if headers were sent, false otherwise.
 added: v0.4.0
 -->
 
-* `name` {String}
+* `name` {string}
 
 Removes a header that's queued for implicit sending.
 
@@ -1050,8 +1050,8 @@ in responses.
 added: v0.4.0
 -->
 
-* `name` {String}
-* `value` {String}
+* `name` {string}
+* `value` {string}
 
 Sets a single header value for implicit headers.  If this header already exists
 in the to-be-sent headers, its value will be replaced.  Use an array of strings
@@ -1091,7 +1091,7 @@ const server = http.createServer((req,res) => {
 added: v0.9.12
 -->
 
-* `msecs` {Number}
+* `msecs` {number}
 * `callback` {Function}
 
 Sets the Socket's timeout value to `msecs`.  If a callback is
@@ -1152,8 +1152,8 @@ status message which was sent out.
 added: v0.1.29
 -->
 
-* `chunk` {String | Buffer}
-* `encoding` {String}
+* `chunk` {string | Buffer}
+* `encoding` {string}
 * `callback` {Function}
 * Returns: {Boolean}
 
@@ -1199,8 +1199,8 @@ changes:
                  the range `[100, 999]`.
 -->
 
-* `statusCode` {Number}
-* `statusMessage` {String}
+* `statusCode` {number}
+* `statusMessage` {string}
 * `headers` {Object}
 
 Sends a response header to the request. The status code is a 3-digit HTTP
@@ -1388,7 +1388,7 @@ received.  Only populated at the `'end'` event.
 added: v0.5.9
 -->
 
-* `msecs` {Number}
+* `msecs` {number}
 * `callback` {Function}
 
 Calls `message.connection.setTimeout(msecs, callback)`.
@@ -1595,28 +1595,28 @@ added: v0.3.6
 -->
 
 * `options` {Object}
-  * `protocol` {String} Protocol to use. Defaults to `'http:'`.
-  * `host` {String} A domain name or IP address of the server to issue the
+  * `protocol` {string} Protocol to use. Defaults to `'http:'`.
+  * `host` {string} A domain name or IP address of the server to issue the
     request to. Defaults to `'localhost'`.
-  * `hostname` {String} Alias for `host`. To support [`url.parse()`][],
+  * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` is preferred over `host`.
-  * `family` {Number} IP address family to use when resolving `host` and
+  * `family` {number} IP address family to use when resolving `host` and
     `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and
     v6 will be used.
-  * `port` {Number} Port of remote server. Defaults to 80.
-  * `localAddress` {String} Local interface to bind for network connections.
-  * `socketPath` {String} Unix Domain Socket (use one of host:port or
+  * `port` {number} Port of remote server. Defaults to 80.
+  * `localAddress` {string} Local interface to bind for network connections.
+  * `socketPath` {string} Unix Domain Socket (use one of host:port or
     socketPath).
-  * `method` {String} A string specifying the HTTP request method. Defaults to
+  * `method` {string} A string specifying the HTTP request method. Defaults to
     `'GET'`.
-  * `path` {String} Request path. Defaults to `'/'`. Should include query
+  * `path` {string} Request path. Defaults to `'/'`. Should include query
     string if any. E.G. `'/index.html?page=12'`. An exception is thrown when
     the request path contains illegal characters. Currently, only spaces are
     rejected but that may change in the future.
   * `headers` {Object} An object containing request headers.
-  * `auth` {String} Basic authentication i.e. `'user:password'` to compute an
+  * `auth` {string} Basic authentication i.e. `'user:password'` to compute an
     Authorization header.
-  * `agent` {http.Agent|Boolean} Controls [`Agent`][] behavior. Possible values:
+  * `agent` {http.Agent|boolean} Controls [`Agent`][] behavior. Possible values:
    * `undefined` (default): use [`http.globalAgent`][] for this host and port.
    * `Agent` object: explicitly use the passed in `Agent`.
    * `false`: causes a new `Agent` with default values to be used.

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -618,7 +618,7 @@ The module that first required this one.
 added: v0.5.1
 -->
 
-* `id` {String}
+* `id` {string}
 * Returns: {Object} `module.exports` from the resolved module
 
 The `module.require` method provides a way to load a module as if

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -123,7 +123,7 @@ added: v0.5.10
 -->
 
 * `handle` {Object}
-* `backlog` {Number}
+* `backlog` {number}
 * `callback` {Function}
 
 The `handle` object can be set to either a server or socket (anything
@@ -149,11 +149,11 @@ added: v0.11.14
 -->
 
 * `options` {Object} - Required. Supports the following properties:
-  * `port` {Number} - Optional.
-  * `host` {String} - Optional.
-  * `backlog` {Number} - Optional.
-  * `path` {String} - Optional.
-  * `exclusive` {Boolean} - Optional.
+  * `port` {number} - Optional.
+  * `host` {string} - Optional.
+  * `backlog` {number} - Optional.
+  * `path` {string} - Optional.
+  * `exclusive` {boolean} - Optional.
 * `callback` {Function} - Optional.
 
 The `port`, `host`, and `backlog` properties of `options`, as well as the
@@ -183,8 +183,8 @@ subsequent call will *re-open* the server using the provided options.
 added: v0.1.90
 -->
 
-* `path` {String}
-* `backlog` {Number}
+* `path` {string}
+* `backlog` {number}
 * `callback` {Function}
 
 Start a local socket server listening for connections on the given `path`.
@@ -349,7 +349,7 @@ About `allowHalfOpen`, refer to [`net.createServer()`][] and [`'end'`][] event.
 added: v0.1.90
 -->
 
-* `had_error` {Boolean} `true` if the socket had a transmission error.
+* `had_error` {boolean} `true` if the socket had a transmission error.
 
 Emitted once the socket is fully closed. The argument `had_error` is a boolean
 which says if the socket was closed due to a transmission error.
@@ -420,10 +420,10 @@ changes:
 Emitted after resolving the hostname but before connecting.
 Not applicable to UNIX sockets.
 
-* `err` {Error|Null} The error object.  See [`dns.lookup()`][].
-* `address` {String} The IP address.
-* `family` {String|Null} The address type.  See [`dns.lookup()`][].
-* `host` {String} The hostname.
+* `err` {Error|null} The error object.  See [`dns.lookup()`][].
+* `address` {string} The IP address.
+* `family` {string|null} The address type.  See [`dns.lookup()`][].
+* `host` {string} The hostname.
 
 ### Event: 'timeout'
 <!-- YAML

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -60,7 +60,7 @@ each CPU/core installed.
 
 The properties included on each object include:
 
-* `model` {String}
+* `model` {string}
 * `speed` {number} (in MHz)
 * `times` {Object}
   * `user` {number} The number of milliseconds the CPU has spent in user mode.
@@ -244,10 +244,10 @@ value is an array of objects that each describe an assigned network address.
 
 The properties available on the assigned network address object include:
 
-* `address` {String} The assigned IPv4 or IPv6 address
-* `netmask` {String} The IPv4 or IPv6 network mask
-* `family` {String} Either `IPv4` or `IPv6`
-* `mac` {String} The MAC address of the network interface
+* `address` {string} The assigned IPv4 or IPv6 address
+* `netmask` {string} The IPv4 or IPv6 network mask
+* `family` {string} Either `IPv4` or `IPv6`
+* `mac` {string} The MAC address of the network interface
 * `internal` {boolean} `true` if the network interface is a loopback or
   similar interface that is not remotely accessible; otherwise `false`
 * `scopeid` {number} The numeric IPv6 scope ID (only specified when `family`
@@ -388,7 +388,7 @@ added: v6.0.0
 -->
 
 * `options` {Object}
-  * `encoding` {String} Character encoding used to interpret resulting strings.
+  * `encoding` {string} Character encoding used to interpret resulting strings.
     If `encoding` is set to `'buffer'`, the `username`, `shell`, and `homedir`
     values will be `Buffer` instances. (Default: 'utf8')
 * Returns: {Object}

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -63,8 +63,8 @@ changes:
     description: Passing a non-string as the `path` argument will throw now.
 -->
 
-* `path` {String}
-* `ext` {String} An optional file extension
+* `path` {string}
+* `ext` {string} An optional file extension
 * Returns: {String}
 
 The `path.basename()` methods returns the last portion of a `path`, similar to
@@ -124,7 +124,7 @@ changes:
     description: Passing a non-string as the `path` argument will throw now.
 -->
 
-* `path` {String}
+* `path` {string}
 * Returns: {String}
 
 The `path.dirname()` method returns the directory name of a `path`, similar to
@@ -148,7 +148,7 @@ changes:
     description: Passing a non-string as the `path` argument will throw now.
 -->
 
-* `path` {String}
+* `path` {string}
 * Returns: {String}
 
 The `path.extname()` method returns the extension of the `path`, from the last
@@ -184,11 +184,11 @@ added: v0.11.15
 -->
 
 * `pathObject` {Object}
-  * `dir` {String}
-  * `root` {String}
-  * `base` {String}
-  * `name` {String}
-  * `ext` {String}
+  * `dir` {string}
+  * `root` {string}
+  * `base` {string}
+  * `name` {string}
+  * `ext` {string}
 * Returns: {String}
 
 The `path.format()` method returns a path string from an object. This is the
@@ -247,7 +247,7 @@ path.format({
 added: v0.11.2
 -->
 
-* `path` {String}
+* `path` {string}
 * Returns: {Boolean}
 
 The `path.isAbsolute()` method determines if `path` is an absolute path.
@@ -282,7 +282,7 @@ A [`TypeError`][] is thrown if `path` is not a string.
 added: v0.1.16
 -->
 
-* `...paths` {String} A sequence of path segments
+* `...paths` {string} A sequence of path segments
 * Returns: {String}
 
 The `path.join()` method joins all given `path` segments together using the
@@ -309,7 +309,7 @@ A [`TypeError`][] is thrown if any of the path segments is not a string.
 added: v0.1.23
 -->
 
-* `path` {String}
+* `path` {string}
 * Returns: {String}
 
 The `path.normalize()` method normalizes the given `path`, resolving `'..'` and
@@ -343,7 +343,7 @@ A [`TypeError`][] is thrown if `path` is not a string.
 added: v0.11.15
 -->
 
-* `path` {String}
+* `path` {string}
 * Returns: {Object}
 
 The `path.parse()` method returns an object whose properties represent
@@ -351,11 +351,11 @@ significant elements of the `path`.
 
 The returned object will have the following properties:
 
-* `root` {String}
-* `dir` {String}
-* `base` {String}
-* `ext` {String}
-* `name` {String}
+* `root` {string}
+* `dir` {string}
+* `base` {string}
+* `ext` {string}
+* `name` {string}
 
 For example on POSIX:
 
@@ -427,8 +427,8 @@ changes:
                  in the return value.
 -->
 
-* `from` {String}
-* `to` {String}
+* `from` {string}
+* `to` {string}
 * Returns: {String}
 
 The `path.relative()` method returns the relative path from `from` to `to`.
@@ -459,7 +459,7 @@ A [`TypeError`][] is thrown if neither `from` nor `to` is a string.
 added: v0.3.4
 -->
 
-* `...paths` {String} A sequence of paths or path segments
+* `...paths` {string} A sequence of paths or path segments
 * Returns: {String}
 
 The `path.resolve()` method resolves a sequence of paths or path segments into

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -276,9 +276,9 @@ lead to sub-optimal application performance, bugs or security vulnerabilities.
 The listener function is called with a single `warning` argument whose value is
 an `Error` object. There are three key properties that describe the warning:
 
-* `name` {String} The name of the warning (currently `Warning` by default).
-* `message` {String} A system-provided description of the warning.
-* `stack` {String} A stack trace to the location in the code where the warning
+* `name` {string} The name of the warning (currently `Warning` by default).
+* `message` {string} A system-provided description of the warning.
+* `stack` {string} A stack trace to the location in the code where the warning
   was issued.
 
 ```js
@@ -498,7 +498,7 @@ property is `undefined`.
 added: v0.1.17
 -->
 
-* `directory` {String}
+* `directory` {string}
 
 The `process.chdir()` method changes the current working directory of the
 Node.js process or throws an exception if doing so fails (for instance, if
@@ -642,10 +642,10 @@ If the Node.js process was not spawned with an IPC channel,
 added: v6.0.0
 -->
 
-* `warning` {String | Error} The warning to emit.
-* `type` {String} When `warning` is a String, `type` is the name to use
+* `warning` {string | Error} The warning to emit.
+* `type` {string} When `warning` is a String, `type` is the name to use
   for the *type* of warning being emitted. Default: `Warning`.
-* `code` {String} A unique identifier for the warning instance being emitted.
+* `code` {string} A unique identifier for the warning instance being emitted.
 * `ctor` {Function} When `warning` is a String, `ctor` is an optional
   function used to limit the generated stack trace. Default
   `process.emitWarning`
@@ -1071,8 +1071,8 @@ setTimeout(() => {
 added: v0.9.4
 -->
 
-* `user` {String|number} The user name or numeric identifier.
-* `extra_group` {String|number} A group name or numeric identifier.
+* `user` {string|number} The user name or numeric identifier.
+* `extra_group` {string|number} A group name or numeric identifier.
 
 The `process.initgroups()` method reads the `/etc/group` file and initializes
 the group access list, using all groups of which the user is a member. This is
@@ -1098,7 +1098,7 @@ added: v0.0.6
 -->
 
 * `pid` {number} A process ID
-* `signal` {String|number} The signal to send, either as a string or number.
+* `signal` {string|number} The signal to send, either as a string or number.
   Defaults to `'SIGTERM'`.
 
 The `process.kill()` method sends the `signal` to the process identified by
@@ -1325,19 +1325,19 @@ tarball.
 
 `process.release` contains the following properties:
 
-* `name` {String} A value that will always be `'node'` for Node.js. For
+* `name` {string} A value that will always be `'node'` for Node.js. For
   legacy io.js releases, this will be `'io.js'`.
-* `sourceUrl` {String} an absolute URL pointing to a _`.tar.gz`_ file containing
+* `sourceUrl` {string} an absolute URL pointing to a _`.tar.gz`_ file containing
   the source code of the current release.
 * `headersUrl`{String} an absolute URL pointing to a _`.tar.gz`_ file containing
   only the source header files for the current release. This file is
   significantly smaller than the full source file and can be used for compiling
   Node.js native add-ons.
-* `libUrl` {String} an absolute URL pointing to a _`node.lib`_ file matching the
+* `libUrl` {string} an absolute URL pointing to a _`node.lib`_ file matching the
   architecture and version of the current release. This file is used for
   compiling Node.js native add-ons. _This property is only present on Windows
   builds of Node.js and will be missing on all other platforms._
-* `lts` {String} a string label identifying the [LTS][] label for this release.
+* `lts` {string} a string label identifying the [LTS][] label for this release.
   If the Node.js release is not an LTS release, this will be `undefined`.
 
 For example:
@@ -1382,7 +1382,7 @@ If Node.js was not spawned with an IPC channel, `process.send()` will be
 added: v2.0.0
 -->
 
-* `id` {String|number} A group name or ID
+* `id` {string|number} A group name or ID
 
 The `process.setegid()` method sets the effective group identity of the process.
 (See setegid(2).) The `id` can be passed as either a numeric ID or a group
@@ -1411,7 +1411,7 @@ Android)
 added: v2.0.0
 -->
 
-* `id` {String|number} A user name or ID
+* `id` {string|number} A user name or ID
 
 The `process.seteuid()` method sets the effective user identity of the process.
 (See seteuid(2).) The `id` can be passed as either a numeric ID or a username
@@ -1439,7 +1439,7 @@ Android)
 added: v0.1.31
 -->
 
-* `id` {String|number} The group name or ID
+* `id` {string|number} The group name or ID
 
 The `process.setgid()` method sets the group identity of the process. (See
 setgid(2).)  The `id` can be passed as either a numeric ID or a group name

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -40,7 +40,7 @@ the module must be directed to the [Punycode.js][] project.
 added: v0.5.1
 -->
 
-* `string` {String}
+* `string` {string}
 
 The `punycode.decode()` method converts a [Punycode][] string of ASCII-only
 characters to the equivalent string of Unicode codepoints.
@@ -55,7 +55,7 @@ punycode.decode('--dqo34k'); // '☃-⌘'
 added: v0.5.1
 -->
 
-* `string` {String}
+* `string` {string}
 
 The `punycode.encode()` method converts a string of Unicode codepoints to a
 [Punycode][] string of ASCII-only characters.
@@ -70,7 +70,7 @@ punycode.encode('☃-⌘'); // '--dqo34k'
 added: v0.6.1
 -->
 
-* `domain` {String}
+* `domain` {string}
 
 The `punycode.toASCII()` method converts a Unicode string representing an
 Internationalized Domain Name to [Punycode][]. Only the non-ASCII parts of the
@@ -89,7 +89,7 @@ punycode.toASCII('example.com'); // 'example.com'
 added: v0.6.1
 -->
 
-* `domain` {String}
+* `domain` {string}
 
 The `punycode.toUnicode()` method converts a string representing a domain name
 containing [Punycode][] encoded characters into Unicode. Only the [Punycode][]
@@ -112,7 +112,7 @@ added: v0.7.0
 added: v0.7.0
 -->
 
-* `string` {String}
+* `string` {string}
 
 The `punycode.ucs2.decode()` method returns an array containing the numeric
 codepoint values of each Unicode symbol in the string.

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -16,7 +16,7 @@ const querystring = require('querystring');
 added: v0.1.25
 -->
 
-* `str` {String}
+* `str` {string}
 
 The `querystring.escape()` method performs URL percent-encoding on the given
 `str` in a manner that is optimized for the specific requirements of URL
@@ -42,10 +42,10 @@ changes:
     description: The `eq` parameter may now have a length of more than `1`.
 -->
 
-* `str` {String} The URL query string to parse
-* `sep` {String} The substring used to delimit key and value pairs in the
+* `str` {string} The URL query string to parse
+* `sep` {string} The substring used to delimit key and value pairs in the
   query string. Defaults to `'&'`.
-* `eq` {String}. The substring used to delimit keys and values in the
+* `eq` {string}. The substring used to delimit keys and values in the
   query string. Defaults to `'='`.
 * `options` {Object}
   * `decodeURIComponent` {Function} The function to use when decoding
@@ -89,9 +89,9 @@ added: v0.1.25
 -->
 
 * `obj` {Object} The object to serialize into a URL query string
-* `sep` {String} The substring used to delimit key and value pairs in the
+* `sep` {string} The substring used to delimit key and value pairs in the
   query string. Defaults to `'&'`.
-* `eq` {String}. The substring used to delimit keys and values in the
+* `eq` {string}. The substring used to delimit keys and values in the
   query string. Defaults to `'='`.
 * `options`
   * `encodeURIComponent` {Function} The function to use when converting
@@ -127,7 +127,7 @@ querystring.stringify({ w: '中文', foo: 'bar' }, null, null,
 <!-- YAML
 added: v0.1.25
 -->
-* `str` {String}
+* `str` {string}
 
 
 The `querystring.unescape()` method performs decoding of URL percent-encoded

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -237,7 +237,7 @@ If the `readline.Interface` was created with `output` set to `null` or
 added: v0.3.3
 -->
 
-* `query` {String} A statement or query to write to `output`, prepended to the
+* `query` {string} A statement or query to write to `output`, prepended to the
   prompt.
 * `callback` {Function} A callback function that is invoked with the user's
   input in response to the `query`.
@@ -276,7 +276,7 @@ The `rl.resume()` method resumes the `input` stream if it has been paused.
 added: v0.1.98
 -->
 
-* `prompt` {String}
+* `prompt` {string}
 
 The `rl.setPrompt()` method sets the prompt that will be written to `output`
 whenever `rl.prompt()` is called.
@@ -286,12 +286,12 @@ whenever `rl.prompt()` is called.
 added: v0.1.98
 -->
 
-* `data` {String}
+* `data` {string}
 * `key` {Object}
   * `ctrl` {boolean} `true` to indicate the `<ctrl>` key.
   * `meta` {boolean} `true` to indicate the `<Meta>` key.
   * `shift` {boolean} `true` to indicate the `<Shift>` key.
-  * `name` {String} The name of the a key.
+  * `name` {string} The name of the a key.
 
 The `rl.write()` method will write either `data` or a key sequence  identified
 by `key` to the `output`. The `key` argument is supported only if `output` is
@@ -467,7 +467,7 @@ added: v0.7.7
 
 * `stream` {Writable}
 * `dx` {number}
-* `dy` {Number}
+* `dy` {number}
 
 The `readline.moveCursor()` method moves the cursor *relative* to its current
 position in a given [TTY][] `stream`.

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -308,7 +308,7 @@ Clearing context...
 added: v0.3.0
 -->
 
-* `keyword` {String} The command keyword (*without* a leading `.` character).
+* `keyword` {string} The command keyword (*without* a leading `.` character).
 * `cmd` {Object|Function} The function to invoke when the command is processed.
 
 The `replServer.defineCommand()` method is used to add new `.`-prefixed commands
@@ -316,7 +316,7 @@ to the REPL instance. Such commands are invoked by typing a `.` followed by the
 `keyword`. The `cmd` is either a Function or an object with the following
 properties:
 
-* `help` {String} Help text to be displayed when `.help` is entered (Optional).
+* `help` {string} Help text to be displayed when `.help` is entered (Optional).
 * `action` {Function} The function to execute, optionally accepting a single
   string argument.
 
@@ -355,7 +355,7 @@ Goodbye!
 added: v0.1.91
 -->
 
-* `preserveCursor` {Boolean}
+* `preserveCursor` {boolean}
 
 The `replServer.displayPrompt()` method readies the REPL instance for input
 from the user, printing the configured `prompt` to a new line in the `output`
@@ -380,7 +380,7 @@ changes:
 -->
 
 * `options` {Object | String}
-  * `prompt` {String} The input prompt to display. Defaults to `> `
+  * `prompt` {string} The input prompt to display. Defaults to `> `
     (with a trailing space).
   * `input` {Readable} The Readable stream from which REPL input will be read.
     Defaults to `process.stdin`.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -354,10 +354,10 @@ See also: [`writable.uncork()`][].
 added: v0.9.4
 -->
 
-* `chunk` {String|Buffer|any} Optional data to write. For streams not operating
+* `chunk` {string|Buffer|any} Optional data to write. For streams not operating
   in object mode, `chunk` must be a string or a `Buffer`. For object mode
   streams, `chunk` may be any JavaScript value other than `null`.
-* `encoding` {String} The encoding, if `chunk` is a String
+* `encoding` {string} The encoding, if `chunk` is a String
 * `callback` {Function} Optional callback for when the stream is finished
 
 Calling the `writable.end()` method signals that no more data will be written
@@ -386,7 +386,7 @@ changes:
     description: This method now returns a reference to `writable`.
 -->
 
-* `encoding` {String} The new default encoding
+* `encoding` {string} The new default encoding
 * Returns: `this`
 
 The `writable.setDefaultEncoding()` method sets the default `encoding` for a
@@ -440,8 +440,8 @@ changes:
                  considered invalid now, even in object mode.
 -->
 
-* `chunk` {String|Buffer} The data to write
-* `encoding` {String} The encoding, if `chunk` is a String
+* `chunk` {string|Buffer} The data to write
+* `encoding` {string} The encoding, if `chunk` is a String
 * `callback` {Function} Callback for when this chunk of data is flushed
 * Returns: {Boolean} `false` if the stream wishes for the calling code to
   wait for the `'drain'` event to be emitted before continuing to write
@@ -625,7 +625,7 @@ Not all [Readable][] streams will emit the `'close'` event.
 added: v0.9.4
 -->
 
-* `chunk` {Buffer|String|any} The chunk of data. For streams that are not
+* `chunk` {Buffer|string|any} The chunk of data. For streams that are not
   operating in object mode, the chunk will be either a string or `Buffer`.
   For streams that are in object mode, the chunk can be any JavaScript value
   other than `null`.
@@ -789,7 +789,7 @@ added: v0.9.4
 
 * `destination` {stream.Writable} The destination for writing data
 * `options` {Object} Pipe options
-  * `end` {Boolean} End the writer when the reader ends. Defaults to `true`.
+  * `end` {boolean} End the writer when the reader ends. Defaults to `true`.
 
 The `readable.pipe()` method attaches a [Writable][] stream to the `readable`,
 causing it to switch automatically into flowing mode and push all of its data
@@ -845,8 +845,8 @@ options.
 added: v0.9.4
 -->
 
-* `size` {Number} Optional argument to specify how much data to read.
-* Return {String|Buffer|Null}
+* `size` {number} Optional argument to specify how much data to read.
+* Return {String|Buffer|null}
 
 The `readable.read()` method pulls some data out of the internal buffer and
 returns it. If no data available to be read, `null` is returned. By default,
@@ -917,7 +917,7 @@ getReadableStreamSomehow()
 added: v0.9.4
 -->
 
-* `encoding` {String} The encoding to use.
+* `encoding` {string} The encoding to use.
 * Returns: `this`
 
 The `readable.setEncoding()` method sets the default character encoding for
@@ -981,7 +981,7 @@ setTimeout(() => {
 added: v0.9.11
 -->
 
-* `chunk` {Buffer|String} Chunk of data to unshift onto the read queue
+* `chunk` {Buffer|string} Chunk of data to unshift onto the read queue
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by
@@ -1236,13 +1236,13 @@ constructor and implement the `writable._write()` method. The
 #### Constructor: new stream.Writable([options])
 
 * `options` {Object}
-  * `highWaterMark` {Number} Buffer level when
+  * `highWaterMark` {number} Buffer level when
     [`stream.write()`][stream-write] starts returning `false`. Defaults to
     `16384` (16kb), or `16` for `objectMode` streams.
-  * `decodeStrings` {Boolean} Whether or not to decode strings into
+  * `decodeStrings` {boolean} Whether or not to decode strings into
     Buffers before passing them to [`stream._write()`][stream-_write].
     Defaults to `true`
-  * `objectMode` {Boolean} Whether or not the
+  * `objectMode` {boolean} Whether or not the
     [`stream.write(anyObj)`][stream-write] is a valid operation. When set,
     it becomes possible to write JavaScript values other than string or
     `Buffer` if supported by the stream implementation. Defaults to `false`
@@ -1295,9 +1295,9 @@ const myWritable = new Writable({
 
 #### writable.\_write(chunk, encoding, callback)
 
-* `chunk` {Buffer|String} The chunk to be written. Will **always**
+* `chunk` {Buffer|string} The chunk to be written. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
-* `encoding` {String} If the chunk is a string, then `encoding` is the
+* `encoding` {string} If the chunk is a string, then `encoding` is the
   character encoding of that string. If chunk is a `Buffer`, or if the
   stream is operating in object mode, `encoding` may be ignored.
 * `callback` {Function} Call this function (optionally with an error
@@ -1417,12 +1417,12 @@ constructor and implement the `readable._read()` method.
 #### new stream.Readable([options])
 
 * `options` {Object}
-  * `highWaterMark` {Number} The maximum number of bytes to store in
+  * `highWaterMark` {number} The maximum number of bytes to store in
     the internal buffer before ceasing to read from the underlying
     resource. Defaults to `16384` (16kb), or `16` for `objectMode` streams
-  * `encoding` {String} If specified, then buffers will be decoded to
+  * `encoding` {string} If specified, then buffers will be decoded to
     strings using the specified encoding. Defaults to `null`
-  * `objectMode` {Boolean} Whether this stream should behave
+  * `objectMode` {boolean} Whether this stream should behave
     as a stream of objects. Meaning that [`stream.read(n)`][stream-read] returns
     a single value instead of a Buffer of size n. Defaults to `false`
   * `read` {Function} Implementation for the [`stream._read()`][stream-_read]
@@ -1469,7 +1469,7 @@ const myReadable = new Readable({
 
 #### readable.\_read(size)
 
-* `size` {Number} Number of bytes to read asynchronously
+* `size` {number} Number of bytes to read asynchronously
 
 *Note*: **This function MUST NOT be called by application code directly.** It
 should be implemented by child classes, and called only by the internal Readable
@@ -1500,8 +1500,8 @@ user programs.
 
 #### readable.push(chunk[, encoding])
 
-* `chunk` {Buffer|Null|String} Chunk of data to push into the read queue
-* `encoding` {String} Encoding of String chunks.  Must be a valid
+* `chunk` {Buffer|null|string} Chunk of data to push into the read queue
+* `encoding` {string} Encoding of String chunks.  Must be a valid
   Buffer encoding, such as `'utf8'` or `'ascii'`
 * Returns {Boolean} `true` if additional chunks of data may continued to be
   pushed; `false` otherwise.
@@ -1631,13 +1631,13 @@ constructor and implement *both* the `readable._read()` and
 
 * `options` {Object} Passed to both Writable and Readable
   constructors. Also has the following fields:
-  * `allowHalfOpen` {Boolean} Defaults to `true`. If set to `false`, then
+  * `allowHalfOpen` {boolean} Defaults to `true`. If set to `false`, then
     the stream will automatically end the readable side when the
     writable side ends and vice versa.
-  * `readableObjectMode` {Boolean} Defaults to `false`. Sets `objectMode`
+  * `readableObjectMode` {boolean} Defaults to `false`. Sets `objectMode`
     for readable side of the stream. Has no effect if `objectMode`
     is `true`.
-  * `writableObjectMode` {Boolean} Defaults to `false`. Sets `objectMode`
+  * `writableObjectMode` {boolean} Defaults to `false`. Sets `objectMode`
     for writable side of the stream. Has no effect if `objectMode`
     is `true`.
 
@@ -1873,9 +1873,9 @@ user programs.
 
 #### transform.\_transform(chunk, encoding, callback)
 
-* `chunk` {Buffer|String} The chunk to be transformed. Will **always**
+* `chunk` {Buffer|string} The chunk to be transformed. Will **always**
   be a buffer unless the `decodeStrings` option was set to `false`.
-* `encoding` {String} If the chunk is a string, then this is the
+* `encoding` {string} If the chunk is a string, then this is the
   encoding type. If chunk is a buffer, then this is the special
   value - 'buffer', ignore it in this case.
 * `callback` {Function} A callback function (optionally with an error

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -204,11 +204,11 @@ The formatting process operates as follows:
 
 * `URL` {URL} A [WHATWG URL][] object
 * `options` {Object}
-  * `auth` {Boolean} `true` if the serialized URL string should include the
+  * `auth` {boolean} `true` if the serialized URL string should include the
     username and password, `false` otherwise. Defaults to `true`.
-  * `fragment` {Boolean} `true` if the serialized URL string should include the
+  * `fragment` {boolean} `true` if the serialized URL string should include the
     fragment, `false` otherwise. Defaults to `true`.
-  * `search` {Boolean} `true` if the serialized URL string should include the
+  * `search` {boolean} `true` if the serialized URL string should include the
     search query, `false` otherwise. Defaults to `true`.
   * `unicode` (Boolean) `true` if Unicode characters appearing in the host
     component of the URL string should be encoded directly as opposed to being
@@ -245,12 +245,12 @@ be experimental.
 added: v0.1.25
 -->
 
-* `urlString` {String} The URL string to parse.
-* `parseQueryString` {Boolean} If `true`, the `query` property will always
+* `urlString` {string} The URL string to parse.
+* `parseQueryString` {boolean} If `true`, the `query` property will always
   be set to an object returned by the [`querystring`][] module's `parse()`
   method. If `false`, the `query` property on the returned URL object will be an
   unparsed, undecoded string. Defaults to `false`.
-* `slashesDenoteHost` {Boolean} If `true`, the first token after the literal
+* `slashesDenoteHost` {boolean} If `true`, the first token after the literal
   string `//` and preceding the next `/` will be interpreted as the `host`.
   For instance, given `//foo/bar`, the result would be
   `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
@@ -276,8 +276,8 @@ changes:
                  contains a hostname.
 -->
 
-* `from` {String} The Base URL being resolved against.
-* `to` {String} The HREF URL being resolved.
+* `from` {string} The Base URL being resolved against.
+* `to` {string} The HREF URL being resolved.
 
 The `url.resolve()` method resolves a target URL relative to a base URL in a
 manner similar to that of a Web browser resolving an anchor tag HREF.
@@ -355,8 +355,8 @@ object returned by `url.parse()` are shown. Below it are properties of a WHATWG
 ### Class: URL
 #### Constructor: new URL(input[, base])
 
-* `input` {String} The input URL to parse
-* `base` {String | URL} The base URL to resolve against if the `input` is not
+* `input` {string} The input URL to parse
+* `base` {string | URL} The base URL to resolve against if the `input` is not
   absolute.
 
 Creates a new `URL` object by parsing the `input` relative to the `base`. If
@@ -742,7 +742,7 @@ Instantiate a new empty `URLSearchParams` object.
 
 #### Constructor: new URLSearchParams(string)
 
-* `string` {String} A query string
+* `string` {string} A query string
 
 Parse the `string` as a query string, and use it to instantiate a new
 `URLSearchParams` object. A leading `'?'`, if present, is ignored.
@@ -838,14 +838,14 @@ new URLSearchParams([
 
 #### urlSearchParams.append(name, value)
 
-* `name` {String}
-* `value` {String}
+* `name` {string}
+* `value` {string}
 
 Append a new name-value pair to the query string.
 
 #### urlSearchParams.delete(name)
 
-* `name` {String}
+* `name` {string}
 
 Remove all name-value pairs whose name is `name`.
 
@@ -879,15 +879,16 @@ myURL.searchParams.forEach((value, name, searchParams) => {
 
 #### urlSearchParams.get(name)
 
-* `name` {String}
-* Returns: {String | Null}
+* `name` {string}
+* Returns: {string} or `null` if there is no name-value pair with the given
+  `name`.
 
 Returns the value of the first name-value pair whose name is `name`. If there
 are no such pairs, `null` is returned.
 
 #### urlSearchParams.getAll(name)
 
-* `name` {String}
+* `name` {string}
 * Returns: {Array}
 
 Returns the values of all name-value pairs whose name is `name`. If there are
@@ -895,7 +896,7 @@ no such pairs, an empty array is returned.
 
 #### urlSearchParams.has(name)
 
-* `name` {String}
+* `name` {string}
 * Returns: {Boolean}
 
 Returns `true` if there is at least one name-value pair whose name is `name`.
@@ -919,8 +920,8 @@ for (const name of params.keys()) {
 
 #### urlSearchParams.set(name, value)
 
-* `name` {String}
-* `value` {String}
+* `name` {string}
+* `value` {string}
 
 Sets the value in the `URLSearchParams` object associated with `name` to
 `value`. If there are any pre-existing name-value pairs whose names are `name`,
@@ -994,7 +995,7 @@ for (const [name, value] of params) {
 
 ### require('url').domainToASCII(domain)
 
-* `domain` {String}
+* `domain` {string}
 * Returns: {String}
 
 Returns the [Punycode][] ASCII serialization of the `domain`. If `domain` is an
@@ -1017,7 +1018,7 @@ the new `URL` implementation but is not part of the WHATWG URL standard.
 
 ### require('url').domainToUnicode(domain)
 
-* `domain` {String}
+* `domain` {string}
 * Returns: {String}
 
 Returns the Unicode serialization of the `domain`. If `domain` is an invalid

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -15,7 +15,7 @@ const util = require('util');
 added: v0.11.3
 -->
 
-* `section` {String} A string identifying the portion of the application for
+* `section` {string} A string identifying the portion of the application for
   which the `debuglog` function is being created.
 * Returns: {Function} The logging function
 
@@ -93,7 +93,7 @@ property take precedence over `--trace-deprecation` and
 added: v0.5.3
 -->
 
-* `format` {String} A `printf`-like format string.
+* `format` {string} A `printf`-like format string.
 
 The `util.format()` method returns a formatted string using the first argument
 as a `printf`-like format.
@@ -416,7 +416,7 @@ deprecated: v0.11.3
 
 > Stability: 0 - Deprecated: Use [`console.error()`][] instead.
 
-* `string` {String} The message to print to `stderr`
+* `string` {string} The message to print to `stderr`
 
 Deprecated predecessor of `console.error`.
 
@@ -428,7 +428,7 @@ deprecated: v0.11.3
 
 > Stability: 0 - Deprecated: Use [`console.error()`][] instead.
 
-* `...strings` {String} The message to print to `stderr`
+* `...strings` {string} The message to print to `stderr`
 
 Deprecated predecessor of `console.error`.
 
@@ -830,7 +830,7 @@ deprecated: v6.0.0
 
 > Stability: 0 - Deprecated: Use a third party module instead.
 
-* `string` {String}
+* `string` {string}
 
 The `util.log()` method prints the given `string` to `stdout` with an included
 timestamp.

--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -4,12 +4,12 @@ const jsDocPrefix = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/';
 const jsDocUrl = jsDocPrefix + 'Reference/Global_Objects/';
 const jsPrimitiveUrl = jsDocPrefix + 'Data_structures';
 const jsPrimitives = {
-  'Integer': 'Number',  // this is for extending
-  'Number': 'Number',
-  'String': 'String',
-  'Boolean': 'Boolean',
-  'Null': 'Null',
-  'Symbol': 'Symbol'
+  'integer': 'Number',  // this is for extending
+  'number': 'Number',
+  'string': 'String',
+  'boolean': 'Boolean',
+  'null': 'Null',
+  'symbol': 'Symbol'
 };
 const jsGlobalTypes = [
   'Error', 'Object', 'Function', 'Array', 'TypedArray', 'Uint8Array',
@@ -67,7 +67,16 @@ module.exports = {
       typeText = typeText.trim();
       if (typeText) {
         let typeUrl = null;
-        const primitive = jsPrimitives[typeText];
+
+        // To support type[], we store the full string and use
+        // the bracket-less version to lookup the type URL
+        const typeTextFull = typeText;
+        if (/\[]$/.test(typeText)) {
+          typeText = typeText.slice(0, -2);
+        }
+
+        const primitive = jsPrimitives[typeText.toLowerCase()];
+
         if (primitive !== undefined) {
           typeUrl = `${jsPrimitiveUrl}#${primitive}_type`;
         } else if (jsGlobalTypes.indexOf(typeText) !== -1) {
@@ -78,9 +87,9 @@ module.exports = {
 
         if (typeUrl) {
           typeLinks.push('<a href="' + typeUrl + '" class="type">&lt;' +
-            typeText + '&gt;</a>');
+            typeTextFull + '&gt;</a>');
         } else {
-          typeLinks.push('<span class="type">&lt;' + typeText + '&gt;</span>');
+          typeLinks.push('<span class="type">&lt;' + typeTextFull + '&gt;</span>');
         }
       }
     });


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
The first commit capitalizes all primitive types so the parser can pick them up.
The second commit adds logic to the doctool to allow parsing of `Type[]` array syntax.

#### Before
<img width="857" src="https://cloud.githubusercontent.com/assets/115237/22620107/756927ea-eb04-11e6-9ae6-05a24ecf0d89.png">

#### After
<img width="874" src="https://cloud.githubusercontent.com/assets/115237/22620110/7e05c71e-eb04-11e6-9393-e4c3432b7108.png">
