### PR TITLE
util, debugger: remove internalUtil.error

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const internalUtil = require('internal/util');
 const util = require('util');
 const path = require('path');
 const net = require('net');
@@ -11,6 +10,11 @@ const inherits = util.inherits;
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 const Buffer = require('buffer').Buffer;
+const prefix = `(${process.release.name}:${process.pid}) `;
+
+function error(msg) {
+  console.error(`${prefix}${msg}`);
+}
 
 exports.start = function(argv, stdin, stdout) {
   argv || (argv = process.argv.slice(2));
@@ -32,8 +36,8 @@ exports.start = function(argv, stdin, stdout) {
   stdin.resume();
 
   process.on('uncaughtException', function(e) {
-    internalUtil.error('There was an internal error in Node\'s debugger. ' +
-                       'Please report this bug.');
+    error('There was an internal error in Node\'s debugger. ' +
+          'Please report this bug.');
     console.error(e.message);
     console.error(e.stack);
     if (interface_.child) interface_.child.kill();
@@ -521,7 +525,7 @@ Client.prototype.mirrorObject = function(handle, depth, cb) {
     cb = cb || function() {};
     this.reqLookup(propertyRefs, function(err, res) {
       if (err) {
-        internalUtil.error('problem with reqLookup');
+        error('problem with reqLookup');
         cb(null, handle);
         return;
       }
@@ -1672,7 +1676,7 @@ Interface.prototype.trySpawn = function(cb) {
         process._debugProcess(pid);
       } catch (e) {
         if (e.code === 'ESRCH') {
-          internalUtil.error(`Target process: ${pid} doesn't exist.`);
+          error(`Target process: ${pid} doesn't exist.`);
           process.exit(1);
         }
         throw e;
@@ -1741,7 +1745,7 @@ Interface.prototype.trySpawn = function(cb) {
   function connectError() {
     // If it's failed to connect 10 times then print failed message
     if (connectionAttempts >= 10) {
-      internalUtil.error(' failed to connect, please retry');
+      error(' failed to connect, please retry');
       process.exit(1);
     }
     setTimeout(attemptConnect, 500);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -16,19 +16,6 @@ exports.deprecate = function(fn, msg, code) {
   return exports._deprecate(fn, msg, code);
 };
 
-exports.error = function(msg) {
-  const fmt = `${prefix}${msg}`;
-  if (arguments.length > 1) {
-    const args = new Array(arguments.length);
-    args[0] = fmt;
-    for (var i = 1; i < arguments.length; ++i)
-      args[i] = arguments[i];
-    console.error.apply(console, args);
-  } else {
-    console.error(fmt);
-  }
-};
-
 exports.trace = function(msg) {
   console.trace(`${prefix}${msg}`);
 };

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -4,7 +4,6 @@
 const common = require('../common');
 const path = require('path');
 const assert = require('assert');
-const spawnSync = require('child_process').spawnSync;
 
 const binding = process.binding('util');
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
@@ -59,12 +58,3 @@ try {
 }
 
 assert(/bad_syntax\.js:1/.test(arrowMessage));
-
-const args = [
-  '--expose-internals',
-  '-e',
-  "require('internal/util').error('foo %d', 5)"
-];
-const result = spawnSync(process.argv[0], args, { encoding: 'utf8' });
-assert.strictEqual(result.stderr.indexOf('%'), -1);
-assert(/foo 5/.test(result.stderr));


### PR DESCRIPTION
The internalUtil.error() function was only used by _debugger.js.

Remove it!

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

util, debugger