### PR TITLE
http: docs deprecate ServerResponse.prototype.writeHeader()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -523,6 +523,17 @@ Type: Runtime
 of V8 5.8. It is replaced by Inspector which is activated with `--inspect`
 instead.
 
+<a id="DEP0063"></a>
+#### DEP0063: ServerResponse.prototype.writeHeader()
+
+Type: Documentation-only
+
+The `http` module `ServerResponse.prototype.writeHeader()` API has been
+deprecated. Please use `ServerResponse.prototype.writeHead()` instead.
+
+*Note*: The `ServerResponse.prototype.writeHeader()` method was never documented
+as an officially supported API.
+
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -231,9 +231,8 @@ function writeHead(statusCode, reason, obj) {
   this._storeHeader(statusLine, headers);
 }
 
-ServerResponse.prototype.writeHeader = function writeHeader() {
-  this.writeHead.apply(this, arguments);
-};
+// Docs-only deprecated: DEP0063
+ServerResponse.prototype.writeHeader = ServerResponse.prototype.writeHead;
 
 
 function Server(requestListener) {


### PR DESCRIPTION
The ServerResponse class has an undocumented writeHeader()
API that simply forwards on to the documented writeHead()
method. This adds a docs-only deprecation for the undocumented
method.

TODO: This will need to update the static deprecation identifier before landing

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

http