### PR TITLE
test: cover dgram socket close during bind case

### DIFF
--- a/test/parallel/test-dgram-close-during-bind.js
+++ b/test/parallel/test-dgram-close-during-bind.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+const socket = dgram.createSocket('udp4');
+const lookup = socket._handle.lookup;
+
+// Test the scenario where the socket is closed during a bind operation.
+socket._handle.bind = common.mustNotCall('bind() should not be called.');
+
+socket._handle.lookup = common.mustCall(function(address, callback) {
+  socket.close(common.mustCall(() => {
+    lookup.call(this, address, callback);
+  }));
+});
+
+socket.bind(common.mustNotCall('Socket should not bind.'));


### PR DESCRIPTION
This commit tests the scenario where a dgram socket closes during a call to `Socket#bind()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test