### PR TITLE
test: add regex to assert in zlib-write-after-close

### DIFF
--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -6,7 +6,10 @@ const zlib = require('zlib');
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.close(common.mustCall(function() {}));
-  assert.throws(function() {
-    unzip.write(out);
-  });
+  assert.throws(
+    function() {
+      unzip.write(out);
+    },
+    /^Error: zlib binding closed$/
+  );
 }));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -6,10 +6,5 @@ const zlib = require('zlib');
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.close(common.mustCall(function() {}));
-  assert.throws(
-    function() {
-      unzip.write(out);
-    },
-    /^Error: zlib binding closed$/
-  );
+  assert.throws( () => unzip.write(out), /^Error: zlib binding closed$/ );
 }));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -6,5 +6,5 @@ const zlib = require('zlib');
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.close(common.mustCall(function() {}));
-  assert.throws( () => unzip.write(out), /^Error: zlib binding closed$/ );
+  assert.throws(() => unzip.write(out), /^Error: zlib binding closed$/);
 }));


### PR DESCRIPTION
[docs for assert.throws()](https://t.co/tI4bglVVy3) allows the addition of a regular expression argument.

test/parallel/test-zlib-write-after-close.js line 9 contains an assert.throws() call which only has a single argument.

Per NodeToDo have added regex argument to the assert.throws() call to validate received error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test