### PR TITLE
test: refactor test-http-response-statuscode

### DIFF
--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -6,76 +6,54 @@ const http = require('http');
 const MAX_REQUESTS = 13;
 let reqNum = 0;
 
-const createErrorMessage = (code) => {
-  return new RegExp(`^RangeError: Invalid status code: ${code}$`);
-};
+function test(res, header, code) {
+  const errRegExp = new RegExp(`^RangeError: Invalid status code: ${code}$`);
+  assert.throws(() => {
+    res.writeHead(header);
+  }, errRegExp);
+}
 
 const server = http.Server(common.mustCall(function(req, res) {
   switch (reqNum) {
     case 0:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(-1);
-      }), createErrorMessage(-1));
+      test(res, -1, '-1');
       break;
     case 1:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(Infinity);
-      }), createErrorMessage(Infinity));
+      test(res, Infinity, 'Infinity');
       break;
     case 2:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(NaN);
-      }), createErrorMessage(NaN));
+      test(res, NaN, 'NaN');
       break;
     case 3:
-      assert.throws(common.mustCall(() => {
-        res.writeHead({});
-      }), createErrorMessage('\\[object Object\\]'));
+      test(res, {}, '\\[object Object\\]');
       break;
     case 4:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(99);
-      }), createErrorMessage(99));
+      test(res, 99, '99');
       break;
     case 5:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(1000);
-      }), createErrorMessage(1000));
+      test(res, 1000, '1000');
       break;
     case 6:
-      assert.throws(common.mustCall(() => {
-        res.writeHead('1000');
-      }), createErrorMessage('1000'));
+      test(res, '1000', '1000');
       break;
     case 7:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(null);
-      }), createErrorMessage(null));
+      test(res, null, 'null');
       break;
     case 8:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(true);
-      }), createErrorMessage(true));
+      test(res, true, 'true');
       break;
     case 9:
-      assert.throws(common.mustCall(() => {
-        res.writeHead([]);
-      }), createErrorMessage([]));
+      test(res, [], '');
       break;
     case 10:
-      assert.throws(common.mustCall(() => {
-        res.writeHead('this is not valid');
-      }), createErrorMessage('this is not valid'));
+      test(res, 'this is not valid', 'this is not valid');
       break;
     case 11:
-      assert.throws(common.mustCall(() => {
-        res.writeHead('404 this is not valid either');
-      }), createErrorMessage('404 this is not valid either'));
+      test(res, '404 this is not valid either', '404 this is not valid either');
       break;
     case 12:
-      assert.throws(common.mustCall(() => {
-        res.writeHead();
-      }), createErrorMessage(undefined));
+      assert.throws(() => { res.writeHead(); },
+                    /^RangeError: Invalid status code: undefined$/);
       this.close();
       break;
     default:


### PR DESCRIPTION
* move repeated code to function
* use strings for expected error (exposes result for [] as empty string)
* remove unneeded `common.mustCall()` usage with function arguments that
  are not callbacks

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http