### PR TITLE
util: cleanup internalUtil.deprecate

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -10,12 +10,6 @@ const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 // `util` module makes it accessible without having to `require('util')` there.
 exports.customInspectSymbol = Symbol('util.inspect.custom');
 
-// All the internal deprecations have to use this function only, as this will
-// prepend the prefix to the actual message.
-exports.deprecate = function(fn, msg, code) {
-  return exports._deprecate(fn, msg, code);
-};
-
 exports.trace = function(msg) {
   console.trace(`${prefix}${msg}`);
 };
@@ -23,11 +17,11 @@ exports.trace = function(msg) {
 // Mark that a method should not be used.
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
-exports._deprecate = function(fn, msg, code) {
+exports.deprecate = function deprecate(fn, msg, code) {
   // Allow for deprecating things in the process of starting up.
   if (global.process === undefined) {
     return function() {
-      return exports._deprecate(fn, msg).apply(this, arguments);
+      return exports.deprecate(fn, msg, code).apply(this, arguments);
     };
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,7 +96,7 @@ exports.format = function(f) {
 };
 
 
-exports.deprecate = internalUtil._deprecate;
+exports.deprecate = internalUtil.deprecate;
 
 
 var debugs = {};


### PR DESCRIPTION
There were two functions `deprecate` and `_deprecate` that were really just aliases of each other. Simplify

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
internal util