### PR TITLE
test: wrap callbacks in mustCall() for test-http-agent-destroyed-socket.js 

### DIFF
--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -45,14 +45,12 @@ const server = http.createServer(function(req, res) {
       request1.socket.destroy();
 
       response.once('close', function() {
-        console.log('called');
         // assert request2 was removed from the queue
         assert(!agent.requests[key]);
         console.log("waiting for request2.onSocket's nextTick");
         process.nextTick(common.mustCall(function() {
           // assert that the same socket was not assigned to request2,
           // since it was destroyed.
-          console.log('called 2');
           assert.notStrictEqual(request1.socket, request2.socket);
           assert(!request2.socket.destroyed, 'the socket is destroyed');
         }));

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -1,15 +1,15 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(function(req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.end('Hello World\n');
-}).listen(0, function() {
+}).listen(0, common.mustCall(function() {
   const agent = new http.Agent({maxSockets: 1});
 
-  agent.on('free', function(socket, host, port) {
+  agent.on('free', function(socket) {
     console.log('freeing socket. destroyed? ', socket.destroyed);
   });
 
@@ -20,7 +20,7 @@ const server = http.createServer(function(req, res) {
     path: '/'
   };
 
-  const request1 = http.get(requestOptions, function(response) {
+  const request1 = http.get(requestOptions, common.mustCall(function(response) {
     // assert request2 is queued in the agent
     const key = agent.getName(requestOptions);
     assert.strictEqual(agent.requests[key].length, 1);
@@ -29,7 +29,7 @@ const server = http.createServer(function(req, res) {
       console.log('request1 socket closed');
     });
     response.pipe(process.stdout);
-    response.on('end', function() {
+    response.on('end', common.mustCall(function() {
       console.log('response1 done');
       /////////////////////////////////
       //
@@ -45,20 +45,22 @@ const server = http.createServer(function(req, res) {
       request1.socket.destroy();
 
       response.once('close', function() {
+        console.log('called');
         // assert request2 was removed from the queue
         assert(!agent.requests[key]);
         console.log("waiting for request2.onSocket's nextTick");
-        process.nextTick(function() {
+        process.nextTick(common.mustCall(function() {
           // assert that the same socket was not assigned to request2,
           // since it was destroyed.
+          console.log('called 2');
           assert.notStrictEqual(request1.socket, request2.socket);
           assert(!request2.socket.destroyed, 'the socket is destroyed');
-        });
+        }));
       });
-    });
-  });
+    }));
+  }));
 
-  const request2 = http.get(requestOptions, function(response) {
+  const request2 = http.get(requestOptions, common.mustCall(function(response) {
     assert(!request2.socket.destroyed);
     assert(request1.socket.destroyed);
     // assert not reusing the same socket, since it was destroyed.
@@ -82,5 +84,5 @@ const server = http.createServer(function(req, res) {
       if (gotResponseEnd && gotClose)
         server.close();
     }
-  });
-});
+  }));
+}));


### PR DESCRIPTION
Wrap the callbacks which make assertions in common.mustcall() to ensure they are called

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Tests for http
