### PR TITLE
doc: fixed occurences of "the the"

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -193,7 +193,7 @@ the process is spawned. The default options are:
 }
 ```
 
-If `timeout` is greater than `0`, the parent will send the the signal
+If `timeout` is greater than `0`, the parent will send the signal
 identified by the `killSignal` property (the default is `'SIGTERM'`) if the
 child runs longer than `timeout` milliseconds.
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -471,7 +471,7 @@ If the data to be written can be generated or fetched on demand, it is
 recommended to encapsulate the logic into a [Readable][] and use
 [`stream.pipe()`][]. However, if calling `write()` is preferred, it is
 possible to respect backpressure and avoid memory issues using the
-the [`'drain'`][] event:
+[`'drain'`][] event:
 
 ```js
 function write (data, cb) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -220,8 +220,8 @@ static void ares_sockstate_cb(void* data,
       task = ares_task_create(env, sock);
       if (task == nullptr) {
         /* This should never happen unless we're out of memory or something */
-        /* is seriously wrong. The socket won't be polled, but the the query */
-        /* will eventually time out. */
+        /* is seriously wrong. The socket won't be polled, but the query will */
+        /* eventually time out. */
         return;
       }
 

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -36,6 +36,6 @@ if (process.argv[2] === 'child') {
   test({ NODE_NO_WARNINGS: '01' });
   test({ NODE_NO_WARNINGS: '2' });
   // Don't test the number 1 because it will come through as a string in the
-  // the child process environment.
+  // child process environment.
   test({ NODE_NO_WARNINGS: '1' });
 }


### PR DESCRIPTION
I identified a number of files where it said "the the" in the comments of the source code and in general documentation texts. I replaced occurences with a single instance of "the".

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc