### PR TITLE
doc: link to readable and writeable stream section

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1765,8 +1765,8 @@ cases:
 [Signal Events]: #process_signal_events
 [Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
 [TTY]: tty.html#tty_tty
-[Writable]: stream.html
-[Readable]: stream.html
+[Writable]: stream.html#stream_writable_streams
+[Readable]: stream.html#stream_readable_streams
 [Child Process]: child_process.html
 [Cluster]: cluster.html
 [`process.exitCode`]: #process_process_exitcode

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -518,8 +518,8 @@ rl.on('line', (line) => {
 
 [`process.stdin`]: process.html#process_process_stdin
 [`process.stdout`]: process.html#process_process_stdout
-[Writable]: stream.html
-[Readable]: stream.html
+[Writable]: stream.html#stream_writable_streams
+[Readable]: stream.html#stream_readable_streams
 [TTY]: tty.html
 [`SIGTSTP`]: readline.html#readline_event_sigtstp
 [`SIGCONT`]: readline.html#readline_event_sigcont


### PR DESCRIPTION
Modify the [Writable] and [Readable] links so they point
directly to the right sections in the stream.html doc

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc