### PR TITLE
doc: reduce font size on smaller screens

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -487,7 +487,7 @@ th > *:last-child, td > *:last-child {
 
 @media only screen and (max-width: 1024px) {
   #content {
-    font-size: 2.5em;
+    font-size: 1.6em;
     overflow: visible;
   }
   #column1.interior {


### PR DESCRIPTION
The font size for tablet sized screens (or half a laptop screen) is overly
large, reduce it to a more readable size.

Fixes: https://github.com/nodejs/nodejs.org/issues/919

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc