### PR TITLE
test: Run test-setproctitle where setting the process title is supported by libuv

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -21,6 +21,10 @@ assert.notStrictEqual(process.title, title);
 process.title = title;
 assert.strictEqual(process.title, title);
 
+// Test setting the title but do not try to run `ps` on Windows.
+if (common.isWindows)
+  return;
+
 exec(`ps -p ${process.pid} -o args=`, function callback(error, stdout, stderr) {
   assert.ifError(error);
   assert.strictEqual(stderr, '');

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 // FIXME add sunos support
-if (!(common.isFreeBSD || common.isOSX || common.isLinux)) {
+if (common.isSunOS) {
   console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
   return;
 }


### PR DESCRIPTION
Setting the process title has been enabled in libuv on AIX and z/OS.
The latest level of libuv skips only skips testing of uv_set_process_title when __sun is #defined.
The Node.js test for supported platforms was getting long so now it only checks for the one unsupported platform the same way as libuv.

This change simplifies the skip test so the test is only skipped when common.isSunOS is true to match libuv. The corresponding libuv test is here:
https://github.com/nodejs/node/blob/master/deps/uv/test/test-process-title.c#L63

It was updated when support for setting the process title was added to AIX and z/OS and included in Node.js when libuv was upgraded under PR #11094 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test
