### PR TITLE
http: should support userland Agent

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -68,9 +68,9 @@ function ClientRequest(options, cb) {
     }
     // Explicitly pass through this statement as agent will not be used
     // when createConnection is provided.
-  } else if (!(agent instanceof Agent.Agent)) {
+  } else if (typeof agent.addRequest !== 'function') {
     throw new TypeError(
-      'Agent option must be an instance of http.Agent, undefined or false.'
+      'Agent option must be an Agent-like object, undefined, or false.'
     );
   }
   self.agent = agent;

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -49,7 +49,7 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
   failingAgentOptions.forEach((agent) => {
     assert.throws(
       () => createRequest(agent),
-      /^TypeError: Agent option must be an instance of http.Agent/,
+      /^TypeError: Agent option must be an Agent-like object/,
       `Expected typeof agent: ${typeof agent} to be rejected`
     );
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

https://github.com/nodejs/node/pull/10053 assert agent **must be** instance of `http.Agent`, it make userland Agents are broken. (e.g.: https://github.com/request/tunnel-agent/blob/master/index.js#L47) 

I think we should keep userland Agents still can work on the future is very important.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http