### PR TITLE
dgram: remove this aliases

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -132,10 +132,9 @@ function replaceHandle(self, newHandle) {
 }
 
 Socket.prototype.bind = function(port_ /*, address, callback*/) {
-  var self = this;
   let port = port_;
 
-  self._healthCheck();
+  this._healthCheck();
 
   if (this._bindState !== BIND_STATE_UNBOUND)
     throw new Error('Socket is already bound');
@@ -143,12 +142,12 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   this._bindState = BIND_STATE_BINDING;
 
   if (typeof arguments[arguments.length - 1] === 'function')
-    self.once('listening', arguments[arguments.length - 1]);
+    this.once('listening', arguments[arguments.length - 1]);
 
   if (port instanceof UDP) {
-    replaceHandle(self, port);
-    startListening(self);
-    return self;
+    replaceHandle(this, port);
+    startListening(this);
+    return this;
   }
 
   var address;
@@ -164,17 +163,17 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
   }
 
   // defaulting address for bind to all interfaces
-  if (!address && self._handle.lookup === lookup4) {
+  if (!address && this._handle.lookup === lookup4) {
     address = '0.0.0.0';
-  } else if (!address && self._handle.lookup === lookup6) {
+  } else if (!address && this._handle.lookup === lookup6) {
     address = '::';
   }
 
   // resolve address first
-  self._handle.lookup(address, function(err, ip) {
+  this._handle.lookup(address, (err, ip) => {
     if (err) {
-      self._bindState = BIND_STATE_UNBOUND;
-      self.emit('error', err);
+      this._bindState = BIND_STATE_UNBOUND;
+      this.emit('error', err);
       return;
     }
 
@@ -182,51 +181,50 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
       cluster = require('cluster');
 
     var flags = 0;
-    if (self._reuseAddr)
+    if (this._reuseAddr)
       flags |= UV_UDP_REUSEADDR;
 
     if (cluster.isWorker && !exclusive) {
-      function onHandle(err, handle) {
+      const onHandle = (err, handle) => {
         if (err) {
           var ex = exceptionWithHostPort(err, 'bind', ip, port);
-          self.emit('error', ex);
-          self._bindState = BIND_STATE_UNBOUND;
+          this.emit('error', ex);
+          this._bindState = BIND_STATE_UNBOUND;
           return;
         }
 
-        if (!self._handle)
+        if (!this._handle)
           // handle has been closed in the mean time.
           return handle.close();
 
-        replaceHandle(self, handle);
-        startListening(self);
-      }
-      cluster._getServer(self, {
+        replaceHandle(this, handle);
+        startListening(this);
+      };
+      cluster._getServer(this, {
         address: ip,
         port: port,
-        addressType: self.type,
+        addressType: this.type,
         fd: -1,
         flags: flags
       }, onHandle);
-
     } else {
-      if (!self._handle)
+      if (!this._handle)
         return; // handle has been closed in the mean time
 
-      const err = self._handle.bind(ip, port || 0, flags);
+      const err = this._handle.bind(ip, port || 0, flags);
       if (err) {
         var ex = exceptionWithHostPort(err, 'bind', ip, port);
-        self.emit('error', ex);
-        self._bindState = BIND_STATE_UNBOUND;
+        this.emit('error', ex);
+        this._bindState = BIND_STATE_UNBOUND;
         // Todo: close?
         return;
       }
 
-      startListening(self);
+      startListening(this);
     }
   });
 
-  return self;
+  return this;
 };
 
 
@@ -326,7 +324,6 @@ Socket.prototype.send = function(buffer,
                                  port,
                                  address,
                                  callback) {
-  const self = this;
   let list;
 
   if (address || (port && typeof port !== 'function')) {
@@ -358,24 +355,26 @@ Socket.prototype.send = function(buffer,
   if (typeof callback !== 'function')
     callback = undefined;
 
-  self._healthCheck();
+  this._healthCheck();
 
-  if (self._bindState === BIND_STATE_UNBOUND)
-    self.bind({port: 0, exclusive: true}, null);
+  if (this._bindState === BIND_STATE_UNBOUND)
+    this.bind({port: 0, exclusive: true}, null);
 
   if (list.length === 0)
     list.push(Buffer.alloc(0));
 
   // If the socket hasn't been bound yet, push the outbound packet onto the
   // send queue and send after binding is complete.
-  if (self._bindState !== BIND_STATE_BOUND) {
-    enqueue(self, self.send.bind(self, list, port, address, callback));
+  if (this._bindState !== BIND_STATE_BOUND) {
+    enqueue(this, this.send.bind(this, list, port, address, callback));
     return;
   }
 
-  self._handle.lookup(address, function afterDns(ex, ip) {
-    doSend(ex, self, ip, list, address, port, callback);
-  });
+  const afterDns = (ex, ip) => {
+    doSend(ex, this, ip, list, address, port, callback);
+  };
+
+  this._handle.lookup(address, afterDns);
 };
 
 


### PR DESCRIPTION
This commit removes `self = this` style assignments from `dgram`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dgram