### PR TITLE
fs: include more fs.stat*() optimizations

### DIFF
--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -4,20 +4,30 @@ const common = require('../common');
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
-  kind: ['lstat', 'stat']
+  n: [20e4],
+  kind: ['fstat', 'lstat', 'stat']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
+  const kind = conf.kind;
+  var arg;
+  if (kind === 'fstat')
+    arg = fs.openSync(__filename, 'r');
+  else
+    arg = __filename;
 
   bench.start();
   (function r(cntr, fn) {
-    if (cntr-- <= 0)
-      return bench.end(n);
-    fn(__filename, function() {
+    if (cntr-- <= 0) {
+      bench.end(n);
+      if (kind === 'fstat')
+        fs.closeSync(arg);
+      return;
+    }
+    fn(arg, function() {
       r(cntr, fn);
     });
-  }(n, fs[conf.kind]));
+  }(n, fs[kind]));
 }

--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -4,36 +4,23 @@ const common = require('../common');
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
+  n: [1e6],
   kind: ['fstatSync', 'lstatSync', 'statSync']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  var fn;
-  var i;
-  switch (conf.kind) {
-    case 'statSync':
-    case 'lstatSync':
-      fn = fs[conf.kind];
-      bench.start();
-      for (i = 0; i < n; i++) {
-        fn(__filename);
-      }
-      bench.end(n);
-      break;
-    case 'fstatSync':
-      fn = fs.fstatSync;
-      const fd = fs.openSync(__filename, 'r');
-      bench.start();
-      for (i = 0; i < n; i++) {
-        fn(fd);
-      }
-      bench.end(n);
-      fs.closeSync(fd);
-      break;
-    default:
-      throw new Error('Invalid kind argument');
+  const kind = conf.kind;
+  const arg = (kind === 'fstatSync' ? fs.openSync(__filename, 'r') : __dirname);
+  const fn = fs[conf.kind];
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    fn(arg);
   }
+  bench.end(n);
+
+  if (kind === 'fstat')
+    fs.closeSync(arg);
 }

