### PR TITLE
src: use .data() instead of .c_str()

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -550,7 +550,7 @@ void AgentImpl::WorkerRunIO() {
   std::string script_path;
   if (!script_name_.empty()) {
     uv_fs_t req;
-    if (0 == uv_fs_realpath(&child_loop_, &req, script_name_.c_str(), nullptr))
+    if (0 == uv_fs_realpath(&child_loop_, &req, script_name_.data(), nullptr))
       script_path = std::string(reinterpret_cast<char*>(req.ptr));
     uv_fs_req_cleanup(&req);
   }

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -26,7 +26,7 @@ void Escape(std::string* string) {
 
 std::string GetWsUrl(const std::string& host, int port, const std::string& id) {
   char buf[1024];
-  snprintf(buf, sizeof(buf), "%s:%d/%s", host.c_str(), port, id.c_str());
+  snprintf(buf, sizeof(buf), "%s:%d/%s", host.data(), port, id.data());
   return buf;
 }
 
@@ -94,7 +94,7 @@ void PrintDebuggerReadyMessage(const std::string& host,
     fprintf(out,
             "    chrome-devtools://devtools/bundled/inspector.html?"
             "experiments=true&v8only=true&ws=%s\n",
-            GetWsUrl(host, port, id).c_str());
+            GetWsUrl(host, port, id).data());
   }
   fflush(out);
 }
