### PR TITLE
errors: port internal/fs errors to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -686,6 +686,11 @@ communication channel to a child process. See [`child.send()`] and
 Used generically to identify when an invalid or unexpected value has been
 passed in an options object.
 
+<a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
+### ERR_INVALID_OPT_VALUE_ENCODING
+
+Used when an invalid or unknown file encoding is passed.
+
 <a id="ERR_INVALID_REPL_EVAL_CONFIG"></a>
 ### ERR_INVALID_REPL_EVAL_CONFIG
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -142,6 +142,8 @@ E('ERR_INVALID_OPT_VALUE',
   (name, value) => {
     return `The value "${String(value)}" is invalid for option "${name}"`;
   });
+E('ERR_INVALID_OPT_VALUE_ENCODING',
+  (value) => `The value "${String(value)}" is invalid for option "encoding"`);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
 E('ERR_INVALID_SYNC_FORK_INPUT',

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -2,6 +2,7 @@
 
 const Buffer = require('buffer').Buffer;
 const Writable = require('stream').Writable;
+const errors = require('internal/errors');
 const fs = require('fs');
 const util = require('util');
 
@@ -18,16 +19,16 @@ const {
 
 function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
-    throw new Error(`Unknown encoding: ${encoding}`);
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE_ENCODING', encoding);
   }
 }
 
-function stringToFlags(flag) {
-  if (typeof flag === 'number') {
-    return flag;
+function stringToFlags(flags) {
+  if (typeof flags === 'number') {
+    return flags;
   }
 
-  switch (flag) {
+  switch (flags) {
     case 'r' : return O_RDONLY;
     case 'rs' : // Fall through.
     case 'sr' : return O_RDONLY | O_SYNC;
@@ -52,7 +53,7 @@ function stringToFlags(flag) {
     case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
   }
 
-  throw new Error('Unknown file open flag: ' + flag);
+  throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'flags', flags);
 }
 
 // Temporary hack for process.stdout and process.stderr when piped to files.

--- a/test/parallel/test-fs-assert-encoding-error.js
+++ b/test/parallel/test-fs-assert-encoding-error.js
@@ -4,72 +4,75 @@ const assert = require('assert');
 const fs = require('fs');
 
 const options = 'test';
-const unknownEncodingMessage = /^Error: Unknown encoding: test$/;
+const expectedError = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE_ENCODING',
+  type: TypeError,
+}, 17);
 
 assert.throws(() => {
   fs.readFile('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.readFileSync('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.readdir('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.readdirSync('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.readlink('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.readlinkSync('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.writeFile('path', 'data', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.writeFileSync('path', 'data', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.appendFile('path', 'data', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.appendFileSync('path', 'data', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.watch('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.realpath('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.realpathSync('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.mkdtemp('path', options, common.mustNotCall());
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.mkdtempSync('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.ReadStream('path', options);
-}, unknownEncodingMessage);
+}, expectedError);
 
 assert.throws(() => {
   fs.WriteStream('path', options);
-}, unknownEncodingMessage);
+}, expectedError);

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -21,7 +21,7 @@
 
 // Flags: --expose_internals
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const fs = require('fs');
@@ -55,30 +55,29 @@ assert.strictEqual(stringToFlags('xa'), O_APPEND | O_CREAT | O_WRONLY | O_EXCL);
 assert.strictEqual(stringToFlags('ax+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
 assert.strictEqual(stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
 
+const expectedError =
+  common.expectsError({code: 'ERR_INVALID_OPT_VALUE', type: TypeError}, 23);
+
 ('+ +a +r +w rw wa war raw r++ a++ w++ x +x x+ rx rx+ wxx wax xwx xxx')
   .split(' ')
   .forEach(function(flags) {
     assert.throws(
       () => stringToFlags(flags),
-      new RegExp(`^Error: Unknown file open flag: ${escapeRegExp(flags)}`)
+      expectedError
     );
   });
 
 assert.throws(
   () => stringToFlags({}),
-  /^Error: Unknown file open flag: \[object Object\]$/
+  expectedError
 );
 
 assert.throws(
   () => stringToFlags(true),
-  /^Error: Unknown file open flag: true$/
+  expectedError
 );
 
 assert.throws(
   () => stringToFlags(null),
-  /^Error: Unknown file open flag: null$/
+  expectedError
 );
-
-function escapeRegExp(string) {
-  return string.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
-}

--- a/test/parallel/test-fs-read-file-assert-encoding.js
+++ b/test/parallel/test-fs-read-file-assert-encoding.js
@@ -6,8 +6,12 @@ const fs = require('fs');
 
 const encoding = 'foo-8';
 const filename = 'bar.txt';
+const expectedError = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE_ENCODING',
+  type: TypeError,
+});
 
 assert.throws(
   fs.readFile.bind(fs, filename, { encoding }, common.mustNotCall()),
-  new RegExp(`^Error: Unknown encoding: ${encoding}$`)
+  expectedError
 );

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -1,10 +1,13 @@
 // Flags: --expose-internals
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const fs = require('internal/fs');
 
 assert.doesNotThrow(() => fs.assertEncoding());
 assert.doesNotThrow(() => fs.assertEncoding('utf8'));
-assert.throws(() => fs.assertEncoding('foo'), /^Error: Unknown encoding: foo$/);
+common.expectsError(
+  () => fs.assertEncoding('foo'),
+  {code: 'ERR_INVALID_OPT_VALUE_ENCODING', type: TypeError}
+);


### PR DESCRIPTION
* Assign codes to errors reported by internal/fs.js

Ref: #11273

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Semver-major because this updates specific error messages and converts errors over to use the new internal/errors.js mechanism.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, fs