### PR TITLE
benchmark: fix timer display in progress output

### DIFF
--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -15,9 +15,9 @@ function fraction(numerator, denominator) {
 
 function getTime(diff) {
   const time = Math.ceil(diff[0] + diff[1] / 1e9);
-  const seconds = pad(time % 60, 2, '0');
-  const minutes = pad(Math.floor(time / 60) % (60 * 60), 2, '0');
-  const hours = pad(Math.floor(time / (60 * 60)), 2, '0');
+  const hours = pad(Math.floor(time / 3600), 2, '0');
+  const minutes = pad(Math.floor((time % 3600) / 60), 2, '0');
+  const seconds = pad((time % 3600) % 60, 2, '0');
   return `${hours}:${minutes}:${seconds}`;
 }
 


### PR DESCRIPTION
This commit fixes an issue where the minutes would not display properly on the benchmark timer once an hour had elapsed.

/cc @AndreasMadsen @joyeecheung

Lint: https://ci.nodejs.org/job/node-test-linter/6921/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* benchmark
