### PR TITLE
Http rawheaders allocation optimization

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -61,7 +61,8 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   parser.incoming = new IncomingMessage(parser.socket);
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
-  parser.incoming.httpVersion = HttpVersion[versionMajor][versionMinor] || versionMajor + '.' + versionMinor;
+  parser.incoming.httpVersion = HttpVersion[versionMajor][versionMinor] ||
+    versionMajor + '.' + versionMinor;
   parser.incoming.url = url;
 
   var n = headers.length;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -9,7 +9,7 @@ const incoming = require('_http_incoming');
 const IncomingMessage = incoming.IncomingMessage;
 const readStart = incoming.readStart;
 const readStop = incoming.readStop;
-const HttpVersion = [[], ['1.0', '1.1']];
+const httpVersion = [[], ['1.0', '1.1']];
 
 const debug = require('util').debuglog('http');
 exports.debug = debug;
@@ -61,7 +61,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   parser.incoming = new IncomingMessage(parser.socket);
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
-  parser.incoming.httpVersion = HttpVersion[versionMajor][versionMinor] ||
+  parser.incoming.httpVersion = httpVersion[versionMajor][versionMinor] ||
     versionMajor + '.' + versionMinor;
   parser.incoming.url = url;
 

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -9,6 +9,7 @@ const incoming = require('_http_incoming');
 const IncomingMessage = incoming.IncomingMessage;
 const readStart = incoming.readStart;
 const readStop = incoming.readStop;
+const HttpVersion = [[], ['1.0', '1.1']];
 
 const debug = require('util').debuglog('http');
 exports.debug = debug;
@@ -60,7 +61,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   parser.incoming = new IncomingMessage(parser.socket);
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
-  parser.incoming.httpVersion = versionMajor + '.' + versionMinor;
+  parser.incoming.httpVersion = HttpVersion[versionMajor][versionMinor] || versionMajor + '.' + versionMinor;
   parser.incoming.url = url;
 
   var n = headers.length;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -62,7 +62,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   parser.incoming.httpVersionMajor = versionMajor;
   parser.incoming.httpVersionMinor = versionMinor;
   parser.incoming.httpVersion = httpVersion[versionMajor][versionMinor] ||
-    versionMajor + '.' + versionMinor;
+                                versionMajor + '.' + versionMinor;
   parser.incoming.url = url;
 
   var n = headers.length;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -1,7 +1,13 @@
 'use strict';
 
+const binding = process.binding('http_parser');
+const knownHttpHeaders = binding.knownHttpHeaders;
+const lowerCaseHttpHeaderLookup = Object.create(null);
 const util = require('util');
 const Stream = require('stream');
+for (var i = 0; i < knownHttpHeaders.length; i++) {
+  lowerCaseHttpHeaderLookup[knownHttpHeaders[i][1]] = knownHttpHeaders[i][2];
+}
 
 function readStart(socket) {
   if (socket && !socket._paused && socket.readable)
@@ -112,170 +118,35 @@ function _addHeaderLines(headers, n) {
     }
 
     for (var i = 0; i < n; i += 2) {
-      this._addHeaderLine(headers[i], headers[i + 1], dest);
+      if (typeof headers[i] === 'number') {
+        var headerEntry = knownHttpHeaders[headers[i]];
+        headers[i] = headerEntry[0];
+        _saveHeaderLine(headerEntry[1], headers[i + 1], headerEntry[2], dest);
+      } else {
+        _addHeaderLine(headers[i], headers[i + 1], dest);
+      }
     }
   }
 }
 
