### PR TITLE
build: fix building with ninja on linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -42,12 +42,19 @@
         'os_posix': 1,
         'v8_postmortem_support%': 'true',
       }],
-      ['GENERATOR == "ninja" or OS== "mac"', {
+      ['OS== "mac"', {
         'OBJ_DIR': '<(PRODUCT_DIR)/obj',
         'V8_BASE': '<(PRODUCT_DIR)/libv8_base.a',
       }, {
-        'OBJ_DIR': '<(PRODUCT_DIR)/obj.target',
-        'V8_BASE': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
+        'conditions': [
+          ['GENERATOR=="ninja"', {
+            'OBJ_DIR': '<(PRODUCT_DIR)/obj',
+            'V8_BASE': '<(PRODUCT_DIR)/obj/deps/v8/src/libv8_base.a',
+          }, {
+            'OBJ_DIR': '<(PRODUCT_DIR)/obj.target',
+            'V8_BASE': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
+          }],
+        ],
       }],
       ['openssl_fips != ""', {
         'OPENSSL_PRODUCT': 'libcrypto.a',

--- a/node.gyp
+++ b/node.gyp
@@ -392,7 +392,7 @@
                     ['OS in "linux freebsd" and node_shared=="false"', {
                       'ldflags': [
                         '-Wl,--whole-archive,'
-                            '<(PRODUCT_DIR)/obj.target/deps/openssl/'
+                            '<(OBJ_DIR)/deps/openssl/'
                             '<(OPENSSL_PRODUCT)',
                         '-Wl,--no-whole-archive',
                       ],


### PR DESCRIPTION
On Linux, `ninja` appears to place `libv8_base.a` inside `OBJ_DIR`, as opposed to `ninja` on OS X which places it outside of that directory. Furthermore, the expected `OBJ_DIR` value (`obj.target/`) is actually just `obj/` for `ninja`. This patch solves both of these issues by setting `OBJ_DIR` and `V8_BASE` to the
correct values for `ninja` on Linux specifically.

Fixes: https://github.com/nodejs/node/issues/9861

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem

build
