### PR TITLE
errors: assign error code to bootstrap_node created error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -558,6 +558,7 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
+
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
@@ -587,6 +588,14 @@ An error using the `'ERR_STDOUT_CLOSE'` code is thrown specifically when an
 attempt is made to close the `process.stdout` stream. By design, Node.js does
 not allow `stdout` or `stderr` Streams to be closed by user code.
 
+<a id="ERR_UNKNOWN_BUILTIN_MODULE"></a>
+### ERR_UNKNOWN_BUILTIN_MODULE
+
+The `'ERR_UNKNOWN_BUILTIN_MODULE'` error code is used to identify a specific
+kind of internal Node.js error that should not typically be triggered by user
+code. Instances of this error point to an internal bug within the Node.js
+binary itself.
+
 <a id="ERR_UNKNOWN_STDIN_TYPE"></a>
 ### ERR_UNKNOWN_STDIN_TYPE
 
@@ -604,6 +613,7 @@ an attempt is made to launch a Node.js process with an unknown `stdout` or
 `stderr` file type. Errors of this kind cannot *typically* be caused by errors
 in user code, although it is not impossible. Occurrences of this error are most
 likely an indication of a bug within Node.js itself.
+
 
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -462,7 +462,13 @@
     }
 
     if (!NativeModule.exists(id)) {
-      throw new Error(`No such native module ${id}`);
+      // Model the error off the internal/errors.js model, but
+      // do not use that module given that it could actually be
+      // the one causing the error if there's a bug in Node.js
+      const err = new Error(`No such built-in module: ${id}`);
+      err.code = 'ERR_UNKNOWN_BUILTIN_MODULE';
+      err.name = 'Error [ERR_UNKNOWN_BUILTIN_MODULE]';
+      throw err;
     }
 
     process.moduleLoadList.push(`NativeModule ${id}`);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,6 +86,7 @@ E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
+E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
 // Add new errors from here...
 
 function invalidArgType(name, expected, actual) {


### PR DESCRIPTION
This does not use the internal/errors.js module because the error in question may actually be *caused* by an attempt to load internal/errors.js. This error should only be encountered in the case of a bug within Node.js itself.

Ref: https://github.com/nodejs/node/issues/11273

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

errors, src