### PR TITLE
doc: use common malformed instead of misformatted

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -382,7 +382,7 @@ When set, the well known "root" CAs (like VeriSign) will be extended with the
 extra certificates in `file`. The file should consist of one or more trusted
 certificates in PEM format. A message will be emitted (once) with
 [`process.emitWarning()`][emit_warning] if the file is missing or
-misformatted, but any errors are otherwise ignored.
+malformed, but any errors are otherwise ignored.
 
 Note that neither the well known nor extra certificates are used when the `ca`
 options property is explicitly specified for a TLS or HTTPS client or server.


### PR DESCRIPTION
This PR updates documentation included in the new well-known CAs feature to change the word "misformatted" to "malformed" since the word "misformatted" is less common.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
