### PR TITLE
timers: unlock the timers API

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -1,6 +1,6 @@
 # Timers
 
-> Stability: 3 - Locked
+> Stability: 2 - Stable
 
 The `timer` module exposes a global API for scheduling functions to
 be called at some future period of time. Because the timer functions are


### PR DESCRIPTION
Change the Stability Index on timers from Locked to Stable.

Note that this is not intended to encourage changes to the timers API,
but to allow it when its useful for Node.js (as has happened in
violation of the documented stability level), and possibly to simplify
the stability levels by removing Locked altogether.

Refs: https://github.com/nodejs/node/issues/11200

@nodejs/ctc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers