### PR TITLE
doc: update V8 debugger doc to mention --inspect-brk

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -197,8 +197,8 @@ V8 Inspector can be enabled by passing the `--inspect` flag when starting a
 Node.js application. It is also possible to supply a custom port with that flag,
 e.g. `--inspect=9222` will accept DevTools connections on port 9222.
 
-To break on the first line of the application code, provide the `--debug-brk`
-flag in addition to `--inspect`.
+To break on the first line of the application code, pass the `--inspect-brk`
+flag instead of `--inspect`.
 
 ```txt
 $ node --inspect index.js


### PR DESCRIPTION
Node now supports the `--inspect-brk` flag, which does the same thing
as `--inspect --debug-brk`. One thing that's nice about the new flag is
that it uses "inspect" language -- this is a suggested update to the
docs.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
