### PR TITLE
dns.lookup return a string with no options

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -15,8 +15,8 @@ For example, looking up `iana.org`.
 ```js
 const dns = require('dns');
 
-dns.lookup('iana.org', (err, addresses, family) => {
-  console.log('addresses:', addresses);
+dns.lookup('iana.org', (err, address, family) => {
+  console.log('address:', address);
 });
 ```
 


### PR DESCRIPTION
If all is false (default) the return value is not an array, using a pluralized variable name is confusing
