### PR TITLE
deps: back-port b049d1a from V8 upstream

### DIFF
--- a/deps/v8/src/zone/zone.h
+++ b/deps/v8/src/zone/zone.h
@@ -63,15 +63,8 @@ class V8_EXPORT_PRIVATE Zone final {
   AccountingAllocator* allocator() const { return allocator_; }
 
  private:
-// All pointers returned from New() have this alignment.  In addition, if the
-// object being allocated has a size that is divisible by 8 then its alignment
-// will be 8. ASan requires 8-byte alignment.
-#ifdef V8_USE_ADDRESS_SANITIZER
-  static const size_t kAlignment = 8;
-  STATIC_ASSERT(kPointerSize <= 8);
-#else
-  static const size_t kAlignment = kPointerSize;
-#endif
+  // All pointers returned from New() are 8-byte aligned.
+  static const size_t kAlignmentInBytes = 8;
 
   // Never allocate segments smaller than this size in bytes.
   static const size_t kMinimumSegmentSize = 8 * KB;
@@ -105,7 +98,7 @@ class V8_EXPORT_PRIVATE Zone final {
 
   // The free region in the current (front) segment is represented as
   // the half-open interval [position, limit). The 'position' variable
-  // is guaranteed to be aligned as dictated by kAlignment.
+  // is guaranteed to be aligned as dictated by kAlignmentInBytes.
   Address position_;
   Address limit_;
 

--- a/deps/v8/test/unittests/BUILD.gn
+++ b/deps/v8/test/unittests/BUILD.gn
@@ -129,6 +129,7 @@ v8_executable("unittests") {
     "wasm/switch-logic-unittest.cc",
     "wasm/wasm-macro-gen-unittest.cc",
     "wasm/wasm-module-builder-unittest.cc",
+    "zone/zone-unittest.cc",
   ]
 
   if (v8_current_cpu == "arm") {

--- a/deps/v8/test/unittests/unittests.gyp
+++ b/deps/v8/test/unittests/unittests.gyp
@@ -117,6 +117,7 @@
       'test-utils.cc',
       'unicode-unittest.cc',
       'value-serializer-unittest.cc',
+      'zone/zone-unittest.cc',
       'wasm/asm-types-unittest.cc',
       'wasm/ast-decoder-unittest.cc',
       'wasm/control-transfer-unittest.cc',

--- a/deps/v8/test/unittests/zone/zone-unittest.cc
+++ b/deps/v8/test/unittests/zone/zone-unittest.cc
@@ -1,0 +1,23 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/zone/zone.h"
+
+#include "src/zone/accounting-allocator.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace v8 {
+namespace internal {
+
+TEST(Zone, 8ByteAlignment) {
+  AccountingAllocator allocator;
+  Zone zone(&allocator);
+
+  for (size_t i = 0; i < 16; ++i) {
+    ASSERT_EQ(reinterpret_cast<intptr_t>(zone.New(i)) % 8, 0);
+  }
+}
+
+}  // namespace internal
+}  // namespace v8


### PR DESCRIPTION
Original commit message:

    Ensure we align zone memory at 8 byte boundaries on all platforms

    BUG=v8:5668
    R=verwaest@chromium.org

    Review-Url: https://codereview.chromium.org/2672203002

CI: https://ci.nodejs.org/job/node-test-pull-request/6245/
V8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/557/