### PR TITLE
test: skip IPv6 test on non-IPv6 systems

### DIFF
--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -26,7 +26,7 @@ const dgram = require('dgram');
   socket.bind(0, common.localhostIPv4);
 }
 
-{
+if (common.hasIPv6) {
   // IPv6 Test
   const socket = dgram.createSocket('udp6');
   const localhost = '::1';


### PR DESCRIPTION
Until recently, test-dgram-address would fail on machines without IPv6 but still exit
with a successful return code. (It would console.log() the error but not
actually fail.)

Now that the test has been updated such that it will fail the IPv6 part
of the test if there is an error event emitted by the socket, skip the
test on systems not equipped with IPv6.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram