### PR TITLE
test: cover dgram socket close during cluster bind

### DIFF
--- a/test/parallel/test-dgram-cluster-close-during-bind.js
+++ b/test/parallel/test-dgram-cluster-close-during-bind.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const dgram = require('dgram');
+
+if (common.isWindows) {
+  common.skip('dgram clustering is currently not supported on windows.');
+  return;
+}
+
+if (cluster.isMaster) {
+  cluster.fork();
+} else {
+  // When the socket attempts to bind, it requests a handle from the cluster.
+  // Close the socket before returning the handle from the cluster.
+  const socket = dgram.createSocket('udp4');
+  const _getServer = cluster._getServer;
+
+  cluster._getServer = common.mustCall(function(self, options, callback) {
+    socket.close(common.mustCall(() => {
+      _getServer.call(this, self, options, common.mustCall((err, handle) => {
+        assert.strictEqual(err, 0);
+
+        // When the socket determines that it was already closed, it will
+        // close the handle. Use handle.close() to terminate the test.
+        const close = handle.close;
+
+        handle.close = common.mustCall(function() {
+          setImmediate(() => cluster.worker.disconnect());
+          return close.call(this);
+        });
+
+        callback(err, handle);
+      }));
+    }));
+  });
+
+  socket.bind(common.mustNotCall('Socket should not bind.'));
+}


### PR DESCRIPTION
When a non-exclusive dgram socket is bound from a cluster worker, it attempts to get a handle from the `cluster` module. This commit adds coverage for the case where the socket is
closed while querying the `cluster` module for a handle.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
