### PR TITLE
errors, readline: migrate to use internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -594,6 +594,12 @@ an argument of the wrong type has been passed to a Node.js API.
 The `'ERR_INVALID_CALLBACK'` error code is used generically to identify that
 a callback function is required and has not been provided to a Node.js API.
 
+<a id="ERR_INVALID_CURSOR_POS"></a>
+### ERR_INVALID_CURSOR_POS
+
+The `'ERR_INVALID_CURSOR_POS'` is thrown specifically when a cursor on a given
+stream is attempted to move to a specified row without a specified column.
+
 <a id="ERR_INVALID_FILE_URL_HOST"></a>
 ### ERR_INVALID_FILE_URL_HOST
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -559,7 +559,6 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
-
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -559,6 +559,7 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
+
 <a id="nodejs-error-codes"></a>
 ## Node.js Error Codes
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -124,6 +124,7 @@ E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FD', (fd) => `"fd" must be a positive integer: ${fd}`);
+E('ERR_INVALID_CURSOR_POS', 'Can\'t set cursor row without setting its column');
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
@@ -150,6 +151,7 @@ E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
 E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
+E('ERR_NON_NEGATIVE_NUMBER', 'number must be non-negative');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -151,7 +151,6 @@ E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
 E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
-E('ERR_NON_NEGATIVE_NUMBER', 'number must be non-negative');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -124,7 +124,8 @@ E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FD', (fd) => `"fd" must be a positive integer: ${fd}`);
-E('ERR_INVALID_CURSOR_POS', 'Can\'t set cursor row without setting its column');
+E('ERR_INVALID_CURSOR_POS',
+   'Cannot set cursor row without setting its column');
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -125,7 +125,7 @@ E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FD', (fd) => `"fd" must be a positive integer: ${fd}`);
 E('ERR_INVALID_CURSOR_POS',
-   'Cannot set cursor row without setting its column');
+  'Cannot set cursor row without setting its column');
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -96,7 +96,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   if (completer && typeof completer !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_CALLBACK');
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'completer', completer);
   }
 
   if (historySize === undefined) {
@@ -106,7 +106,11 @@ function Interface(input, output, completer, terminal) {
   if (typeof historySize !== 'number' ||
       isNaN(historySize) ||
       historySize < 0) {
-    throw new errors.TypeError('ERR_NON_NEGATIVE_NUMBER');
+    throw new errors.RangeError(
+      'ERR_INVALID_OPT_VALUE',
+      'historySize',
+      historySize
+    );
   }
 
   // backwards compat; check the isTTY prop of the output stream

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -27,6 +27,7 @@
 
 'use strict';
 
+const errors = require('internal/errors');
 const { debug, inherits } = require('util');
 const Buffer = require('buffer').Buffer;
 const EventEmitter = require('events');
@@ -57,7 +58,6 @@ const ESCAPE_DECODER = Symbol('escape-decoder');
 
 // GNU readline library - keyseq-timeout is 500ms (default)
 const ESCAPE_CODE_TIMEOUT = 500;
-const errors = require('internal/errors');
 
 
 function createInterface(input, output, completer, terminal) {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -57,6 +57,7 @@ const ESCAPE_DECODER = Symbol('escape-decoder');
 
 // GNU readline library - keyseq-timeout is 500ms (default)
 const ESCAPE_CODE_TIMEOUT = 500;
+const errors = require('internal/errors');
 
 
 function createInterface(input, output, completer, terminal) {
@@ -95,7 +96,7 @@ function Interface(input, output, completer, terminal) {
   }
 
   if (completer && typeof completer !== 'function') {
-    throw new TypeError('Argument "completer" must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   if (historySize === undefined) {
@@ -105,7 +106,7 @@ function Interface(input, output, completer, terminal) {
   if (typeof historySize !== 'number' ||
       isNaN(historySize) ||
       historySize < 0) {
-    throw new TypeError('Argument "historySize" must be a positive number');
+    throw new errors.TypeError('ERR_NON_NEGATIVE_NUMBER');
   }
 
   // backwards compat; check the isTTY prop of the output stream
@@ -281,7 +282,12 @@ Interface.prototype._onLine = function(line) {
 
 Interface.prototype._writeToOutput = function _writeToOutput(stringToWrite) {
   if (typeof stringToWrite !== 'string')
-    throw new TypeError('"stringToWrite" argument must be a string');
+    throw new errors.TypeError(
+      'ERR_INVALID_ARG_TYPE',
+      'stringToWrite',
+      'string',
+      stringToWrite
+    );
 
   if (this.output !== null && this.output !== undefined)
     this.output.write(stringToWrite);
@@ -1056,7 +1062,7 @@ function cursorTo(stream, x, y) {
     return;
 
   if (typeof x !== 'number')
-    throw new Error('Can\'t set cursor row without also setting it\'s column');
+    throw new errors.Error('ERR_INVALID_CURSOR_POS');
 
   if (typeof y !== 'number') {
     stream.write(CSI`${x + 1}G`);

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -78,7 +78,7 @@ assert.throws(
   common.expectsError({
     type: Error,
     code: 'ERR_INVALID_CURSOR_POS',
-    message: 'Can\'t set cursor row without setting its column'
+    message: 'Cannot set cursor row without setting its column'
   }));
 assert.strictEqual(writable.data, '');
 

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -77,7 +77,8 @@ assert.throws(
   () => readline.cursorTo(writable, 'a', 1),
   common.expectsError({
     type: Error,
-    message: /^Can't set cursor row without also setting it's column$/
+    code: 'ERR_INVALID_CURSOR_POS',
+    message: 'Can\'t set cursor row without setting its column'
   }));
 assert.strictEqual(writable.data, '');
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -315,7 +315,11 @@ function isWarned(emitter) {
       input: fi,
       completer: 'string is not valid'
     });
-  }, common.expectsError('ERR_INVALID_CALLBACK', TypeError));
+  }, common.expectsError({
+    type: TypeError,
+    code: 'ERR_INVALID_CALLBACK',
+    message: 'callback must be a function'
+  }));
 
   // duplicate lines are removed from history when
   // `options.removeHistoryDuplicates` is `true`

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -317,8 +317,7 @@ function isWarned(emitter) {
     });
   }, common.expectsError({
     type: TypeError,
-    code: 'ERR_INVALID_CALLBACK',
-    message: 'callback must be a function'
+    code: 'ERR_INVALID_OPT_VALUE'
   }));
 
   // duplicate lines are removed from history when

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -315,14 +315,7 @@ function isWarned(emitter) {
       input: fi,
       completer: 'string is not valid'
     });
-  }, function(err) {
-    if (err instanceof TypeError) {
-      if (/Argument "completer" must be a function/.test(err)) {
-        return true;
-      }
-    }
-    return false;
-  });
+  }, common.expectsError('ERR_INVALID_CALLBACK', TypeError));
 
   // duplicate lines are removed from history when
   // `options.removeHistoryDuplicates` is `true`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Migrate [lib/readline.js](https://github.com/nodejs/node/blob/master/lib/readline.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js).

Refs: #11273

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, readline