### PR TITLE
deps: backport 2bd7464 from upstream V8

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -123,7 +123,7 @@ Prerequisites:
 To run the tests:
 
 ```text
-> .\vcbuild test
+> .\vcbuild nosign test
 ```
 
 To test if Node.js was built correctly:
@@ -172,7 +172,7 @@ $ ./configure --with-intl=small-icu --download=all
 ##### Windows:
 
 ```text
-> .\vcbuild small-icu download-all
+> .\vcbuild nosign small-icu download-all
 ```
 
 The `small-icu` mode builds with English-only data. You can add full
@@ -195,7 +195,7 @@ $ ./configure --with-intl=full-icu --download=all
 ##### Windows:
 
 ```text
-> .\vcbuild full-icu download-all
+> .\vcbuild nosign full-icu download-all
 ```
 
 #### Building without Intl support
@@ -212,7 +212,7 @@ $ ./configure --with-intl=none
 ##### Windows:
 
 ```text
-> .\vcbuild intl-none
+> .\vcbuild nosign intl-none
 ```
 
 #### Use existing installed ICU (Unix / OS X only):
@@ -251,7 +251,7 @@ First unpack latest ICU to `deps/icu`
 as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```text
-> .\vcbuild full-icu
+> .\vcbuild nosign full-icu
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,13 +117,13 @@ Prerequisites:
   and tools which can be included in the global `PATH`.
 
 ```text
-> vcbuild nosign
+> .\vcbuild nosign
 ```
 
 To run the tests:
 
 ```text
-> vcbuild test
+> .\vcbuild test
 ```
 
 To test if Node.js was built correctly:
@@ -172,7 +172,7 @@ $ ./configure --with-intl=small-icu --download=all
 ##### Windows:
 
 ```text
-> vcbuild small-icu download-all
+> .\vcbuild small-icu download-all
 ```
 
 The `small-icu` mode builds with English-only data. You can add full
@@ -195,7 +195,7 @@ $ ./configure --with-intl=full-icu --download=all
 ##### Windows:
 
 ```text
-> vcbuild full-icu download-all
+> .\vcbuild full-icu download-all
 ```
 
 #### Building without Intl support
@@ -212,7 +212,7 @@ $ ./configure --with-intl=none
 ##### Windows:
 
 ```text
-> vcbuild intl-none
+> .\vcbuild intl-none
 ```
 
 #### Use existing installed ICU (Unix / OS X only):
@@ -251,7 +251,7 @@ First unpack latest ICU to `deps/icu`
 as `deps/icu` (You'll have: `deps/icu/source/...`)
 
 ```text
-> vcbuild full-icu
+> .\vcbuild full-icu
 ```
 
 ## Building Node.js with FIPS-compliant OpenSSL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ $ ./configure && make -j8 test
 Windows:
 
 ```text
