### PR TITLE
tls: use emitWarning() for dhparam < 2048 bits

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const internalUtil = require('internal/util');
 const tls = require('tls');
 
 const SSL_OP_CIPHER_SERVER_PREFERENCE =
@@ -99,7 +98,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   if (options.dhparam) {
     const warning = c.context.setDHParam(options.dhparam);
     if (warning)
-      internalUtil.trace(warning);
+      process.emitWarning(warning, 'SecurityWarning');
   }
 
   if (options.crl) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const binding = process.binding('util');
-const prefix = `(${process.release.name}:${process.pid}) `;
 
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
@@ -9,10 +8,6 @@ const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 // The `buffer` module uses this. Defining it here instead of in the public
 // `util` module makes it accessible without having to `require('util')` there.
 exports.customInspectSymbol = Symbol('util.inspect.custom');
-
-exports.trace = function(msg) {
-  console.trace(`${prefix}${msg}`);
-};
 
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -933,7 +933,7 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("DH parameter is less than 1024 bits");
   } else if (size < 2048) {
     args.GetReturnValue().Set(FIXED_ONE_BYTE_STRING(
-        env->isolate(), "WARNING: DH parameter is less than 2048 bits"));
+        env->isolate(), "DH parameter is less than 2048 bits"));
   }
 
   SSL_CTX_set_options(sc->ctx_, SSL_OP_SINGLE_DH_USE);

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -1,3 +1,4 @@
+// Flags: --no-warnings
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -22,6 +23,9 @@ let nsuccess = 0;
 let ntests = 0;
 const ciphers = 'DHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
 
+// Test will emit a warning because the DH parameter size is < 2048 bits
+common.expectWarning('SecurityWarning',
+                     'DH parameter is less than 2048 bits');
 
 function loadDHParam(n) {
   let path = common.fixturesDir;


### PR DESCRIPTION
When a dhparam less than 2048 bits was used, a warning was being printed directly to console.error using an internalUtil.trace function that was not used anywhere else. This replaces it with a proper process warning and removes the internalUtil.trace function.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
tls