### PR TITLE
fs: avoid emitting error EBADF for double close

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1855,28 +1855,27 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  var self = this;
   if (cb)
     this.once('close', cb);
+
   if (this.closed || typeof this.fd !== 'number') {
     if (typeof this.fd !== 'number') {
-      this.once('open', close);
+      this.once('open', this.close.bind(this, null));
       return;
     }
     return process.nextTick(() => this.emit('close'));
   }
-  this.closed = true;
-  close();
 
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
-      if (er)
-        self.emit('error', er);
-      else
-        self.emit('close');
-    });
-    self.fd = null;
-  }
+  this.closed = true;
+
+  fs.close(this.fd, (er) => {
+    if (er)
+      this.emit('error', er);
+    else
+      this.emit('close');
+  });
+
+  this.fd = null;
 };
 
 

--- a/test/parallel/test-fs-read-stream-double-close.js
+++ b/test/parallel/test-fs-read-stream-double-close.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+const s = fs.createReadStream(__filename);
+
+s.close(common.mustCall(noop));
+s.close(common.mustCall(noop));
+
+function noop() {}

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+
+common.refreshTmpDir();
+
+const s = fs.createWriteStream(path.join(common.tmpDir, 'rw'));
+
+s.close(common.mustCall(noop));
+s.close(common.mustCall(noop));
+
+function noop() {}


### PR DESCRIPTION
Changed the logic in fs.ReadStream and fs.WriteStream so that
close always calls the prototype method rather than the internal
event listener.

Fixes: https://github.com/nodejs/node/issues/2950

cc @evanlucas @Trott @bnoordhuis 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

fs, stream