### PR TITLE
fs: allow read/write to accept an ArrayBuffer

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1716,7 +1716,7 @@ changes:
 -->
 
 * `fd` {integer}
-* `buffer` {Buffer|Uint8Array}
+* `buffer` {Buffer|Uint8Array|ArrayBuffer}
 * `offset` {integer}
 * `length` {integer}
 * `position` {integer}
@@ -2525,7 +2525,7 @@ changes:
 -->
 
 * `fd` {integer}
-* `buffer` {Buffer|Uint8Array}
+* `buffer` {Buffer|Uint8Array|ArrayBuffer}
 * `offset` {integer}
 * `length` {integer}
 * `position` {integer}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -28,7 +28,8 @@ const constants = process.binding('constants').fs;
 const { S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK } = constants;
 const util = require('util');
 const pathModule = require('path');
-const { isUint8Array, createPromise, promiseResolve } = process.binding('util');
+const { isUint8Array, isArrayBuffer, createPromise, promiseResolve } =
+  process.binding('util');
 
 const binding = process.binding('fs');
 const fs = exports;
@@ -670,11 +671,37 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
     callback && callback(err, bytesRead || 0, buffer);
   }
 
+  if (typeof position !== 'number')
+    position = null;
+  if (typeof offset !== 'number')
+    offset = 0;
+  if (typeof length !== 'number')
+    length = buffer.byteLength - offset;
+
+  readAll(fd, buffer, offset, length, position, 0, wrapper);
+};
+
+function readAll(fd, buffer, offset, length, position, totalRead, callback) {
   var req = new FSReqWrap();
-  req.oncomplete = wrapper;
+  req.oncomplete = function oncomplete(readErr, bytesRead) {
+    if (readErr) {
+      return callback(readErr);
+    }
+
+    totalRead += bytesRead;
+    offset += bytesRead;
+    length -= bytesRead;
+    if (position !== null) position += bytesRead;
+
+    if (bytesRead === 0 || length === 0) {
+      return callback(null, totalRead);
+    }
+
+    readAll(fd, buffer, offset, length, position, totalRead, callback);
+  };
 
   binding.read(fd, buffer, offset, length, position, req);
-};
+}
 
 Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
@@ -684,7 +711,23 @@ fs.readSync = function(fd, buffer, offset, length, position) {
     return 0;
   }
 
-  return binding.read(fd, buffer, offset, length, position);
+  if (typeof position !== 'number')
+    position = null;
+  if (typeof offset !== 'number')
+    offset = 0;
+  if (typeof length !== 'number')
+    length = buffer.byteLength - offset;
+
+  var totalRead = 0;
+  while (true) {
+    const bytesRead = binding.read(fd, buffer, offset, length, position);
+    totalRead += bytesRead;
+    offset += bytesRead;
+    length -= bytesRead;
+    if (position !== null) position += bytesRead;
+    if (bytesRead === 0 || length === 0)
+      return totalRead;
+  }
 };
 
 // usage:
@@ -697,22 +740,22 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     callback(err, written || 0, buffer);
   }
 
