### PR TITLE
test: make tests pass when configured --without-ssl

### DIFF
--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -2,8 +2,12 @@
   'targets': [
     {
       'target_name': 'binding',
-      'sources': ['binding.cc'],
-      'include_dirs': ['../../../deps/openssl/openssl/include'],
+      'conditions': [
+         ['node_use_openssl=="true"', {
+           'sources': ['binding.cc'],
+           'include_dirs': ['../../../deps/openssl/openssl/include'],
+         }]
+      ]
     },
   ]
 }

--- a/test/addons/openssl-binding/test.js
+++ b/test/addons/openssl-binding/test.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const common = require('../../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  process.exit(0);
+}
 const assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 const bytes = new Uint8Array(1024);

--- a/test/common.js
+++ b/test/common.js
@@ -638,3 +638,10 @@ exports.expectsError = function expectsError({code, type, message}) {
     return true;
   };
 };
+
+exports.skipIfInspectorDisabled = function skipIfInspectorDisabled() {
+  if (!exports.hasCrypto) {
+    exports.skip('missing ssl support so inspector is disabled');
+    process.exit(0);
+  }
+};

--- a/test/fixtures/tls-connect.js
+++ b/test/fixtures/tls-connect.js
@@ -6,6 +6,9 @@
 const common = require('../common');
 const fs = require('fs');
 const join = require('path').join;
+// Check if Node was compiled --without-ssl and if so exit early
+// as the require of tls will otherwise throw an Error.
+checkCrypto();
 const tls = require('tls');
 const util = require('util');
 
@@ -18,6 +21,7 @@ function checkCrypto() {
   }
   return exports;
 }
+
 
 exports.assert = require('assert');
 exports.debug = util.debuglog('test');

--- a/test/fixtures/tls-connect.js
+++ b/test/fixtures/tls-connect.js
@@ -22,7 +22,6 @@ function checkCrypto() {
   return exports;
 }
 
-
 exports.assert = require('assert');
 exports.debug = util.debuglog('test');
 exports.tls = tls;

--- a/test/fixtures/tls-connect.js
+++ b/test/fixtures/tls-connect.js
@@ -8,19 +8,16 @@ const fs = require('fs');
 const join = require('path').join;
 // Check if Node was compiled --without-ssl and if so exit early
 // as the require of tls will otherwise throw an Error.
-checkCrypto();
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  process.exit(0);
+}
 const tls = require('tls');
 const util = require('util');
 
-module.exports = exports = checkCrypto;
-
-function checkCrypto() {
-  if (!common.hasCrypto) {
-    common.skip('missing crypto');
-    process.exit(0);
-  }
+module.exports = exports = function() {
   return exports;
-}
+};
 
 exports.assert = require('assert');
 exports.debug = util.debuglog('test');

--- a/test/fixtures/tls-connect.js
+++ b/test/fixtures/tls-connect.js
@@ -15,10 +15,6 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 const util = require('util');
 
-module.exports = exports = function() {
-  return exports;
-};
-
 exports.assert = require('assert');
 exports.debug = util.debuglog('test');
 exports.tls = tls;

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const helper = require('./inspector-helper.js');
 

--- a/test/parallel/test-cluster-inspector-debug-port.js
+++ b/test/parallel/test-cluster-inspector-debug-port.js
@@ -1,6 +1,7 @@
 'use strict';
 // Flags: --inspect={PORT}
 const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const cluster = require('cluster');
 const debuggerPort = common.PORT;

--- a/test/parallel/test-tls-addca.js
+++ b/test/parallel/test-tls-addca.js
@@ -8,7 +8,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, keys, tls
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 const contextWithoutCert = tls.createSecureContext({});
 const contextWithCert = tls.createSecureContext({});

