### PR TITLE
cluster: properly handle --inspect-{brk,port}

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -115,7 +115,7 @@ function createWorkerProcess(id, env) {
 
   for (var i = 0; i < execArgv.length; i++) {
     const match = execArgv[i].match(
-      /^(--inspect|--debug|--debug-(brk|port))(=\d+)?$/
+      /^(--inspect|--inspect-(brk|port)|--debug|--debug-(brk|port))(=\d+)?$/
     );
 
     if (match) {

--- a/test/parallel/test-cluster-inspector-debug-port.js
+++ b/test/parallel/test-cluster-inspector-debug-port.js
@@ -27,6 +27,8 @@ if (cluster.isMaster) {
   fork(4, ['--inspect', '--debug']);
   fork(5, [`--debug=${debuggerPort}`, '--inspect']);
   fork(6, ['--inspect', `--debug-port=${debuggerPort}`]);
+  fork(7, [`--inspect-port=${debuggerPort}`]);
+  fork(8, ['--inspect', `--inspect-port=${debuggerPort}`]);
 } else {
   const hasDebugArg = process.execArgv.some(function(arg) {
     return /inspect/.test(arg);


### PR DESCRIPTION
cluster wasn't properly handling the `--inspect-brk=${port}` and `--inspect-port=${port}` arguments to the children.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

cluster, test