### PR TITLE
doc: various improvements to net.md

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -271,7 +271,8 @@ added: v0.1.90
 
 Start a TCP server listening for connections on the given `port` and `host`.
 
-If `port` is omitted or is 0, the operating system will assign an arbitrary unused port, which can be retrieved by using `server.address().port`
+If `port` is omitted or is 0, the operating system will assign an arbitrary
+unused port, which can be retrieved by using `server.address().port`
 after the [`'listening'`][] event has been emitted.
 
 If `host` is omitted, the server will accept connections on the

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -3,7 +3,7 @@
 > Stability: 2 - Stable
 
 The `net` module provides an asynchronous network API for creating stream-based
-servers ([`net.Server`][]) and clients ([`net.Socket`][]) that implement TCP
+servers ([`net.createServer()`][]) and clients ([`net.createConnection()`][]) that implement TCP
 or local communications (domain sockets on UNIX, named pipes on Windows).
 It can be accessed using:
 
@@ -155,7 +155,8 @@ on Linux. The default value of this parameter is 511 (not 512).
 
 Note:
 
-* All [`net.Socket`][] are set to `SO_REUSEADDR`(See [socket(7)][] for details).
+* All [`net.Socket`][] are set to `SO_REUSEADDR` (See [socket(7)][] for
+  details).
 * The `server.listen()` method may be called multiple times. Each
   subsequent call will *re-open* the server using the provided options.
 
@@ -405,14 +406,16 @@ See also: the return values of `socket.write()`
 added: v0.1.90
 -->
 
-Emitted when the other end of the socket sends a FIN packet.
+Emitted when the other end of the socket sends a FIN packet, thus ending the
+readable side of the socket.
 
 By default (`allowHalfOpen` is `false`) the socket will send a FIN packet
 back and destroy its file descriptor once it has written out its pending
 write queue. However, if `allowHalfOpen` is set to `true`, the socket will
-not automatically [`end()`][`socket.end()`] its side, allowing the user to
-write arbitrary amounts of data. The user must call [`end()`][`socket.end()`]
-explicitly to close the connection.
+not automatically [`end()`][`socket.end()`] its writable side, allowing the
+user to write arbitrary amounts of data. The user must call
+[`end()`][`socket.end()`] explicitly to close the connection (i.e. sending a
+FIN packet back).
 
 ### Event: 'error'
 <!-- YAML
@@ -978,6 +981,7 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
 [`dns.lookup()` hints]: dns.html#dns_supported_getaddrinfo_flags
 [`EventEmitter`]: events.html#events_class_eventemitter
+[`net.createConnection()`]: #net_net_createconnection_options_connectlistener
 [`net.createServer()`]: #net_net_createserver_options_connectionlistener
 [`net.Server`]: #net_class_net_server
 [`net.Socket`]: #net_class_net_socket

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -82,7 +82,7 @@ var server = net.createServer((socket) => {
   throw err;
 });
 
-// grab a random port.
+// grab an arbitrary unused port.
 server.listen(() => {
   console.log('opened server on', server.address());
 });
@@ -136,10 +136,12 @@ what it listens to.
 
 Possible signatures:
 
-* [`server.listen(handle[, backlog][, callback])`][`server.listen(handle, backlog, callback)`]
-* [`server.listen(options[, callback])`][`server.listen(options, callback)`]
-* [`server.listen(path[, backlog][, callback])`][`server.listen(path, backlog, callback)`] for local servers
-* [`server.listen([port][, host][, backlog][, callback])`][`server.listen(port, host, backlog, callback)`] for TCP servers
+* [`server.listen(handle[, backlog][, callback])`][`server.listen(handle)`]
+* [`server.listen(options[, callback])`][`server.listen(options)`]
+* [`server.listen(path[, backlog][, callback])`][`server.listen(path)`]
+  for local servers
+* [`server.listen([port][, host][, backlog][, callback])`][`server.listen(port, host)`]
+  for TCP servers
 
 This function is asynchronous.  When the server starts listening, the
 [`'listening'`][] event will be emitted.  The last parameter `callback`
@@ -153,7 +155,7 @@ on Linux. The default value of this parameter is 511 (not 512).
 
 Note:
 
-* All [`net.Socket`][] are set to `SO_REUSEADDR`.
+* All [`net.Socket`][] are set to `SO_REUSEADDR`(See [socket(7)][] for details).
 * The `server.listen()` method may be called multiple times. Each
   subsequent call will *re-open* the server using the provided options.
 
@@ -207,9 +209,9 @@ added: v0.11.14
   functions
 
 If `port` is specified, it behaves the same as
-[`server.listen([port][, hostname][, backlog][, callback])`][`server.listen(port, host, backlog, callback)`].
+[`server.listen([port][, hostname][, backlog][, callback])`][`server.listen(port, host)`].
 Otherwise, if `path` is specified, it behaves the same as
-[`server.listen(path[, backlog][, callback])`][`server.listen(path, backlog, callback)`].
+[`server.listen(path[, backlog][, callback])`][`server.listen(path)`].
 If none of them is specified, an error will be thrown.
 
 If `exclusive` is `false` (default), then cluster workers will use the same
@@ -269,8 +271,7 @@ added: v0.1.90
 
 Start a TCP server listening for connections on the given `port` and `host`.
 
