### PR TITLE
doc,test: args to `buffer.copy` can be Uint8Arrays

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -977,7 +977,7 @@ A `RangeError` will be thrown if: `targetStart < 0`, `sourceStart < 0`,
 added: v0.1.90
 -->
 
-* `target` {Buffer} A `Buffer` to copy into.
+* `target` {Buffer|Uint8Array} A `Buffer` or [`Uint8Array`] to copy into.
 * `targetStart` {Integer} The offset within `target` at which to begin
   copying to. **Default:** `0`
 * `sourceStart` {Integer} The offset within `buf` at which to begin copying from.

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -118,3 +118,29 @@ assert.strictEqual(b.copy(c, 0, 100, 10), 0);
 
 // when targetStart > targetLength, zero copied
 assert.strictEqual(b.copy(c, 512, 0, 10), 0);
+
+// Test that the `target` can be a Uint8Array.
+{
+  const d = new Uint8Array(c);
+  // copy 512 bytes, from 0 to 512.
+  b.fill(++cntr);
+  d.fill(++cntr);
+  const copied = b.copy(d, 0, 0, 512);
+  assert.strictEqual(512, copied);
+  for (let i = 0; i < d.length; i++) {
+    assert.strictEqual(b[i], d[i]);
+  }
+}
+
+// Test that the source can be a Uint8Array, too.
+{
+  const e = new Uint8Array(b);
+  // copy 512 bytes, from 0 to 512.
+  e.fill(++cntr);
+  c.fill(++cntr);
+  const copied = Buffer.prototype.copy.call(e, c, 0, 0, 512);
+  assert.strictEqual(512, copied);
+  for (let i = 0; i < c.length; i++) {
+    assert.strictEqual(e[i], c[i]);
+  }
+}


### PR DESCRIPTION
This was semi-overlooked in https://github.com/nodejs/node/pull/10236 because it always worked and didn’t need additional changes.

Ref: https://github.com/nodejs/node/pull/10236

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer

CI: https://ci.nodejs.org/job/node-test-commit/8059/