### PR TITLE
buffer: add tests for Buffer.prototype.inspect() and refactor

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -531,12 +531,10 @@ Buffer.prototype.equals = function equals(b) {
 Buffer.prototype[internalUtil.customInspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
-  if (this.length > 0) {
-    str = this.toString('hex', 0, max).match(/.{2}/g).join(' ');
-    if (this.length > max)
-      str += ' ... ';
-  }
-  return '<' + this.constructor.name + ' ' + str + '>';
+  str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim();
+  if (this.length > max)
+    str += ' ... ';
+  return `<${this.constructor.name} ${str}>`;
 };
 Buffer.prototype.inspect = Buffer.prototype[internalUtil.customInspectSymbol];
 

--- a/test/parallel/test-buffer-prototype-inspect.js
+++ b/test/parallel/test-buffer-prototype-inspect.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+
+// lib/buffer.js defines Buffer.prototype.inspect() to override how buffers are
+// presented by util.inspect().
+
+const assert = require('assert');
+const util = require('util');
+
+{
+  const buf = Buffer.from('fhqwhgads');
+  assert.strictEqual(util.inspect(buf), '<Buffer 66 68 71 77 68 67 61 64 73>');
+}
+
+{
+  const buf = Buffer.from('');
+  assert.strictEqual(util.inspect(buf), '<Buffer >');
+}
+
+{
+  const buf = Buffer.from('x'.repeat(51));
+  assert.ok(/^<Buffer (78 ){50}\.\.\. >$/.test(util.inspect(buf)));
+}


### PR DESCRIPTION
First commit: lib/buffer.js defines Buffer.prototype.inspect() to override how buffers are presented by util.inspect(). Add basic tests for it. (This test completes code coverage for the function. Previously, the condition where the `this.length > 0` was always `true` during test runs. This adds a test where it will be `false`.)

Second commit: Now that tests are in place, refactor. Replace toString().match().join() with toString().replace().trim(). This enables the elimination of a length check becuase replace() will return empty string if Buffer is empty whereas match() returns null. (To be clear, I don't think the `.length` check is a performance liability or anything like that. I just think that fewer logic branches usually makes for code that is easier to understand.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer test