### PR TITLE
doc: fixed readable.isPaused() 'Added in version' annotation

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -737,7 +737,7 @@ end
 preferred over the use of the `'readable'` event.
 
 ##### readable.isPaused()
-<!--
+<!-- YAML
 added: v0.11.14
 -->
 


### PR DESCRIPTION
readable.isPaused(): added a missing YAML placeholder so the 'Added in version' annotation can be displayed in docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc