### PR TITLE
test: reduce buffer size in buffer-creation test

### DIFF
--- a/test/sequential/test-buffer-creation-regression.js
+++ b/test/sequential/test-buffer-creation-regression.js
@@ -20,9 +20,9 @@ const acceptableOOMErrors = [
   'Invalid array buffer length'
 ];
 
-const size = 8589934592; /* 1 << 33 */
-const offset = 4294967296; /* 1 << 32 */
 const length = 1000;
+const offset = 4294967296; /* 1 << 32 */
+const size = offset + length;
 let arrayBuffer;
 
 try {


### PR DESCRIPTION
As the test test/sequential/test-buffer-creation-regression.js fails
in SmartOS, it would be better not to allocate a huge chunk of memory.

Ref: https://github.com/nodejs/node/issues/10166

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
