### PR TITLE
test: cases to querystring related to empty string

### DIFF
--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -232,8 +232,20 @@ assert.doesNotThrow(function() {
   assert.strictEqual(f, 'a:b;q:x%3Ay%3By%3Az');
 }
 
+// empty string
+assert.strictEqual(qs.stringify(), '');
+assert.strictEqual(qs.stringify(0), '');
+assert.strictEqual(qs.stringify([]), '');
+assert.strictEqual(qs.stringify(null), '');
+assert.strictEqual(qs.stringify(true), '');
+
 check(qs.parse(), {});
 
+// empty sep
+check(qs.parse('a', []), { a: '' });
+
+// empty eq
+check(qs.parse('a', null, []), { '': 'a' });
 
 // Test limiting
 assert.strictEqual(


### PR DESCRIPTION
Increase coverage of querystring:
+ https://coverage.nodejs.org/coverage-4cafa60c99f0d755/root/querystring.js.html

This test case will cover these lines:
+ https://github.com/nodejs/node/blob/4cafa60c99f0d755b1df3a29357e19a92b97eed8/lib/querystring.js#L250
+ https://github.com/nodejs/node/blob/4cafa60c99f0d755b1df3a29357e19a92b97eed8/lib/querystring.js#L254

Together with https://github.com/nodejs/node/pull/11326, the coverage will be 100%.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
