### PR TITLE
url: spec-compliant URLSearchParams serializer

### DIFF
--- a/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-searchparams-serialize.js
@@ -7,7 +7,7 @@ const inputs = require('../fixtures/url-inputs.js').searchParams;
 const bench = common.createBenchmark(main, {
   type: Object.keys(inputs),
   method: ['legacy', 'whatwg'],
-  n: [1e5]
+  n: [1e6]
 });
 
 function useLegacy(n, input, prop) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const util = require('util');
-const { StorageObject } = require('internal/querystring');
+const { hexTable, StorageObject } = require('internal/querystring');
 const binding = process.binding('url');
 const context = Symbol('context');
 const cannotBeBase = Symbol('cannot-be-base');
@@ -597,18 +597,99 @@ function getParamsFromObject(obj) {
   return values;
 }
 
-function getObjectFromParams(array) {
-  const obj = new StorageObject();
-  for (var i = 0; i < array.length; i += 2) {
-    const name = array[i];
-    const value = array[i + 1];
-    if (obj[name]) {
-      obj[name].push(value);
-    } else {
-      obj[name] = [value];
+// Adapted from querystring's implementation.
+// Ref: https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
+const noEscape = [
+//0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x00 - 0x0F
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0x10 - 0x1F
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, // 0x20 - 0x2F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, // 0x30 - 0x3F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x40 - 0x4F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, // 0x50 - 0x5F
+  0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0x60 - 0x6F
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0  // 0x70 - 0x7F
+];
+
+// Special version of hexTable that uses `+` for U+0020 SPACE.
+const paramHexTable = hexTable.slice();
+paramHexTable[0x20] = '+';
+
+function escapeParam(str) {
+  const len = str.length;
+  if (len === 0)
+    return '';
+
+  var out = '';
+  var lastPos = 0;
+
+  for (var i = 0; i < len; i++) {
+    var c = str.charCodeAt(i);
+
+    // ASCII
+    if (c < 0x80) {
+      if (noEscape[c] === 1)
+        continue;
+      if (lastPos < i)
+        out += str.slice(lastPos, i);
+      lastPos = i + 1;
+      out += paramHexTable[c];
+      continue;
     }
+
+    if (lastPos < i)
+      out += str.slice(lastPos, i);
+
+    // Multi-byte characters ...
+    if (c < 0x800) {
+      lastPos = i + 1;
+      out += paramHexTable[0xC0 | (c >> 6)] +
+             paramHexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    if (c < 0xD800 || c >= 0xE000) {
+      lastPos = i + 1;
+      out += paramHexTable[0xE0 | (c >> 12)] +
+             paramHexTable[0x80 | ((c >> 6) & 0x3F)] +
+             paramHexTable[0x80 | (c & 0x3F)];
+      continue;
+    }
+    // Surrogate pair
+    ++i;
+    var c2;
+    if (i < len)
+      c2 = str.charCodeAt(i) & 0x3FF;
+    else {
+      // This branch should never happen because all URLSearchParams entries
+      // should already be converted to USVString. But, included for
+      // completion's sake anyway.
+      c2 = 0;
+    }
+    lastPos = i + 1;
+    c = 0x10000 + (((c & 0x3FF) << 10) | c2);
+    out += paramHexTable[0xF0 | (c >> 18)] +
+           paramHexTable[0x80 | ((c >> 12) & 0x3F)] +
+           paramHexTable[0x80 | ((c >> 6) & 0x3F)] +
+           paramHexTable[0x80 | (c & 0x3F)];
   }
-  return obj;
+  if (lastPos === 0)
+    return str;
+  if (lastPos < len)
+    return out + str.slice(lastPos);
+  return out;
+}
+
+// application/x-www-form-urlencoded serializer
+// Ref: https://url.spec.whatwg.org/#concept-urlencoded-serializer
+function serializeParams(array) {
+  const len = array.length;
+  if (len === 0)
+    return '';
+
+  var output = `${escapeParam(array[0])}=${escapeParam(array[1])}`;
+  for (var i = 2; i < len; i += 2)
+    output += `&${escapeParam(array[i])}=${escapeParam(array[i + 1])}`;
+  return output;
 }
 
 // Mainly to mitigate func-name-matching ESLint rule
@@ -993,7 +1074,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
-    return querystring.stringify(getObjectFromParams(this[searchParams]));
+    return serializeParams(this[searchParams]);
   }
 });
 

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -4639,7 +4639,7 @@ module.exports =
     "port": "",
     "pathname": "/foo/bar",
     "search": "??a=b&c=d",
-    // "searchParams": "%3Fa=b&c=d",
+    "searchParams": "%3Fa=b&c=d",
     "hash": ""
   },
   "# Scheme only",

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -120,12 +120,12 @@ function runURLSearchParamTests() {
     // And in the other direction, altering searchParams propagates
     // back to 'search'.
     searchParams.append('i', ' j ')
-    // assert_equals(url.search, '?e=f&g=h&i=+j+')
-    // assert_equals(url.searchParams.toString(), 'e=f&g=h&i=+j+')
+    assert_equals(url.search, '?e=f&g=h&i=+j+')
+    assert_equals(url.searchParams.toString(), 'e=f&g=h&i=+j+')
     assert_equals(searchParams.get('i'), ' j ')
 
     searchParams.set('e', 'updated')
-    // assert_equals(url.search, '?e=updated&g=h&i=+j+')
+    assert_equals(url.search, '?e=updated&g=h&i=+j+')
     assert_equals(searchParams.get('e'), 'updated')
 
     var url2 = bURL('http://example.org/file??a=b&c=d')

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -11,7 +11,7 @@ const {
 /* eslint-disable */
 var params;  // Strict mode fix for WPT.
 /* WPT Refs:
-   https://github.com/w3c/web-platform-tests/blob/405394a/url/urlsearchparams-constructor.html
+   https://github.com/w3c/web-platform-tests/blob/e94c604916/url/urlsearchparams-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 test(function() {
@@ -154,7 +154,7 @@ test(function() {
 }, "Constructor with sequence of sequences of strings");
 
 [
-//   { "input": {"+": "%C2"}, "output": [[" ", "\uFFFD"]], "name": "object with +" },
+  { "input": {"+": "%C2"}, "output": [["+", "%C2"]], "name": "object with +" },
   { "input": {c: "x", a: "?"}, "output": [["c", "x"], ["a", "?"]], "name": "object with two keys" },
   { "input": [["c", "x"], ["a", "?"]], "output": [["c", "x"], ["a", "?"]], "name": "array with two keys" }
 ].forEach((val) => {

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -10,14 +10,14 @@ const { test, assert_equals } = common.WPT;
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
-// test(function() {
-//     var params = new URLSearchParams();
-//     params.append('a', 'b c');
-//     assert_equals(params + '', 'a=b+c');
-//     params.delete('a');
-//     params.append('a b', 'c');
-//     assert_equals(params + '', 'a+b=c');
-// }, 'Serialize space');
+test(function() {
+    var params = new URLSearchParams();
+    params.append('a', 'b c');
+    assert_equals(params + '', 'a=b+c');
+    params.delete('a');
+    params.append('a b', 'c');
+    assert_equals(params + '', 'a+b=c');
+}, 'Serialize space');
 
 test(function() {
     var params = new URLSearchParams();
@@ -114,8 +114,8 @@ test(function() {
     var params;
     params = new URLSearchParams('a=b&c=d&&e&&');
     assert_equals(params.toString(), 'a=b&c=d&e=');
-    // params = new URLSearchParams('a = b &a=b&c=d%20');
-    // assert_equals(params.toString(), 'a+=+b+&a=b&c=d+');
+    params = new URLSearchParams('a = b &a=b&c=d%20');
+    assert_equals(params.toString(), 'a+=+b+&a=b&c=d+');
     // The lone '=' _does_ survive the roundtrip.
     params = new URLSearchParams('a=&a=b');
     assert_equals(params.toString(), 'a=&a=b');

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -7,7 +7,7 @@ const URL = require('url').URL;
 // Tests below are not from WPT.
 const serialized = 'a=a&a=1&a=true&a=undefined&a=null&a=%EF%BF%BD' +
                    '&a=%EF%BF%BD&a=%F0%9F%98%80&a=%EF%BF%BD%EF%BF%BD' +
-                   '&a=%5Bobject%20Object%5D';
+                   '&a=%5Bobject+Object%5D';
 const values = ['a', 1, true, undefined, null, '\uD83D', '\uDE00',
                 '\uD83D\uDE00', '\uDE00\uD83D', {}];
 const normalizedValues = ['a', '1', 'true', 'undefined', 'null', '\uFFFD',


### PR DESCRIPTION
Differences with `querystring` module (which the serializer currently depends on):

code point | `querystring` | spec
:--------------:|:-----------:|:-------:
U+0020 <code>&nbsp;</code> | `%20` | `+`
U+0027 `'` | `'` | `%27`
U+0028 `(` | `(` | `%28`
U+0029 `)` | `)` | `%29`
U+007E `~` | `~` | `%7E`

A C++ implementation cannot seem to reach the JS version's performance.

<details><summary>Benchmark: before vs. after</summary>

```
                                                                                                    improvement confidence      p.value
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="altspaces"          56.97 %        *** 1.131841e-33
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodefake"         85.79 %        *** 8.380179e-49
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodelast"        133.54 %        *** 4.568047e-52
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodemany"        136.69 %        *** 3.839133e-66
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="manyblankpairs"    102.90 %        *** 2.115923e-35
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="manypairs"         423.66 %        *** 2.121638e-43
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multicharsep"      136.13 %        *** 1.320596e-54
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multivalue"         88.71 %        *** 1.524783e-59
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multivaluemany"     25.24 %        *** 3.994424e-41
 url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="noencode"          135.61 %        *** 3.251158e-44
```
</details>

<details><summary>Benchmark: legacy (<code>querystring</code>) vs. WHATWG</summary>

```
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="noencode": 2,671,975.4115417274
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="noencode": 3,008,967.4994620117
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="multicharsep": 2,615,972.2291527316
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multicharsep": 2,885,936.0222384227
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="encodefake": 1,493,426.4438126145
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodefake": 1,641,878.4775006676
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="encodemany": 2,565,969.8400934297
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodemany": 3,025,840.9510215684
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="encodelast": 2,613,356.200269775
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="encodelast": 2,901,369.8722106437
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="multivalue": 2,615,576.6498150555
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multivalue": 2,502,413.2021715143
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="multivaluemany": 1,383,932.6225206275
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="multivaluemany": 985,021.4923070684
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="manypairs": 399,773.9756297489
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="manypairs": 804,542.90558165
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="manyblankpairs": 14,459,573.094118012
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="manyblankpairs": 10,583,700.054130334
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="legacy" type="altspaces": 1,092,358.4670786818
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method="whatwg" type="altspaces": 1,174,023.8424377916
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url