### PR TITLE
errors, util: migrate to using internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -715,6 +715,12 @@ in some cases may accept `func(undefined)` but not `func()`). In most native
 Node.js APIs, `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
 
+<a id="ERR_REQUIRED_ARG"></a>
+### ERR_REQUIRED_ARG
+
+The `'ERR_REQUIRED_ARG'` error code is used generically when a required 
+argument is not passed to a function or is undefined.
+
 <a id="ERR_SOCKET_ALREADY_BOUND"></a>
 ### ERR_SOCKET_ALREADY_BOUND
 An error using the `'ERR_SOCKET_ALREADY_BOUND'` code is thrown when an attempt

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -148,6 +148,9 @@ E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
 E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
+E('ERR_REQUIRED_ARG', (name) => {
+  return `The "${name}" argument is required and cannot be undefined`;
+});
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);

--- a/lib/util.js
+++ b/lib/util.js
@@ -938,25 +938,28 @@ exports.log = function() {
  * functions as prototype setup using normal JavaScript does not work as
  * expected during bootstrapping (see mirror.js in r114903).
  *
- * @param {function} ctor Constructor function which needs to inherit the
- *     prototype.
- * @param {function} superCtor Constructor function to inherit prototype from.
+ * @param {function} constructor Constructor function which needs to inherit 
+ *     the prototype.
+ * @param {function} superConstructor Constructor function to inherit 
+ *     prototype from.
  * @throws {TypeError} Will error if either constructor is null, or if
  *     the super constructor lacks a prototype.
  */
-exports.inherits = function(ctor, superCtor) {
+exports.inherits = function(constructor, superConstructor) {
+  if (constructor === undefined || constructor === null)
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'constructor', 
+      'function');
 
-  if (ctor === undefined || ctor === null)
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ctor', 'function');
+  if (superConstructor === undefined || superConstructor === null)
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superConstructor',
+      'function');
 
-  if (superCtor === undefined || superCtor === null)
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor', 'function');
+  if (superConstructor.prototype === undefined)
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                'superConstructor.prototype', 'function');
 
-  if (superCtor.prototype === undefined)
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor.prototype',
-                               'function');
-  ctor.super_ = superCtor;
-  Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
+  constructor.super_ = superConstructor;
+  Object.setPrototypeOf(constructor.prototype, superConstructor.prototype);
 };
 
 exports._extend = function(target, source) {

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -44,6 +44,7 @@ assert.strictEqual(util.format(symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('foo', symbol), 'foo Symbol(foo)');
 assert.strictEqual(util.format('%s', symbol), 'Symbol(foo)');
 assert.strictEqual(util.format('%j', symbol), 'undefined');
+// This error is thrown by a cast, so common.expectsError not necessary.
 assert.throws(function() {
   util.format('%d', symbol);
 }, TypeError);

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -6,7 +6,7 @@ const inherits = require('util').inherits;
 const errCheck = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor" argument must be of type function'
+  message: 'The "superConstructor" argument must be of type function'
 });
 
 // super constructor
@@ -85,7 +85,8 @@ assert.throws(function() {
 }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "superCtor.prototype" argument must be of type function'
+    message: 'The "superConstructor.prototype" argument must be of type \
+      function'
 })
 );
 assert.throws(function() {
@@ -96,6 +97,6 @@ assert.throws(function() {
 }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "ctor" argument must be of type function'
+    message: 'The "constructor" argument must be of type function'
 })
 );

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -8,7 +8,9 @@ const opts = {showProxy: true};
 
 const target = {};
 const handler = {
-  get: function() { throw new Error('Getter should not be called'); }
+  get: function() {
+    throw new Error('Getter should not be called');
+  }
 };
 const proxyObj = new Proxy(target, handler);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Ref: [#11273](https://github.com/nodejs/node/issues/11273)
Semver-major bacause error messages changed

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

`vcbuild test` has a few errors, but they are unrelated to the systems I modified.
##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors, util
