### PR TITLE
doc: stdout, stderr and stdin are all Duplex streams

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1509,8 +1509,10 @@ Android)
 
 * {Stream}
 
-The `process.stderr` property returns a [Writable][] stream connected to
-`stderr` (fd `2`).
+The `process.stderr` property returns a stream connected to
+`stderr` (fd `2`). It is a [`net.Socket`][] (which is a [Duplex][]
+stream) unless fd `2` refers to a file, in which case it is
+a [Writable][] stream.
 
 Note: `process.stderr` differs from other Node.js streams in important ways,
 see [note on process I/O][] for more information.
@@ -1519,8 +1521,10 @@ see [note on process I/O][] for more information.
 
 * {Stream}
 
-The `process.stdin` property returns a [Readable][] stream equivalent to or
-associated with `stdin` (fd `0`).
+The `process.stdin` property returns a stream connected to
+`stdin` (fd `0`). It is a [`net.Socket`][] (which is a [Duplex][]
+stream) unless fd `0` refers to a file, in which case it is
+a [Readable][] stream.
 
 For example:
 
@@ -1539,7 +1543,7 @@ process.stdin.on('end', () => {
 });
 ```
 
-As a [Readable][] stream, `process.stdin` can also be used in "old" mode that
+As a [Duplex][] stream, `process.stdin` can also be used in "old" mode that
 is compatible with scripts written for Node.js prior to v0.10.
 For more information see [Stream compatibility][].
 
@@ -1551,8 +1555,10 @@ must call `process.stdin.resume()` to read from it. Note also that calling
 
 * {Stream}
 
-The `process.stdout` property returns a [Writable][] stream connected to
-`stdout` (fd `1`).
+The `process.stdout` property returns a stream connected to
+`stdout` (fd `1`). It is a [`net.Socket`][] (which is a [Duplex][]
+stream) unless fd `1` refers to a file, in which case it is
+a [Writable][] stream.
 
 For example, to copy process.stdin to process.stdout:
 
@@ -1793,6 +1799,7 @@ cases:
 [TTY]: tty.html#tty_tty
 [Writable]: stream.html#stream_writable_streams
 [Readable]: stream.html#stream_readable_streams
+[Duplex]: stream.html#stream_duplex_and_transform_streams
 [Child Process]: child_process.html
 [Cluster]: cluster.html
 [`process.exitCode`]: #process_process_exitcode


### PR DESCRIPTION
doc: stdout, stderr and stdin are all Duplex streams but documentation states otherwise

This is a fix for https://github.com/nodejs/node/issues/9201

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
