### PR TITLE
errors: port internal/net errors to internal/errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,3 +86,4 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('ERR_PORT_ARGUMENT', '"port" argument must be >= 0 and < 65536');

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 module.exports = { isLegalPort, assertPort };
 
 // Check that the port number is not NaN when coerced to a number,
@@ -14,5 +16,5 @@ function isLegalPort(port) {
 
 function assertPort(port) {
   if (typeof port !== 'undefined' && !isLegalPort(port))
-    throw new RangeError('"port" argument must be >= 0 and < 65536');
+    throw errors.RangeError('ERR_PORT_ARGUMENT',port);
 }

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -16,5 +16,5 @@ function isLegalPort(port) {
 
 function assertPort(port) {
   if (typeof port !== 'undefined' && !isLegalPort(port))
-    throw errors.RangeError('ERR_PORT_ARGUMENT',port);
+    throw errors.RangeError('ERR_PORT_ARGUMENT');
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
 - Assign codes to errors reported by internal/net.js

Ref: #11273

Semver-major because this updates specific error messages and converts errors over to use the new internal/errors.js mechanism.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

errors, net