-If `port` is omitted or is 0, the operating system will assign a random
-port, which can be retrieved by using `server.address().port`
+If `port` is omitted or is 0, the operating system will assign an arbitrary unused port, which can be retrieved by using `server.address().port`
 after the [`'listening'`][] event has been emitted.
 
 If `host` is omitted, the server will accept connections on the
@@ -982,10 +983,10 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`net.Socket`]: #net_class_net_socket
 [`server.getConnections()`]: #net_server_getconnections_callback
 [`server.listen()`]: #net_server_listen
-[`server.listen(handle, backlog, callback)`]: #net_server_listen_handle_backlog_callback
-[`server.listen(options, callback)`]: #net_server_listen_options_callback
-[`server.listen(port, host, backlog, callback)`]: #net_server_listen_port_host_backlog_callback
-[`server.listen(path, backlog, callback)`]: #net_server_listen_path_backlog_callback
+[`server.listen(handle)`]: #net_server_listen_handle_backlog_callback
+[`server.listen(options)`]: #net_server_listen_options_callback
+[`server.listen(port, host)`]: #net_server_listen_port_host_backlog_callback
+[`server.listen(path)`]: #net_server_listen_path_backlog_callback
 [`server.close()`]: #net_server_close_callback
 [`socket.connect(options, connectListener)`]: #net_socket_connect_options_connectlistener
 [`socket.connect`]: #net_socket_connect_options_connectlistener
@@ -996,5 +997,6 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`stream.setEncoding()`]: stream.html#stream_readable_setencoding_encoding
 [half-closed]: https://tools.ietf.org/html/rfc1122#section-4.2.2.13
 [Readable Stream]: stream.html#stream_class_stream_readable
+[socket(7)]: http://man7.org/linux/man-pages/man7/socket.7.html
 [unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
 [unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -2,7 +2,7 @@
 
 > Stability: 2 - Stable
 
-The `net` module provides an asynchronous network API for creating
+The `net` module provides an asynchronous network API for creating stream-based
 servers ([`net.Server`][]) and clients ([`net.Socket`][]) that implement TCP
 or local communications (domain sockets on UNIX, named pipes on Windows).
 It can be accessed using:

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -3,9 +3,9 @@
 > Stability: 2 - Stable
 
 The `net` module provides an asynchronous network API for creating stream-based
-servers ([`net.createServer()`][]) and clients ([`net.createConnection()`][]) that implement TCP
-or local communications (domain sockets on UNIX, named pipes on Windows).
-It can be accessed using:
+servers ([`net.createServer()`][]) and clients ([`net.createConnection()`][])
+that implement TCP or local communications (domain sockets on UNIX, named pipes
+on Windows). It can be accessed using:
 
 ```js
 const net = require('net');
@@ -162,8 +162,8 @@ Note:
 
 One of the most common errors raised when listening is `EADDRINUSE`.
 This happens when another server is already listening on the requested
-`port` / `path` / `handle`. One way to handle this would be to retry after a certain
-amount of time:
+`port` / `path` / `handle`. One way to handle this would be to retry
+after a certain amount of time:
 
 ```js
 server.on('error', (e) => {
@@ -190,7 +190,8 @@ Start a server listening for connections on a given `handle` that has
 already been bound to a port, a UNIX domain socket, or a Windows named pipe.
 
 The `handle` object can be either a server, a socket (anything with an
-underlying `_handle` member), or an object with a `fd` member that is a valid file descriptor.
+underlying `_handle` member), or an object with a `fd` member that is a
+valid file descriptor.
 
 *Note*: Listening on a file descriptor is not supported on Windows.
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -977,7 +977,6 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`connect()`]: #net_socket_connect_options_connectlistener
 [`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
 [`dns.lookup()` hints]: dns.html#dns_supported_getaddrinfo_flags
-[`socket.end()`]: #net_socket_end_data_encoding
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`net.createServer()`]: #net_net_createserver_options_connectionlistener
 [`net.Server`]: #net_class_net_server
@@ -986,12 +985,13 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`server.listen()`]: #net_server_listen
 [`server.listen(handle)`]: #net_server_listen_handle_backlog_callback
 [`server.listen(options)`]: #net_server_listen_options_callback
-[`server.listen(port, host)`]: #net_server_listen_port_host_backlog_callback
 [`server.listen(path)`]: #net_server_listen_path_backlog_callback
+[`server.listen(port, host)`]: #net_server_listen_port_host_backlog_callback
 [`server.close()`]: #net_server_close_callback
 [`socket.connect(options, connectListener)`]: #net_socket_connect_options_connectlistener
 [`socket.connect`]: #net_socket_connect_options_connectlistener
 [`socket.destroy()`]: #net_socket_destroy_exception
+[`socket.end()`]: #net_socket_end_data_encoding
 [`socket.setTimeout()`]: #net_socket_settimeout_timeout_callback
 [`socket.resume()`]: #net_socket_resume
 [`socket.pause()`]: #net_socket_pause


### PR DESCRIPTION
* Improve general description of the module, specifically,
  explain that it provides TCP or local communications
  (domain sockets on UNIX, named pipes on Windows) functionalities.
* Improve explanation of `allowHalfOpen`
* Nest the overloaded `server.listen()` API in a list, explain
  the common arguments and notes in the same place.

Some minor improvements:

* Add description to the `net.Server` constructor
* Add type annotations to `server.listen()`
* Add contexts to method links

TODO: do the same thing to`net.Socket` if this one is good to go.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net, doc