### PR TITLE
test, url: URLSearchParams splits across lines

### DIFF
--- a/test/parallel/test-whatwg-url-searchparams-inspect.js
+++ b/test/parallel/test-whatwg-url-searchparams-inspect.js
@@ -13,7 +13,8 @@ assert.strictEqual(util.inspect(sp.keys()),
                    "URLSearchParamsIterator { 'a', 'b', 'b' }");
 assert.strictEqual(util.inspect(sp.values()),
                    "URLSearchParamsIterator { 'a', 'b', 'c' }");
-
+assert.strictEqual(util.inspect(sp.keys(), {breakLength: 1}),
+                   "URLSearchParamsIterator {\n  'a',\n  'b',\n  'b' }");
 const iterator = sp.entries();
 assert.strictEqual(util.inspect(iterator),
                    "URLSearchParamsIterator { [ 'a', 'a' ], [ 'b', 'b' ], " +


### PR DESCRIPTION
The member methods of URLSearchParams should split across multiple lines with `util.inspect` depending on an option `breakLength`.

This test increases the coverage of internal/url.js:
+ https://coverage.nodejs.org/coverage-3429991d8b43474c/root/internal/url.js.html

The following line will be called:
+ https://github.com/nodejs/node/blob/82ddf96828b1358e9d9abcff3c9b28bedb06a113/lib/internal/url.js#L1057-L1059

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test,url