### PR TITLE
doc: document clientRequest.aborted

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -450,6 +450,14 @@ added: v0.3.8
 Marks the request as aborting. Calling this will cause remaining data
 in the response to be dropped and the socket to be destroyed.
 
+### request.aborted
+<!-- YAML
+added: v0.11.14
+-->
+
+If a request has been aborted, this value is the time when the request was
+aborted, in milliseconds since 1 January 1970 00:00:00 UTC.
+
 ### request.end([data][, encoding][, callback])
 <!-- YAML
 added: v0.1.90


### PR DESCRIPTION
Add documentation for http clientRequest.aborted.

This property was added in https://github.com/nodejs/node-v0.x-archive/pull/7533. It's not prefixed so it doesn't seem to be private. It appears necessary to use it to check if a request was explicitly aborted (i.e. with `req.abort()`) inside of a `req.on("error", ...)` listener.

(I was surprised that the "error" event fires after explicitly calling `req.abort()`, but doubt that behavior can change. As @cjihrig pointed out [here](https://github.com/nodejs/node-v0.x-archive/issues/9278#issuecomment-76967400), aborting a connection is not an error.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, http