### PR TITLE
src: add HAVE_OPENSSL directive to openssl_config

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4311,8 +4311,10 @@ void Init(int* argc,
         SafeGetenv("NODE_PRESERVE_SYMLINKS", &text) && text[0] == '1';
   }
 
+#if HAVE_OPENSSL
   if (openssl_config.empty())
     SafeGetenv("OPENSSL_CONF", &openssl_config);
+#endif
 
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
   std::string node_options;


### PR DESCRIPTION
Currently when building with the following configuration options:
$ ./configure --without-ssl && make

The following link error is reported:

Undefined symbols for architecture x86_64:
  "node::openssl_config", referenced from:
      node::Init(int*, char const**, int*, char const***) in node.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see
invocation)

Adding an HAVE_OPENSSL directive around this code allows the build to
pass.

PR-URL: https://github.com/nodejs/node/pull/11618
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src