### PR TITLE
Unlock module and remove Locked from stability index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,15 +46,6 @@ $ git remote add upstream git://github.com/nodejs/node.git
 For developing new features and bug fixes, the `master` branch should be pulled
 and built upon.
 
-#### Respect the stability index
-
-The rules for the master branch are less strict; consult the
-[stability index](./doc/api/documentation.md#stability-index) for details.
-
-In a nutshell, modules are at varying levels of API stability. Bug fixes are
-always welcome but API or behavioral changes to modules at stability level 3
-(Locked) are off-limits.
-
 #### Dependencies
 
 Node.js has several bundled dependencies in the *deps/* and the *tools/*

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -56,12 +56,6 @@ The API has proven satisfactory. Compatibility with the npm ecosystem
 is a high priority, and will not be broken unless absolutely necessary.
 ```
 
-```txt
-Stability: 3 - Locked
-Only bug fixes, security fixes, and performance improvements will be accepted.
-Please do not suggest API changes in this area; they will be refused.
-```
-
 ## JSON Output
 
 > Stability: 1 - Experimental

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1,6 +1,6 @@
 # Modules
 
-> Stability: 3 - Locked
+> Stability: 2 - Stable
 
 <!--name=module-->
 


### PR DESCRIPTION
First commit: Unlock module.
    
Update documentation for `module` to reflect stability index 2 (Stable)
rather than 3 (Locked).

Second commit: Remove Locked from stability index.    

The stability index 3 (Locked) is unused and is being eliminated. Remove
it from the documentation about the stability index.

Refs: https://github.com/nodejs/node/issues/11200

@nodejs/ctc 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc module 