@@ -294,7 +294,7 @@ void InspectorSocketServer::SessionTerminated(int session_id) {
 
 bool InspectorSocketServer::RespondToGet(InspectorSocket* socket,
                                          const std::string& path) {
-  const char* command = MatchPathSegment(path.c_str(), "/json");
+  const char* command = MatchPathSegment(path.data(), "/json");
   if (command == nullptr)
     return false;
 
@@ -357,7 +357,7 @@ bool InspectorSocketServer::Start(uv_loop_t* loop) {
   loop_ = loop;
   sockaddr_in addr;
   uv_tcp_init(loop_, &server_);
-  uv_ip4_addr(host_.c_str(), port_, &addr);
+  uv_ip4_addr(host_.data(), port_, &addr);
   int err = uv_tcp_bind(&server_,
                         reinterpret_cast<const struct sockaddr*>(&addr), 0);
   if (err == 0)
@@ -372,7 +372,7 @@ bool InspectorSocketServer::Start(uv_loop_t* loop) {
   if (err != 0 && connected_sessions_.empty()) {
     if (out_ != NULL) {
       fprintf(out_, "Starting inspector on %s:%d failed: %s\n",
-              host_.c_str(), port_, uv_strerror(err));
+              host_.data(), port_, uv_strerror(err));
       fflush(out_);
     }
     uv_close(reinterpret_cast<uv_handle_t*>(&server_), nullptr);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3102,7 +3102,7 @@ void SetupProcessObject(Environment* env,
     // Did the user attempt (via env var or parameter) to set an ICU path?
     READONLY_PROPERTY(process,
                       "icu_data_dir",
-                      OneByteString(env->isolate(), icu_data_dir.c_str()));
+                      OneByteString(env->isolate(), icu_data_dir.data()));
   }
 #endif
 
@@ -3819,7 +3819,7 @@ static void StartDebug(Environment* env, const char* path,
     debugger_running = env->debugger_agent()->Start(debug_options);
     if (debugger_running == false) {
       fprintf(stderr, "Starting debugger on %s:%d failed\n",
-              debug_options.host_name().c_str(), debug_options.port());
+              debug_options.host_name().data(), debug_options.port());
       fflush(stderr);
     }
   }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -842,11 +842,11 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
     if (!extra_root_certs_file.empty()) {
       unsigned long err = AddCertsFromFile(  // NOLINT(runtime/int)
                                            root_cert_store,
-                                           extra_root_certs_file.c_str());
+                                           extra_root_certs_file.data());
       if (err) {
         ProcessEmitWarning(sc->env(),
                            "Ignoring extra certs from `%s`, load failed: %s\n",
-                           extra_root_certs_file.c_str(),
+                           extra_root_certs_file.data(),
                            ERR_error_string(err, nullptr));
       }
     }

--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -21,7 +21,7 @@ inline std::string remove_brackets(const std::string& host) {
 int parse_and_validate_port(const std::string& port) {
   char* endptr;
   errno = 0;
-  const long result = strtol(port.c_str(), &endptr, 10);  // NOLINT(runtime/int)
+  const long result = strtol(port.data(), &endptr, 10);  // NOLINT(runtime/int)
   if (errno != 0 || *endptr != '\0'|| result < 1024 || result > 65535) {
     fprintf(stderr, "Debug port must be in range 1024 to 65535.\n");
     exit(12);

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -416,7 +416,7 @@ bool InitializeICUDirectory(const std::string& path) {
     return (status == U_ZERO_ERROR);
   } else {
     flag_icu_data_dir = true;
-    u_setDataDirectory(path.c_str());
+    u_setDataDirectory(path.data());
     return true;  // No error.
   }
 }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -90,7 +90,7 @@ using v8::Value;
 #define SET_HAVE_FRAGMENT() url.flags |= URL_FLAGS_HAS_FRAGMENT;
 
 #define UTF8STRING(isolate, str)                                              \
-  String::NewFromUtf8(isolate, str.c_str(), v8::NewStringType::kNormal)       \
+  String::NewFromUtf8(isolate, str.data(), v8::NewStringType::kNormal)       \
     .ToLocalChecked()
 
 namespace url {
@@ -400,7 +400,7 @@ namespace url {
     }
 
     // Check to see if it's an IPv4 IP address
-    type = ParseIPv4Host(host, decoded.c_str(), decoded.length());
+    type = ParseIPv4Host(host, decoded.data(), decoded.length());
     if (type == HOST_TYPE_IPV4 || type == HOST_TYPE_FAILED)
       goto end;
 
@@ -1206,7 +1206,7 @@ namespace url {
                 buffer[1] = ':';
               }
               SET_HAVE_PATH()
-              std::string segment(buffer.c_str(), buffer.size());
+              std::string segment(buffer.data(), buffer.size());
               url.path.push_back(segment);
             }
             buffer.clear();
@@ -1285,7 +1285,7 @@ namespace url {
     argv[ARG_FLAGS] = Integer::NewFromUnsigned(isolate, url.flags);
     if (!IS_FAILED(url.flags)) {
       if (DOES_HAVE_SCHEME(url))
-        argv[ARG_PROTOCOL] = OneByteString(isolate, url.scheme.c_str());
+        argv[ARG_PROTOCOL] = OneByteString(isolate, url.scheme.data());
       if (DOES_HAVE_USERNAME(url))
         argv[ARG_USERNAME] = UTF8STRING(isolate, url.username);
       if (DOES_HAVE_PASSWORD(url))
@@ -1345,7 +1345,7 @@ namespace url {
     }
     args.GetReturnValue().Set(
         String::NewFromUtf8(env->isolate(),
-                            output.c_str(),
+                            output.data(),
                             v8::NewStringType::kNormal).ToLocalChecked());
   }
 
@@ -1365,7 +1365,7 @@ namespace url {
     WriteHost(&host, &out);
     args.GetReturnValue().Set(
         String::NewFromUtf8(env->isolate(),
-                            out.c_str(),
+                            out.data(),
                             v8::NewStringType::kNormal).ToLocalChecked());
   }
 
@@ -1385,7 +1385,7 @@ namespace url {
     WriteHost(&host, &out);
     args.GetReturnValue().Set(
         String::NewFromUtf8(env->isolate(),
-                            out.c_str(),
+                            out.data(),
                             v8::NewStringType::kNormal).ToLocalChecked());
   }
 

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -31,7 +31,7 @@ void Agent::Start(v8::Platform* platform, const char* enabled_categories) {
     while (category_list.good()) {
       std::string category;
       getline(category_list, category, ',');
-      trace_config->AddIncludedCategory(category.c_str());
+      trace_config->AddIncludedCategory(category.data());
     }
   } else {
     trace_config->AddIncludedCategory("v8");

--- a/src/tracing/node_trace_writer.cc
+++ b/src/tracing/node_trace_writer.cc
@@ -59,7 +59,7 @@ void NodeTraceWriter::OpenNewFileForStreaming() {
   uv_fs_t req;
   std::ostringstream log_file;
   log_file << "node_trace." << file_num_ << ".log";
-  fd_ = uv_fs_open(tracing_loop_, &req, log_file.str().c_str(),
+  fd_ = uv_fs_open(tracing_loop_, &req, log_file.str().data(),
       O_CREAT | O_WRONLY | O_TRUNC, 0644, NULL);
   CHECK_NE(fd_, -1);
   uv_fs_req_cleanup(&req);
@@ -139,7 +139,7 @@ void NodeTraceWriter::WriteToFile(std::string&& str, int highest_request_id) {
   write_req->str = std::move(str);
   write_req->writer = this;
   write_req->highest_request_id = highest_request_id;
-  uv_buf_t uv_buf = uv_buf_init(const_cast<char*>(write_req->str.c_str()),
+  uv_buf_t uv_buf = uv_buf_init(const_cast<char*>(write_req->str.data()),
       write_req->str.length());
   request_mutex_.Lock();
   // Manage a queue of WriteRequest objects because the behavior of uv_write is


### PR DESCRIPTION
Since C++11 onwards, .data() is required to be null terminated, and can
be used always instead of .c_str().


I mildly prefer c_str(), but if Node only supports C++11, this will convert to .data().
##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src

cf. https://github.com/nodejs/node/pull/11006#discussion_r100238194

