### PR TITLE
test: failing behaviour on sandboxed Proxy

### DIFF
--- a/test/known_issues/test-vm-proxy-failure-CP.js
+++ b/test/known_issues/test-vm-proxy-failure-CP.js
@@ -1,0 +1,18 @@
+'use strict';
+
+//Sandbox throws in CopyProperties() despite no code being run
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const handler = {
+    getOwnPropertyDescriptor: (target, prop) => {
+      throw new Error('whoops');
+    }
+};
+const sandbox = new Proxy({foo: 'bar'}, handler);
+const context = vm.createContext(sandbox);
+
+
+assert.doesNotThrow(() => vm.runInContext('', context));

--- a/test/parallel/test-vm-proxies.js
+++ b/test/parallel/test-vm-proxies.js
@@ -16,16 +16,3 @@ sandbox = { Proxy: Proxy };
 vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert.strictEqual(typeof sandbox.Proxy, 'function');
 assert.strictEqual(sandbox.Proxy, Proxy);
-
-// Handle a sandbox that throws while copying properties
-assert.throws(() => {
-  const handler = {
-    getOwnPropertyDescriptor: (target, prop) => {
-      throw new Error('whoops');
-    }
-  };
-  const sandbox = new Proxy({foo: 'bar'}, handler);
-  const context = vm.createContext(sandbox);
-
-  vm.runInContext('', context);
-}, /whoops/);


### PR DESCRIPTION
CopyProperties() causes sandboxed Proxy to throw error
despite no code being run. The CopyProperties() function 
will be removed shortly with the updates to the V8 API.

Here, failing Proxy test case is moved to known_issues.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

