### PR TITLE
src: remove outdated FIXME in node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5999,7 +5999,6 @@ void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
 #endif /* NODE_FIPS_MODE */
 }
 
-// FIXME(bnoordhuis) Handle global init correctly.
 void InitCrypto(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,


### PR DESCRIPTION
Issue 4641 contains a FIXME regarding the InitCrypto function. After
discussing this with bnoordhuis it seems to be an outdated comment.

Refs: https://github.com/nodejs/node/issues/4641

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src