### PR TITLE
buffer: Preallocate array with buffer length in Buffer#toJSON

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -810,8 +810,8 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 
 
 Buffer.prototype.toJSON = function() {
-  if (this.length) {
-    const data = [];
+  if (this.length > 0) {
+    const data = new Array(this.length);
     for (var i = 0; i < this.length; ++i)
       data[i] = this[i];
     return { type: 'Buffer', data };


### PR DESCRIPTION
Because the final array length is known, it's better to allocate its
final length at initialization time to avoid future reallocations.

It also adds an explicit buffer length greater than 0 comparison so
it's more readable, avoids the internal ToBoolean call and follows the
standard Node.js API format (as it can be checked in other similar
structures where 'length > 0' is preferred over 'length')

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer
