### PR TITLE
(backport 7.x) lib: deprecate node --debug at runtime

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -1,5 +1,9 @@
 'use strict';
 
+process.emitWarning(
+  'node --debug is deprecated. Please use node --inspect instead.',
+  'DeprecationWarning');
+
 const assert = require('assert');
 const net = require('net');
 const util = require('util');

--- a/test/parallel/test-debug-port-from-cmdline.js
+++ b/test/parallel/test-debug-port-from-cmdline.js
@@ -2,11 +2,18 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const os = require('os');
 
 const debugPort = common.PORT;
 const args = ['--interactive', '--debug-port=' + debugPort];
 const childOptions = { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] };
 const child = spawn(process.execPath, args, childOptions);
+
+const reDeprecationWarning = new RegExp(
+  /^\(node:\d+\) DeprecationWarning: /.source +
+  /node --debug is deprecated. /.source +
+  /Please use node --inspect instead.$/.source
+);
 
 child.stdin.write("process.send({ msg: 'childready' });\n");
 
@@ -37,12 +44,20 @@ function processStderrLine(line) {
 }
 
 function assertOutputLines() {
-  const expectedLines = [
-    'Starting debugger agent.',
-    'Debugger listening on 127.0.0.1:' + debugPort,
+  // need a var so can swap the first two lines in following
+  // eslint-disable-next-line no-var
+  var expectedLines = [
+    /^Starting debugger agent.$/,
+    reDeprecationWarning,
+    new RegExp(`^Debugger listening on 127.0.0.1:${debugPort}$`)
   ];
+
+  if (os.platform() === 'win32') {
+    expectedLines[1] = expectedLines[0];
+    expectedLines[0] = reDeprecationWarning;
+  }
 
   assert.strictEqual(outputLines.length, expectedLines.length);
   for (let i = 0; i < expectedLines.length; i++)
-    assert(expectedLines[i].includes(outputLines[i]));
+    assert(expectedLines[i].test(outputLines[i]));
 }

--- a/test/parallel/test-debug-signal-cluster.js
+++ b/test/parallel/test-debug-signal-cluster.js
@@ -8,7 +8,8 @@ const path = require('path');
 
 const port = common.PORT;
 const serverPath = path.join(common.fixturesDir, 'clustered-server', 'app.js');
-const args = [`--debug-port=${port}`, serverPath];
+// cannot use 'Flags: --no-deprecation' since it doesn't effect child
+const args = [`--debug-port=${port}`, '--no-deprecation', serverPath];
 const options = { stdio: ['inherit', 'inherit', 'pipe', 'ipc'] };
 const child = spawn(process.execPath, args, options);
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

lib

---

Backport of #10970. Same except removed the new deprecation code.