### PR TITLE
test: refactor common.expectsError()

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -622,11 +622,13 @@ exports.expectsError = function expectsError(code, type, message) {
   return function(error) {
     assert.strictEqual(error.code, code);
     if (type !== undefined)
-      assert(error instanceof type, 'error is not the expected type');
-    if (message !== undefined) {
-      if (!util.isRegExp(message))
-        message = new RegExp(String(message));
-      assert(message.test(error.message), 'error.message does not match');
+      assert(error instanceof type,
+             `${error} is not the expected type ${type}`);
+    if (message instanceof RegExp) {
+      assert(message.test(error.message),
+             `${error.message} does not match ${message}`);
+    } else if (typeof message === 'string') {
+      assert.strictEqual(error.message, message);
     }
     return true;
   };

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -107,10 +107,10 @@ assert.throws(() => {
   assert.throws(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
   }, common.expectsError('TEST_ERROR_1', RangeError));
-}, /^AssertionError: error is not the expected type/);
+}, /^AssertionError: .+ is not the expected type \S/);
 
 assert.throws(() => {
   assert.throws(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
   }, common.expectsError('TEST_ERROR_1', TypeError, /^Error for testing 2/));
-}, /^AssertionError: error.message does not match/);
+}, /AssertionError: .+ does not match \S/);


### PR DESCRIPTION
* Report values in assertions.
* Strict equality match if message is a string.
* instanceof/typeof instead of deprecated util.isRegExp()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test errors