### PR TITLE
Adding regular expression as an argument to an assert.throws()

### DIFF
--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -14,4 +14,5 @@ assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
 assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
-assert.throws(() => Buffer.alloc(1).equals('abc'));
+assert.throws(() => Buffer.alloc(1).equals('abc'),
+              /^TypeError: Argument must be a Buffer or Uint8Array$/);


### PR DESCRIPTION
Per @Trott's recommendation, I added a regular expression to an assert.throws() inside test/parallel/test-buffer-equals.js.