### PR TITLE
test: include all stdio strings for fork()

### DIFF
--- a/test/parallel/test-child-process-fork-stdio-string-variant.js
+++ b/test/parallel/test-child-process-fork-stdio-string-variant.js
@@ -12,16 +12,19 @@ const childScript = `${common.fixturesDir}/child-process-spawn-node`;
 const errorRegexp = /^TypeError: Incorrect value of stdio option:/;
 const malFormedOpts = {stdio: '33'};
 const payload = {hello: 'world'};
-const stringOpts = {stdio: 'pipe'};
 
 assert.throws(() => fork(childScript, malFormedOpts), errorRegexp);
 
-const child = fork(childScript, stringOpts);
+function test(stringVariant) {
+  const child = fork(childScript, {stdio: stringVariant});
 
-child.on('message', (message) => {
-  assert.deepStrictEqual(message, {foo: 'bar'});
-});
+  child.on('message', common.mustCall((message) => {
+    assert.deepStrictEqual(message, {foo: 'bar'});
+  }));
 
-child.send(payload);
+  child.send(payload);
 
-child.on('exit', common.mustCall((code) => assert.strictEqual(code, 0)));
+  child.on('exit', common.mustCall((code) => assert.strictEqual(code, 0)));
+}
+
+['pipe', 'inherit', 'ignore'].forEach(test);


### PR DESCRIPTION
test-child-process-fork-stdio-string-variant was only testing 'pipe' for
its `stdio` value. Add `inherit` and `ignore`.

Also added a `common.mustCall()` to verify that the `message` event is
triggered.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process