### PR TITLE
test: improve message in net-connect-local-error

### DIFF
--- a/test/parallel/test-net-connect-local-error.js
+++ b/test/parallel/test-net-connect-local-error.js
@@ -10,6 +10,14 @@ const client = net.connect({
 });
 
 client.on('error', common.mustCall(function onError(err) {
-  assert.strictEqual(err.localPort, common.PORT);
-  assert.strictEqual(err.localAddress, common.localhostIPv4);
+  assert.strictEqual(
+    err.localPort,
+    common.PORT,
+    `${err.localPort} !== ${common.PORT} in ${err}`
+  );
+  assert.strictEqual(
+    err.localAddress,
+    common.localhostIPv4,
+    `${err.localAddress} !== ${common.localhostIPv4} in ${err}`
+  );
 }));


### PR DESCRIPTION
test-net-connect-local-error can fail with messages that report
`AssertionError: undefined === 12346`. Unfortunately, this doesn't
provide sufficient information to identify what went wrong with the
test. Increase information provided.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net