### PR TITLE
buffer: auto random fill Buffer(num) and new Buffer(num)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -22,11 +22,14 @@
 'use strict';
 
 const binding = process.binding('buffer');
+const config = process.binding('config');
 const { compare: compare_, compareOffset } = binding;
 const { isArrayBuffer, isSharedArrayBuffer, isUint8Array } =
     process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
+const zeroFillBuffers = !!config.zeroFillBuffers;
+const randomFill = zeroFillBuffers ? 0 : Math.floor(Math.random() * 256);
 
 class FastBuffer extends Uint8Array {
   constructor(arg1, arg2, arg3) {
@@ -102,7 +105,7 @@ function Buffer(arg, encodingOrOffset, length) {
         'If encoding is specified then the first argument must be a string'
       );
     }
-    return Buffer.allocUnsafe(arg);
+    return Buffer.allocUnsafe(arg).fill(randomFill);
   }
   return Buffer.from(arg, encodingOrOffset, length);
 }

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,4 +1,5 @@
 #include "node.h"
+#include "node_buffer.h"
 #include "node_i18n.h"
 #include "env.h"
 #include "env-inl.h"
@@ -48,6 +49,9 @@ void InitConfig(Local<Object> target,
 
   if (config_preserve_symlinks)
     READONLY_BOOLEAN_PROPERTY("preserveSymlinks");
+
+  if (zero_fill_all_buffers)
+    READONLY_BOOLEAN_PROPERTY("zeroFillBuffers");
 
   if (!config_warning_file.empty()) {
     Local<String> name = OneByteString(env->isolate(), "warningFile");


### PR DESCRIPTION
@addaleax @nodejs/ctc

This is an alternate approach for #11806 that uses `fill()` to fill the `new Buffer(num)`/`Buffer(num)` after allocation. The changes are less disruptive but occur in two steps. The performance profile is a bit better.

~~This also includes the same `--pending-deprecation` addition that is in #11806 and the conditionally-emitted deprecationwarning that is off by default.~~ The `--pending-deprecation` stuff has been separated out into a separate PR: https://github.com/nodejs/node/pull/11968

Again, this is a work in progress

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

buffer