### PR TITLE
 test: improve crypto coverage

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -182,6 +182,10 @@ let firstByte = ecdh1.getPublicKey('buffer', 'compressed')[0];
 assert(firstByte === 2 || firstByte === 3);
 firstByte = ecdh1.getPublicKey('buffer', 'hybrid')[0];
 assert(firstByte === 6 || firstByte === 7);
+// format value should be string
+assert.throws(() => {
+  ecdh1.getPublicKey('buffer', 10);
+}, /^TypeError: Bad format: 10$/);
 
 // ECDH should check that point is on curve
 const ecdh3 = crypto.createECDH('secp256k1');
@@ -277,3 +281,8 @@ ecdh5.setPrivateKey(cafebabeKey, 'hex');
   // Verify object state did not change.
   assert.strictEqual(ecdh5.getPrivateKey('hex'), cafebabeKey);
 });
+
+// invalid test: curve argument is undefined
+assert.throws(() => {
+  crypto.createECDH();
+}, /^TypeError: "curve" argument should be a string$/);


### PR DESCRIPTION
This PR improves [test coverage](https://coverage.nodejs.org/coverage-2db3b941a9384a03/root/crypto.js.html) on crypto dh functions.
Just add 2 exceptions check.
Please review.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
