### PR TITLE
test: increase dgram ref()/unref() coverage

### DIFF
--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -1,7 +1,14 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const dgram = require('dgram');
 
 // should not hang, see #1282
 dgram.createSocket('udp4');
 dgram.createSocket('udp6');
+
+{
+  // Test the case of ref()'ing a socket with no handle.
+  const s = dgram.createSocket('udp4');
+
+  s.close(common.mustCall(() => s.ref()));
+}

--- a/test/parallel/test-dgram-unref.js
+++ b/test/parallel/test-dgram-unref.js
@@ -2,8 +2,18 @@
 const common = require('../common');
 const dgram = require('dgram');
 
-const s = dgram.createSocket('udp4');
-s.bind();
-s.unref();
+{
+  // Test the case of unref()'ing a socket with a handle.
+  const s = dgram.createSocket('udp4');
+  s.bind();
+  s.unref();
+}
+
+{
+  // Test the case of unref()'ing a socket with no handle.
+  const s = dgram.createSocket('udp4');
+
+  s.close(common.mustCall(() => s.unref()));
+}
 
 setTimeout(common.mustNotCall(), 1000).unref();


### PR DESCRIPTION
This commit completes code coverage for `dgram`'s `Socket#ref()` and `Socket#unref()` methods.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test