### PR TITLE
errors,net: change internal/net.js to use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -562,6 +562,17 @@ found [here][online].
   the connected party did not properly respond after a period of time. Usually
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
+  
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
+
+<a id="ERR_INVALID_PORT"></a>
+### ERR_INVALID_PORT
+
+An error using the `'ERR_INVALID_PORT'` code is thrown specifically when an attempt 
+is made to provide a network port which is not in the range of valid port numbers 
+(0-65535)
+
 
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
@@ -575,6 +586,7 @@ found [here][online].
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,3 +86,6 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('ERR_INVALID_PORT', (port) => {
+  return `Port must be >= 0 and < 65536, got "${port}"`;
+});

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 module.exports = { isLegalPort, assertPort };
 
 // Check that the port number is not NaN when coerced to a number,
@@ -14,5 +16,5 @@ function isLegalPort(port) {
 
 function assertPort(port) {
   if (typeof port !== 'undefined' && !isLegalPort(port))
-    throw new RangeError('"port" argument must be >= 0 and < 65536');
+    throw new errors.RangeError('ERR_INVALID_PORT', port);
 }

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -3,6 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
+const portRangeError = common.expectsError('ERR_INVALID_PORT', RangeError);
+
 function close() { this.close(); }
 
 // From lib/net.js
@@ -36,7 +38,7 @@ listenVariants.forEach((listenVariant, i) => {
       return;
     }
     assert.throws(() => listenVariant(port, common.mustNotCall()),
-                  /"port" argument must be >= 0 and < 65536/i);
+                  portRangeError);
   });
 
   [null, true, false].forEach((port) =>

--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const net = require('net');
 
 const invalidPort = -1 >>> 0;
-const errorMessage = /"port" argument must be >= 0 and < 65536/;
+const portRangeError = common.expectsError('ERR_INVALID_PORT', RangeError);
 
 net.Server().listen(common.PORT, function() {
   const address = this.address();
@@ -17,14 +17,14 @@ net.Server().listen(common.PORT, function() {
 // The first argument is a configuration object
 assert.throws(() => {
   net.Server().listen({ port: invalidPort }, common.mustNotCall());
-}, errorMessage);
+}, portRangeError);
 
 // The first argument is the port, no IP given.
 assert.throws(() => {
   net.Server().listen(invalidPort, common.mustNotCall());
-}, errorMessage);
+}, portRangeError);
 
 // The first argument is the port, the second an IP.
 assert.throws(() => {
   net.Server().listen(invalidPort, '0.0.0.0', common.mustNotCall());
-}, errorMessage);
+}, portRangeError);


### PR DESCRIPTION
Change [internal/net.js](https://github.com/nodejs/node/tree/master/lib/internal/net.js) so it makes use of the new [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js) module.

See https://github.com/nodejs/node/issues/11273 for more info.

cc @jasnell

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
errors,net
