### PR TITLE
dgram: refactor dgram to module.exports

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -57,7 +57,7 @@ function newHandle(type) {
 }
 
 
-exports._createSocketHandle = function(address, port, addressType, fd, flags) {
+function _createSocketHandle(address, port, addressType, fd, flags) {
   // Opening an existing fd is not supported for UDP handles.
   assert(typeof fd !== 'number' || fd < 0);
 
@@ -72,7 +72,7 @@ exports._createSocketHandle = function(address, port, addressType, fd, flags) {
   }
 
   return handle;
-};
+}
 
 
 function Socket(type, listener) {
@@ -99,12 +99,11 @@ function Socket(type, listener) {
     this.on('message', listener);
 }
 util.inherits(Socket, EventEmitter);
-exports.Socket = Socket;
 
 
-exports.createSocket = function(type, listener) {
+function createSocket(type, listener) {
   return new Socket(type, listener);
-};
+}
 
 
 function startListening(socket) {
@@ -584,4 +583,10 @@ Socket.prototype.unref = function() {
     this._handle.unref();
 
   return this;
+};
+
+module.exports = {
+  _createSocketHandle,
+  createSocket,
+  Socket
 };


### PR DESCRIPTION
Refactor dgram module to use the more efficient
module.exports = {} pattern.

See https://github.com/nodejs/node/pull/11611

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dgram