### PR TITLE
test: use expectsError in test-debug-agent.js

### DIFF
--- a/test/parallel/test-debug-agent.js
+++ b/test/parallel/test-debug-agent.js
@@ -1,12 +1,13 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const debug = require('_debug_agent');
 
 assert.throws(
   () => { debug.start(); },
-  function(err) {
-    return (err instanceof assert.AssertionError &&
-            err.message === 'Debugger agent running without bindings!');
-  }
+  common.expectsError(
+    undefined,
+    assert.AssertionError,
+    'Debugger agent running without bindings!'
+  )
 );


### PR DESCRIPTION
Use common.expectsError() in place of inline validation function in
test-debug-agent.js.

like #11409 #11408

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test errors debugger
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
