### PR TITLE
benchmark: fix punycode and get-ciphers benchmark

### DIFF
--- a/benchmark/crypto/get-ciphers.js
+++ b/benchmark/crypto/get-ciphers.js
@@ -18,6 +18,6 @@ function main(conf) {
       method();
   }
   bench.start();
-  for (; i < n; i++) method();
+  for (i = 0; i < n; i++) method();
   bench.end(n);
 }

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -46,7 +46,7 @@ function runPunycode(n, val) {
   for (; i < n; i++)
     usingPunycode(val);
   bench.start();
-  for (; i < n; i++)
+  for (i = 0; i < n; i++)
     usingPunycode(val);
   bench.end(n);
 }


### PR DESCRIPTION
I've missed two for loops without initialization in https://github.com/nodejs/node/pull/9615. This adds missing `i = 0` to those loops in `punycode` and `get-ciphers` benchmarks.

Sorry for the trouble.

/cc @mcollina @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmarks
