### PR TITLE
crypto: Use system CAs instead of using bundled ones

### DIFF
--- a/configure
+++ b/configure
@@ -144,6 +144,11 @@ parser.add_option('--openssl-fips',
     dest='openssl_fips',
     help='Build OpenSSL using FIPS canister .o file in supplied folder')
 
+parser.add_option('--openssl-use-def-ca-store',
+    action='store_true',
+    dest='use_openssl_ca_store',
+    help='Use OpenSSL supplied CA store instead of compiled-in Mozilla CA copy.')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -939,6 +944,8 @@ def configure_openssl(o):
   o['variables']['node_use_openssl'] = b(not options.without_ssl)
   o['variables']['node_shared_openssl'] = b(options.shared_openssl)
   o['variables']['openssl_no_asm'] = 1 if options.openssl_no_asm else 0
+  if options.use_openssl_ca_store:
+    o['defines'] += ['NODE_OPENSSL_CERT_STORE']
   if options.openssl_fips:
     o['variables']['openssl_fips'] = options.openssl_fips
     fips_dir = os.path.join(root_dir, 'deps', 'openssl', 'fips')

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -709,10 +709,14 @@ static X509_STORE* NewRootCertStore() {
   }
 
   X509_STORE* store = X509_STORE_new();
+#if defined(NODE_OPENSSL_CERT_STORE)
+  X509_STORE_set_default_paths(store);
+#else
   for (auto& cert : *root_certs_vector) {
     X509_up_ref(cert);
     X509_STORE_add_cert(store, cert);
   }
+#endif
 
   return store;
 }


### PR DESCRIPTION
This is a backport of a patch included in 7.5.0



NodeJS can already use an external, shared OpenSSL library. This
library knows where to look for OS managed certificates. Allow
a compile-time option to use this CA store by default instead of
using bundled certificates.

In case when using bundled OpenSSL, the paths are also valid for
majority of Linux systems without additional intervention. If
this is not set, we can use SSL_CERT_DIR to point it to correct
location.

Fixes: https://github.com/nodejs/node/issues/3159
PR-URL: https://github.com/nodejs/node/pull/8334
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Fedor Indutny <fedor.indutny@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
