### PR TITLE
backport: v4.x - #11452 - doc: restrict the ES.Next features usage in tests

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -189,6 +189,21 @@ const assert = require('assert');
 const freelist = require('internal/freelist');
 ```
 
+### ES.Next features
+
+For performance considerations, we only use a selected subset of ES.Next
+features in JavaScript code in the `lib` directory. However, when writing
+tests, for the ease of backporting, it is encouraged to use those ES.Next
+features that can be used directly without a flag in [all maintained branches]
+(https://github.com/nodejs/lts), you can check [node.green](http://node.green)
+for all available features in each release.
+
+For example:
+
+* `let` and `const` over `var`
+* Template literals over string concatenation
+* Arrow functions when appropriate
+
 ## Naming Test Files
 
 Test files are named using kebab casing. The first component of the name is


### PR DESCRIPTION
Backport of #11452 to v4.x.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc