### PR TITLE
test, url: check the origin of the blob URLs

### DIFF
--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -5622,5 +5622,33 @@ module.exports =
     "input": "non-special://[:80/",
     "base": "about:blank",
     "failure": true
+  },
+  {
+    "input": "blob:https://example.com:443/",
+    "base": "about:blank",
+    "href": "blob:https://example.com:443/",
+    "protocol": "blob:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "https://example.com:443/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "blob:d3958f5c-0777-0845-9dcf-2cb28783acaf",
+    "base": "about:blank",
+    "href": "blob:d3958f5c-0777-0845-9dcf-2cb28783acaf",
+    "protocol": "blob:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "d3958f5c-0777-0845-9dcf-2cb28783acaf",
+    "search": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
In the getter of the origin in URL, the URL that has blob protocol will be parsed in a function called "originFor". Add test cases to the `url-tests-additional` fixture to test that.

This test increases the coverage of internal/url.js:
+ https://coverage.nodejs.org/coverage-3429991d8b43474c/root/internal/url.js.html

The following lines will be covered:
+ https://github.com/nodejs/node/blob/a196895ecceeda4f7ba1059a95a06f1463e517fa/lib/internal/url.js#L1064-L1073

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test, url