### PR TITLE
doc: add missing function to test common doc

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -180,6 +180,22 @@ Platform normalizes the `dd` command
 
 Check if there is more than 1gb of total memory.
 
+### expectsError(code[, type[, message]])
+* `code` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+  expected error must have this value for its `code` property
+* `type` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+  expected error must be an instance of `type`
+* `message` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+  or [&lt;RegExp>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+  if a string is provided for `message`, expected error must have it for its
+  `message` property; if a regular expression is provided for `message`, the
+  regular expression must match the `message` property of the expected error
+
+* return function suitable for use as a validation function passed as the second
+  argument to `assert.throws()`
+
+The expected error should be [subclassed by the `internal/errors` module](https://github.com/nodejs/node/blob/master/doc/guides/using-internal-errors.md#api).
+
 ### expectWarning(name, expected)
 * `name` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 * `expected` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) | [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)


### PR DESCRIPTION
Add documentation for `common.expectsError()` to `test/README.md`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test doc