### PR TITLE
test: add two test cases for querystring

### DIFF
--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -288,6 +288,11 @@ assert.strictEqual(
     Object.keys(qs.parse('a=1&b=1&c=1', null, null, { maxKeys: 1 })).length,
     1);
 
+// Test limiting with a case that starts from `&`
+assert.strictEqual(
+    Object.keys(qs.parse('&a', null, null, { maxKeys: 1 })).length,
+    0);
+
 // Test removing limit
 function testUnlimitedKeys() {
   const query = {};
@@ -334,6 +339,8 @@ assert.strictEqual(qs.unescapeBuffer('a%20').toString(), 'a ');
 assert.strictEqual(qs.unescapeBuffer('a%2g').toString(), 'a%2g');
 assert.strictEqual(qs.unescapeBuffer('a%%').toString(), 'a%%');
 
+// Test invalid encoded string
+check(qs.parse('%\u0100=%\u0101'), { '%Ā': '%ā' });
 
 // Test custom decode
 function demoDecode(str) {


### PR DESCRIPTION
This test will improve `querystring` coverage:
+ https://coverage.nodejs.org/coverage-88035bc60d49b4e5/root/querystring.js.html

The following lines will be called with the cases:
+ https://github.com/nodejs/node/blob/88035bc60d49b4e575f73255d534d01589a209d5/lib/querystring.js#L332
+ https://github.com/nodejs/node/blob/88035bc60d49b4e575f73255d534d01589a209d5/lib/querystring.js#L399

##### Checklist
- [x] `make -j4 test`
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test