### PR TITLE
tools: enable one-var-declaration-per-line ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -103,6 +103,7 @@ rules:
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]
   no-tabs: 2
   no-trailing-spaces: 2
+  one-var-declaration-per-line: 2
   operator-linebreak: [2, after]
   quotes: [2, single, avoid-escape]
   semi: 2

--- a/benchmark/domain/domain-fn-args.js
+++ b/benchmark/domain/domain-fn-args.js
@@ -12,14 +12,14 @@ var gargs = [1, 2, 3];
 
 function main(conf) {
 
-  var args, n = +conf.n;
+  var n = +conf.n;
   var myArguments = gargs.slice(0, conf.arguments);
   bench.start();
 
   bdomain.enter();
   for (var i = 0; i < n; i++) {
     if (myArguments.length >= 2) {
-      args = Array.prototype.slice.call(myArguments, 1);
+      var args = Array.prototype.slice.call(myArguments, 1);
       fn.apply(this, args);
     } else {
       fn.call(this);

--- a/benchmark/es/destructuring-bench.js
+++ b/benchmark/es/destructuring-bench.js
@@ -9,9 +9,9 @@ const bench = common.createBenchmark(main, {
 });
 
 function runSwapManual(n) {
-  var i = 0, x, y, r;
+  var x, y, r;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < n; i++) {
     x = 1, y = 2;
     r = x;
     x = y;
@@ -23,9 +23,9 @@ function runSwapManual(n) {
 }
 
 function runSwapDestructured(n) {
-  var i = 0, x, y;
+  var x, y;
   bench.start();
-  for (; i < n; i++) {
+  for (var i = 0; i < n; i++) {
     x = 1, y = 2;
     [x, y] = [y, x];
     assert.strictEqual(x, 2);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -126,7 +126,8 @@ exports.exec = function(command /*, options, callback*/) {
 
 
 exports.execFile = function(file /*, args, options, callback*/) {
-  var args = [], callback;
+  var args = [];
+  var callback;
   var options = {
     encoding: 'utf8',
     timeout: 0,

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -427,9 +427,9 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
         if (!maxColumns || maxColumns === Infinity) {
           maxColumns = 1;
         }
-        var group = [], c;
+        var group = [];
         for (var i = 0, compLen = completions.length; i < compLen; i++) {
-          c = completions[i];
+          var c = completions[i];
           if (c === '') {
             handleGroup(self, group, width, maxColumns);
             group = [];

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -266,7 +266,9 @@ function REPLServer(prompt,
     code = code.replace(/\n$/, '');
     code = preprocess(code);
 
-    var err, result, retry = false, input = code, wrappedErr;
+    var retry = false;
+    var input = code;
+    var err, result, wrappedErr;
     // first, create the Script object to check the syntax
 
     if (code === '\n')

--- a/lib/util.js
+++ b/lib/util.js
@@ -413,8 +413,10 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
-  var base = '', empty = false, braces;
+  var base = '';
+  var empty = false;
   var formatter = formatObject;
+  var braces;
 
   // We can't compare constructors for various objects using a comparison like
   // `constructor === Array` because the object could have come from a different

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -97,9 +97,9 @@ if (process.argv[2] === 'child') {
   let disconnected = 0;
   server.on('listening', function() {
 
-    let j = count, client;
+    let j = count;
     while (j--) {
-      client = net.connect(this.address().port, '127.0.0.1');
+      const client = net.connect(this.address().port, '127.0.0.1');
       client.on('error', function() {
         // This can happen if we kill the child too early.
         // The client should still get a close event afterwards.

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -4,7 +4,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
-let async_completed = 0, async_expected = 0;
+let async_completed = 0;
+let async_expected = 0;
 const unlink = [];
 let skipSymlinks = false;
 

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -16,7 +16,8 @@ const image = fs.readFileSync(common.fixturesDir + '/person.jpg');
 console.log('image.length = ' + image.length);
 
 const total = 10;
-let requests = 0, responses = 0;
+let requests = 0;
+let responses = 0;
 
 const server = http.Server(function(req, res) {
   if (++requests === total) {

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -15,7 +15,8 @@ port = port.port;
 
 server.listen(128);
 
-let sliceCount = 0, eofCount = 0;
+let sliceCount = 0;
+let eofCount = 0;
 
 let writeCount = 0;
 let recvCount = 0;

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -36,7 +36,8 @@ assert.strictEqual(m.search, `?${serialized}`);
 
 assert.strictEqual(sp[Symbol.iterator], sp.entries);
 
-let key, val, n = 0;
+let key, val;
+let n = 0;
 for ([key, val] of sp) {
   assert.strictEqual(key, 'a');
   assert.strictEqual(val, String(values[n++]));

--- a/test/pummel/test-net-pause.js
+++ b/test/pummel/test-net-pause.js
@@ -4,7 +4,8 @@ const assert = require('assert');
 const net = require('net');
 
 const N = 200;
-let recv = '', chars_recved = 0;
+let recv = '';
+let chars_recved = 0;
 
 const server = net.createServer(function(connection) {
   function write(j) {


### PR DESCRIPTION
This rule enforces new lines around variable declarations. It is
configured to spot only variables that are initialized.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark, lib, test, tools