### PR TITLE
build: build a x64 build by default on Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -14,7 +14,7 @@ if /i "%1"=="/?" goto help
 @rem Process arguments.
 set config=Release
 set target=Build
-set target_arch=x86
+set target_arch=x64
 set target_env=
 set noprojgen=
 set nobuild=


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

I'm quite sure most people are interested in x64 builds in 2017, and defaulting to x86 causes confusion, see for example https://github.com/nodejs/node/issues/11500.