### PR TITLE
test: use common.expectsError() in test-http-request-invalid-method-error.js

### DIFF
--- a/test/parallel/test-http-request-invalid-method-error.js
+++ b/test/parallel/test-http-request-invalid-method-error.js
@@ -1,12 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
 assert.throws(
   () => { http.request({method: '\0'}); },
-  (error) => {
-    return (error instanceof TypeError) &&
-      /Method must be a valid HTTP token/.test(error);
-  }
+  common.expectsError(undefined, TypeError, 'Method must be a valid HTTP token')
 );


### PR DESCRIPTION
Use common.expectsError() instead of rolling own validation function in
test-http-request-invalid-method-error.js. common.expectsError() didn't
exist when the test was written, but now it does.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http errors