### PR TITLE
test: refactor test-http-response-splitting

### DIFF
--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -19,23 +19,23 @@ const y = 'foo⠊Set-Cookie: foo=bar';
 
 let count = 0;
 
+function test(res, code, header) {
+  assert.throws(() => {
+    res.writeHead(code, header);
+  }, /^TypeError: The header content contains invalid characters$/);
+}
+
 const server = http.createServer((req, res) => {
   switch (count++) {
     case 0:
       const loc = url.parse(req.url, true).query.lang;
-      assert.throws(common.mustCall(() => {
-        res.writeHead(302, {Location: `/foo?lang=${loc}`});
-      }));
+      test(res, 302, {Location: `/foo?lang=${loc}`});
       break;
     case 1:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo': x});
-      }));
+      test(res, 200, {'foo': x});
       break;
     case 2:
-      assert.throws(common.mustCall(() => {
-        res.writeHead(200, {'foo': y});
-      }));
+      test(res, 200, {'foo': y});
       break;
     default:
       common.fail('should not get to here.');


### PR DESCRIPTION
* move repeated code to function
* remove unneeded `common.mustCall()` usage with function arguments that
  are not callbacks
* add error message checking

like #11274.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test http
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->