### PR TITLE
internal/util: use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -748,6 +748,12 @@ Used when data cannot be sent on a socket.
 
 Used when a call is made and the UDP subsystem is not running.
 
+<a id="ERR_NO_CRYPTO"></a>
+### ERR_NO_CRYPTO
+
+Used when an attempt is made to use crypto features while Node.js is not
+compiled with OpenSSL crypto support.
+
 <a id="ERR_STDERR_CLOSE"></a>
 ### ERR_STDERR_CLOSE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -155,6 +155,7 @@ E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
 E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
+E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -34,7 +34,7 @@ function deprecate(fn, msg, code) {
   }
 
   if (code !== undefined && typeof code !== 'string')
-    throw new TypeError('`code` argument must be a string');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'string');
 
   var warned = false;
   function deprecated(...args) {
@@ -79,7 +79,7 @@ function decorateErrorStack(err) {
 
 function assertCrypto() {
   if (noCrypto)
-    throw new Error('Node.js is not compiled with openssl crypto support');
+    throw new errors.Error('ERR_NO_CRYPTO');
 }
 
 // The loop should only run at most twice, retrying with lowercased enc

--- a/test/parallel/test-internal-util-assertCrypto.js
+++ b/test/parallel/test-internal-util-assertCrypto.js
@@ -1,14 +1,16 @@
 // Flags: --expose-internals
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const util = require('internal/util');
 
+const expectedError = common.expectsError({
+  code: 'ERR_NO_CRYPTO',
+  type: Error
+});
+
 if (!process.versions.openssl) {
-  assert.throws(
-    () => util.assertCrypto(),
-    /^Error: Node\.js is not compiled with openssl crypto support$/
-  );
+  assert.throws(() => util.assertCrypto(), expectedError);
 } else {
   assert.doesNotThrow(() => util.assertCrypto());
 }


### PR DESCRIPTION
Change [internal/util.js](https://github.com/nodejs/node/tree/master/lib/internal/util.js) so it makes use of the new [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js) module.

See https://github.com/nodejs/node/issues/11273 for more info.

cc @jasnell
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
error
