### PR TITLE
fix test-module-loading test case

### DIFF
--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -99,7 +99,8 @@ console.error('test name clashes');
 const my_path = require('../fixtures/path');
 assert.ok(my_path.path_func instanceof Function);
 // this one does not exist and should throw
-assert.throws(function() { require('./utils'); });
+assert.throws(function() { require('./utils'); },
+              /^Error: Cannot find module '.\/utils'$/);
 
 let errorThrown = false;
 try {

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -126,7 +126,7 @@ assert.strictEqual(require('../fixtures/registerExt.hello.world').test,
                    'passed');
 
 console.error('load custom file types that return non-strings');
-require.extensions['.test'] = function(module, filename) {
+require.extensions['.test'] = function(module) {
   module.exports = {
     custom: 'passed'
   };


### PR DESCRIPTION
First contribution to the node repo. This PR provides a small fix to the `test-module-loading` test case. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