--- a/test/parallel/test-tls-ca-concat.js
+++ b/test/parallel/test-tls-ca-concat.js
@@ -7,7 +7,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, keys
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 connect({
   client: {

--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -7,7 +7,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 // agent6-cert.pem includes cert for agent6 and ca3
 connect({

--- a/test/parallel/test-tls-cert-chains-in-ca.js
+++ b/test/parallel/test-tls-cert-chains-in-ca.js
@@ -7,7 +7,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 
 // agent6-cert.pem includes cert for agent6 and ca3, split it apart and

--- a/test/parallel/test-tls-connect-secure-context.js
+++ b/test/parallel/test-tls-connect-secure-context.js
@@ -6,7 +6,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, keys, tls
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 connect({
   client: {

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -6,7 +6,7 @@ const common = require('../common');
 const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'))();
+} = require(join(common.fixturesDir, 'tls-connect'));
 
 connect({
   client: {rejectUnauthorized: false},

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -9,11 +9,6 @@ const {
   connect, keys, tls
 } = require(join(common.fixturesDir, 'tls-connect'));
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
-  return;
-}
-
 test(undefined, (err) => {
   assert.strictEqual(err.message, 'unable to verify the first certificate');
 });

--- a/test/sequential/test-debugger-debug-brk.js
+++ b/test/sequential/test-debugger-debug-brk.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -29,6 +29,7 @@ import test
 import os
 from os.path import join, dirname, exists
 import re
+import ast
 
 
 FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
@@ -64,7 +65,22 @@ class SimpleTestCase(test.TestCase):
       # PORT should match the definition in test/common.js.
       env = { 'PORT': int(os.getenv('NODE_COMMON_PORT', '12346')) }
       env['PORT'] += self.thread_id * 100
-      result += flags_match.group(1).strip().format(**env).split()
+      flag = flags_match.group(1).strip().format(**env).split()
+      # The following block reads config.gypi to extract the v8_enable_inspector
+      # value. This is done to check if the inspector is disabled in which case
+      # the '--inspect' flag cannot be passed to the node process as it will
+      # that will cause node to exit and report the test as failed. The use case
+      # is currently when Node is configured --without-ssl and the tests should
+      # still be runnable but skip any tests that require ssl (which includes the
+      # inspector related tests).
+      with open('config.gypi', 'r') as f:
+        s = f.read()
+        config_gypi = ast.literal_eval(s)
+        v8_disable_inspector = config_gypi['variables']['v8_enable_inspector'] == 0
+        if flag[0].startswith('--inspect') and v8_disable_inspector:
+          print('Skipping as inspector is disabled')
+        else:
+          result += flag
     files_match = FILES_PATTERN.search(source);
     additional_files = []
     if files_match:

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -73,14 +73,10 @@ class SimpleTestCase(test.TestCase):
       # is currently when Node is configured --without-ssl and the tests should
       # still be runnable but skip any tests that require ssl (which includes the
       # inspector related tests).
-      with open('config.gypi', 'r') as f:
-        s = f.read()
-        config_gypi = ast.literal_eval(s)
-        v8_disable_inspector = config_gypi['variables']['v8_enable_inspector'] == 0
-        if flag[0].startswith('--inspect') and v8_disable_inspector:
-          print('Skipping as inspector is disabled')
-        else:
-          result += flag
+      if flag[0].startswith('--inspect') and self.context.v8_enable_inspector == 0:
+        print('Skipping as inspector is disabled')
+      else:
+        result += flag
     files_match = FILES_PATTERN.search(source);
     additional_files = []
     if files_match:

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -69,7 +69,7 @@ class SimpleTestCase(test.TestCase):
       # The following block reads config.gypi to extract the v8_enable_inspector
       # value. This is done to check if the inspector is disabled in which case
       # the '--inspect' flag cannot be passed to the node process as it will
-      # that will cause node to exit and report the test as failed. The use case
+      # cause node to exit and report the test as failed. The use case
       # is currently when Node is configured --without-ssl and the tests should
       # still be runnable but skip any tests that require ssl (which includes the
       # inspector related tests).


### PR DESCRIPTION
This pull request contains a number of commits to enable the tests to pass when having configured node using `--without-ssl`. For example:

```shell
$ ./configure --without-ssl && make -j8 test
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
 - [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test