### PR TITLE
test: add coverage for string array dgram send()

### DIFF
--- a/test/parallel/test-dgram-send-multi-string-array.js
+++ b/test/parallel/test-dgram-send-multi-string-array.js
@@ -1,0 +1,13 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const socket = dgram.createSocket('udp4');
+const data = ['foo', 'bar', 'baz'];
+
+socket.on('message', common.mustCall((msg, rinfo) => {
+  socket.close();
+  assert.deepStrictEqual(msg.toString(), data.join(''));
+}));
+
+socket.bind(() => socket.send(data, socket.address().port, 'localhost'));


### PR DESCRIPTION
This commit adds code coverage for `dgram`'s `Socket#send()` where the data is an array of strings.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test