### PR TITLE
Backport 11037 - v6.x - doc: change logical to bitwise OR in dns lookup

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -77,7 +77,7 @@ Alternatively, `options` can be an object containing these properties:
   `4` or `6`. If not provided, both IP v4 and v6 addresses are accepted.
 * `hints`: {Number} - If present, it should be one or more of the supported
   `getaddrinfo` flags. If `hints` is not provided, then no flags are passed to
-  `getaddrinfo`. Multiple flags can be passed through `hints` by logically
+  `getaddrinfo`. Multiple flags can be passed through `hints` by bitwise
   `OR`ing their values.
   See [supported `getaddrinfo` flags][] for more information on supported
   flags.


### PR DESCRIPTION
The `hints` value will be a number. To specify more than one hints,
their corresponding bits have to be set. So bitwise OR should be used
instead of logical OR.

PR-URL: https://github.com/nodejs/node/pull/11037

Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Timothy Gu <timothygu99@gmail.com>
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc
