### PR TITLE
src: fix delete operator on vm context

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -456,8 +456,12 @@ class ContextifyContext {
 
     Maybe<bool> success = ctx->sandbox()->Delete(ctx->context(), property);
 
-    if (success.IsJust())
-      args.GetReturnValue().Set(success.FromJust());
+    if (success.FromMaybe(false))
+      return;
+
+    // Delete failed on the sandbox, intercept and do not delete on
+    // the global object.
+    args.GetReturnValue().Set(false);
   }
 
 

--- a/test/parallel/test-vm-deleting-property.js
+++ b/test/parallel/test-vm-deleting-property.js
@@ -12,4 +12,4 @@ const res = vm.runInContext(`
   Object.getOwnPropertyDescriptor(this, 'x');
 `, context);
 
-assert.strictEqual(res.value, undefined);
+assert.strictEqual(res, undefined);


### PR DESCRIPTION
In the implementation of the vm module, if a property is successfully deleted
on the sandbox, we also need to delete it on the global_proxy object. Therefore, we
must not call args.GetReturnValue().Set().

We only intercept, i.e., call args.GetReturnValue().Set(), in the
DeleterCallback, if Delete() failed, e.g. because
the property was read only.

This is a breaking change, it fixes one of our known issues. But it does not break any
 tests in [Jest](https://github.com/facebook/jest).

Fixes https://github.com/nodejs/node/issues/6287

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

*If anybody has a better way to word the commit message, I'll happily take it!*