### PR TITLE
test: skip the test with proper TAP message

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -4,8 +4,7 @@ const common = require('../common');
 
 // FIXME add sunos support
 if (common.isSunOS) {
-  console.log(`1..0 # Skipped: Unsupported platform [${process.platform}]`);
-  return;
+  return common.skip(`Unsupported platform [${process.platform}]`);
 }
 
 const assert = require('assert');
@@ -22,8 +21,9 @@ process.title = title;
 assert.strictEqual(process.title, title);
 
 // Test setting the title but do not try to run `ps` on Windows.
-if (common.isWindows)
-  return;
+if (common.isWindows) {
+  return common.skip('Windows does not have "ps" utility');
+}
 
 exec(`ps -p ${process.pid} -o args=`, function callback(error, stdout, stderr) {
   assert.ifError(error);


### PR DESCRIPTION
On Windows, the test simply returns which will be counted as passed.
The test actually skips the rest of the test. So proper TAP message has
to be included while skipping.

This patch uses `common.skip` rather than `console.log` to print the
skip messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test
