### PR TITLE
tools: adds doc links to the stability index reference

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -352,9 +352,12 @@ function linkJsTypeDocs(text) {
 }
 
 function parseAPIHeader(text) {
+  const classNames = 'api_stability api_stability_$2';
+  const docsUrl = 'documentation.html#documentation_stability_index';
+
   text = text.replace(
     STABILITY_TEXT_REG_EXP,
-    '<pre class="api_stability api_stability_$2">$1 $2$3</pre>'
+    `<pre class="${classNames}"><a href="${docsUrl}">$1 $2</a>$3</pre>`
   );
   return text;
 }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
`tools`

##### Description of Change
This modifies the script that generates the docs to create a static link from each Stability Index callout bar to the Stability Index explanations in documentation.html. This was a first-commit request from @Trott. Here is what he pitched to me:

> Many APIs have a Stability Index associated with them. Check out https://nodejs.org/dist/latest-v7.x/docs/api/modules.html#modules_modules for an example (the Modules API is Locked, Stability Index 3).
>It would be great if there could be a link in the Stability Index banner to the definition of the various Stability Indexes. If I don't know what "Locked" means, then I can click the link and find out.
>Modify html.js to include such a link. This will involve some HTML of course, and probably some CSS and maybe some back-and-forth about usability/styling once the PR is open.

I looked for any precedent for styling, and the best I could find is that when features are deprecated, a simple link is put to the new API to use, inside the banner. This similarly just links the first part (e.g. **Stability: 2**) to the documentation.html page. I'm obviously open to other styling suggestions, but this seemed the most straightforward. There doesn't seem to be any precedent in the docs for other things like a `?` icon or similar.

Also I'm just linking to the main anchor for the Stability Index explanations, rather than to a specific one. My thinking here is that there are only a handful of them, and they should all fit nicely above the fold for anyone reading that page. It didn't seem necessary to create additional anchors.

Note that I had to make a couple more variables in the commit here to make the tests pass with the 80 character line limit.