### PR TITLE
governance: add Franziska Hinkelmann to the CTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ more information about the governance of the Node.js project, see
 **Colin Ihrig** &lt;cjihrig@gmail.com&gt;
 * [evanlucas](https://github.com/evanlucas) -
 **Evan Lucas** &lt;evanlucas@me.com&gt; (he/him)
+* [fhinkel](https://github.com/fhinkel) -
+**Franziska Hinkelmann** &lt;franziska.hinkelmann@gmail.com&gt;
 * [fishrock123](https://github.com/fishrock123) -
 **Jeremiah Senkpiel** &lt;fishrock123@rocketmail.com&gt;
 * [indutny](https://github.com/indutny) -
@@ -229,8 +231,6 @@ more information about the governance of the Node.js project, see
 **Alexander Makarenko** &lt;estliberitas@gmail.com&gt;
 * [eugeneo](https://github.com/eugeneo) -
 **Eugene Ostroukhov** &lt;eostroukhov@google.com&gt;
-* [fhinkel](https://github.com/fhinkel) -
-**Franziska Hinkelmann** &lt;franziska.hinkelmann@gmail.com&gt;
 * [firedfox](https://github.com/firedfox) -
 **Daniel Wang** &lt;wangyang0123@gmail.com&gt;
 * [geek](https://github.com/geek) -


### PR DESCRIPTION
@fhinkel was nominated privately within the @nodejs/ctc to join as a new member. Both the CTC and Franziska have responded positively so we have moved into the _trial_ phase where she joins the CTC calls as an observer for a few weeks prior to a formal vote. This trial serves the purpose of ensuring that the nominee is happy to proceed and that the CTC is also comfortable with the addition, in practice though it serves mainly as an ease-in process for the nominee and so the CTC doesn't just spring sudden news on @nodejs/collaborators.

Franziska is with the V8 team at Google, working on the V8 API and ES6 performance improvements. She brings some very impressive credentials as a Node.js Collaborator and will make a very valuable CTC addition:
 * Owns the VM module in V8, which is heavily used in Jest and Jsdom & made the necessary API changes in V8 to fix its long standing issues
 * Currently mentoring an Outreachy Node.js student
 * A TC39 attendee, involved in the discussion around ES6 vs CommonJS modules
 * Responsible for the V8-Node integration branch and backports / updates V8 in Node.js.
 * Involved in review of the NAPI proposal and made sure that it works with V8

Voting will likely take place here on GitHub since it's becoming increasingly difficult to gather the globally distributed CTC for real-time meetings, we'll announce that when it happens in a couple of weeks.

As always, we look forward to the benefits that new membership brings to the CTC. It's a fantastic opportunity to broaden our perspective and challenge existing thinking about how things should be done!