### PR TITLE
test: add coverage for child_process bounds check

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -147,8 +147,8 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   // Make sure that monkey-patching process.execArgv doesn't cause child_process
   // to incorrectly munge execArgv.
   child.exec(
-    `${nodejs} -e 'process.execArgv = ["-e", "console.log(42)", "thirdArg"];
-                   require("child_process").fork("${emptyFile}")'`,
+    `${nodejs} -e "process.execArgv = ['-e', 'console.log(42)', 'thirdArg'];
+                   require('child_process').fork('${emptyFile}')"`,
     common.mustCall((err, stdout, stderr) => {
       assert.ifError(err);
       assert.strictEqual(stdout, '42\n');

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -143,6 +143,17 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
                assert.strictEqual(stdout, '');
                assert.strictEqual(stderr, '');
              }));
+
+  // Make sure that monkey-patching process.execArgv doesn't cause child_process
+  // to incorrectly munge execArgv.
+  child.exec(
+    `${nodejs} -e 'process.execArgv = ["-e", "console.log(42)", "thirdArg"];
+                   require("child_process").fork("${emptyFile}")'`,
+    common.mustCall((err, stdout, stderr) => {
+      assert.ifError(err);
+      assert.strictEqual(stdout, '42\n');
+      assert.strictEqual(stderr, '');
+    }));
 }
 
 // Regression test for https://github.com/nodejs/node/issues/8534.

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -147,8 +147,8 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   // Make sure that monkey-patching process.execArgv doesn't cause child_process
   // to incorrectly munge execArgv.
   child.exec(
-    `${nodejs} -e "process.execArgv = ['-e', 'console.log(42)', 'thirdArg'];
-                   require('child_process').fork('${emptyFile}')"`,
+    `${nodejs} -e "process.execArgv = ['-e', 'console.log(42)', 'thirdArg'];` +
+                  `require('child_process').fork('${emptyFile}')"`,
     common.mustCall((err, stdout, stderr) => {
       assert.ifError(err);
       assert.strictEqual(stdout, '42\n');


### PR DESCRIPTION
Make sure that monkey-patching process.execArgv doesn't cause
child_process to incorrectly munge execArgv in fork().

This basically is adding coverage for an `index > 0` check (see comment
in this commit). Previously, that condition was never false in any of
the tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process