### PR TITLE
url: use `hasIntl` instead of `try-catch`

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -1,15 +1,7 @@
 'use strict';
 
-function importPunycode() {
-  try {
-    return process.binding('icu');
-  } catch (e) {
-    return require('punycode');
-  }
-}
-
-const { toASCII } = importPunycode();
-
+const { toASCII } = process.binding('config').hasIntl ?
+  process.binding('icu') : require('punycode');
 const { StorageObject, hexTable } = require('internal/querystring');
 const internalUrl = require('internal/url');
 exports.parse = urlParse;


### PR DESCRIPTION
Like the other lib codes, we should use `process.binding('config').hasIntl` instead of `try-catch` to make sure `icu` is bonded or not.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
url