### PR TITLE
doc: fix stream documentation for object mode

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -981,7 +981,7 @@ setTimeout(() => {
 added: v0.9.11
 -->
 
-* `chunk` {Buffer|string} Chunk of data to unshift onto the read queue
+* `chunk` {Buffer|string|any} Chunk of data to unshift onto the read queue
 
 The `readable.unshift()` method pushes a chunk of data back into the internal
 buffer. This is useful in certain situations where a stream is being consumed by
@@ -1295,8 +1295,9 @@ const myWritable = new Writable({
 
 #### writable.\_write(chunk, encoding, callback)
 
-* `chunk` {Buffer|string} The chunk to be written. Will **always**
-  be a buffer unless the `decodeStrings` option was set to `false`.
+* `chunk` {Buffer|string|any} The chunk to be written. Will **always**
+  be a buffer unless the `decodeStrings` option was set to `false`
+  or the stream is operating in object mode.
 * `encoding` {string} If the chunk is a string, then `encoding` is the
   character encoding of that string. If chunk is a `Buffer`, or if the
   stream is operating in object mode, `encoding` may be ignored.
@@ -1500,13 +1501,13 @@ user programs.
 
 #### readable.push(chunk[, encoding])
 
-* `chunk` {Buffer|null|string} Chunk of data to push into the read queue
+* `chunk` {Buffer|null|string|any} Chunk of data to push into the read queue
 * `encoding` {string} Encoding of String chunks.  Must be a valid
   Buffer encoding, such as `'utf8'` or `'ascii'`
 * Returns {boolean} `true` if additional chunks of data may continued to be
   pushed; `false` otherwise.
 
-When `chunk` is a `Buffer` or `string`, the `chunk` of data will be added to the
+When `chunk` is not `null`, the `chunk` of data will be added to the
 internal queue for users of the stream to consume. Passing `chunk` as `null`
 signals the end of the stream (EOF), after which no more data can be written.
 
@@ -1873,8 +1874,9 @@ user programs.
 
 #### transform.\_transform(chunk, encoding, callback)
 
-* `chunk` {Buffer|string} The chunk to be transformed. Will **always**
-  be a buffer unless the `decodeStrings` option was set to `false`.
+* `chunk` {Buffer|string|any} The chunk to be transformed. Will **always**
+  be a buffer unless the `decodeStrings` option was set to `false`
+  or the stream is operating in object mode.
 * `encoding` {string} If the chunk is a string, then this is the
   encoding type. If chunk is a buffer, then this is the special
   value - 'buffer', ignore it in this case.


### PR DESCRIPTION
doc: fixes some trivial documentation mistakes for streams operating in object mode

For `unshift()`, `_write()`, `push()` and `_transform()`, the data type of the `chunk` parameter is extended with `any` and the documentation is corrected to take into account that streams can operate in object mode.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
documentation