-
-// This function is used to help avoid the lowercasing of a field name if it
-// matches a 'traditional cased' version of a field name. It then returns the
-// lowercased name to both avoid calling toLowerCase() a second time and to
-// indicate whether the field was a 'no duplicates' field. If a field is not a
-// 'no duplicates' field, a `0` byte is prepended as a flag. The one exception
-// to this is the Set-Cookie header which is indicated by a `1` byte flag, since
-// it is an 'array' field and thus is treated differently in _addHeaderLines().
-// TODO: perhaps http_parser could be returning both raw and lowercased versions
-// of known header names to avoid us having to call toLowerCase() for those
-// headers.
-/* eslint-disable max-len */
-// 'array' header list is taken from:
-// https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
-/* eslint-enable max-len */
-function matchKnownFields(field) {
-  var low = false;
-  while (true) {
-    switch (field) {
-      case 'Content-Type':
-      case 'content-type':
-        return 'content-type';
-      case 'Content-Length':
-      case 'content-length':
-        return 'content-length';
-      case 'User-Agent':
-      case 'user-agent':
-        return 'user-agent';
-      case 'Referer':
-      case 'referer':
-        return 'referer';
-      case 'Host':
-      case 'host':
-        return 'host';
-      case 'Authorization':
-      case 'authorization':
-        return 'authorization';
-      case 'Proxy-Authorization':
-      case 'proxy-authorization':
-        return 'proxy-authorization';
-      case 'If-Modified-Since':
-      case 'if-modified-since':
-        return 'if-modified-since';
-      case 'If-Unmodified-Since':
-      case 'if-unmodified-since':
-        return 'if-unmodified-since';
-      case 'From':
-      case 'from':
-        return 'from';
-      case 'Location':
-      case 'location':
-        return 'location';
-      case 'Max-Forwards':
-      case 'max-forwards':
-        return 'max-forwards';
-      case 'Retry-After':
-      case 'retry-after':
-        return 'retry-after';
-      case 'ETag':
-      case 'etag':
-        return 'etag';
-      case 'Last-Modified':
-      case 'last-modified':
-        return 'last-modified';
-      case 'Server':
-      case 'server':
-        return 'server';
-      case 'Age':
-      case 'age':
-        return 'age';
-      case 'Expires':
-      case 'expires':
-        return 'expires';
-      case 'Set-Cookie':
-      case 'set-cookie':
-        return '\u0001';
-      // The fields below are not used in _addHeaderLine(), but they are common
-      // headers where we can avoid toLowerCase() if the mixed or lower case
-      // versions match the first time through.
-      case 'Transfer-Encoding':
-      case 'transfer-encoding':
-        return '\u0000transfer-encoding';
-      case 'Date':
-      case 'date':
-        return '\u0000date';
-      case 'Connection':
-      case 'connection':
-        return '\u0000connection';
-      case 'Cache-Control':
-      case 'cache-control':
-        return '\u0000cache-control';
-      case 'Vary':
-      case 'vary':
-        return '\u0000vary';
-      case 'Content-Encoding':
-      case 'content-encoding':
-        return '\u0000content-encoding';
-      case 'Cookie':
-      case 'cookie':
-        return '\u0000cookie';
-      case 'Origin':
-      case 'origin':
-        return '\u0000origin';
-      case 'Upgrade':
-      case 'upgrade':
-        return '\u0000upgrade';
-      case 'Expect':
-      case 'expect':
-        return '\u0000expect';
-      case 'If-Match':
-      case 'if-match':
-        return '\u0000if-match';
-      case 'If-None-Match':
-      case 'if-none-match':
-        return '\u0000if-none-match';
-      case 'Accept':
-      case 'accept':
-        return '\u0000accept';
-      case 'Accept-Encoding':
-      case 'accept-encoding':
-        return '\u0000accept-encoding';
-      case 'Accept-Language':
-      case 'accept-language':
-        return '\u0000accept-language';
-      case 'X-Forwarded-For':
-      case 'x-forwarded-for':
-        return '\u0000x-forwarded-for';
-      case 'X-Forwarded-Host':
-      case 'x-forwarded-host':
-        return '\u0000x-forwarded-host';
-      case 'X-Forwarded-Proto':
-      case 'x-forwarded-proto':
-        return '\u0000x-forwarded-proto';
-      default:
-        if (low)
-          return '\u0000' + field;
-        field = field.toLowerCase();
-        low = true;
-    }
-  }
-}
-// Add the given (field, value) pair to the message
+// Save the given (field, value) pair to the message.
+// Note: This is a static function and not on IncomingMessage unlike
+// _addHeaderLine. This method is created in addition to _addHeaderLine so:
+// 1. Backward compatibility is maintained for user code that use _addHeaderLine
+// 2. User code can't call _saveHeaderLine
 //
 // Per RFC2616, section 4.2 it is acceptable to join multiple instances of the
 // same header with a ', ' if the header in question supports specification of
 // multiple values this way. If not, we declare the first instance the winner
 // and drop the second. Extended header fields (those beginning with 'x-') are
 // always joined.
-IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
-function _addHeaderLine(field, value, dest) {
-  field = matchKnownFields(field);
-  var flag = field.charCodeAt(0);
+function _saveHeaderLine(lowercaseField, value, flag, dest) {
   if (flag === 0) {
-    field = field.slice(1);
     // Make comma-separated list
-    if (typeof dest[field] === 'string') {
-      dest[field] += ', ' + value;
+    if (typeof dest[lowercaseField] === 'string') {
+      dest[lowercaseField] += ', ' + value;
     } else {
-      dest[field] = value;
+      dest[lowercaseField] = value;
     }
   } else if (flag === 1) {
     // Array header -- only Set-Cookie at the moment
@@ -286,9 +157,21 @@ function _addHeaderLine(field, value, dest) {
     }
   } else {
     // Drop duplicates
-    if (dest[field] === undefined)
-      dest[field] = value;
+    if (dest[lowercaseField] === undefined)
+      dest[lowercaseField] = value;
   }
+}
+
+IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
+function _addHeaderLine(field, value, dest) {
+  // knownHeader in lower case
+  var flag = lowerCaseHttpHeaderLookup[field];
+  // if not, convert to lower and try one more time
+  if (flag === undefined) {
+    field = field.toLowerCase();
+    flag = lowerCaseHttpHeaderLookup[field] || 0;
+  }
+  _saveHeaderLine(field, value, flag, dest);
 }
 
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -174,9 +174,9 @@ function _saveHeaderLine(lowercaseField, value, flag, dest) {
 
 IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
 function _addHeaderLine(field, value, dest) {
-  // knownHeader in lower case
+  // Check if field is already lower-case and one of the known header.
   var flag = lowerCaseHttpHeaderLookup[field];
-  // if not, convert to lower and try one more time
+  // If not, convert to lower and try one more time.
   if (flag === undefined) {
     field = field.toLowerCase();
     flag = lowerCaseHttpHeaderLookup[field] || 0;

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -1,13 +1,22 @@
-'use strict';
+﻿'use strict';
 
 const binding = process.binding('http_parser');
 const knownHttpHeaders = binding.knownHttpHeaders;
-const lowerCaseHttpHeaderLookup = Object.create(null);
 const util = require('util');
 const Stream = require('stream');
-for (var i = 0; i < knownHttpHeaders.length; i++) {
-  lowerCaseHttpHeaderLookup[knownHttpHeaders[i][1]] = knownHttpHeaders[i][2];
-}
+const lowerCaseHttpHeaderLookup = (function() {
+  var code = 'return Object.create(null, {';
+  for (var i = 0; i < knownHttpHeaders.length; ++i) {
+    const origName = knownHttpHeaders[i][1];
+    const lowName = knownHttpHeaders[i][2];
+    code += `${JSON.stringify(origName)}: {`;
+    code += `value: ${JSON.stringify(lowName)}, enumerable: true`;
+    code += '},';
+  }
+  code += '})';
+  return new Function(code)();
+})();
+
 
 function readStart(socket) {
   if (socket && !socket._paused && socket.readable)
@@ -20,6 +29,7 @@ function readStop(socket) {
     socket.pause();
 }
 exports.readStop = readStop;
+
 
 /* Abstract base class for ServerRequest and ClientResponse. */
 function IncomingMessage(socket) {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -15,7 +15,6 @@ function readStop(socket) {
 }
 exports.readStop = readStop;
 
-
 /* Abstract base class for ServerRequest and ClientResponse. */
 function IncomingMessage(socket) {
   Stream.Readable.call(this);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -199,7 +199,12 @@ class Parser : public AsyncWrap {
     CHECK_LT(num_fields_, arraysize(fields_));
     CHECK_EQ(num_fields_, num_values_ + 1);
 
-    fields_[num_fields_ - 1].Update(at, length);
+    if (parser_.header_state && parser_.traditional_case_http_headers) {
+      knownFields_[num_fields_ - 1] = parser_.header_state - 1;
+    } else {
+      knownFields_[num_fields_ - 1] = -1;
+      fields_[num_fields_ - 1].Update(at, length);
+    }
 
     return 0;
   }
@@ -647,7 +652,9 @@ class Parser : public AsyncWrap {
     do {
       size_t j = 0;
       while (i < num_values_ && j < arraysize(argv) / 2) {
-        argv[j * 2] = fields_[i].ToString(env());
+        argv[j * 2] = knownFields_[i] != -1 ?
+          Local<Value>::Cast(Integer::New(env()->isolate(), knownFields_[i])) :
+          fields_[i].ToString(env());
         argv[j * 2 + 1] = values_[i].ToString(env());
         i++;
         j++;
@@ -659,7 +666,6 @@ class Parser : public AsyncWrap {
 
     return headers;
   }
-
 
   // spill headers and request path to JS land
   void Flush() {
@@ -698,6 +704,7 @@ class Parser : public AsyncWrap {
 
 
   http_parser parser_;
+  unsigned int knownFields_[32];  // known HTTP header fields
   StringPtr fields_[32];  // header fields
   StringPtr values_[32];  // header values
   StringPtr url_;
@@ -762,6 +769,25 @@ void InitHttpParser(Local<Object> target,
   HTTP_METHOD_MAP(V)
 #undef V
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "methods"), methods);
+
+  Local<Array> knownHttpHeaders = Array::New(env->isolate());
+  Local<Object> lowerCaseKnowHttpHeaderObj = Object::New(env->isolate());
+  Local<Array> knownHttpHeaderEntry;
+
+  int index = 0;
+#define XX(headerName, lowerCaseHeaderName, enumFriendlyName, flag) \
+  knownHttpHeaderEntry = Array::New(env->isolate(), 3); \
+  knownHttpHeaderEntry->Set(0, FIXED_ONE_BYTE_STRING(env->isolate(),  \
+                               #headerName)); \
+  knownHttpHeaderEntry->Set(1, FIXED_ONE_BYTE_STRING(env->isolate(),  \
+                               #lowerCaseHeaderName)); \
+  knownHttpHeaderEntry->Set(2, Integer::New(env->isolate(), flag)); \
+  knownHttpHeaders->Set(index++, knownHttpHeaderEntry);
+    HTTP_HEADER_MAP(XX)
+#undef XX
+
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "knownHttpHeaders"),
+              knownHttpHeaders);
 
   env->SetProtoMethod(t, "close", Parser::Close);
   env->SetProtoMethod(t, "execute", Parser::Execute);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -200,9 +200,9 @@ class Parser : public AsyncWrap {
     CHECK_EQ(num_fields_, num_values_ + 1);
 
     if (parser_.header_state && parser_.traditional_case_http_headers) {
-      knownFields_[num_fields_ - 1] = parser_.header_state - 1;
+      known_fields_[num_fields_ - 1] = parser_.header_state - 1;
     } else {
-      knownFields_[num_fields_ - 1] = -1;
+      known_fields_[num_fields_ - 1] = -1;
       fields_[num_fields_ - 1].Update(at, length);
     }
 
@@ -652,8 +652,8 @@ class Parser : public AsyncWrap {
     do {
       size_t j = 0;
       while (i < num_values_ && j < arraysize(argv) / 2) {
-        argv[j * 2] = knownFields_[i] != -1 ?
-          Local<Value>::Cast(Integer::New(env()->isolate(), knownFields_[i])) :
+        argv[j * 2] = known_fields_[i] != -1 ?
+          Local<Value>::Cast(Integer::New(env()->isolate(), known_fields_[i])) :
           fields_[i].ToString(env());
         argv[j * 2 + 1] = values_[i].ToString(env());
         i++;
@@ -666,6 +666,7 @@ class Parser : public AsyncWrap {
 
     return headers;
   }
+
 
   // spill headers and request path to JS land
   void Flush() {
@@ -703,10 +704,11 @@ class Parser : public AsyncWrap {
   }
 
 
+  static const int kNumFields = 32;
   http_parser parser_;
-  unsigned int knownFields_[32];  // known HTTP header fields
-  StringPtr fields_[32];  // header fields
-  StringPtr values_[32];  // header values
+  unsigned int known_fields_[kNumFields];  // known HTTP header fields
+  StringPtr fields_[kNumFields];  // header fields
+  StringPtr values_[kNumFields];  // header values
   StringPtr url_;
   StringPtr status_message_;
   size_t num_fields_;
@@ -775,13 +777,13 @@ void InitHttpParser(Local<Object> target,
   Local<Array> knownHttpHeaderEntry;
 
   int index = 0;
-#define XX(headerName, lowerCaseHeaderName, enumFriendlyName, flag) \
-  knownHttpHeaderEntry = Array::New(env->isolate(), 3); \
+#define XX(headerName, lowerCaseHeaderName, enumFriendlyName, flag)   \
+  knownHttpHeaderEntry = Array::New(env->isolate(), 3);               \
   knownHttpHeaderEntry->Set(0, FIXED_ONE_BYTE_STRING(env->isolate(),  \
-                               #headerName)); \
+                               #headerName));                         \
   knownHttpHeaderEntry->Set(1, FIXED_ONE_BYTE_STRING(env->isolate(),  \
-                               #lowerCaseHeaderName)); \
-  knownHttpHeaderEntry->Set(2, Integer::New(env->isolate(), flag)); \
+                               #lowerCaseHeaderName));                \
+  knownHttpHeaderEntry->Set(2, Integer::New(env->isolate(), flag));   \
   knownHttpHeaders->Set(index++, knownHttpHeaderEntry);
     HTTP_HEADER_MAP(XX)
 #undef XX


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Every time a request comes, new string is allocated for the http field. However this can be avoided if the http field is one of the known http header name. I modified `http_parser` to keep track of known headers during parsing and pass an index to `node` which maps to an entry in `knownHttpHeaders` array. This array is a look up of known http headers, populated using macros exposed in `http_parser`. If there is a valid index returned by `parser` we know that it is a known http header for which there already
exist a `string` in Jsland and with this we can avoid an allocation of these http fields. If `parser` doesn't return a valid index we continue old route and create a new `v8::string`.

`knownHttpHeaders` is further utilized to populate another lookup `lowerCaseHttpHeaderLookup` which stores flag information of the header. With that we don't need to prepend the header name with
a flag and perform `.charCodeAt()` and `.slice()` operation on fieldName in Jsland.

I verified http core performance and surprisingly i don't see much change in it except in `bench-parse.js` where i occasionally see regression around 5%. I do see 1.8% improvement in Techempower benchmark.

I didn't include test/benchmarks because existing test/benchmarks are good enough to test this feature.

This has dependency on https://github.com/nodejs/http-parser/pull/352  and hence CI might fail until it is accepted and merged into node core.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http