### PR TITLE
backport of 11074 - doc: replace newlines in deprecation with space

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -183,7 +183,7 @@ function parseLists(input) {
           headingIndex = -1;
           heading = null;
         }
-        tok.text = parseAPIHeader(tok.text);
+        tok.text = parseAPIHeader(tok.text).replace(/\n/g, ' ');
         output.push({ type: 'html', text: tok.text });
         return;
       } else if (state === 'MAYBE_STABILITY_BQ') {


### PR DESCRIPTION
Backport of #11074

As it is, each line in the deprecation heading which are wrapped at 80
characters in the *.md files, are shown in different lines. For example

    > Stability: 0 - Deprecated: Use
    > `Buffer.from(arrayBuffer[, byteOffset [, length]])`
    > instead.

is shown in three different lines. This patch replaces the newlines
with space characters, so that the output will be in single line.

PR-URL: https://github.com/nodejs/node/pull/11074

Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Jeremiah Senkpiel <fishrock123@rocketmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Timothy Gu <timothygu99@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Michaël Zasso <targos@protonmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
