### PR TITLE
test, url: turn on WPT tests on empty params pairs

### DIFF
--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -112,8 +112,8 @@ test(function() {
 
 test(function() {
     var params;
-    // params = new URLSearchParams('a=b&c=d&&e&&');
-    // assert_equals(params.toString(), 'a=b&c=d&e=');
+    params = new URLSearchParams('a=b&c=d&&e&&');
+    assert_equals(params.toString(), 'a=b&c=d&e=');
     // params = new URLSearchParams('a = b &a=b&c=d%20');
     // assert_equals(params.toString(), 'a+=+b+&a=b&c=d+');
     // The lone '=' _does_ survive the roundtrip.


### PR DESCRIPTION
This is fixed by https://github.com/nodejs/node/pull/11234. This PR turns on the tests accordingly.

Refs: https://github.com/nodejs/node/pull/11234

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url-whatwg, test