### PR TITLE
deps: cherry-pick 0ba513f05 from V8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 6
 #define V8_BUILD_NUMBER 326
-#define V8_PATCH_LEVEL 55
+#define V8_PATCH_LEVEL 56
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -7330,7 +7330,13 @@ namespace {
 
 Maybe<bool> GetPropertyDescriptorWithInterceptor(LookupIterator* it,
                                                  PropertyDescriptor* desc) {
-  if (it->state() == LookupIterator::INTERCEPTOR) {
+  bool has_access = true;
+  if (it->state() == LookupIterator::ACCESS_CHECK) {
+    has_access = it->HasAccess() || JSObject::AllCanRead(it);
+    it->Next();
+  }
+
+  if (has_access && it->state() == LookupIterator::INTERCEPTOR) {
     Isolate* isolate = it->isolate();
     Handle<InterceptorInfo> interceptor = it->GetInterceptor();
     if (!interceptor->descriptor()->IsUndefined(isolate)) {
@@ -7374,6 +7380,7 @@ Maybe<bool> GetPropertyDescriptorWithInterceptor(LookupIterator* it,
       }
     }
   }
+  it->Restart();
   return Just(false);
 }
 }  // namespace

--- a/deps/v8/test/cctest/test-api-interceptors.cc
+++ b/deps/v8/test/cctest/test-api-interceptors.cc
@@ -609,6 +609,50 @@ THREADED_TEST(SetterCallbackFunctionDeclarationInterceptorThrow) {
 
   CHECK_EQ(set_was_called, false);
 }
+namespace {
+int descriptor_was_called;
+
+void PropertyDescriptorCallback(
+    Local<Name> name, const v8::PropertyCallbackInfo<v8::Value>& info) {
+  // Intercept the callback by setting a different descriptor.
+  descriptor_was_called++;
+  const char* code =
+      "var desc = {value: 5};"
+          "desc;";
+  Local<Value> descriptor = v8_compile(code)
+      ->Run(info.GetIsolate()->GetCurrentContext())
+      .ToLocalChecked();
+  info.GetReturnValue().Set(descriptor);
+}
+}  // namespace
+
+// Check that the descriptor callback is called on the global object.
+THREADED_TEST(DescriptorCallbackOnGlobalObject) {
+    v8::HandleScope scope(CcTest::isolate());
+    LocalContext env;
+    v8::Local<v8::FunctionTemplate> templ =
+    v8::FunctionTemplate::New(CcTest::isolate());
+
+    v8::Local<ObjectTemplate> object_template = templ->InstanceTemplate();
+    object_template->SetHandler(v8::NamedPropertyHandlerConfiguration(
+    nullptr, nullptr, PropertyDescriptorCallback, nullptr, nullptr, nullptr));
+    v8::Local<v8::Context> ctx =
+    v8::Context::New(CcTest::isolate(), nullptr, object_template);
+
+    descriptor_was_called = 0;
+
+    // Declare function.
+    v8::Local<v8::String> code = v8_str(
+    "var x = 42; var desc = Object.getOwnPropertyDescriptor(this, 'x'); "
+    "desc.value;");
+    CHECK_EQ(5, v8::Script::Compile(ctx, code)
+    .ToLocalChecked()
+    ->Run(ctx)
+    .ToLocalChecked()
+    ->Int32Value(ctx)
+    .FromJust());
+    CHECK_EQ(1, descriptor_was_called);
+}
 
 bool get_was_called_in_order = false;
 bool define_was_called_in_order = false;
@@ -4516,7 +4560,7 @@ TEST(NamedAllCanReadInterceptor) {
   ExpectInt32("checked.whatever", 17);
   CHECK(!CompileRun("Object.getOwnPropertyDescriptor(checked, 'whatever')")
              ->IsUndefined());
-  CHECK_EQ(5, access_check_data.count);
+  CHECK_EQ(6, access_check_data.count);
 
   access_check_data.result = false;
   ExpectInt32("checked.whatever", intercept_data_0.value);
@@ -4525,7 +4569,7 @@ TEST(NamedAllCanReadInterceptor) {
     CompileRun("Object.getOwnPropertyDescriptor(checked, 'whatever')");
     CHECK(try_catch.HasCaught());
   }
-  CHECK_EQ(7, access_check_data.count);
+  CHECK_EQ(9, access_check_data.count);
 
   intercept_data_1.should_intercept = true;
   ExpectInt32("checked.whatever", intercept_data_1.value);
@@ -4534,7 +4578,7 @@ TEST(NamedAllCanReadInterceptor) {
     CompileRun("Object.getOwnPropertyDescriptor(checked, 'whatever')");
     CHECK(try_catch.HasCaught());
   }
-  CHECK_EQ(9, access_check_data.count);
+  CHECK_EQ(12, access_check_data.count);
   g_access_check_data = nullptr;
 }
 
@@ -4603,7 +4647,7 @@ TEST(IndexedAllCanReadInterceptor) {
   ExpectInt32("checked[15]", 17);
   CHECK(!CompileRun("Object.getOwnPropertyDescriptor(checked, '15')")
              ->IsUndefined());
-  CHECK_EQ(5, access_check_data.count);
+  CHECK_EQ(6, access_check_data.count);
 
   access_check_data.result = false;
   ExpectInt32("checked[15]", intercept_data_0.value);
@@ -4612,7 +4656,7 @@ TEST(IndexedAllCanReadInterceptor) {
     CompileRun("Object.getOwnPropertyDescriptor(checked, '15')");
     CHECK(try_catch.HasCaught());
   }
-  CHECK_EQ(7, access_check_data.count);
+  CHECK_EQ(9, access_check_data.count);
 
   intercept_data_1.should_intercept = true;
   ExpectInt32("checked[15]", intercept_data_1.value);
@@ -4621,7 +4665,7 @@ TEST(IndexedAllCanReadInterceptor) {
     CompileRun("Object.getOwnPropertyDescriptor(checked, '15')");
     CHECK(try_catch.HasCaught());
   }
-  CHECK_EQ(9, access_check_data.count);
+  CHECK_EQ(12, access_check_data.count);
 
   g_access_check_data = nullptr;
 }


### PR DESCRIPTION
Original commit message:
    
    [api] Fix DescriptorInterceptor with access check.

    The DescriptorInterceptor should intercept all
    Object.getOwnPropertyDescriptor calls. This CL fixes
    the interceptor's behavior if the iterator state is
    ACCESS_CHECK.

    BUG=

    Review-Url: https://codereview.chromium.org/2707263002
    Cr-Commit-Position: refs/heads/master@{#43417}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps V8

This fix is needed to use the GenericNamedPropertyDescriptorCallback on the global object in node_contextify.cc. 

5.6 is [not maintained anymore](https://build.chromium.org/p/client.v8.branches/console), therefore not backmerged upstream. 

cc/ @nodejs/v8 