### PR TITLE
benchmark: obj property access benchmark

### DIFF
--- a/benchmark/es/obj-bench.js
+++ b/benchmark/es/obj-bench.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common.js');
+const Obj1 = require('../fixtures/moduleA');
+const Obj2 = require('../fixtures/moduleB');
+
+const bench = common.createBenchmark(main, {
+  // TODO(jasnell): A and B are not great labels, not sure what would be better
+  method: ['A', 'B'],
+  access: ['direct', 'indirect'],
+  millions: [10]
+});
+
+function run(n, obj, direct) {
+  var i;
+  if (direct) {
+    bench.start();
+    for (i = 0; i < n; i++) {
+      obj.A();
+      obj.B();
+      obj.C;
+    }
+    bench.end(n / 1e6);
+  } else {
+    const A = obj.A;
+    const B = obj.B;
+    bench.start();
+    for (i = 0; i < n; i++) {
+      A();
+      B();
+      obj.C;
+    }
+    bench.end(n / 1e6);
+  }
+}
+
+function main(conf) {
+  const n = +conf.millions * 1e6;
+  const direct = conf.access === 'direct';
+
+  switch (conf.method) {
+    case 'A':
+      // Uses the {A, B, C: 1}; Syntax
+      run(n, Obj1, direct);
+      break;
+    case 'B':
+      // Uses the obj = {}; obj.A = A; obj.B = B; obj.C = 1; Syntax
+      run(n, Obj2, direct);
+      break;
+    default:
+      throw new Error('Unexpected type');
+  }
+}

--- a/benchmark/fixtures/moduleA.js
+++ b/benchmark/fixtures/moduleA.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function A() {}
+
+function B() {}
+
+module.exports = {
+  A,
+  B,
+  C: 1
+};

--- a/benchmark/fixtures/moduleB.js
+++ b/benchmark/fixtures/moduleB.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.A = function() {};
+
+exports.B = function() {};
+
+exports.C = 1;


### PR DESCRIPTION
Benchmark that compares the obj property access patterns being
used in core today. Specifically comparing the two patterns:

```js
function A() {};
function B() {};
var obj = {A, B, C: 1};
```

and

```js
function A() {}
function B() {}
var obj = {};
obj.A = A;
obj.B = B;
obj.C = 1;
```

@mscdex @nodejs/benchmarking 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark