### PR TITLE
cli: ensure --check flag works for piped-in code

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -116,7 +116,7 @@
       if (process._eval != null && !process._forceRepl) {
         if (process._syntax_check_only != null) {
           console.error('--check and --eval flags are mutually exclusive.');
-          process.exit(1);
+          process.exit(9);
         }
         // User passed '-e' or '--eval' arguments to Node without '-i' or
         // '--interactive'

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -136,7 +136,7 @@
           // read the source
           const filename = Module._resolveFilename(process.argv[1]);
           var source = fs.readFileSync(filename, 'utf-8');
-          checkScriptSyntax(source);
+          checkScriptSyntax(source, filename);
           process.exit(0);
         }
 
@@ -178,7 +178,7 @@
 
           process.stdin.on('end', function() {
             if (process._syntax_check_only != null) {
-              checkScriptSyntax(code);
+              checkScriptSyntax(code, '[stdin]');
             } else {
               process._eval = code;
               evalScript('[stdin]');
@@ -442,7 +442,7 @@
     }
   }
 
-  function checkScriptSyntax(source) {
+  function checkScriptSyntax(source, filename) {
     const Module = NativeModule.require('module');
     const vm = NativeModule.require('vm');
     const internalModule = NativeModule.require('internal/module');
@@ -452,7 +452,7 @@
     // wrap it
     source = Module.wrap(source);
     // compile the script, this will throw if it fails
-    new vm.Script(source, {displayErrors: true});
+    new vm.Script(source, {displayErrors: true, filename});
   }
 
   // Below you find a minimal module system, which is used to load the node

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -132,18 +132,11 @@
 
         // check if user passed `-c` or `--check` arguments to Node.
         if (process._syntax_check_only != null) {
-          const vm = NativeModule.require('vm');
           const fs = NativeModule.require('fs');
-          const internalModule = NativeModule.require('internal/module');
           // read the source
           const filename = Module._resolveFilename(process.argv[1]);
           var source = fs.readFileSync(filename, 'utf-8');
-          // remove shebang and BOM
-          source = internalModule.stripBOM(source.replace(/^#!.*/, ''));
-          // wrap it
-          source = Module.wrap(source);
-          // compile the script, this will throw if it fails
-          new vm.Script(source, {filename: filename, displayErrors: true});
+          checkScriptSyntax(source);
           process.exit(0);
         }
 
@@ -184,8 +177,12 @@
           });
 
           process.stdin.on('end', function() {
-            process._eval = code;
-            evalScript('[stdin]');
+            if (process._syntax_check_only != null) {
+              checkScriptSyntax(code);
+            } else {
+              process._eval = code;
+              evalScript('[stdin]');
+            }
           });
         }
       }
@@ -443,6 +440,19 @@
       // Main entry point into most programs:
       entryFunction();
     }
