### PR TITLE
util: use ES2015+ Object.is to check negative zero

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -602,9 +602,8 @@ function formatValue(ctx, value, recurseTimes) {
 
 
 function formatNumber(ctx, value) {
-  // Format -0 as '-0'. Strict equality won't distinguish 0 from -0,
-  // so instead we use the fact that 1 / -0 < 0 whereas 1 / 0 > 0 .
-  if (value === 0 && 1 / value < 0)
+  // Format -0 as '-0'. Strict equality won't distinguish 0 from -0.
+  if (Object.is(value, -0))
     return ctx.stylize('-0', 'number');
   return ctx.stylize('' + value, 'number');
 }


### PR DESCRIPTION
The [original code](https://github.com/nodejs/node/commit/b3e4fc6a48b97b52bd19de43c76b7082dcab4988) is written in 2013. Today we can use more simple way [`Object.is`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/is), which was introduced in ECMAScript 6, to check whether the value is negative zero or not.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util
