### PR TITLE
src: fix throw error for 304 responses with 'trailer' header set

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -217,6 +217,11 @@ function writeHead(statusCode, reason, obj) {
     // This class of status code indicates a provisional response,
     // consisting only of the Status-Line and optional headers, and is
     // terminated by an empty line.
+
+    if(statusCode == 304 && (headers.hasOwnProperty('trailer') || headers.hasOwnProperty('Trailer')){
+      throw new Error('Trailer header is set for 304 response.');
+    }
+    
     this._hasBody = false;
   }
 

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -14,4 +14,5 @@ assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
 assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
-assert.throws(() => Buffer.alloc(1).equals('abc'));
+assert.throws(() => Buffer.alloc(1).equals('abc'),
+              /^TypeError: Argument must be a Buffer or Uint8Array$/);


### PR DESCRIPTION
Added check in writeHead() for 304 responses with 'trailer' header set.