### PR TITLE
test: add vm module edge cases

### DIFF
--- a/test/known_issues/test-vm-attributes-property-not-on-sandbox.js
+++ b/test/known_issues/test-vm-attributes-property-not-on-sandbox.js
@@ -1,0 +1,25 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+// The QueryCallback explicitly calls GetRealNamedPropertyAttributes
+// on the global proxy if the property is not found on the sandbox.
+//
+// foo is not defined on the sandbox until we call CopyProperties().
+// In the QueryCallback, we do not find the property on the sandbox
+// and look up its PropertyAttributes on the global_proxy().
+// PropertyAttributes are always flattened to a value
+// descriptor.
+const sandbox = {};
+vm.createContext(sandbox);
+const code = `Object.defineProperty(
+               this,
+               'foo',
+               { get: function() {return 17} }
+             );
+             var desc = Object.getOwnPropertyDescriptor(this, 'foo');`;
+
+vm.runInContext(code, sandbox);
+// The descriptor is flattened. We wrongly have typeof desc.value = 'number'.
+assert.strictEqual(typeof sandbox.desc.get, 'function');

--- a/test/parallel/test-vm-property-not-on-sandbox.js
+++ b/test/parallel/test-vm-property-not-on-sandbox.js
@@ -1,0 +1,37 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+// This, admittedly contrived, example tests an edge cases of the vm module.
+//
+// The GetterCallback explicitly checks the global_proxy() if a property is
+// not found on the sandbox. In the following test, the explicit check
+// inside the callback yields different results than deferring the
+// check until after the callback. The check is deferred if the
+// callback does not intercept, i.e., if args.GetReturnValue().Set() is
+// not called.
+
+// Check that the GetterCallback explicitly calls GetRealNamedProperty()
+// on the global proxy if the property is not found on the sandbox.
+//
+// foo is not defined on the sandbox until we call CopyProperties().
+// In the GetterCallback, we do not find the property on the sandbox and
+// get the property from the global proxy. Since the return value is
+// the sandbox, we replace it by
+// the global_proxy to keep the correct identities.
+//
+// This test case is partially inspired by
+// https://github.com/nodejs/node/issues/855
+const sandbox = {console};
+sandbox.document = {defaultView: sandbox};
+vm.createContext(sandbox);
+const code = `Object.defineProperty(
+               this,
+               'foo',
+               { get: function() {return document.defaultView} }
+             );
+             var result = foo === this;`;
+
+vm.runInContext(code, sandbox);
+assert.strictEqual(sandbox.result, true);


### PR DESCRIPTION
This PR adds two, admittedly contrived, examples that test edge cases of the vm module.


They demonstrate that the if statements `if (maybe_rv.IsEmpty())` and
`if (maybe_prop_attr.IsNothing())` in the GetterCallback
and the QueryCallback in [src/node_contextify.cc](https://github.com/nodejs/node/blob/master/src/node_contextify.cc#L355)
are observable. So far we have no tests that break when these 
statements are removed (neither does [Jest](https://github.com/facebook/jest)). 

Both GetterCallback and QueryCallback
explicitly check the global_proxy() if a property is
not found on the sandbox. In these tests, the explicit check
inside the callback yields different results than deferring the
check until after the callback. The check is deferred, if the
callbacks do not intercept, i.e., if args.GetReturnValue().Set() is
not called.

Since we're working on fixing several of the vm issues, I'd like to have these 
tests so we're at least aware if we cause any breaking changes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test