### PR TITLE
(v4.x backport) dgram: fix possibly deoptimizing use of arguments

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -134,7 +134,7 @@ function replaceHandle(self, newHandle) {
   self._handle = newHandle;
 }
 
-Socket.prototype.bind = function(port_ /*, address, callback*/) {
+Socket.prototype.bind = function(port_, address_ /*, callback*/) {
   var self = this;
   let port = port_;
 
@@ -145,7 +145,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
 
   this._bindState = BIND_STATE_BINDING;
 
-  if (typeof arguments[arguments.length - 1] === 'function')
+  if (arguments.length && typeof arguments[arguments.length - 1] === 'function')
     self.once('listening', arguments[arguments.length - 1]);
 
   if (port instanceof UDP) {
@@ -162,7 +162,7 @@ Socket.prototype.bind = function(port_ /*, address, callback*/) {
     exclusive = !!port.exclusive;
     port = port.port;
   } else {
-    address = typeof arguments[1] === 'function' ? '' : arguments[1];
+    address = typeof address_ === 'function' ? '' : address_;
     exclusive = false;
   }
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
dgram

Backport of #11242