### PR TITLE
url: call toString before valueOf when stringifying

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -26,7 +26,7 @@ const IteratorPrototype = Object.getPrototypeOf(
 const unpairedSurrogateRe =
     /([^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 function toUSVString(val) {
-  const str = '' + val;
+  const str = `${val}`;
   // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are
   // slower than `unpairedSurrogateRe.exec()`.
   const match = unpairedSurrogateRe.exec(str);
@@ -218,7 +218,7 @@ function onParseHashComplete(flags, protocol, username, password,
 class URL {
   constructor(input, base) {
     // toUSVString is not needed.
-    input = '' + input;
+    input = `${input}`;
     if (base !== undefined && !(base instanceof URL))
       base = new URL(base);
     parse(this, input, base);
@@ -329,7 +329,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(input) {
       // toUSVString is not needed.
-      input = '' + input;
+      input = `${input}`;
       parse(this, input);
     }
   },
@@ -348,7 +348,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(scheme) {
       // toUSVString is not needed.
-      scheme = '' + scheme;
+      scheme = `${scheme}`;
       if (scheme.length === 0)
         return;
       binding.parse(scheme, binding.kSchemeStart, null, this[context],
@@ -363,7 +363,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(username) {
       // toUSVString is not needed.
-      username = '' + username;
+      username = `${username}`;
       if (!this.hostname)
         return;
       const ctx = this[context];
@@ -384,7 +384,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(password) {
       // toUSVString is not needed.
-      password = '' + password;
+      password = `${password}`;
       if (!this.hostname)
         return;
       const ctx = this[context];
@@ -410,7 +410,7 @@ Object.defineProperties(URL.prototype, {
     set(host) {
       const ctx = this[context];
       // toUSVString is not needed.
-      host = '' + host;
+      host = `${host}`;
       if (this[cannotBeBase] ||
           (this[special] && host.length === 0)) {
         // Cannot set the host if cannot-be-base is set or
@@ -435,7 +435,7 @@ Object.defineProperties(URL.prototype, {
     set(host) {
       const ctx = this[context];
       // toUSVString is not needed.
-      host = '' + host;
+      host = `${host}`;
       if (this[cannotBeBase] ||
           (this[special] && host.length === 0)) {
         // Cannot set the host if cannot-be-base is set or
@@ -460,7 +460,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(port) {
       // toUSVString is not needed.
-      port = '' + port;
+      port = `${port}`;
       const ctx = this[context];
       if (!ctx.host || this[cannotBeBase] ||
           this.protocol === 'file:')
@@ -484,7 +484,7 @@ Object.defineProperties(URL.prototype, {
     },
     set(path) {
       // toUSVString is not needed.
-      path = '' + path;
+      path = `${path}`;
       if (this[cannotBeBase])
         return;
       binding.parse(path, binding.kPathStart, null, this[context],
@@ -533,7 +533,7 @@ Object.defineProperties(URL.prototype, {
     set(hash) {
       const ctx = this[context];
       // toUSVString is not needed.
-      hash = '' + hash;
+      hash = `${hash}`;
       if (this.protocol === 'javascript:')
         return;
       if (!hash) {
@@ -1125,12 +1125,12 @@ function originFor(url, base) {
 
 function domainToASCII(domain) {
   // toUSVString is not needed.
-  return binding.domainToASCII('' + domain);
+  return binding.domainToASCII(`${domain}`);
 }
 
 function domainToUnicode(domain) {
   // toUSVString is not needed.
-  return binding.domainToUnicode('' + domain);
+  return binding.domainToUnicode(`${domain}`);
 }
 
 // Utility function that converts a URL object into an ordinary

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -58,7 +58,10 @@ test(function() {
     params.set('a');
   }, /^TypeError: "name" and "value" arguments must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.set(obj, 'b'), /^Error: toString$/);
   assert.throws(() => params.set('a', obj), /^Error: toString$/);

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -209,7 +209,10 @@ test(() => {
 }
 
 {
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
 
   assert.throws(() => new URLSearchParams({ a: obj }), /^Error: toString$/);

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -52,7 +52,10 @@ test(function() {
     params.delete();
   }, /^TypeError: "name" argument must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.delete(obj), /^Error: toString$/);
   assert.throws(() => params.delete(sym),

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -43,7 +43,10 @@ test(function() {
     params.get();
   }, /^TypeError: "name" argument must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.get(obj), /^Error: toString$/);
   assert.throws(() => params.get(sym),

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -47,7 +47,10 @@ test(function() {
     params.getAll();
   }, /^TypeError: "name" argument must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.getAll(obj), /^Error: toString$/);
   assert.throws(() => params.getAll(sym),

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -46,7 +46,10 @@ test(function() {
     params.has();
   }, /^TypeError: "name" argument must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.has(obj), /^Error: toString$/);
   assert.throws(() => params.has(sym),

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -44,7 +44,10 @@ test(function() {
     params.set('a');
   }, /^TypeError: "name" and "value" arguments must be specified$/);
 
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   assert.throws(() => params.append(obj, 'b'), /^Error: toString$/);
   assert.throws(() => params.append('a', obj), /^Error: toString$/);

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -107,7 +107,10 @@ startURLSettersTests()
 
 {
   const url = new URL('http://example.com/');
-  const obj = { toString() { throw new Error('toString'); } };
+  const obj = {
+    toString() { throw new Error('toString'); },
+    valueOf() { throw new Error('valueOf'); }
+  };
   const sym = Symbol();
   const props = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(url));
   for (const [name, { set }] of Object.entries(props)) {


### PR DESCRIPTION
The ES addition operator calls the ToPrimitive() abstract operation without hint String, leading a subsequent OrdinaryToPrimitive() to call `valueOf()` first on an object rather than the desired `toString()`.

Instead, use template literals which directly call ToString() abstract operation, per Web IDL spec.

This issue is particularly visible in the example below:

```js
const { URLSearchParams } = url;
const searchParams = new URLSearchParams();
searchParams.set('name', {
  toString() { return 'toString'; },
  valueOf() { return 'valueOf'; }
});
console.log(searchParams.get('name'));
```

In the browser, the above prints `toString`, while in current master it prints `valueOf`.

Fixes: b610a4db1c2919f88711962f5797f25ecb1cd36b "url: enforce valid UTF-8 in WHATWG parser"
Refs: https://github.com/nodejs/node/commit/b610a4db1c2919f88711962f5797f25ecb1cd36b#commitcomment-21200056
Refs: https://tc39.github.io/ecma262/#sec-addition-operator-plus-runtime-semantics-evaluation
Refs: https://tc39.github.io/ecma262/#sec-template-literals-runtime-semantics-evaluation

/cc @nodejs/url

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url