### PR TITLE
doc: remove extraneous paragraph from assert doc

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -5,10 +5,6 @@
 The `assert` module provides a simple set of assertion tests that can be used to
 test invariants.
 
-The API for the `assert` module is [Locked][]. This means that there will be no
-additions or changes to any of the methods implemented and exposed by the
-module.
-
 ## assert(value[, message])
 <!-- YAML
 added: v0.5.9
@@ -466,7 +462,6 @@ assert.throws(myFunction, 'missing foo', 'did not throw with expected message');
 assert.throws(myFunction, /missing foo/, 'did not throw with expected message');
 ```
 
-[Locked]: documentation.html#documentation_stability_index
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
 [`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message
 [`assert.ok()`]: #assert_assert_ok_value_message


### PR DESCRIPTION
The stability index is explained elsewhere in the documentation. It is
not necessary to repeat the information about Locked stability index in
the assert documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc assert