### PR TITLE
dgram: fix possibly deoptimizing use of arguments

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -131,7 +131,7 @@ function replaceHandle(self, newHandle) {
   self._handle = newHandle;
 }
 
-Socket.prototype.bind = function(port_ /*, address, callback*/) {
+Socket.prototype.bind = function(port_, address_ /*, callback*/) {
   let port = port_;
 
   this._healthCheck();
@@ -141,7 +141,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
   this._bindState = BIND_STATE_BINDING;
 
-  if (typeof arguments[arguments.length - 1] === 'function')
+  if (arguments.length && typeof arguments[arguments.length - 1] === 'function')
     this.once('listening', arguments[arguments.length - 1]);
 
   if (port instanceof UDP) {
@@ -158,7 +158,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
     exclusive = !!port.exclusive;
     port = port.port;
   } else {
-    address = typeof arguments[1] === 'function' ? '' : arguments[1];
+    address = typeof address_ === 'function' ? '' : address_;
     exclusive = false;
   }
 


### PR DESCRIPTION
##### Checklist
- [x] `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dgram

`Socket.prototype.bind()` could be called [without any parameters](https://nodejs.org/api/dgram.html#dgram_socket_bind_port_address_callback), so these two `argumets[i]` access could be out of bounds and in some cases, they could possibly cause deoptimizations.

See #10323 and [this comment](https://github.com/nodejs/node/issues/10323#issuecomment-267994204).

Simple benchmarks show no performance degradation after these fixes:

<details>
<summary>Before the fixes (click me):</summary>

```
Release\node.exe benchmark/run.js dgram

dgram\array-vs-concat.js
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=64: 0.020413423614270235
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=64: 0.021318266009095838
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=64: 0.019609797889062242
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=64: 0.019302305834389945
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=64: 0.01900702749359504
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=64: 0.01977512456652689
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=64: 0.01851072553812215
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=64: 0.017478000829858897
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=256: 0.07938080698605825
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=256: 0.0855544579455885
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=256: 0.07881817147108744
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=256: 0.0832426052123247
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=256: 0.07797182769977243
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=256: 0.07792084119847094
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=256: 0.07242495183569352
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=256: 0.0696691928137009
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=512: 0.15721200435278507
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=512: 0.16872753136365387
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=512: 0.15311587573130966
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=512: 0.16432945990120004
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=512: 0.14867930449630173
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=512: 0.15411421586943283
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=512: 0.14246760509260645
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=512: 0.1400713009510874
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=1024: 0.30470850422160667
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=1024: 0.34434221844106455
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=1024: 0.2936385315600058
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=1024: 0.33183344658041314
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=1024: 0.29042121350964345
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=1024: 0.3063331945971229
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=1024: 0.27943412975786086
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=1024: 0.2784225109326032

dgram\multi-buffer.js
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=64: 0.02109223689568203
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=64: 0.00021308793192767727
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=64: 0.020769684203563888
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=64: 0.00020998096567558024
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=64: 0.019055577450296804
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=64: 0.00019089016428317388
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=64: 0.017463130851958403
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=64: 0.00016713763827638084
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=256: 0.07621227958382061
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=256: 0.000786385696591585
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=256: 0.07953054364342717
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=256: 0.000822598733015174
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=256: 0.07772456562145642
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=256: 0.0007808260317662278
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=256: 0.07101652936095898
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=256: 0.0006966008157853522
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=1024: 0.3328152160090698
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=1024: 0.0034209370041683894
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=1024: 0.32470062459007615
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=1024: 0.003283094375923841
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=1024: 0.30292024861897976
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=1024: 0.0030532452230243104
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=1024: 0.2830325958167614
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=1024: 0.002782114387379061

dgram\offset-length.js
dgram\offset-length.js dur=5 type="send" num=100 len=1: 0.0003186605782046186
dgram\offset-length.js dur=5 type="recv" num=100 len=1: 0.0000031769599503666797
dgram\offset-length.js dur=5 type="send" num=100 len=64: 0.020222469566660867
dgram\offset-length.js dur=5 type="recv" num=100 len=64: 0.0002057548934626847
dgram\offset-length.js dur=5 type="send" num=100 len=256: 0.08161113157755215
dgram\offset-length.js dur=5 type="recv" num=100 len=256: 0.0008216365582010693
dgram\offset-length.js dur=5 type="send" num=100 len=1024: 0.32363771818021053
dgram\offset-length.js dur=5 type="recv" num=100 len=1024: 0.003236732567751061

dgram\single-buffer.js
dgram\single-buffer.js dur=5 type="send" num=100 len=1: 0.0003342798746881872
dgram\single-buffer.js dur=5 type="recv" num=100 len=1: 0.0000033101247505441493
dgram\single-buffer.js dur=5 type="send" num=100 len=64: 0.02125277483374607
dgram\single-buffer.js dur=5 type="recv" num=100 len=64: 0.0002109600303668221
dgram\single-buffer.js dur=5 type="send" num=100 len=256: 0.08510005742141984
dgram\single-buffer.js dur=5 type="recv" num=100 len=256: 0.0008434335153269099
dgram\single-buffer.js dur=5 type="send" num=100 len=1024: 0.34175360960982193
dgram\single-buffer.js dur=5 type="recv" num=100 len=1024: 0.0033519836980728415
```
</details>
<details>
<summary>After the fixes (click me):</summary>

```
Release\node.exe benchmark/run.js dgram

dgram\array-vs-concat.js
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=64: 0.019998298310699464
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=64: 0.020904479923743967
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=64: 0.019426704035245376
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=64: 0.02046648568936641
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=64: 0.01960815187460356
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=64: 0.019201306011310242
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=64: 0.018536654183278375
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=64: 0.01757510205628739
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=256: 0.08034578243828928
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=256: 0.08519467597300402
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=256: 0.07898968697148778
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=256: 0.08293523756844151
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=256: 0.07538359651203853
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=256: 0.07822343326554314
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=256: 0.07283978673371065
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=256: 0.07053324621949313
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=512: 0.15340200560018824
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=512: 0.16960205295424957
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=512: 0.151996097230419
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=512: 0.16555537538214277
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=512: 0.14713204203132063
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=512: 0.15214141468659234
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=512: 0.14297984421232035
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=512: 0.14285304254474696
dgram\array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=1024: 0.3082238531303529
dgram\array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=1024: 0.3361665646123714
dgram\array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=1024: 0.294009967416119
dgram\array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=1024: 0.32938506370801257
dgram\array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=1024: 0.2864018671443685
dgram\array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=1024: 0.31041893053693237
dgram\array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=1024: 0.27774562208741815
dgram\array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=1024: 0.2815659463416438

dgram\multi-buffer.js
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=64: 0.02133989201632066
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=64: 0.00021426996651214555
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=64: 0.020489658144534215
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=64: 0.00020654497899215277
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=64: 0.019427196594262293
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=64: 0.00019346245583245347
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=64: 0.017423741845451392
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=64: 0.0001772565741828839
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=256: 0.08348197207417823
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=256: 0.0008519555090428148
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=256: 0.08416651660960886
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=256: 0.0008262619526430367
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=256: 0.07613223548983997
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=256: 0.0007724666359888078
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=256: 0.07022821961092969
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=256: 0.0007028155301349925
dgram\multi-buffer.js dur=5 type="send" chunks=1 num=100 len=1024: 0.33990335582138237
dgram\multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=1024: 0.0033347779207178047
dgram\multi-buffer.js dur=5 type="send" chunks=2 num=100 len=1024: 0.33114827659574847
dgram\multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=1024: 0.0032325424185883026
dgram\multi-buffer.js dur=5 type="send" chunks=4 num=100 len=1024: 0.3056387475814086
dgram\multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=1024: 0.0030595000668458276
dgram\multi-buffer.js dur=5 type="send" chunks=8 num=100 len=1024: 0.28056936065128824
dgram\multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=1024: 0.002799337607058917

dgram\offset-length.js
dgram\offset-length.js dur=5 type="send" num=100 len=1: 0.000320474058761629
dgram\offset-length.js dur=5 type="recv" num=100 len=1: 0.0000032165942722401654
dgram\offset-length.js dur=5 type="send" num=100 len=64: 0.020712717203098478
dgram\offset-length.js dur=5 type="recv" num=100 len=64: 0.00020774881433332406
dgram\offset-length.js dur=5 type="send" num=100 len=256: 0.08191056081895902
dgram\offset-length.js dur=5 type="recv" num=100 len=256: 0.0008227156793202832
dgram\offset-length.js dur=5 type="send" num=100 len=1024: 0.32907221457431485
dgram\offset-length.js dur=5 type="recv" num=100 len=1024: 0.003244538888218392

dgram\single-buffer.js
dgram\single-buffer.js dur=5 type="send" num=100 len=1: 0.00033545141368716293
dgram\single-buffer.js dur=5 type="recv" num=100 len=1: 0.0000033181468268436883
dgram\single-buffer.js dur=5 type="send" num=100 len=64: 0.021114216973934095
dgram\single-buffer.js dur=5 type="recv" num=100 len=64: 0.00020900284156453758
dgram\single-buffer.js dur=5 type="send" num=100 len=256: 0.08428150916647331
dgram\single-buffer.js dur=5 type="recv" num=100 len=256: 0.0008478502422047072
dgram\single-buffer.js dur=5 type="send" num=100 len=1024: 0.3420805345205732
dgram\single-buffer.js dur=5 type="recv" num=100 len=1024: 0.003354160146381448
```
</details>