### PR TITLE
child_process: remove empty if condition

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -216,9 +216,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       stderr = Buffer.concat(_stderr);
     }
 
-    if (ex) {
-      // Will be handled later
-    } else if (code === 0 && signal === null) {
+    if (!ex && code === 0 && signal === null) {
       callback(null, stdout, stderr);
       return;
     }


### PR DESCRIPTION
This commit replaces an empty if-else-if with a single if condition.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process