### PR TITLE
test: changed test1 of test-vm-timeout.js so that entire error messag…

### DIFF
--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -6,7 +6,15 @@ const vm = require('vm');
 // Test 1: Timeout of 100ms executing endless loop
 assert.throws(function() {
   vm.runInThisContext('while(true) {}', { timeout: 100 });
-});
+},
+  function(err) {
+    if ( (err instanceof Error) && /^Script execution timed out\.$/.test(err.message) ) {
+      return true;
+    }
+  }
+
+  
+);
 
 // Test 2: Timeout must be >= 0ms
 assert.throws(function() {


### PR DESCRIPTION
…e would be matched in assert.throw

Before test 1 of test-vm-timeout.js would match any error, now it looks specifically for the error message "Script execution timed out."


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