-  var req = new FSReqWrap();
-  req.oncomplete = wrapper;
-
-  if (isUint8Array(buffer)) {
+  if (isUint8Array(buffer) || isArrayBuffer(buffer)) {
     callback = maybeCallback(callback || position || length || offset);
     if (typeof offset !== 'number') {
       offset = 0;
     }
     if (typeof length !== 'number') {
-      length = buffer.length - offset;
+      length = buffer.byteLength - offset;
     }
     if (typeof position !== 'number') {
       position = null;
     }
-    return binding.writeBuffer(fd, buffer, offset, length, position, req);
+    return writeAll(fd, true, buffer, offset, length, position, 0, wrapper);
   }
+
+  var req = new FSReqWrap();
+  req.oncomplete = wrapper;
 
   if (typeof buffer !== 'string')
     buffer += '';
@@ -737,15 +780,16 @@ Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
 // OR
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
-  if (isUint8Array(buffer)) {
+  if (isUint8Array(buffer) || isArrayBuffer(buffer)) {
     if (position === undefined)
       position = null;
     if (typeof offset !== 'number')
       offset = 0;
     if (typeof length !== 'number')
-      length = buffer.length - offset;
-    return binding.writeBuffer(fd, buffer, offset, length, position);
+      length = buffer.byteLength - offset;
+    return writeAllSync(fd, buffer, offset, length, position);
   }
+
   if (typeof buffer !== 'string')
     buffer += '';
   if (offset === undefined)
@@ -1243,34 +1287,44 @@ fs.futimesSync = function(fd, atime, mtime) {
   binding.futimes(fd, atime, mtime);
 };
 
-function writeAll(fd, isUserFd, buffer, offset, length, position, callback) {
-  // write(fd, buffer, offset, length, position, callback)
-  fs.write(fd, buffer, offset, length, position, function(writeErr, written) {
+function writeAll(
+    fd, isUserFd, buffer, offset, length, position, total, callback) {
+  const req = new FSReqWrap();
+  req.oncomplete = function oncomplete(writeErr, written) {
     if (writeErr) {
-      if (isUserFd) {
-        callback(writeErr);
-      } else {
-        fs.close(fd, function() {
-          callback(writeErr);
-        });
-      }
-    } else {
-      if (written === length) {
-        if (isUserFd) {
-          callback(null);
-        } else {
-          fs.close(fd, callback);
-        }
-      } else {
-        offset += written;
-        length -= written;
-        if (position !== null) {
-          position += written;
-        }
-        writeAll(fd, isUserFd, buffer, offset, length, position, callback);
-      }
+      if (isUserFd) callback(writeErr);
+      else fs.close(fd, () => callback(writeErr));
+      return;
     }
-  });
+
+    total += written;
+
+    if (written === length || written === 0) {
+      if (isUserFd) callback(null, total);
+      else fs.close(fd, callback);
+      return;
+    }
+
+    offset += written;
+    length -= written;
+    if (position !== null) position += written;
+    writeAll(fd, isUserFd, buffer, offset, length, position, total, callback);
+  };
+
+  return binding.writeBuffer(fd, buffer, offset, length, position, req);
+}
+
+function writeAllSync(fd, buffer, offset, length, position) {
+  var totalWritten = 0;
+  while (length > 0) {
+    const written = binding.writeBuffer(fd, buffer, offset, length, position);
+    // CHECK_GE(written, 0)
+    totalWritten += written;
+    offset += written;
+    length -= written;
+    if (position !== null) position += written;
+  }
+  return totalWritten;
 }
 
 fs.writeFile = function(path, data, options, callback) {
@@ -1296,7 +1350,7 @@ fs.writeFile = function(path, data, options, callback) {
       data : Buffer.from('' + data, options.encoding || 'utf8');
     var position = /a/.test(flag) ? null : 0;
 
-    writeAll(fd, isUserFd, buffer, 0, buffer.length, position, callback);
+    writeAll(fd, isUserFd, buffer, 0, buffer.length, position, 0, callback);
   }
 };
 

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -15,8 +15,8 @@ assert.throws(() => {
           0,
           'utf-8',
           common.mustNotCall());
-}, /^TypeError: Second argument needs to be a buffer$/);
+}, /^TypeError: Second argument needs to be a buffer or ArrayBuffer$/);
 
 assert.throws(() => {
   fs.readSync(fd, expected.length, 0, 'utf-8');
-}, /^TypeError: Second argument needs to be a buffer$/);
+}, /^TypeError: Second argument needs to be a buffer or ArrayBuffer$/);

