### PR TITLE
util: eliminate unecessary internal/util export

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -96,11 +96,8 @@ exports.decorateErrorStack = function decorateErrorStack(err) {
 };
 
 exports.isError = function isError(e) {
-  return exports.objectToString(e) === '[object Error]' || e instanceof Error;
-};
-
-exports.objectToString = function objectToString(o) {
-  return Object.prototype.toString.call(o);
+  return Object.prototype.toString.call(e) === '[object Error]' ||
+         e instanceof Error;
 };
 
 const noCrypto = !process.versions.openssl;


### PR DESCRIPTION
The objectToString method was only being used in one place
within internalUtil. It didn't make sense to have it as
a separate exported mnethod.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
internal util