### PR TITLE
lib: removed unused msg parameter in debug_agent

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -108,7 +108,7 @@ function Client(agent, socket) {
 }
 util.inherits(Client, Transform);
 
-Client.prototype.destroy = function destroy(msg) {
+Client.prototype.destroy = function destroy() {
   this.socket.destroy();
 
   this.emit('close');


### PR DESCRIPTION
Removed the msg parameter in the Client function
of _debug_agent.js, because it is unused.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib