### PR TITLE
errors, string_decoder: migrate to internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -775,13 +775,12 @@ internal bug within the Node.js binary itself.
 
 <a id="ERR_UNK_ENCODING"></a>
 ### ERR_UNK_ENCODING
-=======
+
 <a id="ERR_UNKNOWN_ENCODING"></a>
 ### ERR_UNKNOWN_ENCODING
->>>>>>> doc: fix typos and make the error code more verbose
 
 The `'ERR_UNKNOWN_ENCODING'` error code is used when an invalid or unknown
-file encoding is passed.
+character encoding is passed to a method.
 
 <a id="ERR_UNKNOWN_SIGNAL"></a>
 ### ERR_UNKNOWN_SIGNAL

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -562,6 +562,7 @@ found [here][online].
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
+<<<<<<< HEAD
 <a id="ERR_ARG_NOT_ITERABLE"></a>
 ### ERR_ARG_NOT_ITERABLE
 
@@ -773,6 +774,12 @@ Used to identify a specific kind of internal Node.js error that should not
 typically be triggered by user code. Instances of this error point to an
 internal bug within the Node.js binary itself.
 
+<a id="ERR_UNK_ENCODING"></a>
+### ERR_UNK_ENCODING
+
+The `'ERR_UNK_ENCODING'` error code is used when an invalid or unknown
+file encoding is passed.
+
 <a id="ERR_UNKNOWN_SIGNAL"></a>
 ### ERR_UNKNOWN_SIGNAL
 
@@ -799,6 +806,7 @@ are most likely an indication of a bug within Node.js itself.
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`child.kill()`]: child_process.html#child_process_child_kill_signal
 [`child.send()`]: child_process.html#child_process_child_send_message_sendhandle_options_callback
+[`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
@@ -817,6 +825,7 @@ are most likely an indication of a bug within Node.js itself.
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -562,7 +562,6 @@ found [here][online].
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 
-<<<<<<< HEAD
 <a id="ERR_ARG_NOT_ITERABLE"></a>
 ### ERR_ARG_NOT_ITERABLE
 
@@ -776,8 +775,12 @@ internal bug within the Node.js binary itself.
 
 <a id="ERR_UNK_ENCODING"></a>
 ### ERR_UNK_ENCODING
+=======
+<a id="ERR_UNKNOWN_ENCODING"></a>
+### ERR_UNKNOWN_ENCODING
+>>>>>>> doc: fix typos and make the error code more verbose
 
-The `'ERR_UNK_ENCODING'` error code is used when an invalid or unknown
+The `'ERR_UNKNOWN_ENCODING'` error code is used when an invalid or unknown
 file encoding is passed.
 
 <a id="ERR_UNKNOWN_SIGNAL"></a>

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -166,6 +166,7 @@ E('ERR_TRANSFORM_WITH_LENGTH_0',
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
+E('ERR_UNK_ENCODING', 'Unknown encoding: %s');
 E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,6 +112,7 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
+<<<<<<< HEAD
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);
@@ -166,7 +167,7 @@ E('ERR_TRANSFORM_WITH_LENGTH_0',
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
-E('ERR_UNK_ENCODING', 'Unknown encoding: %s');
+E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s');
 E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,7 +112,6 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
-<<<<<<< HEAD
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -42,7 +42,7 @@ function normalizeEncoding(enc) {
 exports.StringDecoder = StringDecoder;
 function StringDecoder(encoding) {
   this.encoding = normalizeEncoding(encoding);
-  let nb;
+  var nb;
   switch (this.encoding) {
     case 'utf16le':
       this.text = utf16Text;
@@ -71,8 +71,8 @@ function StringDecoder(encoding) {
 StringDecoder.prototype.write = function(buf) {
   if (buf.length === 0)
     return '';
-  let r;
-  let i;
+  var r;
+  var i;
   if (this.lastNeed) {
     r = this.fillLast(buf);
     if (r === undefined)
@@ -120,10 +120,10 @@ function utf8CheckByte(byte) {
 // incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
 // needed to complete the UTF-8 character (if applicable) are returned.
 function utf8CheckIncomplete(self, buf, i) {
-  let j = buf.length - 1;
+  var j = buf.length - 1;
   if (j < i)
     return 0;
-  let nb = utf8CheckByte(buf[j]);
+  var nb = utf8CheckByte(buf[j]);
   if (nb >= 0) {
     if (nb > 0)
       self.lastNeed = nb - 1;
@@ -182,7 +182,7 @@ function utf8CheckExtraBytes(self, buf, p) {
 // Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
 function utf8FillLast(buf) {
   const p = this.lastTotal - this.lastNeed;
-  const r = utf8CheckExtraBytes(this, buf, p);
+  var r = utf8CheckExtraBytes(this, buf, p);
   if (r !== undefined)
     return r;
   if (this.lastNeed <= buf.length) {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -42,7 +42,7 @@ function normalizeEncoding(enc) {
 exports.StringDecoder = StringDecoder;
 function StringDecoder(encoding) {
   this.encoding = normalizeEncoding(encoding);
-  var nb;
+  let nb;
   switch (this.encoding) {
     case 'utf16le':
       this.text = utf16Text;
@@ -71,8 +71,8 @@ function StringDecoder(encoding) {
 StringDecoder.prototype.write = function(buf) {
   if (buf.length === 0)
     return '';
-  var r;
-  var i;
+  let r;
+  let i;
   if (this.lastNeed) {
     r = this.fillLast(buf);
     if (r === undefined)
@@ -120,10 +120,10 @@ function utf8CheckByte(byte) {
 // incomplete multi-byte UTF-8 character. The total number of bytes (2, 3, or 4)
 // needed to complete the UTF-8 character (if applicable) are returned.
 function utf8CheckIncomplete(self, buf, i) {
-  var j = buf.length - 1;
+  let j = buf.length - 1;
   if (j < i)
     return 0;
-  var nb = utf8CheckByte(buf[j]);
+  let nb = utf8CheckByte(buf[j]);
   if (nb >= 0) {
     if (nb > 0)
       self.lastNeed = nb - 1;
@@ -182,7 +182,7 @@ function utf8CheckExtraBytes(self, buf, p) {
 // Attempts to complete a multi-byte UTF-8 character using bytes from a Buffer.
 function utf8FillLast(buf) {
   const p = this.lastTotal - this.lastNeed;
-  var r = utf8CheckExtraBytes(this, buf, p);
+  const r = utf8CheckExtraBytes(this, buf, p);
   if (r !== undefined)
     return r;
   if (this.lastNeed <= buf.length) {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -32,7 +32,7 @@ function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);
   if (typeof nenc !== 'string' &&
       (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc)))
-    throw new errors.Error('ERR_UNK_ENCODING', enc);
+    throw new errors.Error('ERR_UNKNOWN_ENCODING', enc);
   return nenc || enc;
 }
 

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -24,6 +24,7 @@
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
 const isEncoding = Buffer[internalUtil.kIsEncodingSymbol];
+const errors = require('internal/errors');
 
 // Do not cache `Buffer.isEncoding` when checking encoding names as some
 // modules monkey-patch it to support additional encodings
@@ -31,7 +32,7 @@ function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);
   if (typeof nenc !== 'string' &&
       (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc)))
-    throw new Error(`Unknown encoding: ${enc}`);
+    throw new errors.Error('ERR_UNK_ENCODING', enc);
   return nenc || enc;
 }
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const inspect = require('util').inspect;
 const StringDecoder = require('string_decoder').StringDecoder;
@@ -124,13 +124,15 @@ assert.strictEqual(decoder.write(Buffer.from('3DD8', 'hex')), '');
 assert.strictEqual(decoder.write(Buffer.from('4D', 'hex')), '');
 assert.strictEqual(decoder.end(), '\ud83d');
 
+const expectedError = common.expectsError('ERR_UNK_ENCODING', Error);
+
 assert.throws(() => {
   new StringDecoder(1);
-}, /^Error: Unknown encoding: 1$/);
+}, expectedError, 'Unknown encoding: 1');
 
 assert.throws(() => {
   new StringDecoder('test');
-}, /^Error: Unknown encoding: test$/);
+}, expectedError, 'Unknown encoding: test');
 
 // test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -124,7 +124,7 @@ assert.strictEqual(decoder.write(Buffer.from('3DD8', 'hex')), '');
 assert.strictEqual(decoder.write(Buffer.from('4D', 'hex')), '');
 assert.strictEqual(decoder.end(), '\ud83d');
 
-const expectedError = common.expectsError('ERR_UNK_ENCODING', Error);
+const expectedError = common.expectsError('ERR_UNKNOWN_ENCODING', Error);
 
 assert.throws(() => {
   new StringDecoder(1);


### PR DESCRIPTION
Fixes #11273  

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
string_decoder, test, errors
