### PR TITLE
test: delay child exit in AIX for pseudo-tty tests

### DIFF
--- a/test/pseudo-tty/no_dropped_stdio.js
+++ b/test/pseudo-tty/no_dropped_stdio.js
@@ -1,7 +1,7 @@
 // https://github.com/nodejs/node/issues/6456#issuecomment-219320599
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
-require('../common');
+const common = require('../common');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
@@ -11,5 +11,9 @@ let out = ('o'.repeat(48) + '\n').repeat(20);
 // This results in 1025 bytes, just enough to overflow the 1kb OS X TTY buffer.
 out += 'o'.repeat(24) + 'O';
 
-process.stdout.write(out);
-process.exit(0);
+// In AIX, the child exits even before the python parent
+// can setup the readloop. Provide a reasonable delay.
+setTimeout(function() {
+  process.stdout.write(out);
+  process.exit(0);
+}, common.isAix ? 200 : 0);

--- a/test/pseudo-tty/no_interleaved_stdio.js
+++ b/test/pseudo-tty/no_interleaved_stdio.js
@@ -1,7 +1,7 @@
 // https://github.com/nodejs/node/issues/6456#issuecomment-219320599
 // https://gist.github.com/isaacs/1495b91ec66b21d30b10572d72ad2cdd
 'use strict';
-require('../common');
+const common = require('../common');
 
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
@@ -13,5 +13,9 @@ out += 'o'.repeat(24) + 'O';
 
 const err = '__This is some stderr__';
 
-process.stdout.write(out);
-process.stderr.write(err);
+// In AIX, the child exits even before the python parent
+// can setup the readloop. Provide a reasonable delay.
+setTimeout(function() {
+  process.stdout.write(out);
+  process.stderr.write(err);
+}, common.isAix ? 200 : 0);

--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -1,8 +1,5 @@
 prefix pseudo-tty
 
 [$system==aix]
-# test issue only, covered under https://github.com/nodejs/node/issues/7973
-no_dropped_stdio           : SKIP
-no_interleaved_stdio       : SKIP
 # being investigated under https://github.com/nodejs/node/issues/9728
 test-tty-wrap              : FAIL, PASS

--- a/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
+++ b/test/pseudo-tty/test-stderr-stdout-handle-sigwinch.js
@@ -27,4 +27,8 @@ process.stdout._refreshSize = wrap(originalRefreshSizeStdout,
                                    process.stdout,
                                    'calling stdout._refreshSize');
 
-process.emit('SIGWINCH');
+// In AIX, the child exits even before the python parent
+// can setup the readloop. Provide a reasonable delay.
+setTimeout(function() {
+  process.emit('SIGWINCH');
+}, common.isAix ? 200 : 0);


### PR DESCRIPTION
The tests in pseudo-tty takes the form of child node writing some data
and exiting, while parent python consume them through pseudo tty
implementations, and validate the result.

While there is no synchronization between child and parent, this works
for most platforms, except AIX, where the child exits even before the
parent could setup the read loop, under race conditions

Fixing the race condition is ideally done through sending ACK messages
to and forth, but involves massive changes and have side effect. The
workaround is to address them in AIX alone, by adding a reasonable delay.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
