### PR TITLE
path: rename sep to SEPARATOR and delimiter to DELIMITER

### DIFF
--- a/deps/npm/lib/utils/lifecycle.js
+++ b/deps/npm/lib/utils/lifecycle.js
@@ -291,7 +291,7 @@ function runCmd_ (cmd, pkg, env, wd, stage, unsafe, uid, gid, cb_) {
         er.code = 'ELIFECYCLE'
       }
       fs.stat(npm.dir, function (statError, d) {
-        if (statError && statError.code === 'ENOENT' && npm.dir.split(path.sep).slice(-1)[0] === 'node_modules') {
+        if (statError && statError.code === 'ENOENT' && npm.dir.split(path.SEPARATOR).slice(-1)[0] === 'node_modules') {
           log.warn('', 'Local package.json exists, but node_modules missing, did you mean to install?')
         }
       })

--- a/deps/npm/test/tap/outdated-json.js
+++ b/deps/npm/test/tap/outdated-json.js
@@ -31,13 +31,13 @@ var expected = {
     current: '1.3.3',
     wanted: '1.3.3',
     latest: '1.5.1',
-    location: 'node_modules' + path.sep + 'underscore'
+    location: 'node_modules' + path.SEPARATOR + 'underscore'
   },
   request: {
     current: '0.9.5',
     wanted: '0.9.5',
     latest: '2.27.0',
-    location: 'node_modules' + path.sep + 'request'
+    location: 'node_modules' + path.SEPARATOR + 'request'
   }
 }
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -79,7 +79,7 @@ path.basename('/foo/bar/baz/asdf/quux.html', '.html')
 A [`TypeError`][] is thrown if `path` is not a string or if `ext` is given
 and is not a string.
 
-## path.delimiter
+## path.DELIMITER
 <!-- YAML
 added: v0.9.3
 -->
@@ -97,7 +97,7 @@ For example, on POSIX:
 console.log(process.env.PATH)
 // Prints: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
 
-process.env.PATH.split(path.delimiter)
+process.env.PATH.split(path.DELIMITER)
 // Returns: ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
 ```
 
@@ -107,7 +107,7 @@ On Windows:
 console.log(process.env.PATH)
 // Prints: 'C:\Windows\system32;C:\Windows;C:\Program Files\node\'
 
-process.env.PATH.split(path.delimiter)
+process.env.PATH.split(path.DELIMITER)
 // Returns: ['C:\\Windows\\system32', 'C:\\Windows', 'C:\\Program Files\\node\\']
 ```
 
@@ -192,7 +192,7 @@ For example, on POSIX:
 
 ```js
 // If `dir`, `root` and `base` are provided,
-// `${dir}${path.sep}${base}`
+// `${dir}${path.SEPARATOR}${base}`
 // will be returned. `root` is ignored.
 path.format({
   root: '/ignored',
@@ -480,7 +480,7 @@ path.resolve('wwwroot', 'static_files/png/', '../gif/image.gif')
 
 A [`TypeError`][] is thrown if any of the arguments is not a string.
 
-## path.sep
+## path.SEPARATOR
 <!-- YAML
 added: v0.7.9
 -->
@@ -495,14 +495,14 @@ Provides the platform-specific path segment separator:
 For example on POSIX:
 
 ```js
-'foo/bar/baz'.split(path.sep)
+'foo/bar/baz'.split(path.SEPARATOR)
 // Returns: ['foo', 'bar', 'baz']
 ```
 
 On Windows:
 
 ```js
