### PR TITLE
doc: fix a typo in api/process.md

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -298,7 +298,7 @@ too many listeners have been added to an event
 
 ```txt
 $ node
-> event.defaultMaxListeners = 1;
+> events.defaultMaxListeners = 1;
 > process.on('foo', () => {});
 > process.on('foo', () => {});
 > (node:38638) Warning: Possible EventEmitter memory leak detected. 2 foo
@@ -311,7 +311,7 @@ adds a custom handler to the `'warning'` event:
 ```txt
 $ node --no-warnings
 > var p = process.on('warning', (warning) => console.warn('Do not do that!'));
-> event.defaultMaxListeners = 1;
+> events.defaultMaxListeners = 1;
 > process.on('foo', () => {});
 > process.on('foo', () => {});
 > Do not do that!


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

In process `warning` event sample code, it should be `events.defaultMaxListeners`