### PR TITLE
build: depend on python2 specifically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include config.mk
 
 BUILDTYPE ?= Release
-PYTHON ?= python
+PYTHON ?= python2
 DESTDIR ?=
 SIGN ?=
 PREFIX ?= /usr/local

--- a/common.gypi
+++ b/common.gypi
@@ -9,7 +9,7 @@
     'library%': 'static_library',     # allow override to 'shared_library' for DLL/.so builds
     'component%': 'static_library',   # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
-    'python%': 'python',
+    'python%': 'python2',
 
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 if sys.version_info[0] != 2 or sys.version_info[1] not in (6, 7):

--- a/node.gyp
+++ b/node.gyp
@@ -628,7 +628,7 @@
               ],
               'outputs': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
               'action': [
-                'python',
+                'python2',
                 'tools/mkssldef.py',
                 '<@(mkssldef_flags)',
                 '-o',
@@ -702,7 +702,7 @@
                 '<(SHARED_INTERMEDIATE_DIR)/v8_inspector_protocol_json.h',
               ],
               'action': [
-                'python',
+                'python2',
                 'tools/compress_json.py',
                 '<@(_inputs)',
                 '<@(_outputs)',
@@ -739,7 +739,7 @@
             }]
           ],
           'action': [
-            'python',
+            'python2',
             'tools/js2c.py',
             '<@(_outputs)',
             '<@(_inputs)',

--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -5,7 +5,7 @@ const ch = require('child_process');
 
 const SIZE = 100000;
 
-const cp = ch.spawn('python', ['-c', 'print ' + SIZE + ' * "C"'], {
+const cp = ch.spawn('python2', ['-c', 'print ' + SIZE + ' * "C"'], {
   stdio: 'inherit'
 });
 

--- a/test/pummel/test-child-process-spawn-loop.js
+++ b/test/pummel/test-child-process-spawn-loop.js
@@ -9,7 +9,7 @@ const N = 40;
 let finished = false;
 
 function doSpawn(i) {
-  const child = spawn('python', ['-c', 'print ' + SIZE + ' * "C"']);
+  const child = spawn('python2', ['-c', 'print ' + SIZE + ' * "C"']);
   let count = 0;
 
   child.stdout.setEncoding('ascii');

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -96,7 +96,7 @@ function killMeTwiceCallback(err, stdout, stderr) {
 }
 
 
-exec('python -c "print 200000*\'C\'"', {maxBuffer: 1000},
+exec('python2 -c "print 200000*\'C\'"', {maxBuffer: 1000},
      function(err, stdout, stderr) {
        assert.ok(err);
        assert.ok(/maxBuffer/.test(err.message));


### PR DESCRIPTION
This solves the problem of not being able to build node on system
where both python2 and python3 is installed and python3 is the
default.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
build system

...i will send patches for "dep" and "tools" to their respective upstream but this solves the problem for the node part.