### PR TITLE
src: clean up MaybeStackBuffer usage in i18n

### DIFF
--- a/benchmark/url/whatwg-url-idna.js
+++ b/benchmark/url/whatwg-url-idna.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common.js');
+const { domainToASCII, domainToUnicode } = require('url');
+
+const inputs = {
+  empty: {
+    ascii: '',
+    unicode: ''
+  },
+  none: {
+    ascii: 'passports',
+    unicode: 'passports'
+  },
+  some: {
+    ascii: 'Paßstraße',
+    unicode: 'xn--Pastrae-1vae'
+  },
+  all: {
+    ascii: '他们不说中文',
+    unicode: 'xn--ihqwczyycu19kkg2c'
+  },
+  nonstring: {
+    ascii: { toString() { return ''; } },
+    unicode: { toString() { return ''; } }
+  }
+};
+
+const bench = common.createBenchmark(main, {
+  input: Object.keys(inputs),
+  to: ['ascii', 'unicode'],
+  n: [5e6]
+});
+
+function main(conf) {
+  const n = conf.n | 0;
+  const to = conf.to;
+  const input = inputs[conf.input][to];
+  const method = to === 'ascii' ? domainToASCII : domainToUnicode;
+
+  common.v8ForceOptimization(method, input);
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    method(input);
+  }
+  bench.end(n);
+}

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -204,6 +204,35 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
 // because ArrayBufferAllocator::Free() deallocates it again with free().
 // Mixing operator new and free() is undefined behavior so don't do that.
 v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
+
+// Construct a Buffer from a MaybeStackBuffer (and also its subclasses like
+// Utf8Value and TwoByteValue).
+// If |buf| is invalidated, an empty MaybeLocal is returned, and nothing is
+// changed.
+// If |buf| contains actual data, this method takes ownership of |buf|'s
+// underlying buffer. However, |buf| itself can be reused even after this call,
+// but its capacity, if increased through AllocateSufficientStorage, is not
+// guaranteed to stay the same.
+template <typename T>
+static v8::MaybeLocal<v8::Object> New(Environment* env,
+                                      MaybeStackBuffer<T>* buf) {
+  v8::MaybeLocal<v8::Object> ret;
+  char* src = reinterpret_cast<char*>(buf->out());
+  const size_t len_in_bytes = buf->length() * sizeof(buf->out()[0]);
+
+  if (buf->IsAllocated())
+    ret = New(env, src, len_in_bytes);
+  else if (!buf->IsInvalidated())
+    ret = Copy(env, src, len_in_bytes);
+
+  if (ret.IsEmpty())
+    return ret;
+
+  if (buf->IsAllocated())
+    buf->Release();
+
+  return ret;
+}
 }  // namespace Buffer
 
 }  // namespace node

--- a/src/util.h
+++ b/src/util.h
@@ -394,7 +394,7 @@ class BufferValue : public MaybeStackBuffer<char> {
 
 #define SPREAD_BUFFER_ARG(val, name)                                          \
   CHECK((val)->IsUint8Array());                                               \
-  Local<v8::Uint8Array> name = (val).As<v8::Uint8Array>();                    \
+  v8::Local<v8::Uint8Array> name = (val).As<v8::Uint8Array>();                \
   v8::ArrayBuffer::Contents name##_c = name->Buffer()->GetContents();         \
   const size_t name##_offset = name->ByteOffset();                            \
   const size_t name##_length = name->ByteLength();                            \

--- a/src/util.h
+++ b/src/util.h
@@ -331,13 +331,13 @@ class MaybeStackBuffer {
   }
 
   void SetLength(size_t length) {
-    // capacity_ stores how much memory was allocated.
+    // capacity() returns how much memory is actually available.
     CHECK_LE(length, capacity());
     length_ = length;
   }
 
   void SetLengthAndZeroTerminate(size_t length) {
-    // length_ stores how much memory was allocated.
+    // capacity() returns how much memory is actually available.
     CHECK_LE(length + 1, capacity());
     SetLength(length);
 

--- a/src/util.h
+++ b/src/util.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <type_traits>  // std::remove_reference
 
@@ -304,29 +305,40 @@ class MaybeStackBuffer {
     return length_;
   }
 
-  // Call to make sure enough space for `storage` entries is available.
-  // There can only be 1 call to AllocateSufficientStorage or Invalidate
-  // per instance.
+  // Current maximum capacity of the buffer with which SetLength() can be used
+  // without first calling AllocateSufficientStorage().
+  size_t capacity() const {
+    return IsAllocated() ? capacity_ :
+                           IsInvalidated() ? 0 : kStackStorageSize;
+  }
+
+  // Make sure enough space for `storage` entries is available.
+  // This method can be called multiple times throughout the lifetime of the
+  // buffer, but once this has been called Invalidate() cannot be used.
+  // Content of the buffer in the range [0, length()) is preserved.
   void AllocateSufficientStorage(size_t storage) {
-    if (storage <= kStackStorageSize) {
-      buf_ = buf_st_;
-    } else {
-      buf_ = Malloc<T>(storage);
+    CHECK(!IsInvalidated());
+    if (storage > capacity()) {
+      bool was_allocated = IsAllocated();
+      T* allocated_ptr = was_allocated ? buf_ : nullptr;
+      buf_ = Realloc(allocated_ptr, storage);
+      capacity_ = storage;
+      if (!was_allocated && length_ > 0)
+        memcpy(buf_, buf_st_, length_ * sizeof(buf_[0]));
     }
 
-    // Remember how much was allocated to check against that in SetLength().
     length_ = storage;
   }
 
   void SetLength(size_t length) {
-    // length_ stores how much memory was allocated.
-    CHECK_LE(length, length_);
+    // capacity_ stores how much memory was allocated.
+    CHECK_LE(length, capacity());
     length_ = length;
   }
 
   void SetLengthAndZeroTerminate(size_t length) {
     // length_ stores how much memory was allocated.
-    CHECK_LE(length + 1, length_);
+    CHECK_LE(length + 1, capacity());
     SetLength(length);
 
     // T() is 0 for integer types, nullptr for pointers, etc.
@@ -334,24 +346,35 @@ class MaybeStackBuffer {
   }
 
   // Make derefencing this object return nullptr.
-  // Calling this is mutually exclusive with calling
-  // AllocateSufficientStorage.
+  // This method can be called multiple times throughout the lifetime of the
+  // buffer, but once this has been called AllocateSufficientStorage() cannot
+  // be used.
   void Invalidate() {
-    CHECK_EQ(buf_, buf_st_);
+    CHECK(!IsAllocated());
     length_ = 0;
     buf_ = nullptr;
   }
 
-  bool IsAllocated() {
-    return buf_ != buf_st_;
+  // If the buffer is stored in the heap rather than on the stack.
+  bool IsAllocated() const {
+    return !IsInvalidated() && buf_ != buf_st_;
   }
 
+  // If Invalidate() has been called.
+  bool IsInvalidated() const {
+    return buf_ == nullptr;
+  }
+
+  // Release ownership of the malloc'd buffer.
+  // Note: This does not free the buffer.
   void Release() {
+    CHECK(IsAllocated());
     buf_ = buf_st_;
     length_ = 0;
+    capacity_ = 0;
   }
 
-  MaybeStackBuffer() : length_(0), buf_(buf_st_) {
+  MaybeStackBuffer() : length_(0), capacity_(0), buf_(buf_st_) {
     // Default to a zero-length, null-terminated buffer.
     buf_[0] = T();
   }
@@ -361,12 +384,14 @@ class MaybeStackBuffer {
   }
 
   ~MaybeStackBuffer() {
-    if (buf_ != buf_st_)
+    if (IsAllocated())
       free(buf_);
   }
 
  private:
   size_t length_;
+  // capacity of the malloc'ed buf_
+  size_t capacity_;
   T* buf_;
   T buf_st_[kStackStorageSize];
 };

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -132,3 +132,127 @@ TEST(UtilTest, UncheckedCalloc) {
   TEST_AND_FREE(UncheckedCalloc(0));
   TEST_AND_FREE(UncheckedCalloc(1));
 }
+
+template <typename T>
+static void MaybeStackBufferBasic() {
+  using node::MaybeStackBuffer;
+
+  MaybeStackBuffer<T> buf;
+  size_t old_length;
+  size_t old_capacity;
+
+  /* Default constructor */
+  EXPECT_EQ(0U, buf.length());
+  EXPECT_FALSE(buf.IsAllocated());
+  EXPECT_GT(buf.capacity(), buf.length());
+
+  /* SetLength() expansion */
+  buf.SetLength(buf.capacity());
+  EXPECT_EQ(buf.capacity(), buf.length());
+  EXPECT_FALSE(buf.IsAllocated());
+
+  /* Means of accessing raw buffer */
+  EXPECT_EQ(buf.out(), *buf);
+  EXPECT_EQ(&buf[0], *buf);
+
+  /* Basic I/O */
+  for (size_t i = 0; i < buf.length(); i++)
+    buf[i] = static_cast<T>(i);
+  for (size_t i = 0; i < buf.length(); i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+
+  /* SetLengthAndZeroTerminate() */
+  buf.SetLengthAndZeroTerminate(buf.capacity() - 1);
+  EXPECT_EQ(buf.capacity() - 1, buf.length());
+  for (size_t i = 0; i < buf.length(); i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+  buf.SetLength(buf.capacity());
+  EXPECT_EQ(0, buf[buf.length() - 1]);
+
+  /* Initial Realloc */
+  old_length = buf.length() - 1;
+  old_capacity = buf.capacity();
+  buf.AllocateSufficientStorage(buf.capacity() * 2);
+  EXPECT_EQ(buf.capacity(), buf.length());
+  EXPECT_TRUE(buf.IsAllocated());
+  for (size_t i = 0; i < old_length; i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+  EXPECT_EQ(0, buf[old_length]);
+
+  /* SetLength() reduction and expansion */
+  for (size_t i = 0; i < buf.length(); i++)
+    buf[i] = static_cast<T>(i);
+  buf.SetLength(10);
+  for (size_t i = 0; i < buf.length(); i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+  buf.SetLength(buf.capacity());
+  for (size_t i = 0; i < buf.length(); i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+
+  /* Subsequent Realloc */
+  old_length = buf.length();
+  old_capacity = buf.capacity();
+  buf.AllocateSufficientStorage(old_capacity * 1.5);
+  EXPECT_EQ(buf.capacity(), buf.length());
+  EXPECT_EQ(static_cast<size_t>(old_capacity * 1.5), buf.length());
+  EXPECT_TRUE(buf.IsAllocated());
+  for (size_t i = 0; i < old_length; i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+
+  /* Basic I/O on Realloc'd buffer */
+  for (size_t i = 0; i < buf.length(); i++)
+    buf[i] = static_cast<T>(i);
+  for (size_t i = 0; i < buf.length(); i++)
+    EXPECT_EQ(static_cast<T>(i), buf[i]);
+
+  /* Release() */
+  T* rawbuf = buf.out();
+  buf.Release();
+  EXPECT_EQ(0U, buf.length());
+  EXPECT_FALSE(buf.IsAllocated());
+  EXPECT_GT(buf.capacity(), buf.length());
+  free(rawbuf);
+}
+
+TEST(UtilTest, MaybeStackBuffer) {
+  using node::MaybeStackBuffer;
+
+  MaybeStackBufferBasic<uint8_t>();
+  MaybeStackBufferBasic<uint16_t>();
+
+  // Constructor with size parameter
+  {
+    MaybeStackBuffer<unsigned char> buf(100);
+    EXPECT_EQ(100U, buf.length());
+    EXPECT_FALSE(buf.IsAllocated());
+    EXPECT_GT(buf.capacity(), buf.length());
+    buf.SetLength(buf.capacity());
+    EXPECT_EQ(buf.capacity(), buf.length());
+    EXPECT_FALSE(buf.IsAllocated());
+    for (size_t i = 0; i < buf.length(); i++)
+      buf[i] = static_cast<unsigned char>(i);
+    for (size_t i = 0; i < buf.length(); i++)
+      EXPECT_EQ(static_cast<unsigned char>(i), buf[i]);
+
+    MaybeStackBuffer<unsigned char> bigbuf(10000);
+    EXPECT_EQ(10000U, bigbuf.length());
+    EXPECT_TRUE(bigbuf.IsAllocated());
+    EXPECT_EQ(bigbuf.length(), bigbuf.capacity());
+    for (size_t i = 0; i < bigbuf.length(); i++)
+      bigbuf[i] = static_cast<unsigned char>(i);
+    for (size_t i = 0; i < bigbuf.length(); i++)
+      EXPECT_EQ(static_cast<unsigned char>(i), bigbuf[i]);
+  }
+
+  // Invalidated buffer
+  {
+    MaybeStackBuffer<char> buf;
+    buf.Invalidate();
+    EXPECT_TRUE(buf.IsInvalidated());
+    EXPECT_FALSE(buf.IsAllocated());
+    EXPECT_EQ(0U, buf.length());
+    EXPECT_EQ(0U, buf.capacity());
+    buf.Invalidate();
+    EXPECT_TRUE(buf.IsInvalidated());
+  }
+}

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -22,9 +22,9 @@ const tests = {
 
 for (const test in tests) {
   const dest = buffer.transcode(orig, 'utf8', test);
-  assert.strictEqual(dest.length, tests[test].length);
+  assert.strictEqual(dest.length, tests[test].length, `utf8->${test} length`);
   for (let n = 0; n < tests[test].length; n++)
-    assert.strictEqual(dest[n], tests[test][n]);
+    assert.strictEqual(dest[n], tests[test][n], `utf8->${test} char ${n}`);
 }
 
 {


### PR DESCRIPTION
This PR can roughly be divided into two parts. It first cleans up `MaybeStackBuffer` itself:

- Make `IsAllocated()` work for invalidated buffers
- Add `capacity()` method for finding out the actual capacity, not the   current size, of the buffer
- Allow multiple calls to `AllocateSufficientStorage()` and `Invalidate()`
- Add more descriptive comments describing the purpose of the methods
- Assert buffer is malloc'd in `Release()`

Then, it aims to make the usage of `MaybeStackBuffer` in `node_i18n` more orthodox:

- Templatize `MaybeStackBuffer<T>`-to`Buffer` conversion function (`AsBuffer()`) and move it to `Buffer` namespace as a private constructor
  - The original plan was to move it to `MaybeStackBuffer`, but there are multiple problems in doing that due to header/class dependency. On the other hand, `Buffer` is as good as a home for the function as any.
- Use the new `MaybeStackBuffer::storage()` instead of defining its own version of `kStackStorageSize` (which may get out of sync with the official one in `MaybeStackBuffer`)
- Instead of requiring a `len` parameter to `AsBuffer()`, use `MaybeStackBuffer::SetLength()` uniformly
- If possible, avoid double conversion in `ToASCII()`/`ToUnicode()`

That last bullet point brings a nice performance enhancement for `url.domainToASCII()`/`domainToUnicode()` with short strings (`n` reduced to 1×10<sup>6</sup> since this method is not as susceptible to JIT fluctuations):

```
                                                                 improvement confidence      p.value
 url/whatwg-url-idna.js n=1000000 to="ascii" input="all"             45.22 %        *** 1.498146e-11
 url/whatwg-url-idna.js n=1000000 to="ascii" input="empty"            1.51 %            3.121468e-01
 url/whatwg-url-idna.js n=1000000 to="ascii" input="none"             9.04 %        *** 5.434629e-06
 url/whatwg-url-idna.js n=1000000 to="ascii" input="nonstring"        0.45 %            8.529213e-01
 url/whatwg-url-idna.js n=1000000 to="ascii" input="some"            42.67 %        *** 9.040307e-15
 url/whatwg-url-idna.js n=1000000 to="unicode" input="all"           58.61 %        *** 3.859159e-16
 url/whatwg-url-idna.js n=1000000 to="unicode" input="empty"         -1.54 %            6.379120e-01
 url/whatwg-url-idna.js n=1000000 to="unicode" input="none"          10.67 %        *** 5.320423e-08
 url/whatwg-url-idna.js n=1000000 to="unicode" input="nonstring"     -0.90 %            5.238741e-01
 url/whatwg-url-idna.js n=1000000 to="unicode" input="some"          56.80 %        *** 8.087484e-16
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src