### PR TITLE
Backport test abort on timeout to v4.x

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -564,11 +564,11 @@ class TestOutput(object):
       return execution_failed
 
 
-def KillProcessWithID(pid):
+def KillProcessWithID(pid, signal_to_send=signal.SIGTERM):
   if utils.IsWindows():
     os.popen('taskkill /T /F /PID %d' % pid)
   else:
-    os.kill(pid, signal.SIGTERM)
+    os.kill(pid, signal_to_send)
 
 
 MAX_SLEEP_TIME = 0.1
@@ -586,6 +586,17 @@ def Win32SetErrorMode(mode):
   except ImportError:
     pass
   return prev_error_mode
+
+
+def KillTimedOutProcess(context, pid):
+  signal_to_send = signal.SIGTERM
+  if context.abort_on_timeout:
+    # Using SIGABRT here allows the OS to generate a core dump that can be
+    # looked at post-mortem, which helps for investigating failures that are
+    # difficult to reproduce.
+    signal_to_send = signal.SIGABRT
+  KillProcessWithID(pid, signal_to_send)
+
 
 def RunProcess(context, timeout, args, **rest):
   if context.verbose: print "#", " ".join(args)
@@ -626,7 +637,7 @@ def RunProcess(context, timeout, args, **rest):
     while True:
       if time.time() >= end_time:
         # Kill the process and wait for it to exit.
-        KillProcessWithID(process.pid)
+        KillTimedOutProcess(context, process.pid)
         exit_code = process.wait()
         timed_out = True
         break
@@ -647,7 +658,7 @@ def RunProcess(context, timeout, args, **rest):
   while exit_code is None:
     if (not end_time is None) and (time.time() >= end_time):
       # Kill the process and wait for it to exit.
-      KillProcessWithID(process.pid)
+      KillTimedOutProcess(context, process.pid)
       exit_code = process.wait()
       timed_out = True
     else:
@@ -855,7 +866,7 @@ class Context(object):
 
   def __init__(self, workspace, buildspace, verbose, vm, expect_fail,
                timeout, processor, suppress_dialogs,
-               store_unexpected_output, repeat):
+               store_unexpected_output, repeat, abort_on_timeout):
     self.workspace = workspace
     self.buildspace = buildspace
     self.verbose = verbose
@@ -866,6 +877,7 @@ class Context(object):
     self.suppress_dialogs = suppress_dialogs
     self.store_unexpected_output = store_unexpected_output
     self.repeat = repeat
+    self.abort_on_timeout = abort_on_timeout
 
   def GetVm(self, arch, mode):
     if arch == 'none':
@@ -1400,6 +1412,9 @@ def BuildOptions():
   result.add_option('--repeat',
       help='Number of times to repeat given tests',
       default=1, type="int")
+  result.add_option('--abort-on-timeout',
+      help='Send SIGABRT instead of SIGTERM to kill processes that time out',
+      default=False, dest="abort_on_timeout")
   return result
 
 
@@ -1579,7 +1594,8 @@ def Main():
                     processor,
                     options.suppress_dialogs,
                     options.store_unexpected_output,
-                    options.repeat)
+                    options.repeat,
+                    options.abort_on_timeout)
   # First build the required targets
   if not options.no_build:
     reqs = [ ]

--- a/tools/test.py
+++ b/tools/test.py
@@ -1414,7 +1414,7 @@ def BuildOptions():
       default=1, type="int")
   result.add_option('--abort-on-timeout',
       help='Send SIGABRT instead of SIGTERM to kill processes that time out',
-      default=False, dest="abort_on_timeout")
+      default=False, action="store_true", dest="abort_on_timeout")
   return result
 
 


### PR DESCRIPTION
Backports https://github.com/nodejs/node/pull/11086 and https://github.com/nodejs/node/pull/11153 to v4.x-staging so that `--abort-on-timeout` can be enabled on the CI platform. See https://github.com/nodejs/build/issues/613 for more context.

Another backport to v6.x-staging will be submitted asap.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