--- a/test/parallel/test-fs-write-arraybuffer.js
+++ b/test/parallel/test-fs-write-arraybuffer.js
@@ -1,0 +1,168 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const expected = new ArrayBuffer(Buffer.byteLength('hello'));
+Buffer.from(expected).write('hello');
+
+common.refreshTmpDir();
+
+// sync tests
+
+// fs.writeSync with all parameters provided:
+{
+  const filename = path.join(common.tmpDir, 'write1.txt');
+  const fd = fs.openSync(filename, 'w', 0o644);
+  const written = fs.writeSync(fd, expected, 0, expected.byteLength, null);
+  assert.strictEqual(expected.byteLength, written);
+  fs.closeSync(fd);
+  const found = fs.readFileSync(filename, 'utf8');
+  assert.strictEqual(Buffer.from(expected).toString(), found);
+}
+
+// fs.writeSync with a buffer, without the length parameter:
+{
+  const filename = path.join(common.tmpDir, 'write2.txt');
+  const fd = fs.openSync(filename, 'w', 0o644);
+  const written = fs.writeSync(fd, expected, 3);
+  assert.strictEqual(2, written);
+  fs.closeSync(fd);
+  const found = fs.readFileSync(filename, 'utf8');
+  assert.strictEqual('lo', found);
+}
+
+// fs.writeSync with a buffer, without the offset and length parameters:
+{
+  const filename = path.join(common.tmpDir, 'write3.txt');
+  const fd = fs.openSync(filename, 'w', 0o644);
+  const written = fs.writeSync(fd, expected);
+  assert.strictEqual(expected.byteLength, written);
+  fs.closeSync(fd);
+  const found = fs.readFileSync(filename, 'utf8');
+  assert.deepStrictEqual(Buffer.from(expected).toString(), found);
+}
+
+// fs.writeSync with the offset passed as undefined:
+{
+  const filename = path.join(common.tmpDir, 'write4.txt');
+  const fd = fs.openSync(filename, 'w', 0o644);
+  const written = fs.writeSync(fd, expected, undefined);
+  assert.strictEqual(expected.byteLength, written);
+  fs.closeSync(fd);
+  const found = fs.readFileSync(filename, 'utf8');
+  assert.deepStrictEqual(Buffer.from(expected).toString(), found);
+}
+
+// fs.writeSync with offset and length passed as undefined:
+{
+  const filename = path.join(common.tmpDir, 'write5.txt');
+  const fd = fs.openSync(filename, 'w', 0o644);
+  const written = fs.writeSync(fd, expected, undefined, undefined);
+  assert.strictEqual(expected.byteLength, written);
+  fs.closeSync(fd);
+  const found = fs.readFileSync(filename, 'utf8');
+  assert.strictEqual(Buffer.from(expected).toString(), found);
+}
+
+// async tests
+
+// fs.write with all parameters provided:
+{
+  const filename = path.join(common.tmpDir, 'write1.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
+    assert.ifError(err);
+
+    const cb = common.mustCall((err, written) => {
+      assert.ifError(err);
+
+      assert.strictEqual(expected.byteLength, written);
+      fs.closeSync(fd);
+
+      const found = fs.readFileSync(filename, 'utf8');
+      assert.strictEqual(Buffer.from(expected).toString(), found);
+    });
+
+    fs.write(fd, expected, 0, expected.byteLength, null, cb);
+  }));
+}
+
+// fs.write with a buffer, without the length parameter:
+{
+  const filename = path.join(common.tmpDir, 'write2.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
+    assert.ifError(err);
+
+    const cb = common.mustCall((err, written) => {
+      assert.ifError(err);
+
+      assert.strictEqual(2, written);
+      fs.closeSync(fd);
+
+      const found = fs.readFileSync(filename, 'utf8');
+      assert.strictEqual('lo', found);
+    });
+
+    fs.write(fd, expected, 3, cb);
+  }));
+}
+
+// fs.write with a buffer, without the offset and length parameters:
+{
+  const filename = path.join(common.tmpDir, 'write3.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+    assert.ifError(err);
+
+    const cb = common.mustCall(function(err, written) {
+      assert.ifError(err);
+
+      assert.strictEqual(expected.byteLength, written);
+      fs.closeSync(fd);
+
+      const found = fs.readFileSync(filename, 'utf8');
+      assert.deepStrictEqual(Buffer.from(expected).toString(), found);
+    });
+
+    fs.write(fd, expected, cb);
+  }));
+}
+
+// fs.write with the offset passed as undefined followed by the callback:
+{
+  const filename = path.join(common.tmpDir, 'write4.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
+    assert.ifError(err);
+
+    const cb = common.mustCall(function(err, written) {
+      assert.ifError(err);
+
+      assert.strictEqual(expected.byteLength, written);
+      fs.closeSync(fd);
+
+      const found = fs.readFileSync(filename, 'utf8');
+      assert.deepStrictEqual(Buffer.from(expected).toString(), found);
+    });
+
+    fs.write(fd, expected, undefined, cb);
+  }));
+}
+
+// fs.write with offset and length passed as undefined followed by the callback:
+{
+  const filename = path.join(common.tmpDir, 'write5.txt');
+  fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
+    assert.ifError(err);
+
+    const cb = common.mustCall((err, written) => {
+      assert.ifError(err);
+
+      assert.strictEqual(expected.byteLength, written);
+      fs.closeSync(fd);
+
+      const found = fs.readFileSync(filename, 'utf8');
+      assert.strictEqual(Buffer.from(expected).toString(), found);
+    });
+
+    fs.write(fd, expected, undefined, undefined, cb);
+  }));
+}


### PR DESCRIPTION
**Checklist**
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

**Affected core subsystem(s):**
fs


`fs.read()` and `fs.write()` now accept an `ArrayBuffer`.

Typed Arrays are limited in size by a max index of Smi (`0x7fffffff` on
x64 and `0x3fffffff` on ia32). While, in V8, `ArrayBuffer`s are limited to
max `size_t`. Though for practical reasons it would be limited to
`Number.MAX_SAFE_INTEGER` (or approximately 8PB).

So now the maximum file size that can be read/written is only limited by
the amount of available memory. This presents a problem to fully test
because it requires that at least 4GB of memory be available.

To implement this, one shortcoming of `uv_buf_init()` was addressed. The
`len` argument is an unsigned int. Whereas the `len` property of a
`uv_buf_t` is a `size_t`. So `len` needs to be set manually. Otherwise it
could be truncated.

CI: https://ci.nodejs.org/job/node-test-commit/8191/