### PR TITLE
src: add HAVE_OPENSSL directive to openssl_config

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4233,8 +4233,10 @@ void Init(int* argc,
   if (config_warning_file.empty())
     SafeGetenv("NODE_REDIRECT_WARNINGS", &config_warning_file);
 
+#if HAVE_OPENSSL
   if (openssl_config.empty())
     SafeGetenv("OPENSSL_CONF", &openssl_config);
+#endif
 
   // Parse a few arguments which are specific to Node.
   int v8_argc;


### PR DESCRIPTION
Currently when building with the following configuration options:
$ ./configure --without-ssl && make

The following link error is reported:

Undefined symbols for architecture x86_64:
  "node::openssl_config", referenced from:
      node::Init(int*, char const**, int*, char const***) in node.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see
invocation)

Adding an HAVE_OPENSSL directive around this code allows the build to
pass.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src