### PR TITLE
child_process: exit spawnSync with null on signal

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -650,12 +650,17 @@ Local<Object> SyncProcessRunner::BuildResultObject() {
                    Integer::New(env()->isolate(), GetError()));
   }
 
-  if (exit_status_ >= 0)
-    js_result->Set(env()->status_string(),
-        Number::New(env()->isolate(), static_cast<double>(exit_status_)));
-  else
+  if (exit_status_ >= 0) {
+    if (term_signal_ > 0) {
+      js_result->Set(env()->status_string(), Null(env()->isolate()));
+    } else {
+      js_result->Set(env()->status_string(),
+          Number::New(env()->isolate(), static_cast<double>(exit_status_)));
+    }
+  } else {
     // If exit_status_ < 0 the process was never started because of some error.
     js_result->Set(env()->status_string(), Null(env()->isolate()));
+  }
 
   if (term_signal_ > 0)
     js_result->Set(env()->signal_string(),

--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -1,12 +1,11 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
   setInterval(() => {}, 1000);
 } else {
-  const exitCode = common.isWindows ? 1 : 0;
   const { SIGKILL } = process.binding('constants').os.signals;
 
   function spawn(killSignal) {
@@ -14,7 +13,7 @@ if (process.argv[2] === 'child') {
                                [__filename, 'child'],
                                {killSignal, timeout: 100});
 
-    assert.strictEqual(child.status, exitCode);
+    assert.strictEqual(child.status, null);
     assert.strictEqual(child.error.code, 'ETIMEDOUT');
     return child;
   }


### PR DESCRIPTION
This commit sets the `spawnSync()` exit code to `null` when the child is killed via signal. This brings the behavior more in sync with `spawn()`.

Fixes: https://github.com/nodejs/node/issues/11284

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process