### PR TITLE
errors: migrate lib/console

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -570,6 +570,13 @@ The `'ERR_ARG_NOT_ITERABLE'` error code is used generically to identify that an
 iterable argument (i.e. a value that works with `for...of` loops) is required,
 but not provided to a Node.js API.
 
+<a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
+### ERR_CONSOLE_WRITABLE_STREAM
+
+The `ERR_CONSOLE_WRITABLE_STREAM` error code is thrown when `Console` is
+instantiated without `stdout` stream or when `stdout` or `stderr` streams
+are not writable.
+
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -21,6 +21,7 @@
 
 'use strict';
 
+const errors = require('internal/errors');
 const util = require('util');
 
 function Console(stdout, stderr, ignoreErrors = true) {
@@ -28,12 +29,12 @@ function Console(stdout, stderr, ignoreErrors = true) {
     return new Console(stdout, stderr, ignoreErrors);
   }
   if (!stdout || typeof stdout.write !== 'function') {
-    throw new TypeError('Console expects a writable stream instance');
+    throw new errors.TypeError('ERR_CONSOLE_WRITABLE_STREAM', 'stdout');
   }
   if (!stderr) {
     stderr = stdout;
   } else if (typeof stderr.write !== 'function') {
-    throw new TypeError('Console expects writable stream instances');
+    throw new errors.TypeError('ERR_CONSOLE_WRITABLE_STREAM', 'stderr');
   }
 
   var prop = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,6 +112,8 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
+E('ERR_CONSOLE_WRITABLE_STREAM',
+  (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -37,16 +37,28 @@ assert.strictEqual('function', typeof Console);
 
 // make sure that the Console constructor throws
 // when not given a writable stream instance
-assert.throws(() => {
-  new Console();
-}, /^TypeError: Console expects a writable stream instance$/);
+assert.throws(
+  () => { new Console(); },
+  common.expectsError({
+    code: 'ERR_CONSOLE_WRITABLE_STREAM',
+    type: TypeError,
+    message: /stdout/
+  })
+);
 
 // Console constructor should throw if stderr exists but is not writable
-assert.throws(() => {
-  out.write = common.noop;
-  err.write = undefined;
-  new Console(out, err);
-}, /^TypeError: Console expects writable stream instances$/);
+assert.throws(
+  () => {
+    out.write = common.noop;
+    err.write = undefined;
+    new Console(out, err);
+  },
+  common.expectsError({
+    code: 'ERR_CONSOLE_WRITABLE_STREAM',
+    type: TypeError,
+    message: /stderr/
+  })
+);
 
 out.write = err.write = (d) => {};
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Migrate [console.js](https://github.com/nodejs/node/blob/master/lib/console.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js).

Refs: https://github.com/nodejs/node/issues/11273

cc @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
