### PR TITLE
console: fixup `console.dir()` error handling

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -103,7 +103,10 @@ Console.prototype.error = Console.prototype.warn;
 
 Console.prototype.dir = function dir(object, options) {
   options = Object.assign({customInspect: false}, options);
-  write(this._ignoreErrors, this._stdout, `${util.inspect(object, options)}\n`);
+  write(this._ignoreErrors,
+        this._stdout,
+        `${util.inspect(object, options)}\n`,
+        this._stdoutErrorHandler);
 };
 
 

--- a/test/parallel/test-console-async-write-error.js
+++ b/test/parallel/test-console-async-write-error.js
@@ -4,14 +4,16 @@ const { Console } = require('console');
 const { Writable } = require('stream');
 const assert = require('assert');
 
-const out = new Writable({
-  write: common.mustCall((chunk, enc, callback) => {
-    process.nextTick(callback, new Error('foobar'));
-  })
-});
+for (const method of ['dir', 'log', 'warn']) {
+  const out = new Writable({
+    write: common.mustCall((chunk, enc, callback) => {
+      process.nextTick(callback, new Error('foobar'));
+    })
+  });
 
-const c = new Console(out, out, true);
+  const c = new Console(out, out, true);
 
-assert.doesNotThrow(() => {
-  c.log('abc');
-});
+  assert.doesNotThrow(() => {
+    c[method]('abc');
+  });
+}

--- a/test/parallel/test-console-sync-write-error.js
+++ b/test/parallel/test-console-sync-write-error.js
@@ -4,44 +4,46 @@ const { Console } = require('console');
 const { Writable } = require('stream');
 const assert = require('assert');
 
-{
-  const out = new Writable({
-    write: common.mustCall((chunk, enc, callback) => {
-      callback(new Error('foobar'));
-    })
-  });
+for (const method of ['dir', 'log', 'warn']) {
+  {
+    const out = new Writable({
+      write: common.mustCall((chunk, enc, callback) => {
+        callback(new Error('foobar'));
+      })
+    });
 
-  const c = new Console(out, out, true);
+    const c = new Console(out, out, true);
 
-  assert.doesNotThrow(() => {
-    c.log('abc');
-  });
-}
+    assert.doesNotThrow(() => {
+      c[method]('abc');
+    });
+  }
 
-{
-  const out = new Writable({
-    write: common.mustCall((chunk, enc, callback) => {
-      throw new Error('foobar');
-    })
-  });
+  {
+    const out = new Writable({
+      write: common.mustCall((chunk, enc, callback) => {
+        throw new Error('foobar');
+      })
+    });
 
-  const c = new Console(out, out, true);
+    const c = new Console(out, out, true);
 
-  assert.doesNotThrow(() => {
-    c.log('abc');
-  });
-}
+    assert.doesNotThrow(() => {
+      c[method]('abc');
+    });
+  }
 
-{
-  const out = new Writable({
-    write: common.mustCall((chunk, enc, callback) => {
-      setImmediate(() => callback(new Error('foobar')));
-    })
-  });
+  {
+    const out = new Writable({
+      write: common.mustCall((chunk, enc, callback) => {
+        setImmediate(() => callback(new Error('foobar')));
+      })
+    });
 
-  const c = new Console(out, out, true);
+    const c = new Console(out, out, true);
 
-  assert.doesNotThrow(() => {
-    c.log('abc');
-  });
+    assert.doesNotThrow(() => {
+      c[method]('abc');
+    });
+  }
 }


### PR DESCRIPTION
Apply the `console: do not emit error events` changes properly to `console.dir()`.

This was overlooked in f18e08d820dde161788d95a5603546ceca021e90 (https://github.com/nodejs/node/pull/9744).

Ref: https://github.com/nodejs/node/commit/f18e08d820dde161788d95a5603546ceca021e90#commitcomment-20934407

/cc @Fishrock123

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

console