### PR TITLE
http: simple code refactoring

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -105,7 +105,6 @@ function Agent(options) {
 }
 
 util.inherits(Agent, EventEmitter);
-exports.Agent = Agent;
 
 Agent.defaultMaxSockets = Infinity;
 
@@ -314,4 +313,7 @@ Agent.prototype.destroy = function destroy() {
   }
 };
 
-exports.globalAgent = new Agent();
+module.exports = {
+  Agent,
+  globalAgent: new Agent()
+};

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -66,8 +66,7 @@ function isInvalidPath(s) {
 }
 
 function ClientRequest(options, cb) {
-  var self = this;
-  OutgoingMessage.call(self);
+  OutgoingMessage.call(this);
 
   if (typeof options === 'string') {
     options = url.parse(options);
@@ -95,12 +94,12 @@ function ClientRequest(options, cb) {
       'Agent option must be an instance of http.Agent, undefined or false.'
     );
   }
-  self.agent = agent;
+  this.agent = agent;
 
   var protocol = options.protocol || defaultAgent.protocol;
   var expectedProtocol = defaultAgent.protocol;
-  if (self.agent && self.agent.protocol)
-    expectedProtocol = self.agent.protocol;
+  if (this.agent && this.agent.protocol)
+    expectedProtocol = this.agent.protocol;
 
   var path;
   if (options.path) {
@@ -121,15 +120,15 @@ function ClientRequest(options, cb) {
   }
 
   const defaultPort = options.defaultPort ||
-                      self.agent && self.agent.defaultPort;
+                      this.agent && this.agent.defaultPort;
 
   var port = options.port = options.port || defaultPort || 80;
   var host = options.host = options.hostname || options.host || 'localhost';
 
   var setHost = (options.setHost === undefined);
 
-  self.socketPath = options.socketPath;
-  self.timeout = options.timeout;
+  this.socketPath = options.socketPath;
+  this.timeout = options.timeout;
 
   var method = options.method;
   var methodIsString = (typeof method === 'string');
@@ -141,14 +140,14 @@ function ClientRequest(options, cb) {
     if (!common._checkIsHttpToken(method)) {
       throw new TypeError('Method must be a valid HTTP token');
     }
-    method = self.method = method.toUpperCase();
+    method = this.method = method.toUpperCase();
   } else {
-    method = self.method = 'GET';
+    method = this.method = 'GET';
   }
 
-  self.path = options.path || '/';
+  this.path = options.path || '/';
   if (cb) {
-    self.once('response', cb);
+    this.once('response', cb);
   }
 
   var headersArray = Array.isArray(options.headers);
@@ -157,7 +156,7 @@ function ClientRequest(options, cb) {
       var keys = Object.keys(options.headers);
       for (var i = 0; i < keys.length; i++) {
         var key = keys[i];
-        self.setHeader(key, options.headers[key]);
+        this.setHeader(key, options.headers[key]);
       }
     }
     if (host && !this.getHeader('host') && setHost) {
@@ -190,21 +189,22 @@ function ClientRequest(options, cb) {
       method === 'DELETE' ||
       method === 'OPTIONS' ||
       method === 'CONNECT') {
-    self.useChunkedEncodingByDefault = false;
+    this.useChunkedEncodingByDefault = false;
   } else {
-    self.useChunkedEncodingByDefault = true;
+    this.useChunkedEncodingByDefault = true;
   }
 
   if (headersArray) {
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
                       options.headers);
-  } else if (self.getHeader('expect')) {
-    if (self._header) {
+  } else if (this.getHeader('expect')) {
+    if (this._header) {
       throw new Error('Can\'t render headers after they are sent to the ' +
                       'client');
     }
-    self._storeHeader(self.method + ' ' + self.path + ' HTTP/1.1\r\n',
-                      self[outHeadersKey]);
+
+    this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
+                      this[outHeadersKey]);
   }
 
   this._ended = false;
@@ -216,72 +216,65 @@ function ClientRequest(options, cb) {
   this.maxHeadersCount = null;
 
   var called = false;
-  if (self.socketPath) {
-    self._last = true;
-    self.shouldKeepAlive = false;
+
+  const oncreate = (err, socket) => {
+    if (called)
+      return;
+    called = true;
+    if (err) {
+      process.nextTick(() => this.emit('error', err));
+      return;
+    }
+    this.onSocket(socket);
+    this._deferToConnect(null, null, () => this._flush());
+  };
+
+  if (this.socketPath) {
+    this._last = true;
+    this.shouldKeepAlive = false;
     const optionsPath = {
-      path: self.socketPath,
-      timeout: self.timeout
+      path: this.socketPath,
+      timeout: this.timeout
     };
-    const newSocket = self.agent.createConnection(optionsPath, oncreate);
+    const newSocket = this.agent.createConnection(optionsPath, oncreate);
     if (newSocket && !called) {
       called = true;
-      self.onSocket(newSocket);
+      this.onSocket(newSocket);
     } else {
       return;
     }
-  } else if (self.agent) {
+  } else if (this.agent) {
     // If there is an agent we should default to Connection:keep-alive,
     // but only if the Agent will actually reuse the connection!
     // If it's not a keepAlive agent, and the maxSockets==Infinity, then
     // there's never a case where this socket will actually be reused
-    if (!self.agent.keepAlive && !Number.isFinite(self.agent.maxSockets)) {
-      self._last = true;
-      self.shouldKeepAlive = false;
+    if (!this.agent.keepAlive && !Number.isFinite(this.agent.maxSockets)) {
+      this._last = true;
+      this.shouldKeepAlive = false;
     } else {
-      self._last = false;
-      self.shouldKeepAlive = true;
+      this._last = false;
+      this.shouldKeepAlive = true;
     }
-    self.agent.addRequest(self, options);
+    this.agent.addRequest(this, options);
   } else {
     // No agent, default to Connection:close.
-    self._last = true;
-    self.shouldKeepAlive = false;
+    this._last = true;
+    this.shouldKeepAlive = false;
     if (typeof options.createConnection === 'function') {
       const newSocket = options.createConnection(options, oncreate);
       if (newSocket && !called) {
         called = true;
-        self.onSocket(newSocket);
+        this.onSocket(newSocket);
       } else {
         return;
       }
     } else {
       debug('CLIENT use net.createConnection', options);
-      self.onSocket(net.createConnection(options));
+      this.onSocket(net.createConnection(options));
     }
   }
 
-  function oncreate(err, socket) {
-    if (called)
-      return;
-    called = true;
-    if (err) {
-      process.nextTick(function() {
-        self.emit('error', err);
-      });
-      return;
-    }
-    self.onSocket(socket);
-    self._deferToConnect(null, null, function() {
-      self._flush();
-      self = null;
-    });
-  }
-
-  self._deferToConnect(null, null, function() {
-    self._flush();
-    self = null;
-  });
+  this._deferToConnect(null, null, () => this._flush());
 }
 
 util.inherits(ClientRequest, OutgoingMessage);
@@ -304,7 +297,7 @@ ClientRequest.prototype._implicitHeader = function _implicitHeader() {
 
 ClientRequest.prototype.abort = function abort() {
   if (!this.aborted) {
-    process.nextTick(emitAbortNT, this);
+    process.nextTick(emitAbortNT.bind(this));
   }
   // Mark as aborting so we can avoid sending queued request data
   // This is used as a truthy flag elsewhere. The use of Date.now is for
@@ -328,8 +321,8 @@ ClientRequest.prototype.abort = function abort() {
 };
 
 
-function emitAbortNT(self) {
-  self.emit('abort');
+function emitAbortNT() {
+  this.emit('abort');
 }
 
 
@@ -681,26 +674,25 @@ function _deferToConnect(method, arguments_, cb) {
   // calls that happen either now (when a socket is assigned) or
   // in the future (when a socket gets assigned out of the pool and is
   // eventually writable).
-  var self = this;
 
-  function callSocketMethod() {
+  const callSocketMethod = () => {
     if (method)
-      self.socket[method].apply(self.socket, arguments_);
+      this.socket[method].apply(this.socket, arguments_);
 
     if (typeof cb === 'function')
       cb();
-  }
+  };
 
-  var onSocket = function onSocket() {
-    if (self.socket.writable) {
+  const onSocket = () => {
+    if (this.socket.writable) {
       callSocketMethod();
     } else {
-      self.socket.once('connect', callSocketMethod);
+      this.socket.once('connect', callSocketMethod);
     }
   };
 
-  if (!self.socket) {
-    self.once('socket', onSocket);
+  if (!this.socket) {
+    this.once('socket', onSocket);
   } else {
     onSocket();
   }
@@ -709,10 +701,7 @@ function _deferToConnect(method, arguments_, cb) {
 ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   if (callback) this.once('timeout', callback);
 
-  var self = this;
-  function emitTimeout() {
-    self.emit('timeout');
-  }
+  const emitTimeout = () => this.emit('timeout');
 
   if (this.socket && this.socket.writable) {
     if (this.timeoutCb)

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -286,7 +286,6 @@ function ClientRequest(options, cb) {
 
 util.inherits(ClientRequest, OutgoingMessage);
 
-exports.ClientRequest = ClientRequest;
 
 ClientRequest.prototype._finish = function _finish() {
   DTRACE_HTTP_CLIENT_REQUEST(this, this.connection);
@@ -751,4 +750,8 @@ ClientRequest.prototype.setSocketKeepAlive =
 
 ClientRequest.prototype.clearTimeout = function clearTimeout(cb) {
   this.setTimeout(0, cb);
+};
+
+module.exports = {
+  ClientRequest
 };

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -32,12 +32,6 @@ const readStart = incoming.readStart;
 const readStop = incoming.readStop;
 
 const debug = require('util').debuglog('http');
-exports.debug = debug;
-
-exports.CRLF = '\r\n';
-exports.chunkExpression = /(?:^|\W)chunked(?:$|\W)/i;
-exports.continueExpression = /(?:^|\W)100-continue(?:$|\W)/i;
-exports.methods = methods;
 
 const kOnHeaders = HTTPParser.kOnHeaders | 0;
 const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
@@ -194,7 +188,6 @@ var parsers = new FreeList('parsers', 1000, function() {
 
   return parser;
 });
-exports.parsers = parsers;
 
 
 // Free the parser and also break any links that it
@@ -227,7 +220,6 @@ function freeParser(parser, req, socket) {
     socket.parser = null;
   }
 }
-exports.freeParser = freeParser;
 
 
 function ondrain() {
@@ -239,7 +231,6 @@ function httpSocketSetup(socket) {
   socket.removeListener('drain', ondrain);
   socket.on('drain', ondrain);
 }
-exports.httpSocketSetup = httpSocketSetup;
 
 /**
  * Verifies that the given val is a valid HTTP token
@@ -306,7 +297,6 @@ function checkIsHttpToken(val) {
   }
   return true;
 }
-exports._checkIsHttpToken = checkIsHttpToken;
 
 /**
  * True if val contains an invalid field-vchar
@@ -360,4 +350,16 @@ function checkInvalidHeaderChar(val) {
   }
   return false;
 }
-exports._checkInvalidHeaderChar = checkInvalidHeaderChar;
+
+module.exports = {
+  _checkInvalidHeaderChar: checkInvalidHeaderChar,
+  _checkIsHttpToken: checkIsHttpToken,
+  chunkExpression: /(?:^|\W)chunked(?:$|\W)/i,
+  continueExpression: /(?:^|\W)100-continue(?:$|\W)/i,
+  CRLF: '\r\n',
+  debug,
+  freeParser,
+  httpSocketSetup,
+  methods,
+  parsers
+};

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -28,14 +28,11 @@ function readStart(socket) {
   if (socket && !socket._paused && socket.readable)
     socket.resume();
 }
-exports.readStart = readStart;
 
 function readStop(socket) {
   if (socket)
     socket.pause();
 }
-exports.readStop = readStop;
-
 
 /* Abstract base class for ServerRequest and ClientResponse. */
 function IncomingMessage(socket) {
@@ -81,9 +78,6 @@ function IncomingMessage(socket) {
   this._dumped = false;
 }
 util.inherits(IncomingMessage, Stream.Readable);
-
-
-exports.IncomingMessage = IncomingMessage;
 
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
@@ -323,4 +317,10 @@ IncomingMessage.prototype._dump = function _dump() {
     this._dumped = true;
     this.resume();
   }
+};
+
+module.exports = {
+  IncomingMessage,
+  readStart,
+  readStop
 };

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -625,7 +625,7 @@ const crlf_buf = Buffer.from('\r\n');
 OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
   if (this.finished) {
     var err = new Error('write after end');
-    process.nextTick(writeAfterEndNT, this, err, callback);
+    process.nextTick(writeAfterEndNT.bind(this), err, callback);
 
     return true;
   }
@@ -684,8 +684,8 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
 };
 
 
-function writeAfterEndNT(self, err, callback) {
-  self.emit('error', err);
+function writeAfterEndNT(err, callback) {
+  this.emit('error', err);
   if (callback) callback(err);
 }
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -887,3 +887,8 @@ OutgoingMessage.prototype.flushHeaders = function flushHeaders() {
 OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
   this.flushHeaders();
 }, 'OutgoingMessage.flush is deprecated. Use flushHeaders instead.', 'DEP0001');
+
+
+module.exports = {
+  OutgoingMessage
+};

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -36,7 +36,7 @@ const httpSocketSetup = common.httpSocketSetup;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const outHeadersKey = require('internal/http').outHeadersKey;
 
-const STATUS_CODES = exports.STATUS_CODES = {
+const STATUS_CODES = {
   100: 'Continue',
   101: 'Switching Protocols',
   102: 'Processing',                 // RFC 2518, obsoleted by RFC 4918
@@ -127,8 +127,6 @@ ServerResponse.prototype._finish = function _finish() {
   OutgoingMessage.prototype._finish.call(this);
 };
 
-
-exports.ServerResponse = ServerResponse;
 
 ServerResponse.prototype.statusCode = 200;
 ServerResponse.prototype.statusMessage = undefined;
@@ -290,9 +288,6 @@ Server.prototype.setTimeout = function setTimeout(msecs, callback) {
 };
 
 
-exports.Server = Server;
-
-
 function connectionListener(socket) {
   debug('SERVER new http connection');
 
@@ -363,7 +358,7 @@ function connectionListener(socket) {
 
   socket._paused = false;
 }
-exports._connectionListener = connectionListener;
+
 
 function updateOutgoingData(socket, state, delta) {
   state.outgoingData += delta;
@@ -640,3 +635,10 @@ function socketOnWrap(ev, fn) {
 
   return res;
 }
+
+module.exports = {
+  STATUS_CODES,
+  Server,
+  ServerResponse,
+  _connectionListener: connectionListener
+};

--- a/lib/http.js
+++ b/lib/http.js
@@ -20,35 +20,43 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-exports.IncomingMessage = require('_http_incoming').IncomingMessage;
-
-exports.OutgoingMessage = require('_http_outgoing').OutgoingMessage;
-
-exports.METHODS = require('_http_common').methods.slice().sort();
 
 const agent = require('_http_agent');
-exports.Agent = agent.Agent;
-exports.globalAgent = agent.globalAgent;
-
-const server = require('_http_server');
-exports.ServerResponse = server.ServerResponse;
-exports.STATUS_CODES = server.STATUS_CODES;
-exports._connectionListener = server._connectionListener;
-const Server = exports.Server = server.Server;
-
-exports.createServer = function createServer(requestListener) {
-  return new Server(requestListener);
-};
-
 const client = require('_http_client');
-const ClientRequest = exports.ClientRequest = client.ClientRequest;
+const common = require('_http_common');
+const incoming = require('_http_incoming');
+const outgoing = require('_http_outgoing');
+const server = require('_http_server');
 
-exports.request = function request(options, cb) {
+const Server = server.Server;
+const ClientRequest = client.ClientRequest;
+
+function createServer(requestListener) {
+  return new Server(requestListener);
+}
+
+function request(options, cb) {
   return new ClientRequest(options, cb);
-};
+}
 
-exports.get = function get(options, cb) {
-  var req = exports.request(options, cb);
+function get(options, cb) {
+  var req = request(options, cb);
   req.end();
   return req;
+}
+
+module.exports = {
+  _connectionListener: server._connectionListener,
+  METHODS: common.methods.slice().sort(),
+  STATUS_CODES: server.STATUS_CODES,
+  Agent: agent.Agent,
+  ClientRequest,
+  globalAgent: agent.globalAgent,
+  IncomingMessage: incoming.IncomingMessage,
+  OutgoingMessage: outgoing.OutgoingMessage,
+  Server,
+  ServerResponse: server.ServerResponse,
+  createServer,
+  get,
+  request
 };


### PR DESCRIPTION
Some simple code hygiene cleanups.

* Use the more efficient `module.exports = {}` pattern,
* Eliminate unnecessary uses of `self`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
http