### PR TITLE
http: add bytesRead property to IncomingMessage

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1257,6 +1257,12 @@ added: v0.4.2
 Indicates that the underlying connection was closed.
 Just like `'end'`, this event occurs only once per response.
 
+### message.bytesRead
+
+* {Number}
+
+Returns the value of `socket.bytesRead` 
+
 ### message.destroy([error])
 <!-- YAML
 added: v0.3.0

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -118,6 +118,12 @@ function _addHeaderLines(headers, n) {
   }
 }
 
+Object.defineProperty(IncomingMessage.prototype, 'bytesRead', {
+  get: function() {
+    return this.socket ? this.socket.bytesRead : 0;
+  }
+});
+
 
 // This function is used to help avoid the lowercasing of a field name if it
 // matches a 'traditional cased' version of a field name. It then returns the

--- a/test/parallel/test-http-incoming-bytesRead.js
+++ b/test/parallel/test-http-incoming-bytesRead.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const IncomingMessage = require('http').IncomingMessage;
+
+let incomingMessage;
+
+incomingMessage = new IncomingMessage();
+assert.strictEqual(incomingMessage.bytesRead, 0);
+
+incomingMessage = new IncomingMessage({bytesRead: 0});
+assert.strictEqual(incomingMessage.bytesRead, 0);
+
+incomingMessage = new IncomingMessage({bytesRead: 2});
+assert.strictEqual(incomingMessage.bytesRead, 2);


### PR DESCRIPTION
http: add `bytesRead` property to `IncomingMessage`

The bytesRead property is a getter that returns the value of
`socket.bytesRead`. If no `socket` was passed, it will default to `0`.

Fixes: https://github.com/nodejs/node/issues/11507

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http
