### PR TITLE
src: fix recent --icu-data-dir= regression

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -124,7 +124,7 @@ function setupConfig(_source) {
     const oldV8BreakIterator = Intl.v8BreakIterator;
     const des = Object.getOwnPropertyDescriptor(Intl, 'v8BreakIterator');
     des.value = require('internal/util').deprecate(function v8BreakIterator() {
-      if (processConfig.hasSmallICU && !process.icu_data_dir) {
+      if (processConfig.hasSmallICU && !processConfig.icuDataDir) {
         // Intl.v8BreakIterator() would crash w/ fatal error, so throw instead.
         throw new Error('v8BreakIterator: full ICU data not installed. ' +
                         'See https://github.com/nodejs/node/wiki/Intl');
@@ -134,8 +134,6 @@ function setupConfig(_source) {
                                                    'DEP0017');
     Object.defineProperty(Intl, 'v8BreakIterator', des);
   }
-  // Don’t let icu_data_dir leak through.
-  delete process.icu_data_dir;
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -156,7 +156,7 @@ static const char* trace_enabled_categories = nullptr;
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
 // Path to ICU data (for i18n / Intl)
-static std::string icu_data_dir;  // NOLINT(runtime/string)
+std::string icu_data_dir;  // NOLINT(runtime/string)
 #endif
 
 // used by C++ modules as well
@@ -3094,17 +3094,6 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(versions,
                     "ares",
                     FIXED_ONE_BYTE_STRING(env->isolate(), ARES_VERSION_STR));
-
-#if defined(NODE_HAVE_I18N_SUPPORT) && defined(U_ICU_VERSION)
-  // ICU-related versions are now handled on the js side, see bootstrap_node.js
-
-  if (!icu_data_dir.empty()) {
-    // Did the user attempt (via env var or parameter) to set an ICU path?
-    READONLY_PROPERTY(process,
-                      "icu_data_dir",
-                      OneByteString(env->isolate(), icu_data_dir.c_str()));
-  }
-#endif
 
   const char node_modules_version[] = NODE_STRINGIFY(NODE_MODULE_VERSION);
   READONLY_PROPERTY(

--- a/src/node.cc
+++ b/src/node.cc
@@ -3742,7 +3742,7 @@ static void ParseArgs(int* argc,
 #endif /* HAVE_OPENSSL */
 #if defined(NODE_HAVE_I18N_SUPPORT)
     } else if (strncmp(arg, "--icu-data-dir=", 15) == 0) {
-      icu_data_dir.assign(arg, 15);
+      icu_data_dir.assign(arg + 15);
 #endif
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -39,8 +39,11 @@ void InitConfig(Local<Object> target,
   READONLY_BOOLEAN_PROPERTY("hasSmallICU");
 #endif  // NODE_HAVE_SMALL_ICU
 
-  if (flag_icu_data_dir)
-    READONLY_BOOLEAN_PROPERTY("usingICUDataDir");
+  target->DefineOwnProperty(env->context(),
+                            OneByteString(env->isolate(), "icuDataDir"),
+                            OneByteString(env->isolate(), icu_data_dir.data()))
+      .FromJust();
+
 #endif  // NODE_HAVE_I18N_SUPPORT
 
   if (config_preserve_symlinks)

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -70,8 +70,6 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-bool flag_icu_data_dir = false;
-
 namespace i18n {
 
 const size_t kStorageSize = 1024;
@@ -415,7 +413,6 @@ bool InitializeICUDirectory(const std::string& path) {
 #endif  // !NODE_HAVE_SMALL_ICU
     return (status == U_ZERO_ERROR);
   } else {
-    flag_icu_data_dir = true;
     u_setDataDirectory(path.c_str());
     return true;  // No error.
   }

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -10,7 +10,7 @@
 
 namespace node {
 
-extern bool flag_icu_data_dir;
+extern std::string icu_data_dir;  // NOLINT(runtime/string)
 
 namespace i18n {
 

--- a/test/parallel/test-intl-no-icu-data.js
+++ b/test/parallel/test-intl-no-icu-data.js
@@ -1,0 +1,7 @@
+// Flags: --icu-data-dir=test/fixtures/empty/
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// No-op when ICU case mappings are unavailable.
+assert.strictEqual('ç'.toLocaleUpperCase('el'), 'ç');

--- a/test/parallel/test-intl-no-icu-data.js
+++ b/test/parallel/test-intl-no-icu-data.js
@@ -2,6 +2,8 @@
 'use strict';
 require('../common');
 const assert = require('assert');
+const config = process.binding('config');
 
 // No-op when ICU case mappings are unavailable.
 assert.strictEqual('ç'.toLocaleUpperCase('el'), 'ç');
+assert.strictEqual(config.icuDataDir, 'test/fixtures/empty/');


### PR DESCRIPTION
Commit a8734af ("src: make copies of startup environment variables")
introduced a regression in the capturing of the --icu-data-dir= switch.

This commit fixes that and shuffles code around so it can be properly
unit-tested.

cc @sam-github @srl295