### PR TITLE
WIP: cluster: make scheduler configurable

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -709,10 +709,15 @@ True if the process is not a master (it is the negation of `cluster.isMaster`).
 ## cluster.schedulingPolicy
 <!-- YAML
 added: v0.11.2
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/11546
+    description: The scheduling policy can now be user defined.
 -->
 
-The scheduling policy, either `cluster.SCHED_RR` for round-robin or
-`cluster.SCHED_NONE` to leave it to the operating system. This is a
+The scheduling policy, either `cluster.SCHED_RR` for round-robin,
+`cluster.SCHED_NONE` to leave it to the operating system, or
+`cluster.SCHED_CUSTOM` for a user defined scheduling algorightm. This is a
 global setting and effectively frozen once you spawn the first worker
 or call `cluster.setupMaster()`, whatever comes first.
 
@@ -722,7 +727,7 @@ distribute IOCP handles without incurring a large performance hit.
 
 `cluster.schedulingPolicy` can also be set through the
 `NODE_CLUSTER_SCHED_POLICY` environment variable. Valid
-values are `"rr"` and `"none"`.
+values are `"rr"`, `"none"`, and `"custom"`.
 
 ## cluster.settings
 <!-- YAML
@@ -759,12 +764,16 @@ changes:
   - version: v6.4.0
     pr-url: https://github.com/nodejs/node/pull/7838
     description: The `stdio` option is supported now.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/11546
+    description: The `scheduler` option is now supported.
 -->
 
 * `settings` {Object}
   * `exec` {string} file path to worker file.  (Default=`process.argv[1]`)
   * `args` {Array} string arguments passed to worker.
     (Default=`process.argv.slice(2)`)
+  * `scheduler` {Function} a synchronous function used to schedule connections.
   * `silent` {boolean} whether or not to send output to parent's stdio.
     (Default=`false`)
   * `stdio` {Array} Configures the stdio of forked processes. When this option
@@ -857,6 +866,59 @@ the worker's unique id is the easiest way to find the worker.
 socket.on('data', (id) => {
   const worker = cluster.workers[id];
 });
