### PR TITLE
util: throw toJSON errors when formatting %j

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,13 +17,17 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
+const CIRCULAR_ERROR_MESSAGE = 'Converting circular structure to JSON';
+
 var Debug;
 
 function tryStringify(arg) {
   try {
     return JSON.stringify(arg);
-  } catch (_) {
-    return '[Circular]';
+  } catch (err) {
+    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
+      return '[Circular]';
+    throw err;
   }
 }
 

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -65,6 +65,16 @@ assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
   assert.strictEqual(util.format('%j', o), '[Circular]');
 }
 
+{
+  const o = {
+    toJSON() {
+      throw new Error('Not a circular object but still not serializable');
+    }
+  };
+  assert.throws(() => util.format('%j', o),
+                /^Error: Not a circular object but still not serializable$/);
+}
+
 // Errors
 const err = new Error('foo');
 assert.strictEqual(util.format(err), err.stack);


### PR DESCRIPTION
[Documentation](https://nodejs.org/api/util.html#util_util_format_format_args) says:

> - `%j` - JSON. Replaced with the string `'[Circular]'` if the argument contains circular references.

Correct me if I'm wrong, but I believe because of that this is a semver-patch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util