### PR TITLE
test: add Unicode characters regression test

### DIFF
--- a/lib/internal/test/unicode.js
+++ b/lib/internal/test/unicode.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// This module exists entirely for regression testing purposes.
+// See `test/parallel/test-internal-unicode.js`.
+
+module.exports = '✓';

--- a/node.gyp
+++ b/node.gyp
@@ -97,6 +97,7 @@
       'lib/internal/readline.js',
       'lib/internal/repl.js',
       'lib/internal/socket_list.js',
+      'lib/internal/test/unicode.js',
       'lib/internal/url.js',
       'lib/internal/util.js',
       'lib/internal/v8_prof_polyfill.js',

--- a/test/parallel/test-internal-unicode.js
+++ b/test/parallel/test-internal-unicode.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+
+// Flags: --expose-internals
+//
+// This test ensures that UTF-8 characters can be used in core JavaScript
+// libraries built into Node's binary.
+
+const assert = require('assert');
+const character = require('internal/test/unicode');
+
+assert.strictEqual(character, '✓');


### PR DESCRIPTION
This test ensures that UTF-8 characters can be used in core JavaScript modules built into Node's binary.

Refs: https://github.com/nodejs/node/pull/11129

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test