### PR TITLE
doc: argument types for assert methods

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -9,6 +9,8 @@ test invariants.
 <!-- YAML
 added: v0.5.9
 -->
+* `value` {any}
+* `message` {any}
 
 An alias of [`assert.ok()`][] .
 
@@ -41,6 +43,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/5910
     description: Handle non-`Uint8Array` typed arrays correctly.
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests for deep equality between the `actual` and `expected` parameters.
 Primitive values are compared with the equal comparison operator ( `==` ).
@@ -112,6 +117,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/5910
     description: Handle non-`Uint8Array` typed arrays correctly.
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Generally identical to `assert.deepEqual()` with two exceptions. First,
 primitive values are compared using the strict equality operator ( `===` ).
@@ -143,6 +151,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/3276
     description: The `error` parameter can now be an arrow function.
 -->
+* `block` {Function}
+* `error` {RegExp|Function}
+* `message` {any}
 
 Asserts that the function `block` does not throw an error. See
 [`assert.throws()`][] for more details.
@@ -198,6 +209,9 @@ assert.doesNotThrow(
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests shallow, coercive equality between the `actual` and `expected` parameters
 using the equal comparison operator ( `==` ).
@@ -224,6 +238,10 @@ parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
+* `operator` {String}
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`.
@@ -243,6 +261,7 @@ assert.fail(1, 2, 'whoops', '>');
 <!-- YAML
 added: v0.1.97
 -->
+* `value` {any}
 
 Throws `value` if `value` is truthy. This is useful when testing the `error`
 argument in callbacks.
@@ -264,6 +283,9 @@ assert.ifError(new Error());
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests for any deep inequality. Opposite of [`assert.deepEqual()`][].
 
@@ -308,6 +330,9 @@ parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v1.2.0
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests for deep strict inequality. Opposite of [`assert.deepStrictEqual()`][].
 
@@ -329,6 +354,9 @@ the `message` parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests shallow, coercive inequality with the not equal comparison operator
 ( `!=` ).
@@ -354,6 +382,9 @@ parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests strict inequality as determined by the strict not equal operator
 ( `!==` ).
@@ -379,6 +410,8 @@ If the values are strictly equal, an `AssertionError` is thrown with a
 <!-- YAML
 added: v0.1.21
 -->
+* `value` {any}
+* `message` {any}
 
 Tests if `value` is truthy. It is equivalent to
 `assert.equal(!!value, true, message)`.
@@ -406,6 +439,9 @@ assert.ok(false, 'it\'s false');
 <!-- YAML
 added: v0.1.21
 -->
+* `actual` {any}
+* `expected` {any}
+* `message` {any}
 
 Tests strict equality as determined by the strict equality operator ( `===` ).
 
@@ -434,6 +470,9 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/3276
     description: The `error` parameter can now be an arrow function.
 -->
+* `block` {Function}
+* `error` {RegExp|Function}
+* `message` {any}
 
 Expects the function `block` to throw an error.
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
documentation

##### Description of changes
Added argument data types to the docs for the ```assert``` module.

[Issue](https://github.com/nodejs/node/issues/9399)