### PR TITLE
buffer: remove Uint8Array check

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1056,8 +1056,6 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
 
 
 function checkInt(buffer, value, offset, ext, max, min) {
-  if (!isUint8Array(buffer))
-    throw new TypeError('"buffer" argument must be a Buffer or Uint8Array');
   if (value > max || value < min)
     throw new TypeError('"value" argument is out of bounds');
   if (offset + ext > buffer.length)

--- a/test/parallel/test-buffer-write-noassert.js
+++ b/test/parallel/test-buffer-write-noassert.js
@@ -20,14 +20,10 @@ function write(funx, args, result, res) {
     );
   }
 
-  {
-    const error = /Int/.test(funx) ?
-      /^TypeError: "buffer" argument must be a Buffer or Uint8Array$/ :
-      /^TypeError: argument should be a Buffer$/;
-
+  if (!/Int/.test(funx)) {
     assert.throws(
       () => Buffer.alloc(9)[funx].apply(new Uint32Array(1), args),
-      error
+      /^TypeError: argument should be a Buffer$/
     );
   }
 


### PR DESCRIPTION
This makes write[U]Int* operations on Buffer with `noAssert=false` about 3 times faster.

See https://github.com/nodejs/node/issues/11245#issuecomment-279050724 for background and benchmark results.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer