### PR TITLE
lib: introduce constant MAX_TICKS

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -5,7 +5,7 @@ exports.setup = setupNextTick;
 function setupNextTick() {
   const promises = require('internal/process/promises');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
-  const MAX_TICKS = 1e4;
+  const kMaxCallbacksPerTick = 1e4;
   var nextTickQueue = [];
   var microtasksScheduled = false;
 
@@ -97,7 +97,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (MAX_TICKS < tickInfo[kIndex])
+        if (kMaxCallbacksPerTick < tickInfo[kIndex])
           tickDone();
       }
       tickDone();
@@ -121,7 +121,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (MAX_TICKS < tickInfo[kIndex])
+        if (kMaxCallbacksPerTick < tickInfo[kIndex])
           tickDone();
         if (domain)
           domain.exit();

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -5,6 +5,7 @@ exports.setup = setupNextTick;
 function setupNextTick() {
   const promises = require('internal/process/promises');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
+  const MAX_TICKS = 1e4;
   var nextTickQueue = [];
   var microtasksScheduled = false;
 
@@ -96,7 +97,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (1e4 < tickInfo[kIndex])
+        if (MAX_TICKS < tickInfo[kIndex])
           tickDone();
       }
       tickDone();
@@ -120,7 +121,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (1e4 < tickInfo[kIndex])
+        if (MAX_TICKS < tickInfo[kIndex])
           tickDone();
         if (domain)
           domain.exit();

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const kMaxCallbacksPerTick = 1e4;
+// This value is used to prevent the nextTickQueue from becoming too
+// large and cause the process to run out of memory. When this value
+// is reached the nextTimeQueue array will be shortend (see tickDone
+// for details).
+const kMaxCallbacksUntilQueueIsShortened = 1e4;
 
 exports.setup = setupNextTick;
 
@@ -98,7 +102,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (kMaxCallbacksPerTick < tickInfo[kIndex])
+        if (kMaxCallbacksUntilQueueIsShortened < tickInfo[kIndex])
           tickDone();
       }
       tickDone();
@@ -122,7 +126,7 @@ function setupNextTick() {
         // callback invocation with small numbers of arguments to avoid the
         // performance hit associated with using `fn.apply()`
         _combinedTickCallback(args, callback);
-        if (kMaxCallbacksPerTick < tickInfo[kIndex])
+        if (kMaxCallbacksUntilQueueIsShortened < tickInfo[kIndex])
           tickDone();
         if (domain)
           domain.exit();

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -1,11 +1,12 @@
 'use strict';
 
+const kMaxCallbacksPerTick = 1e4;
+
 exports.setup = setupNextTick;
 
 function setupNextTick() {
   const promises = require('internal/process/promises');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
-  const kMaxCallbacksPerTick = 1e4;
   var nextTickQueue = [];
   var microtasksScheduled = false;
 


### PR DESCRIPTION
Currently the maximum number of tick is duplicated in two places. This
commit introduces a constant that both can use.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib