### PR TITLE
test: fail when child died in fork-net

### DIFF
--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const fork = require('child_process').fork;
 const net = require('net');
@@ -81,9 +81,10 @@ if (process.argv[2] === 'child') {
 
   const child = fork(process.argv[1], ['child']);
 
-  child.on('exit', function() {
-    console.log('CHILD: died');
-  });
+  child.on('exit', common.mustCall(function(code, signal) {
+    const message = `CHILD: died with ${code}, ${signal}`;
+    assert.strictEqual(code, 0, message);
+  }));
 
   // send net.Server to child and test by connecting
   const testServer = function(callback) {
@@ -192,7 +193,6 @@ if (process.argv[2] === 'child') {
 
       testSocket(function() {
         socketSuccess = true;
-        child.kill();
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Previously when the child dies with errors in this test, the parent will just hang and timeout, the errors in the child would be swallowed. This PR makes it fail so at least there is more information about why this test fails.

On a side note, looks like this test is the only test that is touching the `options instanceof TCP` section in `net.Server.prototyp.listen`, and it is touching an undocumented API (calling `net.Server.prototyp.listen` on the TCP handle directly instead of putting it in an object's `handle` or `_handle`) indirectly through child_process. This probably means the documented API for handles (like `{handle: new TCP()}`) doesn't get any direct test coverage.

Refs: https://github.com/nodejs/node/pull/11667

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, child_process, net