### PR TITLE
child_process: increase default maxBuffer to 1024*1024 bytes

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -136,7 +136,7 @@ added: v0.1.90
      command line parsing should be compatible with `cmd.exe`.)
   * `timeout` {number} (Default: `0`)
   * `maxBuffer` {number} Largest amount of data in bytes allowed on stdout or
-    stderr. (Default: `200*1024`) If exceeded, the child process is terminated.
+    stderr. (Default: `1024*1024`) If exceeded, the child process is terminated.
     See caveat at [`maxBuffer` and Unicode][].
   * `killSignal` {string|integer} (Default: `'SIGTERM'`)
   * `uid` {number} Sets the user identity of the process. (See setuid(2).)

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -146,7 +146,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   var options = {
     encoding: 'utf8',
     timeout: 0,
-    maxBuffer: 200 * 1024,
+    maxBuffer: 1024 * 1024,
     killSignal: 'SIGTERM',
     cwd: null,
     env: null,


### PR DESCRIPTION
child_process: increase default maxBuffer to 1024*1024

Increase the default `maxBuffer` for `child_process.exec` from 200 * 1024 bytes to 1024 KB.

This is a fix for https://github.com/nodejs/node/issues/9829

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process
