### PR TITLE
process: implement resourceUsage()

### DIFF
--- a/benchmark/process/resourceUsage.js
+++ b/benchmark/process/resourceUsage.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var common = require('../common.js');
+var bench = common.createBenchmark(main, {
+  n: [1e6]
+});
+
+function main(conf) {
+  var n = +conf.n;
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    process.resourceUsage();
+  }
+  bench.end(n);
+}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1356,6 +1356,48 @@ In custom builds from non-release versions of the source tree, only the
 `name` property may be present. The additional properties should not be
 relied upon to exist.
 
+## process.resourceUsage()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Object} containing resource usage measures for the current process
+
+Note: Windows only provides the following resource usage measures:
+
+- `userCpuTimeUsedSec`
+- `userCpuTimeUsedMs`
+- `systemCpuTimeUsedSec`
+- `systemCpuTimeUsedMs`
+
+On Windows, all other values are `0`.
+
+On Linux, some fields may or may not be used/set to non-zero values depending on
+the kernel version. See the getrusage(2) man page for more information.
+
+Example return value:
+
+```js
+    { userCpuTimeUsedSec: 0,
+      userCpuTimeUsedMs: 159729,
+      systemCpuTimeUsedSec: 0,
+      systemCpuTimeUsedMs: 30597,
+      maxResidentSetSize: 20426752,
+      integralSharedMemorySize: 0,
+      integralUnsharedDataSize: 0,
+      integralUnsharedStackSize: 0,
+      pageReclaims: 3002,
+      pageFaults: 2250,
+      swaps: 0,
+      blockInputOperations: 0,
+      blockOutputOperations: 0,
+      ipcMessagesSent: 55,
+      ipcMessagesReceived: 54,
+      signalsReceived: 0,
+      voluntaryContextSwitches: 92,
+      involuntaryContextSwitches: 374 }
+```
+
 ## process.send(message[, sendHandle[, options]][, callback])
 <!-- YAML
 added: v0.5.9

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1369,6 +1369,8 @@ Note: Windows only provides the following resource usage measures:
 - `userCpuTimeUsedMs`
 - `systemCpuTimeUsedSec`
 - `systemCpuTimeUsedMs`
+- `blockInputOperations`
+- `blockOutputOperations`
 
 On Windows, all other values are `0`.
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -39,6 +39,7 @@
     _process.setup_hrtime();
     _process.setup_cpuUsage();
     _process.setupMemoryUsage();
+    _process.setupResourceUsage();
     _process.setupConfig(NativeModule._source);
     NativeModule.require('internal/process/warning').setup();
     NativeModule.require('internal/process/next_tick').setup();

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -12,6 +12,7 @@ function lazyConstants() {
 exports.setup_cpuUsage = setup_cpuUsage;
 exports.setup_hrtime = setup_hrtime;
 exports.setupMemoryUsage = setupMemoryUsage;
+exports.setupResourceUsage = setupResourceUsage;
 exports.setupConfig = setupConfig;
 exports.setupKillAndExit = setupKillAndExit;
 exports.setupSignalHandlers = setupSignalHandlers;
@@ -113,6 +114,35 @@ function setupMemoryUsage() {
       heapTotal: memValues[1],
       heapUsed: memValues[2],
       external: memValues[3]
+    };
+  };
+}
+
+function setupResourceUsage() {
+  const resourceUsage_ = process.resourceUsage;
+  const resValues = new Float64Array(18);
+
+  process.resourceUsage = function resourceUsage() {
+    resourceUsage_(resValues);
+    return {
+      userCpuTimeUsedSec: resValues[0],
+      userCpuTimeUsedMs: resValues[1],
+      systemCpuTimeUsedSec: resValues[2],
+      systemCpuTimeUsedMs: resValues[3],
+      maxResidentSetSize: resValues[4],
+      integralSharedMemorySize: resValues[5],
+      integralUnsharedDataSize: resValues[6],
+      integralUnsharedStackSize: resValues[7],
+      pageReclaims: resValues[8],
+      pageFaults: resValues[9],
+      swaps: resValues[10],
+      blockInputOperations: resValues[11],
+      blockOutputOperations: resValues[12],
+      ipcMessagesSent: resValues[13],
+      ipcMessagesReceived: resValues[14],
+      signalsReceived: resValues[15],
+      voluntaryContextSwitches: resValues[16],
+      involuntaryContextSwitches: resValues[17]
     };
   };
 }

