### PR TITLE
debugger, errors: migrate to use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -575,9 +575,18 @@ found [here][online].
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 [V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [vm]: vm.html
+
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
+
+<a id="ERR_UNK_STATE"></a>
+### ERR_INVALID_CALLBACK
+
+The `'ERR_UNK_STATE'` error code is used to identify that the current state is not known.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -586,7 +586,7 @@ found [here][online].
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
-<a id="ERR_UNK_STATE"></a>
-### ERR_INVALID_CALLBACK
+<a id="ERR_UNKNOWN_DEBUGGER_STATE"></a>
+### ERR_UNKNOWN_DEBUGGER_STATE
 
-The `'ERR_UNK_STATE'` error code is used to identify that the current state is not known.
+The `'ERR_UNKNOWN_DEBUGGER_STATE'` error code is used to identify that the state of the debugger is not known.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -589,4 +589,5 @@ found [here][online].
 <a id="ERR_UNKNOWN_DEBUGGER_STATE"></a>
 ### ERR_UNKNOWN_DEBUGGER_STATE
 
-The `'ERR_UNKNOWN_DEBUGGER_STATE'` error code is used to identify that the state of the debugger is not known.
+The `'ERR_UNKNOWN_DEBUGGER_STATE'` error code is used to identify that the state
+of the debugger is not known, possibly set by code outside the debugger module.

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -11,6 +11,7 @@ const inherits = util.inherits;
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 const Buffer = require('buffer').Buffer;
+const errors = require('internal/errors');
 
 exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
@@ -126,7 +127,7 @@ Protocol.prototype.execute = function(d) {
       break;
 
     default:
-      throw new Error('Unknown state');
+      throw new errors.Error('ERR_UNK_STATE');
   }
 };
 

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -127,7 +127,7 @@ Protocol.prototype.execute = function(d) {
       break;
 
     default:
-      throw new errors.Error('ERR_UNK_STATE');
+      throw new errors.Error('ERR_UNKNOWN_DEBUGGER_STATE');
   }
 };
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,4 +86,4 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
-E('ERR_UNK_STATE', 'Unknown state');
+E('ERR_UNKNOWN_DEBUGGER_STATE', 'Unknown state');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -86,3 +86,4 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('ERR_UNK_STATE', 'Unknown state');

--- a/test/parallel/test-debug-protocol-execute.js
+++ b/test/parallel/test-debug-protocol-execute.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const debug = require('_debugger');
 
@@ -16,5 +16,5 @@ assert.strictEqual(protocol.res.body, undefined);
 protocol.state = 'sterrance';
 assert.throws(
   () => { protocol.execute('grumblecakes'); },
-  /^Error: Unknown state$/
+  common.expectsError('ERR_UNK_STATE', Error)
 );

--- a/test/parallel/test-debug-protocol-execute.js
+++ b/test/parallel/test-debug-protocol-execute.js
@@ -16,5 +16,5 @@ assert.strictEqual(protocol.res.body, undefined);
 protocol.state = 'sterrance';
 assert.throws(
   () => { protocol.execute('grumblecakes'); },
-  common.expectsError('ERR_UNK_STATE', Error)
+  common.expectsError('ERR_UNKNOWN_DEBUGGER_STATE', Error)
 );


### PR DESCRIPTION
Fixes #11273 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
debugger, errors, test
