### PR TITLE
test: limit lint rule disabling in message test

### DIFF
--- a/test/message/nexttick_throw.js
+++ b/test/message/nexttick_throw.js
@@ -5,7 +5,7 @@ process.nextTick(function() {
   process.nextTick(function() {
     process.nextTick(function() {
       process.nextTick(function() {
-        // eslint-disable-next-line
+        // eslint-disable-next-line no-undef
         undefined_reference_error_maker;
       });
     });


### PR DESCRIPTION
nexttick_throw.js has a comment that disables all ESLint rules for a
line. Change it to only disable the one ESLint rule that the line
violates.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test