+  }
+
+  function checkScriptSyntax(source) {
+    const Module = NativeModule.require('module');
+    const vm = NativeModule.require('vm');
+    const internalModule = NativeModule.require('internal/module');
+
+    // remove shebang and BOM
+    source = internalModule.stripBOM(source.replace(/^#!.*/, ''));
+    // wrap it
+    source = Module.wrap(source);
+    // compile the script, this will throw if it fails
+    new vm.Script(source, {displayErrors: true});
   }
 
   // Below you find a minimal module system, which is used to load the node

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -114,6 +114,10 @@
       }
 
       if (process._eval != null && !process._forceRepl) {
+        if (process._syntax_check_only != null) {
+          console.error('--check and --eval flags are mutually exclusive.');
+          process.exit(1);
+        }
         // User passed '-e' or '--eval' arguments to Node without '-i' or
         // '--interactive'
         preloadModules();

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -114,10 +114,6 @@
       }
 
       if (process._eval != null && !process._forceRepl) {
-        if (process._syntax_check_only != null) {
-          console.error('--check and --eval flags are mutually exclusive.');
-          process.exit(9);
-        }
         // User passed '-e' or '--eval' arguments to Node without '-i' or
         // '--interactive'
         preloadModules();

--- a/src/node.cc
+++ b/src/node.cc
@@ -3800,6 +3800,12 @@ static void ParseArgs(int* argc,
   }
 #endif
 
+  if (eval_string != nullptr && syntax_check_only) {
+    fprintf(stderr,
+            "%s: either --check or --eval can be used, not both\n", argv[0]);
+    exit(9);
+  }
+
   // Copy remaining arguments.
   const unsigned int args_left = nargs - index;
   memcpy(new_argv + new_argc, argv + index, args_left * sizeof(*argv));

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -99,7 +99,7 @@ syntaxArgs.forEach(function(args) {
   assert.strictEqual(c.status, 0, 'code == ' + c.status);
 });
 
-// should should throw if code piped from stdin with --check has bad syntax
+// should throw if code piped from stdin with --check has bad syntax
 // loop each possible option, `-c` or `--check`
 syntaxArgs.forEach(function(args) {
   const stdin = 'var foo bar;';

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -52,6 +52,9 @@ const syntaxArgs = [
     // no stdout should be produced
     assert.strictEqual(c.stdout, '', 'stdout produced');
 
+    // stderr should include the filename
+    assert(c.stderr.startsWith(file), "stderr doesn't start with the filename");
+
     // stderr should have a syntax error message
     const match = c.stderr.match(/^SyntaxError: Unexpected identifier$/m);
     assert(match, 'stderr incorrect');
@@ -94,4 +97,23 @@ syntaxArgs.forEach(function(args) {
   assert.strictEqual(c.stderr, '', 'stderr produced');
 
   assert.strictEqual(c.status, 0, 'code == ' + c.status);
+});
+
+// should should throw if code piped from stdin with --check has bad syntax
+// loop each possible option, `-c` or `--check`
+syntaxArgs.forEach(function(args) {
+  const stdin = 'var foo bar;';
+  const c = spawnSync(node, args, {encoding: 'utf8', input: stdin});
+
+  // stderr should include '[stdin]' as the filename
+  assert(c.stderr.startsWith('[stdin]'), "stderr doesn't start with [stdin]");
+
+  // no stdout or stderr should be produced
+  assert.strictEqual(c.stdout, '', 'stdout produced');
+
+  // stderr should have a syntax error message
+  const match = c.stderr.match(/^SyntaxError: Unexpected identifier$/m);
+  assert(match, 'stderr incorrect');
+
+  assert.strictEqual(c.status, 1, 'code == ' + c.status);
 });

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -126,7 +126,7 @@ syntaxArgs.forEach(function(args) {
 
     assert.strictEqual(
       c.stderr,
-      '--check and --eval flags are mutually exclusive.\n'
+      `${node}: either --check or --eval can be used, not both\n`
     );
 
     assert.strictEqual(c.status, 9, 'code === ' + c.status);

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -117,3 +117,18 @@ syntaxArgs.forEach(function(args) {
 
   assert.strictEqual(c.status, 1, 'code == ' + c.status);
 });
+
+// should throw if -c and -e flags are both passed
+['-c', '--check'].forEach(function(checkFlag) {
+  ['-e', '--eval'].forEach(function(evalFlag) {
+    const args = [checkFlag, evalFlag, 'foo'];
+    const c = spawnSync(node, args, {encoding: 'utf8'});
+
+    assert.strictEqual(
+      c.stderr,
+      '--check and --eval flags are mutually exclusive.\n'
+    );
+
+    assert.strictEqual(c.status, 1, 'code == ' + c.status);
+  });
+});

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -82,3 +82,16 @@ const syntaxArgs = [
     assert.strictEqual(c.status, 1, 'code == ' + c.status);
   });
 });
+
+// should not execute code piped from stdin with --check
+// loop each possible option, `-c` or `--check`
+syntaxArgs.forEach(function(args) {
+  const stdin = 'throw new Error("should not get run");';
+  const c = spawnSync(node, args, {encoding: 'utf8', input: stdin});
+
+  // no stdout or stderr should be produced
+  assert.strictEqual(c.stdout, '', 'stdout produced');
+  assert.strictEqual(c.stderr, '', 'stderr produced');
+
+  assert.strictEqual(c.status, 0, 'code == ' + c.status);
+});

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -129,6 +129,6 @@ syntaxArgs.forEach(function(args) {
       '--check and --eval flags are mutually exclusive.\n'
     );
 
-    assert.strictEqual(c.status, 9, 'code == ' + c.status);
+    assert.strictEqual(c.status, 9, 'code === ' + c.status);
   });
 });

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -129,6 +129,6 @@ syntaxArgs.forEach(function(args) {
       '--check and --eval flags are mutually exclusive.\n'
     );
 
-    assert.strictEqual(c.status, 1, 'code == ' + c.status);
+    assert.strictEqual(c.status, 9, 'code == ' + c.status);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

Previously, the --check CLI flag had no effect when run on code piped
from stdin. This commit updates the bootstrap logic to handle the
--check flag the same way regardless of whether the code is piped from
stdin.

Fixes: https://github.com/nodejs/node/issues/11680

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

lib