### PR TITLE
test: improve crypto coverage

### DIFF
--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -37,3 +37,6 @@ assert.strictEqual(certificate.exportChallenge(spkacFail), '');
 function stripLineEndings(obj) {
   return obj.replace(/\n/g, '');
 }
+
+// direct call Certificate() should return instance
+assert(crypto.Certificate() instanceof crypto.Certificate);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -70,3 +70,10 @@ const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
   verified = verStream.verify(certPem, s3);
   assert.strictEqual(verified, true, 'sign and verify (stream)');
 }
+
+// Test throws exception when key options is null
+{
+  assert.throws(() => {
+    crypto.createSign('RSA-SHA1').update('Test123').sign(null, 'base64');
+  }, /^Error: No key provided to sign$/);
+}


### PR DESCRIPTION
This PR improves [test coverage](https://coverage.nodejs.org/coverage-2db3b941a9384a03/root/crypto.js.html) on crypto includes as below:
- call Certificate function directly
- check exception when sign option is undefined

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
N/A