### PR TITLE
assert: apply minor refactoring

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,7 +1,3 @@
-// http://wiki.commonjs.org/wiki/Unit_Testing/1.0
-//
-// THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!
-//
 // Originally from narwhal.js (http://narwhaljs.org)
 // Copyright (c) 2009 Thomas Robinson <280north.com>
 //
@@ -213,7 +209,7 @@ function _deepEqual(actual, expected, strict, memos) {
 }
 
 function isArguments(object) {
-  return Object.prototype.toString.call(object) == '[object Arguments]';
+  return Object.prototype.toString.call(object) === '[object Arguments]';
 }
 
 function objEquiv(a, b, strict, actualVisitedObjects) {
@@ -299,7 +295,7 @@ function expectedException(actual, expected) {
     return false;
   }
 
-  if (Object.prototype.toString.call(expected) == '[object RegExp]') {
+  if (Object.prototype.toString.call(expected) === '[object RegExp]') {
     return expected.test(actual);
   }
 


### PR DESCRIPTION
* Remove comment referring to the CommonJS Unit Testing 1.0 spec. This
  module is no longer intended to comply with that spec.
* Remove puzzling "THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!"
  comment. No doubt, it made sense at one time.
* Favor `===` over `==` in two places.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert