### PR TITLE
doc: fix typo in STYLE_GUIDE.md

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -57,7 +57,7 @@
 * When using underscores, asterisks and backticks please use proper escaping (**\\\_**, **\\\*** and **\\\`** instead of **\_**, **\*** and **\`**)
 * References to constructor functions should use PascalCase
 * References to constructor instances should be camelCased
-* References to methods should be used with parenthesis: `socket.end()` instead of `socket.end`
+* References to methods should be used with parentheses: `socket.end()` instead of `socket.end`
 
 [plugin]: http://editorconfig.org/#download
 [Oxford comma]: https://en.wikipedia.org/wiki/Serial_comma


### PR DESCRIPTION
`parenthesis` is singular, `parentheses` is plural.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc