### PR TITLE
Backport test abort on timeout to v6.x

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1399,7 +1399,7 @@ def BuildOptions():
       default=1, type="int")
   result.add_option('--abort-on-timeout',
       help='Send SIGABRT instead of SIGTERM to kill processes that time out',
-      default=False, dest="abort_on_timeout")
+      default=False, action="store_true", dest="abort_on_timeout")
   return result
 
 


### PR DESCRIPTION
Backports https://github.com/nodejs/node/pull/11086 and https://github.com/nodejs/node/pull/11153 to v6.x-staging so that `--abort-on-timeout` can be enabled on the CI platform. See https://github.com/nodejs/build/issues/613 for more context.

Another backport to v4.x-staging was submitted at https://github.com/nodejs/node/pull/11351.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
