### PR TITLE
Update stream.md - fix issue in setEncoding method

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -911,10 +911,11 @@ added: v0.9.4
 * `encoding` {String} The encoding to use.
 * Returns: `this`
 
-The `readable.setEncoding()` method sets the default character encoding for
-data read from the Readable stream.
+The `readable.setEncoding()` method sets the character encoding for
+data read from the Readable stream. 
 
-Setting an encoding causes the stream data
+By default, no encoding is assigned and stream data will be returned as 
+Buffer objects.  Setting an encoding causes the stream data
 to be returned as string of the specified encoding rather than as `Buffer`
 objects. For instance, calling `readable.setEncoding('utf8')` will cause the
 output data will be interpreted as UTF-8 data, and passed as strings. Calling
@@ -924,10 +925,6 @@ string format.
 The Readable stream will properly handle multi-byte characters delivered through
 the stream that would otherwise become improperly decoded if simply pulled from
 the stream as `Buffer` objects.
-
-Encoding can be disabled by calling `readable.setEncoding(null)`. This approach
-is useful when working with binary data or with large multi-byte strings spread
-out over multiple chunks.
 
 ```js
 const readable = getReadableStreamSomehow();


### PR DESCRIPTION
Removed an incorrect reference to the use of setEncoding(null) as the proper way to handling binary streams or to disable encoding, and explained that the default encoding is "no encoding", and that this is the correct approach for dealing with binary data via Buffers.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] documentation is changed or added

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Affects documentation only
