### PR TITLE
vm: refactor vm module

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -34,17 +34,11 @@ Script.prototype.runInContext = function(contextifiedSandbox, options) {
 };
 
 Script.prototype.runInNewContext = function(sandbox, options) {
-  var context = exports.createContext(sandbox);
+  var context = createContext(sandbox);
   return this.runInContext(context, options);
 };
 
-exports.Script = Script;
-
-exports.createScript = function(code, options) {
-  return new Script(code, options);
-};
-
-exports.createContext = function(sandbox) {
+function createContext(sandbox) {
   if (sandbox === undefined) {
     sandbox = {};
   } else if (binding.isContext(sandbox)) {
@@ -53,28 +47,11 @@ exports.createContext = function(sandbox) {
 
   binding.makeContext(sandbox);
   return sandbox;
-};
+}
 
-exports.runInDebugContext = function(code) {
-  return binding.runInDebugContext(code);
-};
-
-exports.runInContext = function(code, contextifiedSandbox, options) {
-  var script = new Script(code, options);
-  return script.runInContext(contextifiedSandbox, options);
-};
-
-exports.runInNewContext = function(code, sandbox, options) {
-  var script = new Script(code, options);
-  return script.runInNewContext(sandbox, options);
-};
-
-exports.runInThisContext = function(code, options) {
-  var script = new Script(code, options);
-  return script.runInThisContext(options);
-};
-
-exports.isContext = binding.isContext;
+function createScript(code, options) {
+  return new Script(code, options);
+}
 
 // Remove all SIGINT listeners and re-attach them after the wrapped function
 // has executed, so that caught SIGINT are handled by the listeners again.
@@ -100,3 +77,31 @@ function sigintHandlersWrap(fn, thisArg, argsArray) {
     }
   }
 }
+
+function runInDebugContext(code) {
+  return binding.runInDebugContext(code);
+}
+
+function runInContext(code, contextifiedSandbox, options) {
+  return createScript(code, options)
+    .runInContext(contextifiedSandbox, options);
+}
+
+function runInNewContext(code, sandbox, options) {
+  return createScript(code, options).runInNewContext(sandbox, options);
+}
+
+function runInThisContext(code, options) {
+  return createScript(code, options).runInThisContext(options);
+}
+
+module.exports = {
+  Script,
+  createContext,
+  createScript,
+  runInDebugContext,
+  runInContext,
+  runInNewContext,
+  runInThisContext,
+  isContext: binding.isContext
+};

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -3,7 +3,8 @@
 with(this){__filename}
 ^^^^
 SyntaxError: Strict mode code may not include a with statement
