### PR TITLE
doc: add per-item changelogs

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -30,6 +30,16 @@ assert(false, 'it\'s false');
 ## assert.deepEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: v6.4.0, v4.7.1
+    pr-url: https://github.com/nodejs/node/pull/8002
+    description: Typed array slices are handled correctly now.
+  - version: v6.1.0, v4.5.0
+    pr-url: https://github.com/nodejs/node/pull/6432
+    description: Objects with circular references can be used as inputs now.
+  - version: v5.10.1, v4.4.3
+    pr-url: https://github.com/nodejs/node/pull/5910
+    description: Handle non-`Uint8Array` typed arrays correctly.
 -->
 
 Tests for deep equality between the `actual` and `expected` parameters.
@@ -91,6 +101,16 @@ parameter is undefined, a default error message is assigned.
 ## assert.deepStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v1.2.0
+changes:
+  - version: v6.4.0, v4.7.1
+    pr-url: https://github.com/nodejs/node/pull/8002
+    description: Typed array slices are handled correctly now.
+  - version: v6.1.0
+    pr-url: https://github.com/nodejs/node/pull/6432
+    description: Objects with circular references can be used as inputs now.
+  - version: v5.10.1, v4.4.3
+    pr-url: https://github.com/nodejs/node/pull/5910
+    description: Handle non-`Uint8Array` typed arrays correctly.
 -->
 
 Generally identical to `assert.deepEqual()` with two exceptions. First,
@@ -115,6 +135,13 @@ parameter is undefined, a default error message is assigned.
 ## assert.doesNotThrow(block[, error][, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: v5.11.0, v4.4.5
+    pr-url: https://github.com/nodejs/node/pull/2407
+    description: The `message` parameter is respected now.
+  - version: v4.2.0
+    pr-url: https://github.com/nodejs/node/pull/3276
+    description: The `error` parameter can now be an arrow function.
 -->
 
 Asserts that the function `block` does not throw an error. See
@@ -402,6 +429,10 @@ If the values are not strictly equal, an `AssertionError` is thrown with a
 ## assert.throws(block[, error][, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: v4.2.0
+    pr-url: https://github.com/nodejs/node/pull/3276
+    description: The `error` parameter can now be an arrow function.
 -->
 
 Expects the function `block` to throw an error.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -138,6 +138,15 @@ extra care *must* be taken in order to avoid introducing security
 vulnerabilities into an application.
 
 ## Buffers and Character Encodings
+<!-- YAML
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7111
+    description: Introduced `latin1` as an alias for `binary`.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2859
+    description: Removed the deprecated `raw` and `raws` encodings.
+-->
 
 `Buffer` instances are commonly used to represent sequences of encoded characters
 such as UTF-8, UCS2, Base64 or even Hex-encoded data. It is possible to
@@ -188,6 +197,12 @@ that the server actually returned win-1252-encoded data, and using `'latin1'`
 encoding may incorrectly decode the characters.
 
 ## Buffers and TypedArray
+<!-- YAML
+changes:
+  - version: v3.0.0
+    pr-url: https://github.com/nodejs/node/pull/2002
+    description: The `Buffer`s class now inherits from `Uint8Array`.
+-->
 
 `Buffer` instances are also [`Uint8Array`] instances. However, there are subtle
 incompatibilities with the TypedArray specification in ECMAScript 2015.
@@ -298,6 +313,13 @@ It can be constructed in a variety of ways.
 ### new Buffer(array)
 <!-- YAML
 deprecated: v6.0.0
+changes:
+  - version: v7.2.1
+    pr-url: https://github.com/nodejs/node/pull/9529
+    description: Calling this constructor no longer emits a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8169
+    description: Calling this constructor emits a deprecation warning now.
 -->
 
 > Stability: 0 - Deprecated: Use [`Buffer.from(array)`] instead.
