### PR TITLE
http: subclass of Agent can override the initialization

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -63,6 +63,17 @@ function Agent(options) {
   self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
   self.maxFreeSockets = self.options.maxFreeSockets || 256;
 
+  self.init();
+}
+
+util.inherits(Agent, EventEmitter);
+
+Agent.defaultMaxSockets = Infinity;
+
+Agent.prototype.createConnection = net.createConnection;
+
+Agent.prototype.init = function init() {
+  var self = this;
   self.on('free', function(socket, options) {
     var name = self.getName(options);
     debug('agent.on(free)', name);
@@ -105,13 +116,7 @@ function Agent(options) {
       }
     }
   });
-}
-
-util.inherits(Agent, EventEmitter);
-
-Agent.defaultMaxSockets = Infinity;
-
-Agent.prototype.createConnection = net.createConnection;
+};
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function getName(options) {

--- a/test/parallel/test-http-agent-subclass.js
+++ b/test/parallel/test-http-agent-subclass.js
@@ -1,0 +1,65 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const http = require('http');
+
+class DestroyAgent extends http.Agent {
+  constructor(options = {}) {
+    // change all socket keepAlive by default
+    options.keepAlive = true;
+    super(options);
+
+    this.requestCount = 0;
+    this.destroyCount = 0;
+  }
+
+  init() {
+    this.on('free', (socket, options) => {
+      const name = this.getName(options);
+      console.info('free socket %s', name);
+      this.destroyCount++;
+      socket.destroy();
+    });
+  }
+
+  addRequest(req, options) {
+    this.requestCount++;
+    console.info('new request %s %s', req.method, req.path);
+    return super.addRequest(req, options);
+  }
+}
+
+const server = http.Server(function(req, res) {
+  res.writeHead(200);
+  res.end('hello world\n');
+});
+
+server.listen(0, () => {
+  const port = server.address().port;
+  const destroyAgent = new DestroyAgent();
+  http.get({ port: port, path: '/', agent: destroyAgent }, (res) => {
+    res.resume();
+    res.on('end', () => {
+      http.get({ port: port, path: '/again', agent: destroyAgent }, (res) => {
+        res.resume();
+        res.on('end', () => {
+          // wait socket "close callbacks" phase execute
+          setTimeout(() => {
+            console.error('requestCount: %s, destroyCount: %s, closing server',
+                          destroyAgent.requestCount, destroyAgent.destroyCount);
+            assert.strictEqual(destroyAgent.requestCount, 2);
+            assert.strictEqual(destroyAgent.destroyCount, 2);
+            server.close();
+          }, 100);
+        });
+      }).on('error', function(e) {
+        console.log('Error!', e);
+        process.exit(1);
+      });
+    });
+  }).on('error', function(e) {
+    console.log('Error!', e);
+    process.exit(1);
+  });
+});


### PR DESCRIPTION
Make userland's Agent inherit from http.Agent more easily.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
