### PR TITLE
doc: add note that vm module is not a security mechanism

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -15,7 +15,7 @@ JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
 
 *Note*: The vm module is not a security mechanism.
-Do not use it to run untrusted scripts.
+Do not use it to run untrusted code.
 
 ## Class: vm.Script
 <!-- YAML

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -14,7 +14,8 @@ const vm = require('vm');
 JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
 
-*Note*: The vm module makes a wrong impression as a security mechanism. In fact, it is not at all, you shouldn't use it to run untrusted scripts.
+*Note*: The vm module is not a security mechanism.
+Do not use it to run untrusted scripts.
 
 ## Class: vm.Script
 <!-- YAML

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -14,6 +14,8 @@ const vm = require('vm');
 JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
 
+*Note*: The vm module makes a wrong impression as a security mechanism. In fact, it is not at all, you shouldn't use it to run untrusted scripts.
+
 ## Class: vm.Script
 <!-- YAML
 added: v0.3.1

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -15,7 +15,7 @@ JavaScript code can be compiled and run immediately or compiled, saved, and run
 later.
 
 *Note*: The vm module is not a security mechanism.
-Do not use it to run untrusted code.
+**Do not use it to run untrusted code**.
 
 ## Class: vm.Script
 <!-- YAML


### PR DESCRIPTION
the text added in this commit should warn users about
wrong idea that vm module can be secure to run unsafe scripts
in sandboxes

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, vm

Hi, 
As it mentioned in issue #11550 the VM module can be mistakenly used as a security mechanism and it should be great to have a note that VM module it is not about security. 