### PR TITLE
net: remove an unused internal module `assertPort`

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -9,13 +9,6 @@ function isLegalPort(port) {
   return +port === (+port >>> 0) && port <= 0xFFFF;
 }
 
-
-function assertPort(port) {
-  if (typeof port !== 'undefined' && !isLegalPort(port))
-    throw new RangeError('"port" argument must be >= 0 and < 65536');
-}
-
 module.exports = {
-  isLegalPort,
-  assertPort
+  isLegalPort
 };


### PR DESCRIPTION
Since a module `assertPort` in `lib/internal/net.js` is not used anymore, we can remove it. The coverage of `lib/internal/net.js` will be 100% with this.
+ https://coverage.nodejs.org/coverage-055482c21e2df944/root/internal/net.js.html

See also: https://github.com/nodejs/node/pull/11667

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test`
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
net