### PR TITLE
Have console.timeEnd return the elapsed time.

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -122,10 +122,10 @@ Console.prototype.timeEnd = function timeEnd(label) {
     return;
   }
   const duration = process.hrtime(time);
-  const ms = duration[0] * 1000 + duration[1] / 1e6;
-  this.log('%s: %sms', label, ms.toFixed(3));
+  const ms = (duration[0] * 1000 + duration[1] / 1e6).toFixed(3);
+  this.log('%s: %sms', label, ms);
   this._times.delete(label);
-	return ms.toFixed(3);//return the elapsed time
+  return ms;
 };
 
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -125,6 +125,7 @@ Console.prototype.timeEnd = function timeEnd(label) {
   const ms = duration[0] * 1000 + duration[1] / 1e6;
   this.log('%s: %sms', label, ms.toFixed(3));
   this._times.delete(label);
+	return ms.toFixed(3);//return the elapsed time
 };
 
 


### PR DESCRIPTION
Some browsers do this already, but Node.js certainly should.

##### Affected core subsystem(s)
Console
