### PR TITLE
deps: cherry-pick 7c982e7 from V8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 372
-#define V8_PATCH_LEVEL 40
+#define V8_PATCH_LEVEL 41
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/compiler/ppc/instruction-selector-ppc.cc
+++ b/deps/v8/src/compiler/ppc/instruction-selector-ppc.cc
@@ -245,7 +245,7 @@ void InstructionSelector::VisitStore(Node* node) {
   MachineRepresentation rep = store_rep.representation();
 
   if (write_barrier_kind != kNoWriteBarrier) {
-    DCHECK_EQ(MachineRepresentation::kTagged, rep);
+    DCHECK(CanBeTaggedPointer(rep));
     AddressingMode addressing_mode;
     InstructionOperand inputs[3];
     size_t input_count = 0;

--- a/deps/v8/src/compiler/s390/instruction-selector-s390.cc
+++ b/deps/v8/src/compiler/s390/instruction-selector-s390.cc
@@ -343,7 +343,7 @@ void InstructionSelector::VisitStore(Node* node) {
   MachineRepresentation rep = store_rep.representation();
 
   if (write_barrier_kind != kNoWriteBarrier) {
-    DCHECK_EQ(MachineRepresentation::kTagged, rep);
+    DCHECK(CanBeTaggedPointer(rep));
     AddressingMode addressing_mode;
     InstructionOperand inputs[3];
     size_t input_count = 0;


### PR DESCRIPTION
Original commit message:

    PPC/s390: [Turbofan]: Use new MachineTypes in access-builder.

    Port 56429fc14671a10749190a4dfeacd38b7270f6f5

    Original Commit Message:

        Introduced MachineType::TaggedSigned() and TaggedPointer().

        The idea is to quit using the representational dimension of Type, and
        instead encode this information in the MachineRepresentation (itself
        lightly wrapped in MachineType, along with MachineSemantic).

        There are three parts to the whole change:

        1) Places that set the machine representation - constant nodes, loads nad
           stores, global object and native context specialization.

        2) Places that propagate type/representation - this is representation
           inference (aka simplified lowering). At the end of this process we
           expect to have a MachineRepresentation for every node. An interesting
           part of this is phi merging.

        3) Places that examine representation - WriteBarrier elimination does this.
           Currently it's looking at the Type representation dimension, but as
           a part of this change (or in a soon-to-follow change) it can simply
           examine the MachineRepresentation.

    R=mvstanton@chromium.org, joransiu@ca.ibm.com, jyan@ca.ibm.com, michael_dawson@ca.ibm.com
    BUG=
    LOG=N

    Review-Url: https://codereview.chromium.org/2662223003
    Cr-Commit-Position: refs/heads/master@{#42817}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
V8

##### Description of change
This [port](https://github.com/v8/v8/commit/7c982e7ecf7669c05af199bf827dd80110f37cad) is in V8 5.6/5.7 but couldn't make it to V8 5.5.
When node master moves to 5.6, it should have this commit, so only affects node version with V8 5.5

/cc @nodejs/v8