### PR TITLE
(v7.x backport) child_process: fix deoptimizing use of arguments

### DIFF
--- a/benchmark/child_process/child-process-params.js
+++ b/benchmark/child_process/child-process-params.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const common = require('../common.js');
+const cp = require('child_process');
+
+const command = 'echo';
+const args = ['hello'];
+const options = {};
+const cb = () => {};
+
+const configs = {
+  n: [1e3],
+  methodName: [
+    'exec', 'execSync',
+    'execFile', 'execFileSync',
+    'spawn', 'spawnSync',
+  ],
+  params: [1, 2, 3, 4],
+};
+
+const bench = common.createBenchmark(main, configs);
+
+function main(conf) {
+  const n = +conf.n;
+  const methodName = conf.methodName;
+  const params = +conf.params;
+
+  const method = cp[methodName];
+
+  switch (methodName) {
+    case 'exec':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options, cb).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, options);
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execFile':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options).kill();
+          bench.end(n);
+          break;
+        case 4:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options, cb).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'execFileSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args);
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options);
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'spawn':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command).kill();
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args).kill();
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options).kill();
+          bench.end(n);
+          break;
+      }
+      break;
+    case 'spawnSync':
+      switch (params) {
+        case 1:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command);
+          bench.end(n);
+          break;
+        case 2:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args);
+          bench.end(n);
+          break;
+        case 3:
+          bench.start();
+          for (let i = 0; i < n; i++) method(command, args, options);
+          bench.end(n);
+          break;
+      }
+      break;
+  }
+}

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -79,16 +79,10 @@ exports._forkChild = function(fd) {
 };
 
 
-function normalizeExecArgs(command /*, options, callback*/) {
-  let options;
-  let callback;
-
-  if (typeof arguments[1] === 'function') {
+function normalizeExecArgs(command, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
     options = undefined;
-    callback = arguments[1];
-  } else {
-    options = arguments[1];
-    callback = arguments[2];
   }
 
   // Make a shallow copy so we don't clobber the user's options object.
@@ -142,7 +136,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     callback = arguments[pos++];
   }
 
-  if (!callback && arguments[pos] != null) {
+  if (!callback && pos < arguments.length && arguments[pos] != null) {
     throw new TypeError('Incorrect value of args option');
   }
 
@@ -175,6 +169,8 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   var ex = null;
 
+  var cmd = file;
+
   function exithandler(code, signal) {
     if (exited) return;
     exited = true;
@@ -202,7 +198,6 @@ exports.execFile = function(file /*, args, options, callback*/) {
       return;
     }
 
-    var cmd = file;
     if (args.length !== 0)
       cmd += ' ' + args.join(' ');
 
@@ -311,18 +306,15 @@ function _convertCustomFds(options) {
   }
 }
 
-function normalizeSpawnArguments(file /*, args, options*/) {
-  var args, options;
-
-  if (Array.isArray(arguments[1])) {
-    args = arguments[1].slice(0);
-    options = arguments[2];
-  } else if (arguments[1] !== undefined &&
-             (arguments[1] === null || typeof arguments[1] !== 'object')) {
+function normalizeSpawnArguments(file, args, options) {
+  if (Array.isArray(args)) {
+    args = args.slice(0);
+  } else if (args !== undefined &&
+             (args === null || typeof args !== 'object')) {
     throw new TypeError('Incorrect value of args option');
   } else {
+    options = args;
     args = [];
-    options = arguments[1];
   }
 
   if (options === undefined)


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
child_process, benchmark

Backport of #11535