### PR TITLE
WHATWG URL origin cleanup + tests

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1112,7 +1112,6 @@ function originFor(url, base) {
     case 'https:':
     case 'ws:':
     case 'wss:':
-    case 'file':
       origin = new TupleOrigin(protocol.slice(0, -1),
                                url[context].host,
                                url[context].port,

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -142,3 +142,19 @@ assert.strictEqual(url.searchParams, oldParams);
   assert.strictEqual(opts.search, '?l=24');
   assert.strictEqual(opts.hash, '#test');
 }
+
+// Test special origins
+[
+  { expected: 'https://whatwg.org',
+    url: 'blob:https://whatwg.org/d0360e2f-caee-469f-9a2f-87d5b0456f6f' },
+  { expected: 'ftp://example.org', url: 'ftp://example.org/foo' },
+  { expected: 'gopher://gopher.quux.org', url: 'gopher://gopher.quux.org/1/' },
+  { expected: 'http://example.org', url: 'http://example.org/foo' },
+  { expected: 'https://example.org', url: 'https://example.org/foo' },
+  { expected: 'ws://example.org', url: 'ws://example.org/foo' },
+  { expected: 'wss://example.org', url: 'wss://example.org/foo' },
+  { expected: 'null', url: 'file:///tmp/mock/path' },
+  { expected: 'null', url: 'npm://nodejs/rules' }
+].forEach((test) => {
+  assert.strictEqual(new URL(test.url).origin, test.expected);
+});


### PR DESCRIPTION
`'file'` should have been `'file:'` but since the WHATWG URL spec suggests using an opaque origin (which is what was already being used for file URLs), we'll just keep using that, making this merely a cleanup.

Additionally, some more origin tests are added.

CI: https://ci.nodejs.org/job/node-test-pull-request/6708/

/cc @nodejs/url

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* url-whatwg