+```
+
+## Custom Scheduling
+<!-- YAML
+added: REPLACEME
+-->
+
+The cluster master's scheduling algorithm can be customized by setting
+`cluster.schedulingPolicy` to `cluster.SCHED_CUSTOM` and passing a function
+as the `scheduler` option to `cluster.setupMaster()`. The `scheduler` is a
+synchronous function, whose signature is `scheduler(workers[, socket])`.
+
+* `workers` {Array} an array of cluster workers that the request can be
+  distributed to.
+* `socket` {net.Socket} a socket that can be used for connection based
+  scheduling. There is some overhead associated with creating `socket`, so it is
+  not provided by default. If the scheduling policy requires access to `socket`,
+  set `exposeSocket` to `true` on the `scheduler` function.
+
+The scheduling function should return the worker that will handle the
+connection. However, the worker should not be removed from `workers`. If a
+cluster worker is not returned from the scheduler, the connection will not be
+processed at that time. An example that implements round robin scheduling is
+shown below.
+
+```javascript
+'use strict';
+const cluster = require('cluster');
+const http = require('http');
+
+if (cluster.isMaster) {
+  function scheduler(workers, socket) {
+    const worker = workers.shift();
+
+    if (worker === undefined)
+      return;
+
+    workers.shift(worker);  // Add to the end of the queue.
+
+    return worker;
+  }
+
+  scheduler.exposeSocket = true;  // Expose the socket even though it is unused.
+  cluster.schedulingPolicy = cluster.SCHED_CUSTOM;
+  cluster.setupMaster({ scheduler });
+
+  cluster.fork();
+  cluster.fork();
+} else {
+  http.createServer((req, res) => {
+    res.end(`hello from ${cluster.worker.id}\n`);
+  }).listen(8080);
+}
 ```
 
 [`child_process.fork()`]: child_process.html#child_process_child_process_fork_modulepath_args_options

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -709,15 +709,10 @@ True if the process is not a master (it is the negation of `cluster.isMaster`).
 ## cluster.schedulingPolicy
 <!-- YAML
 added: v0.11.2
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/11546
-    description: The scheduling policy can now be user defined.
 -->
 
-The scheduling policy, either `cluster.SCHED_RR` for round-robin,
-`cluster.SCHED_NONE` to leave it to the operating system, or
-`cluster.SCHED_CUSTOM` for a user defined scheduling algorightm. This is a
+The scheduling policy, either `cluster.SCHED_RR` for round-robin or
+`cluster.SCHED_NONE` to leave it to the operating system. This is a
 global setting and effectively frozen once you spawn the first worker
 or call `cluster.setupMaster()`, whatever comes first.
 
@@ -727,7 +722,7 @@ distribute IOCP handles without incurring a large performance hit.
 
 `cluster.schedulingPolicy` can also be set through the
 `NODE_CLUSTER_SCHED_POLICY` environment variable. Valid
-values are `"rr"`, `"none"`, and `"custom"`.
+values are `"rr"` and `"none"`.
 
 ## cluster.settings
 <!-- YAML
@@ -873,10 +868,9 @@ socket.on('data', (id) => {
 added: REPLACEME
 -->
 
-The cluster master's scheduling algorithm can be customized by setting
-`cluster.schedulingPolicy` to `cluster.SCHED_CUSTOM` and passing a function
-as the `scheduler` option to `cluster.setupMaster()`. The `scheduler` is a
-synchronous function, whose signature is `scheduler(workers[, socket])`.
+The cluster master's scheduling algorithm can be customized by passing a
+function as the `scheduler` option to `cluster.setupMaster()`. The `scheduler`
+is a synchronous function, whose signature is `scheduler(workers[, socket])`.
 
 * `workers` {Array} an array of cluster workers that the request can be
   distributed to.
@@ -886,10 +880,10 @@ synchronous function, whose signature is `scheduler(workers[, socket])`.
   set `exposeSocket` to `true` on the `scheduler` function.
 
 The scheduling function should return the worker that will handle the
-connection. However, the worker should not be removed from `workers`. If a
-cluster worker is not returned from the scheduler, the connection will not be
-processed at that time. An example that implements round robin scheduling is
-shown below.
+connection. However, the `workers` array should under no condition be
+mutated. If a cluster worker is not returned from the scheduler, the
+connection will not be processed at that time. An example that implements round
+robin scheduling is shown below.
 
 ```javascript
 'use strict';
@@ -909,7 +903,6 @@ if (cluster.isMaster) {
   }
 
   scheduler.exposeSocket = true;  // Expose the socket even though it is unused.
-  cluster.schedulingPolicy = cluster.SCHED_CUSTOM;
   cluster.setupMaster({ scheduler });
 
   cluster.fork();

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -12,7 +12,6 @@ const cluster = new EventEmitter();
 const intercom = new EventEmitter();
 const SCHED_NONE = 1;
 const SCHED_RR = 2;
-const SCHED_CUSTOM = 3;
 
 module.exports = cluster;
 
@@ -23,7 +22,6 @@ cluster.workers = {};
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
 cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
-cluster.SCHED_CUSTOM = SCHED_CUSTOM; // User defined scheduler.
 
 var ids = 0;
 var debugPortOffset = 1;
