### PR TITLE
lib: remove unnecessary assignments with _extend

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -121,7 +121,7 @@ Agent.prototype.addRequest = function addRequest(req, options) {
   }
 
   options = util._extend({}, options);
-  options = util._extend(options, this.options);
+  util._extend(options, this.options);
 
   if (!options.servername) {
     options.servername = options.host;
@@ -176,7 +176,7 @@ Agent.prototype.addRequest = function addRequest(req, options) {
 Agent.prototype.createSocket = function createSocket(req, options, cb) {
   var self = this;
   options = util._extend({}, options);
-  options = util._extend(options, self.options);
+  util._extend(options, self.options);
 
   if (!options.servername) {
     options.servername = options.host;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -978,9 +978,9 @@ function normalizeConnectArgs(listArgs) {
   // the host/port/path args that it knows about, not the tls options.
   // This means that options.host overrides a host arg.
   if (listArgs[1] !== null && typeof listArgs[1] === 'object') {
-    options = util._extend(options, listArgs[1]);
+    util._extend(options, listArgs[1]);
   } else if (listArgs[2] !== null && typeof listArgs[2] === 'object') {
-    options = util._extend(options, listArgs[2]);
+    util._extend(options, listArgs[2]);
   }
 
   return (cb) ? [options, cb] : [options];

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -146,7 +146,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   }
 
   if (pos < arguments.length && typeof arguments[pos] === 'object') {
-    options = util._extend(options, arguments[pos++]);
+    util._extend(options, arguments[pos++]);
   } else if (pos < arguments.length && arguments[pos] == null) {
     pos++;
   }

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -48,8 +48,8 @@ cluster.setupMaster = function(options) {
     execArgv: process.execArgv,
     silent: false
   };
-  settings = util._extend(settings, cluster.settings);
-  settings = util._extend(settings, options || {});
+  util._extend(settings, cluster.settings);
+  util._extend(settings, options || {});
 
   // Tell V8 to write profile data for each process to a separate file.
   // Without --logfile=v8-%p.log, everything ends up in a single, unusable
@@ -110,7 +110,7 @@ function createWorkerProcess(id, env) {
   var execArgv = cluster.settings.execArgv.slice();
   var debugPort = 0;
 
-  workerEnv = util._extend(workerEnv, env);
+  util._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
   for (var i = 0; i < execArgv.length; i++) {


### PR DESCRIPTION
The first parameter to `util._extend` is the target object. Assigning
the target object to the result of `util._extend` is not necessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

lib
