### PR TITLE
tools: remove NODE_PATH from environment for tests

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -702,8 +702,13 @@ def Execute(args, context, timeout=None, env={}, faketty=False):
     fd_in = 0
     pty_out = None
 
-  # Extend environment
   env_copy = os.environ.copy()
+
+  # Remove NODE_PATH
+  if "NODE_PATH" in env_copy:
+    del env_copy["NODE_PATH"]  
+
+  # Extend environment
   for key, value in env.iteritems():
     env_copy[key] = value
 


### PR DESCRIPTION
Unset `NODE_PATH` environment variable when running tests.

On Ubuntu 16.04, some users experience test failures due to internal
libraries being installed in `/usr/lib/nodejs/internal` and `NODE_PATH`
including `/usr/lib/nodejs`. Tests that expect internal libraries to be
off limits without the `--expose-internals` flag will fail in this
situation. Currently, those tests are `test/parallel/test-repl.js` and
`test/parallel/test-internal-modules.js`.

This situation seems to (probably) be caused by some
not-entirely-uncommon package that gets installed.

Regardless, tests should ignore the user's `NODE_PATH`. (`NODE_PATH` is
tested in `test/parallel/test-module-globalpaths-nodepath.js` and
`test/parallel/test-require-dot.js`.)

Refs: https://twitter.com/trott/status/835729396900061184

/cc @bengl @nodejs/testing @nodejs/build 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test