### PR TITLE
deps: fix CLEAR_HASH macro to be usable as a single statement

### DIFF
--- a/deps/zlib/deflate.c
+++ b/deps/zlib/deflate.c
@@ -190,8 +190,11 @@ local const config configuration_table[10] = {
  * prev[] will be initialized on the fly.
  */
 #define CLEAR_HASH(s) \
-    s->head[s->hash_size-1] = NIL; \
-    zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
+    do { \
+        s->head[s->hash_size-1] = NIL; \
+        zmemzero((Bytef *)s->head, \
+                 (unsigned)(s->hash_size-1)*sizeof(*s->head)); \
+    } while (0)
 
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32


### PR DESCRIPTION
As it is used in deflateParams().

Cherry-pick: https://github.com/madler/zlib/commit/38e8ce32afbaa82f67d992b9f3056f281fe69259

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [?] commit message follows commit guidelines

##### Affected core subsystem(s)
deps, zlib


@bnoordhuis I'm not sure what the style is for landing upstream fixes, is this good enough? Or should it look like https://github.com/madler/zlib/commit/38e8ce32afbaa82f67d992b9f3056f281fe69259?
