### PR TITLE
errors: add duplicate symbol checking in E() and increase coverage

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -60,6 +60,8 @@ function message(key, args) {
 // Utility function for registering the error codes. Only used here. Exported
 // *only* to allow for testing.
 function E(sym, val) {
+  const assert = lazyAssert();
+  assert(messages.has(sym) === false, `Error symbol: ${sym} was already used.`);
   messages.set(sym, typeof val === 'function' ? val : String(val));
 }
 

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -12,6 +12,7 @@ const err1 = new errors.Error('TEST_ERROR_1', 'test');
 const err2 = new errors.TypeError('TEST_ERROR_1', 'test');
 const err3 = new errors.RangeError('TEST_ERROR_1', 'test');
 const err4 = new errors.Error('TEST_ERROR_2', 'abc', 'xyz');
+const err5 = new errors.Error('TEST_ERROR_1');
 
 assert(err1 instanceof Error);
 assert.strictEqual(err1.name, 'Error[TEST_ERROR_1]');
@@ -32,6 +33,11 @@ assert(err4 instanceof Error);
 assert.strictEqual(err4.name, 'Error[TEST_ERROR_2]');
 assert.strictEqual(err4.message, 'abc xyz');
 assert.strictEqual(err4.code, 'TEST_ERROR_2');
+
+assert(err5 instanceof Error);
+assert.strictEqual(err5.name, 'Error[TEST_ERROR_1]');
+assert.strictEqual(err5.message, 'Error for testing purposes: %s');
+assert.strictEqual(err5.code, 'TEST_ERROR_1');
 
 assert.throws(
   () => new errors.Error('TEST_FOO_KEY'),
@@ -118,3 +124,9 @@ assert.throws(() => {
                            type: TypeError,
                            message: /^Error for testing 2/ }));
 }, /AssertionError: .+ does not match \S/);
+
+assert.doesNotThrow(() => errors.E('TEST_ERROR_USED_SYMBOL'));
+assert.throws(
+  () => errors.E('TEST_ERROR_USED_SYMBOL'),
+  /^AssertionError: Error symbol: TEST_ERROR_USED_SYMBOL was already used\.$/
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Add duplicate error symbol checking in `E()` to avoid potential confusing result.

Improve coverage of `internal/errors.js`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors