### PR TITLE
test: qs.escape with multibyte characters under 0x800

### DIFF
--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -8,6 +8,7 @@ assert.deepStrictEqual(qs.escape(5), '5');
 assert.deepStrictEqual(qs.escape('test'), 'test');
 assert.deepStrictEqual(qs.escape({}), '%5Bobject%20Object%5D');
 assert.deepStrictEqual(qs.escape([5, 10]), '5%2C10');
+assert.deepStrictEqual(qs.escape('Ŋōđĕ'), '%C5%8A%C5%8D%C4%91%C4%95');
 
 // using toString for objects
 assert.strictEqual(


### PR DESCRIPTION
Improve test coverage of `querystring`:
+ https://coverage.nodejs.org/coverage-fcedd715bbd618cb/root/querystring.js.html

This test case will cover these lines:
+ https://github.com/nodejs/node/blob/fcedd715bbd618cba6c6d1c8bfbb09239b105158/lib/querystring.js#L169-L173

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test