### PR TITLE
tools: add ASCII only lint rule in lib/

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -3,3 +3,4 @@ rules:
   require-buffer: 2
   buffer-constructor: 2
   no-let-in-for-declaration: 2
+  only-ascii-characters: 2

--- a/lib/console.js
+++ b/lib/console.js
@@ -72,7 +72,7 @@ function createWriteErrorHandler(stream) {
       // If there was an error, it will be emitted on `stream` as
       // an `error` event. Adding a `once` listener will keep that error
       // from becoming an uncaught exception, but since the handler is
-      // removed after the event, non-console.* writes won’t be affected.
+      // removed after the event, non-console.* writes won't be affected.
       stream.once('error', noop);
     }
   };
@@ -90,7 +90,7 @@ function write(ignoreErrors, stream, string, errorhandler) {
 
     stream.write(string, errorhandler);
   } catch (e) {
-    // Sorry, there’s no proper way to pass along the error here.
+    // Sorry, there's no proper way to pass along the error here.
   } finally {
     stream.removeListener('error', noop);
   }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -32,6 +32,8 @@ const kOnTimeout = TimerWrap.kOnTimeout | 0;
 const TIMEOUT_MAX = 2147483647; // 2^31-1
 
 
+/* eslint-disable only-ascii-characters */
+
 // HOW and WHY the timers implementation works the way it does.
 //
 // Timers are crucial to Node.js. Internally, any TCP I/O connection creates a
@@ -104,6 +106,8 @@ const TIMEOUT_MAX = 2147483647; // 2^31-1
 // timers within (or creation of a new list).
 // However, these operations combined have shown to be trivial in comparison to
 // other alternative timers architectures.
+
+/* eslint-enable only-ascii-characters */
 
 
 // Object maps containing linked lists of timers, keyed and sorted by their

--- a/tools/eslint-rules/only-ascii-characters.js
+++ b/tools/eslint-rules/only-ascii-characters.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Prohibit the use of non-ascii characters
+ * @author Kalon Hinds
+ */
+
+/* eslint no-control-regex:0 */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const nonAsciiPattern = new RegExp('([^\x00-\x7F])', 'g');
+const suggestions = {
+  '’': '\'',
+  '—': '-'
+};
+const reportError = ({line, column, character}, node, context) => {
+  const suggestion = suggestions[character];
+
+  let message = `Non-ASCII character ${character} detected.`;
+
+  message = suggestion ?
+    `${message} Consider replacing with: ${suggestion}` : message;
+
+  context.report({
+    node,
+    message,
+    loc: {
+      line,
+      column
+    }
+  });
+};
+
+module.exports = {
+  create: (context) => {
+    return {
+      Program: (node) => {
+        const source = context.getSourceCode();
+        const sourceTokens = source.getTokens(node);
+        const commentTokens = source.getAllComments();
+        const tokens = sourceTokens.concat(commentTokens);
+
+        tokens.forEach((token) => {
+          const { value } = token;
+          const matches = value.match(nonAsciiPattern);
+
+          if (!matches) return;
+
+          const { loc } = token;
+          const character = matches[0];
+          const column = loc.start.column + value.indexOf(character);
+
+          reportError({
+            line: loc.start.line,
+            column,
+            character
+          }, node, context);
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
Detects if files in lib/ contain non-ASCII characters and
raises a linting error. Also removes non-ASCII characters from
lib/timers.js

Fixes: https://github.com/nodejs/node/issues/11209

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, lib