### PR TITLE
CRYPTO: Add configure option to use system CA certificates

### DIFF
--- a/configure
+++ b/configure
@@ -269,6 +269,10 @@ parser.add_option('--systemtap-includes',
     action='store',
     dest='systemtap_includes',
     help='directory containing systemtap header files')
+parser.add_option('--system-ca-certificates',
+    action='store',
+    dest='system_ca_certs',
+    help='Location of the system-provided certificate bundle')
 
 parser.add_option('--tag',
     action='store',
@@ -913,6 +917,8 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  o['variables']['system_ca_certs'] = options.system_ca_certs or ''
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib

--- a/node.gyp
+++ b/node.gyp
@@ -408,7 +408,11 @@
                   ],
                 }],
               ],
-            }]]
+            }],
+            [ 'system_ca_certs!=""', {
+              'defines': [ 'SYSTEM_CA_CERTS="<(system_ca_certs)"' ],
+            }]
+          ]
         }, {
           'defines': [ 'HAVE_OPENSSL=0' ]
         }],


### PR DESCRIPTION
This patch allows distribution packagers to pass a
`--system-ca-certificates` argument to `./configure` in order to
specify a CA certificate bundle file on the system on which Node
will be installed. If this argument is passed, Node will *only*
use the system CA certificates and not its internal built-in ones,
though they can still be extended through the use of the
NODE_EXTRA_CA_CERTS environment variable.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
crypto
