### PR TITLE
buffer: auto random fill Buffer(num) and new Buffer(num)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -69,6 +69,15 @@ function createUnsafeArrayBuffer(size) {
   }
 }
 
+function createRandomFillBuffer(size) {
+  zeroFill[0] = 3;
+  try {
+    return new ArrayBuffer(size);
+  } finally {
+    zeroFill[0] = 1;
+  }
+}
+
 function createPool() {
   poolSize = Buffer.poolSize;
   allocPool = createUnsafeArrayBuffer(poolSize);
@@ -103,7 +112,8 @@ function Buffer(arg, encodingOrOffset, length) {
         'If encoding is specified then the first argument must be a string'
       );
     }
-    return Buffer.allocUnsafe(arg);
+    assertSize(arg);
+    return new FastBuffer(createRandomFillBuffer(arg));
   }
   return Buffer.from(arg, encodingOrOffset, length);
 }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,11 +23,13 @@
 'use strict';
 
 const binding = process.binding('buffer');
+const config = process.binding('config');
 const { compare: compare_, compareOffset } = binding;
 const { isArrayBuffer, isSharedArrayBuffer, isUint8Array } =
     process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
+const pendingDeprecation = !!config.pendingDeprecation;
 
 class FastBuffer extends Uint8Array {
   constructor(arg1, arg2, arg3) {
@@ -94,6 +96,12 @@ function alignPool() {
   }
 }
 
+var bufferWarn = true;
+const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
+                      'recommended for use due to security and usability ' +
+                      'concerns. Please use the new Buffer.alloc(), ' +
+                      'Buffer.allocUnsafe(), or Buffer.from() construction ' +
+                      'methods instead.';
 /**
  * The Buffer() construtor is deprecated in documentation and should not be
  * used moving forward. Rather, developers should use one of the three new
@@ -106,6 +114,14 @@ function alignPool() {
  **/
 function Buffer(arg, encodingOrOffset, length) {
   // Common case.
+  if (pendingDeprecation && bufferWarn) {
+    // This is a *pending* deprecation warning. It is not emitted by
+    // default unless the --pending-deprecation command-line flag is
+    // used or the NODE_PENDING_DEPRECATION=1 envvar is set.
+    process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
+    bufferWarn = false;
+  }
+
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {
       throw new Error(

--- a/src/node.cc
+++ b/src/node.cc
@@ -209,6 +209,10 @@ bool trace_warnings = false;
 // that is used by lib/module.js
 bool config_preserve_symlinks = false;
 
+// Set by ParseArgs when --pending-deprecation or NODE_PENDING_DEPRECATION
+// is used.
+bool config_pending_deprecation = false;
+
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
 std::string config_warning_file;  // NOLINT(runtime/string)
 
@@ -3744,6 +3748,8 @@ static void ParseArgs(int* argc,
       short_circuit = true;
     } else if (strcmp(arg, "--zero-fill-buffers") == 0) {
       zero_fill_all_buffers = true;
+    } else if (strcmp(arg, "--pending-deprecation") == 0) {
+      config_pending_deprecation = true;
     } else if (strcmp(arg, "--v8-options") == 0) {
       new_v8_argv[new_v8_argc] = "--help";
       new_v8_argc += 1;
@@ -4252,6 +4258,12 @@ void Init(int* argc,
   // --no_foo from the command line.
   V8::SetFlagsFromString(NODE_V8_OPTIONS, sizeof(NODE_V8_OPTIONS) - 1);
 #endif
+
+  {
+    std::string text;
+    config_pending_deprecation =
+        SafeGetenv("NODE_PENDING_DEPRECATION", &text) && text[0] == '1';
+  }
 
   // Allow for environment set preserving symlinks.
   {

--- a/src/node.cc
+++ b/src/node.cc
@@ -1036,10 +1036,15 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
 
 
 void* ArrayBufferAllocator::Allocate(size_t size) {
-  if (zero_fill_field_ || zero_fill_all_buffers)
+  if (zero_fill_all_buffers || zero_fill_field_ == 1) {
     return node::UncheckedCalloc(size);
-  else
-    return node::UncheckedMalloc(size);
+  } else if (zero_fill_field_ == 3) {
+    void* mem = node::UncheckedMalloc(size);
+    if (mem != nullptr)
+      memset(mem, random_fill_value_, size);
+    return mem;
+  }
+  return node::UncheckedMalloc(size);
 }
 
 static bool DomainHasErrorHandler(const Environment* env,

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -49,6 +49,9 @@ void InitConfig(Local<Object> target,
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
 
+  if (config_pending_deprecation)
+    READONLY_BOOLEAN_PROPERTY("pendingDeprecation");
+
   if (!config_warning_file.empty()) {
     Local<String> name = OneByteString(env->isolate(), "warningFile");
     Local<String> value = String::NewFromUtf8(env->isolate(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -196,6 +196,11 @@ inline bool IsBigEndian() {
 
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:
+  ArrayBufferAllocator() {
+    unsigned int seed = time(NULL);
+    random_fill_value_ = rand_r(&seed) % 256;
+  }
+
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }
 
   virtual void* Allocate(size_t size);  // Defined in src/node.cc
@@ -205,6 +210,7 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
 
  private:
   uint32_t zero_fill_field_ = 1;  // Boolean but exposed as uint32 to JS land.
+  uint8_t random_fill_value_;
 };
 
 // Clear any domain and/or uncaughtException handlers to force the error's

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -70,6 +70,10 @@ extern bool config_preserve_symlinks;
 // it to stderr.
 extern std::string config_warning_file;  // NOLINT(runtime/string)
 
+// Set in node.cc by ParseArgs when --pending-deprecation or
+// NODE_PENDING_DEPRECATION is used
+extern bool config_pending_deprecation;
+
 // Tells whether it is safe to call v8::Isolate::GetCurrent().
 extern bool v8_initialized;
 

--- a/test/parallel/test-buffer-pending-deprecation.js
+++ b/test/parallel/test-buffer-pending-deprecation.js
@@ -1,0 +1,15 @@
+// Flags: --pending-deprecation --no-warnings
+'use strict';
+
+const common = require('../common');
+const Buffer = require('buffer').Buffer;
+
+const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
+                      'recommended for use due to security and usability ' +
+                      'concerns. Please use the new Buffer.alloc(), ' +
+                      'Buffer.allocUnsafe(), or Buffer.from() construction ' +
+                      'methods instead.';
+
+common.expectWarning('DeprecationWarning', bufferWarning);
+
+new Buffer(10);


### PR DESCRIPTION
@addaleax @nodejs/ctc ...

This PR does a couple things as a *proposal* to bring some closure to https://github.com/nodejs/node/issues/9531

* As suggested by @addaleax, a pseudo-random byte value is selected at startup and used to auto-fill `new Buffer(num)` and `Buffer(num)`.

* A new `--pending-deprecation` command-line flag and `NODE_PENDING_DEPRECATION=1` environment variable is added that allows *conditional* off-by-default pending deprecation warnings.

* A pending deprecation warning is added for `Buffer()` and `new Buffer()`. This is off by default and will only be emitted when the new command line flag is set.

These are separated out into multiple commits.

There is a definite significant performance hit to `new Buffer(num)` and `Buffer(num)` using this. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
buffer