### PR TITLE
string_decoder: support Uint8Array input to methods

### DIFF
--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -2,9 +2,9 @@
 
 > Stability: 2 - Stable
 
-The `string_decoder` module provides an API for decoding `Buffer` objects into
-strings in a manner that preserves encoded multi-byte UTF-8 and UTF-16
-characters. It can be accessed using:
+The `string_decoder` module provides an API for decoding `Buffer` and
+`Uint8Array` objects into strings in a manner that preserves encoded multi-byte
+UTF-8 and UTF-16 characters. It can be accessed using:
 
 ```js
 const StringDecoder = require('string_decoder').StringDecoder;
@@ -53,9 +53,14 @@ Creates a new `StringDecoder` instance.
 ### stringDecoder.end([buffer])
 <!-- YAML
 added: v0.9.3
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/11613
+    description: The `buffer` argument can now be a `Uint8Array` instance.
 -->
 
-* `buffer` {Buffer} A `Buffer` containing the bytes to decode.
+* `buffer` {Buffer|Uint8Array} A `Buffer` or `Uint8Array` containing the bytes
+  to decode.
 
 Returns any remaining input stored in the internal buffer as a string. Bytes
 representing incomplete UTF-8 and UTF-16 characters will be replaced with
@@ -69,12 +74,16 @@ is performed before returning the remaining input.
 added: v0.1.99
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/11613
+    description: The `buffer` argument can now be a `Uint8Array` instance.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/9618
     description: Each invalid character is now replaced by a single replacement
                  character instead of one for each individual byte.
 -->
 
-* `buffer` {Buffer} A `Buffer` containing the bytes to decode.
+* `buffer` {Buffer|Uint8Array} A `Buffer` or `Uint8Array` containing the bytes
+  to decode.
 
 Returns a decoded string, ensuring that any incomplete multibyte characters at
 the end of the `Buffer` are omitted from the returned string and stored in an

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -24,6 +24,9 @@
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
 const isEncoding = Buffer[internalUtil.kIsEncodingSymbol];
+const {
+  copy, latin1Slice, asciiSlice, hexSlice, utf8Slice, ucs2Slice, base64Slice
+} = process.binding('buffer');
 
 // Do not cache `Buffer.isEncoding` when checking encoding names as some
 // modules monkey-patch it to support additional encodings
@@ -57,8 +60,16 @@ function StringDecoder(encoding) {
       this.end = base64End;
       nb = 3;
       break;
-    default:
-      this.write = simpleWrite;
+    case 'hex':
+      this.write = hexText;
+      this.end = simpleEnd;
+      return;
+    case 'latin1':
+      this.write = latin1Text;
+      this.end = simpleEnd;
+      return;
+    case 'ascii':
+      this.write = asciiText;
       this.end = simpleEnd;
       return;
   }
@@ -67,9 +78,12 @@ function StringDecoder(encoding) {
   this.lastChar = Buffer.allocUnsafe(nb);
 }
 
+// TODO(addaleax): This method should not accept strings as input.
 StringDecoder.prototype.write = function(buf) {
   if (buf.length === 0)
     return '';
+  if (typeof buf === 'string')
+    return buf;
   var r;
   var i;
   if (this.lastNeed) {
@@ -94,10 +108,10 @@ StringDecoder.prototype.text = utf8Text;
 // Attempts to complete a partial non-UTF-8 character using bytes from a Buffer
 StringDecoder.prototype.fillLast = function(buf) {
   if (this.lastNeed <= buf.length) {
-    buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed);
+    copy(buf, this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed);
     return this.lastChar.toString(this.encoding, 0, this.lastTotal);
   }
-  buf.copy(this.lastChar, this.lastTotal - this.lastNeed, 0, buf.length);
+  copy(buf, this.lastChar, this.lastTotal - this.lastNeed, 0, buf.length);
   this.lastNeed -= buf.length;
 };
 
@@ -185,10 +199,10 @@ function utf8FillLast(buf) {
   if (r !== undefined)
     return r;
   if (this.lastNeed <= buf.length) {
-    buf.copy(this.lastChar, p, 0, this.lastNeed);
-    return this.lastChar.toString(this.encoding, 0, this.lastTotal);
+    copy(buf, this.lastChar, p, 0, this.lastNeed);
+    return utf8Slice(this.lastChar, 0, this.lastTotal);
   }
-  buf.copy(this.lastChar, p, 0, buf.length);
+  copy(buf, this.lastChar, p, 0, buf.length);
   this.lastNeed -= buf.length;
 }
 
@@ -198,11 +212,11 @@ function utf8FillLast(buf) {
 function utf8Text(buf, i) {
   const total = utf8CheckIncomplete(this, buf, i);
   if (!this.lastNeed)
-    return buf.toString('utf8', i);
+    return utf8Slice(buf, i, buf.length);
   this.lastTotal = total;
   const end = buf.length - (total - this.lastNeed);
-  buf.copy(this.lastChar, 0, end);
-  return buf.toString('utf8', i, end);
+  copy(buf, this.lastChar, 0, end);
+  return utf8Slice(buf, i, end);
 }
 
 // For UTF-8, a replacement character is added when ending on a partial
@@ -220,7 +234,7 @@ function utf8End(buf) {
 // decode the last character properly.
 function utf16Text(buf, i) {
   if ((buf.length - i) % 2 === 0) {
-    const r = buf.toString('utf16le', i);
+    const r = ucs2Slice(buf, i, buf.length);
     if (r) {
       const c = r.charCodeAt(r.length - 1);
       if (c >= 0xD800 && c <= 0xDBFF) {
@@ -236,7 +250,7 @@ function utf16Text(buf, i) {
   this.lastNeed = 1;
   this.lastTotal = 2;
   this.lastChar[0] = buf[buf.length - 1];
-  return buf.toString('utf16le', i, buf.length - 1);
+  return ucs2Slice(buf, i, buf.length - 1);
 }
 
 // For UTF-16LE we do not explicitly append special replacement characters if we
@@ -245,7 +259,7 @@ function utf16End(buf) {
   const r = (buf && buf.length ? this.write(buf) : '');
   if (this.lastNeed) {
     const end = this.lastTotal - this.lastNeed;
-    return r + this.lastChar.toString('utf16le', 0, end);
+    return r + ucs2Slice(this.lastChar, 0, end);
   }
   return r;
 }
@@ -253,7 +267,7 @@ function utf16End(buf) {
 function base64Text(buf, i) {
   const n = (buf.length - i) % 3;
   if (n === 0)
-    return buf.toString('base64', i);
+    return base64Slice(buf, i, buf.length);
   this.lastNeed = 3 - n;
   this.lastTotal = 3;
   if (n === 1) {
@@ -262,20 +276,28 @@ function base64Text(buf, i) {
     this.lastChar[0] = buf[buf.length - 2];
     this.lastChar[1] = buf[buf.length - 1];
   }
-  return buf.toString('base64', i, buf.length - n);
+  return base64Slice(buf, i, buf.length - n);
 }
 
 
 function base64End(buf) {
   const r = (buf && buf.length ? this.write(buf) : '');
   if (this.lastNeed)
-    return r + this.lastChar.toString('base64', 0, 3 - this.lastNeed);
+    return r + base64Slice(this.lastChar, 0, 3 - this.lastNeed);
   return r;
 }
 
 // Pass bytes on through for single-byte encodings (e.g. ascii, latin1, hex)
-function simpleWrite(buf) {
-  return buf.toString(this.encoding);
+function latin1Text(buf) {
+  return latin1Slice(buf, 0, buf.length);
+}
+
+function asciiText(buf) {
+  return asciiSlice(buf, 0, buf.length);
+}
+
+function hexText(buf) {
+  return hexSlice(buf, 0, buf.length);
 }
 
 function simpleEnd(buf) {

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -28,51 +28,106 @@ const {
   copy, latin1Slice, asciiSlice, hexSlice, utf8Slice, ucs2Slice, base64Slice
 } = process.binding('buffer');
 
-// Do not cache `Buffer.isEncoding` when checking encoding names as some
-// modules monkey-patch it to support additional encodings
-function normalizeEncoding(enc) {
-  const nenc = internalUtil.normalizeEncoding(enc);
-  if (typeof nenc !== 'string' &&
-      (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc)))
-    throw new Error(`Unknown encoding: ${enc}`);
-  return nenc || enc;
+const encodings = [
+  // 0
+  [
+    'utf8', // normalized encoding name string
+    4, // buffer size
+    (self) => { self.fillLast = utf8FillLast; } // StringDecoder initialization
+  ],
+  // 1
+  [
+    'utf16le',
+    4,
+    (self) => { self.text = utf16Text; self.end = utf16End; }
+  ],
+  // 2
+  [
+    'latin1',
+    0,
+    (self) => { self.text = latin1Text; self.end = simpleEnd; }
+  ],
+  // 3
+  [
+    'base64',
+    3,
+    (self) => { self.text = base64Text; self.end = base64End; }
+  ],
+  // 4
+  [
+    'ascii',
+    0,
+    (self) => { self.text = asciiText; self.end = simpleEnd; }
+  ],
+  // 5
+  [
+    'hex',
+    0,
+    (self) => { self.text = hexText; self.end = simpleEnd; }
+  ]
+];
+
+function translateEncoding(enc) {
+  if (!enc) return 0;
+  enc += '';
+  switch (enc.length) {
+    case 4:
+      if (enc === 'utf8') return 0;
+      if (enc === 'ucs2') return 1;
+      enc = enc.toLowerCase();
+      if (enc === 'utf8') return 0;
+      if (enc === 'ucs2') return 1;
+      break;
+    case 5:
+      if (enc === 'utf-8') return 0;
+      if (enc === 'ascii') return 4;
+      if (enc === 'ucs-2') return 1;
+      enc = enc.toLowerCase();
+      if (enc === 'utf-8') return 0;
+      if (enc === 'ascii') return 4;
+      if (enc === 'ucs-2') return 1;
+      break;
+    case 7:
+      return (enc === 'utf16le' || enc.toLowerCase() === 'utf16le' ? 1 : -1);
+    case 8:
+      return (enc === 'utf-16le' || enc.toLowerCase() === 'utf-16le' ? 1 : -1);
+    case 6:
+      if (enc === 'latin1') return 2;
+      if (enc === 'binary') return 2;
+      if (enc === 'base64') return 3;
+      enc = enc.toLowerCase();
+      if (enc === 'latin1') return 2;
+      if (enc === 'binary') return 2;
+      if (enc === 'base64') return 3;
+      break;
+    case 3:
+      return (enc === 'hex' || enc.toLowerCase() === 'hex' ? 5 : -1);
+  }
+  return -1;
 }
 
 // StringDecoder provides an interface for efficiently splitting a series of
 // buffers into a series of JS strings without breaking apart multi-byte
 // characters.
+// Do not cache `Buffer.isEncoding` when checking encoding names as some
+// modules monkey-patch it to support additional encodings
 exports.StringDecoder = StringDecoder;
-function StringDecoder(encoding) {
-  this.encoding = normalizeEncoding(encoding);
-  var nb;
-  switch (this.encoding) {
-    case 'utf16le':
-      this.text = utf16Text;
-      this.end = utf16End;
-      nb = 4;
-      break;
-    case 'utf8':
-      this.fillLast = utf8FillLast;
-      nb = 4;
-      break;
-    case 'base64':
-      this.text = base64Text;
-      this.end = base64End;
-      nb = 3;
-      break;
-    case 'hex':
-      this.write = hexText;
-      this.end = simpleEnd;
-      return;
-    case 'latin1':
-      this.write = latin1Text;
-      this.end = simpleEnd;
-      return;
-    case 'ascii':
-      this.write = asciiText;
-      this.end = simpleEnd;
-      return;
+function StringDecoder(enc) {
+  var info;
+  const encIdx = translateEncoding(enc);
+  if (encIdx === -1) {
+    if (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc))
+      throw new Error(`Unknown encoding: ${enc}`);
+    this.encoding = enc;
+    return;
+  } else {
+    info = encodings[encIdx];
   }
+  this.encoding = info[0];
+  const nb = info[1];
+  info[2](this);
+  if (nb === 0)
+    return;
   this.lastNeed = 0;
   this.lastTotal = 0;
   this.lastChar = Buffer.allocUnsafe(nb);


### PR DESCRIPTION
This includes a bit of refactoring for the `Buffer` internals to keep up performance. Some quick benchmark results (only the `string-decoder` benchmark, excluding the bigger input/chunk sizes and with reduced `n`):
```
$ ./node benchmark/compare.js --new ./node --old ./node-d08836003c57 --runs 5 --filter string-decoder.js string_decoder| Rscript benchmark/compare.R
[00:01:37|% 100| 1/1 files | 10/10 runs | 20/20 configs]: Done
                                                                                      improvement confidence      p.value
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=128 encoding="ascii"            14.65 %        *** 1.092735e-06
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=128 encoding="base64-ascii"      8.52 %        *** 6.202910e-05
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=128 encoding="base64-utf8"       5.27 %            7.176679e-02
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=128 encoding="utf16le"           4.37 %          * 1.891394e-02
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=128 encoding="utf8"             14.01 %        *** 1.475088e-04
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=32 encoding="ascii"             20.33 %        *** 1.058625e-08
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=32 encoding="base64-ascii"       8.51 %          * 1.025246e-02
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=32 encoding="base64-utf8"       -0.67 %            8.260933e-01
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=32 encoding="utf16le"           10.16 %        *** 6.193190e-05
 string_decoder/string-decoder.js n=250000 chunk=16 inlen=32 encoding="utf8"               7.54 %        *** 6.250636e-04
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=128 encoding="ascii"            16.56 %        *** 1.856548e-05
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=128 encoding="base64-ascii"      8.68 %        *** 2.254509e-05
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=128 encoding="base64-utf8"       6.20 %            7.669403e-02
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=128 encoding="utf16le"           7.12 %        *** 2.359718e-05
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=128 encoding="utf8"              3.33 %          * 1.040546e-02
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=32 encoding="ascii"             18.07 %        *** 9.677031e-07
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=32 encoding="base64-ascii"      12.49 %         ** 4.455920e-03
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=32 encoding="base64-utf8"        2.96 %            2.299725e-01
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=32 encoding="utf16le"            9.82 %        *** 8.056526e-06
 string_decoder/string-decoder.js n=250000 chunk=64 inlen=32 encoding="utf8"               7.09 %        *** 7.882838e-04
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

string_decoder, buffer