### PR TITLE
net: remove misleading comment

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -205,10 +205,6 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 
 // the user has called .end(), and all the bytes have been
 // sent out to the other side.
-// If allowHalfOpen is false, or if the readable side has
-// ended already, then destroy.
-// If allowHalfOpen is true, then we need to do a shutdown,
-// so that only the writable side will be cleaned up.
 function onSocketFinish() {
   // If still connecting - defer handling 'finish' until 'connect' will happen
   if (this.connecting) {


### PR DESCRIPTION
The allowHalfOpen comment was added in commit 8a3befa ("net: Refactor
to use streams2") from 2012 but it wasn't true even then as far as I
can tell: Node.js simply always does a shutdown(2) first.

It is true that streams2 withholds the 'end' event when allowHalfOpen
is true but the comment is about a callback that hangs off the 'finish'
event that is emitted after calling `socket.end()`.
