### PR TITLE
test: refactor test-tls-cert-chains-in-ca

### DIFF
--- a/test/parallel/test-tls-cert-chains-in-ca.js
+++ b/test/parallel/test-tls-cert-chains-in-ca.js
@@ -12,8 +12,7 @@ const {
 
 // agent6-cert.pem includes cert for agent6 and ca3, split it apart and
 // provide ca3 in the .ca property.
-const agent6Chain = keys.agent6.cert.split('-----END CERTIFICATE-----')
-  .map((c) => { return c + '-----END CERTIFICATE-----'; });
+const agent6Chain = keys.agent6.cert.split(/(?=-----BEGIN CERTIFICATE-----)/);
 const agent6End = agent6Chain[0];
 const agent6Middle = agent6Chain[1];
 connect({


### PR DESCRIPTION
When splitting PEM string into separate certs, use non-capturing regexp
to avoid having to put the separator back with .map(). As a bonus,
this splits the PEM into two certs, rather than 2 certs and a third
crufty whitespace-only string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls