### PR TITLE
url: don't scan number twice

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3718,7 +3718,9 @@ static void ParseArgs(int* argc,
       new_v8_argv[new_v8_argc] = "--help";
       new_v8_argc += 1;
     } else if (strncmp(arg, "--v8-pool-size=", 15) == 0) {
-      v8_thread_pool_size = atoi(arg + 15);
+      v8_thread_pool_size =
+          StringToUint64InRange(arg + 15, 1, INT_MAX)
+          .FromMaybe(v8_thread_pool_size);
 #if HAVE_OPENSSL
     } else if (strncmp(arg, "--tls-cipher-list=", 18) == 0) {
       default_cipher_list = arg + 18;

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -278,41 +278,6 @@ namespace url {
     return type;
   }
 
-  static inline int64_t ParseNumber(const char* start, const char* end) {
-    unsigned R = 10;
-    if (end - start >= 2 && start[0] == '0' && (start[1] | 0x20) == 'x') {
-      start += 2;
-      R = 16;
-    }
-    if (end - start == 0) {
-      return 0;
-    } else if (R == 10 && end - start > 1 && start[0] == '0') {
-      start++;
-      R = 8;
-    }
-    const char* p = start;
-
-    while (p < end) {
-      const char ch = p[0];
-      switch (R) {
-        case 8:
-          if (ch < '0' || ch > '7')
-            return -1;
-          break;
-        case 10:
-          if (!ASCII_DIGIT(ch))
-            return -1;
-          break;
-        case 16:
-          if (!ASCII_HEX_DIGIT(ch))
-            return -1;
-          break;
-      }
-      p++;
-    }
-    return strtoll(start, NULL, R);
-  }
-
   static url_host_type ParseIPv4Host(url_host* host,
                                      const char* input,
                                      size_t length) {
@@ -333,11 +298,13 @@ namespace url {
       if (ch == '.' || ch == kEOL) {
         if (++parts > 4)
           goto end;
-        if (pointer - mark == 0)
+        const ptrdiff_t size = pointer - mark;
+        if (size == 0)
           break;
-        int64_t n = ParseNumber(mark, pointer);
-        if (n < 0)
+        auto maybe_n = StringToUint64(mark, size);
+        if (maybe_n.IsNothing())
           goto end;
+        uint64_t n = maybe_n.FromJust();
 
         if (n > 255) {
           tooBigNumbers++;

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -320,6 +320,80 @@ bool StringEqualNoCaseN(const char* a, const char* b, size_t length) {
   return true;
 }
 
+inline v8::Maybe<uint64_t> StringToUint64(const char* string, size_t size,
+                                          NumberBase base) {
+  const char* const end = string + size;
+  const char* p = string;
+  uint64_t result = 0;
+
+  if (size == 0)
+    return v8::Nothing<uint64_t>();
+
+  if (size > 1 && p[0] == '0') {
+    // Intentionally accepts "0x" and "0X" as valid aliases for "0".
+    if ((base == NumberBase::kAny || base == NumberBase::kHexadecimal) &&
+        (p[1] | 32) == 'x') {
+      base = NumberBase::kHexadecimal;
+      p += 2;
+    } else if (base == NumberBase::kAny || base == NumberBase::kOctal) {
+      base = NumberBase::kOctal;
+      p += 1;
+    }
+  }
+
+  if (base == NumberBase::kAny)
+    base = NumberBase::kDecimal;
+
+  for (; p < end; p += 1) {
+    // Intentional wraparound for values < '0'.
+    uint8_t ch = static_cast<uint8_t>(p[0]) - '0';
+
+    // Digits 0-7 are always in range.
+    if (ch > 7) {
+      // Adjust for non-digits in hexadecimal numbers.
+      if (ch > 9) {
+        ch = (ch | 32) - '\'';  // Intentional wraparound for values < '\''.
+        if (ch < 10)
+          return v8::Nothing<uint64_t>();
+      }
+
+      if (ch >= base)
+        return v8::Nothing<uint64_t>();
+    }
+
+    // XXX(bnoordhuis) Detect overflow and return nothing?
+    result *= static_cast<uint64_t>(base);
+    result += ch;
+  }
+
+  if (p == end)
+    return v8::Just(result);
+
+  return v8::Nothing<uint64_t>();
+}
+
+inline v8::Maybe<uint64_t> StringToUint64(const char* string, NumberBase base) {
+  return StringToUint64(string, strlen(string), base);
+}
+
+inline v8::Maybe<uint64_t> StringToUint64InRange(const char* string,
+                                                 size_t size,
+                                                 uint64_t lower,
+                                                 uint64_t upper,
+                                                 NumberBase base) {
+  auto result = StringToUint64(string, size, base);
+  if (lower <= result.FromMaybe(lower) && upper >= result.FromMaybe(upper))
+    return result;
+  return v8::Nothing<uint64_t>();
+}
+
+inline v8::Maybe<uint64_t> StringToUint64InRange(const char* string,
+                                                 uint64_t lower,
+                                                 uint64_t upper,
+                                                 NumberBase base) {
+  return StringToUint64InRange(string, strlen(string), lower, upper, base);
+}
+
 inline size_t MultiplyWithOverflowCheck(size_t a, size_t b) {
   size_t ret = a * b;
   if (a != 0)

--- a/src/util.h
+++ b/src/util.h
@@ -269,6 +269,34 @@ inline bool StringEqualNoCase(const char* a, const char* b);
 // strncasecmp() is locale-sensitive.  Use StringEqualNoCaseN() instead.
 inline bool StringEqualNoCaseN(const char* a, const char* b, size_t length);
 
+enum NumberBase : unsigned {
+  kAny = 0,
+  kOctal = 8,
+  kDecimal = 10,
+  kHexadecimal = 16
+};
+
+// Parse a string to uint64_t.
+inline v8::Maybe<uint64_t> StringToUint64(const char* string, size_t size,
+                                          NumberBase base = NumberBase::kAny);
+
+inline v8::Maybe<uint64_t> StringToUint64(const char* string,
+                                          NumberBase base = NumberBase::kAny);
+
+// Parse a string to uint64_t in the range lower:upper inclusive.
+inline v8::Maybe<uint64_t> StringToUint64InRange(const char* string,
+                                                 size_t size,
+                                                 uint64_t lower,
+                                                 uint64_t upper,
+                                                 NumberBase base =
+                                                     NumberBase::kAny);
+
+inline v8::Maybe<uint64_t> StringToUint64InRange(const char* string,
+                                                 uint64_t lower,
+                                                 uint64_t upper,
+                                                 NumberBase base =
+                                                     NumberBase::kAny);
+
 // Allocates an array of member type T. For up to kStackStorageSize items,
 // the stack is used, otherwise malloc().
 template <typename T, size_t kStackStorageSize = 1024>

--- a/test/cctest/util.cc
+++ b/test/cctest/util.cc
@@ -90,6 +90,47 @@ TEST(UtilTest, ToLower) {
   EXPECT_EQ('a', ToLower('A'));
 }
 
+TEST(UtilTest, StringToUint64) {
+  using node::NumberBase;
+  using node::StringToUint64;
+  EXPECT_TRUE(StringToUint64("").IsNothing());
+  EXPECT_TRUE(StringToUint64("", 1).IsNothing());
+  EXPECT_TRUE(StringToUint64("+1").IsNothing());
+  EXPECT_TRUE(StringToUint64("-1").IsNothing());
+  EXPECT_TRUE(StringToUint64("bad").IsNothing());
+  EXPECT_TRUE(StringToUint64("8", NumberBase::kOctal).IsNothing());
+  EXPECT_TRUE(StringToUint64("18", NumberBase::kOctal).IsNothing());
+  EXPECT_TRUE(StringToUint64("A", NumberBase::kDecimal).IsNothing());
+  EXPECT_TRUE(StringToUint64("2A", NumberBase::kDecimal).IsNothing());
+  EXPECT_TRUE(StringToUint64("G", NumberBase::kHexadecimal).IsNothing());
+  EXPECT_TRUE(StringToUint64("3G", NumberBase::kHexadecimal).IsNothing());
+  EXPECT_EQ(0ULL, StringToUint64("0").FromMaybe(-1));
+  EXPECT_EQ(0ULL, StringToUint64("0x").FromMaybe(-1));
+  EXPECT_EQ(0ULL, StringToUint64("0X").FromMaybe(-1));
+  EXPECT_EQ(42ULL, StringToUint64("42").FromMaybe(-1));
+  EXPECT_EQ(493ULL, StringToUint64("0755").FromMaybe(-1));
+  EXPECT_EQ(2989ULL, StringToUint64("0xbad").FromMaybe(-1));
+  EXPECT_EQ(2989ULL, StringToUint64("0XBAD").FromMaybe(-1));
+  EXPECT_EQ(2989ULL,
+            StringToUint64("BAD", NumberBase::kHexadecimal).FromMaybe(-1));
+  static const uint64_t kMaxUint64(-1);
+  EXPECT_EQ(kMaxUint64,
+            StringToUint64("01777777777777777777777").FromMaybe(0));
+  EXPECT_EQ(kMaxUint64,
+            StringToUint64("18446744073709551615").FromMaybe(0));
+  EXPECT_EQ(kMaxUint64,
+            StringToUint64("0xFFFFFFFFFFFFFFFF").FromMaybe(0));
+}
+
+TEST(UtilTest, StringToUint64InRange) {
+  using node::NumberBase;
+  using node::StringToUint64InRange;
+  EXPECT_TRUE(StringToUint64InRange("0", 1, 42).IsNothing());
+  EXPECT_TRUE(StringToUint64InRange("43", 7, 42).IsNothing());
+  EXPECT_EQ(1ULL, StringToUint64InRange("1", 1, 42).FromMaybe(-1));
+  EXPECT_EQ(42ULL, StringToUint64InRange("42", 1, 42).FromMaybe(-1));
+}
+
 namespace node {
   void LowMemoryNotification() {}
 }


### PR DESCRIPTION
Rewrite ParseNumber() to validate and parse the string in one go instead
of validating first, then validating and parsing again with strtoll().

This commit adds utility functions for parsing a string to uint64_t and
also updates two other functions where we used strtol() and atoi().