### PR TITLE
linkedlist: remove unused methods

### DIFF
--- a/lib/internal/linkedlist.js
+++ b/lib/internal/linkedlist.js
@@ -5,24 +5,10 @@ function init(list) {
   list._idlePrev = list;
 }
 
-// create a new linked list
-function create() {
-  const list = { _idleNext: null, _idlePrev: null };
-  init(list);
-  return list;
-}
-
 // show the most idle item
 function peek(list) {
   if (list._idlePrev === list) return null;
   return list._idlePrev;
-}
-
-// remove the most idle item from the list
-function shift(list) {
-  const first = list._idlePrev;
-  remove(first);
-  return first;
 }
 
 // remove a item from its list
@@ -61,9 +47,7 @@ function isEmpty(list) {
 
 module.exports = {
   init,
-  create,
   peek,
-  shift,
   remove,
   append,
   isEmpty

--- a/test/parallel/test-timers-linked-list.js
+++ b/test/parallel/test-timers-linked-list.js
@@ -41,14 +41,8 @@ L.append(list, D);
 // list -> A -> B -> C -> D
 assert.strictEqual(A, L.peek(list));
 
-assert.strictEqual(A, L.shift(list));
-// list -> B -> C -> D
-assert.strictEqual(B, L.peek(list));
-
-assert.strictEqual(B, L.shift(list));
-// list -> C -> D
-assert.strictEqual(C, L.peek(list));
-
+L.remove(A);
+L.remove(B);
 // B is already removed, so removing it again shouldn't hurt.
 L.remove(B);
 // list -> C -> D
@@ -86,26 +80,10 @@ L.append(list, A);
 
 // Append should REMOVE C from the list and append it to the end.
 L.append(list, C);
-
 // list -> D -> B -> A -> C
-assert.strictEqual(D, L.shift(list));
-// list -> B -> A -> C
-assert.strictEqual(B, L.peek(list));
-assert.strictEqual(B, L.shift(list));
-// list -> A -> C
-assert.strictEqual(A, L.peek(list));
-assert.strictEqual(A, L.shift(list));
-// list -> C
-assert.strictEqual(C, L.peek(list));
-assert.strictEqual(C, L.shift(list));
-// list
-assert.ok(L.isEmpty(list));
 
-const list2 = L.create();
-const list3 = L.create();
-assert.ok(L.isEmpty(list2));
-assert.ok(L.isEmpty(list3));
-
-// Objects should have identical keys/properties, but be different objects.
-assert.deepStrictEqual(list2, list3);
-assert.notStrictEqual(list2, list3);
+assert.strictEqual(D, L.peek(list));
+assert.strictEqual(B, L.peek(D));
+assert.strictEqual(A, L.peek(B));
+assert.strictEqual(C, L.peek(A));
+assert.strictEqual(list, L.peek(C));


### PR DESCRIPTION
This should probably only land once lib/_linklist.js is removed to avoid any breakage. Since that private module has been (runtime) deprecated since v5.0.0, should it be removed in v8.0.0? If not, I can mark this as 'in progress' or similar until it is removed. Thoughts @nodejs/ctc?

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)

* lib/src
