### PR TITLE
test: test bottom-up merge sort in URLSearchParams

### DIFF
--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -55,12 +55,25 @@ const { test, assert_array_equals } = common.WPT;
 /* eslint-enable */
 
 // Tests below are not from WPT.
-;[
+
+// Test bottom-up iterative stable merge sort
+const tests = [{input: '', output: []}];
+const pairs = [];
+for (let i = 10; i < 100; i++) {
+  pairs.push([`a${i}`, 'b']);
+  tests[0].output.push([`a${i}`, 'b']);
+}
+tests[0].input = pairs.sort(() => Math.random() > 0.5)
+  .map((pair) => pair.join('=')).join('&');
+
+tests.push(
   {
     'input': 'z=a&=b&c=d',
     'output': [['', 'b'], ['c', 'd'], ['z', 'a']]
   }
-].forEach((val) => {
+);
+
+tests.forEach((val) => {
   test(() => {
     const params = new URLSearchParams(val.input);
     let i = 0;


### PR DESCRIPTION
Following up for this commit: https://github.com/nodejs/node/commit/02d1e32fe351078ae7d7e2e0dfb7fe3fa5f75986 to increase the reduced coverage. The bottom-up iterative stable merge sort is called only when the length of provided value is larger than 100. Added a test for it.

This increases the coverage of `internal/url.js`,
+ https://coverage.nodejs.org/coverage-e4e7cd5bd202084b/root/internal/url.js.html

and the following lines will be covered.
+ https://github.com/nodejs/node/blob/e4e7cd5bd202084b4e6af401a634ca151e82d956/lib/internal/url.js#L701-L727
+ https://github.com/nodejs/node/blob/e4e7cd5bd202084b4e6af401a634ca151e82d956/lib/internal/url.js#L886-L900

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test