### PR TITLE
build: fix llvm version detection in freebsd-10

### DIFF
--- a/configure
+++ b/configure
@@ -576,8 +576,7 @@ def get_version_helper(cc, regexp):
 
 def get_llvm_version(cc):
   return get_version_helper(
-    cc, r"(^clang version|^FreeBSD clang version|based on LLVM) " +
-    "([3-9]\.[0-9]+)")
+    cc, r"(^(?:FreeBSD )?clang version|based on LLVM) ([3-9]\.[0-9]+)")
 
 def get_xcode_version(cc):
   return get_version_helper(

--- a/configure
+++ b/configure
@@ -576,7 +576,8 @@ def get_version_helper(cc, regexp):
 
 def get_llvm_version(cc):
   return get_version_helper(
-      cc, r"(^clang version|based on LLVM) ([3-9]\.[0-9]+)")
+      cc, r"(^clang version|^FreeBSD clang version|based on LLVM) " +
+      "([3-9]\.[0-9]+)")
 
 def get_xcode_version(cc):
   return get_version_helper(

--- a/configure
+++ b/configure
@@ -576,12 +576,12 @@ def get_version_helper(cc, regexp):
 
 def get_llvm_version(cc):
   return get_version_helper(
-      cc, r"(^clang version|^FreeBSD clang version|based on LLVM) " +
-      "([3-9]\.[0-9]+)")
+    cc, r"(^clang version|^FreeBSD clang version|based on LLVM) " +
+    "([3-9]\.[0-9]+)")
 
 def get_xcode_version(cc):
   return get_version_helper(
-      cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
+    cc, r"(^Apple LLVM version) ([5-9]\.[0-9]+)")
 
 def get_gas_version(cc):
   try:


### PR DESCRIPTION
In FreeBSD-10, the banner of clang version start with "FreeBSD clang version" but the current `configure` checks `/^clang version/` so that `llvm_version` is 0 and openssl is built with asm_obsolete. 

This can be seen in the CI output of https://ci.nodejs.org/job/node-test-commit-freebsd/7417/nodes=freebsd10-64/consoleFull that `'llvm_version': 0,` in the current configure output. 

With this fix, the clang version banner can be checked properly in FreeBSD-10. The result of  https://ci.nodejs.org/job/node-test-commit-freebsd/7419/nodes=freebsd10-64/consoleFull shows that  ` 'llvm_version': '3.4',`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

CC: @nodejs/platform-freebsd or @nodejs/build 