### PR TITLE
test: add coverage to dgram receive error case

### DIFF
--- a/test/parallel/test-dgram-recv-error.js
+++ b/test/parallel/test-dgram-recv-error.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const s = dgram.createSocket('udp4');
+
+s.on('error', common.mustCall((err) => {
+  s.close();
+
+  // Don't check the full error message, as the errno is not important here.
+  assert(/^Error: recvmsg/.test(err));
+  assert.strictEqual(err.syscall, 'recvmsg');
+}));
+
+s.on('message', common.mustNotCall('no message should be received.'));
+s.bind(common.mustCall(() => s._handle.onmessage(-1, s._handle, null, null)));


### PR DESCRIPTION
This commit adds coverage for the case where a dgram socket
handle receives a message, but `nread` < 0, indicating an error.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test