-'foo\\bar\\baz'.split(path.sep)
+'foo\\bar\\baz'.split(path.SEPARATOR)
 // Returns: ['foo', 'bar', 'baz']
 ```
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -626,7 +626,7 @@ Module._initPaths = function() {
 
   var nodePath = process.env['NODE_PATH'];
   if (nodePath) {
-    paths = nodePath.split(path.delimiter).filter(function(path) {
+    paths = nodePath.split(path.DELIMITER).filter(function(path) {
       return !!path;
     }).concat(paths);
   }

--- a/lib/path.js
+++ b/lib/path.js
@@ -1119,8 +1119,8 @@ const win32 = {
   },
 
 
-  sep: '\\',
-  delimiter: ';',
+  SEPARATOR: '\\',
+  DELIMITER: ';',
   win32: null,
   posix: null
 };
@@ -1580,8 +1580,8 @@ const posix = {
   },
 
 
-  sep: '/',
-  delimiter: ':',
+  SEPARATOR: '/',
+  DELIMITER: ':',
   win32: null,
   posix: null
 };

--- a/test/common.js
+++ b/test/common.js
@@ -76,7 +76,8 @@ function rmdirSync(p, originalEr) {
       const enc = exports.isLinux ? 'buffer' : 'utf8';
       fs.readdirSync(p, enc).forEach((f) => {
         if (f instanceof Buffer) {
-          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
+          const buf = Buffer.concat([Buffer.from(p),
+                                     Buffer.from(path.SEPARATOR), f]);
           rimrafSync(buf);
         } else {
           rimrafSync(path.join(p, f));

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -12,7 +12,7 @@ if (!common.isLinux) {
 
 common.refreshTmpDir();
 const filename = '\uD83D\uDC04';
-const root = Buffer.from(`${common.tmpDir}${path.sep}`);
+const root = Buffer.from(`${common.tmpDir}${path.SEPARATOR}`);
 const filebuff = Buffer.from(filename, 'ucs2');
 const fullpath = Buffer.concat([root, filebuff]);
 

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -16,7 +16,7 @@ const filenameOne = 'watch.txt';
 
 common.refreshTmpDir();
 
-const testsubdir = fs.mkdtempSync(testDir + path.sep);
+const testsubdir = fs.mkdtempSync(testDir + path.SEPARATOR);
 const relativePathOne = path.join(path.basename(testsubdir), filenameOne);
 const filepathOne = path.join(testsubdir, filenameOne);
 

--- a/test/parallel/test-os-homedir-no-envvar.js
+++ b/test/parallel/test-os-homedir-no-envvar.js
@@ -15,7 +15,7 @@ if (process.argv[2] === 'child') {
   const home = os.homedir();
 
   assert.strictEqual(typeof home, 'string');
-  assert(home.includes(path.sep));
+  assert(home.includes(path.SEPARATOR));
 } else {
   if (common.isWindows)
     delete process.env.USERPROFILE;

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -132,17 +132,17 @@ const home = os.homedir();
 
 console.log('homedir = ' + home);
 is.string(home);
-assert.ok(home.includes(path.sep));
+assert.ok(home.includes(path.SEPARATOR));
 
 if (common.isWindows && process.env.USERPROFILE) {
   assert.strictEqual(home, process.env.USERPROFILE);
   delete process.env.USERPROFILE;
-  assert.ok(os.homedir().includes(path.sep));
+  assert.ok(os.homedir().includes(path.SEPARATOR));
   process.env.USERPROFILE = home;
 } else if (!common.isWindows && process.env.HOME) {
   assert.strictEqual(home, process.env.HOME);
   delete process.env.HOME;
-  assert.ok(os.homedir().includes(path.sep));
+  assert.ok(os.homedir().includes(path.SEPARATOR));
   process.env.HOME = home;
 }
 
@@ -160,13 +160,13 @@ if (common.isWindows) {
 } else {
   is.number(pwd.uid);
   is.number(pwd.gid);
-  assert.ok(pwd.shell.includes(path.sep));
+  assert.ok(pwd.shell.includes(path.SEPARATOR));
   assert.strictEqual(pwd.uid, pwdBuf.uid);
   assert.strictEqual(pwd.gid, pwdBuf.gid);
   assert.strictEqual(pwd.shell, pwdBuf.shell.toString('utf8'));
 }
 
 is.string(pwd.username);
-assert.ok(pwd.homedir.includes(path.sep));
+assert.ok(pwd.homedir.includes(path.SEPARATOR));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -550,17 +550,17 @@ relativeTests.forEach((test) => {
 assert.strictEqual(failures.length, 0, failures.join(''));
 
 
-// path.sep tests
+// path.SEPARATOR tests
 // windows
-assert.strictEqual(path.win32.sep, '\\');
+assert.strictEqual(path.win32.SEPARATOR, '\\');
 // posix
-assert.strictEqual(path.posix.sep, '/');
+assert.strictEqual(path.posix.SEPARATOR, '/');
 
-// path.delimiter tests
+// path.DELIMITER tests
 // windows
-assert.strictEqual(path.win32.delimiter, ';');
+assert.strictEqual(path.win32.DELIMITER, ';');
 // posix
-assert.strictEqual(path.posix.delimiter, ':');
+assert.strictEqual(path.posix.DELIMITER, ':');
 
 
 // path._makeLong tests

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -120,7 +120,7 @@ assert.doesNotThrow(
       function a() {
         ++watchSeenFour;
         assert.strictEqual(1, watchSeenFour);
-        fs.unwatchFile('.' + path.sep + filenameFour, a);
+        fs.unwatchFile('.' + path.SEPARATOR + filenameFour, a);
       }
       fs.watchFile(filenameFour, a);
     }

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -74,7 +74,7 @@ setImmediate(function() {
 });
 
 const filenameThree = 'newfile.txt';
-const testsubdir = fs.mkdtempSync(testDir + path.sep);
+const testsubdir = fs.mkdtempSync(testDir + path.SEPARATOR);
 const filepathThree = path.join(testsubdir, filenameThree);
 
 assert.doesNotThrow(

--- a/tools/eslint/lib/cli-engine.js
+++ b/tools/eslint/lib/cli-engine.js
@@ -375,7 +375,7 @@ function getCacheFile(cacheFile, cwd) {
     cacheFile = path.normalize(cacheFile);
 
     const resolvedCacheFile = path.resolve(cwd, cacheFile);
-    const looksLikeADirectory = cacheFile[cacheFile.length - 1 ] === path.sep;
+    const looksLikeADirectory = cacheFile[cacheFile.length - 1 ] === path.SEPARATOR;
 
     /**
      * return the name for the cache file in case the provided parameter is a directory


### PR DESCRIPTION
Rename the constant `path.sep` to `path.SEPARATOR` and `path.delimiter` to `path.DELIMITER` to have a more consistent naming convention regarding constants. 

This is a PR for the issue reported in https://github.com/nodejs/node/issues/10441

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
path
