### PR TITLE
update licenses and remove v8_inspector deps license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -487,8 +487,32 @@ The externally maintained libraries used by Node.js are:
 
 - libuv, located at deps/uv, is licensed as follows:
   """
-    libuv is part of the Node project: http://nodejs.org/
-    libuv may be distributed alone under Node's license:
+    libuv is licensed for use as follows:
+
+    ====
+    Copyright (c) 2015-present libuv project contributors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    ====
+
+    This license applies to parts of libuv originating from the
+    https://github.com/joyent/libuv repository:
 
     ====
 
@@ -1018,7 +1042,7 @@ The externally maintained libraries used by Node.js are:
 - ESLint, located at tools/eslint, is licensed as follows:
   """
     ESLint
-    Copyright jQuery Foundation and other contributors, https://jquery.org/
+    Copyright JS Foundation and other contributors, https://js.foundation
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -1086,37 +1110,6 @@ The externally maintained libraries used by Node.js are:
     WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
     ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-  """
-
-- v8_inspector, located at deps/v8_inspector/third_party/v8_inspector, is licensed as follows:
-  """
-    // Copyright 2015 The Chromium Authors. All rights reserved.
-    //
-    // Redistribution and use in source and binary forms, with or without
-    // modification, are permitted provided that the following conditions are
-    // met:
-    //
-    //    * Redistributions of source code must retain the above copyright
-    // notice, this list of conditions and the following disclaimer.
-    //    * Redistributions in binary form must reproduce the above
-    // copyright notice, this list of conditions and the following disclaimer
-    // in the documentation and/or other materials provided with the
-    // distribution.
-    //    * Neither the name of Google Inc. nor the names of its
-    // contributors may be used to endorse or promote products derived from
-    // this software without specific prior written permission.
-    //
-    // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   """
 
 - jinja2, located at deps/v8_inspector/third_party/jinja2, is licensed as follows:

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -82,9 +82,6 @@ addlicense "gtest" "deps/gtest" "$(cat ${rootdir}/deps/gtest/LICENSE)"
 addlicense "node-weak" "test/gc/node_modules/weak" \
            "$(cat ${rootdir}/test/gc/node_modules/weak/LICENSE)"
 
-# v8_inspector
-addlicense "v8_inspector" "deps/v8_inspector/third_party/v8_inspector" \
-           "$(cat ${rootdir}/deps/v8_inspector/third_party/v8_inspector/LICENSE)"
 # Build tooling for v8_inspector
 addlicense "jinja2" "deps/v8_inspector/third_party/jinja2" \
            "$(cat ${rootdir}/deps/v8_inspector/third_party/jinja2/LICENSE)"


### PR DESCRIPTION
#9028 made Node.js use the V8
inspector bundled with the deps/v8 and removed the third party
dependency. We can safely omit the non-existent license file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
