### PR TITLE
internal: lazy load fs due to circular dependency

### DIFF
--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -2,7 +2,6 @@
 
 const Buffer = require('buffer').Buffer;
 const Writable = require('stream').Writable;
-const fs = require('fs');
 const util = require('util');
 const constants = process.binding('constants').fs;
 
@@ -14,6 +13,15 @@ const O_RDWR = constants.O_RDWR | 0;
 const O_SYNC = constants.O_SYNC | 0;
 const O_TRUNC = constants.O_TRUNC | 0;
 const O_WRONLY = constants.O_WRONLY | 0;
+
+let fs;
+// Lazy load fs due to a circular dependency.
+function lazyFS() {
+  if (!fs) {
+    fs = require('fs');
+  }
+  return fs;
+}
 
 function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
@@ -72,7 +80,7 @@ function SyncWriteStream(fd, options) {
 util.inherits(SyncWriteStream, Writable);
 
 SyncWriteStream.prototype._write = function(chunk, encoding, cb) {
-  fs.writeSync(this.fd, chunk, 0, chunk.length);
+  lazyFS().writeSync(this.fd, chunk, 0, chunk.length);
   cb();
   return true;
 };
@@ -82,7 +90,7 @@ SyncWriteStream.prototype._destroy = function() {
     return;
 
   if (this.autoClose)
-    fs.closeSync(this.fd);
+    lazyFS().closeSync(this.fd);
 
   this.fd = null;
   return true;

--- a/test/parallel/test-stdin-require.js
+++ b/test/parallel/test-stdin-require.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const path = require('path');
+
+common.refreshTmpDir();
+const filename = path.join(__dirname, '..', 'fixtures', 'baz.js');
+const out = path.join(common.tmpDir, 'js.out');
+const bin = process.execPath;
+const input = `require('${filename}'); console.log('PASS');`;
+const cmd = common.isWindows ?
+  `echo "${input}" | ${bin} > ${out} 2>&1; more ${out}` :
+  `echo "${input}" | ${bin} &> ${out}; cat ${out}`;
+
+const result = execSync(cmd).toString();
+assert.strictEqual(result.trim(), 'PASS');
+fs.unlinkSync(out);


### PR DESCRIPTION
The fs module requires internal/fs and internal/fs requires fs which
causes a circular dependency. This change lazy loads fs inside of
internal/fs to prevent assertEncoding from breaking when requiring via
stdin.

Fixes: https://github.com/nodejs/node/issues/11257

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
internal/fs