### PR TITLE
test: remove obsolete eslint-disable comment

### DIFF
--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -75,12 +75,10 @@ demoBug('POST /1', '/22 HTTP/1.1\r\n' +
         'Content-Length: 4\r\n\r\n' +
         'pong');
 
-/* eslint-disable align-function-arguments */
 demoBug('POST /1/22 HTTP/1.1\r\n' +
         'Content-Type: tex', 't/plain\r\n' +
         'Content-Length: 4\r\n\r\n' +
         'pong');
-/* eslint-enable align-function-arguments */
 
 process.on('exit', function() {
   assert.strictEqual(2, headersComplete);


### PR DESCRIPTION
The align-function-arguments custom rule is obsolete and has been
removed from the code base. Remove comment that used to disable it for
one file.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test