### PR TITLE
test: fix flaky test-http-set-timeout-server

### DIFF
--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -138,10 +138,13 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
 
 test(function serverResponseTimeoutWithPipeline(cb) {
   let caughtTimeout = '';
+  let secReceived = false;
   process.on('exit', function() {
     assert.strictEqual(caughtTimeout, '/2');
   });
   const server = http.createServer(function(req, res) {
+    if (req.url === '/2')
+      secReceived = true;
     const s = res.setTimeout(50, function() {
       caughtTimeout += req.url;
     });
@@ -149,9 +152,11 @@ test(function serverResponseTimeoutWithPipeline(cb) {
     if (req.url === '/1') res.end();
   });
   server.on('timeout', function(socket) {
-    socket.destroy();
-    server.close();
-    cb();
+    if (secReceived) {
+      socket.destroy();
+      server.close();
+      cb();
+    }
   });
   server.listen(common.mustCall(function() {
     const port = server.address().port;


### PR DESCRIPTION
It can happen that the connection and server is closed before the second
reponse has been processed by server. In this case, the
`res.setTimeout()` callback will never be called causing the test to
fail. Fix this by only closing the connection and server when the 2nd
has been received.

Fixes: https://github.com/nodejs/node/issues/11768
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test