### PR TITLE
doc: fix stylistic issues in api/net.md

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -40,7 +40,7 @@ double-backslashes, such as:
 
 ```js
 net.createServer().listen(
-    path.join('\\\\?\\pipe', process.cwd(), 'myctl'))
+    path.join('\\\\?\\pipe', process.cwd(), 'myctl'));
 ```
 
 ## Class: net.Server
@@ -107,7 +107,7 @@ Returns an object with `port`, `family`, and `address` properties:
 Example:
 
 ```js
-var server = net.createServer((socket) => {
+const server = net.createServer((socket) => {
   socket.end('goodbye\n');
 }).on('error', (err) => {
   // handle errors here
@@ -758,7 +758,7 @@ socket.setTimeout(3000);
 socket.on('timeout', () => {
   console.log('socket timeout');
   socket.end();
-})
+});
 ```
 
 If `timeout` is 0, then the existing idle timeout is disabled.
@@ -997,8 +997,8 @@ server.listen(8124, () => {
 
 Test this by using `telnet`:
 
-```sh
-telnet localhost 8124
+```console
+$ telnet localhost 8124
 ```
 
 To listen on the socket `/tmp/echo.sock` the third line from the last would
@@ -1012,8 +1012,8 @@ server.listen('/tmp/echo.sock', () => {
 
 Use `nc` to connect to a UNIX domain socket server:
 
-```js
-nc -U /tmp/echo.sock
+```console
+$ nc -U /tmp/echo.sock
 ```
 
 ## net.isIP(input)


### PR DESCRIPTION
* Change `var` to `const` in an example of server creation.
* Add missing semicolons.
* Use `console` syntax highlighting instead of `js` in the `nc` command invocation example and add a shell prompt symbol to be consistent with the rest of the documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc