### PR TITLE
test: improve buffer.includes error verification tests

### DIFF
--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -275,15 +275,17 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
   }
 }
 
+const expectedError =
+  /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
 assert.throws(function() {
   b.includes(function() { });
-});
+}, expectedError);
 assert.throws(function() {
   b.includes({});
-});
+}, expectedError);
 assert.throws(function() {
   b.includes([]);
-});
+}, expectedError);
 
 // test truncation of Number arguments to uint8
 {

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -277,13 +277,13 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
 
 const expectedError =
   /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
-assert.throws(function() {
-  b.includes(function() { });
+assert.throws(() => {
+  b.includes(() => {});
 }, expectedError);
-assert.throws(function() {
+assert.throws(() => {
   b.includes({});
 }, expectedError);
-assert.throws(function() {
+assert.throws(() => {
   b.includes([]);
 }, expectedError);
 


### PR DESCRIPTION
Verify specific errors thrown by `buffer.includes` and change tests to use arrow functions as per [latest testing guide](https://github.com/nodejs/node/pull/11150/files).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tests, buffer
