### PR TITLE
test: add hasCrypto check to tls-legacy-deprecated

### DIFF
--- a/test/parallel/test-tls-legacy-deprecated.js
+++ b/test/parallel/test-tls-legacy-deprecated.js
@@ -1,6 +1,10 @@
 // Flags: --no-warnings
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 const assert = require('assert');
 const tls = require('tls');
 


### PR DESCRIPTION
Currently test-tls-legacy-deprecated will fail if node
was built using --without-ssl. This commit adds a check to
verify that crypto support exists and if not skip this test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test