### PR TITLE
doc: note removeListener doesn't work with once()

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -499,7 +499,10 @@ added: v0.1.26
 -->
 
 Removes the specified `listener` from the listener array for the event named
-`eventName`.
+`eventName`. 
+
+Note that a `listener` added with `once()` cannot be removed using 
+`removeListener`. To achieve that, use `removeAllListeners`.
 
 ```js
 var callback = (stream) => {


### PR DESCRIPTION
The once method wraps the function, rendering it different than the original.

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc
