### PR TITLE
tools: enable no-throw-literal ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -40,6 +40,7 @@ rules:
   no-octal: 2
   no-redeclare: 2
   no-self-assign: 2
+  no-throw-literal: 2
   no-unused-labels: 2
   no-useless-call: 2
   no-useless-escape: 2

--- a/test/message/throw_custom_error.js
+++ b/test/message/throw_custom_error.js
@@ -2,4 +2,5 @@
 require('../common');
 
 // custom error throwing
+// eslint-disable-next-line no-throw-literal
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });

--- a/test/message/throw_custom_error.out
+++ b/test/message/throw_custom_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_custom_error.js:5
+*test*message*throw_custom_error.js:6
 throw ({ name: 'MyCustomError', message: 'This is a custom message' });
 ^
 MyCustomError: This is a custom message

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -6,6 +6,7 @@ console.error('before');
 
 (function() {
 	// these lines should contain tab!
+	// eslint-disable-next-line no-throw-literal
 	throw ({ foo: 'bar' });
 })();
 

--- a/test/message/throw_in_line_with_tabs.out
+++ b/test/message/throw_in_line_with_tabs.out
@@ -1,5 +1,5 @@
 before
-*test*message*throw_in_line_with_tabs.js:9
+*test*message*throw_in_line_with_tabs.js:10
 	throw ({ foo: 'bar' });
 	^
 [object Object]

--- a/test/message/throw_non_error.js
+++ b/test/message/throw_non_error.js
@@ -2,4 +2,5 @@
 require('../common');
 
 // custom error throwing
+// eslint-disable-next-line no-throw-literal
 throw ({ foo: 'bar' });

--- a/test/message/throw_non_error.out
+++ b/test/message/throw_non_error.out
@@ -1,4 +1,4 @@
-*test*message*throw_non_error.js:5
+*test*message*throw_non_error.js:6
 throw ({ foo: 'bar' });
 ^
 [object Object]

--- a/test/message/throw_null.js
+++ b/test/message/throw_null.js
@@ -1,4 +1,5 @@
 'use strict';
 require('../common');
 
+// eslint-disable-next-line no-throw-literal
 throw null;

--- a/test/message/throw_null.out
+++ b/test/message/throw_null.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_null.js:4
+*test*message*throw_null.js:5
 throw null;
 ^
 null

--- a/test/message/throw_undefined.js
+++ b/test/message/throw_undefined.js
@@ -1,4 +1,5 @@
 'use strict';
 require('../common');
 
+// eslint-disable-next-line no-throw-literal
 throw undefined;

--- a/test/message/throw_undefined.out
+++ b/test/message/throw_undefined.out
@@ -1,5 +1,5 @@
 
-*test*message*throw_undefined.js:4
+*test*message*throw_undefined.js:5
 throw undefined;
 ^
 undefined

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -394,7 +394,7 @@ threw = false;
 try {
   assert.throws(
       function() {
-        throw ({});
+        throw ({}); // eslint-disable-line no-throw-literal
       },
       Array
   );
@@ -576,6 +576,7 @@ testBlockTypeError(assert.throws, undefined);
 testBlockTypeError(assert.doesNotThrow, undefined);
 
 // https://github.com/nodejs/node/issues/3275
+// eslint-disable-next-line no-throw-literal
 assert.throws(() => { throw 'error'; }, (err) => err === 'error');
 assert.throws(() => { throw new Error(); }, (err) => err instanceof Error);
 

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
@@ -23,7 +23,7 @@ testCases.findByPath = function(path) {
     return testCase.path === path;
   });
   if (matching.length === 0) {
-    throw 'failed to find test case with path ' + path;
+    common.fail(`failed to find test case with path ${path}`);
   }
   return matching[0];
 };

--- a/test/parallel/test-tls-econnreset.js
+++ b/test/parallel/test-tls-econnreset.js
@@ -49,8 +49,8 @@ const ca = [ cert, cacert ];
 let clientError = null;
 let connectError = null;
 
-const server = tls.createServer({ ca: ca, cert: cert, key: key }, (conn) => {
-  throw 'unreachable';
+const server = tls.createServer({ ca: ca, cert: cert, key: key }, () => {
+  common.fail('should be unreachable');
 }).on('tlsClientError', function(err, conn) {
   assert(!clientError && conn);
   clientError = err;


### PR DESCRIPTION
    Only throw the Error object itself or an object using the Error object
    as base objects for user-defined exceptions.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test