### PR TITLE
timers: fix not to close reused timer handle

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -222,7 +222,6 @@ function listOnTimeout() {
   // As such, we can remove the list and clean up the TimerWrap C++ handle.
   debug('%d list empty', msecs);
   assert(L.isEmpty(list));
-  this.close();
 
   // Either refedLists[msecs] or unrefedLists[msecs] may have been removed and
   // recreated since the reference to `list` was created. Make sure they're
@@ -232,6 +231,13 @@ function listOnTimeout() {
   } else if (list === refedLists[msecs]) {
     delete refedLists[msecs];
   }
+
+  // Do not close the underlying handle if its ownership has changed
+  // (e.g it was unrefed in its callback).
+  if (this.owner)
+    return;
+
+  this.close();
 }
 
 

--- a/test/parallel/test-timers-unrefed-in-callback.js
+++ b/test/parallel/test-timers-unrefed-in-callback.js
@@ -30,7 +30,7 @@ function Test1() {
 
   const timer1 = setInterval(() => {
     timer1.unref();
-    if (counter1++ === 10) {
+    if (counter1++ === 3) {
       clearInterval(timer1);
       server.close(() => {
         Test2();
@@ -49,13 +49,13 @@ function Test2() {
 
   const timer2 = setInterval(() => {
     timer2.unref();
-    if (counter2++ === 10)
+    if (counter2++ === 3)
       server.close();
   }, 1);
 }
 
 process.on('exit', () => {
-  assert.strictEqual(counter1, 11);
+  assert.strictEqual(counter1, 4);
 });
 
 Test1();

--- a/test/parallel/test-timers-unrefed-in-callback.js
+++ b/test/parallel/test-timers-unrefed-in-callback.js
@@ -1,0 +1,61 @@
+'use strict';
+// Checks that setInterval timers keep running even when they're
+// unrefed within their callback.
+
+require('../common');
+const assert = require('assert');
+const net = require('net');
+
+let counter1 = 0;
+let counter2 = 0;
+
+// Test1 checks that clearInterval works as expected for a timer
+// unrefed within its callback: it removes the timer and its callback
+// is not called anymore. Note that the only reason why this test is
+// robust is that:
+// 1. the repeated timer it creates has a delay of 1ms
+// 2. when this test is completed, another test starts that creates a
+//    new repeated timer with the same delay (1ms)
+// 3. because of the way timers are implemented in libuv, if two
+//    repeated timers A and B are created in that order with the same
+//    delay, it is guaranteed that the first occurrence of timer A
+//    will fire before the first occurrence of timer B
+// 4. as a result, when the timer created by Test2 fired 11 times, if
+//    the timer created by Test1 hadn't been removed by clearInterval,
+//    it would have fired 11 more times, and the assertion in the
+//    process'exit event handler would fail.
+function Test1() {
+  // server only for maintaining event loop
+  const server = net.createServer().listen(0);
+
+  const timer1 = setInterval(() => {
+    timer1.unref();
+    if (counter1++ === 10) {
+      clearInterval(timer1);
+      server.close(() => {
+        Test2();
+      });
+    }
+  }, 1);
+}
+
+
+// Test2 checks setInterval continues even if it is unrefed within
+// timer callback. counter2 continues to be incremented more than 11
+// until server close completed.
+function Test2() {
+  // server only for maintaining event loop
+  const server = net.createServer().listen(0);
+
+  const timer2 = setInterval(() => {
+    timer2.unref();
+    if (counter2++ === 10)
+      server.close();
+  }, 1);
+}
+
+process.on('exit', () => {
+  assert.strictEqual(counter1, 11);
+});
+
+Test1();


### PR DESCRIPTION
This issue was originally reported by @darai0512 via private communication.

He found that `timer.unref` in setInterval callback leads the timer not to be repeated. 
It can reproduced with this sample  that setInterval `counter1` stops at 0.
```js
const net = require('net');
let counter1 = 0;
const server = net.createServer().listen(0);

const timer1 = setInterval(() => {
  console.log('counter1:', counter1);
  timer1.unref();
  if (counter1++ === 10)
    server.close();
}, 1);
````

The timer handle is reused when it is unrefed in order to avoid new
callback in beforeExit(#3407). If it is unrefed within a setInterval
callback, the reused timer handle is closed so that setInterval no
longer keep working. This fix does not close the handle in case of
setInterval.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timer

CC: @fishrock123, @misterdjules for timer maintainer.
