### PR TITLE
src: remove unused typedef

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2400,8 +2400,6 @@ struct node_module* get_linked_module(const char* name) {
   return mp;
 }
 
-typedef void (UV_DYNAMIC* extInit)(Local<Object> exports);
-
 // DLOpen is process.dlopen(module, filename).
 // Used to load 'module.node' dynamically shared objects.
 //


### PR DESCRIPTION
Seems to have been overlooked in commit dd93c53 ("Make node::DLOpen use
uv_dlopen") from 2011.