### PR TITLE
tools: suggest python2 command in configure

### DIFF
--- a/configure
+++ b/configure
@@ -2,7 +2,16 @@
 
 import sys
 if sys.version_info[0] != 2 or sys.version_info[1] not in (6, 7):
-  sys.stdout.write("Please use either Python 2.6 or 2.7\n")
+  sys.stderr.write('Please use either Python 2.6 or 2.7')
+
+  from distutils.spawn import find_executable as which
+  python2 = which('python2') or which('python2.6') or which('python2.7')
+
+  if python2:
+    sys.stderr.write(':\n\n')
+    sys.stderr.write('  ' + python2 + ' ' + ' '.join(sys.argv))
+
+  sys.stderr.write('\n')
   sys.exit(1)
 
 import errno


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tools

As suggested by @jbergstroem, this text should be helpful to people on systems where `python` is `python3`. Will print:

```
Please use either Python 2.6 or 2.7
You can try using a different interpreter like this:

  PYTHON=/usr/bin/python2 ./configure
```

Ref: https://github.com/nodejs/node/issues/9512#issuecomment-279701847