### PR TITLE
http: include provided status code in range error

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -161,9 +161,11 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 
 ServerResponse.prototype.writeHead = writeHead;
 function writeHead(statusCode, reason, obj) {
+  var originalStatusCode = statusCode;
+
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999)
-    throw new RangeError(`Invalid status code: ${statusCode}`);
+    throw new RangeError(`Invalid status code: ${originalStatusCode}`);
 
   if (typeof reason === 'string') {
     // writeHead(statusCode, reasonPhrase[, headers])

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -20,17 +20,17 @@ const server = http.Server(common.mustCall(function(req, res) {
     case 1:
       assert.throws(common.mustCall(() => {
         res.writeHead(Infinity);
-      }), createErrorMessage(0));
+      }), createErrorMessage(Infinity));
       break;
     case 2:
       assert.throws(common.mustCall(() => {
         res.writeHead(NaN);
-      }), createErrorMessage(0));
+      }), createErrorMessage(NaN));
       break;
     case 3:
       assert.throws(common.mustCall(() => {
         res.writeHead({});
-      }), createErrorMessage(0));
+      }), createErrorMessage('\\[object Object\\]'));
       break;
     case 4:
       assert.throws(common.mustCall(() => {
@@ -45,37 +45,37 @@ const server = http.Server(common.mustCall(function(req, res) {
     case 6:
       assert.throws(common.mustCall(() => {
         res.writeHead('1000');
-      }), createErrorMessage(1000));
+      }), createErrorMessage('1000'));
       break;
     case 7:
       assert.throws(common.mustCall(() => {
         res.writeHead(null);
-      }), createErrorMessage(0));
+      }), createErrorMessage(null));
       break;
     case 8:
       assert.throws(common.mustCall(() => {
         res.writeHead(true);
-      }), createErrorMessage(1));
+      }), createErrorMessage(true));
       break;
     case 9:
       assert.throws(common.mustCall(() => {
         res.writeHead([]);
-      }), createErrorMessage(0));
+      }), createErrorMessage([]));
       break;
     case 10:
       assert.throws(common.mustCall(() => {
         res.writeHead('this is not valid');
-      }), createErrorMessage(0));
+      }), createErrorMessage('this is not valid'));
       break;
     case 11:
       assert.throws(common.mustCall(() => {
         res.writeHead('404 this is not valid either');
-      }), createErrorMessage(0));
+      }), createErrorMessage('404 this is not valid either'));
       break;
     case 12:
       assert.throws(common.mustCall(() => {
         res.writeHead();
-      }), createErrorMessage(0));
+      }), createErrorMessage(undefined));
       this.close();
       break;
     default:


### PR DESCRIPTION
`ServerResponse#writeHead()` coerces the user provided status code to a number and then performs a range check. If the check fails, a range error is thrown. The coerced status code is included in the error message. This commit uses the user provided status code instead. Hopefully, this will make the error message less confusing.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http