### PR TITLE
errors, querystring: migrate to internal/errors.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -255,6 +255,13 @@ will affect any stack trace captured *after* the value has been changed.
 If set to a non-number value, or set to a negative number, stack traces will
 not capture any frames.
 
+#### error.code
+
+* {String}
+
+The `error.code` property is a string label that identifies the kind of error.
+See [Node.js Error Codes][] for details about specific codes.
+
 #### error.message
 
 * {String}
@@ -563,6 +570,14 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
+
+<a id="ERR_MALFORMED_URI"></a>
+### ERR_MALFORMED_URI
+The `'ERR_MALFORMED_URI'` error code is used generically to identify that
+a malformed URI has been provided to a Node.js API.
+
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
 [`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
@@ -575,6 +590,7 @@ found [here][online].
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -68,6 +68,7 @@ module.exports = exports = {
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),
   RangeError: makeNodeError(RangeError),
+  URIError: makeNodeError(URIError),
   E // This is exported only to facilitate testing.
 };
 
@@ -86,3 +87,4 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('ERR_URI_MALFORMED', 'URI malformed');

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -2,6 +2,7 @@
 
 const { Buffer } = require('buffer');
 const { StorageObject, hexTable } = require('internal/querystring');
+const errors = require('internal/errors');
 const QueryString = module.exports = {
   unescapeBuffer,
   // `unescape()` is a JS global, so we need to use a different local name
@@ -175,7 +176,7 @@ function qsEscape(str) {
     if (i < str.length)
       c2 = str.charCodeAt(i) & 0x3FF;
     else
-      throw new URIError('URI malformed');
+      throw new errors.URIError('ERR_URI_MALFORMED');
     lastPos = i + 1;
     c = 0x10000 + (((c & 0x3FF) << 10) | c2);
     out += hexTable[0xF0 | (c >> 18)] +

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const inspect = require('util').inspect;
 
@@ -219,7 +219,7 @@ qsWeirdObjects.forEach(function(testCase) {
 // invalid surrogate pair throws URIError
 assert.throws(function() {
   qs.stringify({ foo: '\udc00' });
-}, URIError);
+}, common.expectsError('ERR_URI_MALFORMED', URIError, 'URI malformed'));
 
 // coerce numbers to string
 assert.strictEqual('foo=0', qs.stringify({ foo: 0 }));

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -138,7 +138,7 @@ function check(actual, expected, input) {
           `Expected keys: ${inspect(expectedKeys)}`;
   }
   assert.deepStrictEqual(actualKeys, expectedKeys, msg);
-  expectedKeys.forEach(function(key) {
+  expectedKeys.forEach((key) => {
     if (typeof input === 'string') {
       msg = `Input: ${inspect(input)}\n` +
             `Key: ${inspect(key)}\n` +
@@ -152,23 +152,22 @@ function check(actual, expected, input) {
 }
 
 // test that the canonical qs is parsed properly.
-qsTestCases.forEach(function(testCase) {
-  check(qs.parse(testCase[0]), testCase[2], testCase[0]);
-});
+qsTestCases.forEach((testCase) =>
+  check(qs.parse(testCase[0]), testCase[2], testCase[0]));
 
 // test that the colon test cases can do the same
-qsColonTestCases.forEach(function(testCase) {
-  check(qs.parse(testCase[0], ';', ':'), testCase[2], testCase[0]);
-});
+qsColonTestCases.forEach((testCase) =>
+  check(qs.parse(testCase[0], ';', ':'), testCase[2], testCase[0])
+);
 
 // test the weird objects, that they get parsed properly
-qsWeirdObjects.forEach(function(testCase) {
-  check(qs.parse(testCase[1]), testCase[2], testCase[1]);
-});
+qsWeirdObjects.forEach((testCase) =>
+  check(qs.parse(testCase[1]), testCase[2], testCase[1])
+);
 
-qsNoMungeTestCases.forEach(function(testCase) {
-  assert.deepStrictEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
-});
+qsNoMungeTestCases.forEach((testCase) =>
+  assert.deepStrictEqual(testCase[0], qs.stringify(testCase[1], '&', '='))
+);
 
 // test the nested qs-in-qs case
 {
@@ -204,20 +203,20 @@ qsNoMungeTestCases.forEach(function(testCase) {
 // now test stringifying
 
 // basic
-qsTestCases.forEach(function(testCase) {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[2]));
-});
+qsTestCases.forEach((testCase) =>
+  assert.strictEqual(testCase[1], qs.stringify(testCase[2]))
+);
 
-qsColonTestCases.forEach(function(testCase) {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[2], ';', ':'));
-});
+qsColonTestCases.forEach((testCase) =>
+  assert.strictEqual(testCase[1], qs.stringify(testCase[2], ';', ':'))
+);
 
-qsWeirdObjects.forEach(function(testCase) {
-  assert.strictEqual(testCase[1], qs.stringify(testCase[0]));
-});
+qsWeirdObjects.forEach((testCase) =>
+  assert.strictEqual(testCase[1], qs.stringify(testCase[0]))
+);
 
 // invalid surrogate pair throws URIError
-assert.throws(function() {
+assert.throws(() => {
   qs.stringify({ foo: '\udc00' });
 }, common.expectsError('ERR_URI_MALFORMED', URIError, 'URI malformed'));
 
@@ -241,9 +240,7 @@ assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
   assert.strictEqual(f, 'a=b&q=x%3Dy%26y%3Dz');
 }
 
-assert.doesNotThrow(function() {
-  qs.parse(undefined);
-});
+assert.doesNotThrow(() => qs.parse(undefined));
 
 // nested in colon
 {


### PR DESCRIPTION
<!--
Fixes #11273 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, querystring, test
