### PR TITLE
net: refactor net module to module.exports

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -62,9 +62,9 @@ function isPipeName(s) {
   return typeof s === 'string' && toNumber(s) === false;
 }
 
-exports.createServer = function(options, connectionListener) {
+function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
-};
+}
 
 
 // Target API:
@@ -79,7 +79,7 @@ exports.createServer = function(options, connectionListener) {
 // connect(port, [host], [cb])
 // connect(path, [cb]);
 //
-exports.connect = exports.createConnection = function() {
+function connect() {
   const args = new Array(arguments.length);
   for (var i = 0; i < arguments.length; i++)
     args[i] = arguments[i];
@@ -95,7 +95,7 @@ exports.connect = exports.createConnection = function() {
   }
 
   return Socket.prototype.connect.call(socket, options, cb);
-};
+}
 
 
 // Returns an array [options, cb], where options is an object,
@@ -135,7 +135,6 @@ function normalizeArgs(args) {
   else
     return [options, cb];
 }
-exports._normalizeArgs = normalizeArgs;
 
 
 // called when creating new Socket, or when re-using a closed Socket
@@ -332,9 +331,6 @@ function writeAfterFIN(chunk, encoding, cb) {
     process.nextTick(cb, er);
   }
 }
-
-exports.Socket = Socket;
-exports.Stream = Socket; // Legacy naming.
 
 Socket.prototype.read = function(n) {
   if (n === 0)
@@ -850,7 +846,8 @@ function afterWrite(status, handle, req, err) {
 }
 
 
-function connect(self, address, port, addressType, localAddress, localPort) {
+function internalConnect(
+  self, address, port, addressType, localAddress, localPort) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
 
@@ -964,7 +961,7 @@ Socket.prototype.connect = function() {
   this.writable = true;
 
   if (pipe) {
-    connect(this, options.path);
+    internalConnect(this, options.path);
   } else {
     lookupAndConnect(this, options);
   }
@@ -979,7 +976,7 @@ function lookupAndConnect(self, options) {
   var localAddress = options.localAddress;
   var localPort = options.localPort;
 
-  if (localAddress && !exports.isIP(localAddress))
+  if (localAddress && !cares.isIP(localAddress))
     throw new TypeError('"localAddress" option must be a valid IP: ' +
                         localAddress);
 
@@ -996,11 +993,11 @@ function lookupAndConnect(self, options) {
   port |= 0;
 
   // If host is an IP, skip performing a lookup
-  var addressType = exports.isIP(host);
+  var addressType = cares.isIP(host);
   if (addressType) {
     process.nextTick(function() {
       if (self.connecting)
-        connect(self, host, port, addressType, localAddress, localPort);
+        internalConnect(self, host, port, addressType, localAddress, localPort);
     });
     return;
   }
@@ -1040,12 +1037,12 @@ function lookupAndConnect(self, options) {
       process.nextTick(connectErrorNT, self, err);
     } else {
       self._unrefTimer();
-      connect(self,
-              ip,
-              port,
-              addressType,
-              localAddress,
-              localPort);
+      internalConnect(self,
+                      ip,
+                      port,
+                      addressType,
+                      localAddress,
+                      localPort);
     }
   });
 }
@@ -1177,7 +1174,6 @@ function Server(options, connectionListener) {
   this.pauseOnConnect = !!options.pauseOnConnect;
 }
 util.inherits(Server, EventEmitter);
-exports.Server = Server;
 
 
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
@@ -1244,7 +1240,6 @@ function createServerHandle(address, port, addressType, fd) {
 
   return handle;
 }
-exports._createServerHandle = createServerHandle;
 
 
 Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
@@ -1618,20 +1613,12 @@ Server.prototype.unref = function() {
   return this;
 };
 
-
-exports.isIP = cares.isIP;
-
-
-exports.isIPv4 = cares.isIPv4;
-
-
-exports.isIPv6 = cares.isIPv6;
-
+var _setSimultaneousAccepts;
 
 if (process.platform === 'win32') {
   var simultaneousAccepts;
 
-  exports._setSimultaneousAccepts = function(handle) {
+  _setSimultaneousAccepts = function(handle) {
     if (handle === undefined) {
       return;
     }
@@ -1647,5 +1634,20 @@ if (process.platform === 'win32') {
     }
   };
 } else {
-  exports._setSimultaneousAccepts = function(handle) {};
+  _setSimultaneousAccepts = function(handle) {};
 }
+
+module.exports = {
+  _createServerHandle: createServerHandle,
+  _normalizeArgs: normalizeArgs,
+  _setSimultaneousAccepts,
+  connect,
+  createConnection: connect,
+  createServer,
+  isIP: cares.isIP,
+  isIPv4: cares.isIPv4,
+  isIPv6: cares.isIPv6,
+  Server,
+  Socket,
+  Stream: Socket, // Legacy naming
+};


### PR DESCRIPTION
Refactor net module to use the more efficient
module.exports = {} pattern.
Also renames internal "connect" function to "internalConnect"
to avoid collision with exported "connect".

See https://github.com/nodejs/node/pull/11611

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net