### PR TITLE
process: backport process.emitWarning() API

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -123,7 +123,7 @@ Prerequisites:
 To run the tests:
 
 ```text
-> .\vcbuild test
+> .\vcbuild nosign test
 ```
 
 To test if Node.js was built correctly:
@@ -172,7 +172,7 @@ $ ./configure --with-intl=small-icu --download=all
 ##### Windows:
 
 ```text
-> .\vcbuild small-icu download-all
+> .\vcbuild nosign small-icu download-all
 ```
 
 The `small-icu` mode builds with English-only data. You can add full
@@ -195,7 +195,7 @@ $ ./configure --with-intl=full-icu --download=all
 ##### Windows:
 
 ```text
-> .\vcbuild full-icu download-all
+> .\vcbuild nosign full-icu download-all
 ```
 
 #### Building without Intl support
@@ -212,7 +212,7 @@ $ ./configure --with-intl=none
 ##### Windows:
 
 ```text
-> .\vcbuild intl-none
+> .\vcbuild nosign intl-none
 ```
 
 #### Use existing installed ICU (Unix / OS X only):
@@ -251,7 +251,7 @@ First unpack latest ICU to `deps/icu`
 as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```text
-> .\vcbuild full-icu
+> .\vcbuild nosign full-icu
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,13 +117,13 @@ Prerequisites:
   and tools which can be included in the global `PATH`.
 
 ```text
-> vcbuild nosign
+> .\vcbuild nosign
 ```
 
 To run the tests:
 
 ```text
-> vcbuild test
+> .\vcbuild test
 ```
 
 To test if Node.js was built correctly:
@@ -172,7 +172,7 @@ $ ./configure --with-intl=small-icu --download=all
 ##### Windows:
 
 ```text
-> vcbuild small-icu download-all
+> .\vcbuild small-icu download-all
 ```
 
 The `small-icu` mode builds with English-only data. You can add full
@@ -195,7 +195,7 @@ $ ./configure --with-intl=full-icu --download=all
 ##### Windows:
 
 ```text
-> vcbuild full-icu download-all
+> .\vcbuild full-icu download-all
 ```
 
 #### Building without Intl support
@@ -212,7 +212,7 @@ $ ./configure --with-intl=none
 ##### Windows:
 
 ```text
-> vcbuild intl-none
+> .\vcbuild intl-none
 ```
 
 #### Use existing installed ICU (Unix / OS X only):
@@ -251,7 +251,7 @@ First unpack latest ICU to `deps/icu`
 as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```text
-> vcbuild full-icu
+> .\vcbuild full-icu
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ $ ./configure && make -j8 test
 Windows:
 
 ```text
-> vcbuild test
+ .\vcbuild nosign test
 ```
 
 (See the [BUILDING.md](./BUILDING.md) for more details.)
@@ -172,11 +172,11 @@ Windows:
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-Running `make test`/`vcbuild test` will run the linter as well unless one or
+Running `make test`/`.\vcbuild nosign test` will run the linter as well unless one or
 more tests fail.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild jslint`.
+`make lint`/`.\vcbuild nosign jslint`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 45
+#define V8_PATCH_LEVEL 46
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/runtime/runtime-debug.cc
+++ b/deps/v8/src/runtime/runtime-debug.cc
@@ -670,7 +670,8 @@ RUNTIME_FUNCTION(Runtime_GetFrameDetails) {
     // Use the value from the stack.
     if (scope_info->LocalIsSynthetic(i)) continue;
     locals->set(local * 2, scope_info->LocalName(i));
-    locals->set(local * 2 + 1, frame_inspector.GetExpression(i));
+    locals->set(local * 2 + 1,
+            frame_inspector.GetExpression(scope_info->StackLocalIndex(i)));
     local++;
   }
   if (local < local_count) {

--- a/deps/v8/test/mjsunit/regress/regress-5071.js
+++ b/deps/v8/test/mjsunit/regress/regress-5071.js
@@ -1,0 +1,27 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-debug-as debug
+
+'use strict';
+var Debug = debug.Debug;
+
+function listener(event, exec_state, event_data, data) {
+  assertEquals(2, exec_state.frameCount());
+  assertEquals("a", exec_state.frame(0).localName(0));
+  assertEquals("1", exec_state.frame(0).localValue(0).value());
+  assertEquals(1, exec_state.frame(0).localCount());
+}
+
+Debug.setListener(listener);
+
+function f() {
+  var a = 1;
+  {
+    let b = 2;
+    debugger;
+  }
+}
+
+f();

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -106,6 +106,43 @@ added: v0.11.14
 
 Throw errors for deprecations.
 
+### `--no-warnings`
+<!-- YAML
+added: REPLACEME
+-->
+
+Silence all process warnings.
+
+*Note*: In newer versions of Node.js (e.g. 6.x and higher), The `--no-warnings`
+flag also silences deprecation notices. In Node.js 4.x, however, deprecations
+do *not* use the `process.emitWarning()` API and are not affected by this flag. 
+
+### `--trace-warnings`
+<!-- YAML
+added: REPLACEME
+-->
+
+Print stack traces for process warnings.
+
+*Note*: In newer versions of Node.js (e.g. 6.x and higher), The
+`--trace-warnings` flag also impacts deprecation notices. In Node.js 4.x,
+however, deprecations do *not* use the `process.emitWarning()` API and are not
+affected by this flag.
+
+### `--redirect-warnings=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+Write process warnings to the given file instead of printing to stderr. The
+file will be created if it does not exist, and will be appended to if it does.
+If an error occurs while attempting to write the warning to the file, the
+warning will be written to stderr instead.
+
+*Note*: In newer versions of Node.js (e.g. 6.x and higher), The
+`--redirect-warnings=file` flag also impacts deprecation notices. In Node.js
+4.x, however, deprecations do *not* use the `process.emitWarning()` API and are
+not affected by this flag.
 
 ### `--trace-sync-io`
 <!-- YAML
@@ -214,6 +251,12 @@ added: v0.11.15
 Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small-icu support.
 
+### `NODE_NO_WARNINGS=1`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set to `1`, process warnings are silenced.
 
 ### `NODE_REPL_HISTORY=file`
 <!-- YAML
@@ -238,6 +281,17 @@ misformatted, but any errors are otherwise ignored.
 
 Note that neither the well known nor extra certificates are used when the `ca`
 options property is explicitly specified for a TLS or HTTPS client or server.
+
+### `NODE_REDIRECT_WARNINGS=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set, process warnings will be emitted to the given file instead of
+printing to stderr. The file will be created if it does not exist, and will be
+appended to if it does. If an error occurs while attempting to write the
+warning to the file, the warning will be written to stderr instead. This is
+equivalent to using the `--redirect-warnings=file` command-line flag.
 
 [emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [Buffer]: buffer.html#buffer_buffer

--- a/doc/node.1
+++ b/doc/node.1
@@ -104,6 +104,18 @@ Print stack traces for deprecations.
 Throw errors for deprecations.
 
 .TP
+.BR \-\-no\-warnings
+Silence all process warnings (including deprecations).
+
+.TP
+.BR \-\-trace\-warnings
+Print stack traces for process warnings (including deprecations).
+
+.TP
+.BR \-\-redirect\-warnings=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+
+.TP
 .BR \-\-trace\-sync\-io
 Print a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
@@ -153,11 +165,20 @@ Data path for ICU (Intl object) data. Will extend linked-in data when compiled
 with small\-icu support.
 
 .TP
+.BR NODE_NO_WARNINGS =\fI1\fR
+When set to \fI1\fR, process warnings are silenced.
+
+.TP
 .BR NODE_REPL_HISTORY =\fIfile\fR
 Path to the file used to store the persistent REPL history. The default path
 is ~/.node_repl_history, which is overridden by this variable. Setting the
 value to an empty string ("" or " ") disables persistent REPL history.
 
+.TP
+.BR NODE_REDIRECT_WARNINGS=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+(equivalent to using the \-\-redirect\-warnings=\fIfile\fR command-line
+argument).
 
 .SH BUGS
 Bugs are tracked in GitHub Issues:

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -4,12 +4,12 @@
 #include "util.h"
 #include "util-inl.h"
 
-
 namespace node {
 
 using v8::Context;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 using v8::ReadOnly;
 
@@ -28,10 +28,21 @@ using v8::ReadOnly;
 void InitConfig(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
-#ifdef NODE_FIPS_MODE
   Environment* env = Environment::GetCurrent(context);
+
+#ifdef NODE_FIPS_MODE
   READONLY_BOOLEAN_PROPERTY("fipsMode");
 #endif
+
+  if (!config_warning_file.empty()) {
+    Local<String> name = OneByteString(env->isolate(), "warningFile");
+    Local<String> value = String::NewFromUtf8(env->isolate(),
+                                              config_warning_file.data(),
+                                              v8::NewStringType::kNormal,
+                                              config_warning_file.size())
+                                                .ToLocalChecked();
+    target->DefineOwnProperty(env->context(), name, value).FromJust();
+  }
 }
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 
 struct sockaddr;
 
@@ -29,6 +30,12 @@ struct sockaddr;
   } while (0)
 
 namespace node {
+
+// Set in node.cc by ParseArgs when --redirect-warnings= is used.
+// Used to redirect warning output to a file rather than sending
+// it to stderr.
+extern std::string config_warning_file;  // NOLINT(runtime/string
+
 
 // Forward declaration
 class Environment;

--- a/test/fixtures/warnings.js
+++ b/test/fixtures/warnings.js
@@ -1,0 +1,3 @@
+'use strict';
+
+process.emitWarning('a bad practice warning');

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  process.emitWarning('foo');
+} else {
+  function test(env) {
+    const cmd = `${process.execPath} ${__filename} child`;
+
+    cp.exec(cmd, { env }, common.mustCall((err, stdout, stderr) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stdout, '');
+
+      if (env.NODE_NO_WARNINGS === '1')
+        assert.strictEqual(stderr, '');
+      else
+        assert(/Warning: foo$/.test(stderr.trim()));
+    }));
+  }
+
+  test({});
+  test(process.env);
+  test({ NODE_NO_WARNINGS: undefined });
+  test({ NODE_NO_WARNINGS: null });
+  test({ NODE_NO_WARNINGS: 'foo' });
+  test({ NODE_NO_WARNINGS: true });
+  test({ NODE_NO_WARNINGS: false });
+  test({ NODE_NO_WARNINGS: {} });
+  test({ NODE_NO_WARNINGS: [] });
+  test({ NODE_NO_WARNINGS: function() {} });
+  test({ NODE_NO_WARNINGS: 0 });
+  test({ NODE_NO_WARNINGS: -1 });
+  test({ NODE_NO_WARNINGS: '0' });
+  test({ NODE_NO_WARNINGS: '01' });
+  test({ NODE_NO_WARNINGS: '2' });
+  // Don't test the number 1 because it will come through as a string in the
+  // the child process environment.
+  test({ NODE_NO_WARNINGS: '1' });
+}

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -1,0 +1,54 @@
+// Flags: --no-warnings
+// The flag suppresses stderr output but the warning event will still emit
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const util = require('util');
+
+process.on('warning', common.mustCall((warning) => {
+  assert(warning);
+  assert(/^(Warning|CustomWarning)/.test(warning.name));
+  assert.strictEqual(warning.message, 'A Warning');
+  if (warning.code) assert.strictEqual(warning.code, 'CODE001');
+}, 8));
+
+process.emitWarning('A Warning');
+process.emitWarning('A Warning', 'CustomWarning');
+process.emitWarning('A Warning', CustomWarning);
+process.emitWarning('A Warning', 'CustomWarning', CustomWarning);
+process.emitWarning('A Warning', 'CustomWarning', 'CODE001');
+
+function CustomWarning() {
+  Error.call(this);
+  this.name = 'CustomWarning';
+  this.message = 'A Warning';
+  this.code = 'CODE001';
+  Error.captureStackTrace(this, CustomWarning);
+}
+util.inherits(CustomWarning, Error);
+process.emitWarning(new CustomWarning());
+
+const warningNoToString = new CustomWarning();
+warningNoToString.toString = null;
+process.emitWarning(warningNoToString);
+
+const warningThrowToString = new CustomWarning();
+warningThrowToString.toString = function() {
+  throw new Error('invalid toString');
+};
+process.emitWarning(warningThrowToString);
+
+// TypeError is thrown on invalid input
+assert.throws(() => process.emitWarning(1), TypeError);
+assert.throws(() => process.emitWarning({}), TypeError);
+assert.throws(() => process.emitWarning(true), TypeError);
+assert.throws(() => process.emitWarning([]), TypeError);
+assert.throws(() => process.emitWarning('', {}), TypeError);
+assert.throws(() => process.emitWarning('', '', {}), TypeError);
+assert.throws(() => process.emitWarning('', 1), TypeError);
+assert.throws(() => process.emitWarning('', '', 1), TypeError);
+assert.throws(() => process.emitWarning('', true), TypeError);
+assert.throws(() => process.emitWarning('', '', true), TypeError);
+assert.throws(() => process.emitWarning('', []), TypeError);
+assert.throws(() => process.emitWarning('', '', []), TypeError);

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the NODE_REDIRECT_WARNINGS environment variable by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {env: {NODE_REDIRECT_WARNINGS: warnpath}})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the --redirect-warnings command line flag by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {execArgv: [`--redirect-warnings=${warnpath}`]})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));


### PR DESCRIPTION
Backport of the `process.emitWarning()` API to Node.js 4.x

Includes:
* The `process.emitWarning()` method
* The `--no-warnings` and `--trace-warnings` command line flags
* The `NODE_NO_WARNINGS` environment variable
* The `--redirect-warnings=file` command line flag
* The `NODE_REDIRECT_WARNINGS` environment variable

This *does not* change any of the existing deprecation or warning notices emitted by Node.js itself as that would be a breaking semver-major change. Accordingly, the command line flags and environment variables have *no impact* on deprecation warnings.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
process