-    at Object.exports.runInThisContext (vm.js:*)
+    at createScript (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
@@ -15,10 +16,11 @@ SyntaxError: Strict mode code may not include a with statement
 [eval]:1
 throw new Error("hello")
 ^
+
 Error: hello
     at [eval]:1:7
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
@@ -28,10 +30,11 @@ Error: hello
 [eval]:1
 throw new Error("hello")
 ^
+
 Error: hello
     at [eval]:1:7
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
@@ -42,20 +45,23 @@ Error: hello
 [eval]:1
 var x = 100; y = x;
                ^
+
 ReferenceError: y is not defined
     at [eval]:1:16
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([eval]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
     at runCallback (timers.js:*:*)
     at tryOnImmediate (timers.js:*:*)
     at processImmediate [as _immediateCallback] (timers.js:*:*)
+
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^
 10
+
 [eval]:1
 var ______________________________________________; throw 10
                                                     ^

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -1,10 +1,10 @@
 [stdin]
-
 [stdin]:1
 with(this){__filename}
 ^^^^
 SyntaxError: Strict mode code may not include a with statement
-    at Object.exports.runInThisContext (vm.js:*)
+    at createScript (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
@@ -13,28 +13,28 @@ SyntaxError: Strict mode code may not include a with statement
     at processImmediate [as _immediateCallback] (timers.js:*:*)
 42
 42
-
 [stdin]:1
 throw new Error("hello")
 ^
+
 Error: hello
-    at [stdin]:1:*
+    at [stdin]:1:7
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
     at runCallback (timers.js:*:*)
     at tryOnImmediate (timers.js:*:*)
     at processImmediate [as _immediateCallback] (timers.js:*:*)
-
 [stdin]:1
 throw new Error("hello")
 ^
+
 Error: hello
     at [stdin]:1:*
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)
@@ -42,14 +42,14 @@ Error: hello
     at tryOnImmediate (timers.js:*:*)
     at processImmediate [as _immediateCallback] (timers.js:*:*)
 100
-
 [stdin]:1
 var x = 100; y = x;
                ^
+
 ReferenceError: y is not defined
     at [stdin]:1:16
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> ([stdin]-wrapper:*:*)
     at Module._compile (module.js:*:*)
     at Immediate.<anonymous> (bootstrap_node.js:*:*)

--- a/test/message/undefined_reference_in_new_context.out
+++ b/test/message/undefined_reference_in_new_context.out
@@ -1,13 +1,13 @@
 before
-
 evalmachine.<anonymous>:1
 foo.bar = 5;
 ^
+
 ReferenceError: foo is not defined
     at evalmachine.<anonymous>:1:1
     at ContextifyScript.Script.runInContext (vm.js:*)
     at ContextifyScript.Script.runInNewContext (vm.js:*)
-    at Object.exports.runInNewContext (vm.js:*)
+    at Object.runInNewContext (vm.js:*)
     at Object.<anonymous> (*test*message*undefined_reference_in_new_context.js:*)
     at Module._compile (module.js:*)
     at *..js (module.js:*)

--- a/test/message/vm_display_runtime_error.out
+++ b/test/message/vm_display_runtime_error.out
@@ -1,12 +1,12 @@
 beginning
-
 test.vm:1
 throw new Error("boo!")
 ^
+
 Error: boo!
     at test.vm:1:7
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> (*test*message*vm_display_runtime_error.js:*)
     at Module._compile (module.js:*)
     at Object.Module._extensions..js (module.js:*)

--- a/test/message/vm_display_syntax_error.out
+++ b/test/message/vm_display_syntax_error.out
@@ -1,10 +1,10 @@
 beginning
-
 foo.vm:1
 var 4;
     ^
 SyntaxError: Unexpected number
-    at Object.exports.runInThisContext (vm.js:*)
+    at createScript (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> (*test*message*vm_display_syntax_error.js:*)
     at Module._compile (module.js:*)
     at Object.Module._extensions..js (module.js:*)
@@ -13,12 +13,12 @@ SyntaxError: Unexpected number
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
     at run (bootstrap_node.js:*)
-    at startup (bootstrap_node.js:*)
 test.vm:1
 var 5;
     ^
 SyntaxError: Unexpected number
-    at Object.exports.runInThisContext (vm.js:*)
+    at createScript (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> (*test*message*vm_display_syntax_error.js:*)
     at Module._compile (module.js:*)
     at Object.Module._extensions..js (module.js:*)
@@ -27,4 +27,3 @@ SyntaxError: Unexpected number
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
     at run (bootstrap_node.js:*)
-    at startup (bootstrap_node.js:*)

--- a/test/message/vm_dont_display_runtime_error.out
+++ b/test/message/vm_dont_display_runtime_error.out
@@ -3,10 +3,11 @@ middle
 test.vm:1
 throw new Error("boo!")
 ^
+
 Error: boo!
     at test.vm:1:7
     at ContextifyScript.Script.runInThisContext (vm.js:*)
-    at Object.exports.runInThisContext (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> (*test*message*vm_dont_display_runtime_error.js:*)
     at Module._compile (module.js:*)
     at Object.Module._extensions..js (module.js:*)

--- a/test/message/vm_dont_display_syntax_error.out
+++ b/test/message/vm_dont_display_syntax_error.out
@@ -3,8 +3,10 @@ middle
 test.vm:1
 var 5;
     ^
+
 SyntaxError: Unexpected number
-    at Object.exports.runInThisContext (vm.js:*)
+    at createScript (vm.js:*)
+    at Object.runInThisContext (vm.js:*)
     at Object.<anonymous> (*test*message*vm_dont_display_syntax_error.js:*)
     at Module._compile (module.js:*)
     at Object.Module._extensions..js (module.js:*)
@@ -13,4 +15,3 @@ SyntaxError: Unexpected number
     at Function.Module._load (module.js:*)
     at Module.runMain (module.js:*)
     at run (bootstrap_node.js:*)
-    at startup (bootstrap_node.js:*)


### PR DESCRIPTION
Switch to the more efficient module.exports = {} pattern.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
vm