### PR TITLE
test: add two test cases for querystring

### DIFF
--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -69,6 +69,7 @@ const qsTestCases = [
   ['a&a&a&a&', 'a=&a=&a=&a=', { a: [ '', '', '', '' ] }],
   ['a=&a=value&a=', 'a=&a=value&a=', { a: [ '', 'value', '' ] }],
   ['foo+bar=baz+quux', 'foo%20bar=baz%20quux', { 'foo bar': 'baz quux' }],
+  ['+foo=+bar', '%20foo=%20bar', { ' foo': ' bar' }],
   [null, '', {}],
   [undefined, '', {}]
 ];
@@ -333,6 +334,7 @@ assert.strictEqual(0xa2, b[18]);
 assert.strictEqual(0xe6, b[19]);
 
 assert.strictEqual(qs.unescapeBuffer('a+b', true).toString(), 'a b');
+assert.strictEqual(qs.unescapeBuffer('a+b').toString(), 'a+b');
 assert.strictEqual(qs.unescapeBuffer('a%').toString(), 'a%');
 assert.strictEqual(qs.unescapeBuffer('a%2').toString(), 'a%2');
 assert.strictEqual(qs.unescapeBuffer('a%20').toString(), 'a ');


### PR DESCRIPTION
Test cases:
+ Cover untested branch in the state machine with the strings that its first letter is `+` in the key/value.
+ `qs.unescapeBuffer` shouldn't decode `+` to space.

This test increases the coverage of querystring.js:
+ https://coverage.nodejs.org/coverage-d42296bd985ae7df/root/querystring.js.html

The following branches will be skipped:
+ https://github.com/nodejs/node/blob/d4e1eaf43cc01ba1d151697f916abff4524062eb/lib/querystring.js#L64-L65
+ https://github.com/nodejs/node/blob/d4e1eaf43cc01ba1d151697f916abff4524062eb/lib/querystring.js#L405-L406
+ https://github.com/nodejs/node/blob/d4e1eaf43cc01ba1d151697f916abff4524062eb/lib/querystring.js#L413-L414

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test`
- [x] tests are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test