### PR TITLE
fs: getOption to populate passed in default values

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -56,7 +56,7 @@ function getOptions(options, defaultOptions) {
 
   if (options.encoding !== 'buffer')
     assertEncoding(options.encoding);
-  return options;
+  return Object.assign({}, defaultOptions, options);
 }
 
 function copyObject(source) {
@@ -293,7 +293,7 @@ fs.readFile = function(path, options, callback) {
   }
 
   binding.open(pathModule._makeLong(path),
-               stringToFlags(options.flag || 'r'),
+               stringToFlags(options.flag),
                0o666,
                req);
 };
@@ -1201,7 +1201,7 @@ function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
 fs.writeFile = function(path, data, options, callback) {
   callback = maybeCallback(arguments[arguments.length - 1]);
   options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'w' });
-  const flag = options.flag || 'w';
+  const flag = options.flag;
 
   if (isFd(path)) {
     writeFd(path, true);
@@ -1260,7 +1260,7 @@ fs.appendFile = function(path, data, options, callback) {
   options = copyObject(options);
 
   // force append behavior when using a supplied file descriptor
-  if (!options.flag || isFd(path))
+  if (isFd(path))
     options.flag = 'a';
 
   fs.writeFile(path, data, options, callback);
@@ -1739,7 +1739,7 @@ function ReadStream(path, options) {
     return new ReadStream(path, options);
 
   // a little bit bigger buffer and water marks by default
-  options = copyObject(getOptions(options, {}));
+  options = copyObject(getOptions(options, { flag: 'r' }));
   if (options.highWaterMark === undefined)
     options.highWaterMark = 64 * 1024;
 
@@ -1903,7 +1903,7 @@ function WriteStream(path, options) {
   if (!(this instanceof WriteStream))
     return new WriteStream(path, options);
 
-  options = copyObject(getOptions(options, {}));
+  options = copyObject(getOptions(options, {flag: 'w'}));
 
   Writable.call(this, options);
 

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -48,7 +48,7 @@ let paused = false;
 }
 
 {
-  const file3 = fs.createReadStream(fn, Object.create({encoding: 'utf8'}));
+  const file3 = fs.createReadStream(fn, Object.assign({}, {encoding: 'utf8'}));
   file3.length = 0;
   file3.on('data', function(data) {
     assert.strictEqual(typeof data, 'string');
@@ -66,7 +66,7 @@ let paused = false;
 }
 
 {
-  const options = Object.create({bufferSize: 1, start: 1, end: 2});
+  const options = Object.assign({}, {bufferSize: 1, start: 1, end: 2});
   const file4 = fs.createReadStream(rangeFile, options);
   assert.strictEqual(file4.start, 1);
   assert.strictEqual(file4.end, 2);
@@ -80,7 +80,7 @@ let paused = false;
 }
 
 {
-  const options = Object.create({bufferSize: 1, start: 1});
+  const options = Object.assign({}, {bufferSize: 1, start: 1});
   const file5 = fs.createReadStream(rangeFile, options);
   assert.strictEqual(file5.start, 1);
   file5.data = '';
@@ -94,7 +94,7 @@ let paused = false;
 
 // https://github.com/joyent/node/issues/2320
 {
-  const options = Object.create({bufferSize: 1.23, start: 1});
+  const options = Object.assign({}, {bufferSize: 1.23, start: 1});
   const file6 = fs.createReadStream(rangeFile, options);
   assert.strictEqual(file6.start, 1);
   file6.data = '';
@@ -108,12 +108,12 @@ let paused = false;
 
 {
   assert.throws(function() {
-    fs.createReadStream(rangeFile, Object.create({start: 10, end: 2}));
+    fs.createReadStream(rangeFile, Object.assign({}, {start: 10, end: 2}));
   }, /"start" option must be <= "end" option/);
 }
 
 {
-  const options = Object.create({start: 0, end: 0});
+  const options = Object.assign({}, {start: 0, end: 0});
   const stream = fs.createReadStream(rangeFile, options);
   assert.strictEqual(stream.start, 0);
   assert.strictEqual(stream.end, 0);
@@ -137,7 +137,7 @@ let paused = false;
 
 {
   let file7 =
-    fs.createReadStream(rangeFile, Object.create({autoClose: false }));
+    fs.createReadStream(rangeFile, Object.assign({}, {autoClose: false }));
   assert.strictEqual(file7.autoClose, false);
   file7.on('data', function() {});
   file7.on('end', common.mustCall(function() {
@@ -150,7 +150,7 @@ let paused = false;
 
   function file7Next() {
     // This will tell us if the fd is usable again or not.
-    file7 = fs.createReadStream(null, Object.create({fd: file7.fd, start: 0 }));
+    file7 = fs.createReadStream(null, Object.assign({}, {fd: file7.fd, start: 0 }));
     file7.data = '';
     file7.on('data', function(data) {
       file7.data += data;
@@ -167,7 +167,7 @@ let paused = false;
 
 // Just to make sure autoClose won't close the stream because of error.
 {
-  const options = Object.create({fd: 13337, autoClose: false});
+  const options = Object.assign({}, {fd: 13337, autoClose: false});
   const file8 = fs.createReadStream(null, options);
   file8.on('data', function() {});
   file8.on('error', common.mustCall(function() {}));


### PR DESCRIPTION
In `fs.js`, the `getOption` can be improved to populate the option object with the passed in defaultOptions if the default options are not there in the original option object. This way we don't have to do `options.flag || 'w'` etc.

For example in the `fs.writeFile`

```js
fs.writeFile = function(file, options, cb) {
    options = getOptions(options, {flag: 'w'});
    /* later somewhere */
    flags = options.flags || 'w'
   
    /* could have just been the below had getOptions populated the default values if it did not exist */
    flags = options.flags 
}
```
Similar patterns are present in few more parts of the `fs` module
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
fs, test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
