### PR TITLE
child_process: fix deoptimizing use of arguments

### DIFF
--- a/benchmark/child_process/child-process-params.js
+++ b/benchmark/child_process/child-process-params.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const common = require('../common.js');
+const cp = require('child_process');
+
+const command = 'echo';
+const args = ['hello'];
+const options = {};
+const cb = () => {};
+
+const configs = {
+  n: [1e3],
+  methodName: [
+    'exec', 'execSync',
+    'execFile', 'execFileSync',
+    'spawn', 'spawnSync',
+  ],
+  params: [1, 2, 3, 4],
+};
+
+const bench = common.createBenchmark(main, configs);
+
+function main(conf) {
+  const n = +conf.n;
+  const methodName = conf.methodName;
+  const params = +conf.params;
+
+  const method = cp[methodName];
+
+  switch (methodName) {
+    case 'exec':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options, cb).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options);
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execFile':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options).kill();
+          bench.end(n);
+          break;
+        case 4:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options, cb).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execFileSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args);
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options);
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'spawn':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'spawnSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args);
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options);
+          bench.end(n);
+          break;
+      }
+      break;
+  }
+}

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -93,16 +93,10 @@ exports._forkChild = function(fd) {
 };
 
 
-function normalizeExecArgs(command /*, options, callback*/) {
-  let options;
-  let callback;
-
-  if (typeof arguments[1] === 'function') {
+function normalizeExecArgs(command, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
     options = undefined;
-    callback = arguments[1];
-  } else {
-    options = arguments[1];
-    callback = arguments[2];
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
@@ -156,7 +150,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     callback = arguments[pos++];
   }
 
-  if (!callback && arguments[pos] != null) {
+  if (!callback && pos < arguments.length && arguments[pos] != null) {
     throw new TypeError('Incorrect value of args option');
   }
 
@@ -195,6 +189,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   var ex = null;
 
+  var cmd = file;
+
   function exithandler(code, signal) {
     if (exited) return;
     exited = true;
@@ -222,7 +218,6 @@ exports.execFile = function(file /*, args, options, callback*/) {
       return;
     }
 
-    var cmd = file;
     if (args.length !== 0)
       cmd += ' ' + args.join(' ');
 
@@ -330,21 +325,18 @@ function _convertCustomFds(options) {
   }
 }
 
-function normalizeSpawnArguments(file /*, args, options*/) {
-  var args, options;
-
+function normalizeSpawnArguments(file, args, options) {
   if (typeof file !== 'string' || file.length === 0)
     throw new TypeError('"file" argument must be a non-empty string');
 
-  if (Array.isArray(arguments[1])) {
-    args = arguments[1].slice(0);
-    options = arguments[2];
-  } else if (arguments[1] !== undefined &&
-             (arguments[1] === null || typeof arguments[1] !== 'object')) {
+  if (Array.isArray(args)) {
+    args = args.slice(0);
+  } else if (args !== undefined &&
+             (args === null || typeof args !== 'object')) {
     throw new TypeError('Incorrect value of args option');
   } else {
+    options = args;
     args = [];
-    options = arguments[1];
   }
 
   if (options === undefined)


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process, benchmarks

This is the last unaddressed case from mentioned in the https://github.com/nodejs/node/issues/10323. PR fixes three functions.

1\. Function `normalizeExecArgs()` is called by `exports.exec()` and `exports.execSync()` with a variable number of parameters.

To check deoptimizations, run this code with `--trace_opt --trace_deopt` flags:
```js
const execSync = require('child_process').execSync;
for (let i = 0; i < 1e3; i++) execSync('echo');
```
You will see messages about `normalizeExecArgs()` deoptimization.

None of the current benchmarks checks this case: the only benchmark calling `exports.exec()` does it once and always with 2 parameters.

2\. Function `exports.execFile()` is called by users with a variable number of parameters. See also https://github.com/nodejs/node/issues/10323#issuecomment-268038165

To check deoptimizations, run this code with `--trace_opt --trace_deopt` flags:
```js
const execFile = require('child_process').execFile;
for (let i = 0; i < 1e3; i++) execFile('echo').kill();
```
You will see messages about `exports.execFile()` deoptimization.

None of the current benchmarks checks `exports.execFile()`.

3\. Function `normalizeSpawnArguments()` is called by `exports.spawn()`, `exports.spawnSync()`, and `exports.execFileSync()` with a variable number of parameters.

To check deoptimizations, run this code with `--trace_opt --trace_deopt` flags:
```js
const spawnSync = require('child_process').spawnSync;
for (let i = 0; i < 1e3; i++) spawnSync('echo');
```
You will see messages about `normalizeSpawnArguments()` deoptimization.

None of the current benchmarks checks `exports.spawnSync()` or `exports.execFileSync()`. Two of them call `exports.spawn()` once with 3 params (not appropriate). One of them calls `exports.spawn()` 1000 times with 2 params, but it does not cover all sub-cases.

4\. While fixing these cases, I've found an absolutely new deopt case in the `exports.execFile()` function introduced by v8 5.6. See the fourth commit and explanation [in the upstream issue](https://bugs.chromium.org/p/v8/issues/detail?id=6010).

5\. As changes affect almost all main `child_process` methods (except `.fork()`), I've added a benchmark calling these 6 methods with 1, 2, 3, and 4 params (when it is appropriate). Benchmarking is a bit murky  in this case because of many external sync/async processes involved, but it seems no significant degradation is caused, moreover some tiny improvement is evident.
```
                                                                                  improvement confidence      p.value
 child_process\\child-process-params.js params=1 methodName="exec" n=1000              0.59 %            6.187539e-02
 child_process\\child-process-params.js params=1 methodName="execFile" n=1000          0.62 %          * 2.916666e-02
 child_process\\child-process-params.js params=1 methodName="execFileSync" n=1000      0.32 %            5.213650e-01
 child_process\\child-process-params.js params=1 methodName="execSync" n=1000          0.26 %          * 4.716863e-02
 child_process\\child-process-params.js params=1 methodName="spawn" n=1000             0.69 %        *** 2.204024e-04
 child_process\\child-process-params.js params=1 methodName="spawnSync" n=1000         0.19 %            7.165778e-01
 child_process\\child-process-params.js params=2 methodName="exec" n=1000              0.72 %          * 4.544538e-02
 child_process\\child-process-params.js params=2 methodName="execFile" n=1000          0.68 %          * 2.451089e-02
 child_process\\child-process-params.js params=2 methodName="execFileSync" n=1000     -0.30 %            5.470930e-01
 child_process\\child-process-params.js params=2 methodName="execSync" n=1000          0.30 %            1.907476e-01
 child_process\\child-process-params.js params=2 methodName="spawn" n=1000             0.40 %         ** 6.548929e-03
 child_process\\child-process-params.js params=2 methodName="spawnSync" n=1000         0.51 %            2.825198e-01
 child_process\\child-process-params.js params=3 methodName="exec" n=1000              0.37 %            2.182035e-01
 child_process\\child-process-params.js params=3 methodName="execFile" n=1000          0.86 %        *** 1.298733e-06
 child_process\\child-process-params.js params=3 methodName="execFileSync" n=1000      0.22 %            7.333930e-01
 child_process\\child-process-params.js params=3 methodName="spawn" n=1000             0.95 %         ** 7.015692e-03
 child_process\\child-process-params.js params=3 methodName="spawnSync" n=1000        -0.43 %            4.574352e-01
 child_process\\child-process-params.js params=4 methodName="execFile" n=1000          1.15 %        *** 6.094645e-07
```