### PR TITLE
lib: make NativeModule._cache private

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -438,7 +438,7 @@
   }
 
   NativeModule._source = process.binding('natives');
-  NativeModule._cache = {};
+  var _cache = {};
 
   NativeModule.require = function(id) {
     if (id === 'native_module') {
@@ -465,7 +465,7 @@
   };
 
   NativeModule.getCached = function(id) {
-    return NativeModule._cache[id];
+    return _cache[id];
   };
 
   NativeModule.exists = function(id) {
@@ -527,7 +527,7 @@
   };
 
   NativeModule.prototype.cache = function() {
-    NativeModule._cache[this.id] = this;
+    _cache[this.id] = this;
   };
 
   startup();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
* Bootstrap

Following @addaleax [suggestion on help](https://github.com/nodejs/help/issues/478), I made the NativeModule._cache totally private to prevent any future tempering with it.

I have not found any documentation nor test regarding this part of code, so I did not update any.
