### PR TITLE
doc: fix typo in dgram doc

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -448,8 +448,8 @@ boolean `reuseAddr` field.
 
 When `reuseAddr` is `true` [`socket.bind()`][] will reuse the address, even if
 another process has already bound a socket on it. `reuseAddr` defaults to
-`false`. An optional `callback` function can be passed specified which is added
-as a listener for `'message'` events.
+`false`. The optional `callback` function is added as a listener for `'message'`
+events.
 
 Once the socket is created, calling [`socket.bind()`][] will instruct the
 socket to begin listening for datagram messages. When `address` and `port` are


### PR DESCRIPTION
There is a typographical error in the dgram documentation. Reword to
eliminate the error and increase clarity.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dgram doc