### PR TITLE
test: apply strict mode in test-repl

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -1,4 +1,6 @@
-/* eslint-disable max-len, strict */
+/* eslint-disable max-len */
+'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 


### PR DESCRIPTION
Strict mode for the test will not automatically enable strict mode
in the REPL object. Enable strict mode in the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl