### PR TITLE
timers, errors: migrate to internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -558,6 +558,9 @@ found [here][online].
   the connected party did not properly respond after a period of time. Usually
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
+  
+<a id="ERROR_CODES"></a>
+### ERROR CODES
 
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
@@ -584,6 +587,9 @@ API when a callbackified `Promise` is rejected with a falsy value (e.g. `null`).
 ### ERR_INDEX_OUT_OF_RANGE
 
 Used when a given index is out of the accepted range.
+
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
 
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
@@ -799,6 +805,7 @@ are most likely an indication of a bug within Node.js itself.
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`child.kill()`]: child_process.html#child_process_child_kill_signal
 [`child.send()`]: child_process.html#child_process_child_send_message_sendhandle_options_callback
+[`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
@@ -817,6 +824,7 @@ are most likely an indication of a bug within Node.js itself.
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -179,6 +179,9 @@ E('ERR_V8BREAKITERATOR', 'full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 // Add new errors from here...
 
+E('ERR_INVALID_ARG_TYPE', invalidArgType);
+E('ERR_INVALID_CALLBACK', 'callback must be a function');
+
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();
   assert(name, 'name is required');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -31,6 +31,7 @@ const assert = require('assert');
 const util = require('util');
 const debug = util.debuglog('timer');
 const kOnTimeout = TimerWrap.kOnTimeout | 0;
+<<<<<<< HEAD
 const initTriggerId = async_hooks.initTriggerId;
 // Two arrays that share state between C++ and JS.
 const { async_hook_fields, async_uid_fields } = async_wrap;
@@ -45,6 +46,9 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
 const async_id_symbol = Symbol('asyncId');
 const trigger_id_symbol = Symbol('triggerAsyncId');
 
+=======
+const errors = require('internal/errors');
+>>>>>>> timers, test: migrate to internal/errors.js
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1
 
@@ -408,11 +412,11 @@ const unenroll = exports.unenroll = function(item) {
 // Using existing objects as timers slightly reduces object overhead.
 exports.enroll = function(item, msecs) {
   if (typeof msecs !== 'number') {
-    throw new TypeError('"msecs" argument must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'msecs', 'number');
   }
 
   if (msecs < 0 || !isFinite(msecs)) {
-    throw new RangeError('"msecs" argument must be ' +
+    throw new errors.RangeError('ERR_INVALID_ARG_TYPE', 'msecs',
                          'a non-negative finite number');
   }
 
@@ -437,7 +441,7 @@ exports.enroll = function(item, msecs) {
 
 function setTimeout(callback, after, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var len = arguments.length;
@@ -534,7 +538,7 @@ const clearTimeout = exports.clearTimeout = function(timer) {
 
 exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var len = arguments.length;
@@ -829,7 +833,7 @@ function Immediate() {
 
 function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var i, args;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -31,7 +31,7 @@ const assert = require('assert');
 const util = require('util');
 const debug = util.debuglog('timer');
 const kOnTimeout = TimerWrap.kOnTimeout | 0;
-<<<<<<< HEAD
+
 const initTriggerId = async_hooks.initTriggerId;
 // Two arrays that share state between C++ and JS.
 const { async_hook_fields, async_uid_fields } = async_wrap;
@@ -46,9 +46,7 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
 const async_id_symbol = Symbol('asyncId');
 const trigger_id_symbol = Symbol('triggerAsyncId');
 
-=======
 const errors = require('internal/errors');
->>>>>>> timers, test: migrate to internal/errors.js
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1
 

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -35,14 +35,24 @@ const validDelays = [0, 0.001, 1, 1e6];
 
 for (let i = 0; i < nonNumericDelays.length; i++) {
   assert.throws(function() {
+<<<<<<< HEAD
     s.setTimeout(nonNumericDelays[i], common.noop);
   }, TypeError);
+=======
+    s.setTimeout(nonNumericDelays[i], noop);
+  }, common.expectsError('ERR_INVALID_ARG_TYPE', TypeError));
+>>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
   assert.throws(function() {
+<<<<<<< HEAD
     s.setTimeout(badRangeDelays[i], common.noop);
   }, RangeError);
+=======
+    s.setTimeout(badRangeDelays[i], noop);
+  }, common.expectsError('ERR_INVALID_ARG_TYPE', RangeError));
+>>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < validDelays.length; i++) {

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -34,37 +34,50 @@ const validDelays = [0, 0.001, 1, 1e6];
 
 
 for (let i = 0; i < nonNumericDelays.length; i++) {
+<<<<<<< HEAD
   assert.throws(function() {
 <<<<<<< HEAD
     s.setTimeout(nonNumericDelays[i], common.noop);
   }, TypeError);
 =======
+=======
+  assert.throws(() => {
+>>>>>>> test: refactor functions to use arrow functions
     s.setTimeout(nonNumericDelays[i], noop);
   }, common.expectsError('ERR_INVALID_ARG_TYPE', TypeError));
 >>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
+<<<<<<< HEAD
   assert.throws(function() {
 <<<<<<< HEAD
     s.setTimeout(badRangeDelays[i], common.noop);
   }, RangeError);
 =======
+=======
+  assert.throws(() => {
+>>>>>>> test: refactor functions to use arrow functions
     s.setTimeout(badRangeDelays[i], noop);
   }, common.expectsError('ERR_INVALID_ARG_TYPE', RangeError));
 >>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < validDelays.length; i++) {
+<<<<<<< HEAD
   assert.doesNotThrow(function() {
     s.setTimeout(validDelays[i], common.noop);
+=======
+  assert.doesNotThrow(() => {
+    s.setTimeout(validDelays[i], noop);
+>>>>>>> test: refactor functions to use arrow functions
   });
 }
 
 const server = net.Server();
-server.listen(0, common.mustCall(function() {
-  const socket = net.createConnection(this.address().port);
-  socket.setTimeout(1, common.mustCall(function() {
+server.listen(0, common.mustCall(() => {
+  const socket = net.createConnection(server.address().port);
+  socket.setTimeout(1, common.mustCall(() => {
     socket.destroy();
     server.close();
   }));

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -34,43 +34,20 @@ const validDelays = [0, 0.001, 1, 1e6];
 
 
 for (let i = 0; i < nonNumericDelays.length; i++) {
-<<<<<<< HEAD
-  assert.throws(function() {
-<<<<<<< HEAD
-    s.setTimeout(nonNumericDelays[i], common.noop);
-  }, TypeError);
-=======
-=======
   assert.throws(() => {
->>>>>>> test: refactor functions to use arrow functions
     s.setTimeout(nonNumericDelays[i], noop);
   }, common.expectsError('ERR_INVALID_ARG_TYPE', TypeError));
->>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
-<<<<<<< HEAD
-  assert.throws(function() {
-<<<<<<< HEAD
-    s.setTimeout(badRangeDelays[i], common.noop);
-  }, RangeError);
-=======
-=======
   assert.throws(() => {
->>>>>>> test: refactor functions to use arrow functions
     s.setTimeout(badRangeDelays[i], noop);
   }, common.expectsError('ERR_INVALID_ARG_TYPE', RangeError));
->>>>>>> timers, test: migrate to internal/errors.js
 }
 
 for (let i = 0; i < validDelays.length; i++) {
-<<<<<<< HEAD
-  assert.doesNotThrow(function() {
-    s.setTimeout(validDelays[i], common.noop);
-=======
   assert.doesNotThrow(() => {
     s.setTimeout(validDelays[i], noop);
->>>>>>> test: refactor functions to use arrow functions
   });
 }
 

--- a/test/parallel/test-timers-throw-when-cb-not-function.js
+++ b/test/parallel/test-timers-throw-when-cb-not-function.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 function doSetTimeout(callback, after) {
@@ -8,18 +8,20 @@ function doSetTimeout(callback, after) {
   };
 }
 
+const expectedError = common.expectsError('ERR_INVALID_CALLBACK', TypeError);
+
 assert.throws(doSetTimeout('foo'),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetTimeout({foo: 'bar'}),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetTimeout(),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetTimeout(undefined, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetTimeout(null, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetTimeout(false, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 
 
 function doSetInterval(callback, after) {
@@ -29,17 +31,17 @@ function doSetInterval(callback, after) {
 }
 
 assert.throws(doSetInterval('foo'),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetInterval({foo: 'bar'}),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetInterval(),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetInterval(undefined, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetInterval(null, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetInterval(false, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 
 
 function doSetImmediate(callback, after) {
@@ -49,14 +51,14 @@ function doSetImmediate(callback, after) {
 }
 
 assert.throws(doSetImmediate('foo'),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetImmediate({foo: 'bar'}),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetImmediate(),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetImmediate(undefined, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetImmediate(null, 0),
-              /"callback" argument must be a function/);
+              expectedError);
 assert.throws(doSetImmediate(false, 0),
-              /"callback" argument must be a function/);
+              expectedError);


### PR DESCRIPTION
Fixes #11273 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers, errors, test