### PR TITLE
tty: avoid oob warning in TTYWrap::GetWindowSize()

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -55,7 +55,7 @@ function WriteStream(fd) {
   // Ref: https://github.com/nodejs/node/pull/1771#issuecomment-119351671
   this._handle.setBlocking(process.env.NODE_TTY_UNSAFE_ASYNC !== '1');
 
-  var winSize = [];
+  var winSize = new Array(2);
   var err = this._handle.getWindowSize(winSize);
   if (!err) {
     this.columns = winSize[0];
@@ -72,7 +72,7 @@ WriteStream.prototype.isTTY = true;
 WriteStream.prototype._refreshSize = function() {
   var oldCols = this.columns;
   var oldRows = this.rows;
-  var winSize = [];
+  var winSize = new Array(2);
   var err = this._handle.getWindowSize(winSize);
   if (err) {
     this.emit('error', errnoException(err, 'getWindowSize'));


### PR DESCRIPTION
If we run node with flag `--trace_array_abuse`, we will see many warnings like  

```
[OOB array elements write (array length = 1, element accessed = 1) in new ~WriteStream+877 at tty.js:59]
```

These logs generated by [`CheckArrayAbuse`](https://github.com/nodejs/node/blob/d0d02b6c88ce41958df068f59e9e2699645e5dda/deps/v8/src/objects.cc#L4951). If we set env `NODE_DEBUG`, we get these messages for `tty` module. Other warnings generated from [process.binding](https://github.com/nodejs/node/blob/d0d02b6c88ce41958df068f59e9e2699645e5dda/src/node.cc#L2644) and [StackPush](https://github.com/nodejs/node/blob/d0d02b6c88ce41958df068f59e9e2699645e5dda/deps/v8/src/js/array.js#L116)

##### Step to reproduce:

```sh
NODE_DEBUG=module node --trace_array_abuse -e ''
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
tty
