### PR TITLE
doc: linkable commit message guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,9 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 - [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
 - [ ] tests and/or benchmarks are included
 - [ ] documentation is changed or added
-- [ ] commit message follows commit guidelines
+- [ ] commit message follows [commit guidelines][]
 
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
+
+[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#required-format-for-commit-logs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 ##### Affected core subsystem(s)
 <!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
 
-[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#required-format-for-commit-logs
+[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ $ git add my/changed/files
 $ git commit
 ```
 
-### Required format for commit logs
+### Commit guidelines
 
 Writing good commit logs is important. A commit log should describe what
 changed and why. Follow these guidelines when writing one:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ $ git add my/changed/files
 $ git commit
 ```
 
+### Required format for commit logs
+
 Writing good commit logs is important. A commit log should describe what
 changed and why. Follow these guidelines when writing one:
 


### PR DESCRIPTION
Put the commit guidelines themselves under a heading to be more
prominent, and to allow linking directly to them (instead of the section
on how to use git).

Link the pull request template to the guidelines, so contributors can
find them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
