### PR TITLE
build: fail on CI if leftover processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,11 @@ test-ci-js: | clear-stalled
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
+	# Clean up any leftover processes
+	PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
+	if [ "$${PS_OUT}" ]; then \
+		echo $${PS_OUT} | $(XARGS) kill; exit 1; \
+	fi
 
 test-ci: LOGLEVEL := info
 test-ci: | clear-stalled build-addons
@@ -297,6 +302,11 @@ test-ci: | clear-stalled build-addons
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES) $(CI_JS_SUITES)
+	# Clean up any leftover processes
+	PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
+	if [ "$${PS_OUT}" ]; then \
+		echo $${PS_OUT} | $(XARGS) kill; exit 1; \
+	fi
 
 test-release: test-build
 	$(PYTHON) tools/test.py --mode=release


### PR DESCRIPTION
If any tests leave processes running after testing results are complete, fail the test run.

Dependent on https://github.com/nodejs/node/pull/11246

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build test