### PR TITLE
process: fix typo in comments

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -75,7 +75,7 @@ function setup_cpuUsage() {
 
 // The 3 entries filled in by the original process.hrtime contains
 // the upper/lower 32 bits of the second part of the value,
-// and the renamining nanoseconds of the value.
+// and the remaining nanoseconds of the value.
 function setup_hrtime() {
   const _hrtime = process.hrtime;
   const hrValues = new Uint32Array(3);


### PR DESCRIPTION
Fixing a typo in comments, the word 'remaining' had a typo.
Fixes: https://github.com/nodejs/node/issues/11491

##### Checklist
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
process
