### PR TITLE
test: Fix flaky test-vm-timeout-rethrow

### DIFF
--- a/test/sequential/test-vm-timeout-rethrow.js
+++ b/test/sequential/test-vm-timeout-rethrow.js
@@ -5,9 +5,7 @@ const vm = require('vm');
 const spawn = require('child_process').spawn;
 
 if (process.argv[2] === 'child') {
-  const code = 'let j = 0;\n' +
-               'while(true);\n' +
-               'j;';
+  const code = 'while(true);';
 
   const ctx = vm.createContext();
 

--- a/test/sequential/test-vm-timeout-rethrow.js
+++ b/test/sequential/test-vm-timeout-rethrow.js
@@ -9,11 +9,7 @@ if (process.argv[2] === 'child') {
                'while(true);\n' +
                'j;';
 
-  const ctx = vm.createContext({
-    add: function(x, y) {
-      return x + y;
-    }
-  });
+  const ctx = vm.createContext();
 
   vm.runInContext(code, ctx, { timeout: 1 });
 } else {

--- a/test/sequential/test-vm-timeout-rethrow.js
+++ b/test/sequential/test-vm-timeout-rethrow.js
@@ -6,7 +6,7 @@ const spawn = require('child_process').spawn;
 
 if (process.argv[2] === 'child') {
   const code = 'let j = 0;\n' +
-               'for (let i = 0; i < 1000000; i++) j += add(i, i + 1);\n' +
+               'while(true);\n' +
                'j;';
 
   const ctx = vm.createContext({


### PR DESCRIPTION
The intention of test case is to make sure that `timeout` property is honored
and the code in context terminates and throws correct exception. However in
test case, the code inside context would complete before `timeout` for windows
and would sometimes fail. Updated the code so it guarantee to not complete
execution until timeout is triggered.

Fixes: #11261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
