### PR TITLE
http: make `globalAgent` of `http` and `https` overridable

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,4 +1,9 @@
 'use strict';
+
+const url = require('url');
+const util = require('util');
+const urlToOptions = require('internal/url').urlToOptions;
+
 exports.IncomingMessage = require('_http_incoming').IncomingMessage;
 
 exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;
@@ -23,11 +28,22 @@ const client = require('_http_client');
 const ClientRequest = exports.ClientRequest = client.ClientRequest;
 
 exports.request = function request(options, cb) {
+  if (typeof options === 'string') {
+    options = url.parse(options);
+    if (!options.hostname) {
+      throw new Error('Unable to determine the domain name');
+    }
+  } else if (options instanceof url.URL) {
+    options = urlToOptions(options);
+  } else {
+    options = util._extend({}, options);
+  }
+  options._defaultAgent = options._defaultAgent || exports.globalAgent;
   return new ClientRequest(options, cb);
 };
 
 exports.get = function get(options, cb) {
-  var req = exports.request(options, cb);
+  const req = exports.request(options, cb);
   req.end();
   return req;
 };

--- a/lib/https.js
+++ b/lib/https.js
@@ -114,7 +114,7 @@ inherits(Agent, http.Agent);
 Agent.prototype.createConnection = createConnection;
 
 Agent.prototype.getName = function getName(options) {
-  var name = http.Agent.prototype.getName.call(this, options);
+  let name = http.Agent.prototype.getName.call(this, options);
 
   name += ':';
   if (options.ca)
@@ -202,12 +202,12 @@ exports.request = function request(options, cb) {
   } else {
     options = util._extend({}, options);
   }
-  options._defaultAgent = globalAgent;
+  options._defaultAgent = options._defaultAgent || exports.globalAgent;
   return http.request(options, cb);
 };
 
 exports.get = function get(options, cb) {
-  var req = exports.request(options, cb);
+  const req = exports.request(options, cb);
   req.end();
   return req;
 };


### PR DESCRIPTION
Previously `globalAgent` of `http` and `https` cannot be overriden by simply assigning a new value. This exposes those properties to allow overriding by assignment.

Fixes #9057 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http

