### PR TITLE
WIP: module,errors: port module to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -255,6 +255,13 @@ will affect any stack trace captured *after* the value has been changed.
 If set to a non-number value, or set to a negative number, stack traces will
 not capture any frames.
 
+#### error.code
+
+* {string}
+
+The `error.code` property is a string label that identifies the kind of error.
+See [Node.js Error Codes][] for details about specific codes.
+
 ### error.message
 
 * {string}
@@ -550,6 +557,15 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
+<a id="nodejs-error-codes"></a>
+## Node.js Error Codes
+
+<a id="MODULE_NOT_FOUND"></a>
+### MODULE_NOT_FOUND
+
+The `'MODULE_NOT_FOUND'` error is thrown if `require()` is called on
+file that does not exist.
+
 [`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
 [`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
 [`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
@@ -562,6 +578,7 @@ found [here][online].
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
+[Node.js Error Codes]: #nodejs-error-codes
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -88,3 +88,7 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ASSERTION', (msg) => msg);
 // Add new errors from here...
+E('MODULE_NOT_FOUND', (request) => `Cannot find module '${request}'`);
+E('ERR_PARSING_JSON', (filePath, message) => (
+  `Error parsing '${filePath}': ${message}`
+));

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,6 +23,7 @@
 
 const NativeModule = require('native_module');
 const util = require('util');
+const errors = require('internal/errors');
 const internalModule = require('internal/module');
 const vm = require('vm');
 const assert = require('assert').ok;
@@ -482,8 +483,7 @@ Module._resolveFilename = function(request, parent, isMain) {
   // look up the filename first, since that's the cache key.
   var filename = Module._findPath(request, paths, isMain);
   if (!filename) {
-    var err = new Error(`Cannot find module '${request}'`);
-    err.code = 'MODULE_NOT_FOUND';
+    const err = new errors.Error('MODULE_NOT_FOUND', request);
     throw err;
   }
   return filename;

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
+const errors = require('../../lib/internal/errors');
 
 const node = process.execPath;
 
@@ -76,7 +77,8 @@ const syntaxArgs = [
     assert.strictEqual(c.stdout, '', 'stdout produced');
 
     // stderr should have a module not found error message
-    const match = c.stderr.match(/^Error: Cannot find module/m);
+    const expectedError = new errors.Error('MODULE_NOT_FOUND', file);
+    const match = c.stderr.match(expectedError.message);
     assert(match, 'stderr incorrect');
 
     assert.strictEqual(c.status, 1, 'code == ' + c.status);

--- a/test/parallel/test-internal-modules.js
+++ b/test/parallel/test-internal-modules.js
@@ -2,10 +2,13 @@
 const common = require('../common');
 const path = require('path');
 const assert = require('assert');
+const errors = require('../../lib/internal/errors');
 
+const internalModuleName = 'internal/freelist';
+const expectedError = new errors.Error('MODULE_NOT_FOUND', internalModuleName);
 assert.throws(function() {
-  require('internal/freelist');
-}, /^Error: Cannot find module 'internal\/freelist'$/);
+  require(internalModuleName);
+}, new RegExp(expectedError.message));
 
 assert.strictEqual(
   require(path.join(common.fixturesDir, 'internal-modules')),

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -23,6 +23,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const errors = require('../../lib/internal/errors');
 
 common.globalCheck = false;
 common.refreshTmpDir();
@@ -343,8 +344,10 @@ function error_test() {
       expect: 'undefined\n' + prompt_unix },
     // REPL should get a normal require() function, not one that allows
     // access to internal modules without the --expose_internals flag.
-    { client: client_unix, send: 'require("internal/repl")',
-      expect: /^Error: Cannot find module 'internal\/repl'/ },
+    {
+      client: client_unix, send: 'require("internal/repl")',
+      expect: new RegExp(new errors.Error('MODULE_NOT_FOUND', 'internal/repl').message)
+    },
     // REPL should handle quotes within regexp literal in multiline mode
     { client: client_unix,
       send: "function x(s) {\nreturn s.replace(/'/,'');\n}",

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -24,6 +24,7 @@ require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
+const errors = require('../../lib/internal/errors');
 
 console.error('load test-module-loading.js');
 
@@ -120,8 +121,10 @@ console.error('test name clashes');
 const my_path = require('../fixtures/path');
 assert.ok(my_path.path_func instanceof Function);
 // this one does not exist and should throw
-assert.throws(function() { require('./utils'); },
-              /^Error: Cannot find module '.\/utils'$/);
+const notFoundPath = './utils';
+const notFoundError = new errors.Error('MODULE_NOT_FOUND', notFoundPath);
+assert.throws(function() { require(notFoundPath); },
+              new RegExp(notFoundError.message));
 
 let errorThrown = false;
 try {
@@ -224,6 +227,7 @@ const children = module.children.reduce(function red(set, child) {
 
 assert.deepStrictEqual(children, {
   'common.js': {},
+  '../lib/internal/errors.js': {},
   'fixtures/not-main-module.js': {},
   'fixtures/a.js': {
     'fixtures/b/c.js': {


### PR DESCRIPTION
Porting `module.js` to use `internal/errors.js` according to tracking issue #11273 and sample PR #11294.

Porting module can be tricky because it's errors are commonly parsed in user-land.

This code sets some properties on caught errors from JSON parsing(example: https://github.com/nodejs/node/blob/master/lib/module.js#L94-L95) should those be left unchanged(as those are really not node libs' errors) or rethrown as new internal error(as we want every error from node to become standardized)?

Additionally to me it makes sense to also leave in setting `error.code` for backwards compatibility on `MODULE_NOT_FOUND` error(https://github.com/nodejs/node/blob/master/lib/module.js#L471). Case against that would again be that if we're going to break backwards compatibility, let's just clean it up really nice as we're doing that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, module