### PR TITLE
zlib: refactor zlib module

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -186,3 +186,23 @@ exports.toLength = function toLength(argument) {
   const len = toInteger(argument);
   return len <= 0 ? 0 : Math.min(len, Number.MAX_SAFE_INTEGER);
 };
+
+// Useful for Wrapping an ES6 Class with a constructor Function that
+// does not require the new keyword. For instance:
+//   class A { constructor(x) {this.x = x;}}
+//   const B = createClassWrapper(A);
+//   B() instanceof A // true
+//   B() instanceof B // true
+exports.createClassWrapper = function createClassWrapper(type) {
+  const fn = function(...args) {
+    return Reflect.construct(type, args, new.target || type);
+  };
+  // Mask the wrapper function name and length values
+  Object.defineProperties(fn, {
+    name: {value: type.name},
+    length: {value: type.length}
+  });
+  Object.setPrototypeOf(fn, type);
+  fn.prototype = type.prototype;
+  return fn;
+};

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -1,31 +1,16 @@
 'use strict';
 
 const Buffer = require('buffer').Buffer;
+const internalUtil = require('internal/util');
 const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
-const util = require('util');
 const assert = require('assert').ok;
 const kMaxLength = require('buffer').kMaxLength;
 const kRangeErrorMessage = 'Cannot create final Buffer. It would be larger ' +
-                           'than 0x' + kMaxLength.toString(16) + ' bytes';
+                           `than 0x${kMaxLength.toString(16)} bytes`;
 
 const constants = process.binding('constants').zlib;
-
-// These should be considered deprecated
-// expose all the zlib constants
-const bkeys = Object.keys(constants);
-for (var bk = 0; bk < bkeys.length; bk++) {
-  var bkey = bkeys[bk];
-  Object.defineProperty(exports, bkey, {
-    enumerable: true, value: constants[bkey], writable: false
-  });
-}
-
-Object.defineProperty(exports, 'constants', {
-  configurable: false,
-  enumerable: true,
-  value: constants
-});
+const createClassWrapper = internalUtil.createClassWrapper;
 
 // translation table for return codes.
 const codes = {
@@ -46,132 +31,29 @@ for (var ck = 0; ck < ckeys.length; ck++) {
   codes[codes[ckey]] = ckey;
 }
 
-Object.defineProperty(exports, 'codes', {
-  enumerable: true, value: Object.freeze(codes), writable: false
-});
+function isValidFlushFlag(flag) {
+  return flag >= constants.Z_NO_FLUSH &&
+         flag <= constants.Z_BLOCK;
 
-exports.Deflate = Deflate;
-exports.Inflate = Inflate;
-exports.Gzip = Gzip;
-exports.Gunzip = Gunzip;
-exports.DeflateRaw = DeflateRaw;
-exports.InflateRaw = InflateRaw;
-exports.Unzip = Unzip;
+  // Covers: constants.Z_NO_FLUSH (0),
+  //         constants.Z_PARTIAL_FLUSH (1),
+  //         constants.Z_SYNC_FLUSH (2),
+  //         constants.Z_FULL_FLUSH (3),
+  //         constants.Z_FINISH (4), and
+  //         constants.Z_BLOCK (5)
+}
 
-exports.createDeflate = function(o) {
-  return new Deflate(o);
-};
+function isInvalidStrategy(strategy) {
+  return typeof strategy !== 'number' ||
+         strategy < constants.Z_DEFAULT_STRATEGY ||
+         strategy > constants.Z_FIXED;
 
-exports.createInflate = function(o) {
-  return new Inflate(o);
-};
-
-exports.createDeflateRaw = function(o) {
-  return new DeflateRaw(o);
-};
-
-exports.createInflateRaw = function(o) {
-  return new InflateRaw(o);
-};
-
-exports.createGzip = function(o) {
-  return new Gzip(o);
-};
-
-exports.createGunzip = function(o) {
-  return new Gunzip(o);
-};
-
-exports.createUnzip = function(o) {
-  return new Unzip(o);
-};
-
-
-// Convenience methods.
-// compress/decompress a string or buffer in one step.
-exports.deflate = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new Deflate(opts), buffer, callback);
-};
-
-exports.deflateSync = function(buffer, opts) {
-  return zlibBufferSync(new Deflate(opts), buffer);
-};
-
-exports.gzip = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new Gzip(opts), buffer, callback);
-};
-
-exports.gzipSync = function(buffer, opts) {
-  return zlibBufferSync(new Gzip(opts), buffer);
-};
-
-exports.deflateRaw = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new DeflateRaw(opts), buffer, callback);
-};
-
-exports.deflateRawSync = function(buffer, opts) {
-  return zlibBufferSync(new DeflateRaw(opts), buffer);
-};
-
-exports.unzip = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new Unzip(opts), buffer, callback);
-};
-
-exports.unzipSync = function(buffer, opts) {
-  return zlibBufferSync(new Unzip(opts), buffer);
-};
-
-exports.inflate = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new Inflate(opts), buffer, callback);
-};
-
-exports.inflateSync = function(buffer, opts) {
-  return zlibBufferSync(new Inflate(opts), buffer);
-};
-
-exports.gunzip = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new Gunzip(opts), buffer, callback);
-};
-
-exports.gunzipSync = function(buffer, opts) {
-  return zlibBufferSync(new Gunzip(opts), buffer);
-};
-
-exports.inflateRaw = function(buffer, opts, callback) {
-  if (typeof opts === 'function') {
-    callback = opts;
-    opts = {};
-  }
-  return zlibBuffer(new InflateRaw(opts), buffer, callback);
-};
-
-exports.inflateRawSync = function(buffer, opts) {
-  return zlibBufferSync(new InflateRaw(opts), buffer);
-};
+  // Covers: constants.Z_FILTERED, (1)
+  //         constants.Z_HUFFMAN_ONLY (2),
+  //         constants.Z_RLE (3),
+  //         constants.Z_FIXED (4), and
+  //         constants.Z_DEFAULT_STRATEGY (0)
+}
 
 function zlibBuffer(engine, buffer, callback) {
   var buffers = [];
@@ -225,230 +107,326 @@ function zlibBufferSync(engine, buffer) {
   return engine._processChunk(buffer, flushFlag);
 }
 
-// generic zlib
-// minimal 2-byte header
-function Deflate(opts) {
-  if (!(this instanceof Deflate)) return new Deflate(opts);
-  Zlib.call(this, opts, constants.DEFLATE);
+function zlibOnError(message, errno) {
+  // there is no way to cleanly recover.
+  // continuing only obscures problems.
+  _close(this);
+  this._hadError = true;
+
+  var error = new Error(message);
+  error.errno = errno;
+  error.code = codes[errno];
+  this.emit('error', error);
 }
 
-function Inflate(opts) {
-  if (!(this instanceof Inflate)) return new Inflate(opts);
-  Zlib.call(this, opts, constants.INFLATE);
+function flushCallback(level, strategy, callback) {
+  assert(this._handle, 'zlib binding closed');
+  this._handle.params(level, strategy);
+  if (!this._hadError) {
+    this._level = level;
+    this._strategy = strategy;
+    if (callback) callback();
+  }
 }
-
-
-// gzip - bigger header, same deflate compression
-function Gzip(opts) {
-  if (!(this instanceof Gzip)) return new Gzip(opts);
-  Zlib.call(this, opts, constants.GZIP);
-}
-
-function Gunzip(opts) {
-  if (!(this instanceof Gunzip)) return new Gunzip(opts);
-  Zlib.call(this, opts, constants.GUNZIP);
-}
-
-
-// raw - no header
-function DeflateRaw(opts) {
-  if (!(this instanceof DeflateRaw)) return new DeflateRaw(opts);
-  Zlib.call(this, opts, constants.DEFLATERAW);
-}
-
-function InflateRaw(opts) {
-  if (!(this instanceof InflateRaw)) return new InflateRaw(opts);
-  Zlib.call(this, opts, constants.INFLATERAW);
-}
-
-
-// auto-detect header.
-function Unzip(opts) {
-  if (!(this instanceof Unzip)) return new Unzip(opts);
-  Zlib.call(this, opts, constants.UNZIP);
-}
-
-function isValidFlushFlag(flag) {
-  return flag === constants.Z_NO_FLUSH ||
-         flag === constants.Z_PARTIAL_FLUSH ||
-         flag === constants.Z_SYNC_FLUSH ||
-         flag === constants.Z_FULL_FLUSH ||
-         flag === constants.Z_FINISH ||
-         flag === constants.Z_BLOCK;
-}
-
-const strategies = [constants.Z_FILTERED,
-                    constants.Z_HUFFMAN_ONLY,
-                    constants.Z_RLE,
-                    constants.Z_FIXED,
-                    constants.Z_DEFAULT_STRATEGY];
 
 // the Zlib class they all inherit from
 // This thing manages the queue of requests, and returns
 // true or false if there is anything in the queue when
 // you call the .write() method.
+class Zlib extends Transform {
+  constructor(opts, mode) {
+    opts = opts || {};
+    super(opts);
 
-function Zlib(opts, mode) {
-  this._opts = opts = opts || {};
-  this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
+    this._opts = opts;
+    this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
 
-  Transform.call(this, opts);
-
-  if (opts.flush && !isValidFlushFlag(opts.flush)) {
-    throw new Error('Invalid flush flag: ' + opts.flush);
-  }
-  if (opts.finishFlush && !isValidFlushFlag(opts.finishFlush)) {
-    throw new Error('Invalid flush flag: ' + opts.finishFlush);
-  }
-
-  this._flushFlag = opts.flush || constants.Z_NO_FLUSH;
-  this._finishFlushFlag = typeof opts.finishFlush !== 'undefined' ?
-    opts.finishFlush : constants.Z_FINISH;
-
-  if (opts.chunkSize) {
-    if (opts.chunkSize < constants.Z_MIN_CHUNK) {
-      throw new Error('Invalid chunk size: ' + opts.chunkSize);
+    if (opts.flush && !isValidFlushFlag(opts.flush)) {
+      throw new Error('Invalid flush flag: ' + opts.flush);
     }
-  }
-
-  if (opts.windowBits) {
-    if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
-        opts.windowBits > constants.Z_MAX_WINDOWBITS) {
-      throw new Error('Invalid windowBits: ' + opts.windowBits);
+    if (opts.finishFlush && !isValidFlushFlag(opts.finishFlush)) {
+      throw new Error('Invalid flush flag: ' + opts.finishFlush);
     }
-  }
 
-  if (opts.level) {
-    if (opts.level < constants.Z_MIN_LEVEL ||
-        opts.level > constants.Z_MAX_LEVEL) {
-      throw new Error('Invalid compression level: ' + opts.level);
-    }
-  }
+    this._flushFlag = opts.flush || constants.Z_NO_FLUSH;
+    this._finishFlushFlag = opts.finishFlush !== undefined ?
+      opts.finishFlush : constants.Z_FINISH;
 
-  if (opts.memLevel) {
-    if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
-        opts.memLevel > constants.Z_MAX_MEMLEVEL) {
-      throw new Error('Invalid memLevel: ' + opts.memLevel);
-    }
-  }
-
-  if (opts.strategy && !(strategies.includes(opts.strategy)))
-    throw new Error('Invalid strategy: ' + opts.strategy);
-
-  if (opts.dictionary) {
-    if (!(opts.dictionary instanceof Buffer)) {
-      throw new Error('Invalid dictionary: it should be a Buffer instance');
-    }
-  }
-
-  this._handle = new binding.Zlib(mode);
-
-  var self = this;
-  this._hadError = false;
-  this._handle.onerror = function(message, errno) {
-    // there is no way to cleanly recover.
-    // continuing only obscures problems.
-    _close(self);
-    self._hadError = true;
-
-    var error = new Error(message);
-    error.errno = errno;
-    error.code = exports.codes[errno];
-    self.emit('error', error);
-  };
-
-  var level = constants.Z_DEFAULT_COMPRESSION;
-  if (typeof opts.level === 'number') level = opts.level;
-
-  var strategy = constants.Z_DEFAULT_STRATEGY;
-  if (typeof opts.strategy === 'number') strategy = opts.strategy;
-
-  this._handle.init(opts.windowBits || constants.Z_DEFAULT_WINDOWBITS,
-                    level,
-                    opts.memLevel || constants.Z_DEFAULT_MEMLEVEL,
-                    strategy,
-                    opts.dictionary);
-
-  this._buffer = Buffer.allocUnsafe(this._chunkSize);
-  this._offset = 0;
-  this._level = level;
-  this._strategy = strategy;
-
-  this.once('end', this.close);
-
-  Object.defineProperty(this, '_closed', {
-    get: () => !this._handle,
-    configurable: true,
-    enumerable: true
-  });
-}
-
-util.inherits(Zlib, Transform);
-
-Zlib.prototype.params = function(level, strategy, callback) {
-  if (level < constants.Z_MIN_LEVEL ||
-      level > constants.Z_MAX_LEVEL) {
-    throw new RangeError('Invalid compression level: ' + level);
-  }
-  if (!(strategies.includes(strategy)))
-    throw new TypeError('Invalid strategy: ' + strategy);
-
-  if (this._level !== level || this._strategy !== strategy) {
-    var self = this;
-    this.flush(constants.Z_SYNC_FLUSH, function flushCallback() {
-      assert(self._handle, 'zlib binding closed');
-      self._handle.params(level, strategy);
-      if (!self._hadError) {
-        self._level = level;
-        self._strategy = strategy;
-        if (callback) callback();
+    if (opts.chunkSize) {
+      if (opts.chunkSize < constants.Z_MIN_CHUNK) {
+        throw new Error('Invalid chunk size: ' + opts.chunkSize);
       }
-    });
-  } else {
-    process.nextTick(callback);
-  }
-};
-
-Zlib.prototype.reset = function() {
-  assert(this._handle, 'zlib binding closed');
-  return this._handle.reset();
-};
-
-// This is the _flush function called by the transform class,
-// internally, when the last chunk has been written.
-Zlib.prototype._flush = function(callback) {
-  this._transform(Buffer.alloc(0), '', callback);
-};
-
-Zlib.prototype.flush = function(kind, callback) {
-  var ws = this._writableState;
-
-  if (typeof kind === 'function' || (kind === undefined && !callback)) {
-    callback = kind;
-    kind = constants.Z_FULL_FLUSH;
-  }
-
-  if (ws.ended) {
-    if (callback)
-      process.nextTick(callback);
-  } else if (ws.ending) {
-    if (callback)
-      this.once('end', callback);
-  } else if (ws.needDrain) {
-    if (callback) {
-      const drainHandler = () => this.flush(kind, callback);
-      this.once('drain', drainHandler);
     }
-  } else {
-    this._flushFlag = kind;
-    this.write(Buffer.alloc(0), '', callback);
-  }
-};
 
-Zlib.prototype.close = function(callback) {
-  _close(this, callback);
-  process.nextTick(emitCloseNT, this);
-};
+    if (opts.windowBits) {
+      if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
+          opts.windowBits > constants.Z_MAX_WINDOWBITS) {
+        throw new Error('Invalid windowBits: ' + opts.windowBits);
+      }
+    }
+
+    if (opts.level) {
+      if (opts.level < constants.Z_MIN_LEVEL ||
+          opts.level > constants.Z_MAX_LEVEL) {
+        throw new Error('Invalid compression level: ' + opts.level);
+      }
+    }
+
+    if (opts.memLevel) {
+      if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
+          opts.memLevel > constants.Z_MAX_MEMLEVEL) {
+        throw new Error('Invalid memLevel: ' + opts.memLevel);
+      }
+    }
+
+    if (opts.strategy && isInvalidStrategy(opts.strategy))
+      throw new Error('Invalid strategy: ' + opts.strategy);
+
+    if (opts.dictionary) {
+      if (!(opts.dictionary instanceof Buffer)) {
+        throw new Error('Invalid dictionary: it should be a Buffer instance');
+      }
+    }
+
+    this._handle = new binding.Zlib(mode);
+    this._handle.onerror = zlibOnError.bind(this);
+    this._hadError = false;
+
+    var level = constants.Z_DEFAULT_COMPRESSION;
+    if (typeof opts.level === 'number') level = opts.level;
+
+    var strategy = constants.Z_DEFAULT_STRATEGY;
+    if (typeof opts.strategy === 'number') strategy = opts.strategy;
+
+    this._handle.init(opts.windowBits || constants.Z_DEFAULT_WINDOWBITS,
+                      level,
+                      opts.memLevel || constants.Z_DEFAULT_MEMLEVEL,
+                      strategy,
+                      opts.dictionary);
+
+    this._buffer = Buffer.allocUnsafe(this._chunkSize);
+    this._offset = 0;
+    this._level = level;
+    this._strategy = strategy;
+
+    this.once('end', this.close);
+  }
+
+  get _closed() {
+    return !this._handle;
+  }
+
+  params(level, strategy, callback) {
+    if (level < constants.Z_MIN_LEVEL ||
+        level > constants.Z_MAX_LEVEL) {
+      throw new RangeError('Invalid compression level: ' + level);
+    }
+    if (isInvalidStrategy(strategy))
+      throw new TypeError('Invalid strategy: ' + strategy);
+
+    if (this._level !== level || this._strategy !== strategy) {
+      this.flush(constants.Z_SYNC_FLUSH,
+                 flushCallback.bind(this, level, strategy, callback));
+    } else {
+      process.nextTick(callback);
+    }
+  }
+
+  reset() {
+    assert(this._handle, 'zlib binding closed');
+    return this._handle.reset();
+  }
+
+  // This is the _flush function called by the transform class,
+  // internally, when the last chunk has been written.
+  _flush(callback) {
+    this._transform(Buffer.alloc(0), '', callback);
+  }
+
+  flush(kind, callback) {
+    var ws = this._writableState;
+
+    if (typeof kind === 'function' || (kind === undefined && !callback)) {
+      callback = kind;
+      kind = constants.Z_FULL_FLUSH;
+    }
+
+    if (ws.ended) {
+      if (callback)
+        process.nextTick(callback);
+    } else if (ws.ending) {
+      if (callback)
+        this.once('end', callback);
+    } else if (ws.needDrain) {
+      if (callback) {
+        const drainHandler = () => this.flush(kind, callback);
+        this.once('drain', drainHandler);
+      }
+    } else {
+      this._flushFlag = kind;
+      this.write(Buffer.alloc(0), '', callback);
+    }
+  }
+
+  close(callback) {
+    _close(this, callback);
+    process.nextTick(emitCloseNT, this);
+  }
+
+  _transform(chunk, encoding, cb) {
+    var flushFlag;
+    var ws = this._writableState;
+    var ending = ws.ending || ws.ended;
+    var last = ending && (!chunk || ws.length === chunk.length);
+
+    if (chunk !== null && !(chunk instanceof Buffer))
+      return cb(new Error('invalid input'));
+
+    if (!this._handle)
+      return cb(new Error('zlib binding closed'));
+
+    // If it's the last chunk, or a final flush, we use the Z_FINISH flush flag
+    // (or whatever flag was provided using opts.finishFlush).
+    // If it's explicitly flushing at some other time, then we use
+    // Z_FULL_FLUSH. Otherwise, use Z_NO_FLUSH for maximum compression
+    // goodness.
+    if (last)
+      flushFlag = this._finishFlushFlag;
+    else {
+      flushFlag = this._flushFlag;
+      // once we've flushed the last of the queue, stop flushing and
+      // go back to the normal behavior.
+      if (chunk.length >= ws.length) {
+        this._flushFlag = this._opts.flush || constants.Z_NO_FLUSH;
+      }
+    }
+
+    this._processChunk(chunk, flushFlag, cb);
+  }
+
+  _processChunk(chunk, flushFlag, cb) {
+    var availInBefore = chunk && chunk.length;
+    var availOutBefore = this._chunkSize - this._offset;
+    var inOff = 0;
+
+    var self = this;
+
+    var async = typeof cb === 'function';
+
+    if (!async) {
+      var buffers = [];
+      var nread = 0;
+
+      var error;
+      this.on('error', function(er) {
+        error = er;
+      });
+
+      assert(this._handle, 'zlib binding closed');
+      do {
+        var res = this._handle.writeSync(flushFlag,
+                                         chunk, // in
+                                         inOff, // in_off
+                                         availInBefore, // in_len
+                                         this._buffer, // out
+                                         this._offset, //out_off
+                                         availOutBefore); // out_len
+      } while (!this._hadError && callback(res[0], res[1]));
+
+      if (this._hadError) {
+        throw error;
+      }
+
+      if (nread >= kMaxLength) {
+        _close(this);
+        throw new RangeError(kRangeErrorMessage);
+      }
+
+      var buf = Buffer.concat(buffers, nread);
+      _close(this);
+
+      return buf;
+    }
+
+    assert(this._handle, 'zlib binding closed');
+    var req = this._handle.write(flushFlag,
+                                 chunk, // in
+                                 inOff, // in_off
+                                 availInBefore, // in_len
+                                 this._buffer, // out
+                                 this._offset, //out_off
+                                 availOutBefore); // out_len
+
+    req.buffer = chunk;
+    req.callback = callback;
+
+    function callback(availInAfter, availOutAfter) {
+      // When the callback is used in an async write, the callback's
+      // context is the `req` object that was created. The req object
+      // is === this._handle, and that's why it's important to null
+      // out the values after they are done being used. `this._handle`
+      // can stay in memory longer than the callback and buffer are needed.
+      if (this) {
+        this.buffer = null;
+        this.callback = null;
+      }
+
+      if (self._hadError)
+        return;
+
+      var have = availOutBefore - availOutAfter;
+      assert(have >= 0, 'have should not go down');
+
+      if (have > 0) {
+        var out = self._buffer.slice(self._offset, self._offset + have);
+        self._offset += have;
+        // serve some output to the consumer.
+        if (async) {
+          self.push(out);
+        } else {
+          buffers.push(out);
+          nread += out.length;
+        }
+      }
+
+      // exhausted the output buffer, or used all the input create a new one.
+      if (availOutAfter === 0 || self._offset >= self._chunkSize) {
+        availOutBefore = self._chunkSize;
+        self._offset = 0;
+        self._buffer = Buffer.allocUnsafe(self._chunkSize);
+      }
+
+      if (availOutAfter === 0) {
+        // Not actually done.  Need to reprocess.
+        // Also, update the availInBefore to the availInAfter value,
+        // so that if we have to hit it a third (fourth, etc.) time,
+        // it'll have the correct byte counts.
+        inOff += (availInBefore - availInAfter);
+        availInBefore = availInAfter;
+
+        if (!async)
+          return true;
+
+        var newReq = self._handle.write(flushFlag,
+                                        chunk,
+                                        inOff,
+                                        availInBefore,
+                                        self._buffer,
+                                        self._offset,
+                                        self._chunkSize);
+        newReq.callback = callback; // this same function
+        newReq.buffer = chunk;
+        return;
+      }
+
+      if (!async)
+        return false;
+
+      // finished with the chunk.
+      cb();
+    }
+  }
+}
 
 function _close(engine, callback) {
   if (callback)
@@ -466,164 +444,127 @@ function emitCloseNT(self) {
   self.emit('close');
 }
 
-Zlib.prototype._transform = function(chunk, encoding, cb) {
-  var flushFlag;
-  var ws = this._writableState;
-  var ending = ws.ending || ws.ended;
-  var last = ending && (!chunk || ws.length === chunk.length);
-
-  if (chunk !== null && !(chunk instanceof Buffer))
-    return cb(new Error('invalid input'));
-
-  if (!this._handle)
-    return cb(new Error('zlib binding closed'));
-
-  // If it's the last chunk, or a final flush, we use the Z_FINISH flush flag
-  // (or whatever flag was provided using opts.finishFlush).
-  // If it's explicitly flushing at some other time, then we use
-  // Z_FULL_FLUSH. Otherwise, use Z_NO_FLUSH for maximum compression
-  // goodness.
-  if (last)
-    flushFlag = this._finishFlushFlag;
-  else {
-    flushFlag = this._flushFlag;
-    // once we've flushed the last of the queue, stop flushing and
-    // go back to the normal behavior.
-    if (chunk.length >= ws.length) {
-      this._flushFlag = this._opts.flush || constants.Z_NO_FLUSH;
-    }
+// generic zlib
+// minimal 2-byte header
+class Deflate extends Zlib {
+  constructor(opts) {
+    super(opts, constants.DEFLATE);
   }
+}
 
-  this._processChunk(chunk, flushFlag, cb);
-};
-
-Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
-  var availInBefore = chunk && chunk.length;
-  var availOutBefore = this._chunkSize - this._offset;
-  var inOff = 0;
-
-  var self = this;
-
-  var async = typeof cb === 'function';
-
-  if (!async) {
-    var buffers = [];
-    var nread = 0;
-
-    var error;
-    this.on('error', function(er) {
-      error = er;
-    });
-
-    assert(this._handle, 'zlib binding closed');
-    do {
-      var res = this._handle.writeSync(flushFlag,
-                                       chunk, // in
-                                       inOff, // in_off
-                                       availInBefore, // in_len
-                                       this._buffer, // out
-                                       this._offset, //out_off
-                                       availOutBefore); // out_len
-    } while (!this._hadError && callback(res[0], res[1]));
-
-    if (this._hadError) {
-      throw error;
-    }
-
-    if (nread >= kMaxLength) {
-      _close(this);
-      throw new RangeError(kRangeErrorMessage);
-    }
-
-    var buf = Buffer.concat(buffers, nread);
-    _close(this);
-
-    return buf;
+class Inflate extends Zlib {
+  constructor(opts) {
+    super(opts, constants.INFLATE);
   }
+}
 
-  assert(this._handle, 'zlib binding closed');
-  var req = this._handle.write(flushFlag,
-                               chunk, // in
-                               inOff, // in_off
-                               availInBefore, // in_len
-                               this._buffer, // out
-                               this._offset, //out_off
-                               availOutBefore); // out_len
+class Gzip extends Zlib {
+  constructor(opts) {
+    super(opts, constants.GZIP);
+  }
+}
 
-  req.buffer = chunk;
-  req.callback = callback;
+class Gunzip extends Zlib {
+  constructor(opts) {
+    super(opts, constants.GUNZIP);
+  }
+}
 
-  function callback(availInAfter, availOutAfter) {
-    // When the callback is used in an async write, the callback's
-    // context is the `req` object that was created. The req object
-    // is === this._handle, and that's why it's important to null
-    // out the values after they are done being used. `this._handle`
-    // can stay in memory longer than the callback and buffer are needed.
-    if (this) {
-      this.buffer = null;
-      this.callback = null;
-    }
+class DeflateRaw extends Zlib {
+  constructor(opts) {
+    super(opts, constants.DEFLATERAW);
+  }
+}
 
-    if (self._hadError)
-      return;
+class InflateRaw extends Zlib {
+  constructor(opts) {
+    super(opts, constants.INFLATERAW);
+  }
+}
 
-    var have = availOutBefore - availOutAfter;
-    assert(have >= 0, 'have should not go down');
+class Unzip extends Zlib {
+  constructor(opts) {
+    super(opts, constants.UNZIP);
+  }
+}
 
-    if (have > 0) {
-      var out = self._buffer.slice(self._offset, self._offset + have);
-      self._offset += have;
-      // serve some output to the consumer.
-      if (async) {
-        self.push(out);
-      } else {
-        buffers.push(out);
-        nread += out.length;
+function createConvenienceMethod(type, sync) {
+  if (sync) {
+    return function(buffer, opts) {
+      return zlibBufferSync(new type(opts), buffer);
+    };
+  } else {
+    return function(buffer, opts, callback) {
+      if (typeof opts === 'function') {
+        callback = opts;
+        opts = {};
       }
-    }
-
-    // exhausted the output buffer, or used all the input create a new one.
-    if (availOutAfter === 0 || self._offset >= self._chunkSize) {
-      availOutBefore = self._chunkSize;
-      self._offset = 0;
-      self._buffer = Buffer.allocUnsafe(self._chunkSize);
-    }
-
-    if (availOutAfter === 0) {
-      // Not actually done.  Need to reprocess.
-      // Also, update the availInBefore to the availInAfter value,
-      // so that if we have to hit it a third (fourth, etc.) time,
-      // it'll have the correct byte counts.
-      inOff += (availInBefore - availInAfter);
-      availInBefore = availInAfter;
-
-      if (!async)
-        return true;
-
-      var newReq = self._handle.write(flushFlag,
-                                      chunk,
-                                      inOff,
-                                      availInBefore,
-                                      self._buffer,
-                                      self._offset,
-                                      self._chunkSize);
-      newReq.callback = callback; // this same function
-      newReq.buffer = chunk;
-      return;
-    }
-
-    if (!async)
-      return false;
-
-    // finished with the chunk.
-    cb();
+      return zlibBuffer(new type(opts), buffer, callback);
+    };
   }
+}
+
+function createProperty(type) {
+  return {
+    configurable: true,
+    enumerable: true,
+    value: type
+  };
+}
+
+module.exports = {
+  Deflate: createClassWrapper(Deflate),
+  Inflate: createClassWrapper(Inflate),
+  Gzip: createClassWrapper(Gzip),
+  Gunzip: createClassWrapper(Gunzip),
+  DeflateRaw: createClassWrapper(DeflateRaw),
+  InflateRaw: createClassWrapper(InflateRaw),
+  Unzip: createClassWrapper(Unzip),
+
+  // Convenience methods.
+  // compress/decompress a string or buffer in one step.
+  deflate: createConvenienceMethod(Deflate, false),
+  deflateSync: createConvenienceMethod(Deflate, true),
+  gzip: createConvenienceMethod(Gzip, false),
+  gzipSync: createConvenienceMethod(Gzip, true),
+  deflateRaw: createConvenienceMethod(DeflateRaw, false),
+  deflateRawSync: createConvenienceMethod(DeflateRaw, true),
+  unzip: createConvenienceMethod(Unzip, false),
+  unzipSync: createConvenienceMethod(Unzip, true),
+  inflate: createConvenienceMethod(Inflate, false),
+  inflateSync: createConvenienceMethod(Inflate, true),
+  gunzip: createConvenienceMethod(Gunzip, false),
+  gunzipSync: createConvenienceMethod(Gunzip, true),
+  inflateRaw: createConvenienceMethod(InflateRaw, false),
+  inflateRawSync: createConvenienceMethod(InflateRaw, true)
 };
 
-util.inherits(Deflate, Zlib);
-util.inherits(Inflate, Zlib);
-util.inherits(Gzip, Zlib);
-util.inherits(Gunzip, Zlib);
-util.inherits(DeflateRaw, Zlib);
-util.inherits(InflateRaw, Zlib);
-util.inherits(Unzip, Zlib);
+Object.defineProperties(module.exports, {
+  createDeflate: createProperty(module.exports.Deflate),
+  createInflate: createProperty(module.exports.Inflate),
+  createDeflateRaw: createProperty(module.exports.DeflateRaw),
+  createInflateRaw: createProperty(module.exports.InflateRaw),
+  createGzip: createProperty(module.exports.Gzip),
+  createGunzip: createProperty(module.exports.Gunzip),
+  createUnzip: createProperty(module.exports.Unzip),
+  constants: {
+    configurable: false,
+    enumerable: true,
+    value: constants
+  },
+  codes: {
+    enumerable: true,
+    writable: false,
+    value: Object.freeze(codes)
+  }
+});
+
+// These should be considered deprecated
+// expose all the zlib constants
+const bkeys = Object.keys(constants);
+for (var bk = 0; bk < bkeys.length; bk++) {
+  var bkey = bkeys[bk];
+  Object.defineProperty(module.exports, bkey, {
+    enumerable: true, value: constants[bkey], writable: false
+  });
+}

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -31,9 +31,10 @@ for (var ck = 0; ck < ckeys.length; ck++) {
   codes[codes[ckey]] = ckey;
 }
 
-function isValidFlushFlag(flag) {
-  return flag >= constants.Z_NO_FLUSH &&
-         flag <= constants.Z_BLOCK;
+function isInvalidFlushFlag(flag) {
+  return typeof flag !== 'number' ||
+         flag < constants.Z_NO_FLUSH ||
+         flag > constants.Z_BLOCK;
 
   // Covers: constants.Z_NO_FLUSH (0),
   //         constants.Z_PARTIAL_FLUSH (1),
@@ -141,11 +142,11 @@ class Zlib extends Transform {
     this._opts = opts;
     this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
 
-    if (opts.flush && !isValidFlushFlag(opts.flush)) {
-      throw new Error('Invalid flush flag: ' + opts.flush);
+    if (opts.flush && isInvalidFlushFlag(opts.flush)) {
+      throw new RangeError('Invalid flush flag: ' + opts.flush);
     }
-    if (opts.finishFlush && !isValidFlushFlag(opts.finishFlush)) {
-      throw new Error('Invalid flush flag: ' + opts.finishFlush);
+    if (opts.finishFlush && isInvalidFlushFlag(opts.finishFlush)) {
+      throw new RangeError('Invalid flush flag: ' + opts.finishFlush);
     }
 
     this._flushFlag = opts.flush || constants.Z_NO_FLUSH;
@@ -154,37 +155,38 @@ class Zlib extends Transform {
 
     if (opts.chunkSize) {
       if (opts.chunkSize < constants.Z_MIN_CHUNK) {
-        throw new Error('Invalid chunk size: ' + opts.chunkSize);
+        throw new RangeError('Invalid chunk size: ' + opts.chunkSize);
       }
     }
 
     if (opts.windowBits) {
       if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
           opts.windowBits > constants.Z_MAX_WINDOWBITS) {
-        throw new Error('Invalid windowBits: ' + opts.windowBits);
+        throw new RangeError('Invalid windowBits: ' + opts.windowBits);
       }
     }
 
     if (opts.level) {
       if (opts.level < constants.Z_MIN_LEVEL ||
           opts.level > constants.Z_MAX_LEVEL) {
-        throw new Error('Invalid compression level: ' + opts.level);
+        throw new RangeError('Invalid compression level: ' + opts.level);
       }
     }
 
     if (opts.memLevel) {
       if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
           opts.memLevel > constants.Z_MAX_MEMLEVEL) {
-        throw new Error('Invalid memLevel: ' + opts.memLevel);
+        throw new RangeError('Invalid memLevel: ' + opts.memLevel);
       }
     }
 
     if (opts.strategy && isInvalidStrategy(opts.strategy))
-      throw new Error('Invalid strategy: ' + opts.strategy);
+      throw new TypeError('Invalid strategy: ' + opts.strategy);
 
     if (opts.dictionary) {
       if (!(opts.dictionary instanceof Buffer)) {
-        throw new Error('Invalid dictionary: it should be a Buffer instance');
+        throw new TypeError(
+          'Invalid dictionary: it should be a Buffer instance');
       }
     }
 
@@ -280,7 +282,7 @@ class Zlib extends Transform {
     var last = ending && (!chunk || ws.length === chunk.length);
 
     if (chunk !== null && !(chunk instanceof Buffer))
-      return cb(new Error('invalid input'));
+      return cb(new TypeError('invalid input'));
 
     if (!this._handle)
       return cb(new Error('zlib binding closed'));

--- a/test/parallel/test-internal-util-classwrapper.js
+++ b/test/parallel/test-internal-util-classwrapper.js
@@ -1,0 +1,31 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const util = require('internal/util');
+
+const createClassWrapper = util.createClassWrapper;
+
+class A {
+  constructor(a, b, c) {
+    this.a = a;
+    this.b = b;
+    this.c = c;
+  }
+}
+
+const B = createClassWrapper(A);
+
+assert.strictEqual(typeof B, 'function');
+assert(B(1, 2, 3) instanceof B);
+assert(B(1, 2, 3) instanceof A);
+assert(new B(1, 2, 3) instanceof B);
+assert(new B(1, 2, 3) instanceof A);
+assert.strictEqual(B.name, A.name);
+assert.strictEqual(B.length, A.length);
+
+const b = new B(1, 2, 3);
+assert.strictEqual(b.a, 1);
+assert.strictEqual(b.b, 2);
+assert.strictEqual(b.c, 3);

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -15,7 +15,7 @@ assert.ok(new zlib.DeflateRaw() instanceof zlib.DeflateRaw);
 // Throws if `opts.chunkSize` is invalid
 assert.throws(
   () => { new zlib.Deflate({chunkSize: -Infinity}); },
-  /^Error: Invalid chunk size: -Infinity$/
+  /^RangeError: Invalid chunk size: -Infinity$/
 );
 
 // Confirm that maximum chunk size cannot be exceeded because it is `Infinity`.
@@ -24,23 +24,23 @@ assert.strictEqual(zlib.constants.Z_MAX_CHUNK, Infinity);
 // Throws if `opts.windowBits` is invalid
 assert.throws(
   () => { new zlib.Deflate({windowBits: -Infinity}); },
-  /^Error: Invalid windowBits: -Infinity$/
+  /^RangeError: Invalid windowBits: -Infinity$/
 );
 
 assert.throws(
   () => { new zlib.Deflate({windowBits: Infinity}); },
-  /^Error: Invalid windowBits: Infinity$/
+  /^RangeError: Invalid windowBits: Infinity$/
 );
 
 // Throws if `opts.level` is invalid
 assert.throws(
   () => { new zlib.Deflate({level: -Infinity}); },
-  /^Error: Invalid compression level: -Infinity$/
+  /^RangeError: Invalid compression level: -Infinity$/
 );
 
 assert.throws(
   () => { new zlib.Deflate({level: Infinity}); },
-  /^Error: Invalid compression level: Infinity$/
+  /^RangeError: Invalid compression level: Infinity$/
 );
 
 // Throws a RangeError if `level` invalid in  `Deflate.prototype.params()`
@@ -57,12 +57,12 @@ assert.throws(
 // Throws if `opts.memLevel` is invalid
 assert.throws(
   () => { new zlib.Deflate({memLevel: -Infinity}); },
-  /^Error: Invalid memLevel: -Infinity$/
+  /^RangeError: Invalid memLevel: -Infinity$/
 );
 
 assert.throws(
   () => { new zlib.Deflate({memLevel: Infinity}); },
-  /^Error: Invalid memLevel: Infinity$/
+  /^RangeError: Invalid memLevel: Infinity$/
 );
 
 // Does not throw if opts.strategy is valid
@@ -89,13 +89,13 @@ assert.doesNotThrow(
 // Throws if opt.strategy is the wrong type.
 assert.throws(
   () => { new zlib.Deflate({strategy: '' + zlib.constants.Z_RLE }); },
-  /^Error: Invalid strategy: 3$/
+  /^TypeError: Invalid strategy: 3$/
 );
 
 // Throws if opts.strategy is invalid
 assert.throws(
   () => { new zlib.Deflate({strategy: 'this is a bogus strategy'}); },
-  /^Error: Invalid strategy: this is a bogus strategy$/
+  /^TypeError: Invalid strategy: this is a bogus strategy$/
 );
 
 // Throws TypeError if `strategy` is invalid in `Deflate.prototype.params()`
@@ -107,5 +107,5 @@ assert.throws(
 // Throws if opts.dictionary is not a Buffer
 assert.throws(
   () => { new zlib.Deflate({dictionary: 'not a buffer'}); },
-  /^Error: Invalid dictionary: it should be a Buffer instance$/
+  /^TypeError: Invalid dictionary: it should be a Buffer instance$/
 );

--- a/test/parallel/test-zlib-flush-flags.js
+++ b/test/parallel/test-zlib-flush-flags.js
@@ -9,11 +9,11 @@ assert.doesNotThrow(() => {
 
 assert.throws(() => {
   zlib.createGzip({ flush: 'foobar' });
-}, /Invalid flush flag: foobar/);
+}, /^RangeError: Invalid flush flag: foobar$/);
 
 assert.throws(() => {
   zlib.createGzip({ flush: 10000 });
-}, /Invalid flush flag: 10000/);
+}, /^RangeError: Invalid flush flag: 10000$/);
 
 assert.doesNotThrow(() => {
   zlib.createGzip({ finishFlush: zlib.constants.Z_SYNC_FLUSH });
@@ -21,8 +21,8 @@ assert.doesNotThrow(() => {
 
 assert.throws(() => {
   zlib.createGzip({ finishFlush: 'foobar' });
-}, /Invalid flush flag: foobar/);
+}, /^RangeError: Invalid flush flag: foobar$/);
 
 assert.throws(() => {
   zlib.createGzip({ finishFlush: 10000 });
-}, /Invalid flush flag: 10000/);
+}, /^RangeError: Invalid flush flag: 10000$/);


### PR DESCRIPTION
This does several significant things:

1. Refactors the structure of the zlib module, eliminating duplicated code, moving to ES6 classes for simplify inheritance, eliminating some closures and this->self uses. This was done in a way that should preserve API compat (no test changes were required at all for this piece).
2. Makes errors more consistent and improves testing of errors.

Perf impact should be minimal if any.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
zlib