### PR TITLE
https: use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -558,7 +558,7 @@ found [here][online].
   the connected party did not properly respond after a period of time. Usually
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
-
+  
 
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
@@ -702,6 +702,12 @@ in the [WHATWG URL API][] for strict compliance with the specification (which
 in some cases may accept `func(undefined)` but not `func()`). In most native
 Node.js APIs, `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
+
+<a id="ERR_HTTP_NO_DOMAIN"></a>
+### ERR_HTTP_NO_DOMAIN
+
+An error using the `'ERR_HTTP_NO_DOMAIN'` code is thrown specifically when an attempt 
+is made to parse an URL without a valid domain name.
 
 <a id="ERR_STDERR_CLOSE"></a>
 ### ERR_STDERR_CLOSE

--- a/lib/https.js
+++ b/lib/https.js
@@ -30,6 +30,7 @@ const util = require('util');
 const inherits = util.inherits;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
+const errors = require('internal/errors');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -219,7 +220,7 @@ exports.request = function request(options, cb) {
   if (typeof options === 'string') {
     options = url.parse(options);
     if (!options.hostname) {
-      throw new Error('Unable to determine the domain name');
+      throw new errors.Error('ERR_HTTP_NO_DOMAIN');
     }
   } else if (options && options[searchParamsSymbol] &&
              options[searchParamsSymbol][searchParamsSymbol]) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -136,6 +136,7 @@ E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected');
 E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe');
 E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
+E('ERR_HTTP_NO_DOMAIN', 'Unable to determine the domain name');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);


### PR DESCRIPTION
Change [https.js](https://github.com/nodejs/node/tree/master/lib/https.js) so it makes use of the new [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js) module.

See https://github.com/nodejs/node/issues/11273 for more info.

cc @jasnell 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
https
