### PR TITLE
util: convert inspect.styles to prototype-less object

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -166,7 +166,7 @@ Object.defineProperty(inspect, 'defaultOptions', {
 });
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-inspect.colors = {
+inspect.colors = Object.assign(Object.create(null), {
   'bold': [1, 22],
   'italic': [3, 23],
   'underline': [4, 24],
@@ -180,10 +180,10 @@ inspect.colors = {
   'magenta': [35, 39],
   'red': [31, 39],
   'yellow': [33, 39]
-};
+});
 
 // Don't use 'blue' not visible on cmd.exe
-inspect.styles = {
+inspect.styles = Object.assign(Object.create(null), {
   'special': 'cyan',
   'number': 'yellow',
   'boolean': 'yellow',
@@ -194,7 +194,7 @@ inspect.styles = {
   'date': 'magenta',
   // "name": intentionally not styling
   'regexp': 'red'
-};
+});
 
 const customInspectSymbol = internalUtil.customInspectSymbol;
 


### PR DESCRIPTION
Use a prototype-less object for inspect.styles and inspect.colors to allow free modification of Object.protototype in the REPL.

Fixes: https://github.com/nodejs/node/issues/11614

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
- util
