### PR TITLE
src: fix -Wunused-result compiler warning

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -148,7 +148,7 @@ class ContextifyContext {
             desc->set_enumerable(desc_vm_context
                 ->Get(context, env()->enumerable_string()).ToLocalChecked()
                 ->BooleanValue(context).FromJust());
-            sandbox_obj->DefineProperty(context, key, *desc);
+            CHECK(sandbox_obj->DefineProperty(context, key, *desc).FromJust());
         };
 
         if (is_accessor) {


### PR DESCRIPTION
Fix a warning that was introduced in commit 67af1ad ("src: refactor
CopyProperties to remove JS") from a few days ago.  This particular
change was suggested by me, mea culpa.

Fixes the following warning:

    ../src/node_contextify.cc:151:13: warning: ignoring return
    value of function declared with warn_unused_result attribute
    [-Wunused-result]
                sandbox_obj->DefineProperty(context, key, *desc);

CI: https://ci.nodejs.org/job/node-test-pull-request/6233/