### PR TITLE
http: deprecate Agent.prototype.addRequest() legacy sig

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -523,6 +523,12 @@ Type: Runtime
 of V8 5.8. It is replaced by Inspector which is activated with `--inspect`
 instead.
 
+### DEP0063: http.Agent.prototype.addRequest() Legacy API
+
+The legacy `http.Agent.prototype.addRequest(req, host, port, localAddress)`
+variation has been deprecated in favor of
+`http.Agent.prototype.addRequest(req, options)`.
+
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -110,13 +110,18 @@ Agent.prototype.getName = function getName(options) {
   return name;
 };
 
-Agent.prototype.addRequest = function addRequest(req, options) {
+Agent.prototype.addRequest = function addRequest(req, options,
+                                                 port, localAddress) {
   // Legacy API: addRequest(req, host, port, localAddress)
   if (typeof options === 'string') {
+    process.emitWarning(
+      'The Agent.prototype.addRequest(req, host, port, localAddress) ' +
+      'API has been deprecated. Please use Agent.prototype.addRequest(' +
+      'req, options) instead.', 'DeprecationWarning', 'DEP0063');
     options = {
       host: options,
-      port: arguments[2],
-      localAddress: arguments[3]
+      port: port,
+      localAddress: localAddress
     };
   }
 


### PR DESCRIPTION
The legacy signature of Agent.prototype.addRequest() was replaced
four years ago. This emits a runtime deprecation if the legacy
signature is used.

A potentially deoptimizing use of arguments is also fixed.

Ref: https://github.com/nodejs/node/commit/12cd13312b1bd1ea1642c0058bbc14be72c347f0

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

http