### PR TITLE
test: test resolveObject with an empty path

### DIFF
--- a/test/parallel/test-url-relative.js
+++ b/test/parallel/test-url-relative.js
@@ -368,6 +368,9 @@ const relativeTests2 = [
   ['https://example.com/foo',
    'https://user:password@example.com',
    'https://user:password@example.com/foo'],
+
+   // No path at all
+   ['#hash1', '#hash2', '#hash1']
 ];
 relativeTests2.forEach(function(relativeTest) {
   const a = url.resolve(relativeTest[1], relativeTest[0]);


### PR DESCRIPTION
Add a case to test an URL object that has no path at all for `url.resolveObject`.


This test increases the coverage of `lib/url.js`:
+ https://coverage.nodejs.org/coverage-055482c21e2df944/root/url.js.html

The following lines will be checked:
+ https://github.com/nodejs/node/blob/055482c21e2df94446d9796949d1bb810e8331bf/lib/url.js#L846-L849
+ https://github.com/nodejs/node/blob/055482c21e2df94446d9796949d1bb810e8331bf/lib/url.js#L853-L858

This PR was part of https://github.com/nodejs/node/pull/11395 that I created, and I separated a non-breaking change commit from #11395 to this PR. I will update #11395 later.

##### Checklist
- [x] `make -j4 test`
- [x] tests is included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test