### PR TITLE
build: add rule to clean addon tests build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,11 @@ test-npm-publish: $(NODE_EXE)
 test-addons: test-build
 	$(PYTHON) tools/test.py --mode=release addons
 
+test-addons-clean:
+	$(RM) -rf test/addons/??_*/
+	$(RM) -rf test/addons/*/build
+	$(RM) test/addons/.buildstamp test/addons/.docbuildstamp
+
 test-timers:
 	$(MAKE) --directory=tools faketime
 	$(PYTHON) tools/test.py --mode=release timers
@@ -847,10 +852,11 @@ endif
 
 .PHONY: lint cpplint jslint bench clean docopen docclean doc dist distclean \
 	check uninstall install install-includes install-bin all staticlib \
-	dynamiclib test test-all test-addons build-addons website-upload pkg \
-	blog blogclean tar binary release-only bench-http-simple bench-idle \
-	bench-all bench bench-misc bench-array bench-buffer bench-net \
-	bench-http bench-fs bench-tls cctest run-ci test-v8 test-v8-intl \
-	test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci doc-only \
-	$(TARBALL)-headers test-ci test-ci-native test-ci-js build-ci clear-stalled \
-	coverage-clean coverage-build coverage-test coverage list-gtests
+	dynamiclib test test-all test-addons test-addons-clean build-addons \
+	website-upload pkg blog blogclean tar binary release-only \
+	bench-http-simple bench-idle bench-all bench bench-misc bench-array \
+	bench-buffer bench-net bench-http bench-fs bench-tls cctest run-ci test-v8 \
+	test-v8-intl test-v8-benchmarks test-v8-all v8 lint-ci bench-ci jslint-ci \
+	doc-only $(TARBALL)-headers test-ci test-ci-native test-ci-js build-ci \
+	clear-stalled coverage-clean coverage-build coverage-test coverage \
+	list-gtests


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Add a rule to the makefile to clean up files generated during testing addons.

Note: when switching from a newer branch, where the addon tests have been built, to an older branch that don't have some of the addon tests, there would be leftover `build` directories in those test folders.

```
$ ls test/addons/node-module-version/
binding.cc  binding.gyp build test.js
$ git checkout v4.8.0
$ ls test/addons/node-module-version/
build
```

`test/addons/.buildstamp` would try to use node-gyp to build them, only to find the `binding.gyp` missing. If we run this rule before switching branches, there won't be leftover `build` and those test folders would not be kept when the branches are switched. I think the `test/addons/.buildstamp` can have some kind of conditions to avoid that or just delete folders with only `build`, but not sure what's the appropriate way to do this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build