### PR TITLE
errors: port internal/buffer errors to internal/errors

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -26,7 +26,7 @@ exports.transcode = function transcode(source, fromEncoding, toEncoding) {
     return result;
 
   const code = icu.icuErrName(result);
-  const err = new errors.Error('ERR_UNABlE_TRNSC_BUFF', code);
+  const err = new errors.Error('ERR_UNABlE_TRANSCODE_BUFFER', code);
   err.code = code;
   err.errno = result;
   throw err;

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 if (!process.binding('config').hasIntl) {
   return;
 }
@@ -24,7 +26,7 @@ exports.transcode = function transcode(source, fromEncoding, toEncoding) {
     return result;
 
   const code = icu.icuErrName(result);
-  const err = new Error(`Unable to transcode Buffer [${code}]`);
+  const err = new errors.Error('ERR_UNABlE_TRNSC_BUFF', code);
   err.code = code;
   err.errno = result;
   throw err;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,3 +86,4 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('ERR_UNABlE_TRNSC_BUFF', `Unable to transcode Buffer [%s]`);

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -50,12 +50,12 @@ assert.throws(
 
 assert.throws(
   () => buffer.transcode(Buffer.from('a'), 'b', 'utf8'),
-  /^Error: Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]/
+  common.expectsError('ERR_UNABlE_TRANSCODE_BUFFER', Error)
 );
 
 assert.throws(
   () => buffer.transcode(Buffer.from('a'), 'uf8', 'b'),
-  /^Error: Unable to transcode Buffer \[U_ILLEGAL_ARGUMENT_ERROR\]$/
+  common.expectsError('ERR_UNABlE_TRANSCODE_BUFFER', Error)
 );
 
 assert.deepStrictEqual(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
- Assign codes to errors reported by internal/buffer.js

Ref: #11273

cc @jasnell 

Semver-major because this updates specific error messages and converts errors over to use the new internal/errors.js mechanism.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, buffer