### PR TITLE
test: improve console coverage to check ignoreErrors

### DIFF
--- a/test/parallel/test-console-write-without-ignore-errors.js
+++ b/test/parallel/test-console-write-without-ignore-errors.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const { Console } = require('console');
+const { Writable } = require('stream');
+const assert = require('assert');
+const ignoreErrors = false;
+const expected = 'foobarbaz';
+
+{
+  const out = new Writable({
+    write: common.mustCall((chunk, enc, callback) => {
+      const actual = chunk.toString();
+      assert.strictEqual(expected + '\n', actual);
+    })
+  });
+  
+  const c = new Console(out, out, ignoreErrors);
+  c.log(expected);
+}
+
+assert.throws(() => {
+  const err = new Writable({
+    write: common.mustCall((chunk, enc, callback) => {
+      throw new Error('foobar');
+    })
+  });
+  const c = new Console(err, err, ignoreErrors);
+  c.log(expected);
+}, /^Error: foobar$/);


### PR DESCRIPTION
This PR can cover some uncovered lines on `lib/console.js`.
see:https://coverage.nodejs.org/coverage-29ff16f04373d434/root/console.js.html 
I checked `write` function if ignoreErrors is false. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test