### PR TITLE
errors socket_list : Migrate errors to internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -583,7 +583,7 @@ Used when attempting to perform an operation outside the bounds of a `Buffer`.
 <a id="ERR_CHILD_CLOSED_BEFORE_REPLY"></a>
 ### ERR_CHILD_CLOSED_BEFORE_REPLY
 
-Used when a child process is closed before the parent got a replay.
+Used when a child process is closed before the parent received a reply.
 
 <a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
 ### ERR_CONSOLE_WRITABLE_STREAM

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -580,6 +580,11 @@ by the `assert` module.
 
 Used when attempting to perform an operation outside the bounds of a `Buffer`.
 
+<a id="ERR_CHILD_CLOSED_BEFORE_REPLY"></a>
+### ERR_CHILD_CLOSED_BEFORE_REPLY
+
+Used when a child process is closed before the parent got a replay.
+
 <a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
 ### ERR_CONSOLE_WRITABLE_STREAM
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -102,6 +102,7 @@ module.exports = exports = {
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', '%s');
 E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
+E('ERR_CHILD_CLOSED_BEFORE_REPLY','Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
@@ -176,8 +177,7 @@ E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
-// Add new errors from here...
-E('ERR_SLAVE_CLOSED_BEFORE_REPLY','Slave closed before reply');
+
 
 function invalidArgType(name, expected, actual) {
   assert(name, 'name is required');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -177,6 +177,7 @@ E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 // Add new errors from here...
+E('ERR_SLAVE_CLOSED_BEFORE_REPLY','Slave closed before reply');
 
 function invalidArgType(name, expected, actual) {
   assert(name, 'name is required');

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -20,7 +20,7 @@ class SocketListSend extends EventEmitter {
 
     function onclose() {
       self.child.removeListener('internalMessage', onreply);
-      callback(new errors.Error('ERR_SLAVE_CLOSED_BEFORE_REPLY'));
+      callback(new errors.Error('ERR_CHILD_CLOSED_BEFORE_REPLY'));
     }
 
     function onreply(msg) {

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 const EventEmitter = require('events');
 
 // This object keeps track of the sockets that are sent
@@ -18,7 +20,7 @@ class SocketListSend extends EventEmitter {
 
     function onclose() {
       self.child.removeListener('internalMessage', onreply);
-      callback(new Error('child closed before reply'));
+      callback(new errors.Error('ERR_SLAVE_CLOSED_BEFORE_REPLY'));
     }
 
     function onreply(msg) {

--- a/test/parallel/test-internal-socket-list-send.js
+++ b/test/parallel/test-internal-socket-list-send.js
@@ -17,7 +17,11 @@ const key = 'test-key';
   const list = new SocketListSend(child, 'test');
 
   list._request('msg', 'cmd', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'child closed before reply');
+    common.expectsError({
+      code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
+      type: Error,
+      message: 'Child closed before reply received'
+    })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));
 }
@@ -55,7 +59,11 @@ const key = 'test-key';
   const list = new SocketListSend(child, key);
 
   list._request('msg', 'cmd', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'child closed before reply');
+    common.expectsError({
+      code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
+      type: Error,
+      message: 'Child closed before reply received'
+    })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));
 }
@@ -119,7 +127,7 @@ const key = 'test-key';
   const count = 1;
   const child = Object.assign(new EventEmitter(), {
     connected: true,
-    send: function(msg) {
+    send: function() {
       process.nextTick(() => {
         this.emit('disconnect');
         this.emit('internalMessage', { key, count, cmd: 'NODE_SOCKET_COUNT' });
@@ -129,8 +137,12 @@ const key = 'test-key';
 
   const list = new SocketListSend(child, key);
 
-  list.getConnections(common.mustCall((err, msg) => {
-    assert.strictEqual(err.message, 'child closed before reply');
+  list.getConnections(common.mustCall((err) => {
+    common.expectsError({
+      code: 'ERR_CHILD_CLOSED_BEFORE_REPLY',
+      type: Error,
+      message: 'Child closed before reply received'
+    })(err);
     assert.strictEqual(child.listenerCount('internalMessage'), 0);
   }));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
 - Assign codes to errors reported by internal/socket_list.js

Ref: #11273

Semver-major because this updates specific error messages and converts errors over to use the new internal/errors.js mechanism.

cc @jasnell

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

errors, socket_list
