### PR TITLE
errors, path: migrate to use internal/errors.js

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -21,11 +21,11 @@
 
 'use strict';
 
-const inspect = require('util').inspect;
+const errors = require('internal/errors');
 
 function assertPath(path) {
   if (typeof path !== 'string') {
-    throw new TypeError('Path must be a string. Received ' + inspect(path));
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path', 'string');
   }
 }
 
@@ -816,7 +816,7 @@ const win32 = {
 
   basename: function basename(path, ext) {
     if (ext !== undefined && typeof ext !== 'string')
-      throw new TypeError('"ext" argument must be a string');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
     assertPath(path);
     var start = 0;
     var end = -1;
@@ -959,9 +959,8 @@ const win32 = {
 
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
-      throw new TypeError(
-        `Parameter "pathObject" must be an object, not ${typeof pathObject}`
-      );
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
+                                typeof pathObject);
     }
     return _format('\\', pathObject);
   },
@@ -1372,7 +1371,7 @@ const posix = {
 
   basename: function basename(path, ext) {
     if (ext !== undefined && typeof ext !== 'string')
-      throw new TypeError('"ext" argument must be a string');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ext', 'string');
     assertPath(path);
 
     var start = 0;
@@ -1503,9 +1502,8 @@ const posix = {
 
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
-      throw new TypeError(
-        `Parameter "pathObject" must be an object, not ${typeof pathObject}`
-      );
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
+                                typeof pathObject);
     }
     return _format('/', pathObject);
   },

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -16,7 +16,7 @@ assert.throws(function() {
 
 assert.throws(function() {
   fs.watchFile(new Object(), common.noop);
-}, /Path must be a string/);
+}, common.expectsError({code: 'ERR_INVALID_ARG_TYPE', type: TypeError}));
 
 const enoentFile = path.join(common.tmpDir, 'non-existent-file');
 const expectedStatObject = new fs.Stats(

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 
@@ -88,29 +88,21 @@ const unixSpecialCaseFormatTests = [
   [{}, '']
 ];
 
+const expectedMessage = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError
+});
+
 const errors = [
-  {method: 'parse', input: [null],
-   message: /^TypeError: Path must be a string\. Received null$/},
-  {method: 'parse', input: [{}],
-   message: /^TypeError: Path must be a string\. Received {}$/},
-  {method: 'parse', input: [true],
-   message: /^TypeError: Path must be a string\. Received true$/},
-  {method: 'parse', input: [1],
-   message: /^TypeError: Path must be a string\. Received 1$/},
-  {method: 'parse', input: [],
-   message: /^TypeError: Path must be a string\. Received undefined$/},
-  {method: 'format', input: [null],
-   message:
-      /^TypeError: Parameter "pathObject" must be an object, not object$/},
-  {method: 'format', input: [''],
-   message:
-      /^TypeError: Parameter "pathObject" must be an object, not string$/},
-  {method: 'format', input: [true],
-   message:
-      /^TypeError: Parameter "pathObject" must be an object, not boolean$/},
-  {method: 'format', input: [1],
-   message:
-      /^TypeError: Parameter "pathObject" must be an object, not number$/},
+  {method: 'parse', input: [null], message: expectedMessage},
+  {method: 'parse', input: [{}], message: expectedMessage},
+  {method: 'parse', input: [true], message: expectedMessage},
+  {method: 'parse', input: [1], message: expectedMessage},
+  {method: 'parse', input: [], message: expectedMessage},
+  {method: 'format', input: [null], message: expectedMessage},
+  {method: 'format', input: [''], message: expectedMessage},
+  {method: 'format', input: [true], message: expectedMessage},
+  {method: 'format', input: [1], message: expectedMessage},
 ];
 
 checkParseFormat(path.win32, winPaths);

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -372,7 +372,7 @@ function fail(fn) {
 
   assert.throws(() => {
     fn.apply(null, args);
-  }, TypeError);
+  }, common.expectsError({code: 'ERR_INVALID_ARG_TYPE', type: TypeError}));
 }
 
 typeErrorTests.forEach((test) => {


### PR DESCRIPTION
Migrate [path.js](https://github.com/nodejs/node/blob/master/lib/path.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js).

Refs: https://github.com/nodejs/node/issues/11273

cc @jasnell

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
errors,path