--- a/src/env.h
+++ b/src/env.h
@@ -227,24 +227,6 @@ namespace node {
   V(write_queue_size_string, "writeQueueSize")                                \
   V(x_forwarded_string, "x-forwarded-for")                                    \
   V(zero_return_string, "ZERO_RETURN")                                        \
-  V(user_cpu_time_used_sec, "userCpuTimeUsedSec")                             \
-  V(user_cpu_time_used_ms, "userCpuTimeUsedMs")                               \
-  V(system_cpu_time_used_sec, "systemCpuTimeUsedSec")                         \
-  V(system_cpu_time_used_ms, "systemCpuTimeUsedMs")                           \
-  V(max_resident_set_size, "maxResidentSetSize")                              \
-  V(integral_shared_mem_size, "integralSharedMemorySize")                     \
-  V(integral_unshared_data_size, "integralUnsharedDataSize")                  \
-  V(integral_unshared_stack_size, "integralUnsharedStackSize")                \
-  V(page_reclaims, "pageReclaims")                                            \
-  V(page_faults, "pageFaults")                                                \
-  V(swaps, "swaps")                                                           \
-  V(block_input_operations, "blockInputOperations")                           \
-  V(block_output_operations, "blockOutputOperations")                         \
-  V(ipc_messages_sent, "ipcMessagesSent")                                     \
-  V(ipc_messages_received, "ipcMessagesReceived")                             \
-  V(signals_received, "signalsReceived")                                      \
-  V(voluntary_context_switches, "voluntaryContextSwitches")                   \
-  V(involuntary_context_switches, "involuntaryContextSwitches")               \
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
   V(as_external, v8::External)                                                \

--- a/src/env.h
+++ b/src/env.h
@@ -227,6 +227,24 @@ namespace node {
   V(write_queue_size_string, "writeQueueSize")                                \
   V(x_forwarded_string, "x-forwarded-for")                                    \
   V(zero_return_string, "ZERO_RETURN")                                        \
+  V(user_cpu_time_used_sec, "userCpuTimeUsedSec")                             \
+  V(user_cpu_time_used_ms, "userCpuTimeUsedMs")                               \
+  V(system_cpu_time_used_sec, "systemCpuTimeUsedSec")                         \
+  V(system_cpu_time_used_ms, "systemCpuTimeUsedMs")                           \
+  V(max_resident_set_size, "maxResidentSetSize")                              \
+  V(integral_shared_mem_size, "integralSharedMemorySize")                     \
+  V(integral_unshared_data_size, "integralUnsharedDataSize")                  \
+  V(integral_unshared_stack_size, "integralUnsharedStackSize")                \
+  V(page_reclaims, "pageReclaims")                                            \
+  V(page_faults, "pageFaults")                                                \
+  V(swaps, "swaps")                                                           \
+  V(block_input_operations, "blockInputOperations")                           \
+  V(block_output_operations, "blockOutputOperations")                         \
+  V(ipc_messages_sent, "ipcMessagesSent")                                     \
+  V(ipc_messages_received, "ipcMessagesReceived")                             \
+  V(signals_received, "signalsReceived")                                      \
+  V(voluntary_context_switches, "voluntaryContextSwitches")                   \
+  V(involuntary_context_switches, "involuntaryContextSwitches")               \
 
 #define ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)                           \
   V(as_external, v8::External)                                                \

--- a/src/node.cc
+++ b/src/node.cc
@@ -2269,45 +2269,31 @@ static void GetResourceUsage(const FunctionCallbackInfo<Value>& args) {
   if (err)
     return env->ThrowUVException(err, "uv_getrusage");
 
-  Local<Object> resource_usage = Object::New(env->isolate());
-  resource_usage->Set(env->user_cpu_time_used_sec(),
-                      Number::New(env->isolate(), rusage.ru_utime.tv_sec));
-  resource_usage->Set(env->user_cpu_time_used_ms(),
-                      Number::New(env->isolate(), rusage.ru_utime.tv_usec));
-  resource_usage->Set(env->system_cpu_time_used_sec(),
-                      Number::New(env->isolate(), rusage.ru_stime.tv_sec));
-  resource_usage->Set(env->system_cpu_time_used_ms(),
-                      Number::New(env->isolate(), rusage.ru_stime.tv_usec));
-  resource_usage->Set(env->max_resident_set_size(),
-                      Number::New(env->isolate(), rusage.ru_maxrss));
-  resource_usage->Set(env->integral_shared_mem_size(),
-                      Number::New(env->isolate(), rusage.ru_ixrss));
-  resource_usage->Set(env->integral_unshared_data_size(),
-                      Number::New(env->isolate(), rusage.ru_idrss));
-  resource_usage->Set(env->integral_unshared_stack_size(),
-                      Number::New(env->isolate(), rusage.ru_isrss));
-  resource_usage->Set(env->page_reclaims(),
-                      Number::New(env->isolate(), rusage.ru_minflt));
-  resource_usage->Set(env->page_faults(),
-                      Number::New(env->isolate(), rusage.ru_majflt));
-  resource_usage->Set(env->swaps(),
-                      Number::New(env->isolate(), rusage.ru_nswap));
-  resource_usage->Set(env->block_input_operations(),
-                      Number::New(env->isolate(), rusage.ru_inblock));
-  resource_usage->Set(env->block_output_operations(),
-                      Number::New(env->isolate(), rusage.ru_oublock));
-  resource_usage->Set(env->ipc_messages_sent(),
-                      Number::New(env->isolate(), rusage.ru_msgsnd));
-  resource_usage->Set(env->ipc_messages_received(),
-                      Number::New(env->isolate(), rusage.ru_msgrcv));
-  resource_usage->Set(env->signals_received(),
-                      Number::New(env->isolate(), rusage.ru_nsignals));
-  resource_usage->Set(env->voluntary_context_switches(),
-                      Number::New(env->isolate(), rusage.ru_nvcsw));
-  resource_usage->Set(env->involuntary_context_switches(),
-                      Number::New(env->isolate(), rusage.ru_nivcsw));
+  // Get the double array pointer from the Float64Array argument.
+  CHECK(args[0]->IsFloat64Array());
+  Local<Float64Array> array = args[0].As<Float64Array>();
+  CHECK_EQ(array->Length(), 18);
+  Local<ArrayBuffer> ab = array->Buffer();
+  double* fields = static_cast<double*>(ab->GetContents().Data());
 
-  args.GetReturnValue().Set(resource_usage);
+  fields[0] = rusage.ru_utime.tv_sec;
+  fields[1] = rusage.ru_utime.tv_usec;
+  fields[2] = rusage.ru_stime.tv_sec;
+  fields[3] = rusage.ru_stime.tv_usec;
+  fields[4] = rusage.ru_maxrss;
+  fields[5] = rusage.ru_ixrss;
+  fields[6] = rusage.ru_idrss;
+  fields[7] = rusage.ru_isrss;
+  fields[8] = rusage.ru_minflt;
+  fields[9] = rusage.ru_majflt;
+  fields[10] = rusage.ru_nswap;
+  fields[11] = rusage.ru_inblock;
+  fields[12] = rusage.ru_oublock;
+  fields[13] = rusage.ru_msgsnd;
+  fields[14] = rusage.ru_msgrcv;
+  fields[15] = rusage.ru_nsignals;
+  fields[16] = rusage.ru_nvcsw;
+  fields[17] = rusage.ru_nivcsw;
 }
 
 

--- a/test/parallel/test-process-resource-usage.js
+++ b/test/parallel/test-process-resource-usage.js
@@ -1,0 +1,22 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const usage = process.resourceUsage();
+
+assert(usage.userCpuTimeUsedSec >= 0);
+assert(usage.userCpuTimeUsedMs >= 0);
+assert(usage.systemCpuTimeUsedSec >= 0);
+assert(usage.systemCpuTimeUsedMs >= 0);
+assert(usage.maxResidentSetSize >= 0);
+assert(usage.integralSharedMemorySize >= 0);
+assert(usage.integralUnsharedDataSize >= 0);
+assert(usage.integralUnsharedStackSize >= 0);
+assert(usage.pageReclaims >= 0);
+assert(usage.pageFaults >= 0);
+assert(usage.swaps >= 0);
+assert(usage.blockInputOperations >= 0);
+assert(usage.blockOutputOperations >= 0);
+assert(usage.ipcMessagesSent >= 0);
+assert(usage.ipcMessagesReceived >= 0);
+assert(usage.voluntaryContextSwitches >= 0);
+assert(usage.involuntaryContextSwitches >= 0);


### PR DESCRIPTION
Picked up from stalled https://github.com/nodejs/node/pull/1568. Not sure we want to do this or not, but let's figure it out and either move forward or close it once and for all...

From @romankl (original author and still listed as the author for the actual commit in this PR):

libuv already provides the `uv_getrusage` function to get the
resource mesaures for the current process.
This change implements the new `process.resourceUsage()` function
to make use of it.

An example output looks like:

```js
{ userCpuTimeUsedSec: 0,
  userCpuTimeUsedMs: 159729,
  systemCpuTimeUsedSec: 0,
  systemCpuTimeUsedMs: 30597,
  maxResidentSetSize: 20426752,
  sharedMemSize: 0,
  integralUnsharedDataSize: 0,
  integralUnsharedStackSize: 0,
  pageReclaims: 3002,
  pageFaults: 2250,
  swaps: 0,
  blockInputOperations: 0,
  blockOutputOperations: 0,
  ipcMessagesSent: 55,
  ipcMessagesReceived: 54,
  signalsReceived: 0,
  voluntaryContextSwitches: 92,
  involuntaryContextSwitches: 374 }
```

Not supported fields on windows are zero.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process