### PR TITLE
test: added test for indexed properties

### DIFF
--- a/test/parallel/test-vm-indexed-properties.js
+++ b/test/parallel/test-vm-indexed-properties.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const code = `Object.defineProperty(this, 99, {
+      value: 20,
+      enumerable: true
+ });`;
+
+
+const sandbox = {};
+const ctx = vm.createContext(sandbox);
+vm.runInContext(code, ctx);
+
+assert.strictEqual(sandbox[99], 20);


### PR DESCRIPTION
Currently, indexed properties are correctly copied
onto the sandbox by CopyProperties().
This will break when CopyProperties() is removed
after adjusting NamedPropertyHandlerConfiguration
config() to use property callbacks from the new
V8 API. To fix it, we will set a config for indexed
properties.

This test is a preparation step for the patch
that removes CopyProperties().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test