### PR TITLE
test: skip tests with common.skip

### DIFF
--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -318,7 +318,7 @@ for (const i in TEST_CASES) {
   }
 
   if (common.hasFipsCrypto && test.iv.length < 24) {
-    console.log('1..0 # Skipped: IV len < 12 bytes unsupported in FIPS mode');
+    common.skip('IV len < 12 bytes unsupported in FIPS mode');
     continue;
   }
 

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -3,16 +3,14 @@
 const common = require('../common');
 
 if (!process.features.tls_sni) {
-  console.log('1..0 # Skipped: node compiled without OpenSSL or ' +
-              'with old OpenSSL version.');
+  common.skip('node compiled without OpenSSL or with old OpenSSL version.');
   return;
 }
 
 const assert = require('assert');
 
 if (!common.hasCrypto) {
-  console.log('1..0 # Skipped: missing crypto');
-  return;
+  return common.skip('missing crypto');
 }
 
 const tls = require('tls');


### PR DESCRIPTION
The `common.skip` function adds proper message in TAP format to skipped
tests. It is better not to have the message rewritten in the tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

test