### PR TITLE
introduce doc linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -839,10 +839,13 @@ cpplint:
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)
 	@$(PYTHON) tools/check-imports.py
 
+doclint:
+	@$(NODE) tools/doc/linter
+
 ifneq ("","$(wildcard tools/eslint/lib/eslint.js)")
-lint: jslint cpplint
+lint: jslint cpplint doclint
 CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+
-lint-ci: jslint-ci cpplint
+lint-ci: jslint-ci cpplint doclint
 	@if ! ( grep -IEqrs "$(CONFLICT_RE)" benchmark deps doc lib src test tools ) \
 		&& ! ( find . -maxdepth 1 -type f | xargs grep -IEqs "$(CONFLICT_RE)" ); then \
 		exit 0 ; \

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1108,14 +1108,14 @@ Test in JavaScript by running:
 const addon = require('./build/Release/addon');
 ```
 
+[Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide
+[Linking to Node.js' own dependencies]: #addons_linking_to_node_js_own_dependencies
+[Native Abstractions for Node.js]: https://github.com/nodejs/nan
 [bindings]: https://github.com/TooTallNate/node-bindings
 [download]: https://github.com/nodejs/node-addon-examples
-[Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide
 [examples]: https://github.com/nodejs/nan/tree/master/examples/
 [installation instructions]: https://github.com/nodejs/node-gyp#installation
 [libuv]: https://github.com/libuv/libuv
-[Linking to Node.js' own dependencies]: #addons_linking_to_node_js_own_dependencies
-[Native Abstractions for Node.js]: https://github.com/nodejs/nan
 [node-gyp]: https://github.com/nodejs/node-gyp
 [require]: globals.html#globals_require
 [v8-docs]: https://v8docs.nodesource.com/

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -566,17 +566,17 @@ assert(Object.is(str1 / 1, str2 / 1));
 For more information, see
 [MDN's guide on equality comparisons and sameness][mdn-equality-guide].
 
+[Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
+[SameValueZero]: https://tc39.github.io/ecma262/#sec-samevaluezero
+[Strict Equality Comparison]: https://tc39.github.io/ecma262/#sec-strict-equality-comparison
+[enumerable "own" properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties
+[mdn-equality-guide]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness
+[prototype-spec]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
+[`Error`]: errors.html#errors_class_error
+[`Object.is()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+[`RegExp`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[`TypeError`]: errors.html#errors_class_typeerror
 [`assert.deepEqual()`]: #assert_assert_deepequal_actual_expected_message
 [`assert.deepStrictEqual()`]: #assert_assert_deepstrictequal_actual_expected_message
 [`assert.ok()`]: #assert_assert_ok_value_message
 [`assert.throws()`]: #assert_assert_throws_block_error_message
-[`Error`]: errors.html#errors_class_error
-[`RegExp`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-[`TypeError`]: errors.html#errors_class_typeerror
-[Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
-[Strict Equality Comparison]: https://tc39.github.io/ecma262/#sec-strict-equality-comparison
-[`Object.is()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-[SameValueZero]: https://tc39.github.io/ecma262/#sec-samevaluezero
-[prototype-spec]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
-[mdn-equality-guide]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness
-[enumerable "own" properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2606,16 +2606,12 @@ buf.fill(0);
 console.log(buf);
 ```
 
-[`buf.compare()`]: #buffer_buf_compare_target_targetstart_targetend_sourcestart_sourceend
-[`buf.buffer`]: #buffer_buf_buffer
-[`buf.entries()`]: #buffer_buf_entries
-[`buf.indexOf()`]: #buffer_buf_indexof_value_byteoffset_encoding
-[`buf.fill()`]: #buffer_buf_fill_value_offset_end_encoding
-[`buf.keys()`]: #buffer_buf_keys
-[`buf.length`]: #buffer_buf_length
-[`buf.slice()`]: #buffer_buf_slice_start_end
-[`buf.values()`]: #buffer_buf_values
-[`buffer.kMaxLength`]: #buffer_buffer_kmaxlength
+[RFC1345]: https://tools.ietf.org/html/rfc1345
+[RFC4648, Section 5]: https://tools.ietf.org/html/rfc4648#section-5
+[WHATWG spec]: https://encoding.spec.whatwg.org/
+[iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
+[`ArrayBuffer#slice()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
+[`ArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
 [`Buffer.alloc()`]: #buffer_class_method_buffer_alloc_size_fill_encoding
 [`Buffer.allocUnsafe()`]: #buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow()`]: #buffer_class_method_buffer_allocunsafeslow_size
@@ -2624,21 +2620,24 @@ console.log(buf);
 [`Buffer.from(buffer)`]: #buffer_class_method_buffer_from_buffer
 [`Buffer.from(string)`]: #buffer_class_method_buffer_from_string_encoding
 [`Buffer.poolSize`]: #buffer_class_property_buffer_poolsize
-[`RangeError`]: errors.html#errors_class_rangeerror
-[`util.inspect()`]: util.html#util_util_inspect_object_options
-
-[`ArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
-[`ArrayBuffer#slice()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
 [`DataView`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
-[iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
 [`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-[RFC1345]: https://tools.ietf.org/html/rfc1345
-[RFC4648, Section 5]: https://tools.ietf.org/html/rfc4648#section-5
-[`String.prototype.length`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length
+[`RangeError`]: errors.html#errors_class_rangeerror
 [`String#indexOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf
 [`String#lastIndexOf()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
-[`TypedArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+[`String.prototype.length`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length
 [`TypedArray.from()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from
+[`TypedArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 [`Uint32Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
 [`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
-[WHATWG spec]: https://encoding.spec.whatwg.org/
+[`buf.buffer`]: #buffer_buf_buffer
+[`buf.compare()`]: #buffer_buf_compare_target_targetstart_targetend_sourcestart_sourceend
+[`buf.entries()`]: #buffer_buf_entries
+[`buf.fill()`]: #buffer_buf_fill_value_offset_end_encoding
+[`buf.indexOf()`]: #buffer_buf_indexof_value_byteoffset_encoding
+[`buf.keys()`]: #buffer_buf_keys
+[`buf.length`]: #buffer_buf_length
+[`buf.slice()`]: #buffer_buf_slice_start_end
+[`buf.values()`]: #buffer_buf_values
+[`buffer.kMaxLength`]: #buffer_buffer_kmaxlength
+[`util.inspect()`]: util.html#util_util_inspect_object_options

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1213,9 +1213,15 @@ This impacts output that includes multibyte character encodings such as UTF-8 or
 UTF-16. For instance, `console.log('中文测试')` will send 13 UTF-8 encoded bytes
 to `stdout` although there are only 4 characters.
 
+[synchronous counterparts]: #child_process_synchronous_process_creation
 [`'error'`]: #child_process_event_error
 [`'exit'`]: #child_process_event_exit
 [`'message'`]: #child_process_event_message
+[`ChildProcess`]: #child_process_child_process
+[`Error`]: errors.html#errors_class_error
+[`EventEmitter`]: events.html#events_class_eventemitter
+[`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
 [`child.channel`]: #child_process_child_channel
 [`child.connected`]: #child_process_child_connected
 [`child.disconnect()`]: #child_process_child_disconnect
@@ -1231,10 +1237,6 @@ to `stdout` although there are only 4 characters.
 [`child_process.fork()`]: #child_process_child_process_fork_modulepath_args_options
 [`child_process.spawn()`]: #child_process_child_process_spawn_command_args_options
 [`child_process.spawnSync()`]: #child_process_child_process_spawnsync_command_args_options
-[`ChildProcess`]: #child_process_child_process
-[`Error`]: errors.html#errors_class_error
-[`EventEmitter`]: events.html#events_class_eventemitter
-[`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [`maxBuffer`]: #child_process_maxbuffer_and_unicode
 [`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket
@@ -1246,5 +1248,3 @@ to `stdout` although there are only 4 characters.
 [`process.on('message')`]: process.html#process_event_message
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`stdio`]: #child_process_options_stdio
-[synchronous counterparts]: #child_process_synchronous_process_creation
-[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -444,9 +444,9 @@ appended to if it does. If an error occurs while attempting to write the
 warning to the file, the warning will be written to stderr instead. This is
 equivalent to using the `--redirect-warnings=file` command-line flag.
 
-[emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [Buffer]: buffer.html#buffer_buffer
-[debugger]: debugger.html
 [REPL]: repl.html
 [SlowBuffer]: buffer.html#buffer_class_slowbuffer
+[debugger]: debugger.html
+[emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [`--openssl-config`]: #cli_openssl_config_file

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -859,13 +859,13 @@ socket.on('data', (id) => {
 });
 ```
 
-[`child_process.fork()`]: child_process.html#child_process_child_process_fork_modulepath_args_options
-[`ChildProcess.send()`]: child_process.html#child_process_child_send_message_sendhandle_options_callback
-[`disconnect`]: child_process.html#child_process_child_disconnect
-[`kill`]: process.html#process_process_kill_pid_signal
-[`server.close()`]: net.html#net_event_close
-[`worker.exitedAfterDisconnect`]: #cluster_worker_exitedafterdisconnect
 [Child Process module]: child_process.html#child_process_child_process_fork_modulepath_args_options
 [child_process event: 'exit']: child_process.html#child_process_event_exit
 [child_process event: 'message']: child_process.html#child_process_event_message
+[`ChildProcess.send()`]: child_process.html#child_process_child_send_message_sendhandle_options_callback
+[`child_process.fork()`]: child_process.html#child_process_child_process_fork_modulepath_args_options
+[`disconnect`]: child_process.html#child_process_child_disconnect
+[`kill`]: process.html#process_process_kill_pid_signal
 [`process` event: `'message'`]: process.html#process_event_message
+[`server.close()`]: net.html#net_event_close
+[`worker.exitedAfterDisconnect`]: #cluster_worker_exitedafterdisconnect

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -298,6 +298,9 @@ added: v0.1.100
 
 The `console.warn()` function is an alias for [`console.error()`][].
 
+[customizing `util.inspect()` colors]: util.html#util_customizing_util_inspect_colors
+[note on process I/O]: process.html#process_a_note_on_process_i_o
+[web-api-assert]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert
 [`console.error()`]: #console_console_error_data_args
 [`console.log()`]: #console_console_log_data_args
 [`console.time()`]: #console_console_time_label
@@ -306,6 +309,3 @@ The `console.warn()` function is an alias for [`console.error()`][].
 [`process.stdout`]: process.html#process_process_stdout
 [`util.format()`]: util.html#util_util_format_format_args
 [`util.inspect()`]: util.html#util_util_inspect_object_options
-[customizing `util.inspect()` colors]: util.html#util_customizing_util_inspect_colors
-[note on process I/O]: process.html#process_a_note_on_process_i_o
-[web-api-assert]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1997,8 +1997,21 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
   </tr>
 </table>
 
-
+[Caveats]: #crypto_support_for_weak_or_compromised_algorithms
+[Crypto Constants]: #crypto_crypto_constants_1
+[HTML5's `keygen` element]: http://www.w3.org/TR/html5/forms.html#the-keygen-element
+[NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
+[NIST SP 800-132]: http://csrc.nist.gov/publications/nistpubs/800-132/nist-sp800-132.pdf
+[OpenSSL cipher list format]: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT
+[OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
+[RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt
+[RFC 3526]: https://www.rfc-editor.org/rfc/rfc3526.txt
+[initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector
+[publicly trusted list of CAs]: https://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt
+[stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
+[stream]: stream.html
 [`Buffer`]: buffer.html
+[`EVP_BytesToKey`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_BytesToKey.html
 [`cipher.final()`]: #crypto_cipher_final_output_encoding
 [`cipher.update()`]: #crypto_cipher_update_data_input_encoding_output_encoding
 [`crypto.createCipher()`]: #crypto_crypto_createcipher_algorithm_password
@@ -2020,7 +2033,6 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`ecdh.generateKeys()`]: #crypto_ecdh_generatekeys_encoding_format
 [`ecdh.setPrivateKey()`]: #crypto_ecdh_setprivatekey_private_key_encoding
 [`ecdh.setPublicKey()`]: #crypto_ecdh_setpublickey_public_key_encoding
-[`EVP_BytesToKey`]: https://www.openssl.org/docs/man1.0.2/crypto/EVP_BytesToKey.html
 [`hash.digest()`]: #crypto_hash_digest_encoding
 [`hash.update()`]: #crypto_hash_update_data_input_encoding
 [`hmac.digest()`]: #crypto_hmac_digest_encoding
@@ -2030,16 +2042,3 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_options
 [`verify.update()`]: #crypto_verifier_update_data_input_encoding
 [`verify.verify()`]: #crypto_verifier_verify_object_signature_signature_format
-[Caveats]: #crypto_support_for_weak_or_compromised_algorithms
-[HTML5's `keygen` element]: http://www.w3.org/TR/html5/forms.html#the-keygen-element
-[initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector
-[NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
-[NIST SP 800-132]: http://csrc.nist.gov/publications/nistpubs/800-132/nist-sp800-132.pdf
-[OpenSSL cipher list format]: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT
-[OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
-[publicly trusted list of CAs]: https://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt
-[RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt
-[RFC 3526]: https://www.rfc-editor.org/rfc/rfc3526.txt
-[stream]: stream.html
-[stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
-[Crypto Constants]: #crypto_crypto_constants_1

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -536,12 +536,17 @@ as an officially supported API.
 
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
-[`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
-[`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
-[`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [from_arraybuffer]: buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length
-[`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
 [from_string_encoding]: buffer.html#buffer_class_method_buffer_from_string_encoding
+[`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
+[`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
+[`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
+[`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`Domain.dispose()`]: domain.html#domain_domain_dispose
+[`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname
+[`Server.connections`]: net.html#net_server_connections
+[`Server.getConnections()`]: net.html#net_server_getconnections_callback
+[`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
 [`SlowBuffer`]: buffer.html#buffer_class_slowbuffer
 [`child_process`]: child_process.html
 [`console.error()`]: console.html#console_console_error_data_args
@@ -549,36 +554,29 @@ as an officially supported API.
 [`crypto.createCredentials()`]: crypto.html#crypto_crypto_createcredentials_details
 [`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
 [`domain`]: domain.html
-[`Domain.dispose()`]: domain.html#domain_domain_dispose
 [`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_public_key_encoding
 [`emitter.listenerCount(eventName)`]: events.html#events_emitter_listenercount_eventname
-[`EventEmitter.listenerCount(emitter, eventName)`]: events.html#events_eventemitter_listenercount_emitter_eventname
-[`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
-[`fs.stat()`]: fs.html#fs_fs_stat_path_callback
 [`fs.access()`]: fs.html#fs_fs_access_path_mode_callback
+[`fs.exists(path, callback)`]: fs.html#fs_fs_exists_path_callback
 [`fs.lchmod(path, mode, callback)`]: fs.html#fs_fs_lchmod_path_mode_callback
 [`fs.lchmodSync(path, mode)`]: fs.html#fs_fs_lchmodsync_path_mode
 [`fs.lchown(path, uid, gid, callback)`]: fs.html#fs_fs_lchown_path_uid_gid_callback
 [`fs.lchownSync(path, uid, gid)`]: fs.html#fs_fs_lchownsync_path_uid_gid
 [`fs.read()`]: fs.html#fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readSync()`]: fs.html#fs_fs_readsync_fd_buffer_offset_length_position
-[`Server.connections`]: net.html#net_server_connections
-[`Server.getConnections()`]: net.html#net_server_getconnections_callback
-[`Server.listen({fd: <number>})`]: net.html#net_server_listen_handle_backlog_callback
+[`fs.stat()`]: fs.html#fs_fs_stat_path_callback
 [`os.networkInterfaces`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`punycode`]: punycode.html
 [`require.extensions`]: globals.html#globals_require_extensions
-[`tls.TLSSocket`]: tls.html#tls_class_tls_tlssocket
 [`tls.CryptoStream`]: tls.html#tls_class_cryptostream
-[`tls.SecurePair`]: tls.html#tls_class_securepair
 [`tls.SecureContext`]: tls.html#tls_tls_createsecurecontext_options
+[`tls.SecurePair`]: tls.html#tls_class_securepair
+[`tls.TLSSocket`]: tls.html#tls_class_tls_tlssocket
 [`tls.createSecureContext()`]: tls.html#tls_tls_createsecurecontext_options
-[`util`]: util.html
+[`util._extend()`]: util.html#util_util_extend_target_source
 [`util.debug()`]: util.html#util_util_debug_string
 [`util.error()`]: util.html#util_util_error_strings
-[`util.puts()`]: util.html#util_util_puts_strings
-[`util.print()`]: util.html#util_util_print_strings
 [`util.isArray()`]: util.html#util_util_isarray_object
 [`util.isBoolean()`]: util.html#util_util_isboolean_object
 [`util.isBuffer()`]: util.html#util_util_isbuffer_object
@@ -595,6 +593,8 @@ as an officially supported API.
 [`util.isSymbol()`]: util.html#util_util_issymbol_object
 [`util.isUndefined()`]: util.html#util_util_isundefined_object
 [`util.log()`]: util.html#util_util_log_string
-[`util._extend()`]: util.html#util_util_extend_target_source
-[`worker.suicide`]: cluster.html#cluster_worker_suicide
+[`util.print()`]: util.html#util_util_print_strings
+[`util.puts()`]: util.html#util_util_puts_strings
+[`util`]: util.html
 [`worker.exitedAfterDisconnect`]: cluster.html#cluster_worker_exitedafterdisconnect
+[`worker.suicide`]: cluster.html#cluster_worker_suicide

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -493,15 +493,15 @@ interfaces" address on a random port (it does the right thing for both `udp4`
 and `udp6` sockets). The bound address and port can be retrieved using
 [`socket.address().address`][] and [`socket.address().port`][].
 
-[`EventEmitter`]: events.html
-[`Buffer`]: buffer.html
+[byte length]: buffer.html#buffer_class_method_buffer_bytelength_string_encoding
 [`'close'`]: #dgram_event_close
+[`Buffer`]: buffer.html
+[`Error`]: errors.html#errors_class_error
+[`EventEmitter`]: events.html
 [`close()`]: #dgram_socket_close_callback
 [`cluster`]: cluster.html
-[`dgram.createSocket()`]: #dgram_dgram_createsocket_options_callback
 [`dgram.Socket#bind()`]: #dgram_socket_bind_options_callback
-[`Error`]: errors.html#errors_class_error
+[`dgram.createSocket()`]: #dgram_dgram_createsocket_options_callback
 [`socket.address().address`]: #dgram_socket_address
 [`socket.address().port`]: #dgram_socket_address
 [`socket.bind()`]: #dgram_socket_bind_port_address_callback
-[byte length]: buffer.html#buffer_class_method_buffer_bytelength_string_encoding

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -476,9 +476,9 @@ They do not use the same set of configuration files than what [`dns.lookup()`][]
 uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 
 [DNS error codes]: #dns_error_codes
-[`dns.lookup()`]: #dns_dns_lookup_hostname_options_callback
-[`dns.resolveSoa()`]: #dns_dns_resolvesoa_hostname_callback
-[`Error`]: errors.html#errors_class_error
 [Implementation considerations section]: #dns_implementation_considerations
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags
 [the official libuv documentation]: http://docs.libuv.org/en/latest/threadpool.html
+[`Error`]: errors.html#errors_class_error
+[`dns.lookup()`]: #dns_dns_lookup_hostname_options_callback
+[`dns.resolveSoa()`]: #dns_dns_resolvesoa_hostname_callback

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -444,12 +444,12 @@ d.run(() => {
 In this example, the `d.on('error')` handler will be triggered, rather
 than crashing the program.
 
+[`Error`]: errors.html#errors_class_error
+[`EventEmitter`]: events.html#events_class_eventemitter
 [`domain.add(emitter)`]: #domain_domain_add_emitter
 [`domain.bind(callback)`]: #domain_domain_bind_callback
 [`domain.dispose()`]: #domain_domain_dispose
 [`domain.exit()`]: #domain_domain_exit
-[`Error`]: errors.html#errors_class_error
-[`EventEmitter`]: events.html#events_class_eventemitter
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
 [`throw`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -563,15 +563,7 @@ found [here][online].
   encountered by [`http`][] or [`net`][] -- often a sign that a `socket.end()`
   was not properly called.
 
-[`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
-[`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
-[`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
-[`fs`]: fs.html
-[`http`]: http.html
-[`https`]: https.html
-[`libuv Error handling`]: http://docs.libuv.org/en/v1.x/errors.html
-[`net`]: net.html
-[`process.on('uncaughtException')`]: process.html#process_event_uncaughtexception
+[V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
@@ -579,5 +571,13 @@ found [here][online].
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
-[V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [vm]: vm.html
+[`fs.readFileSync`]: fs.html#fs_fs_readfilesync_file_options
+[`fs.readdir`]: fs.html#fs_fs_readdir_path_options_callback
+[`fs.unlink`]: fs.html#fs_fs_unlink_path_callback
+[`fs`]: fs.html
+[`http`]: http.html
+[`https`]: https.html
+[`libuv Error handling`]: http://docs.libuv.org/en/v1.x/errors.html
+[`net`]: net.html
+[`process.on('uncaughtException')`]: process.html#process_event_uncaughtexception

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -574,13 +574,13 @@ to indicate an unlimited number of listeners.
 
 Returns a reference to the `EventEmitter`, so that calls can be chained.
 
-[`net.Server`]: net.html#net_class_net_server
-[`fs.ReadStream`]: fs.html#fs_class_fs_readstream
-[`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n
-[`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
-[`emitter.listenerCount()`]: #events_emitter_listenercount_eventname
-[`domain`]: domain.html
-[`process` object's `uncaughtException` event]: process.html#process_event_uncaughtexception
-[`process.on('warning')`]: process.html#process_event_warning
 [stream]: stream.html
 [`--trace-warnings`]: cli.html#cli_trace_warnings
+[`EventEmitter.defaultMaxListeners`]: #events_eventemitter_defaultmaxlisteners
+[`domain`]: domain.html
+[`emitter.listenerCount()`]: #events_emitter_listenercount_eventname
+[`emitter.setMaxListeners(n)`]: #events_emitter_setmaxlisteners_n
+[`fs.ReadStream`]: fs.html#fs_class_fs_readstream
+[`net.Server`]: net.html#net_class_net_server
+[`process.on('warning')`]: process.html#process_event_warning
+[`process` object's `uncaughtException` event]: process.html#process_event_uncaughtexception

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2468,14 +2468,29 @@ The following constants are meant for use with the [`fs.Stats`][] object's
   </tr>
 </table>
 
+[Caveats]: #fs_caveats
+[Common System Errors]: errors.html#errors_common_system_errors
+[FS Constants]: #fs_fs_constants_1
+[MDN-Date-getTime]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime
+[MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
+[Readable Stream]: stream.html#stream_class_stream_readable
+[Writable Stream]: stream.html#stream_class_stream_writable
+[inode]: https://en.wikipedia.org/wiki/Inode
+[`AHAFS`]: https://www.ibm.com/developerworks/aix/library/au-aix_event_infrastructure/
 [`Buffer.byteLength`]: buffer.html#buffer_class_method_buffer_bytelength_string_encoding
 [`Buffer`]: buffer.html#buffer_buffer
-[Caveats]: #fs_caveats
+[`FSEvents`]: https://developer.apple.com/library/mac/documentation/Darwin/Conceptual/FSEvents_ProgGuide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40005289-CH1-SW1
+[`ReadDirectoryChangesW`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465%28v=vs.85%29.aspx
+[`ReadStream`]: #fs_class_fs_readstream
+[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
+[`WriteStream`]: #fs_class_fs_writestream
+[`event ports`]: http://illumos.org/man/port_create
+[`fs.FSWatcher`]: #fs_class_fs_fswatcher
+[`fs.Stats`]: #fs_class_fs_stats
 [`fs.access()`]: #fs_fs_access_path_mode_callback
 [`fs.appendFile()`]: fs.html#fs_fs_appendfile_file_data_options_callback
 [`fs.exists()`]: fs.html#fs_fs_exists_path_callback
 [`fs.fstat()`]: #fs_fs_fstat_fd_callback
-[`fs.FSWatcher`]: #fs_class_fs_fswatcher
 [`fs.futimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
 [`fs.lstat()`]: #fs_fs_lstat_path_callback
 [`fs.mkdtemp()`]: #fs_fs_mkdtemp_prefix_options_callback
@@ -2483,27 +2498,12 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`fs.read()`]: #fs_fs_read_fd_buffer_offset_length_position_callback
 [`fs.readFile`]: #fs_fs_readfile_file_options_callback
 [`fs.stat()`]: #fs_fs_stat_path_callback
-[`fs.Stats`]: #fs_class_fs_stats
 [`fs.utimes()`]: #fs_fs_futimes_fd_atime_mtime_callback
 [`fs.watch()`]: #fs_fs_watch_filename_options_listener
 [`fs.write()`]: #fs_fs_write_fd_buffer_offset_length_position_callback
 [`fs.writeFile()`]: #fs_fs_writefile_file_data_options_callback
-[`net.Socket`]: net.html#net_class_net_socket
-[`ReadStream`]: #fs_class_fs_readstream
-[`stat()`]: fs.html#fs_fs_stat_path_callback
-[`util.inspect(stats)`]: util.html#util_util_inspect_object_options
-[`WriteStream`]: #fs_class_fs_writestream
-[MDN-Date-getTime]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime
-[MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
-[Readable Stream]: stream.html#stream_class_stream_readable
-[Writable Stream]: stream.html#stream_class_stream_writable
-[inode]: https://en.wikipedia.org/wiki/Inode
-[FS Constants]: #fs_fs_constants_1
 [`inotify`]: http://man7.org/linux/man-pages/man7/inotify.7.html
 [`kqueue`]: https://www.freebsd.org/cgi/man.cgi?kqueue
-[`FSEvents`]: https://developer.apple.com/library/mac/documentation/Darwin/Conceptual/FSEvents_ProgGuide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40005289-CH1-SW1
-[`event ports`]: http://illumos.org/man/port_create
-[`ReadDirectoryChangesW`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465%28v=vs.85%29.aspx
-[`AHAFS`]: https://www.ibm.com/developerworks/aix/library/au-aix_event_infrastructure/
-[Common System Errors]: errors.html#errors_common_system_errors
-[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
+[`net.Socket`]: net.html#net_class_net_socket
+[`stat()`]: fs.html#fs_fs_stat_path_callback
+[`util.inspect(stats)`]: util.html#util_util_inspect_object_options

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -272,20 +272,20 @@ added: v0.0.1
 
 [`setTimeout`] is described in the [timers][] section.
 
-[`__dirname`]: #globals_dirname
-[`__filename`]: #globals_filename
-[`console`]: console.html
-[`path.dirname()`]: path.html#path_path_dirname_path
-[`process` object]: process.html#process_process
-[buffer section]: buffer.html
-[module system documentation]: modules.html
 [Modules]: modules.html#modules_modules
+[buffer section]: buffer.html
+[built-in objects]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+[module system documentation]: modules.html
 [native addons]: addons.html
 [timers]: timers.html
+[`__dirname`]: #globals_dirname
+[`__filename`]: #globals_filename
 [`clearImmediate`]: timers.html#timers_clearimmediate_immediate
 [`clearInterval`]: timers.html#timers_clearinterval_timeout
 [`clearTimeout`]: timers.html#timers_cleartimeout_timeout
+[`console`]: console.html
+[`path.dirname()`]: path.html#path_path_dirname_path
+[`process` object]: process.html#process_process
 [`setImmediate`]: timers.html#timers_setimmediate_callback_args
 [`setInterval`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout`]: timers.html#timers_settimeout_callback_delay_args
-[built-in objects]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1706,28 +1706,35 @@ There are a few special headers that should be noted.
 * Sending an Authorization header will override using the `auth` option
   to compute basic authentication.
 
+[Readable Stream]: stream.html#stream_class_stream_readable
+[Writable Stream]: stream.html#stream_class_stream_writable
+[constructor options]: #http_new_agent_options
+[socket.unref()]: net.html#net_socket_unref
+[unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0
+[unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
 [`'checkContinue'`]: #http_event_checkcontinue
 [`'listening'`]: net.html#net_event_listening
 [`'request'`]: #http_event_request
 [`'response'`]: #http_event_response
 [`Agent`]: #http_class_http_agent
+[`EventEmitter`]: events.html#events_class_eventemitter
+[`TypeError`]: errors.html#errors_class_typeerror
 [`agent.createConnection()`]: #http_agent_createconnection_options_callback
 [`destroy()`]: #http_agent_destroy
-[`EventEmitter`]: events.html#events_class_eventemitter
 [`http.Agent`]: #http_class_http_agent
 [`http.ClientRequest`]: #http_class_http_clientrequest
-[`http.globalAgent`]: #http_http_globalagent
 [`http.IncomingMessage`]: #http_class_http_incomingmessage
-[`http.request()`]: #http_http_request_options_callback
 [`http.Server`]: #http_class_http_server
+[`http.globalAgent`]: #http_http_globalagent
+[`http.request()`]: #http_http_request_options_callback
 [`message.headers`]: #http_message_headers
-[`net.createConnection()`]: net.html#net_net_createconnection_options_connectlistener
-[`net.Server`]: net.html#net_class_net_server
 [`net.Server.close()`]: net.html#net_server_close_callback
 [`net.Server.listen()`]: net.html#net_server_listen_handle_backlog_callback
 [`net.Server.listen(path)`]: net.html#net_server_listen_path_backlog_callback
 [`net.Server.listen(port)`]: net.html#net_server_listen_port_hostname_backlog_callback
+[`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket
+[`net.createConnection()`]: net.html#net_net_createconnection_options_connectlistener
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`response.end()`]: #http_response_end_data_encoding_callback
 [`response.setHeader()`]: #http_response_setheader_name_value
@@ -1738,11 +1745,4 @@ There are a few special headers that should be noted.
 [`socket.setKeepAlive()`]: net.html#net_socket_setkeepalive_enable_initialdelay
 [`socket.setNoDelay()`]: net.html#net_socket_setnodelay_nodelay
 [`socket.setTimeout()`]: net.html#net_socket_settimeout_timeout_callback
-[`TypeError`]: errors.html#errors_class_typeerror
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
-[constructor options]: #http_new_agent_options
-[Readable Stream]: stream.html#stream_class_stream_readable
-[Writable Stream]: stream.html#stream_class_stream_writable
-[socket.unref()]: net.html#net_socket_unref
-[unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
-[unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -255,18 +255,18 @@ var req = https.request(options, (res) => {
 
 [`Agent`]: #https_class_https_agent
 [`Buffer`]: buffer.html#buffer_buffer
+[`SSL_METHODS`]: https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
 [`globalAgent`]: #https_https_globalagent
 [`http.Agent`]: http.html#http_class_http_agent
+[`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback
+[`http.Server#timeout`]: http.html#http_server_timeout
+[`http.Server`]: http.html#http_class_http_server
 [`http.close()`]: http.html#http_server_close_callback
 [`http.get()`]: http.html#http_http_get_options_callback
 [`http.listen()`]: http.html#http_server_listen_port_hostname_backlog_callback
 [`http.request()`]: http.html#http_http_request_options_callback
-[`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback
-[`http.Server#timeout`]: http.html#http_server_timeout
-[`http.Server`]: http.html#http_class_http_server
 [`https.Agent`]: #https_class_https_agent
 [`https.request()`]: #https_https_request_options_callback
-[`SSL_METHODS`]: https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
 [`tls.connect()`]: tls.html#tls_tls_connect_options_callback
 [`tls.createServer()`]: tls.html#tls_tls_createserver_options_secureconnectionlistener
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -629,5 +629,5 @@ object.  Since `require()` returns the `module.exports`, and the `module` is
 typically *only* available within a specific module's code, it must be
 explicitly exported in order to be used.
 
-[`Error`]: errors.html#errors_class_error
 [module resolution]: #modules_all_together
+[`Error`]: errors.html#errors_class_error

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -936,6 +936,9 @@ added: v0.3.0
 
 Returns true if input is a version 6 IP address, otherwise returns false.
 
+[Readable Stream]: stream.html#stream_class_stream_readable
+[unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0
+[unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
 [`'close'`]: #net_event_close
 [`'connect'`]: #net_event_connect
 [`'connection'`]: #net_event_connection
@@ -945,23 +948,20 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`'error'`]: #net_event_error_1
 [`'listening'`]: #net_event_listening
 [`'timeout'`]: #net_event_timeout
+[`EventEmitter`]: events.html#events_class_eventemitter
 [`child_process.fork()`]: child_process.html#child_process_child_process_fork_modulepath_args_options
 [`connect()`]: #net_socket_connect_options_connectlistener
 [`destroy()`]: #net_socket_destroy_exception
-[`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
 [`dns.lookup()` hints]: dns.html#dns_supported_getaddrinfo_flags
+[`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
 [`end()`]: #net_socket_end_data_encoding
-[`EventEmitter`]: events.html#events_class_eventemitter
 [`net.Socket`]: #net_class_net_socket
 [`pause()`]: #net_socket_pause
 [`resume()`]: #net_socket_resume
+[`server.close()`]: #net_server_close_callback
 [`server.getConnections()`]: #net_server_getconnections_callback
 [`server.listen(port, host, backlog, callback)`]: #net_server_listen_port_hostname_backlog_callback
-[`server.close()`]: #net_server_close_callback
 [`socket.connect(options, connectListener)`]: #net_socket_connect_options_connectlistener
 [`socket.connect`]: #net_socket_connect_options_connectlistener
 [`socket.setTimeout()`]: #net_socket_settimeout_timeout_callback
 [`stream.setEncoding()`]: stream.html#stream_readable_setencoding_encoding
-[Readable Stream]: stream.html#stream_class_stream_readable
-[unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
-[unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -1172,6 +1172,6 @@ The following error codes are specific to the Windows operating system:
   </tr>
 </table>
 
+[OS Constants]: #os_os_constants
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
-[OS Constants]: #os_os_constants

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -537,7 +537,7 @@ of the `path` methods.
 characters are accepted as path delimiters; however, only the backward slash
 (`\`) will be used in return values.
 
+[`TypeError`]: errors.html#errors_class_typeerror
+[`path.parse()`]: #path_path_parse_path
 [`path.posix`]: #path_path_posix
 [`path.win32`]: #path_path_win32
-[`path.parse()`]: #path_path_parse_path
-[`TypeError`]: errors.html#errors_class_typeerror

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1761,6 +1761,17 @@ cases:
   the high-order bit, and then contain the value of the signal code.
 
 
+[Child Process]: child_process.html
+[Cluster]: cluster.html
+[LTS]: https://github.com/nodejs/LTS/
+[Readable]: stream.html#stream_readable_streams
+[Signal Events]: #process_signal_events
+[Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
+[TTY]: tty.html#tty_tty
+[Writable]: stream.html#stream_writable_streams
+[note on process I/O]: process.html#process_a_note_on_process_i_o
+[process_emit_warning]: #process_process_emitwarning_warning_name_ctor
+[process_warning]: #process_event_warning
 [`'exit'`]: #process_event_exit
 [`'finish'`]: stream.html#stream_event_finish
 [`'message'`]: child_process.html#child_process_event_message
@@ -1770,28 +1781,17 @@ cases:
 [`ChildProcess.kill()`]: child_process.html#child_process_child_kill_signal
 [`ChildProcess.send()`]: child_process.html#child_process_child_send_message_sendhandle_options_callback
 [`ChildProcess`]: child_process.html#child_process_class_childprocess
-[`end()`]: stream.html#stream_writable_end_chunk_encoding_callback
 [`Error`]: errors.html#errors_class_error
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[`end()`]: stream.html#stream_writable_end_chunk_encoding_callback
 [`net.Server`]: net.html#net_class_net_server
 [`net.Socket`]: net.html#net_class_net_socket
 [`process.argv`]: #process_process_argv
-[`process.exit()`]: #process_process_exit_code
-[`process.kill()`]: #process_process_kill_pid_signal
 [`process.execPath`]: #process_process_execpath
+[`process.exit()`]: #process_process_exit_code
+[`process.exitCode`]: #process_process_exitcode
+[`process.kill()`]: #process_process_kill_pid_signal
 [`promise.catch()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
 [`require.main`]: modules.html#modules_accessing_the_main_module
 [`setTimeout(fn, 0)`]: timers.html#timers_settimeout_callback_delay_args
-[note on process I/O]: process.html#process_a_note_on_process_i_o
-[process_emit_warning]: #process_process_emitwarning_warning_name_ctor
-[process_warning]: #process_event_warning
-[Signal Events]: #process_signal_events
-[Stream compatibility]: stream.html#stream_compatibility_with_older_node_js_versions
-[TTY]: tty.html#tty_tty
-[Writable]: stream.html#stream_writable_streams
-[Readable]: stream.html#stream_readable_streams
-[Child Process]: child_process.html
-[Cluster]: cluster.html
-[`process.exitCode`]: #process_process_exitcode
-[LTS]: https://github.com/nodejs/LTS/

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -145,5 +145,5 @@ added: v0.6.1
 
 Returns a string identifying the current [Punycode.js][] version number.
 
-[Punycode]: https://tools.ietf.org/html/rfc3492
 [Punycode.js]: https://mths.be/punycode
+[Punycode]: https://tools.ietf.org/html/rfc3492

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -523,10 +523,10 @@ rl.on('line', (line) => {
 });
 ```
 
-[`process.stdin`]: process.html#process_process_stdin
-[`process.stdout`]: process.html#process_process_stdout
-[Writable]: stream.html#stream_writable_streams
 [Readable]: stream.html#stream_readable_streams
 [TTY]: tty.html
-[`SIGTSTP`]: readline.html#readline_event_sigtstp
+[Writable]: stream.html#stream_writable_streams
 [`SIGCONT`]: readline.html#readline_event_sigcont
+[`SIGTSTP`]: readline.html#readline_event_sigtstp
+[`process.stdin`]: process.html#process_process_stdin
+[`process.stdout`]: process.html#process_process_stdout

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -556,8 +556,8 @@ a `net.Server` and `net.Socket` instance, see: https://gist.github.com/2209310
 For an example of running a REPL instance over [curl(1)][],
 see: https://gist.github.com/2053342
 
-[stream]: stream.html
-[`util.inspect()`]: util.html#util_util_inspect_object_options
-[`readline.Interface`]: readline.html#readline_class_interface
-[`readline.InterfaceCompleter`]: readline.html#readline_use_of_the_completer_function
 [curl(1)]: https://curl.haxx.se/docs/manpage.html
+[stream]: stream.html
+[`readline.InterfaceCompleter`]: readline.html#readline_use_of_the_completer_function
+[`readline.Interface`]: readline.html#readline_class_interface
+[`util.inspect()`]: util.html#util_util_inspect_object_options

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2025,39 +2025,22 @@ has an interesting side effect. Because it *is* a call to
 However, because the argument is an empty string, no data is added to the
 readable buffer so there is nothing for a user to consume.
 
-[`'data'`]: #stream_event_data
-[`'drain'`]: #stream_event_drain
-[`'end'`]: #stream_event_end
-[`'finish'`]: #stream_event_finish
-[`'readable'`]: #stream_event_readable
-[`EventEmitter`]: events.html#events_class_eventemitter
-[`process.stderr`]: process.html#process_process_stderr
-[`process.stdin`]: process.html#process_process_stdin
-[`process.stdout`]: process.html#process_process_stdout
-[`stream.cork()`]: #stream_writable_cork
-[`stream.pipe()`]: #stream_readable_pipe_destination_options
-[`stream.uncork()`]: #stream_writable_uncork
-[`stream.unpipe()`]: #stream_readable_unpipe_destination
-[`stream.wrap()`]: #stream_readable_wrap_stream
-[`writable.cork()`]: #stream_writable_cork
-[`writable.uncork()`]: #stream_writable_uncork
 [API for Stream Consumers]: #stream_api_for_stream_consumers
 [API for Stream Implementers]: #stream_api_for_stream_implementers
-[child process stdin]: child_process.html#child_process_child_stdin
-[child process stdout and stderr]: child_process.html#child_process_child_stdout
 [Compatibility]: #stream_compatibility_with_older_node_js_versions
-[crypto]: crypto.html
 [Duplex]: #stream_class_stream_duplex
-[fs read streams]: fs.html#fs_class_fs_readstream
-[fs write streams]: fs.html#fs_class_fs_writestream
-[`fs.createReadStream()`]: fs.html#fs_fs_createreadstream_path_options
-[`fs.createWriteStream()`]: fs.html#fs_fs_createwritestream_path_options
-[`net.Socket`]: net.html#net_class_net_socket
-[`zlib.createDeflate()`]: zlib.html#zlib_zlib_createdeflate_options
 [HTTP requests, on the client]: http.html#http_class_http_clientrequest
 [HTTP responses, on the server]: http.html#http_class_http_serverresponse
-[http-incoming-message]: http.html#http_class_http_incomingmessage
 [Readable]: #stream_class_stream_readable
+[TCP sockets]: net.html#net_class_net_socket
+[Transform]: #stream_class_stream_transform
+[Writable]: #stream_class_stream_writable
+[child process stdin]: child_process.html#child_process_child_stdin
+[child process stdout and stderr]: child_process.html#child_process_child_stdout
+[crypto]: crypto.html
+[fs read streams]: fs.html#fs_class_fs_readstream
+[fs write streams]: fs.html#fs_class_fs_writestream
+[http-incoming-message]: http.html#http_class_http_incomingmessage
 [stream-_flush]: #stream_transform_flush_callback
 [stream-_read]: #stream_readable_read_size_1
 [stream-_transform]: #stream_transform_transform_chunk_encoding_callback
@@ -2069,8 +2052,25 @@ readable buffer so there is nothing for a user to consume.
 [stream-read]: #stream_readable_read_size
 [stream-resume]: #stream_readable_resume
 [stream-write]: #stream_writable_write_chunk_encoding_callback
-[TCP sockets]: net.html#net_class_net_socket
-[Transform]: #stream_class_stream_transform
-[Writable]: #stream_class_stream_writable
 [zlib]: zlib.html
+[`'data'`]: #stream_event_data
+[`'drain'`]: #stream_event_drain
+[`'end'`]: #stream_event_end
+[`'finish'`]: #stream_event_finish
+[`'readable'`]: #stream_event_readable
+[`EventEmitter`]: events.html#events_class_eventemitter
 [`Symbol.hasInstance`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
+[`fs.createReadStream()`]: fs.html#fs_fs_createreadstream_path_options
+[`fs.createWriteStream()`]: fs.html#fs_fs_createwritestream_path_options
+[`net.Socket`]: net.html#net_class_net_socket
+[`process.stderr`]: process.html#process_process_stderr
+[`process.stdin`]: process.html#process_process_stdin
+[`process.stdout`]: process.html#process_process_stdout
+[`stream.cork()`]: #stream_writable_cork
+[`stream.pipe()`]: #stream_readable_pipe_destination_options
+[`stream.uncork()`]: #stream_writable_uncork
+[`stream.unpipe()`]: #stream_readable_unpipe_destination
+[`stream.wrap()`]: #stream_readable_wrap_stream
+[`writable.cork()`]: #stream_writable_cork
+[`writable.uncork()`]: #stream_writable_uncork
+[`zlib.createDeflate()`]: zlib.html#zlib_zlib_createdeflate_options

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1252,6 +1252,10 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [Stream]: stream.html#stream_stream
 [TLS Session Tickets]: https://www.ietf.org/rfc/rfc5077.txt
 [TLS recommendations]: https://wiki.mozilla.org/Security/Server_Side_TLS
+[asn1.js]: https://npmjs.org/package/asn1.js
+[modifying the default cipher suite]: #tls_modifying_the_default_tls_cipher_suite
+[specific attacks affecting larger AES key sizes]: https://www.schneier.com/blog/archives/2009/07/another_new_aes.html
+[tls.Server]: #tls_class_tls_server
 [`'secureConnect'`]: #tls_event_secureconnect
 [`'secureConnection'`]: #tls_event_secureconnection
 [`crypto.getCurves()`]: crypto.html#crypto_crypto_getcurves
@@ -1265,7 +1269,3 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [`tls.createSecureContext()`]: #tls_tls_createsecurecontext_options
 [`tls.createSecurePair()`]: #tls_tls_createsecurepair_context_isserver_requestcert_rejectunauthorized_options
 [`tls.createServer()`]: #tls_tls_createserver_options_secureconnectionlistener
-[asn1.js]: https://npmjs.org/package/asn1.js
-[modifying the default cipher suite]: #tls_modifying_the_default_tls_cipher_suite
-[specific attacks affecting larger AES key sizes]: https://www.schneier.com/blog/archives/2009/07/another_new_aes.html
-[tls.Server]: #tls_class_tls_server

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1054,26 +1054,26 @@ console.log(myURL.origin);
 ```
 
 
-[`Error`]: errors.html#errors_class_error
-[`querystring`]: querystring.html
-[`TypeError`]: errors.html#errors_class_typeerror
-[WHATWG URL Standard]: https://url.spec.whatwg.org/
-[examples of parsed URLs]: https://url.spec.whatwg.org/#example-url-parsing
-[`url.parse()`]: #url_url_parse_urlstring_parsequerystring_slashesdenotehost
-[`url.format()`]: #url_url_format_urlobject
-[`require('url').format()`]: #url_url_format_url_options
-[`url.toString()`]: #url_url_tostring
 [Punycode]: https://tools.ietf.org/html/rfc5891#section-4.4
-[`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
-[`array.toString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
+[WHATWG URL Standard]: https://url.spec.whatwg.org/
 [WHATWG URL]: #url_the_whatwg_url_api
-[`new URL()`]: #url_constructor_new_url_input_base
-[`url.href`]: #url_url_href
-[`url.search`]: #url_url_search
+[examples of parsed URLs]: https://url.spec.whatwg.org/#example-url-parsing
 [percent-encoded]: #whatwg-percent-encoding
+[stable sorting algorithm]: https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
+[`Error`]: errors.html#errors_class_error
+[`JSON.stringify()`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+[`TypeError`]: errors.html#errors_class_typeerror
 [`URLSearchParams`]: #url_class_urlsearchparams
+[`array.toString()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
+[`new URL()`]: #url_constructor_new_url_input_base
+[`querystring`]: querystring.html
+[`require('url').format()`]: #url_url_format_url_options
+[`url.format()`]: #url_url_format_urlobject
+[`url.href`]: #url_url_href
+[`url.parse()`]: #url_url_parse_urlstring_parsequerystring_slashesdenotehost
+[`url.search`]: #url_url_search
+[`url.toJSON()`]: #url_url_tojson
+[`url.toString()`]: #url_url_tostring
 [`urlSearchParams.entries()`]: #url_urlsearchparams_entries
 [`urlSearchParams@@iterator()`]: #url_urlsearchparams_iterator
-[stable sorting algorithm]: https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
-[`JSON.stringify()`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-[`url.toJSON()`]: #url_url_tojson

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -861,14 +861,14 @@ deprecated: v0.11.3
 
 Deprecated predecessor of `console.log`.
 
-[`Array.isArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
+[Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
+[Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
 [constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179
-[`util.inspect()`]: #util_util_inspect_object_options
-[Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
-[Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
-[`Error`]: errors.html#errors_class_error
-[`console.log()`]: console.html#console_console_log_data_args
-[`console.error()`]: console.html#console_console_error_data_args
+[`Array.isArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
 [`Buffer.isBuffer()`]: buffer.html#buffer_class_method_buffer_isbuffer_obj
+[`Error`]: errors.html#errors_class_error
 [`Object.assign()`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+[`console.error()`]: console.html#console_console_error_data_args
+[`console.log()`]: console.html#console_console_log_data_args
+[`util.inspect()`]: #util_util_inspect_object_options

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -469,15 +469,15 @@ within which it can operate. The process of creating the V8 Context and
 associating it with the `sandbox` object is what this document refers to as
 "contextifying" the `sandbox`.
 
-[indirect `eval()` call]: https://es5.github.io/#x10.4.2
+[V8 Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide#contexts
+[command line option]: cli.html
+[contextified]: #vm_what_does_it_mean_to_contextify_an_object
 [global object]: https://es5.github.io/#x15.1
+[indirect `eval()` call]: https://es5.github.io/#x10.4.2
 [`Error`]: errors.html#errors_class_error
+[`eval()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
 [`script.runInContext()`]: #vm_script_runincontext_contextifiedsandbox_options
 [`script.runInThisContext()`]: #vm_script_runinthiscontext_options
 [`vm.createContext()`]: #vm_vm_createcontext_sandbox
 [`vm.runInContext()`]: #vm_vm_runincontext_code_contextifiedsandbox_options
 [`vm.runInThisContext()`]: #vm_vm_runinthiscontext_code_options
-[`eval()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
-[V8 Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide#contexts
-[contextified]: #vm_what_does_it_mean_to_contextify_an_object
-[command line option]: cli.html

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -557,17 +557,17 @@ added: v0.11.12
 
 Decompress a [Buffer][] or string with [Unzip][].
 
-[`Accept-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-[`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
-[Memory Usage Tuning]: #zlib_memory_usage_tuning
-[zlib documentation]: http://zlib.net/manual.html#Constants
-[options]: #zlib_class_options
-[Deflate]: #zlib_class_zlib_deflate
+[Buffer]: buffer.html
 [DeflateRaw]: #zlib_class_zlib_deflateraw
+[Deflate]: #zlib_class_zlib_deflate
 [Gunzip]: #zlib_class_zlib_gunzip
 [Gzip]: #zlib_class_zlib_gzip
-[Inflate]: #zlib_class_zlib_inflate
 [InflateRaw]: #zlib_class_zlib_inflateraw
+[Inflate]: #zlib_class_zlib_inflate
+[Memory Usage Tuning]: #zlib_memory_usage_tuning
 [Unzip]: #zlib_class_zlib_unzip
+[options]: #zlib_class_options
+[zlib documentation]: http://zlib.net/manual.html#Constants
 [`.flush()`]: #zlib_zlib_flush_kind_callback
-[Buffer]: buffer.html
+[`Accept-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
+[`Content-Encoding`]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11

--- a/tools/doc/linter/index.js
+++ b/tools/doc/linter/index.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { readFileSync, readdirSync } = require('fs');
+const Files = readdirSync('doc/api').filter((f) => f.endsWith('.md')).map(
+  (file) => [`doc/api/${file}`, readFileSync(`doc/api/${file}`).toString()]
+);
+const errors = [];
+const LinterRules = [
+  require('./linksOrderLinter')
+];
+
+Files.forEach(function([fileName, fileContents]) {
+  LinterRules.forEach(function(rule) {
+    rule(fileName, fileContents, errors);
+  });
+});
+
+errors.forEach((error, idx) => console.error(`\t${idx + 1}. ${error}`));
+
+process.exit(errors.length ? 1 : 0);

--- a/tools/doc/linter/linksOrderLinter.js
+++ b/tools/doc/linter/linksOrderLinter.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const LinkRegEx = /^\[.+?\]\s*:.*$/gm;
+const StartsWithAlpha = /^\[[a-z]/i;
+
+function XOR(a, b) {
+  return (a && !b) || (!a && b);
+}
+
+function sortHelper(a, b) {
+  const AStartsWithAlpha = StartsWithAlpha.test(a);
+  const BStartsWithAlpha = StartsWithAlpha.test(b);
+
+  if (XOR(AStartsWithAlpha, BStartsWithAlpha)) {
+    return AStartsWithAlpha ? -1 : 1;
+  } else {
+    return a === b ? 0 : (a < b ? -1 : 1);
+  }
+}
+
+module.exports = function linksOrderLinter(fileName, fileContents, errors) {
+  const links = fileContents.match(LinkRegEx) || [];
+  const sortedLinks = links.slice().sort(sortHelper);
+
+  if (links.some((link, idx) => sortedLinks[idx] !== link)) {
+    errors.push(
+      `Links in ${fileName} are not sorted in case-sensitive ascending order`
+    );
+  }
+};

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -58,7 +58,7 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
-if /i "%1"=="test"          set test_args=%test_args% addons doctool known_issues message parallel sequential -J&set jslint=1&set build_addons=1&goto arg-ok
+if /i "%1"=="test"          set test_args=%test_args% addons doctool known_issues message parallel sequential -J&set jslint=1&set doclint=1&set build_addons=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap addons doctool inspector known_issues message sequential parallel&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&set build_addons=1&goto arg-ok
 if /i "%1"=="test-addons"   set test_args=%test_args% addons&set build_addons=1&goto arg-ok
 if /i "%1"=="test-simple"   set test_args=%test_args% sequential parallel -J&goto arg-ok
@@ -68,9 +68,10 @@ if /i "%1"=="test-inspector" set test_args=%test_args% inspector&goto arg-ok
 if /i "%1"=="test-tick-processor" set test_args=%test_args% tick-processor&goto arg-ok
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
-if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc inspector internet pummel&set build_testgc_addon=1&set jslint=1&goto arg-ok
+if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc inspector internet pummel&set build_testgc_addon=1&set jslint=1&set doclint=1&goto arg-ok
 if /i "%1"=="test-known-issues" set test_args=%test_args% known_issues&goto arg-ok
 if /i "%1"=="test-node-inspect" set test_node_inspect=1&goto arg-ok
+if /i "%1"=="doclint"       set doclint=1&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 if /i "%1"=="jslint-ci"     set jslint_ci=1&goto arg-ok
 if /i "%1"=="package"       set package=1&goto arg-ok
@@ -360,6 +361,12 @@ goto exit
 :jslint-ci
 echo running jslint-ci
 %config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark lib test tools
+goto exit
+
+:doclint
+if not defined doclint goto exit
+echo running doclint
+%config%\node tools\doc\linter
 goto exit
 
 :no-lint


### PR DESCRIPTION
This is an attempt to introduce a simple linter for our documentation files.

The doc linter scans all the `.md` files in the `doc/api` directory and
invokes the linter rule functions one by one, passing the file name,
contents and an array to fill the errors.

If the errors array is not empty, then the linter will exit with code 1

This PR has one rule, which checks if the links in the documentation file are in sorted order. It expects alphabetical link text to be at the top and everything else following them.

---

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

build doc tools

----

cc @nodejs/documentation 
