### PR TITLE
backport v7.x - #9615 - benchmark: remove %OptimizeFunctionOnNextCall

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -235,12 +235,3 @@ it returns to accomplish what they need. This function reports timing
 data to the parent process (usually created by running `compare.js`, `run.js` or
 `scatter.js`).
 
-### v8ForceOptimization(method[, ...args])
-
-Force V8 to mark the `method` for optimization with the native function
-`%OptimizeFunctionOnNextCall()` and return the optimization status
-after that.
-
-It can be used to prevent the benchmark from getting disrupted by the optimizer
-kicking in halfway through. However, this could result in a less effective
-optimization. In general, only use it if you know what it actually does.

--- a/benchmark/buffers/buffer-compare-instance-method.js
+++ b/benchmark/buffers/buffer-compare-instance-method.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   size: [16, 512, 1024, 4096, 16386],
@@ -20,7 +19,6 @@ function main(conf) {
 
   b1[size - 1] = 'b'.charCodeAt(0);
 
-  // Force optimization before starting the benchmark
   switch (args) {
     case 2:
       b0.compare(b1, 0);
@@ -37,8 +35,6 @@ function main(conf) {
     default:
       b0.compare(b1);
   }
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(b0.compare)');
   switch (args) {
     case 2:
       b0.compare(b1, 0);

--- a/benchmark/buffers/buffer-compare-offset.js
+++ b/benchmark/buffers/buffer-compare-offset.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common.js');
-const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   method: ['offset', 'slice'],
@@ -9,18 +8,6 @@ const bench = common.createBenchmark(main, {
 });
 
 function compareUsingSlice(b0, b1, len, iter) {
-
-  // Force optimization before starting the benchmark
-  Buffer.compare(b0.slice(1, len), b1.slice(1, len));
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(Buffer.compare)');
-  eval('%OptimizeFunctionOnNextCall(b0.slice)');
-  eval('%OptimizeFunctionOnNextCall(b1.slice)');
-  Buffer.compare(b0.slice(1, len), b1.slice(1, len));
-  doCompareUsingSlice(b0, b1, len, iter);
-}
-
-function doCompareUsingSlice(b0, b1, len, iter) {
   var i;
   bench.start();
   for (i = 0; i < iter; i++)
@@ -29,16 +16,6 @@ function doCompareUsingSlice(b0, b1, len, iter) {
 }
 
 function compareUsingOffset(b0, b1, len, iter) {
-  len = len + 1;
-  // Force optimization before starting the benchmark
-  b0.compare(b1, 1, len, 1, len);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(b0.compare)');
-  b0.compare(b1, 1, len, 1, len);
-  doCompareUsingOffset(b0, b1, len, iter);
-}
-
-function doCompareUsingOffset(b0, b1, len, iter) {
   var i;
   bench.start();
   for (i = 0; i < iter; i++)

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common.js');
-const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   aligned: ['true', 'false'],
@@ -81,9 +80,7 @@ function main(conf) {
   const buf = createBuffer(len, aligned === 'true');
   const bufferSwap = genMethod(method);
 
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(bufferSwap)');
-
+  bufferSwap(n, buf);
   bench.start();
   bufferSwap(n, buf);
   bench.end(n);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -229,17 +229,3 @@ Benchmark.prototype.report = function(rate, elapsed) {
     type: 'report'
   });
 };
-
-exports.v8ForceOptimization = function(method) {
-  if (typeof method !== 'function')
-    return;
-
-  const v8 = require('v8');
-  v8.setFlagsFromString('--allow_natives_syntax');
-
-  const args = Array.prototype.slice.call(arguments, 1);
-  method.apply(null, args);
-  eval('%OptimizeFunctionOnNextCall(method)');
-  method.apply(null, args);
-  return eval('%GetOptimizationStatus(method)');
-};

--- a/benchmark/crypto/get-ciphers.js
+++ b/benchmark/crypto/get-ciphers.js
@@ -12,9 +12,12 @@ function main(conf) {
   const v = conf.v;
   const method = require(v).getCiphers;
   var i = 0;
-
-  common.v8ForceOptimization(method);
+  // first call to getChipers will dominate the results
+  if (n > 1) {
+    for (; i < n; i++)
+      method();
+  }
   bench.start();
-  for (; i < n; i++) method();
+  for (i = 0; i < n; i++) method();
   bench.end(n);
 }

--- a/benchmark/es/defaultparams-bench.js
+++ b/benchmark/es/defaultparams-bench.js
@@ -22,8 +22,6 @@ function defaultParams(x = 1, y = 2) {
 
 function runOldStyleDefaults(n) {
 
-  common.v8ForceOptimization(oldStyleDefaults);
-
   var i = 0;
   bench.start();
   for (; i < n; i++)
@@ -32,8 +30,6 @@ function runOldStyleDefaults(n) {
 }
 
 function runDefaultParams(n) {
-
-  common.v8ForceOptimization(defaultParams);
 
   var i = 0;
   bench.start();

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -35,8 +35,6 @@ function useArguments() {
 
 function runCopyArguments(n) {
 
-  common.v8ForceOptimization(copyArguments, 1, 2, 'a', 'b');
-
   var i = 0;
   bench.start();
   for (; i < n; i++)
@@ -46,8 +44,6 @@ function runCopyArguments(n) {
 
 function runRestArguments(n) {
 
-  common.v8ForceOptimization(restArguments, 1, 2, 'a', 'b');
-
   var i = 0;
   bench.start();
   for (; i < n; i++)
@@ -56,8 +52,6 @@ function runRestArguments(n) {
 }
 
 function runUseArguments(n) {
-
-  common.v8ForceOptimization(useArguments, 1, 2, 'a', 'b');
 
   var i = 0;
   bench.start();

--- a/benchmark/misc/console.js
+++ b/benchmark/misc/console.js
@@ -4,9 +4,6 @@ const common = require('../common.js');
 const assert = require('assert');
 const Writable = require('stream').Writable;
 const util = require('util');
-const v8 = require('v8');
-
-v8.setFlagsFromString('--allow_natives_syntax');
 
 const methods = [
   'restAndSpread',
@@ -51,14 +48,7 @@ function usingArgumentsAndApplyC() {
   nullStream.write(util.format.apply(null, arguments) + '\n');
 }
 
-function optimize(method, ...args) {
-  method(...args);
-  eval(`%OptimizeFunctionOnNextCall(${method.name})`);
-  method(...args);
-}
-
 function runUsingRestAndConcat(n) {
-  optimize(usingRestAndConcat, 'a', 1);
 
   var i = 0;
   bench.start();
@@ -70,7 +60,6 @@ function runUsingRestAndConcat(n) {
 function runUsingRestAndSpread(n, concat) {
 
   const method = concat ? usingRestAndSpreadC : usingRestAndSpreadTS;
-  optimize(method, 'this is %s of %d', 'a', 1);
 
   var i = 0;
   bench.start();
@@ -82,7 +71,6 @@ function runUsingRestAndSpread(n, concat) {
 function runUsingRestAndApply(n, concat) {
 
   const method = concat ? usingRestAndApplyC : usingRestAndApplyTS;
-  optimize(method, 'this is %s of %d', 'a', 1);
 
   var i = 0;
   bench.start();
@@ -94,7 +82,6 @@ function runUsingRestAndApply(n, concat) {
 function runUsingArgumentsAndApply(n, concat) {
 
   const method = concat ? usingArgumentsAndApplyC : usingArgumentsAndApplyTS;
-  optimize(method, 'this is %s of %d', 'a', 1);
 
   var i = 0;
   bench.start();

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -42,16 +42,16 @@ function usingICU(val) {
 }
 
 function runPunycode(n, val) {
-  common.v8ForceOptimization(usingPunycode, val);
   var i = 0;
-  bench.start();
   for (; i < n; i++)
+    usingPunycode(val);
+  bench.start();
+  for (i = 0; i < n; i++)
     usingPunycode(val);
   bench.end(n);
 }
 
 function runICU(n, val) {
-  common.v8ForceOptimization(usingICU, val);
   var i = 0;
   bench.start();
   for (; i < n; i++)

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -2,7 +2,6 @@
 
 const common = require('../common.js');
 const util = require('util');
-const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
   type: ['extend', 'assign'],
@@ -12,24 +11,17 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   let fn;
   const n = conf.n | 0;
-  let v8command;
 
   if (conf.type === 'extend') {
     fn = util._extend;
-    v8command = '%OptimizeFunctionOnNextCall(util._extend)';
   } else if (conf.type === 'assign') {
     fn = Object.assign;
-    // Object.assign is built-in, cannot be optimized
-    v8command = '';
   }
 
   // Force-optimize the method to test so that the benchmark doesn't
   // get disrupted by the optimizer kicking in halfway through.
   for (var i = 0; i < conf.type.length * 10; i += 1)
     fn({}, process.env);
-
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval(v8command);
 
   var obj = new Proxy({}, { set: function(a, b, c) { return true; } });
 

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   pathext: [
@@ -29,12 +28,6 @@ function main(conf) {
     ext = input.slice(extIdx + 1);
     input = input.slice(0, extIdx);
   }
-
-  // Force optimization before starting the benchmark
-  p.basename(input, ext);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.basename)');
-  p.basename(input, ext);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   pathext: [
@@ -29,12 +28,6 @@ function main(conf) {
     ext = input.slice(extIdx + 1);
     input = input.slice(0, extIdx);
   }
-
-  // Force optimization before starting the benchmark
-  p.basename(input, ext);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.basename)');
-  p.basename(input, ext);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -20,12 +19,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.dirname(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.dirname)');
-  p.dirname(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -20,12 +19,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.dirname(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.dirname)');
-  p.dirname(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -23,12 +22,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.extname(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.extname)');
-  p.extname(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -23,12 +22,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.extname(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.extname)');
-  p.extname(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   props: [
@@ -21,12 +20,6 @@ function main(conf) {
     ext: props[3] || '',
     name: props[4] || '',
   };
-
-  // Force optimization before starting the benchmark
-  p.format(obj);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.format)');
-  p.format(obj);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   props: [
@@ -21,12 +20,6 @@ function main(conf) {
     ext: props[3] || '',
     name: props[4] || '',
   };
-
-  // Force optimization before starting the benchmark
-  p.format(obj);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.format)');
-  p.format(obj);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -18,12 +17,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.isAbsolute(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.isAbsolute)');
-  p.isAbsolute(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -19,12 +18,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.isAbsolute(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.isAbsolute)');
-  p.isAbsolute(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -14,12 +13,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var args = ('' + conf.paths).split('|');
-
-  // Force optimization before starting the benchmark
-  p.join.apply(null, args);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.join)');
-  p.join.apply(null, args);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -14,12 +13,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var args = ('' + conf.paths).split('|');
-
-  // Force optimization before starting the benchmark
-  p.join.apply(null, args);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.join)');
-  p.join.apply(null, args);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -17,12 +16,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p._makeLong(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p._makeLong)');
-  p._makeLong(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -19,12 +18,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.normalize(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.normalize)');
-  p.normalize(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -19,12 +18,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var input = '' + conf.path;
-
-  // Force optimization before starting the benchmark
-  p.normalize(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.normalize)');
-  p.normalize(input);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/parse-posix.js
+++ b/benchmark/path/parse-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -21,14 +20,11 @@ function main(conf) {
   var p = path.posix;
   var input = '' + conf.path;
 
-  // Force optimization before starting the benchmark
-  p.parse(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.parse)');
-  p.parse(input);
-
-  bench.start();
   for (var i = 0; i < n; i++) {
+    p.parse(input);
+  }
+  bench.start();
+  for (i = 0; i < n; i++) {
     p.parse(input);
   }
   bench.end(n);

--- a/benchmark/path/parse-win32.js
+++ b/benchmark/path/parse-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   path: [
@@ -22,14 +21,11 @@ function main(conf) {
   var p = path.win32;
   var input = '' + conf.path;
 
-  // Force optimization before starting the benchmark
-  p.parse(input);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.parse)');
-  p.parse(input);
-
-  bench.start();
   for (var i = 0; i < n; i++) {
+    p.parse(input);
+  }
+  bench.start();
+  for (i = 0; i < n; i++) {
     p.parse(input);
   }
   bench.end(n);

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -26,15 +25,12 @@ function main(conf) {
     to = from.slice(delimIdx + 1);
     from = from.slice(0, delimIdx);
   }
-
-  // Force optimization before starting the benchmark
-  p.relative(from, to);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.relative)');
-  p.relative(from, to);
+  for (var i = 0; i < n; i++) {
+    p.relative(from, to);
+  }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (i = 0; i < n; i++) {
     p.relative(from, to);
   }
   bench.end(n);

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -25,14 +24,13 @@ function main(conf) {
     from = from.slice(0, delimIdx);
   }
 
-  // Force optimization before starting the benchmark
-  p.relative(from, to);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.relative)');
-  p.relative(from, to);
+  // Warmup
+  for (var i = 0; i < n; i++) {
+    p.relative(from, to);
+  }
 
   bench.start();
-  for (var i = 0; i < n; i++) {
+  for (i = 0; i < n; i++) {
     p.relative(from, to);
   }
   bench.end(n);

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -17,12 +16,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.posix;
   var args = ('' + conf.paths).split('|');
-
-  // Force optimization before starting the benchmark
-  p.resolve.apply(null, args);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve.apply(null, args);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var path = require('path');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   paths: [
@@ -17,12 +16,6 @@ function main(conf) {
   var n = +conf.n;
   var p = path.win32;
   var args = ('' + conf.paths).split('|');
-
-  // Force optimization before starting the benchmark
-  p.resolve.apply(null, args);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(p.resolve)');
-  p.resolve.apply(null, args);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -1,8 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var querystring = require('querystring');
-var v8 = require('v8');
-
 var inputs = require('../fixtures/url-inputs.js').searchParams;
 
 var bench = common.createBenchmark(main, {
@@ -14,21 +12,18 @@ function main(conf) {
   var type = conf.type;
   var n = conf.n | 0;
   var input = inputs[type];
+  var i;
 
-  // Force-optimize querystring.parse() so that the benchmark doesn't get
+  // Optimize querystring.parse() so that the benchmark doesn't get
   // disrupted by the optimizer kicking in halfway through.
-  v8.setFlagsFromString('--allow_natives_syntax');
   if (type !== 'multicharsep') {
-    querystring.parse(input);
-    eval('%OptimizeFunctionOnNextCall(querystring.parse)');
-    querystring.parse(input);
+    for (i = 0; i < n; i += 1)
+      querystring.parse(input);
   } else {
-    querystring.parse(input, '&&&&&&&&&&');
-    eval('%OptimizeFunctionOnNextCall(querystring.parse)');
-    querystring.parse(input, '&&&&&&&&&&');
+    for (i = 0; i < n; i += 1)
+      querystring.parse(input, '&&&&&&&&&&');
   }
 
-  var i;
   if (type !== 'multicharsep') {
     bench.start();
     for (i = 0; i < n; i += 1)

--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -1,7 +1,6 @@
 'use strict';
 var common = require('../common.js');
 var querystring = require('querystring');
-var v8 = require('v8');
 
 var bench = common.createBenchmark(main, {
   type: ['noencode', 'encodemany', 'encodelast'],
@@ -35,10 +34,6 @@ function main(conf) {
   // disrupted by the optimizer kicking in halfway through.
   for (var name in inputs)
     querystring.stringify(inputs[name]);
-
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(querystring.stringify)');
-  querystring.stringify(input);
 
   bench.start();
   for (var i = 0; i < n; i += 1)

--- a/benchmark/streams/readable-bigread.js
+++ b/benchmark/streams/readable-bigread.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const v8 = require('v8');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
@@ -14,13 +13,6 @@ function main(conf) {
   const s = new Readable();
   function noop() {}
   s._read = noop;
-
-  // Force optimization before starting the benchmark
-  s.push(b);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(s.read)');
-  s.push(b);
-  while (s.read(128));
 
   bench.start();
   for (var k = 0; k < n; ++k) {

--- a/benchmark/streams/readable-bigunevenread.js
+++ b/benchmark/streams/readable-bigunevenread.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const v8 = require('v8');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
@@ -14,13 +13,6 @@ function main(conf) {
   const s = new Readable();
   function noop() {}
   s._read = noop;
-
-  // Force optimization before starting the benchmark
-  s.push(b);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(s.read)');
-  s.push(b);
-  while (s.read(106));
 
   bench.start();
   for (var k = 0; k < n; ++k) {

--- a/benchmark/streams/readable-boundaryread.js
+++ b/benchmark/streams/readable-boundaryread.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const v8 = require('v8');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
@@ -14,14 +13,6 @@ function main(conf) {
   const s = new Readable();
   function noop() {}
   s._read = noop;
-
-  // Force optimization before starting the benchmark
-  s.push(b);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(s.push)');
-  eval('%OptimizeFunctionOnNextCall(s.read)');
-  s.push(b);
-  while (s.read(32));
 
   bench.start();
   for (var k = 0; k < n; ++k) {

--- a/benchmark/streams/readable-readall.js
+++ b/benchmark/streams/readable-readall.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const v8 = require('v8');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
@@ -14,13 +13,6 @@ function main(conf) {
   const s = new Readable();
   function noop() {}
   s._read = noop;
-
-  // Force optimization before starting the benchmark
-  s.push(b);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(s.read)');
-  s.push(b);
-  while (s.read());
 
   bench.start();
   for (var k = 0; k < n; ++k) {

--- a/benchmark/streams/readable-unevenread.js
+++ b/benchmark/streams/readable-unevenread.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const v8 = require('v8');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
@@ -14,13 +13,6 @@ function main(conf) {
   const s = new Readable();
   function noop() {}
   s._read = noop;
-
-  // Force optimization before starting the benchmark
-  s.push(b);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(s.read)');
-  s.push(b);
-  while (s.read(12));
 
   bench.start();
   for (var k = 0; k < n; ++k) {

--- a/benchmark/tls/convertprotocols.js
+++ b/benchmark/tls/convertprotocols.js
@@ -12,8 +12,11 @@ function main(conf) {
 
   var i = 0;
   var m = {};
-  common.v8ForceOptimization(
-    tls.convertNPNProtocols, ['ABC', 'XYZ123', 'FOO'], m);
+  // First call dominates results
+  if (n > 1) {
+    tls.convertNPNProtocols(['ABC', 'XYZ123', 'FOO'], m);
+    m = {};
+  }
   bench.start();
   for (; i < n; i++) tls.convertNPNProtocols(['ABC', 'XYZ123', 'FOO'], m);
   bench.end(n);

--- a/benchmark/url/url-format.js
+++ b/benchmark/url/url-format.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common.js');
 const url = require('url');
-const v8 = require('v8');
 
 const inputs = {
   slashes: {slashes: true, host: 'localhost'},
@@ -23,9 +22,6 @@ function main(conf) {
   // disrupted by the optimizer kicking in halfway through.
   for (const name in inputs)
     url.format(inputs[name]);
-
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(url.format)');
 
   bench.start();
   for (var i = 0; i < n; i += 1)

--- a/benchmark/url/url-resolve.js
+++ b/benchmark/url/url-resolve.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common.js');
 const url = require('url');
-const v8 = require('v8');
 const hrefs = require('../fixtures/url-inputs.js').urls;
 hrefs.noscheme = 'some.ran/dom/url.thing?oh=yes#whoo';
 
@@ -23,12 +22,6 @@ function main(conf) {
   const n = conf.n | 0;
   const href = hrefs[conf.href];
   const path = paths[conf.path];
-
-  // Force-optimize url.resolve() so that the benchmark doesn't get
-  // disrupted by the optimizer kicking in halfway through.
-  url.resolve(href, path);
-  v8.setFlagsFromString('--allow_natives_syntax');
-  eval('%OptimizeFunctionOnNextCall(url.resolve)');
 
   bench.start();
   for (var i = 0; i < n; i += 1)

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -2,7 +2,6 @@
 
 const util = require('util');
 const common = require('../common');
-const v8 = require('v8');
 const types = [
   'string',
   'number',
@@ -28,12 +27,6 @@ function main(conf) {
   const type = conf.type;
 
   const input = inputs[type];
-
-  v8.setFlagsFromString('--allow_natives_syntax');
-
-  util.format(input[0], input[1]);
-  eval('%OptimizeFunctionOnNextCall(util.format)');
-  util.format(input[0], input[1]);
 
   bench.start();
   for (var i = 0; i < n; i++) {


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/9615 and https://github.com/nodejs/node/pull/11720 fix to v7.x

Removes all instances of `%OptimizeFunctionOnNextCall` from benchmarks

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
benchmark