### PR TITLE
v4.x backport: http: make request.abort() destroy the socket

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -530,7 +530,11 @@ ClientRequest.prototype.onSocket = function(socket) {
 function onSocketNT(req, socket) {
   if (req.aborted) {
     // If we were aborted while waiting for a socket, skip the whole thing.
-    socket.emit('free');
+    if (req.socketPath || !req.agent) {
+      socket.destroy();
+    } else {
+      socket.emit('free');
+    }
   } else {
     tickOnSocket(req, socket);
   }

--- a/test/parallel/test-http-abort-queued-2.js
+++ b/test/parallel/test-http-abort-queued-2.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let socketsCreated = 0;
+
+class Agent extends http.Agent {
+  createConnection(options, oncreate) {
+    const socket = super.createConnection(options, oncreate);
+    socketsCreated++;
+    return socket;
+  }
+}
+
+const server = http.createServer((req, res) => res.end());
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const agent = new Agent({
+    keepAlive: true,
+    maxSockets: 1
+  });
+
+  http.get({agent, port}, (res) => res.resume());
+
+  const req = http.get({agent, port}, common.fail);
+  req.abort();
+
+  http.get({agent, port}, common.mustCall((res) => {
+    res.resume();
+    assert.strictEqual(socketsCreated, 1);
+    agent.destroy();
+    server.close();
+  }));
+}));

--- a/test/parallel/test-http-client-abort-no-agent.js
+++ b/test/parallel/test-http-client-abort-no-agent.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const net = require('net');
+
+const server = http.createServer(common.fail);
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get({
+    createConnection(options, oncreate) {
+      const socket = net.createConnection(options, oncreate);
+      socket.once('close', () => server.close());
+      return socket;
+    },
+    port: server.address().port
+  });
+
+  req.abort();
+}));

--- a/test/parallel/test-http-client-abort-unix-socket.js
+++ b/test/parallel/test-http-client-abort-unix-socket.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+const server = http.createServer(common.fail);
+
+class Agent extends http.Agent {
+  createConnection(options, oncreate) {
+    const socket = super.createConnection(options, oncreate);
+    socket.once('close', () => server.close());
+    return socket;
+  }
+}
+
+common.refreshTmpDir();
+
+server.listen(common.PIPE, common.mustCall(() => {
+  const req = http.get({
+    agent: new Agent(),
+    socketPath: common.PIPE
+  });
+
+  req.abort();
+}));


### PR DESCRIPTION
v4.x backport of #10818.

Commit landed cleanly and tests pass on my machine (macOS 10.11.6).
I'm opening this PR as per this [comment](https://github.com/nodejs/node/pull/10818#issuecomment-285202250).

CI: https://ci.nodejs.org/job/node-test-pull-request/6758/