### PR TITLE
test: fix repl-function-redefinition-edge-case

### DIFF
--- a/test/parallel/test-repl-function-definition-edge-case.js
+++ b/test/parallel/test-repl-function-definition-edge-case.js
@@ -13,7 +13,7 @@ r.input.emit('data', 'function a() { return 42; } (1)\n');
 r.input.emit('data', 'a\n');
 r.input.emit('data', '.exit');
 
-const expected = '1\n[Function a]\n';
+const expected = '1\n[Function: a]\n';
 const got = r.output.accumulator.join('');
 assert.strictEqual(got, expected);
 


### PR DESCRIPTION
`test/known_issues/test-repl-function-redefinition-edge-case.js` had been introduced as a part of https://github.com/nodejs/node/pull/7624 but the meat of the test became fixed in 007386ee81ceeffd65c2248869717b0717db3e46. Despite that, the test continued to fail since it was broken itself: there was a missing colon in the expected output.

This commit adds the missing colon and moves the test from `test/known_issues` to `test/parallel`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test