@@ -315,7 +337,18 @@ const buf = new Buffer([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
 
 ### new Buffer(arrayBuffer[, byteOffset [, length]])
 <!-- YAML
+added: v3.0.0
 deprecated: v6.0.0
+changes:
+  - version: v7.2.1
+    pr-url: https://github.com/nodejs/node/pull/9529
+    description: Calling this constructor no longer emits a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8169
+    description: Calling this constructor emits a deprecation warning now.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4682
+    description: The `byteOffset` and `length` parameters are supported now.
 -->
 
 > Stability: 0 - Deprecated: Use
@@ -360,6 +393,13 @@ console.log(buf);
 ### new Buffer(buffer)
 <!-- YAML
 deprecated: v6.0.0
+changes:
+  - version: v7.2.1
+    pr-url: https://github.com/nodejs/node/pull/9529
+    description: Calling this constructor no longer emits a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8169
+    description: Calling this constructor emits a deprecation warning now.
 -->
 
 > Stability: 0 - Deprecated: Use [`Buffer.from(buffer)`] instead.
@@ -386,6 +426,13 @@ console.log(buf2.toString());
 ### new Buffer(size)
 <!-- YAML
 deprecated: v6.0.0
+changes:
+  - version: v7.2.1
+    pr-url: https://github.com/nodejs/node/pull/9529
+    description: Calling this constructor no longer emits a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8169
+    description: Calling this constructor emits a deprecation warning now.
 -->
 
 > Stability: 0 - Deprecated: Use [`Buffer.alloc()`] instead (also see
@@ -419,6 +466,13 @@ console.log(buf);
 ### new Buffer(string[, encoding])
 <!-- YAML
 deprecated: v6.0.0
+changes:
+  - version: v7.2.1
+    pr-url: https://github.com/nodejs/node/pull/9529
+    description: Calling this constructor no longer emits a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8169
+    description: Calling this constructor emits a deprecation warning now.
 -->
 
 > Stability: 0 - Deprecated:
@@ -508,6 +562,10 @@ A `TypeError` will be thrown if `size` is not a number.
 ### Class Method: Buffer.allocUnsafe(size)
 <!-- YAML
 added: v5.10.0
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7079
+    description: Passing a negative `size` will now throw an error.
 -->
 
 * `size` {Integer} The desired length of the new `Buffer`
@@ -606,6 +664,14 @@ A `TypeError` will be thrown if `size` is not a number.
 ### Class Method: Buffer.byteLength(string[, encoding])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8946
+    description: Passing invalid input will now throw an error.
+  - version: v5.10.0
+    pr-url: https://github.com/nodejs/node/pull/5255
+    description: The `string` parameter can now be any `TypedArray`, `DataView`
+                 or `ArrayBuffer`.
 -->
 
 * `string` {String | Buffer | TypedArray | DataView | ArrayBuffer} A value to
@@ -899,6 +965,10 @@ console.log(buffer.buffer === arrayBuffer);
 ### buf.compare(target[, targetStart[, targetEnd[, sourceStart[, sourceEnd]]]])
 <!-- YAML
 added: v0.11.13
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/5880
+    description: Additional parameters for specifying offsets are supported now.
 -->
 
 * `target` {Buffer|Uint8Array} A `Buffer` or [`Uint8Array`] to compare to
@@ -1079,6 +1149,10 @@ console.log(buf1.equals(buf3));
 ### buf.fill(value[, offset[, end]][, encoding])
 <!-- YAML
 added: v0.5.0
+changes:
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4935
+    description: The `encoding` parameter is supported now.
 -->
 
 * `value` {String | Buffer | Integer} The value to fill `buf` with
@@ -1157,6 +1231,11 @@ console.log(buf.includes('this', 4));
 ### buf.indexOf(value[, byteOffset][, encoding])
 <!-- YAML
 added: v1.5.0
+changes:
+  - version: v5.7.0, v4.4.0
+    pr-url: https://github.com/nodejs/node/pull/4803
+    description: When `encoding` is being passed, the `byteOffset` parameter
+                 is no longer required.
 -->
 
 * `value` {String | Buffer | Uint8Array | Integer} What to search for
@@ -1729,6 +1808,15 @@ console.log(buf.readUIntBE(1, 6).toString(16));
 ### buf.slice([start[, end]])
 <!-- YAML
 added: v0.3.0
+changes:
+  - version: v7.1.0, v6.9.2
+    pr-url: https://github.com/nodejs/node/pull/9341
+    description: Coercing the offsets to integers now handles values outside
+                 the 32-bit integer range properly.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/9101
+    description: All offsets are now coerced to integers before doing any
+                 calculations with them.
 -->
 
 * `start` {Integer} Where the new `Buffer` will start. **Default:** `0`

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -704,6 +704,10 @@ actual byte length is returned.
 ### Class Method: Buffer.compare(buf1, buf2)
 <!-- YAML
 added: v0.11.13
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The arguments can now be `Uint8Array`s.
 -->
 
 * `buf1` {Buffer|Uint8Array}
@@ -729,6 +733,10 @@ console.log(arr.sort(Buffer.compare));
 ### Class Method: Buffer.concat(list[, totalLength])
 <!-- YAML
 added: v0.7.11
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The elements of `list` can now be `Uint8Array`s.
 -->
 
 * `list` {Array} List of `Buffer` or [`Uint8Array`] instances to concat
@@ -966,6 +974,9 @@ console.log(buffer.buffer === arrayBuffer);
 <!-- YAML
 added: v0.11.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The `target` parameter can now be a `Uint8Array`.
   - version: v5.11.0
     pr-url: https://github.com/nodejs/node/pull/5880
     description: Additional parameters for specifying offsets are supported now.
@@ -1124,6 +1135,10 @@ for (const pair of buf.entries()) {
 ### buf.equals(otherBuffer)
 <!-- YAML
 added: v0.11.13
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The arguments can now be `Uint8Array`s.
 -->
 
 * `otherBuffer` {Buffer} A `Buffer` or [`Uint8Array`] to compare to
@@ -1232,6 +1247,9 @@ console.log(buf.includes('this', 4));
 <!-- YAML
 added: v1.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The `value` can now be a `Uint8Array`.
   - version: v5.7.0, v4.4.0
     pr-url: https://github.com/nodejs/node/pull/4803
     description: When `encoding` is being passed, the `byteOffset` parameter
@@ -1341,6 +1359,10 @@ for (const key of buf.keys()) {
 ### buf.lastIndexOf(value[, byteOffset][, encoding])
 <!-- YAML
 added: v6.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The `value` can now be a `Uint8Array`.
 -->
 
 * `value` {String | Buffer | Uint8Array | Integer} What to search for
@@ -1464,6 +1486,9 @@ console.log(buf.length);
 ```
 
 ### buf.parent
+<!-- YAML
+deprecated: REPLACEME
+-->
 
 > Stability: 0 - Deprecated: Use [`buf.buffer`] instead.
 
@@ -2475,6 +2500,10 @@ Note that this is a property on the `buffer` module returned by
 ## buffer.transcode(source, fromEnc, toEnc)
 <!-- YAML
 added: v7.1.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10236
+    description: The `source` parameter can now be a `Uint8Array`.
 -->
 
 * `source` {Buffer|Uint8Array} A `Buffer` or `Uint8Array` instance

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -251,6 +251,10 @@ encoding, `Buffer` objects will be passed to the callback instead.
 ### child_process.fork(modulePath[, args][, options])
 <!-- YAML
 added: v0.5.0
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7811
+    description: The `stdio` option is supported now.
 -->
 
 * `modulePath` {String} The module to run in the child
@@ -302,6 +306,13 @@ not clone the current process.*
 ### child_process.spawn(command[, args][, options])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7696
+    description: The `argv0` option is supported now.
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4598
+    description: The `shell` option is supported now.
 -->
 
 * `command` {String} The command to run
@@ -485,6 +496,10 @@ child.unref();
 #### options.stdio
 <!-- YAML
 added: v0.7.10
+changes:
+  - version: v3.3.1
+    pr-url: https://github.com/nodejs/node/pull/2727
+    description: The value `0` is now accepted as a file descriptor.
 -->
 
 The `options.stdio` option is used to configure the pipes that are established
@@ -574,6 +589,10 @@ configuration at startup.
 ### child_process.execFileSync(file[, args][, options])
 <!-- YAML
 added: v0.11.12
+changes:
+  - version: v6.2.1, v4.5.0
+    pr-url: https://github.com/nodejs/node/pull/6939
+    description: The `encoding` option can now explicitly be set to `buffer`.
 -->
 
 * `file` {String} The name or path of the executable file to run
@@ -660,6 +679,13 @@ execution.**
 ### child_process.spawnSync(command[, args][, options])
 <!-- YAML
 added: v0.11.12
+changes:
+  - version: v6.2.1, v4.5.0
+    pr-url: https://github.com/nodejs/node/pull/6939
+    description: The `encoding` option can now explicitly be set to `buffer`.
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4598
+    description: The `shell` option is supported now.
 -->
 
 * `command` {String} The command to run
@@ -911,6 +937,17 @@ grep.stdin.end();
 ### child.send(message[, sendHandle[, options]][, callback])
 <!-- YAML
 added: v0.5.9
+changes:
+  - version: v5.8.0
+    pr-url: https://github.com/nodejs/node/pull/5283
+    description: The `options` parameter, and the `keepOpen` option
+                 in particular, is supported now.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3516
+    description: This method returns a boolean for flow control now.
+  - version: v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2620
+    description: The `callback` parameter is supported now.
 -->
 
 * `message` {Object}

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -252,6 +252,9 @@ encoding, `Buffer` objects will be passed to the callback instead.
 <!-- YAML
 added: v0.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10866
+    description: The `stdio` option can now be a string.
   - version: v6.4.0
     pr-url: https://github.com/nodejs/node/pull/7811
     description: The `stdio` option is supported now.
@@ -590,6 +593,9 @@ configuration at startup.
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10653
+    description: The `input` option can now be a `Uint8Array`.
   - version: v6.2.1, v4.5.0
     pr-url: https://github.com/nodejs/node/pull/6939
     description: The `encoding` option can now explicitly be set to `buffer`.
@@ -632,6 +638,10 @@ throw.  The [`Error`][] object will contain the entire result from
 ### child_process.execSync(command[, options])
 <!-- YAML
 added: v0.11.12
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10653
+    description: The `input` option can now be a `Uint8Array`.
 -->
 
 * `command` {String} The command to run
@@ -680,6 +690,9 @@ execution.**
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10653
+    description: The `input` option can now be a `Uint8Array`.
   - version: v6.2.1, v4.5.0
     pr-url: https://github.com/nodejs/node/pull/6939
     description: The `encoding` option can now explicitly be set to `buffer`.
@@ -1234,3 +1247,4 @@ to `stdout` although there are only 4 characters.
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`stdio`]: #child_process_options_stdio
 [synchronous counterparts]: #child_process_synchronous_process_creation
+[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -43,6 +43,10 @@ The output of this option is less detailed than this document.
 ### `-e`, `--eval "script"`
 <!-- YAML
 added: v0.5.2
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Built-in libraries are now available as predefined variables.
 -->
 
 Evaluate the following argument as JavaScript. The modules which are
@@ -52,6 +56,10 @@ predefined in the REPL can also be used in `script`.
 ### `-p`, `--print "script"`
 <!-- YAML
 added: v0.6.4
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Built-in libraries are now available as predefined variables.
 -->
 
 Identical to `-e` but prints the result.
@@ -59,7 +67,9 @@ Identical to `-e` but prints the result.
 
 ### `-c`, `--check`
 <!-- YAML
-added: v5.0.0
+added:
+  - v5.0.0
+  - v4.2.0
 -->
 
 Syntax check the script without executing.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -260,6 +260,10 @@ It is not emitted in the worker.
 ### worker.disconnect()
 <!-- YAML
 added: v0.7.7
+changes:
+  - version: v7.3.0
+    pr-url: https://github.com/nodejs/node/pull/10019
+    description: This method now returns a reference to `worker`.
 -->
 
 * Returns: {Worker} A reference to `worker`.
@@ -416,6 +420,10 @@ accidental disconnection.
 ### worker.send(message[, sendHandle][, callback])
 <!-- YAML
 added: v0.7.0
+changes:
+  - version: v4.0.0
+    pr-url: https://github.com/nodejs/node/pull/2620
+    description: The `callback` parameter is supported now.
 -->
 
 * `message` {Object}
@@ -449,6 +457,10 @@ if (cluster.isMaster) {
 <!-- YAML
 added: v0.7.0
 deprecated: v6.0.0
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/3747
+    description: Accessing this property will now emit a deprecation warning.
 -->
 
 > Stability: 0 - Deprecated: Use [`worker.exitedAfterDisconnect`][] instead.
@@ -579,6 +591,13 @@ The `addressType` is one of:
 * `"udp4"` or `"udp6"` (UDP v4 or v6)
 
 ## Event: 'message'
+<!-- YAML
+added: v2.5.0
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5361
+    description: The `worker` parameter is passed now; see below for details.
+-->
 
 * `worker` {cluster.Worker}
 * `message` {Object}
@@ -708,6 +727,10 @@ values are `"rr"` and `"none"`.
 ## cluster.settings
 <!-- YAML
 added: v0.7.1
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7838
+    description: The `stdio` option is supported now.
 -->
 
 * {Object}
@@ -732,6 +755,10 @@ This object is not supposed to be changed or set manually, by you.
 ## cluster.setupMaster([settings])
 <!-- YAML
 added: v0.7.1
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7838
+    description: The `stdio` option is supported now.
 -->
 
 * `settings` {Object}

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -236,6 +236,11 @@ milliseconds to `stdout`. Timer durations are accurate to the sub-millisecond.
 ### console.timeEnd(label)
 <!-- YAML
 added: v0.1.104
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5901
+    description: This method no longer supports multiple calls that don’t map
+                 to individual `console.time()` calls; see below for details.
 -->
 
 Stops a timer that was previously started by calling [`console.time()`][] and

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -53,6 +53,13 @@ myConsole.warn(`Danger ${name}! Danger!`);
 ```
 
 ## Class: Console
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/9744
+    description: Errors that occur while writing to the underlying streams
+                 will now be ignored.
+-->
 
 <!--type=class-->
 

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1384,6 +1384,9 @@ console.log(hashes); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 <!-- YAML
 added: v0.5.5
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/11305
+    description: The `digest` parameter is always required now.
   - version: v6.0.0
     pr-url: https://github.com/nodejs/node/pull/4047
     description: Calling this function without passing the `digest` parameter

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -232,6 +232,10 @@ Returns `this` for method chaining.
 ### cipher.update(data[, input_encoding][, output_encoding])
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the cipher with `data`. If the `input_encoding` argument is given,
@@ -330,6 +334,10 @@ than once will result in an error being thrown.
 ### decipher.setAAD(buffer)
 <!-- YAML
 added: v1.0.0
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/9398
+    description: This method now returns a reference to `decipher`.
 -->
 
 When using an authenticated encryption mode (only `GCM` is currently
@@ -343,6 +351,10 @@ Returns `this` for method chaining.
 ### decipher.setAuthTag(buffer)
 <!-- YAML
 added: v1.0.0
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/9398
+    description: This method now returns a reference to `decipher`.
 -->
 
 When using an authenticated encryption mode (only `GCM` is currently
@@ -376,6 +388,10 @@ Returns `this` for method chaining.
 ### decipher.update(data[, input_encoding][, output_encoding])
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the decipher with `data`. If the `input_encoding` argument is given,
@@ -556,6 +572,10 @@ assert.strictEqual(aliceSecret.toString('hex'), bobSecret.toString('hex'));
 ### ecdh.computeSecret(other_public_key[, input_encoding][, output_encoding])
 <!-- YAML
 added: v0.11.14
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Computes the shared secret using `other_public_key` as the other
@@ -739,6 +759,10 @@ called. Multiple calls will cause an error to be thrown.
 ### hash.update(data[, input_encoding])
 <!-- YAML
 added: v0.1.92
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the hash content with the given `data`, the encoding of which
@@ -821,6 +845,10 @@ called. Multiple calls to `hmac.digest()` will result in an error being thrown.
 ### hmac.update(data[, input_encoding])
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the `Hmac` content with the given `data`, the encoding of which
@@ -922,6 +950,10 @@ called. Multiple calls to `sign.sign()` will result in an error being thrown.
 ### sign.update(data[, input_encoding])
 <!-- YAML
 added: v0.1.92
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the `Sign` content with the given `data`, the encoding of which
@@ -980,6 +1012,10 @@ console.log(verify.verify(publicKey, signature));
 ### verifier.update(data[, input_encoding])
 <!-- YAML
 added: v0.1.92
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default `input_encoding` changed from `binary` to `utf8`.
 -->
 
 Updates the `Verify` content with the given `data`, the encoding of which
@@ -1141,6 +1177,11 @@ The `key` is the raw key used by the `algorithm` and `iv` is an
 ### crypto.createDiffieHellman(prime[, prime_encoding][, generator][, generator_encoding])
 <!-- YAML
 added: v0.11.12
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default for the encoding parameters changed
+                 from `binary` to `utf8`.
 -->
 
 Creates a `DiffieHellman` key exchange object using the supplied `prime` and an
@@ -1342,6 +1383,15 @@ console.log(hashes); // ['DSA', 'DSA-SHA', 'DSA-SHA1', ...]
 ### crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)
 <!-- YAML
 added: v0.5.5
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4047
+    description: Calling this function without passing the `digest` parameter
+                 is deprecated now and will emit a warning.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default encoding for `password` if it is a string changed
+                 from `binary` to `utf8`.
 -->
 
 Provides an asynchronous Password-Based Key Derivation Function 2 (PBKDF2)
@@ -1377,6 +1427,15 @@ An array of supported digest functions can be retrieved using
 ### crypto.pbkdf2Sync(password, salt, iterations, keylen, digest)
 <!-- YAML
 added: v0.9.3
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4047
+    description: Calling this function without passing the `digest` parameter
+                 is deprecated now and will emit a warning.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5522
+    description: The default encoding for `password` if it is a string changed
+                 from `binary` to `utf8`.
 -->
 
 Provides a synchronous Password-Based Key Derivation Function 2 (PBKDF2)

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -244,6 +244,15 @@ chained.
 ### socket.send(msg, [offset, length,] port [, address] [, callback])
 <!-- YAML
 added: v0.1.99
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5929
+    description: On success, `callback` will now be called with an `error`
+                 argument of `null` rather than `0`.
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4374
+    description: The `msg` parameter can be an array now. Also, the `offset`
+                 and `length` parameters are optional now.
 -->
 
 * `msg` {Buffer|String|Array} Message to be sent

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -249,6 +249,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/5929
     description: On success, `callback` will now be called with an `error`
                  argument of `null` rather than `0`.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10473
+    description: The `address` parameter is always optional now.
   - version: v5.7.0
     pr-url: https://github.com/nodejs/node/pull/4374
     description: The `msg` parameter can be an array now. Also, the `offset`

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -65,6 +65,10 @@ resolution.
 ## dns.lookup(hostname[, options], callback)
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: v1.2.0
+    pr-url: https://github.com/nodejs/node/pull/744
+    description: The `all` option is supported now.
 -->
 
 Resolves a hostname (e.g. `'nodejs.org'`) into the first found A (IPv4) or
@@ -198,6 +202,11 @@ one of the error codes listed [here](#dns_error_codes).
 ## dns.resolve4(hostname[, options], callback)
 <!-- YAML
 added: v0.1.16
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/9296
+    description: This method now supports passing `options`,
+                 specifically `options.ttl`.
 -->
 
 Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the
@@ -215,6 +224,11 @@ will contain an array of IPv4 addresses (e.g.
 ## dns.resolve6(hostname[, options], callback)
 <!-- YAML
 added: v0.1.16
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/9296
+    description: This method now supports passing `options`,
+                 specifically `options.ttl`.
 -->
 
 Uses the DNS protocol to resolve a IPv6 addresses (`AAAA` records) for the

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -222,6 +222,11 @@ myEmitter.emit('event');
 ### Event: 'removeListener'
 <!-- YAML
 added: v0.9.3
+changes:
+  - version: v6.1.0, v4.7.0
+    pr-url: https://github.com/nodejs/node/pull/6394
+    description: For listeners attached using `.once()`, the `listener` argument
+                 now yields the original listener function.
 -->
 
 * `eventName` {String|Symbol} The event name
@@ -347,6 +352,11 @@ Returns the number of listeners listening to the event named `eventName`.
 ### emitter.listeners(eventName)
 <!-- YAML
 added: v0.1.26
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/6881
+    description: For listeners attached using `.once()` this returns the
+                 original listeners instead of wrapper functions now.
 -->
 
 Returns a copy of the array of listeners for the event named `eventName`.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -448,6 +448,17 @@ checks fail, and does nothing otherwise.
 ## fs.appendFile(file, data[, options], callback)
 <!-- YAML
 added: v0.6.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7831
+    description: The passed `options` object will never be modified.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Number} filename or file descriptor
@@ -484,6 +495,13 @@ automatically._
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
 added: v0.6.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7831
+    description: The passed `options` object will never be modified.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Number} filename or file descriptor
@@ -498,6 +516,11 @@ The synchronous version of [`fs.appendFile()`][]. Returns `undefined`.
 ## fs.chmod(path, mode, callback)
 <!-- YAML
 added: v0.1.30
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -520,6 +543,11 @@ Synchronous chmod(2). Returns `undefined`.
 ## fs.chown(path, uid, gid, callback)
 <!-- YAML
 added: v0.1.97
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -544,6 +572,11 @@ Synchronous chown(2). Returns `undefined`.
 ## fs.close(fd, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -570,6 +603,13 @@ operations. The specific constants currently defined are described in
 ## fs.createReadStream(path[, options])
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7831
+    description: The passed `options` object will never be modified.
+  - version: v2.3.0
+    pr-url: https://github.com/nodejs/node/pull/1845
+    description: The passed `options` object can be a string now.
 -->
 
 * `path` {String | Buffer}
@@ -631,6 +671,16 @@ If `options` is a string, then it specifies the encoding.
 ## fs.createWriteStream(path[, options])
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7831
+    description: The passed `options` object will never be modified.
+  - version: v5.5.0
+    pr-url: https://github.com/nodejs/node/pull/3679
+    description: The `autoClose` option is supported now.
+  - version: v2.3.0
+    pr-url: https://github.com/nodejs/node/pull/1845
+    description: The passed `options` object can be a string now.
 -->
 
 * `path` {String | Buffer}
@@ -797,6 +847,11 @@ a callback.)
 ## fs.fchmod(fd, mode, callback)
 <!-- YAML
 added: v0.4.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -819,6 +874,11 @@ Synchronous fchmod(2). Returns `undefined`.
 ## fs.fchown(fd, uid, gid, callback)
 <!-- YAML
 added: v0.4.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -843,6 +903,11 @@ Synchronous fchown(2). Returns `undefined`.
 ## fs.fdatasync(fd, callback)
 <!-- YAML
 added: v0.1.96
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -863,6 +928,11 @@ Synchronous fdatasync(2). Returns `undefined`.
 ## fs.fstat(fd, callback)
 <!-- YAML
 added: v0.1.95
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -884,6 +954,11 @@ Synchronous fstat(2). Returns an instance of [`fs.Stats`][].
 ## fs.fsync(fd, callback)
 <!-- YAML
 added: v0.1.96
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -904,6 +979,11 @@ Synchronous fsync(2). Returns `undefined`.
 ## fs.ftruncate(fd, len, callback)
 <!-- YAML
 added: v0.8.6
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -967,6 +1047,15 @@ Synchronous ftruncate(2). Returns `undefined`.
 ## fs.futimes(fd, atime, mtime, callback)
 <!-- YAML
 added: v0.4.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v4.1.0
+    pr-url: https://github.com/nodejs/node/pull/2387
+    description: Numeric strings, `NaN` and `Infinity` are now allowed
+                 time specifiers.
 -->
 
 * `fd` {Integer}
@@ -980,6 +1069,11 @@ descriptor.
 ## fs.futimesSync(fd, atime, mtime)
 <!-- YAML
 added: v0.4.2
+changes:
+  - version: v4.1.0
+    pr-url: https://github.com/nodejs/node/pull/2387
+    description: Numeric strings, `NaN` and `Infinity` are now allowed
+                 time specifiers.
 -->
 
 * `fd` {Integer}
@@ -991,6 +1085,11 @@ Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 ## fs.lchmod(path, mode, callback)
 <!-- YAML
 deprecated: v0.4.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1015,6 +1114,11 @@ Synchronous lchmod(2). Returns `undefined`.
 ## fs.lchown(path, uid, gid, callback)
 <!-- YAML
 deprecated: v0.4.7
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1039,6 +1143,11 @@ Synchronous lchown(2). Returns `undefined`.
 ## fs.link(existingPath, newPath, callback)
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `existingPath` {String | Buffer}
@@ -1061,6 +1170,11 @@ Synchronous link(2). Returns `undefined`.
 ## fs.lstat(path, callback)
 <!-- YAML
 added: v0.1.30
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1083,6 +1197,11 @@ Synchronous lstat(2). Returns an instance of [`fs.Stats`][].
 ## fs.mkdir(path[, mode], callback)
 <!-- YAML
 added: v0.1.8
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1105,6 +1224,14 @@ Synchronous mkdir(2). Returns `undefined`.
 ## fs.mkdtemp(prefix[, options], callback)
 <!-- YAML
 added: v5.10.0
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v6.2.1
+    pr-url: https://github.com/nodejs/node/pull/6828
+    description: The `callback` parameter is optional now.
 -->
 
 * `prefix` {String}
@@ -1278,6 +1405,13 @@ descriptor.
 ## fs.read(fd, buffer, offset, length, position, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.4.0
+    pr-url: https://github.com/nodejs/node/pull/10382
+    description: The `buffer` parameter can now be a `Uint8Array`.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4518
+    description: The `length` parameter can now be `0`.
 -->
 
 * `fd` {Integer}
@@ -1303,6 +1437,11 @@ The callback is given the three arguments, `(err, bytesRead, buffer)`.
 ## fs.readdir(path[, options], callback)
 <!-- YAML
 added: v0.1.8
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1339,6 +1478,18 @@ the filenames returned will be passed as `Buffer` objects.
 ## fs.readFile(file[, options], callback)
 <!-- YAML
 added: v0.1.29
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v5.1.0
+    pr-url: https://github.com/nodejs/node/pull/3740
+    description: The `callback` will always be called with `null` as the `error`
+                 parameter in case of success.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Integer} filename or file descriptor
@@ -1375,6 +1526,10 @@ automatically._
 ## fs.readFileSync(file[, options])
 <!-- YAML
 added: v0.1.8
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Integer} filename or file descriptor
@@ -1390,6 +1545,11 @@ string. Otherwise it returns a buffer.
 ## fs.readlink(path[, options], callback)
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1424,6 +1584,10 @@ the link path returned will be passed as a `Buffer` object.
 ## fs.readSync(fd, buffer, offset, length, position)
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4518
+    description: The `length` parameter can now be `0`.
 -->
 
 * `fd` {Integer}
@@ -1437,6 +1601,18 @@ Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 ## fs.realpath(path[, options], callback)
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7899
+    description: Calling `realpath` now works again for various edge cases
+                 on Windows.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/3594
+    description: The `cache` parameter was removed.
 -->
 
 * `path` {String | Buffer}
@@ -1457,6 +1633,14 @@ the path returned will be passed as a `Buffer` object.
 ## fs.realpathSync(path[, options])
 <!-- YAML
 added: v0.1.31
+changes:
+  - version: v6.4.0
+    pr-url: https://github.com/nodejs/node/pull/7899
+    description: Calling `realpathSync` now works again for various edge cases
+                 on Windows.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/3594
+    description: The `cache` parameter was removed.
 -->
 
 * `path` {String | Buffer};
@@ -1475,6 +1659,11 @@ will be passed as a `Buffer` object.
 ## fs.rename(oldPath, newPath, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `oldPath` {String | Buffer}
@@ -1497,6 +1686,11 @@ Synchronous rename(2). Returns `undefined`.
 ## fs.rmdir(path, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1517,6 +1711,11 @@ Synchronous rmdir(2). Returns `undefined`.
 ## fs.stat(path, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1583,6 +1782,11 @@ Synchronous symlink(2). Returns `undefined`.
 ## fs.truncate(path, len, callback)
 <!-- YAML
 added: v0.8.6
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1607,6 +1811,11 @@ passed as the first argument. In this case, `fs.ftruncateSync()` is called.
 ## fs.unlink(path, callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `path` {String | Buffer}
@@ -1646,6 +1855,15 @@ when possible._
 ## fs.utimes(path, atime, mtime, callback)
 <!-- YAML
 added: v0.4.2
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v4.1.0
+    pr-url: https://github.com/nodejs/node/pull/2387
+    description: Numeric strings, `NaN` and `Infinity` are now allowed
+                 time specifiers.
 -->
 
 * `path` {String | Buffer}
@@ -1668,6 +1886,11 @@ follow these rules:
 ## fs.utimesSync(path, atime, mtime)
 <!-- YAML
 added: v0.4.2
+changes:
+  - version: v4.1.0
+    pr-url: https://github.com/nodejs/node/pull/2387
+    description: Numeric strings, `NaN` and `Infinity` are now allowed
+                 time specifiers.
 -->
 
 * `path` {String | Buffer}
@@ -1679,6 +1902,10 @@ Synchronous version of [`fs.utimes()`][]. Returns `undefined`.
 ## fs.watch(filename[, options][, listener])
 <!-- YAML
 added: v0.5.10
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7831
+    description: The passed `options` object will never be modified.
 -->
 
 * `filename` {String | Buffer}
@@ -1828,6 +2055,17 @@ _Note: [`fs.watch()`][] is more efficient than `fs.watchFile` and
 ## fs.write(fd, buffer[, offset[, length[, position]]], callback)
 <!-- YAML
 added: v0.0.2
+changes:
+  - version: v7.4.0
+    pr-url: https://github.com/nodejs/node/pull/10382
+    description: The `buffer` parameter can now be a `Uint8Array`.
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/7856
+    description: The `offset` and `length` parameters are optional now.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -1860,6 +2098,14 @@ the end of the file.
 ## fs.write(fd, string[, position[, encoding]], callback)
 <!-- YAML
 added: v0.11.5
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/7856
+    description: The `position` parameter is optional now.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
 -->
 
 * `fd` {Integer}
@@ -1896,6 +2142,17 @@ the end of the file.
 ## fs.writeFile(file, data[, options], callback)
 <!-- YAML
 added: v0.1.29
+changes:
+  - version: v7.4.0
+    pr-url: https://github.com/nodejs/node/pull/10382
+    description: The `data` parameter can now be a `Uint8Array`.
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7897
+    description: The `callback` parameter is no longer optional. Not passing
+                 it will emit a deprecation warning.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Integer} filename or file descriptor
@@ -1939,6 +2196,13 @@ automatically._
 ## fs.writeFileSync(file, data[, options])
 <!-- YAML
 added: v0.1.29
+changes:
+  - version: v7.4.0
+    pr-url: https://github.com/nodejs/node/pull/10382
+    description: The `data` parameter can now be a `Uint8Array`.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3163
+    description: The `file` parameter can be a file descriptor now.
 -->
 
 * `file` {String | Buffer | Integer} filename or file descriptor
@@ -1953,6 +2217,13 @@ The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.
 ## fs.writeSync(fd, buffer[, offset[, length[, position]]])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: v7.4.0
+    pr-url: https://github.com/nodejs/node/pull/10382
+    description: The `buffer` parameter can now be a `Uint8Array`.
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/7856
+    description: The `offset` and `length` parameters are optional now.
 -->
 
 * `fd` {Integer}
@@ -1964,6 +2235,10 @@ added: v0.1.21
 ## fs.writeSync(fd, string[, position[, encoding]])
 <!-- YAML
 added: v0.11.5
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/7856
+    description: The `position` parameter is optional now.
 -->
 
 * `fd` {Integer}
@@ -2231,3 +2506,4 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`ReadDirectoryChangesW`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465%28v=vs.85%29.aspx
 [`AHAFS`]: https://www.ibm.com/developerworks/aix/library/au-aix_event_infrastructure/
 [Common System Errors]: errors.html#errors_common_system_errors
+[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -586,6 +586,12 @@ not be emitted.
 ### Event: 'clientError'
 <!-- YAML
 added: v0.1.94
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/4557
+    description: The default action of calling `.destroy()` on the `socket`
+                 will no longer take place if there are listeners attached
+                 for `clientError`.
 -->
 
 * `exception` {Error}
@@ -1178,6 +1184,11 @@ the request body should be sent. See the [`'checkContinue'`][] event on `Server`
 ### response.writeHead(statusCode[, statusMessage][, headers])
 <!-- YAML
 added: v0.1.30
+changes:
+  - version: v5.11.0, v4.4.5
+    pr-url: https://github.com/nodejs/node/pull/6291
+    description: A `RangeError` is thrown if `statusCode` is not a number in
+                 the range `[100, 999]`.
 -->
 
 * `statusCode` {Number}

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -411,6 +411,10 @@ following this event.
 ### Event: 'lookup'
 <!-- YAML
 added: v0.11.3
+changes:
+  - version: v5.10.0
+    pr-url: https://github.com/nodejs/node/pull/5598
+    description: The `host` parameter is supported now.
 -->
 
 Emitted after resolving the hostname but before connecting.
@@ -479,6 +483,15 @@ The amount of bytes sent.
 ### socket.connect(options[, connectListener])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6021
+    description: The `hints` option defaults to `0` in all cases now.
+                 Previously, in the absence of the `family` option it would
+                 default to `dns.ADDRCONFIG | dns.V4MAPPED`.
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/6000
+    description: The `hints` option is supported now.
 -->
 
 Opens the connection for a given socket.

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -333,6 +333,11 @@ https://en.wikipedia.org/wiki/Uname#Examples for more information.
 ## os.tmpdir()
 <!-- YAML
 added: v0.9.9
+changes:
+  - version: v2.0.0
+    pr-url: https://github.com/nodejs/node/pull/747
+    description: This function is now cross-platform consistent and no longer
+                 returns a path with a trailing slash on any platform
 -->
 
 * Returns: {String}
@@ -404,6 +409,12 @@ The following constants are exported by `os.constants`. **Note:** Not all
 constants will be available on every operating system.
 
 ### Signal Constants
+<!-- YAML
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/6093
+    description: Added support for `SIGINFO`.
+-->
 
 The following signal constants are exported by `os.constants.signals`:
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -57,6 +57,10 @@ path.posix.basename('/tmp/myfile.html');
 ## path.basename(path[, ext])
 <!-- YAML
 added: v0.1.25
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Passing a non-string as the `path` argument will throw now.
 -->
 
 * `path` {String}
@@ -114,6 +118,10 @@ process.env.PATH.split(path.delimiter)
 ## path.dirname(path)
 <!-- YAML
 added: v0.1.16
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Passing a non-string as the `path` argument will throw now.
 -->
 
 * `path` {String}
@@ -134,6 +142,10 @@ A [`TypeError`][] is thrown if `path` is not a string.
 ## path.extname(path)
 <!-- YAML
 added: v0.1.25
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5348
+    description: Passing a non-string as the `path` argument will throw now.
 -->
 
 * `path` {String}
@@ -408,6 +420,11 @@ of the `path` methods.
 ## path.relative(from, to)
 <!-- YAML
 added: v0.5.0
+changes:
+  - version: v6.8.0
+    pr-url: https://github.com/nodejs/node/pull/8523
+    description: On Windows, the leading slashes for UNC paths are now included
+                 in the return value.
 -->
 
 * `from` {String}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -203,6 +203,14 @@ to detect application failures and recover or restart as needed.
 ### Event: 'unhandledRejection'
 <!-- YAML
 added: v1.4.1
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/8217
+    description: Not handling Promise rejections has been deprecated.
+  - version: v6.6.0
+    pr-url: https://github.com/nodejs/node/pull/8223
+    description: Unhandled Promise rejections have been will now emit
+                 a process warning.
 -->
 
 The `'unhandledRejection`' event is emitted whenever a `Promise` is rejected and
@@ -1143,6 +1151,10 @@ is no entry script.
 ## process.memoryUsage()
 <!-- YAML
 added: v0.1.16
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/9587
+    description: Added `external` to the returned object.
 -->
 
 * Returns: {Object}
@@ -1178,6 +1190,10 @@ objects managed by V8.
 ## process.nextTick(callback[, ...args])
 <!-- YAML
 added: v0.1.26
+changes:
+  - version: v1.8.1
+    pr-url: https://github.com/nodejs/node/pull/1077
+    description: Additional arguments after `callback` are now supported.
 -->
 
 * `callback` {Function}
@@ -1297,6 +1313,10 @@ console.log(`This platform is ${process.platform}`);
 ## process.release
 <!-- YAML
 added: v3.0.0
+changes:
+  - version: v4.2.0
+    pr-url: https://github.com/nodejs/node/pull/3212
+    description: The `lts` property is now supported.
 -->
 
 The `process.release` property returns an Object containing metadata related to
@@ -1659,6 +1679,10 @@ console.log(`Version: ${process.version}`);
 ## process.versions
 <!-- YAML
 added: v0.2.0
+changes:
+  - version: v4.2.0
+    pr-url: https://github.com/nodejs/node/pull/3102
+    description: The `icu` property is now supported.
 -->
 
 * {Object}

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -1,4 +1,10 @@
 # Punycode
+<!-- YAML
+changes:
+  - version: v7.0.0
+    pr-url: https://github.com/nodejs/node/pull/7941
+    description: Accessing this module will now emit a deprecation warning.
+-->
 
 > Stability: 0 - Deprecated
 

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -30,6 +30,13 @@ necessary by assigning `querystring.escape` to an alternative function.
 ## querystring.parse(str[, sep[, eq[, options]]])
 <!-- YAML
 added: v0.1.25
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6055
+    description: The returned object no longer inherits from `Object.prototype`.
+  - version: v6.0.0, v4.2.4
+    pr-url: https://github.com/nodejs/node/pull/3807
+    description: The `eq` parameter may now have a length of more than `1`.
 -->
 
 * `str` {String} The URL query string to parse

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -31,6 +31,9 @@ necessary by assigning `querystring.escape` to an alternative function.
 <!-- YAML
 added: v0.1.25
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/10967
+    description: Multiple empty entries are now parsed correctly (e.g. `&=&=`).
   - version: v6.0.0
     pr-url: https://github.com/nodejs/node/pull/6055
     description: The returned object no longer inherits from `Object.prototype`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -344,6 +344,13 @@ the current position of the cursor down.
 ## readline.createInterface(options)
 <!-- YAML
 added: v0.1.98
+changes:
+  - version: v6.3.0
+    pr-url: https://github.com/nodejs/node/pull/7125
+    description: The `prompt` option is supported now.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6352
+    description: The `historySize` option can be `0` now.
 -->
 
 * `options` {Object}

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -373,6 +373,10 @@ within the action function for commands registered using the
 ## repl.start([options])
 <!-- YAML
 added: v0.1.91
+changes:
+  - version: v5.8.0
+    pr-url: https://github.com/nodejs/node/pull/5388
+    description: The `options` parameter is optional now.
 -->
 
 * `options` {Object | String}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -380,6 +380,10 @@ file.end('world!');
 ##### writable.setDefaultEncoding(encoding)
 <!-- YAML
 added: v0.11.15
+changes:
+  - version: v6.1.0
+    pr-url: https://github.com/nodejs/node/pull/5040
+    description: This method now returns a reference to `writable`.
 -->
 
 * `encoding` {String} The new default encoding
@@ -429,6 +433,11 @@ See also: [`writable.cork()`][].
 ##### writable.write(chunk[, encoding][, callback])
 <!-- YAML
 added: v0.9.4
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/6170
+    description: Passing `null` as the `chunk` parameter will always be
+                 considered invalid now, even in object mode.
 -->
 
 * `chunk` {String|Buffer} The data to write
@@ -1069,6 +1078,11 @@ myReader.on('readable', () => {
 #### Class: stream.Duplex
 <!-- YAML
 added: v0.9.4
+changes:
+  - version: v6.8.0
+    pr-url: https://github.com/nodejs/node/pull/8834
+    description: Instances of `Duplex` now return `true` when
+                 checking `instanceof stream.Writable`.
 -->
 
 <!--type=class-->
@@ -1190,6 +1204,9 @@ the [API for Stream Consumers][] section). Doing so may lead to adverse
 side effects in application code consuming the stream.
 
 ### Simplified Construction
+<!-- YAML
+added: v1.2.0
+-->
 
 For many simple cases, it is possible to construct a stream without relying on
 inheritance. This can be accomplished by directly creating instances of the

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -67,6 +67,11 @@ is performed before returning the remaining input.
 ### stringDecoder.write(buffer)
 <!-- YAML
 added: v0.1.99
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/9618
+    description: Each invalid character is now replaced by a single replacement
+                 character instead of one for each individual byte.
 -->
 
 * `buffer` {Buffer} A `Buffer` containing the bytes to decode.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -461,6 +461,10 @@ connection is open.
 ### new tls.TLSSocket(socket[, options])
 <!-- YAML
 added: v0.11.4
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2564
+    description: ALPN options are supported now.
 -->
 
 * `socket` {net.Socket} An instance of [`net.Socket`][]
@@ -744,6 +748,13 @@ decrease overall server throughput.
 ## tls.connect(options[, callback])
 <!-- YAML
 added: v0.11.3
+changes:
+  - version: v5.3.0, v4.7.0
+    pr-url: https://github.com/nodejs/node/pull/4246
+    description: The `secureContext` option is supported now.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2564
+    description: ALPN options are supported now.
 -->
 
 * `options` {Object}
@@ -888,6 +899,16 @@ or host argument.
 ## tls.createSecureContext(options)
 <!-- YAML
 added: v0.11.13
+changes:
+  - version: v7.3.0
+    pr-url: https://github.com/nodejs/node/pull/10294
+    description: If the `key` option is an array, individual entries do not
+                 need a `passphrase` property anymore. Array entries can also
+                 just be `string`s or `Buffer`s now.
+  - version: v5.2.0
+    pr-url: https://github.com/nodejs/node/pull/4099
+    description: The `ca` option can now be a single string containing multiple
+                 CA certificates.
 -->
 
 * `options` {Object}
@@ -977,6 +998,10 @@ publicly trusted list of CAs as given in
 ## tls.createServer([options][, secureConnectionListener])
 <!-- YAML
 added: v0.3.2
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2564
+    description: ALPN options are supported now.
 -->
 
 * `options` {Object}
@@ -1151,6 +1176,10 @@ certificate used is properly authorized.
 <!-- YAML
 added: v0.3.2
 deprecated: v0.11.3
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2564
+    description: ALPN options are supported now.
 -->
 
 > Stability: 0 - Deprecated: Use [`tls.TLSSocket`][] instead.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -262,6 +262,18 @@ object.
 ## url.resolve(from, to)
 <!-- YAML
 added: v0.1.25
+changes:
+  - version: v6.6.0
+    pr-url: https://github.com/nodejs/node/pull/8215
+    description: The `auth` fields are now kept intact when `from` and `to`
+                 refer to the same host.
+  - version: v6.5.0, v4.6.2
+    pr-url: https://github.com/nodejs/node/pull/8214
+    description: The `port` field is copied correctly now.
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/1480
+    description: The `auth` fields is cleared now the `to` parameter
+                 contains a hostname.
 -->
 
 * `from` {String} The Base URL being resolved against.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -136,6 +136,10 @@ util.format(1, 2, 3); // '1 2 3'
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/3455
+    description: The `constructor` parameter can refer to an ES6 class now.
 -->
 
 _Note: usage of `util.inherits()` is discouraged. Please use the ES6 `class` and
@@ -203,6 +207,20 @@ stream.write('With ES6');
 ## util.inspect(object[, options])
 <!-- YAML
 added: v0.3.0
+changes:
+  - version: v6.6.0
+    pr-url: https://github.com/nodejs/node/pull/8174
+    description: Custom inspection functions can now return `this`.
+  - version: v6.3.0
+    pr-url: https://github.com/nodejs/node/pull/7499
+    description: The `breakLength` option is supported now.
+  - version: v6.1.0
+    pr-url: https://github.com/nodejs/node/pull/6334
+    description: The `maxArrayLength` option is supported now; in particular,
+                 long arrays are truncated by default.
+  - version: v6.1.0
+    pr-url: https://github.com/nodejs/node/pull/6465
+    description: The `showProxy` option is supported now.
 -->
 
 * `object` {any} Any JavaScript primitive or Object.

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -12,6 +12,10 @@ const v8 = require('v8');
 ## v8.getHeapSpaceStatistics()
 <!-- YAML
 added: v6.0.0
+changes:
+  - version: v7.5.0
+    pr-url: https://github.com/nodejs/node/pull/10186
+    description: Support values exceeding the 32-bit unsigned integer range.
 -->
 
 Returns statistics about the V8 heap spaces, i.e. the segments which make up
@@ -72,6 +76,14 @@ For example:
 ## v8.getHeapStatistics()
 <!-- YAML
 added: v1.0.0
+changes:
+  - version: v7.2.0
+    pr-url: https://github.com/nodejs/node/pull/8610
+    description: Added `malloced_memory`, `peak_malloced_memory`,
+                 and `does_zap_garbage`.
+  - version: v7.5.0
+    pr-url: https://github.com/nodejs/node/pull/10186
+    description: Support values exceeding the 32-bit unsigned integer range.
 -->
 
 Returns an object with the following properties:

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -25,6 +25,11 @@ executed in specific sandboxes (or "contexts").
 ### new vm.Script(code, options)
 <!-- YAML
 added: v0.3.1
+changes:
+  - version: v5.7.0
+    pr-url: https://github.com/nodejs/node/pull/4777
+    description: The `cachedData` and `produceCachedData` options are
+                 supported now.
 -->
 
 * `code` {string} The JavaScript code to compile.
@@ -60,6 +65,10 @@ each run, just for that run.
 ### script.runInContext(contextifiedSandbox[, options])
 <!-- YAML
 added: v0.3.1
+changes:
+  - version: v6.3.0
+    pr-url: https://github.com/nodejs/node/pull/6635
+    description: The `breakOnSigint` option is supported now.
 -->
 
 * `contextifiedSandbox` {Object} A [contextified][] object as returned by the

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -277,6 +277,10 @@ Compression strategy.
 ## Class Options
 <!-- YAML
 added: v0.11.1
+changes:
+  - version: v5.11.0
+    pr-url: https://github.com/nodejs/node/pull/6069
+    description: The `finishFlush` option is supported now.
 -->
 
 <!--type=misc-->
@@ -315,6 +319,17 @@ Compress data using deflate, and do not append a `zlib` header.
 ## Class: zlib.Gunzip
 <!-- YAML
 added: v0.5.8
+changes:
+  - version: v6.0.0
+    pr-url: https://github.com/nodejs/node/pull/5883
+    description: Trailing garbage at the end of the input stream will now
+                 result in an `error` event.
+  - version: v5.9.0
+    pr-url: https://github.com/nodejs/node/pull/5120
+    description: Multiple concatenated gzip file members are supported now.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2595
+    description: A truncated input stream will now result in an `error` event.
 -->
 
 Decompress a gzip stream.
@@ -329,6 +344,10 @@ Compress data using gzip.
 ## Class: zlib.Inflate
 <!-- YAML
 added: v0.5.8
+changes:
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2595
+    description: A truncated input stream will now result in an `error` event.
 -->
 
 Decompress a deflate stream.
@@ -336,6 +355,13 @@ Decompress a deflate stream.
 ## Class: zlib.InflateRaw
 <!-- YAML
 added: v0.5.8
+changes:
+  - version: v6.8.0
+    pr-url: https://github.com/nodejs/node/pull/8512
+    description: Custom dictionaries are now supported by `InflateRaw`.
+  - version: v5.0.0
+    pr-url: https://github.com/nodejs/node/pull/2595
+    description: A truncated input stream will now result in an `error` event.
 -->
 
 Decompress a raw deflate stream.

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -470,6 +470,12 @@ th > *:last-child, td > *:last-child {
   margin-bottom: 0;
 }
 
+.changelog > summary {
+  margin: .5rem 0;
+  padding: .5rem 0;
+  cursor: pointer;
+}
+
 /* simpler clearfix */
 .clearfix:after {
   content: ".";

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -47,7 +47,15 @@ const testData = [
       '<p>Describe <code>Foobar</code> in more detail here.</p>' +
       '<h2>Foobar II<span><a class="mark" href="#foo_foobar_ii" ' +
       'id="foo_foobar_ii">#</a></span></h2>' +
-      '<div class="api_metadata"><span>Added in: v5.3.0, v4.2.0</span></div> ' +
+      '<div class="api_metadata">' +
+      '<details class="changelog"><summary>History</summary>' +
+      '<table><tr><th>Version</th><th>Changes</th></tr>' +
+      '<tr><td>v5.3.0, v4.2.0</td>' +
+      '<td><p><span>Added in: v5.3.0, v4.2.0</span></p>' +
+      '</td></tr>' +
+      '<tr><td>v4.2.0</td><td><p>The <code>error</code> parameter can now be' +
+      'an arrow function.</p></td></tr></table></details>' +
+      '</div> ' +
       '<p>Describe <code>Foobar II</code> in more detail here.</p>' +
       '<h2>Deprecated thingy<span><a class="mark" ' +
       'href="#foo_deprecated_thingy" id="foo_deprecated_thingy">#</a>' +

--- a/test/doctool/test-doctool-json.js
+++ b/test/doctool/test-doctool-json.js
@@ -89,7 +89,8 @@ const testData = [
               textRaw: 'Foobar',
               name: 'foobar',
               meta: {
-                added: ['v1.0.0']
+                added: ['v1.0.0'],
+                changes: []
               },
               desc: '<p>Describe <code>Foobar</code> in more detail ' +
                 'here.</p>\n',
@@ -100,7 +101,14 @@ const testData = [
               textRaw: 'Foobar II',
               name: 'foobar_ii',
               meta: {
-                added: ['v5.3.0', 'v4.2.0']
+                added: ['v5.3.0', 'v4.2.0'],
+                changes: [
+                  { version: 'v4.2.0',
+                    'pr-url': 'https://github.com/nodejs/node/pull/3276',
+                    description: 'The `error` parameter can now be ' +
+                      'an arrow function.'
+                  }
+                ]
               },
               desc: '<p>Describe <code>Foobar II</code> in more detail ' +
                 'here.</p>\n',
@@ -112,7 +120,8 @@ const testData = [
               name: 'deprecated_thingy',
               meta: {
                 added: ['v1.0.0'],
-                deprecated: ['v2.0.0']
+                deprecated: ['v2.0.0'],
+                changes: []
               },
               desc: '<p>Describe <code>Deprecated thingy</code> in more ' +
                 'detail here.</p>\n',

--- a/test/fixtures/doc_with_yaml.md
+++ b/test/fixtures/doc_with_yaml.md
@@ -12,6 +12,10 @@ Describe `Foobar` in more detail here.
 added:
   - v5.3.0
   - v4.2.0
+changes:
+  - version: v4.2.0
+    pr-url: https://github.com/nodejs/node/pull/3276
+    description: The `error` parameter can now be an arrow function.
 -->
 
 Describe `Foobar II` in more detail here.

--- a/tools/doc/common.js
+++ b/tools/doc/common.js
@@ -34,6 +34,11 @@ function extractAndParseYAML(text) {
     meta.deprecated = arrify(deprecated);
   }
 
+  meta.changes = meta.changes || [];
+  meta.changes.forEach((entry) => {
+    entry.description = entry.description.replace(/^\^\s*/, '');
+  });
+
   return meta;
 }
 

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -269,12 +269,40 @@ function parseYAML(text) {
   const meta = common.extractAndParseYAML(text);
   const html = ['<div class="api_metadata">'];
 
+  const added = { description: '' };
+  const deprecated = { description: '' };
+
   if (meta.added) {
-    html.push(`<span>Added in: ${meta.added.join(', ')}</span>`);
+    added.version = meta.added.join(', ');
+    added.description = `<span>Added in: ${added.version}</span>`;
   }
 
   if (meta.deprecated) {
-    html.push(`<span>Deprecated since: ${meta.deprecated.join(', ')} </span>`);
+    deprecated.version = meta.deprecated.join(', ');
+    deprecated.description =
+        `<span>Deprecated since: ${deprecated.version}</span>`;
+  }
+
+  if (meta.changes.length > 0) {
+    let changes = meta.changes.slice();
+    if (added.description) changes.push(added);
+    if (deprecated.description) changes.push(deprecated);
+
+    changes = changes.sort((a, b) => versionSort(a.version, b.version));
+
+    html.push('<details class="changelog"><summary>History</summary>');
+    html.push('<table>');
+    html.push('<tr><th>Version</th><th>Changes</th></tr>');
+
+    changes.forEach((change) => {
+      html.push(`<tr><td>${change.version}</td>`);
+      html.push(`<td>${marked(change.description)}</td></tr>`);
+    });
+
+    html.push('</table>');
+    html.push('</details>');
+  } else {
+    html.push(`${added.description}${deprecated.description}`);
   }
 
   html.push('</div>');
@@ -389,4 +417,15 @@ function getId(text) {
     idCounters[text] = 0;
   }
   return text;
+}
+
+const numberRe = /^(\d*)/;
+function versionSort(a, b) {
+  a = a.trim();
+  b = b.trim();
+  let i = 0;  // common prefix length
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  a = a.substr(i);
+  b = b.substr(i);
+  return +b.match(numberRe)[1] - +a.match(numberRe)[1];
 }


### PR DESCRIPTION
Add per-item changelogs to the docs, for notable changes to the API made between io.js 1.0.0 and now. I have used a somewhat subjective idea of “notable” and focused on changes in how the API is used rather than e.g. bug fixes, so please feel free to point out anything that you feel is missing here or doesn’t belong here.

Also, in cases of LTS backports I’ve listed all versions in which the change was applied.

Example screenshot:
![Example screenshot](https://cloud.githubusercontent.com/assets/899444/23260897/553bc2fa-f9d4-11e6-8500-273a6996328c.png)


/cc @nodejs/documentation @nodejs/collaborators 