-> vcbuild test
+ .\vcbuild nosign test
 ```
 
 (See the [BUILDING.md](./BUILDING.md) for more details.)
@@ -172,11 +172,11 @@ Windows:
 Make sure the linter is happy and that all tests pass. Please, do not submit
 patches that fail either check.
 
-Running `make test`/`vcbuild test` will run the linter as well unless one or
+Running `make test`/`.\vcbuild nosign test` will run the linter as well unless one or
 more tests fail.
 
 If you want to run the linter without running tests, use
-`make lint`/`vcbuild jslint`.
+`make lint`/`.\vcbuild nosign jslint`.
 
 If you are updating tests and just want to run a single test to check it, you
 can use this syntax to run it exactly as the test harness would:

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 46
+#define V8_PATCH_LEVEL 47
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 45
+#define V8_PATCH_LEVEL 46
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/bailout-reason.h
+++ b/deps/v8/src/bailout-reason.h
@@ -310,6 +310,7 @@ namespace internal {
   V(kUnsupportedPhiUseOfConstVariable,                                         \
     "Unsupported phi use of const variable")                                   \
   V(kUnsupportedTaggedImmediate, "Unsupported tagged immediate")               \
+  V(kUnstableConstantTypeHeapObject, "Unstable constant-type heap object")     \
   V(kVariableResolvedToWithContext, "Variable resolved to with context")       \
   V(kWeShouldNotHaveAnEmptyLexicalContext,                                     \
     "We should not have an empty lexical context")                             \

--- a/deps/v8/src/runtime/runtime-debug.cc
+++ b/deps/v8/src/runtime/runtime-debug.cc
@@ -670,7 +670,8 @@ RUNTIME_FUNCTION(Runtime_GetFrameDetails) {
     // Use the value from the stack.
     if (scope_info->LocalIsSynthetic(i)) continue;
     locals->set(local * 2, scope_info->LocalName(i));
-    locals->set(local * 2 + 1, frame_inspector.GetExpression(i));
+    locals->set(local * 2 + 1,
+            frame_inspector.GetExpression(scope_info->StackLocalIndex(i)));
     local++;
   }
   if (local < local_count) {

--- a/deps/v8/src/runtime/runtime-utils.h
+++ b/deps/v8/src/runtime/runtime-utils.h
@@ -85,9 +85,11 @@ namespace internal {
 // Assert that the given argument has a valid value for a LanguageMode
 // and store it in a LanguageMode variable with the given name.
 #define CONVERT_LANGUAGE_MODE_ARG_CHECKED(name, index)        \
-  RUNTIME_ASSERT(args[index]->IsSmi());                       \
-  RUNTIME_ASSERT(is_valid_language_mode(args.smi_at(index))); \
-  LanguageMode name = static_cast<LanguageMode>(args.smi_at(index));
+  RUNTIME_ASSERT(args[index]->IsNumber());                    \
+  int32_t __tmp_##name = 0;                                   \
+  RUNTIME_ASSERT(args[index]->ToInt32(&__tmp_##name));        \
+  RUNTIME_ASSERT(is_valid_language_mode(__tmp_##name));       \
+  LanguageMode name = static_cast<LanguageMode>(__tmp_##name);
 
 
 // Assert that the given argument is a number within the Int32 range

--- a/deps/v8/test/mjsunit/regress/regress-5071.js
+++ b/deps/v8/test/mjsunit/regress/regress-5071.js
@@ -1,0 +1,27 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-debug-as debug
+
+'use strict';
+var Debug = debug.Debug;
+
+function listener(event, exec_state, event_data, data) {
+  assertEquals(2, exec_state.frameCount());
+  assertEquals("a", exec_state.frame(0).localName(0));
+  assertEquals("1", exec_state.frame(0).localValue(0).value());
+  assertEquals(1, exec_state.frame(0).localCount());
+}
+
+Debug.setListener(listener);
+
+function f() {
+  var a = 1;
+  {
+    let b = 2;
+    debugger;
+  }
+}
+
+f();

--- a/deps/v8/test/mjsunit/regress/regress-crbug-659475-1.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-659475-1.js
@@ -1,0 +1,30 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var n;
+
+function Ctor() {
+  n = new Set();
+}
+
+function Check() {
+  n.xyz = 0x826852f4;
+}
+
+Ctor();
+Ctor();
+%OptimizeFunctionOnNextCall(Ctor);
+Ctor();
+
+Check();
+Check();
+%OptimizeFunctionOnNextCall(Check);
+Check();
+
+Ctor();
+Check();
+
+parseInt('AAAAAAAA');

--- a/deps/v8/test/mjsunit/regress/regress-crbug-659475-2.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-659475-2.js
@@ -1,0 +1,32 @@
+
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var n;
+
+function Ctor() {
+  try { } catch (e) {}
+  n = new Set();
+}
+
+function Check() {
+  n.xyz = 0x826852f4;
+}
+
+Ctor();
+Ctor();
+%OptimizeFunctionOnNextCall(Ctor);
+Ctor();
+
+Check();
+Check();
+%OptimizeFunctionOnNextCall(Check);
+Check();
+
+Ctor();
+Check();
+
+parseInt('AAAAAAAA');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
deps

##### Description of change
Backport of bugfix from upstream V8

Original commit message:
For global object property cells, we did not check that the map on the
previous object is still the same for which we actually optimized. So
the optimized code was not in sync with the actual state of the property
cell. When loading from such a global object property cell, Crankshaft
optimizes away any map checks (based on the stable map assumption),
leading to arbitrary memory access in the worst case.

TurboFan has the same bug for stores, but is safe on loads because we
do appropriate map checks there. However mixing TurboFan and Crankshaft
still exposes the bug.

R=yangguo@chromium.org
BUG=chromium:659475

Review-Url: https://codereview.chromium.org/2444233004
Cr-Commit-Position: refs/heads/master@{#40592}

V8 commit: v8/v8@2bd7464
