### PR TITLE
net: Socket.prototype.connect should accept args like net.connect #11761

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -899,23 +899,17 @@ function connect(self, address, port, addressType, localAddress, localPort) {
 }
 
 
-Socket.prototype.connect = function(options, cb) {
+Socket.prototype.connect = function() {
+  const args = new Array(arguments.length);
+  for (var i = 0; i < arguments.length; i++)
+    args[i] = arguments[i];
+  // TODO(joyeecheung): use destructuring when V8 is fast enough
+  const normalized = normalizeArgs(args);
+  const options = normalized[0];
+  const cb = normalized[1];
+
   if (this.write !== Socket.prototype.write)
     this.write = Socket.prototype.write;
-
-  if (options === null || typeof options !== 'object') {
-    // Old API:
-    // connect(port[, host][, cb])
-    // connect(path[, cb]);
-    const args = new Array(arguments.length);
-    for (var i = 0; i < arguments.length; i++)
-      args[i] = arguments[i];
-    const normalized = normalizeArgs(args);
-    const normalizedOptions = normalized[0];
-    const normalizedCb = normalized[1];
-    return Socket.prototype.connect.call(this,
-                                         normalizedOptions, normalizedCb);
-  }
 
   if (this.destroyed) {
     this._readableState.reading = false;

--- a/test/parallel/test-net-socket-connect-without-cb.js
+++ b/test/parallel/test-net-socket-connect-without-cb.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that socket.connect can be called without callback
+// which is optional.
+
+const net = require('net');
+
+const server = net.createServer(common.mustCall(function(conn) {
+  conn.end();
+  server.close();
+})).listen(0, common.mustCall(function() {
+  const client = new net.Socket();
+
+  client.on('connect', common.mustCall(function() {
+    client.end();
+  }));
+
+  client.connect(server.address());
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

`net.Socket.prototype.connect`

https://github.com/nodejs/node/issues/11761