### PR TITLE
test: use expectsError in require-invalid-package

### DIFF
--- a/test/parallel/test-require-invalid-package.js
+++ b/test/parallel/test-require-invalid-package.js
@@ -1,9 +1,9 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // Should be an invalid package path.
-assert.throws(() => require('package.json'), (err) => {
-  return err && err.code === 'MODULE_NOT_FOUND';
-});
+assert.throws(() => require('package.json'),
+              common.expectsError('MODULE_NOT_FOUND')
+);


### PR DESCRIPTION
Use common.expectsError() in place of inline validation function in
test-require-invalid-package.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test errors module