### PR TITLE
util: fix inspecting symbol key in string

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -361,6 +361,10 @@ function formatValue(ctx, value, recurseTimes) {
     // for boxed Strings, we have to remove the 0-n indexed entries,
     // since they just noisy up the output and are redundant
     keys = keys.filter(function(key) {
+      if (typeof key === 'symbol') {
+        return true;
+      }
+
       return !(key >= 0 && key < raw.length);
     });
   }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -51,8 +51,8 @@ assert.strictEqual(util.inspect(Object.create({},
                    '{ visible: 1 }'
 );
 assert.strictEqual(util.inspect(Object.assign(new String('hello'),
-                    { [Symbol('foo')]: 123 }), { showHidden: true }),
-                    '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }')
+                   { [Symbol('foo')]: 123 }), { showHidden: true }),
+                   '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }');
 
 {
   const regexp = /regexp/;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -50,6 +50,9 @@ assert.strictEqual(util.inspect(Object.create({},
   {visible: {value: 1, enumerable: true}, hidden: {value: 2}})),
                    '{ visible: 1 }'
 );
+assert.strictEqual(util.inspect(Object.assign(new String('hello'),
+                    { [Symbol('foo')]: 123 }), { showHidden: true }),
+                    '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }')
 
 {
   const regexp = /regexp/;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I had to use type check to avoid checking Symbols in numeric conditions.

Fixes:  #11659 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- util