### PR TITLE
errors, repl: migrate to use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -624,6 +624,12 @@ process. See [`child.send()`] and [`process.send()`] for more information.
 The `'ERR_INVALID_OPT_VALUE'` error code is used generically to identify when
 an invalid or unexpected value has been passed in an options object.
 
+<a id="ERR_INVALID_REPL_EVAL_CONFIG"></a>
+### ERR_INVALID_REPL_EVAL_CONFIG
+
+Used when both `breakEvalOnSigint` and `eval` options are set
+in the REPL config, which is not supported.
+
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -129,6 +129,8 @@ E('ERR_INVALID_OPT_VALUE',
   (name, value) => {
     return `The value "${String(value)}" is invalid for option "${name}"`;
   });
+E('ERR_INVALID_REPL_EVAL_CONFIG',
+  'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
 E('ERR_INVALID_SYNC_FORK_INPUT',
   (value) => {
     return 'Asynchronous forks do not support Buffer, Uint8Array or string' +

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -56,6 +56,7 @@ const Console = require('console').Console;
 const Module = require('module');
 const domain = require('domain');
 const debug = util.debuglog('repl');
+const errors = require('internal/errors');
 
 const parentModule = module;
 const replMap = new WeakMap();
@@ -138,7 +139,7 @@ function REPLServer(prompt,
   if (breakEvalOnSigint && eval_) {
     // Allowing this would not reflect user expectations.
     // breakEvalOnSigint affects only the behaviour of the default eval().
-    throw new Error('Cannot specify both breakEvalOnSigint and eval for REPL');
+    throw new errors.Error('ERR_INVALID_REPL_EVAL_CONFIG');
   }
 
   var self = this;
@@ -1021,7 +1022,8 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   if (typeof cmd === 'function') {
     cmd = {action: cmd};
   } else if (typeof cmd.action !== 'function') {
-    throw new Error('Bad argument, "action" command must be a function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+      'action', 'function', cmd.action);
   }
   this.commands[keyword] = cmd;
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Migrated `repl` and `internal/repl` to `internal/errors`. Uses some code from #11294 as recommended in #11273.

@jasnell, pinging you for mentoring as this is my first PR to this project, thank you!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
errors, REPL
