### PR TITLE
src: make process.env work with symbols for in/delete

### DIFF
--- a/test/parallel/test-process-env-symbols.js
+++ b/test/parallel/test-process-env-symbols.js
@@ -18,10 +18,11 @@ assert.throws(() => {
   process.env.foo = symbol;
 }, errRegExp);
 
-// Verify that using a symbol with the in operator throws.
-assert.throws(() => {
-  symbol in process.env;
-}, errRegExp);
+// Verify that using a symbol with the in operator returns false.
+assert.strictEqual(symbol in process.env, false);
+
+// Verify that deleting a symbol value returns true.
+assert.strictEqual(delete process.env[symbol], true);
 
 // Checks that well-known symbols like `Symbol.toStringTag` won’t throw.
 assert.doesNotThrow(() => Object.prototype.toString.call(process.env));


### PR DESCRIPTION
The getter for process.env already allows symbols to be used, and `in` operator as a read-only operator can do the same.

`delete a[b]` operator in ES always returns `true` without doing anything when `b in a === false`. Allow symbols in the deleter accordingly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process