### PR TITLE
test: refactor test-readline-keys

### DIFF
--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -3,7 +3,6 @@ const common = require('../common');
 const PassThrough = require('stream').PassThrough;
 const assert = require('assert');
 const inherits = require('util').inherits;
-const extend = require('util')._extend;
 const Interface = require('readline').Interface;
 
 
@@ -11,6 +10,10 @@ function FakeInput() {
   PassThrough.call(this);
 }
 inherits(FakeInput, PassThrough);
+
+function extend(k) {
+  return Object.assign({ ctrl: false, meta: false, shift: false }, k);
+}
 
 
 const fi = new FakeInput();
@@ -32,9 +35,7 @@ function addTest(sequences, expectedKeys) {
     expectedKeys = [ expectedKeys ];
   }
 
-  expectedKeys = expectedKeys.map((k) => {
-    return k ? extend({ ctrl: false, meta: false, shift: false }, k) : k;
-  });
+  expectedKeys = expectedKeys.map(extend);
 
   keys = [];
 
@@ -65,9 +66,7 @@ const addKeyIntervalTest = (sequences, expectedKeys, interval = 550,
       expectedKeys = [ expectedKeys ];
     }
 
-    expectedKeys = expectedKeys.map((k) => {
-      return k ? extend({ ctrl: false, meta: false, shift: false }, k) : k;
-    });
+    expectedKeys = expectedKeys.map(extend);
 
     const keys = [];
     fi.on('keypress', (s, k) => keys.push(k));


### PR DESCRIPTION
* replace `util._extend()` with `Object.assign()`
* extract repeated map function to a single instance
* remove unneeded truthiness-check ternary on Objects

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test readline