### PR TITLE
benchmark: allow multiple values for same config

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -38,7 +38,7 @@ function Benchmark(fn, configs, options) {
 }
 
 Benchmark.prototype._parseArgs = function(argv, configs) {
-  const cliOptions = Object.assign({}, configs);
+  const cliOptions = {};
   const extraOptions = {};
   // Parse configuration arguments
   for (const arg of argv) {
@@ -47,17 +47,20 @@ Benchmark.prototype._parseArgs = function(argv, configs) {
       console.error('bad argument: ' + arg);
       process.exit(1);
     }
+    const config = match[1];
 
-    if (configs[match[1]]) {
+    if (configs[config]) {
       // Infer the type from the config object and parse accordingly
-      const isNumber = typeof configs[match[1]][0] === 'number';
+      const isNumber = typeof configs[config][0] === 'number';
       const value = isNumber ? +match[2] : match[2];
-      cliOptions[match[1]] = [value];
+      if (!cliOptions[config])
+        cliOptions[config] = [];
+      cliOptions[config].push(value);
     } else {
-      extraOptions[match[1]] = match[2];
+      extraOptions[config] = match[2];
     }
   }
-  return { cli: cliOptions, extra: extraOptions };
+  return { cli: Object.assign({}, configs, cliOptions), extra: extraOptions };
 };
 
 Benchmark.prototype._queue = function(options) {


### PR DESCRIPTION
This allows running a benchmark with two or more values for the same option rather than just one or all of them, for example:

```
node benchmark/buffers/buffer-creation.js type=buffer() type=fast-alloc type=fast-alloc-fill
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark