### PR TITLE
util: eliminate unnecessary exports

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -6,9 +6,6 @@ const prefix = `(${process.release.name}:${process.pid}) `;
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 
-exports.getHiddenValue = binding.getHiddenValue;
-exports.setHiddenValue = binding.setHiddenValue;
-
 // The `buffer` module uses this. Defining it here instead of in the public
 // `util` module makes it accessible without having to `require('util')` there.
 exports.customInspectSymbol = Symbol('util.inspect.custom');
@@ -84,14 +81,14 @@ exports._deprecate = function(fn, msg, code) {
 
 exports.decorateErrorStack = function decorateErrorStack(err) {
   if (!(exports.isError(err) && err.stack) ||
-      exports.getHiddenValue(err, kDecoratedPrivateSymbolIndex) === true)
+      binding.getHiddenValue(err, kDecoratedPrivateSymbolIndex) === true)
     return;
 
-  const arrow = exports.getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
+  const arrow = binding.getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
 
   if (arrow) {
     err.stack = arrow + err.stack;
-    exports.setHiddenValue(err, kDecoratedPrivateSymbolIndex, true);
+    binding.setHiddenValue(err, kDecoratedPrivateSymbolIndex, true);
   }
 };
 

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -10,16 +10,18 @@ const path = require('path');
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 
+const decorateErrorStack = internalUtil.decorateErrorStack;
+
 assert.doesNotThrow(function() {
-  internalUtil.decorateErrorStack();
-  internalUtil.decorateErrorStack(null);
-  internalUtil.decorateErrorStack(1);
-  internalUtil.decorateErrorStack(true);
+  decorateErrorStack();
+  decorateErrorStack(null);
+  decorateErrorStack(1);
+  decorateErrorStack(true);
 });
 
 // Verify that a stack property is not added to non-Errors
 const obj = {};
-internalUtil.decorateErrorStack(obj);
+decorateErrorStack(obj);
 assert.strictEqual(obj.stack, undefined);
 
 // Verify that the stack is decorated when possible
@@ -43,8 +45,8 @@ assert(typeof err, 'object');
 checkStack(err.stack);
 
 // Verify that the stack is only decorated once
-internalUtil.decorateErrorStack(err);
-internalUtil.decorateErrorStack(err);
+decorateErrorStack(err);
+decorateErrorStack(err);
 checkStack(err.stack);
 
 // Verify that the stack is only decorated once for uncaught exceptions
@@ -58,7 +60,7 @@ checkStack(result.stderr);
 // Verify that the stack is unchanged when there is no arrow message
 err = new Error('foo');
 let originalStack = err.stack;
-internalUtil.decorateErrorStack(err);
+decorateErrorStack(err);
 assert.strictEqual(originalStack, err.stack);
 
 // Verify that the arrow message is added to the start of the stack when it
@@ -67,9 +69,9 @@ const arrowMessage = 'arrow_message';
 err = new Error('foo');
 originalStack = err.stack;
 
-internalUtil.setHiddenValue(err, kArrowMessagePrivateSymbolIndex, arrowMessage);
-internalUtil.decorateErrorStack(err);
+binding.setHiddenValue(err, kArrowMessagePrivateSymbolIndex, arrowMessage);
+decorateErrorStack(err);
 
 assert.strictEqual(err.stack, `${arrowMessage}${originalStack}`);
-assert.strictEqual(internalUtil
-  .getHiddenValue(err, kDecoratedPrivateSymbolIndex), true);
+assert.strictEqual(
+  binding.getHiddenValue(err, kDecoratedPrivateSymbolIndex), true);

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -4,7 +4,6 @@
 const common = require('../common');
 const path = require('path');
 const assert = require('assert');
-const internalUtil = require('internal/util');
 const spawnSync = require('child_process').spawnSync;
 
 const binding = process.binding('util');
@@ -12,13 +11,13 @@ const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 
 function getHiddenValue(obj, index) {
   return function() {
-    internalUtil.getHiddenValue(obj, index);
+    binding.getHiddenValue(obj, index);
   };
 }
 
 function setHiddenValue(obj, index, val) {
   return function() {
-    internalUtil.setHiddenValue(obj, index, val);
+    binding.setHiddenValue(obj, index, val);
   };
 }
 
@@ -31,7 +30,7 @@ assert.throws(getHiddenValue({}), /index must be an uint32/);
 assert.throws(getHiddenValue({}, null), /index must be an uint32/);
 assert.throws(getHiddenValue({}, []), /index must be an uint32/);
 assert.deepStrictEqual(
-    internalUtil.getHiddenValue({}, kArrowMessagePrivateSymbolIndex),
+    binding.getHiddenValue({}, kArrowMessagePrivateSymbolIndex),
     undefined);
 
 assert.throws(setHiddenValue(), /obj must be an object/);
@@ -44,10 +43,10 @@ assert.throws(setHiddenValue({}, null), /index must be an uint32/);
 assert.throws(setHiddenValue({}, []), /index must be an uint32/);
 const obj = {};
 assert.strictEqual(
-    internalUtil.setHiddenValue(obj, kArrowMessagePrivateSymbolIndex, 'bar'),
+    binding.setHiddenValue(obj, kArrowMessagePrivateSymbolIndex, 'bar'),
     true);
 assert.strictEqual(
-    internalUtil.getHiddenValue(obj, kArrowMessagePrivateSymbolIndex),
+    binding.getHiddenValue(obj, kArrowMessagePrivateSymbolIndex),
     'bar');
 
 let arrowMessage;
@@ -56,7 +55,7 @@ try {
   require(path.join(common.fixturesDir, 'syntax', 'bad_syntax'));
 } catch (err) {
   arrowMessage =
-      internalUtil.getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
+      binding.getHiddenValue(err, kArrowMessagePrivateSymbolIndex);
 }
 
 assert(/bad_syntax\.js:1/.test(arrowMessage));


### PR DESCRIPTION
The getHiddenValue and setHiddenValue functions are exported from internalUtil for no really good reason

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
internal util