### PR TITLE
build: disable C4267 conversion compiler warning

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -188,6 +188,10 @@
         'BufferSecurityCheck': 'true',
         'ExceptionHandling': 0, # /EHsc
         'SuppressStartupBanner': 'true',
+        # Disable "warning C4267: conversion from 'size_t' to 'int',
+        # possible loss of data".  Many originate from our dependencies
+        # and their sheer number drowns out other, more legitimate warnings.
+        'DisableSpecificWarnings': ['4267'],
         'WarnAsError': 'false',
       },
       'VCLibrarianTool': {


### PR DESCRIPTION
Disable "warning C4267: conversion from 'size_t' to 'int', possible
loss of data".  Many originate from our dependencies and their sheer
number drowns out other, more legitimate warnings.

CI: https://ci.nodejs.org/job/node-test-pull-request/6246/