### PR TITLE
benchmarks, util: use various types of values in util.inspect bench

### DIFF
--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -3,14 +3,41 @@ var util = require('util');
 
 var common = require('../common.js');
 
-var bench = common.createBenchmark(main, {n: [5e6]});
+var bench = common.createBenchmark(main, {n: [3e6]});
 
 function main(conf) {
   var n = conf.n | 0;
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    util.inspect({a: 'a', b: 'b', c: 'c', d: 'd'});
+    util.inspect({
+      a: undefined,
+      b: null,
+      c: [, // test for empty array index
+        -0,
+        0,
+        '1',
+        Buffer.from('2'),
+        Symbol('3')
+      ],
+      d: new Set([
+        function() {},
+        function fn() {},
+        () => {}
+      ]),
+      e: new WeakSet([
+        new Promise(() => {}),
+        async () => {}
+      ]),
+      f: new Map([
+        [/regexp/, new Date()],
+      ]),
+      g: new WeakMap([
+        [new Int8Array(), new Uint8Array()],
+        [new Int16Array(), new Uint16Array()],
+        [new Int32Array(), new Uint32Array()]
+      ])
+    });
   }
   bench.end(n);
 }


### PR DESCRIPTION
Because [the current `util.inspect` benchmark only checks the performace for string formatting](https://github.com/nodejs/node/blob/dcfda1007bb74a8354a47852bebe830a23916b6d/benchmark/util/inspect.js#L13), we won't notice the regression for the case when `util.inspect` receives non-string values.

This PR adds various types of values to the test fixture to avoid unnoticed regression in the future.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util
