### PR TITLE
tls: avoid potentially deoptimizing use of arguments

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -298,9 +298,9 @@ var proxiedMethods = [
 
 // Proxy HandleWrap, PipeWrap and TCPWrap methods
 proxiedMethods.forEach(function(name) {
-  tls_wrap.TLSWrap.prototype[name] = function methodProxy() {
+  tls_wrap.TLSWrap.prototype[name] = function methodProxy(...args) {
     if (this._parent[name])
-      return this._parent[name].apply(this._parent, arguments);
+      return this._parent[name].apply(this._parent, args);
   };
 });
 
@@ -990,11 +990,7 @@ function normalizeConnectArgs(listArgs) {
   return (cb) ? [options, cb] : [options];
 }
 
-exports.connect = function(/* [port,] [host,] [options,] [cb] */) {
-  const argsLen = arguments.length;
-  var args = new Array(argsLen);
-  for (var i = 0; i < argsLen; i++)
-    args[i] = arguments[i];
+exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
   args = normalizeConnectArgs(args);
   var options = args[0];
   var cb = args[1];


### PR DESCRIPTION
Replace use of arguments with `...args`

```
 tls/tls-connect.js dur=5 concurrency=1      -9.43 %            0.172136744
 tls/tls-connect.js dur=5 concurrency=10     29.05 %         ** 0.001108115
```

/cc @mscdex 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tls