--- a/benchmark/fs/readFileSync.js
+++ b/benchmark/fs/readFileSync.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var common = require('../common.js');
+var fs = require('fs');
+
+var bench = common.createBenchmark(main, {
+  n: [60e4]
+});
+
+function main(conf) {
+  var n = +conf.n;
+
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    fs.readFileSync(__filename);
+  bench.end(n);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -43,6 +43,7 @@ const internalUtil = require('internal/util');
 const assertEncoding = internalFS.assertEncoding;
 const stringToFlags = internalFS.stringToFlags;
 const getPathFromURL = internalURL.getPathFromURL;
+const { StorageObject } = require('internal/querystring');
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -1514,10 +1515,23 @@ fs.unwatchFile = function(filename, listener) {
 };
 
 
-// Regex to find the device root, including trailing slash. E.g. 'c:\\'.
-const splitRootRe = isWindows ?
-  /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
-  /^[/]*/;
+var splitRoot;
+if (isWindows) {
+  // Regex to find the device root on Windows (e.g. 'c:\\'), including trailing
+  // slash.
+  const splitRootRe = /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/;
+  splitRoot = function splitRoot(str) {
+    return splitRootRe.exec(str)[0];
+  };
+} else {
+  splitRoot = function splitRoot(str) {
+    for (var i = 0; i < str.length; ++i) {
+      if (str.charCodeAt(i) !== 47/*'/'*/)
+        return str.slice(0, i);
+    }
+    return str;
+  };
+}
 
 function encodeRealpathResult(result, options) {
   if (!options || !options.encoding || options.encoding === 'utf8')
@@ -1545,11 +1559,17 @@ if (isWindows) {
   nextPart = function nextPart(p, i) { return p.indexOf('/', i); };
 }
 
+const emptyObj = new StorageObject();
 fs.realpathSync = function realpathSync(p, options) {
-  options = getOptions(options, {});
-  handleError((p = getPathFromURL(p)));
-  if (typeof p !== 'string')
-    p += '';
+  if (!options)
+    options = emptyObj;
+  else
+    options = getOptions(options, emptyObj);
+  if (typeof p !== 'string') {
+    handleError((p = getPathFromURL(p)));
+    if (typeof p !== 'string')
+      p += '';
+  }
   nullCheck(p);
   p = pathModule.resolve(p);
 
@@ -1559,8 +1579,8 @@ fs.realpathSync = function realpathSync(p, options) {
     return maybeCachedResult;
   }
 
-  const seenLinks = {};
-  const knownHard = {};
+  const seenLinks = new StorageObject();
+  const knownHard = new StorageObject();
   const original = p;
 
   // current character position in p
@@ -1573,10 +1593,8 @@ fs.realpathSync = function realpathSync(p, options) {
   var previous;
 
   // Skip over roots
-  var m = splitRootRe.exec(p);
-  pos = m[0].length;
-  current = m[0];
-  base = m[0];
+  current = base = splitRoot(p);
+  pos = current.length;
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
@@ -1615,7 +1633,8 @@ fs.realpathSync = function realpathSync(p, options) {
       // Use stats array directly to avoid creating an fs.Stats instance just
       // for our internal use.
 
-      binding.lstat(pathModule._makeLong(base));
+      var baseLong = pathModule._makeLong(base);
+      binding.lstat(baseLong);
 
       if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
         knownHard[base] = true;
@@ -1631,13 +1650,13 @@ fs.realpathSync = function realpathSync(p, options) {
         var dev = statValues[0/*dev*/].toString(32);
         var ino = statValues[7/*ino*/].toString(32);
         id = `${dev}:${ino}`;
-        if (seenLinks.hasOwnProperty(id)) {
+        if (seenLinks[id]) {
           linkTarget = seenLinks[id];
         }
       }
       if (linkTarget === null) {
-        binding.stat(pathModule._makeLong(base));
-        linkTarget = binding.readlink(pathModule._makeLong(base));
+        binding.stat(baseLong);
+        linkTarget = binding.readlink(baseLong);
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 
@@ -1649,10 +1668,8 @@ fs.realpathSync = function realpathSync(p, options) {
     p = pathModule.resolve(resolvedLink, p.slice(pos));
 
     // Skip over roots
-    m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
+    current = base = splitRoot(p);
+    pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
@@ -1668,17 +1685,22 @@ fs.realpathSync = function realpathSync(p, options) {
 
 fs.realpath = function realpath(p, options, callback) {
   callback = maybeCallback(typeof options === 'function' ? options : callback);
-  options = getOptions(options, {});
-  if (handleError((p = getPathFromURL(p)), callback))
-    return;
-  if (typeof p !== 'string')
-    p += '';
+  if (!options)
+    options = emptyObj;
+  else
+    options = getOptions(options, emptyObj);
+  if (typeof p !== 'string') {
+    if (handleError((p = getPathFromURL(p)), callback))
+      return;
+    if (typeof p !== 'string')
+      p += '';
+  }
   if (!nullCheck(p, callback))
     return;
   p = pathModule.resolve(p);
 
-  const seenLinks = {};
-  const knownHard = {};
+  const seenLinks = new StorageObject();
+  const knownHard = new StorageObject();
 
   // current character position in p
   var pos;
@@ -1689,11 +1711,8 @@ fs.realpath = function realpath(p, options, callback) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  var m = splitRootRe.exec(p);
-  pos = m[0].length;
-  current = m[0];
-  base = m[0];
-  previous = '';
+  current = base = splitRoot(p);
+  pos = current.length;
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
@@ -1756,7 +1775,7 @@ fs.realpath = function realpath(p, options, callback) {
       var dev = statValues[0/*ino*/].toString(32);
       var ino = statValues[7/*ino*/].toString(32);
       id = `${dev}:${ino}`;
-      if (seenLinks.hasOwnProperty(id)) {
+      if (seenLinks[id]) {
         return gotTarget(null, seenLinks[id], base);
       }
     }
@@ -1780,11 +1799,8 @@ fs.realpath = function realpath(p, options, callback) {
   function gotResolvedLink(resolvedLink) {
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
+    current = base = splitRoot(p);
+    pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const constants = process.binding('constants').fs;
+const { S_IFMT, S_IFREG, S_IFLNK } = constants;
 const util = require('util');
 const pathModule = require('path');
 const { isUint8Array } = process.binding('util');
@@ -135,6 +136,24 @@ function makeCallback(cb) {
   };
 }
 
+// Special case of `makeCallback()` that is specific to async `*stat()` calls as
+// an optimization, since the data passed back to the callback needs to be
+// transformed anyway.
+function makeStatsCallback(cb) {
+  if (cb === undefined) {
+    return rethrow();
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('"callback" argument must be a function');
+  }
+
+  return function(err) {
+    if (err) return cb(err);
+    cb(err, statsFromValues());
+  };
+}
+
 function nullCheck(path, callback) {
   if (('' + path).indexOf('\u0000') !== -1) {
     var er = new Error('Path must be a string without null bytes');
@@ -151,7 +170,7 @@ function isFd(path) {
   return (path >>> 0) === path;
 }
 
-// Static method to set the stats properties on a Stats object.
+// Constructor for file stats.
 function Stats(
     dev,
     mode,
@@ -184,40 +203,48 @@ function Stats(
 }
 fs.Stats = Stats;
 
-// Create a C++ binding to the function which creates a Stats object.
-binding.FSInitialize(fs.Stats);
-
-fs.Stats.prototype._checkModeProperty = function(property) {
-  return ((this.mode & constants.S_IFMT) === property);
+Stats.prototype._checkModeProperty = function(property) {
+  return ((this.mode & S_IFMT) === property);
 };
 
-fs.Stats.prototype.isDirectory = function() {
+Stats.prototype.isDirectory = function() {
   return this._checkModeProperty(constants.S_IFDIR);
 };
 
-fs.Stats.prototype.isFile = function() {
-  return this._checkModeProperty(constants.S_IFREG);
+Stats.prototype.isFile = function() {
+  return this._checkModeProperty(S_IFREG);
 };
 
-fs.Stats.prototype.isBlockDevice = function() {
+Stats.prototype.isBlockDevice = function() {
   return this._checkModeProperty(constants.S_IFBLK);
 };
 
-fs.Stats.prototype.isCharacterDevice = function() {
+Stats.prototype.isCharacterDevice = function() {
   return this._checkModeProperty(constants.S_IFCHR);
 };
 
-fs.Stats.prototype.isSymbolicLink = function() {
-  return this._checkModeProperty(constants.S_IFLNK);
+Stats.prototype.isSymbolicLink = function() {
+  return this._checkModeProperty(S_IFLNK);
 };
 
-fs.Stats.prototype.isFIFO = function() {
+Stats.prototype.isFIFO = function() {
   return this._checkModeProperty(constants.S_IFIFO);
 };
 
-fs.Stats.prototype.isSocket = function() {
+Stats.prototype.isSocket = function() {
   return this._checkModeProperty(constants.S_IFSOCK);
 };
+
+const statValues = binding.getStatValues();
+
+function statsFromValues() {
+  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
+                   statValues[4], statValues[5],
+                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
+                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
+                   statValues[10], statValues[11], statValues[12],
+                   statValues[13]);
+}
 
 // Don't allow mode to accidentally be overwritten.
 ['F_OK', 'R_OK', 'W_OK', 'X_OK'].forEach(function(key) {
@@ -275,7 +302,7 @@ fs.exists = function(path, callback) {
   var req = new FSReqWrap();
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
-  function cb(err, stats) {
+  function cb(err) {
     if (callback) callback(err ? false : true);
   }
 };
@@ -284,7 +311,7 @@ fs.existsSync = function(path) {
   try {
     handleError((path = getPathFromURL(path)));
     nullCheck(path);
-    binding.stat(pathModule._makeLong(path), statValues);
+    binding.stat(pathModule._makeLong(path));
     return true;
   } catch (e) {
     return false;
@@ -387,13 +414,19 @@ function readFileAfterOpen(err, fd) {
   binding.fstat(fd, req);
 }
 
-function readFileAfterStat(err, st) {
+function readFileAfterStat(err) {
   var context = this.context;
 
   if (err)
     return context.close(err);
 
-  var size = context.size = st.isFile() ? st.size : 0;
+  // Use stats array directly to avoid creating an fs.Stats instance just for
+  // our internal use.
+  var size;
+  if ((statValues[1/*mode*/] & S_IFMT) === S_IFREG)
+    size = context.size = statValues[8/*size*/];
+  else
+    size = context.size = 0;
 
   if (size === 0) {
     context.buffers = [];
@@ -467,14 +500,13 @@ function tryToString(buf, encoding, callback) {
 
 function tryStatSync(fd, isUserFd) {
   var threw = true;
-  var st;
   try {
-    st = fs.fstatSync(fd);
+    binding.fstat(fd);
     threw = false;
   } finally {
     if (threw && !isUserFd) fs.closeSync(fd);
   }
-  return st;
+  return !threw;
 }
 
 function tryCreateBuffer(size, fd, isUserFd) {
@@ -506,8 +538,13 @@ fs.readFileSync = function(path, options) {
   var isUserFd = isFd(path); // file descriptor ownership
   var fd = isUserFd ? path : fs.openSync(path, options.flag || 'r', 0o666);
 
-  var st = tryStatSync(fd, isUserFd);
-  var size = st.isFile() ? st.size : 0;
+  // Use stats array directly to avoid creating an fs.Stats instance just for
+  // our internal use.
+  var size;
+  if (tryStatSync(fd, isUserFd) && (statValues[1/*mode*/] & S_IFMT) === S_IFREG)
+    size = statValues[8/*size*/];
+  else
+    size = 0;
   var pos = 0;
   var buffer; // single buffer with file data
   var buffers; // list for when size is unknown
@@ -854,12 +891,12 @@ fs.readdirSync = function(path, options) {
 
 fs.fstat = function(fd, callback) {
   var req = new FSReqWrap();
-  req.oncomplete = makeCallback(callback);
+  req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
 };
 
 fs.lstat = function(path, callback) {
-  callback = makeCallback(callback);
+  callback = makeStatsCallback(callback);
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
@@ -869,7 +906,7 @@ fs.lstat = function(path, callback) {
 };
 
 fs.stat = function(path, callback) {
-  callback = makeCallback(callback);
+  callback = makeStatsCallback(callback);
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
@@ -878,32 +915,22 @@ fs.stat = function(path, callback) {
   binding.stat(pathModule._makeLong(path), req);
 };
 
-const statValues = new Float64Array(14);
-function statsFromValues() {
-  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
-                   statValues[4], statValues[5],
-                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
-                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
-                   statValues[10], statValues[11], statValues[12],
-                   statValues[13]);
-}
-
 fs.fstatSync = function(fd) {
-  binding.fstat(fd, statValues);
+  binding.fstat(fd);
   return statsFromValues();
 };
 
 fs.lstatSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  binding.lstat(pathModule._makeLong(path), statValues);
+  binding.lstat(pathModule._makeLong(path));
   return statsFromValues();
 };
 
 fs.statSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  binding.stat(pathModule._makeLong(path), statValues);
+  binding.stat(pathModule._makeLong(path));
   return statsFromValues();
 };
 
@@ -1380,6 +1407,15 @@ function emitStop(self) {
   self.emit('stop');
 }
 
+function statsFromPrevValues() {
+  return new Stats(statValues[14], statValues[15], statValues[16],
+                   statValues[17], statValues[18], statValues[19],
+                   statValues[20] < 0 ? undefined : statValues[20],
+                   statValues[21], statValues[22],
+                   statValues[23] < 0 ? undefined : statValues[23],
+                   statValues[24], statValues[25], statValues[26],
+                   statValues[27]);
+}
 function StatWatcher() {
   EventEmitter.call(this);
 
@@ -1390,13 +1426,13 @@ function StatWatcher() {
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(current, previous, newStatus) {
+  this._handle.onchange = function(newStatus) {
     if (oldStatus === -1 &&
         newStatus === -1 &&
-        current.nlink === previous.nlink) return;
+        statValues[2/*new nlink*/] === statValues[16/*old nlink*/]) return;
 
     oldStatus = newStatus;
-    self.emit('change', current, previous);
+    self.emit('change', statsFromValues(), statsFromPrevValues());
   };
 
   this._handle.onstop = function() {
@@ -1544,7 +1580,7 @@ fs.realpathSync = function realpathSync(p, options) {
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
-    fs.lstatSync(base);
+    binding.lstat(pathModule._makeLong(base));
     knownHard[base] = true;
   }
 
@@ -1576,8 +1612,12 @@ fs.realpathSync = function realpathSync(p, options) {
     if (maybeCachedResolved) {
       resolvedLink = maybeCachedResolved;
     } else {
-      var stat = fs.lstatSync(base);
-      if (!stat.isSymbolicLink()) {
+      // Use stats array directly to avoid creating an fs.Stats instance just
+      // for our internal use.
+
+      binding.lstat(pathModule._makeLong(base));
+
+      if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
         knownHard[base] = true;
         if (cache) cache.set(base, base);
         continue;
@@ -1588,14 +1628,16 @@ fs.realpathSync = function realpathSync(p, options) {
       var linkTarget = null;
       var id;
       if (!isWindows) {
-        id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+        var dev = statValues[0/*dev*/].toString(32);
+        var ino = statValues[7/*ino*/].toString(32);
+        id = `${dev}:${ino}`;
         if (seenLinks.hasOwnProperty(id)) {
           linkTarget = seenLinks[id];
         }
       }
       if (linkTarget === null) {
-        fs.statSync(base);
-        linkTarget = fs.readlinkSync(base);
+        binding.stat(pathModule._makeLong(base));
+        linkTarget = binding.readlink(pathModule._makeLong(base));
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 
@@ -1614,7 +1656,7 @@ fs.realpathSync = function realpathSync(p, options) {
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
-      fs.lstatSync(base);
+      binding.lstat(pathModule._makeLong(base));
       knownHard[base] = true;
     }
   }
@@ -1694,11 +1736,14 @@ fs.realpath = function realpath(p, options, callback) {
     return fs.lstat(base, gotStat);
   }
 
-  function gotStat(err, stat) {
+  function gotStat(err) {
     if (err) return callback(err);
 
+    // Use stats array directly to avoid creating an fs.Stats instance just for
+    // our internal use.
+
     // if not a symlink, skip to the next path part
-    if (!stat.isSymbolicLink()) {
+    if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
       knownHard[base] = true;
       return process.nextTick(LOOP);
     }
@@ -1708,7 +1753,9 @@ fs.realpath = function realpath(p, options, callback) {
     // dev/ino always return 0 on windows, so skip the check.
     let id;
     if (!isWindows) {
-      id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+      var dev = statValues[0/*ino*/].toString(32);
+      var ino = statValues[7/*ino*/].toString(32);
+      id = `${dev}:${ino}`;
       if (seenLinks.hasOwnProperty(id)) {
         return gotTarget(null, seenLinks[id], base);
       }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -199,6 +199,7 @@ inline Environment::Environment(IsolateData* isolate_data,
 #endif
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
+      fs_stats_field_array_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());
@@ -378,6 +379,15 @@ inline char* Environment::http_parser_buffer() const {
 inline void Environment::set_http_parser_buffer(char* buffer) {
   CHECK_EQ(http_parser_buffer_, nullptr);  // Should be set only once.
   http_parser_buffer_ = buffer;
+}
+
+inline double* Environment::fs_stats_field_array() const {
+  return fs_stats_field_array_;
+}
+
+inline void Environment::set_fs_stats_field_array(double* fields) {
+  CHECK_EQ(fs_stats_field_array_, nullptr);  // Should be set only once.
+  fs_stats_field_array_ = fields;
 }
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {

--- a/src/env.h
+++ b/src/env.h
@@ -253,7 +253,6 @@ namespace node {
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(domains_stack_array, v8::Array)                                           \
-  V(fs_stats_constructor_function, v8::Function)                              \
   V(generic_internal_field_template, v8::ObjectTemplate)                      \
   V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
@@ -492,6 +491,9 @@ class Environment {
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
 
+  inline double* fs_stats_field_array() const;
+  inline void set_fs_stats_field_array(double* fields);
+
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
   inline void ThrowRangeError(const char* errmsg);
@@ -599,6 +601,8 @@ class Environment {
   double* heap_space_statistics_buffer_ = nullptr;
 
   char* http_parser_buffer_;
+
+  double* fs_stats_field_array_;
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -162,7 +162,7 @@ NO_RETURN void FatalError(const char* location, const char* message);
 
 void ProcessEmitWarning(Environment* env, const char* fmt, ...);
 
-v8::Local<v8::Value> BuildStatsObject(Environment* env, const uv_stat_t* s);
+void FillStatsArray(double* fields, const uv_stat_t* s);
 
 void SetupProcessObject(Environment* env,
                         int argc,

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -86,12 +86,11 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
   Environment* env = wrap->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-  Local<Value> argv[] = {
-    BuildStatsObject(env, curr),
-    BuildStatsObject(env, prev),
-    Integer::New(env->isolate(), status)
-  };
-  wrap->MakeCallback(env->onchange_string(), arraysize(argv), argv);
+
+  FillStatsArray(env->fs_stats_field_array(), curr);
+  FillStatsArray(env->fs_stats_field_array() + 14, prev);
+  Local<Value> arg = Integer::New(env->isolate(), status);
+  wrap->MakeCallback(env->onchange_string(), 1, &arg);
 }
 
 

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -39,7 +39,7 @@ fs.writeSync = function() {
   throw new Error('BAM');
 };
 
-fs.fstatSync = function() {
+process.binding('fs').fstat = function() {
   throw new Error('BAM');
 };
 


### PR DESCRIPTION
`stat*()` optimizations including:

* Move async `*stat()` functions to `FillStatsArray()` now used by the sync `*stat()` functions

* Avoid creating `fs.Stats` instances for implicit async/sync `*stat()` calls used in various `fs` functions

* Store reference to `Float64Array` data on C++ side for easier/faster access, instead of passing from JS to C++ on every async/sync `*stat()` call

Additionally, there are some further `realpath*()` optimizations, including:

* Skip URL instance check for common (string) cases

* Avoid regexp on non-Windows platforms when parsing the root of a path

* Skip call to `getOptions()` in common case where no `options` is passed

* Avoid `hasOwnProperty()`

Some benchmark results with all of the changes in this PR:

```
                                                                        improvement confidence      p.value
 fs/readfile.js concurrent=1 len=1024 dur=5                                  5.50 %            0.177524964
 fs/readfile.js concurrent=1 len=16777216 dur=5                             -0.26 %            0.860522023
 fs/readfile.js concurrent=10 len=1024 dur=5                                 7.57 %         ** 0.004268331
 fs/readfile.js concurrent=10 len=16777216 dur=5                            -0.35 %            0.374914593
 fs/bench-stat.js kind="fstat" n=200000                                      3.71 %         ** 0.002509243
 fs/bench-stat.js kind="lstat" n=200000                                      3.16 %         ** 0.001381068
 fs/bench-stat.js kind="stat" n=200000                                       4.13 %          * 0.019328676
 fs/readFileSync.js n=600000                                                20.27 %        *** 2.313943e-38
 fs/bench-statSync.js kind="fstatSync" n=1000000                             2.01 %            1.066663e-01
 fs/bench-statSync.js kind="lstatSync" n=1000000                             4.42 %        *** 4.163876e-06
 fs/bench-statSync.js kind="statSync" n=1000000                              3.46 %        *** 1.333101e-06
 fs/bench-realpathSync.js type="resolved" n=300000                          86.06 %        *** 3.681945e-42
 fs/bench-realpathSync.js type="relative" n=400000                          61.71 %        *** 1.349012e-54
 fs/bench-realpath.js type="resolved" n=30000                                6.00 %        *** 3.601045e-11
 fs/bench-realpath.js type="relative" n=100000                               7.61 %        *** 3.163175e-14
 module/module-loader.js useCache="false" fullPath="false" thousands=50      5.05 %        *** 1.426385e-19
 module/module-loader.js useCache="false" fullPath="true" thousands=50       5.15 %        *** 6.171543e-16
```

I'm initially marking this as semver-major because of the changes in `fs.readFile()`, `fs.readFileSync()`, etc. in how they retrieve stats for files/directories. If someone monkey patches `fs.*sync*()`, those monkey matched methods would no longer be called from those changed functions (`fs.readFile()`, etc.). If we feel we shouldn't be worried about this, then I will gladly remove the label.

CI: https://ci.nodejs.org/job/node-test-pull-request/6674/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* fs