### PR TITLE
doc: add active, enroll and unenroll

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -164,19 +164,26 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 
 ## Manual Timers
 
-It is possible to make any object a timer. Reusing an existing object as a timer
-slightly reduces memory consumption. Another advantage is that you control
-when the timer will be started.
+It is possible, but not recommended, to make any object a timer. Under special
+circumstances this can be advantageous. However, in general practice, using
+this API is strongly discouraged. This is due to the fact that when using this API
+it is important to track timer enrollment state. A memory leak will occur if a
+timer is enrolled but never unenrolled.
+
+*Note*: This API is considered *unsafe*. Despite being public, it is subject
+to change at any time.
 
 Example:
 
 ```js
-var timers = require('timers');
-var atimer = {
+'use strict';
+
+const timers = require('timers');
+const atimer = {
   _onTimeout: function() {
     console.log('timeout');
   }
-}
+};
 
 timers.enroll(atimer, 1000); // make the `atimer` object a timer
 timers.active(atimer); // start the timer

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -162,6 +162,50 @@ added: v0.0.1
 
 Cancels a `Timeout` object created by [`setTimeout()`][].
 
+## Manual Timers
+
+It is possible to make any object a timer. Reusing an existing object as a timer
+slightly reduces memory consumption. Another advantage is that you control
+when the timer will be started.
+
+Example:
+
+```js
+var timers = require('timers');
+var atimer = {
+  _onTimeout: function() {
+    console.log('timeout');
+  }
+}
+
+timers.enroll(atimer, 1000); // make the `atimer` object a timer
+timers.active(atimer); // start the timer
+```
+
+### active(object)
+
+* `object` {Timer} A timer created by [`enroll()`][] to start.
+
+Starts a timer that was created by [`enroll()`][]. If the object has an
+`_onTimeout` method, it will be invoked once the timer has completed.
+
+Once a timer has been started, it can be canceled with [`unenroll()`][].
+
+### enroll(object, delay)
+
+* `object` {object} An object to decorate as a timer.
+* `delay` {number} The number of milliseconds to wait before the timer completes.
+
+Decorate an object as a timer and add it to a list of timers to be processed
+via [the Node.js Event Loop][]. Once decorated, the timer can be started with
+[`active()`][].
+
+### unenroll(object)
+
+* `object` {Timer} A timer that has been started by [`active()`][].
+
+Cancel a timer and reset its state.
+
 
 [the Node.js Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick
 [`TypeError`]: errors.html#errors_class_typeerror
@@ -171,3 +215,6 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 [`setImmediate()`]: timers.html#timers_setimmediate_callback_args
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
+[`active()`]: timers.html#timers_active_object
+[`enroll()`]: timers.html#timers_enroll_object_delay
+[`unenroll()`]: timers.html#timers_unenroll_object

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -164,11 +164,9 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 
 ## Manual Timers
 
-It is possible, but not recommended, to make any object a timer. Under special
-circumstances this can be advantageous. However, in general practice, using
-this API is strongly discouraged. This is due to the fact that when using this API
-it is important to track timer enrollment state. A memory leak will occur if a
-timer is enrolled but never unenrolled.
+It is possible (but not recommended) to make any object a timer. In general
+practice, however, using this API is **strongly discouraged** due to the potential
+for memory leaks should such timers fail to be properly unenrolled.
 
 *Note*: This API is considered *unsafe*. Despite being public, it is subject
 to change at any time.
@@ -182,6 +180,7 @@ const timers = require('timers');
 const atimer = {
   _onTimeout: function() {
     console.log('timeout');
+    timers.unenroll(atimer); // remove the timer from the queue
   }
 };
 


### PR DESCRIPTION
This PR adds documentation for the public `timers` methods
`active`, `enroll` and `unenroll`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

doc
