### PR TITLE
test: add support for --gtest_filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ STAGINGSERVER ?= node-www
 LOGLEVEL ?= silent
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
 COVTESTS ?= test
+GTEST_FILTER ?= "*"
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)
@@ -178,7 +179,13 @@ coverage-test: coverage-build
 		| sed 's/<[^>]*>//g'| sed 's/ //g'
 
 cctest: all
-	@out/$(BUILDTYPE)/$@
+	@out/$(BUILDTYPE)/$@ --gtest_filter=$(GTEST_FILTER)
+
+list-gtests:
+ifeq (,$(wildcard out/$(BUILDTYPE)/cctest))
+	$(error Please run 'make cctest' first)
+endif
+	@out/$(BUILDTYPE)/cctest --gtest_list_tests
 
 v8:
 	tools/make-v8.sh
@@ -846,4 +853,4 @@ endif
 	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
 	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci doc-only \
 	$(TARBALL)-headers test-ci test-ci-native test-ci-js build-ci clear-stalled \
-	coverage-clean coverage-build coverage-test coverage
+	coverage-clean coverage-build coverage-test coverage list-gtests


### PR DESCRIPTION
It might be useful to sometimes run a single cctest while debugging/
developing. This commit adds support for Google Test's --gtest_filter
to enable this.

To list the tests available:
```shell
$ make list-gtests
UtilTest.
  ListHead
  StringEqualNoCase
  StringEqualNoCaseN
  ToLower
  Malloc
  Calloc
  UncheckedMalloc
  UncheckedCalloc
InspectorSocketTest.
  ReadsAndWritesInspectorMessage
  BufferEdgeCases
  AcceptsRequestInSeveralWrites
  ExtraTextBeforeRequest
  ExtraLettersBeforeRequest
  RequestWithoutKey
  KillsConnectionOnProtocolViolation
  CanStopReadingFromInspector
  CloseDoesNotNotifyReadCallback
  CloseWorksWithoutReadEnabled
  ReportsHttpGet
  HandshakeCanBeCanceled
  GetThenHandshake
  WriteBeforeHandshake
  CleanupSocketAfterEOF
  EOFBeforeHandshake
  Send1Mb
  ErrorCleansUpTheSocket
InspectorSocketServerTest.
  InspectorSessions
  ServerDoesNothing
  ServerWithoutTargets
  ServerCannotStart
  StoppingServerDoesNotKillConnections
```
Then run a single test:
```shell
$ env GTEST_FILTER=InspectorSocketTest.GetThenHandshake make cctest

Note: Google Test filter = InspectorSocketTest.GetThenHandshake
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from InspectorSocketTest
[ RUN      ] InspectorSocketTest.GetThenHandshake
[       OK ] InspectorSocketTest.GetThenHandshake (0 ms)
[----------] 1 test from InspectorSocketTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (0 ms total)
[  PASSED  ] 1 test.
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test