### PR TITLE
url: avoid instanceof for WHATWG URL

### DIFF
--- a/benchmark/url/url-searchparams-read.js
+++ b/benchmark/url/url-searchparams-read.js
@@ -5,7 +5,7 @@ const { URLSearchParams } = require('url');
 const bench = common.createBenchmark(main, {
   method: ['get', 'getAll', 'has'],
   param: ['one', 'two', 'three', 'nonexistent'],
-  n: [1e6]
+  n: [2e7]
 });
 
 const str = 'one=single&two=first&three=first&two=2nd&three=2nd&three=3rd';

--- a/benchmark/url/whatwg-url-properties.js
+++ b/benchmark/url/whatwg-url-properties.js
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
   prop: ['href', 'origin', 'protocol',
          'username', 'password', 'host', 'hostname', 'port',
          'pathname', 'search', 'searchParams', 'hash'],
-  n: [1e4]
+  n: [3e5]
 });
 
 function setAndGet(n, url, prop, alternative) {

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -239,8 +239,10 @@ class URL {
   constructor(input, base) {
     // toUSVString is not needed.
     input = `${input}`;
-    if (base !== undefined && !(base instanceof URL))
+    if (base !== undefined &&
+        (!base[searchParams] || !base[searchParams][searchParams])) {
       base = new URL(base);
+    }
     parse(this, input, base);
   }
 
@@ -885,7 +887,7 @@ class URLSearchParams {
   }
 
   [util.inspect.custom](recurseTimes, ctx) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
@@ -947,7 +949,7 @@ function merge(out, start, mid, end, lBuffer, rBuffer) {
 
 defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   append(name, value) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 2) {
@@ -961,7 +963,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   delete(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
@@ -982,7 +984,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   get(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
@@ -1000,7 +1002,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   getAll(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
@@ -1019,7 +1021,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   has(name) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 1) {
@@ -1037,7 +1039,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   set(name, value) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (arguments.length < 2) {
@@ -1125,7 +1127,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   // Define entries here rather than [Symbol.iterator] as the function name
   // must be set to `entries`.
   entries() {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
@@ -1133,7 +1135,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   forEach(callback, thisArg = undefined) {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
     if (typeof callback !== 'function') {
@@ -1155,7 +1157,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
 
   // https://heycam.github.io/webidl/#es-iterable
   keys() {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
@@ -1163,7 +1165,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   },
 
   values() {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
@@ -1173,7 +1175,7 @@ defineIDLClass(URLSearchParams.prototype, 'URLSearchParams', {
   // https://heycam.github.io/webidl/#es-stringifier
   // https://url.spec.whatwg.org/#urlsearchparams-stringification-behavior
   toString() {
-    if (!this || !(this instanceof URLSearchParams)) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
       throw new TypeError('Value of `this` is not a URLSearchParams');
     }
 
@@ -1275,8 +1277,10 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParamsIterator', {
 });
 
 function originFor(url, base) {
-  if (!(url instanceof URL))
+  if (url != undefined &&
+      (!url[searchParams] || !url[searchParams][searchParams])) {
     url = new URL(url, base);
+  }
   var origin;
   const protocol = url.protocol;
   switch (protocol) {
@@ -1393,8 +1397,10 @@ function getPathFromURLPosix(url) {
 }
 
 function getPathFromURL(path) {
-  if (!(path instanceof URL))
+  if (path == undefined || !path[searchParams] ||
+      !path[searchParams][searchParams]) {
     return path;
+  }
   if (path.protocol !== 'file:')
     return new TypeError('Only `file:` URLs are supported');
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);


### PR DESCRIPTION
This PR replaces `instanceof` checks with symbol checks. Various relevant results:

```
                                                                             improvement confidence      p.value
 url/url-searchparams-read.js n=50000000 param="nonexistent" method="get"       195.08 %        *** 5.548226e-41
 url/url-searchparams-read.js n=50000000 param="nonexistent" method="getAll"    174.48 %        *** 3.225875e-29
 url/url-searchparams-read.js n=50000000 param="nonexistent" method="has"       190.68 %        *** 9.000669e-32
 url/url-searchparams-read.js n=50000000 param="one" method="get"               269.63 %        *** 2.180791e-33
 url/url-searchparams-read.js n=50000000 param="one" method="getAll"            111.73 %        *** 1.724534e-25
 url/url-searchparams-read.js n=50000000 param="one" method="has"               266.25 %        *** 5.498456e-33
 url/url-searchparams-read.js n=50000000 param="three" method="get"             203.56 %        *** 2.754902e-45
 url/url-searchparams-read.js n=50000000 param="three" method="getAll"          108.95 %        *** 1.790912e-35
 url/url-searchparams-read.js n=50000000 param="three" method="has"             198.65 %        *** 1.896093e-32
 url/url-searchparams-read.js n=50000000 param="two" method="get"               248.88 %        *** 4.737990e-41
 url/url-searchparams-read.js n=50000000 param="two" method="getAll"            112.93 %        *** 2.182157e-31
 url/url-searchparams-read.js n=50000000 param="two" method="has"               224.41 %        *** 2.056153e-30
 url/whatwg-url-properties.js n=10000000 prop="origin" input="auth"              12.59 %         ** 0.0035532598
 url/whatwg-url-properties.js n=10000000 prop="origin" input="dot"               10.53 %         ** 0.0041671062
 url/whatwg-url-properties.js n=10000000 prop="origin" input="file"              72.86 %        *** 0.0004049447
 url/whatwg-url-properties.js n=10000000 prop="origin" input="idn"                5.76 %            0.1494657794
 url/whatwg-url-properties.js n=10000000 prop="origin" input="javascript"        54.73 %         ** 0.0018129659
 url/whatwg-url-properties.js n=10000000 prop="origin" input="long"              10.20 %          * 0.0429791847
 url/whatwg-url-properties.js n=10000000 prop="origin" input="percent"            1.84 %            0.3920201593
 url/whatwg-url-properties.js n=10000000 prop="origin" input="short"             11.54 %        *** 0.0001064664
 url/whatwg-url-properties.js n=10000000 prop="origin" input="ws"                10.64 %         ** 0.0074980105
```

CI: https://ci.nodejs.org/job/node-test-pull-request/6707/

/cc @nodejs/url

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* url-whatwg
