### PR TITLE
build: add node_use_openssl check to install.py

### DIFF
--- a/configure
+++ b/configure
@@ -975,7 +975,6 @@ def configure_openssl(o):
   else:
     o['variables']['openssl_fips'] = ''
 
-
   if options.without_ssl:
     return
   configure_library('openssl', o)

--- a/configure
+++ b/configure
@@ -975,6 +975,7 @@ def configure_openssl(o):
   else:
     o['variables']['openssl_fips'] = ''
 
+
   if options.without_ssl:
     return
   configure_library('openssl', o)

--- a/tools/install.py
+++ b/tools/install.py
@@ -165,7 +165,8 @@ def headers(action):
   if 'false' == variables.get('node_shared_libuv'):
     subdir_files('deps/uv/include', 'include/node/', action)
 
-  if 'false' == variables.get('node_shared_openssl'):
+  if 'true' == variables.get('node_use_openssl') and \
+     'false' == variables.get('node_shared_openssl'):
     subdir_files('deps/openssl/openssl/include/openssl', 'include/node/openssl/', action)
     subdir_files('deps/openssl/config/archs', 'include/node/openssl/archs', action)
     action(['deps/openssl/config/opensslconf.h'], 'include/node/openssl/')


### PR DESCRIPTION
When configuring --without-ssl and then running make install
openssl headers will be copied from deps/openssl to the target
installation directory.

This commit adds a check for is node_use_openssl is set in which
case the headers are not copied.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build