### PR TITLE
errors, console: migrate to use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -255,6 +255,13 @@ will affect any stack trace captured *after* the value has been changed.
 If set to a non-number value, or set to a negative number, stack traces will
 not capture any frames.
 
+#### error.code
+
+* {String}
+
+The `error.code` property is a string label that identifies the kind of error.
+See [Node.js Error Codes][] for details about specific codes.
+
 #### error.message
 
 * {String}
@@ -563,6 +570,53 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
+
+<a id="ERR_INVALID_ARG_TYPE"></a>
+### ERR_INVALID_ARG_TYPE
+
+The `'ERR_INVALID_ARG_TYPE'` error code is used generically to identify that
+an argument of the wrong type has been passed to a Node.js API.
+
+<a id="ERR_INVALID_CALLBACK"></a>
+### ERR_INVALID_CALLBACK
+
+The `'ERR_INVALID_CALLBACK'` error code is used generically to identify that
+a callback function is required and has not been provided to a Node.js API.
+
+<a id="ERR_STDERR_CLOSE"></a>
+### ERR_STDERR_CLOSE
+
+An error using the `'ERR_STDERR_CLOSE'` code is thrown specifically when an
+attempt is made to close the `process.stderr` stream. By design, Node.js does
+not allow `stdout` or `stderr` Streams to be closed by user code.
+
+<a id="ERR_STDOUT_CLOSE"></a>
+### ERR_STDOUT_CLOSE
+
+An error using the `'ERR_STDOUT_CLOSE'` code is thrown specifically when an
+attempt is made to close the `process.stdout` stream. By design, Node.js does
+not allow `stdout` or `stderr` Streams to be closed by user code.
+
+<a id="ERR_UNK_STDIN_TYPE"></a>
+### ERR_UNK_STDIN_TYPE
+
+An error using the `'ERR_UNK_STDIN_TYPE'` code is thrown specifically when an
+attempt is made to launch a Node.js process with an unknown `stdin` file type.
+Errors of this kind cannot *typically* be caused by errors in user code,
+although it is not impossible. Occurrences of this error are most likely an
+indication of a bug within Node.js itself.
+
+<a id="ERR_UNK_STREAM_TYPE"></a>
+### ERR_UNK_STREAM_TYPE
+
+An error using the `'ERR_UNK_STREAM_TYPE'` code is thrown specifically when an
+attempt is made to launch a Node.js process with an unknown `stdout` or
+`stderr` file type. Errors of this kind cannot *typically* be caused by errors
+in user code, although it is not impossible. Occurrences of this error are most
+likely an indication of a bug within Node.js itself.
+
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
 [`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
@@ -575,6 +629,7 @@ found [here][online].
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/lib/console.js
+++ b/lib/console.js
@@ -1,18 +1,19 @@
 'use strict';
 
 const util = require('util');
+const errors = require('internal/errors');
 
 function Console(stdout, stderr) {
   if (!(this instanceof Console)) {
     return new Console(stdout, stderr);
   }
   if (!stdout || typeof stdout.write !== 'function') {
-    throw new TypeError('Console expects a writable stream instance');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'stdout', 'WriteStream');
   }
   if (!stderr) {
     stderr = stdout;
   } else if (typeof stderr.write !== 'function') {
-    throw new TypeError('Console expects writable stream instances');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'stderr', 'WriteStream');
   }
 
   var prop = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -85,4 +85,33 @@ module.exports = exports = {
 //
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
+E('ERR_INVALID_ARG_TYPE', invalidArgType);
+E('ERR_INVALID_CALLBACK', 'callback must be a function');
+E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
+E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
+E('ERR_UNK_STDIN_TYPE', 'Unknown stdin file type');
+E('ERR_UNK_STREAM_TYPE', 'Unknown stream file type');
 // Add new errors from here...
+
+function invalidArgType(name, expected, actual) {
+  const assert = lazyAssert();
+  assert(name, 'name is required');
+  assert(expected, 'expected is required');
+  var msg = `The "${name}" argument must be `;
+  if (Array.isArray(expected)) {
+    var len = expected.length;
+    expected = expected.map((i) => String(i));
+    if (len > 1) {
+      msg += `one of type ${expected.slice(0, len - 1).join(', ')}, or ` +
+             expected[len - 1];
+    } else {
+      msg += `type ${String(expected[0])}`;
+    }
+  } else {
+    msg += `type ${String(expected)}`;
+  }
+  if (arguments.length >= 3) {
+    msg += `. Received type ${typeof actual}`;
+  }
+  return msg;
+}

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -18,14 +18,15 @@ assert.strictEqual('function', typeof Console);
 // when not given a writable stream instance
 assert.throws(() => {
   new Console();
-}, /^TypeError: Console expects a writable stream instance$/);
+}, common.expectsError('ERR_INVALID_ARG_TYPE', TypeError));
+
 
 // Console constructor should throw if stderr exists but is not writable
 assert.throws(() => {
   out.write = () => {};
   err.write = undefined;
   new Console(out, err);
-}, /^TypeError: Console expects writable stream instances$/);
+}, common.expectsError('ERR_INVALID_ARG_TYPE', TypeError));
 
 out.write = err.write = (d) => {};
 


### PR DESCRIPTION
Migrate [lib/console.js](https://github.com/nodejs/node/blob/master/lib/console.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js).

Refs: https://github.com/nodejs/node/issues/11273

cc @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, console
