### PR TITLE
domain,events: support non-object 'error' argument

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -153,9 +153,11 @@ EventEmitter.prototype.emit = function emit(type) {
     if (domain) {
       if (!er)
         er = new Error('Uncaught, unspecified "error" event');
-      er.domainEmitter = this;
-      er.domain = domain;
-      er.domainThrown = false;
+      if (typeof er === 'object' && er !== null) {
+        er.domainEmitter = this;
+        er.domain = domain;
+        er.domainThrown = false;
+      }
       domain.emit('error', er);
     } else if (er instanceof Error) {
       throw er; // Unhandled 'error' event

--- a/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
+++ b/test/parallel/test-event-emitter-no-error-provided-to-error-event.js
@@ -3,12 +3,33 @@ const common = require('../common');
 const assert = require('assert');
 const events = require('events');
 const domain = require('domain');
-const e = new events.EventEmitter();
 
-const d = domain.create();
-d.add(e);
-d.on('error', common.mustCall(function(er) {
-  assert(er instanceof Error, 'error created');
-}));
+{
+  const e = new events.EventEmitter();
+  const d = domain.create();
+  d.add(e);
+  d.on('error', common.mustCall(function(er) {
+    assert(er instanceof Error, 'error created');
+  }));
+  e.emit('error');
+}
 
-e.emit('error');
+for (const arg of [false, null, undefined]) {
+  const e = new events.EventEmitter();
+  const d = domain.create();
+  d.add(e);
+  d.on('error', common.mustCall(function(er) {
+    assert(er instanceof Error, 'error created');
+  }));
+  e.emit('error', arg);
+}
+
+for (const arg of [42, 'fortytwo', true]) {
+  const e = new events.EventEmitter();
+  const d = domain.create();
+  d.add(e);
+  d.on('error', common.mustCall(function(er) {
+    assert.strictEqual(er, arg);
+  }));
+  e.emit('error', arg);
+}


### PR DESCRIPTION
Fix a TypeError when emitting an 'error' argument with a non-object
argument (like a string) when domains are active.

Refs: https://github.com/nodejs/help/issues/501