### PR TITLE
doc: fix WHATWG URL url.protocol example

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -599,7 +599,7 @@ Gets and sets the protocol portion of the URL.
 ```js
 const myURL = new URL('https://example.org');
 console.log(myURL.protocol);
-  // Prints http:
+  // Prints https:
 
 myURL.protocol = 'ftp';
 console.log(myURL.href);


### PR DESCRIPTION
The example given in the `url.protocol` section of the WHATWG URL doc should print `https:` instead of `http:` for `https://example.org`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