@@ -33,8 +31,7 @@ var scheduler = null;
 // XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
 var schedulingPolicy = {
   'none': SCHED_NONE,
-  'rr': SCHED_RR,
-  'custom': SCHED_CUSTOM
+  'rr': SCHED_RR
 }[process.env.NODE_CLUSTER_SCHED_POLICY];
 
 if (schedulingPolicy === undefined) {
@@ -72,14 +69,14 @@ cluster.setupMaster = function(options) {
   initialized = true;
   schedulingPolicy = cluster.schedulingPolicy;  // Freeze policy.
 
-  if (schedulingPolicy === SCHED_RR) {
-    scheduler = RoundRobinHandle.scheduler;
-  } else if (schedulingPolicy === SCHED_CUSTOM) {
+  if (settings.scheduler !== undefined) {
     if (typeof settings.scheduler !== 'function') {
       throw new TypeError('scheduler must be a function');
     }
 
     scheduler = settings.scheduler;
+  } else if (schedulingPolicy === SCHED_RR) {
+    scheduler = RoundRobinHandle.scheduler;
   } else if (schedulingPolicy !== SCHED_NONE) {
     assert(false, `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
   }

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -12,6 +12,7 @@ const cluster = new EventEmitter();
 const intercom = new EventEmitter();
 const SCHED_NONE = 1;
 const SCHED_RR = 2;
+const SCHED_CUSTOM = 3;
 
 module.exports = cluster;
 
@@ -22,15 +23,18 @@ cluster.workers = {};
 cluster.settings = {};
 cluster.SCHED_NONE = SCHED_NONE;  // Leave it to the operating system.
 cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
+cluster.SCHED_CUSTOM = SCHED_CUSTOM; // User defined scheduler.
 
 var ids = 0;
 var debugPortOffset = 1;
 var initialized = false;
+var scheduler = null;
 
 // XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
 var schedulingPolicy = {
   'none': SCHED_NONE,
-  'rr': SCHED_RR
+  'rr': SCHED_RR,
+  'custom': SCHED_CUSTOM
 }[process.env.NODE_CLUSTER_SCHED_POLICY];
 
 if (schedulingPolicy === undefined) {
@@ -67,8 +71,18 @@ cluster.setupMaster = function(options) {
 
   initialized = true;
   schedulingPolicy = cluster.schedulingPolicy;  // Freeze policy.
-  assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
-         `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
+
+  if (schedulingPolicy === SCHED_RR) {
+    scheduler = RoundRobinHandle.scheduler;
+  } else if (schedulingPolicy === SCHED_CUSTOM) {
+    if (typeof settings.scheduler !== 'function') {
+      throw new TypeError('scheduler must be a function');
+    }
+
+    scheduler = settings.scheduler;
+  } else if (schedulingPolicy !== SCHED_NONE) {
+    assert(false, `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
+  }
 
   const hasDebugArg = process.execArgv.some((argv) => {
     return /^(--debug|--debug-brk)(=\d+)?$/.test(argv);
@@ -283,7 +297,7 @@ function queryServer(worker, message) {
     // UDP is exempt from round-robin connection balancing for what should
     // be obvious reasons: it's connectionless. There is nothing to send to
     // the workers except raw datagrams and that's pointless.
-    if (schedulingPolicy !== SCHED_RR ||
+    if (schedulingPolicy === SCHED_NONE ||
         message.addressType === 'udp4' ||
         message.addressType === 'udp6') {
       constructor = SharedHandle;
@@ -294,7 +308,8 @@ function queryServer(worker, message) {
                                             message.port,
                                             message.addressType,
                                             message.fd,
-                                            message.flags);
+                                            message.flags,
+                                            scheduler);
   }
 
   if (!handle.data)

--- a/lib/internal/cluster/round_robin_handle.js
+++ b/lib/internal/cluster/round_robin_handle.js
@@ -2,17 +2,19 @@
 const assert = require('assert');
 const net = require('net');
 const { sendHelper } = require('internal/cluster/utils');
+const create = Object.create;
 const getOwnPropertyNames = Object.getOwnPropertyNames;
 const uv = process.binding('uv');
 
 module.exports = RoundRobinHandle;
 
-function RoundRobinHandle(key, address, port, addressType, fd) {
+function RoundRobinHandle(key, address, port, addrType, fd, flags, scheduler) {
   this.key = key;
-  this.all = {};
-  this.free = [];
+  this.all = create(null);
+  this.workers = [];
   this.handles = [];
   this.handle = null;
+  this.scheduler = scheduler;
   this.server = net.createServer(assert.fail);
 
   if (fd >= 0)
@@ -30,6 +32,17 @@ function RoundRobinHandle(key, address, port, addressType, fd) {
   });
 }
 
+RoundRobinHandle.scheduler = function(workers) {
+  const worker = workers.shift();
+
+  if (worker === undefined)
+    return;
+
+  workers.push(worker);  // Add to the back of the ready queue.
+  return worker;
+};
+
+
 RoundRobinHandle.prototype.add = function(worker, send) {
   assert(worker.id in this.all === false);
   this.all[worker.id] = worker;
@@ -44,7 +57,8 @@ RoundRobinHandle.prototype.add = function(worker, send) {
       send(null, null, null);  // UNIX socket.
     }
 
-    this.handoff(worker);  // In case there are connections pending.
+    this.workers.push(worker);
+    this.handoff();  // In case there are connections pending.
   };
 
   if (this.server === null)
@@ -66,10 +80,10 @@ RoundRobinHandle.prototype.remove = function(worker) {
     return false;
 
   delete this.all[worker.id];
-  const index = this.free.indexOf(worker);
+  const index = this.workers.indexOf(worker);
 
   if (index !== -1)
-    this.free.splice(index, 1);
+    this.workers.splice(index, 1);
 
   if (getOwnPropertyNames(this.all).length !== 0)
     return false;
@@ -84,32 +98,46 @@ RoundRobinHandle.prototype.remove = function(worker) {
 
 RoundRobinHandle.prototype.distribute = function(err, handle) {
   this.handles.push(handle);
-  const worker = this.free.shift();
-
-  if (worker)
-    this.handoff(worker);
+  this.handoff();
 };
 
-RoundRobinHandle.prototype.handoff = function(worker) {
-  if (worker.id in this.all === false) {
-    return;  // Worker is closing (or has closed) the server.
+RoundRobinHandle.prototype.handoff = function() {
+  const handle = this.handles[0];
+  var socket;
+
+  // There are currently no requests to schedule.
+  if (handle === undefined)
+    return;
+
+  if (this.scheduler.exposeSocket === true) {
+    socket = new net.Socket({
+      handle,
+      readable: false,
+      writable: false,
+      pauseOnCreate: true
+    });
   }
 
-  const handle = this.handles.shift();
+  const worker = this.scheduler(this.workers, socket);
 
-  if (handle === undefined) {
-    this.free.push(worker);  // Add to ready queue again.
+  // An invalid worker was returned, or the worker is closing the server.
+  if (worker === null || typeof worker !== 'object' ||
+      worker.id in this.all === false) {
     return;
   }
+
+  this.handles.shift(); // Successfully scheduled, so dequeue.
 
   const message = { act: 'newconn', key: this.key };
 
   sendHelper(worker.process, message, handle, (reply) => {
-    if (reply.accepted)
+    if (reply.accepted) {
       handle.close();
-    else
-      this.distribute(0, handle);  // Worker is shutting down. Send to another.
+    } else {
+      // Worker is shutting down. Send the handle to another worker.
+      this.distribute(0, handle);
+    }
 
-    this.handoff(worker);
+    this.handoff();
   });
 };

--- a/test/parallel/test-cluster-custom-scheduler.js
+++ b/test/parallel/test-cluster-custom-scheduler.js
@@ -1,0 +1,83 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const http = require('http');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const numWorkers = 2;
+  const pattern = [2, 1, 2, 2, 1, 2, 1, 1, 2];
+  let index = 0;
+  let readyCount = 0;
+
+  // The scheduler moves through pattern. Each request is scheduled to the
+  // worker id specified in the current pattern index.
+  function scheduler(workers, socket) {
+    const id = pattern[index];
+    const worker = workers.filter((w) => {
+      return w.id === id;
+    }).pop();
+
+    if (id === 2) {
+      assert.strictEqual(scheduler.exposeSocket, true);
+      assert(socket instanceof net.Socket);
+    } else {
+      assert.strictEqual(scheduler.exposeSocket, false);
+      assert.strictEqual(socket, undefined);
+    }
+
+    if (worker !== undefined)
+      index++;
+
+    return worker;
+  }
+
+  // Create a getter for exposeSocket. If the current item in the pattern is 2,
+  // then expose the socket. Otherwise, hide it.
+  Object.defineProperty(scheduler, 'exposeSocket', {
+    get() { return pattern[index] === 2; }
+  });
+
+  function onMessage(msg) {
+    // Once both workers send a 'ready' signal, indicating that their servers
+    // are listening, begin making HTTP requests.
+    assert.strictEqual(msg.cmd, 'ready');
+    readyCount++;
+
+    if (readyCount === numWorkers)
+      makeRequest(0, msg.port);
+  }
+
+  function makeRequest(reqCount, port) {
+    // Make one request for each element in pattern and then shut down the
+    // workers.
+    if (reqCount >= pattern.length) {
+      for (const id in cluster.workers)
+        cluster.workers[id].disconnect();
+
+      return;
+    }
+
+    http.get({ port }, (res) => {
+      res.on('data', (data) => {
+        assert.strictEqual(+data.toString(), pattern[reqCount]);
+        reqCount++;
+        makeRequest(reqCount, port);
+      });
+    });
+  }
+
+  cluster.schedulingPolicy = cluster.SCHED_CUSTOM;
+  cluster.setupMaster({ scheduler });
+
+  for (let i = 0; i < numWorkers; i++)
+    cluster.fork().on('message', common.mustCall(onMessage));
+
+} else {
+  const server = http.createServer((req, res) => {
+    res.end(cluster.worker.id + '');
+  }).listen(0, () => {
+    process.send({ cmd: 'ready', port: server.address().port });
+  });
+}

--- a/test/parallel/test-cluster-custom-scheduler.js
+++ b/test/parallel/test-cluster-custom-scheduler.js
@@ -68,7 +68,6 @@ if (cluster.isMaster) {
     });
   }
 
-  cluster.schedulingPolicy = cluster.SCHED_CUSTOM;
   cluster.setupMaster({ scheduler });
 
   for (let i = 0; i < numWorkers; i++)


### PR DESCRIPTION
This is a WIP for making the cluster scheduler configurable by users. This still needs docs, tests, etc.

In the current implementation, the `cluster` module exports a `Scheduler` class. The class provides the following methods/hooks:
- `constructor()` - Used to configure data structures for managing connections (handles) and cluster workers.
- `addConnection()` - Called when a new connection is received. This is where the user would store the incoming connection handle to be distributed later.
- `addWorker()` - Called when a new cluster worker is added. This is where the user would add the worker into the pool of workers.
- `removeWorker()` - Called when a cluster worker is being removed from the pool.
- `shutdown()` - Called when the scheduler is finished working. This would be used to clean up any lingering resources such as handles.
- `schedule()` - This is the scheduling algorithm. The output of the algorithm should be a connection handle to distribute, and the worker to distribute it to.

I tried to minimize the exposure of the cluster's inner workings to incoming connection handles. Worker objects are already part of the public API.

Remaining questions:
- Should we enforce that handles from incoming connections are stored in a queue (array)? This would eliminate the need for the current `addConnection()` hook.
- Should we enforce that workers are stored in a ["worker id to worker object"](https://github.com/nodejs/node/blob/751404dc287e9d404a7186d73684e97fabbe3064/lib/internal/cluster/round_robin_handle.js#L35) map, like they currently are? This would eliminate the need for the `addWorker()` and `removeWorker()` hooks.
- If we can get rid of the connections and workers hooks, then the shutdown hook can probably go. Then we could drop the `Scheduler` class, and just provide a `schedule()` function that takes the available workers and handles as input, and schedules accordingly. Ideally, I'd like to go this simpler route, but want to check with some people who are actually doing this in practice to make sure it would be flexible enough. cc: @Yemanu and @redonkulus from #10880. Would this approach work for your needs?

Closes #10880

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
cluster