### PR TITLE
assert: remove unneeded condition

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -294,7 +294,8 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
 };
 
 function expectedException(actual, expected) {
-  if (!actual || !expected) {
+  // actual is guaranteed to be an Error object, but we need to check expected.
+  if (!expected) {
     return false;
   }
 


### PR DESCRIPTION
In `expectedException()`, `actual` is guaranteed to be truthy. We only need to check `expected` for truthiness.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert