### PR TITLE
os: improve loadavg() performance

### DIFF
--- a/benchmark/os/loadavg.js
+++ b/benchmark/os/loadavg.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common.js');
+const loadavg = require('os').loadavg;
+
+const bench = common.createBenchmark(main, {
+  n: [5e6]
+});
+
+function main(conf) {
+  const n = +conf.n;
+
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    loadavg();
+  bench.end(n);
+}

--- a/lib/os.js
+++ b/lib/os.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const binding = process.binding('os');
+const getLoadAvg = binding.getLoadAvg;
 const constants = process.binding('constants').os;
 const internalUtil = require('internal/util');
 const isWindows = process.platform === 'win32';
 
 exports.hostname = binding.getHostname;
-exports.loadavg = binding.getLoadAvg;
 exports.uptime = binding.getUptime;
 exports.freemem = binding.getFreeMem;
 exports.totalmem = binding.getTotalMem;
@@ -16,6 +16,12 @@ exports.release = binding.getOSRelease;
 exports.networkInterfaces = binding.getInterfaceAddresses;
 exports.homedir = binding.getHomeDirectory;
 exports.userInfo = binding.getUserInfo;
+
+const avgValues = new Float64Array(3);
+exports.loadavg = function loadavg() {
+  getLoadAvg(avgValues);
+  return [avgValues[0], avgValues[1], avgValues[2]];
+};
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -28,8 +28,10 @@ namespace node {
 namespace os {
 
 using v8::Array;
+using v8::ArrayBuffer;
 using v8::Boolean;
 using v8::Context;
+using v8::Float64Array;
 using v8::FunctionCallbackInfo;
 using v8::Integer;
 using v8::Local;
@@ -182,14 +184,12 @@ static void GetUptime(const FunctionCallbackInfo<Value>& args) {
 
 
 static void GetLoadAvg(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  double loadavg[3];
+  CHECK(args[0]->IsFloat64Array());
+  Local<Float64Array> array = args[0].As<Float64Array>();
+  CHECK_EQ(array->Length(), 3);
+  Local<ArrayBuffer> ab = array->Buffer();
+  double* loadavg = static_cast<double*>(ab->GetContents().Data());
   uv_loadavg(loadavg);
-  Local<Array> loads = Array::New(env->isolate(), 3);
-  loads->Set(0, Number::New(env->isolate(), loadavg[0]));
-  loads->Set(1, Number::New(env->isolate(), loadavg[1]));
-  loads->Set(2, Number::New(env->isolate(), loadavg[2]));
-  args.GetReturnValue().Set(loads);
 }
 
 


### PR DESCRIPTION
Results with included benchmark:

```
                         improvement confidence      p.value
 os/loadavg.js n=5000000    150.91 %        *** 1.380968e-49
```

CI: https://ci.nodejs.org/job/node-test-pull-request/6563/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* os
