### PR TITLE
test: exclude pseudo-tty test pertinent to #11541

### DIFF
--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -2,5 +2,7 @@ prefix pseudo-tty
 
 [$system==aix]
 # test issue only, covered under https://github.com/nodejs/node/issues/7973
-no_dropped_stdio           : SKIP
-no_interleaved_stdio       : SKIP
+no_dropped_stdio                      : SKIP
+no_interleaved_stdio                  : SKIP
+# test issue: https://github.com/nodejs/node/issues/11541
+test-stderr-stdout-handle-sigwinch    : SKIP


### PR DESCRIPTION
This test pseudo-tty/test-stderr-stdout-handle-sigwinch is newly added 
to v4.x stream and is consistently failing.

We have a couple of issues with pseudo-tty tests in AIX, and while
the investigation is going on, need to skip this test to make CI green.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
