### PR TITLE
test: refactor test-fs-buffer

### DIFF
--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -18,8 +18,8 @@ assert.doesNotThrow(() => {
   fs.open(buf, 'w+', common.mustCall((err, fd) => {
     assert.ifError(err);
     assert(fd);
-    fs.close(fd, common.mustCall(() => {
-      fs.unlinkSync(buf);
+    fs.close(fd, common.mustCall((err) => {
+      assert.ifError(err);
     }));
   }));
 });
@@ -29,13 +29,17 @@ assert.throws(() => {
 }, /path must be a string or Buffer/);
 
 const dir = Buffer.from(common.fixturesDir);
-fs.readdir(dir, 'hex', common.mustCall((err, list) => {
+fs.readdir(dir, 'hex', common.mustCall((err, hexList) => {
   assert.ifError(err);
-  list = list.map((i) => {
-    return Buffer.from(i, 'hex').toString();
-  });
-  fs.readdir(dir, common.mustCall((err, list2) => {
+  fs.readdir(dir, common.mustCall((err, stringList) => {
     assert.ifError(err);
-    assert.deepStrictEqual(list, list2);
+    stringList.forEach((val, idx) => {
+      const fromHexList = Buffer.from(hexList[idx], 'hex').toString();
+      assert.strictEqual(
+        fromHexList,
+        val,
+        `${hexList[idx]} is hex value for ${fromHexList} and not ${val}`
+      );
+    });
   }));
 }));

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -38,7 +38,7 @@ fs.readdir(dir, 'hex', common.mustCall((err, hexList) => {
       assert.strictEqual(
         fromHexList,
         val,
-        `${hexList[idx]} is hex value for ${fromHexList} and not ${val}`
+        `expected ${val}, got ${fromHexList} by hex decoding ${hexList[idx]}`
       );
     });
   }));


### PR DESCRIPTION
* Remove unneeded temp dir cleanup
* Add check for error in `.close()` callback
* Improve error reporting

On that last bullet point, the previous version of the test reported
errors like this:

```
AssertionError: [ '.empty-repl-history-file',
  '.node_repl_history',
  'GH-1899-output.js',
  'GH-892-request.js',
  'a.js',
  'a1.js',
  'agen deepStrictEqual [ '.empty-repl-history-file',
  '.node_repl_history',
  'GH-1899-output.js',
  'GH-892-request.js',
  'a.js',
  'a1.js',
  'agen
```

Now, they look like this:

```
AssertionError: 2a is hex value for * and not catch-stdout-error.js
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs