### PR TITLE
process: Cast promise rejection reason to string

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -57,7 +57,7 @@ function setupPromises(scheduleMicrotasks) {
 
   function emitWarning(uid, reason) {
     const warning = new Error('Unhandled promise rejection ' +
-                              `(rejection id: ${uid}): ${reason}`);
+                              `(rejection id: ${uid}): ${String(reason)}`);
     warning.name = 'UnhandledPromiseRejectionWarning';
     warning.id = uid;
     if (reason instanceof Error) {

--- a/test/common.js
+++ b/test/common.js
@@ -600,17 +600,45 @@ exports.isAlive = function isAlive(pid) {
   }
 };
 
-exports.expectWarning = function(name, expected) {
-  if (typeof expected === 'string')
-    expected = [expected];
-  process.on('warning', exports.mustCall((warning) => {
+function expectWarning(name, expectedMessages) {
+  return exports.mustCall((warning) => {
     assert.strictEqual(warning.name, name);
-    assert.ok(expected.includes(warning.message),
+    assert.ok(expectedMessages.includes(warning.message),
               `unexpected error message: "${warning.message}"`);
     // Remove a warning message after it is seen so that we guarantee that we
     // get each message only once.
-    expected.splice(expected.indexOf(warning.message), 1);
-  }, expected.length));
+    expectedMessages.splice(expectedMessages.indexOf(warning.message), 1);
+  }, expectedMessages.length);
+}
+
+function expectWarningByName(name, expected) {
+  if (typeof expected === 'string') {
+    expected = [expected];
+  }
+  process.on('warning', expectWarning(name, expected));
+}
+
+function expectWarningByMap(warningMap) {
+  const catchWarning = {};
+  Object.keys(warningMap).forEach((name) => {
+    let expected = warningMap[name];
+    if (typeof expected === 'string') {
+      expected = [expected];
+    }
+    catchWarning[name] = expectWarning(name, expected);
+  });
+  process.on('warning', (warning) => catchWarning[warning.name](warning));
+}
+
+// accepts a warning name and description or array of descriptions or a map
+// of warning names to description(s)
+// ensures a warning is generated for each name/description pair
+exports.expectWarning = function(nameOrMap, expected) {
+  if (typeof nameOrMap === 'string') {
+    expectWarningByName(nameOrMap, expected);
+  } else {
+    expectWarningByMap(nameOrMap);
+  }
 };
 
 Object.defineProperty(exports, 'hasIntl', {

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+
+const expectedDeprecationWarning = 'Unhandled promise rejections are ' +
+                                   'deprecated. In the future, promise ' +
+                                   'rejections that are not handled will ' +
+                                   'terminate the Node.js process with a ' +
+                                   'non-zero exit code.';
+const expectedPromiseWarning = 'Unhandled promise rejection (rejection id: ' +
+                               '1): Symbol()';
+
+common.expectWarning({
+  DeprecationWarning: expectedDeprecationWarning,
+  UnhandledPromiseRejectionWarning: expectedPromiseWarning,
+});
+
+// ensure this doesn't crash
+Promise.reject(Symbol());


### PR DESCRIPTION
The unhandled promise rejection warning uses a template literal and
prints the reason a promise was rejected. If rejecting with a symbol,
the symbol failed to convert to a string and the process crashed. Now,
symbols are casted to strings and the process does not crash.

Fixes: https://github.com/nodejs/node/issues/11637

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- ~[ ] documentation is changed or added~
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process