### PR TITLE
doc: make the heading consistent

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -524,7 +524,7 @@ of V8 5.8. It is replaced by Inspector which is activated with `--inspect`
 instead.
 
 <a id="DEP0063"></a>
-#### DEP0063: ServerResponse.prototype.writeHeader()
+### DEP0063: ServerResponse.prototype.writeHeader()
 
 Type: Documentation-only
 


### PR DESCRIPTION
All the other headings are in level 3. This patch fixes the offending
heading to use level 3.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

---

cc @jasnell @ChALkeR 

Ref: https://github.com/nodejs/node/pull/11355/files#r103103460