### PR TITLE
lib: refactor some lib/internals

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -12,7 +12,7 @@ const { isUint8Array } = process.binding('util');
 
 // Transcodes the Buffer from one encoding to another, returning a new
 // Buffer instance.
-exports.transcode = function transcode(source, fromEncoding, toEncoding) {
+function transcode(source, fromEncoding, toEncoding) {
   if (!isUint8Array(source))
     throw new TypeError('"source" argument must be a Buffer or Uint8Array');
   if (source.length === 0) return Buffer.alloc(0);
@@ -28,4 +28,8 @@ exports.transcode = function transcode(source, fromEncoding, toEncoding) {
   err.code = code;
   err.errno = result;
   throw err;
+}
+
+module.exports = {
+  transcode
 };

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -22,13 +22,6 @@ const errnoException = util._errnoException;
 const SocketListSend = SocketList.SocketListSend;
 const SocketListReceive = SocketList.SocketListReceive;
 
-module.exports = {
-  ChildProcess,
-  setupChannel,
-  _validateStdio,
-  getSocketList
-};
-
 // this object contain function to convert TCP objects to native handle objects
 // and back again.
 const handleConversion = {
@@ -891,3 +884,10 @@ function maybeClose(subprocess) {
     subprocess.emit('close', subprocess.exitCode, subprocess.signalCode);
   }
 }
+
+module.exports = {
+  ChildProcess,
+  setupChannel,
+  _validateStdio,
+  getSocketList
+};

--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,24 +1,25 @@
 'use strict';
 
-// This is a free list to avoid creating so many of the same object.
-exports.FreeList = function(name, max, constructor) {
-  this.name = name;
-  this.constructor = constructor;
-  this.max = max;
-  this.list = [];
-};
-
-
-exports.FreeList.prototype.alloc = function() {
-  return this.list.length ? this.list.pop() :
-                            this.constructor.apply(this, arguments);
-};
-
-
-exports.FreeList.prototype.free = function(obj) {
-  if (this.list.length < this.max) {
-    this.list.push(obj);
-    return true;
+class FreeList {
+  constructor(name, max, ctor) {
+    this.name = name;
+    this.ctor = ctor;
+    this.max = max;
+    this.list = [];
   }
-  return false;
-};
+
+  alloc() {
+    return this.list.length ? this.list.pop() :
+                              this.ctor.apply(this, arguments);
+  }
+
+  free(obj) {
+    if (this.list.length < this.max) {
+      this.list.push(obj);
+      return true;
+    }
+    return false;
+  }
+}
+
+module.exports = {FreeList};

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -20,7 +20,6 @@ function assertEncoding(encoding) {
     throw new Error(`Unknown encoding: ${encoding}`);
   }
 }
-exports.assertEncoding = assertEncoding;
 
 function stringToFlags(flag) {
   if (typeof flag === 'number') {
@@ -54,7 +53,6 @@ function stringToFlags(flag) {
 
   throw new Error('Unknown file open flag: ' + flag);
 }
-exports.stringToFlags = stringToFlags;
 
 // Temporary hack for process.stdout and process.stderr when piped to files.
 function SyncWriteStream(fd, options) {
@@ -95,6 +93,9 @@ SyncWriteStream.prototype.destroy = function() {
   return true;
 };
 
-exports.SyncWriteStream = SyncWriteStream;
-
-exports.realpathCacheKey = Symbol('realpathCacheKey');
+module.exports = {
+  assertEncoding,
+  stringToFlags,
+  SyncWriteStream,
+  realpathCacheKey: Symbol('realpathCacheKey')
+};

--- a/lib/internal/linkedlist.js
+++ b/lib/internal/linkedlist.js
@@ -4,7 +4,6 @@ function init(list) {
   list._idleNext = list;
   list._idlePrev = list;
 }
-exports.init = init;
 
 // create a new linked list
 function create() {
@@ -12,15 +11,12 @@ function create() {
   init(list);
   return list;
 }
-exports.create = create;
 
 // show the most idle item
 function peek(list) {
   if (list._idlePrev === list) return null;
   return list._idlePrev;
 }
-exports.peek = peek;
-
 
 // remove the most idle item from the list
 function shift(list) {
@@ -28,8 +24,6 @@ function shift(list) {
   remove(first);
   return first;
 }
-exports.shift = shift;
-
 
 // remove a item from its list
 function remove(item) {
@@ -44,8 +38,6 @@ function remove(item) {
   item._idleNext = null;
   item._idlePrev = null;
 }
-exports.remove = remove;
-
 
 // remove a item from its list and place at the end.
 function append(list, item) {
@@ -62,10 +54,17 @@ function append(list, item) {
   list._idleNext._idlePrev = item;
   list._idleNext = item;
 }
-exports.append = append;
-
 
 function isEmpty(list) {
   return list._idleNext === list;
 }
-exports.isEmpty = isEmpty;
+
+module.exports = {
+  init,
+  create,
+  peek,
+  shift,
+  remove,
+  append,
+  isEmpty
+};

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,7 +1,5 @@
 'use strict';
 
-module.exports = { isLegalPort, assertPort };
-
 // Check that the port number is not NaN when coerced to a number,
 // is an integer and that it falls within the legal range of port numbers.
 function isLegalPort(port) {
@@ -16,3 +14,8 @@ function assertPort(port) {
   if (typeof port !== 'undefined' && !isLegalPort(port))
     throw new RangeError('"port" argument must be >= 0 and < 65536');
 }
+
+module.exports = {
+  isLegalPort,
+  assertPort
+};

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -1,104 +1,105 @@
 'use strict';
 
-module.exports = {SocketListSend, SocketListReceive};
-
 const EventEmitter = require('events');
-const util = require('util');
 
 // This object keep track of the socket there are sended
-function SocketListSend(slave, key) {
-  EventEmitter.call(this);
+class SocketListSend extends EventEmitter {
+  constructor(child, key) {
+    super();
+    this.key = key;
+    this.child = child;
+  }
 
-  this.key = key;
-  this.slave = slave;
+  _request(msg, cmd, callback) {
+    var self = this;
+
+    if (!this.child.connected) return onclose();
+    this.child.send(msg);
+
+    function onclose() {
+      self.child.removeListener('internalMessage', onreply);
+      callback(new Error('child closed before reply'));
+    }
+
+    function onreply(msg) {
+      if (!(msg.cmd === cmd && msg.key === self.key)) return;
+      self.child.removeListener('disconnect', onclose);
+      self.child.removeListener('internalMessage', onreply);
+
+      callback(null, msg);
+    }
+
+    this.child.once('disconnect', onclose);
+    this.child.on('internalMessage', onreply);
+  }
+
+  close(callback) {
+    this._request({
+      cmd: 'NODE_SOCKET_NOTIFY_CLOSE',
+      key: this.key
+    }, 'NODE_SOCKET_ALL_CLOSED', callback);
+  }
+
+  getConnections(callback) {
+    this._request({
+      cmd: 'NODE_SOCKET_GET_COUNT',
+      key: this.key
+    }, 'NODE_SOCKET_COUNT', function(err, msg) {
+      if (err) return callback(err);
+      callback(null, msg.count);
+    });
+  }
 }
-util.inherits(SocketListSend, EventEmitter);
 
-SocketListSend.prototype._request = function(msg, cmd, callback) {
-  var self = this;
-
-  if (!this.slave.connected) return onclose();
-  this.slave.send(msg);
-
-  function onclose() {
-    self.slave.removeListener('internalMessage', onreply);
-    callback(new Error('Slave closed before reply'));
-  }
-
-  function onreply(msg) {
-    if (!(msg.cmd === cmd && msg.key === self.key)) return;
-    self.slave.removeListener('disconnect', onclose);
-    self.slave.removeListener('internalMessage', onreply);
-
-    callback(null, msg);
-  }
-
-  this.slave.once('disconnect', onclose);
-  this.slave.on('internalMessage', onreply);
-};
-
-SocketListSend.prototype.close = function close(callback) {
-  this._request({
-    cmd: 'NODE_SOCKET_NOTIFY_CLOSE',
-    key: this.key
-  }, 'NODE_SOCKET_ALL_CLOSED', callback);
-};
-
-SocketListSend.prototype.getConnections = function getConnections(callback) {
-  this._request({
-    cmd: 'NODE_SOCKET_GET_COUNT',
-    key: this.key
-  }, 'NODE_SOCKET_COUNT', function(err, msg) {
-    if (err) return callback(err);
-    callback(null, msg.count);
-  });
-};
 
 // This object keep track of the socket there are received
-function SocketListReceive(slave, key) {
-  EventEmitter.call(this);
+class SocketListReceive extends EventEmitter {
+  constructor(child, key) {
+    super();
 
-  this.connections = 0;
-  this.key = key;
-  this.slave = slave;
+    this.connections = 0;
+    this.key = key;
+    this.child = child;
 
-  function onempty(self) {
-    if (!self.slave.connected) return;
+    function onempty(self) {
+      if (!self.child.connected) return;
 
-    self.slave.send({
-      cmd: 'NODE_SOCKET_ALL_CLOSED',
-      key: self.key
+      self.child.send({
+        cmd: 'NODE_SOCKET_ALL_CLOSED',
+        key: self.key
+      });
+    }
+
+    this.child.on('internalMessage', (msg) => {
+      if (msg.key !== this.key) return;
+
+      if (msg.cmd === 'NODE_SOCKET_NOTIFY_CLOSE') {
+        // Already empty
+        if (this.connections === 0) return onempty(this);
+
+        // Wait for sockets to get closed
+        this.once('empty', onempty);
+      } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
+        if (!this.child.connected) return;
+        this.child.send({
+          cmd: 'NODE_SOCKET_COUNT',
+          key: this.key,
+          count: this.connections
+        });
+      }
     });
   }
 
-  this.slave.on('internalMessage', (msg) => {
-    if (msg.key !== this.key) return;
+  add(obj) {
+    this.connections++;
 
-    if (msg.cmd === 'NODE_SOCKET_NOTIFY_CLOSE') {
-      // Already empty
-      if (this.connections === 0) return onempty(this);
+    // Notify previous owner of socket about its state change
+    obj.socket.once('close', () => {
+      this.connections--;
 
-      // Wait for sockets to get closed
-      this.once('empty', onempty);
-    } else if (msg.cmd === 'NODE_SOCKET_GET_COUNT') {
-      if (!this.slave.connected) return;
-      this.slave.send({
-        cmd: 'NODE_SOCKET_COUNT',
-        key: this.key,
-        count: this.connections
-      });
-    }
-  });
+      if (this.connections === 0) this.emit('empty', this);
+    });
+  }
 }
-util.inherits(SocketListReceive, EventEmitter);
 
-SocketListReceive.prototype.add = function(obj) {
-  this.connections++;
-
-  // Notify previous owner of socket about its state change
-  obj.socket.once('close', () => {
-    this.connections--;
-
-    if (this.connections === 0) this.emit('empty', this);
-  });
-};
+module.exports = {SocketListSend, SocketListReceive};


### PR DESCRIPTION
Some light refactoring of internals/*.js

* For linkedlist and freelist, this yields about a 5% perf improvement in general
* Consistent use of the module.exports = {} pattern, with module.exports = {} at the end.

(do not squash commits)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
lib/internal