### PR TITLE
build: fix newlines in addon build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ test/addons/.buildstamp: config.gypi \
 #	Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 #	embedded addons have been generated from the documentation.
 	@for dirname in test/addons/*/; do \
-		echo "\nBuilding addon $$PWD/$$dirname" ; \
+		printf "\nBuilding addon $$PWD/$$dirname\n" ; \
 		env MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
 		        --loglevel=$(LOGLEVEL) rebuild \
 			--python="$(PYTHON)" \


### PR DESCRIPTION
Interpretation of escape sequences with echo is not as consistent across platforms as printf, so use the latter instead.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* build
