### PR TITLE
buffer: avoid use of arguments

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -503,12 +503,12 @@ Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
   return binding.copy(this, target, targetStart, sourceStart, sourceEnd);
 };
 
-Buffer.prototype.toString = function() {
+Buffer.prototype.toString = function(encoding, start, end) {
   let result;
   if (arguments.length === 0) {
     result = this.utf8Slice(0, this.length);
   } else {
-    result = slowToString.apply(this, arguments);
+    result = slowToString.call(this, encoding, start, end);
   }
   if (result === undefined)
     throw new Error('"toString()" failed');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -433,10 +433,10 @@ Object.defineProperty(Buffer.prototype, 'offset', {
 });
 
 
-function slowToString(encoding, start, end) {
+function slowToString(buf, encoding, start, end) {
   var loweredCase = false;
 
-  // No need to verify that "this.length <= MAX_UINT32" since it's a read-only
+  // No need to verify that "buf.length <= MAX_UINT32" since it's a read-only
   // property of a typed array.
 
   // This behaves neither like String nor Uint8Array in that we set start/end
@@ -445,13 +445,13 @@ function slowToString(encoding, start, end) {
   // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
   if (start === undefined || start < 0)
     start = 0;
-  // Return early if start > this.length. Done here to prevent potential uint32
+  // Return early if start > buf.length. Done here to prevent potential uint32
   // coercion fail below.
-  if (start > this.length)
+  if (start > buf.length)
     return '';
 
-  if (end === undefined || end > this.length)
-    end = this.length;
+  if (end === undefined || end > buf.length)
+    end = buf.length;
 
   if (end <= 0)
     return '';
@@ -468,27 +468,27 @@ function slowToString(encoding, start, end) {
   while (true) {
     switch (encoding) {
       case 'hex':
-        return this.hexSlice(start, end);
+        return buf.hexSlice(start, end);
 
       case 'utf8':
       case 'utf-8':
-        return this.utf8Slice(start, end);
+        return buf.utf8Slice(start, end);
 
       case 'ascii':
-        return this.asciiSlice(start, end);
+        return buf.asciiSlice(start, end);
 
       case 'latin1':
       case 'binary':
-        return this.latin1Slice(start, end);
+        return buf.latin1Slice(start, end);
 
       case 'base64':
-        return this.base64Slice(start, end);
+        return buf.base64Slice(start, end);
 
       case 'ucs2':
       case 'ucs-2':
       case 'utf16le':
       case 'utf-16le':
-        return this.ucs2Slice(start, end);
+        return buf.ucs2Slice(start, end);
 
       default:
         if (loweredCase)
@@ -508,7 +508,7 @@ Buffer.prototype.toString = function(encoding, start, end) {
   if (arguments.length === 0) {
     result = this.utf8Slice(0, this.length);
   } else {
-    result = slowToString.call(this, encoding, start, end);
+    result = slowToString(this, encoding, start, end);
   }
   if (result === undefined)
     throw new Error('"toString()" failed');


### PR DESCRIPTION
Avoid use of arguments in Buffer.prototype.toString()

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer