### PR TITLE
test: fix incorrect indentation

### DIFF
--- a/test/parallel/test-http-server-unconsume-consume.js
+++ b/test/parallel/test-http-server-unconsume-consume.js
@@ -13,7 +13,7 @@ testServer.on('connect', common.mustCall((req, socket, head) => {
 }));
 testServer.listen(0, common.mustCall(() => {
   http.request({
-      port: testServer.address().port,
-      method: 'CONNECT'
+    port: testServer.address().port,
+    method: 'CONNECT'
   }, (res) => {}).end();
 }));


### PR DESCRIPTION
Indentaiton is off in `test-http-server-unconsume-consume.js`. The linter isn't complaining, but it probably should be.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test