### PR TITLE
url: make path in resolveObject the same as parse

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -849,7 +849,7 @@ Url.prototype.resolveObject = function(relative) {
     result.pathname = null;
     //to support http.request
     if (result.search) {
-      result.path = '/' + result.search;
+      result.path = result.search;
     } else {
       result.path = null;
     }

--- a/test/parallel/test-url-relative.js
+++ b/test/parallel/test-url-relative.js
@@ -370,7 +370,8 @@ const relativeTests2 = [
    'https://user:password@example.com/foo'],
 
    // No path at all
-   ['#hash1', '#hash2', '#hash1']
+   ['#hash1', '#hash2', '#hash1'],
+   ['#hash', '?query', '?query#hash']
 ];
 relativeTests2.forEach(function(relativeTest) {
   const a = url.resolve(relativeTest[1], relativeTest[0]);


### PR DESCRIPTION
`url.resolveObject` should not add `/` automatically to have a compatibility with `url.parse` if provided value doesn't have any path.

I've also added a test for it. It increases the coverage of url.js,
+ https://coverage.nodejs.org/coverage-e4e7cd5bd202084b/root/url.js.html

and it will cover these lines:
+ https://github.com/nodejs/node/blob/e4e7cd5bd202084b4e6af401a634ca151e82d956/lib/url.js#L830-L842

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
url, test