### PR TITLE
readline: remove unneeded eslint-disable comment

### DIFF
--- a/lib/internal/readline.js
+++ b/lib/internal/readline.js
@@ -1,7 +1,6 @@
 'use strict';
 
 // Regex used for ansi escape code splitting
-// eslint-disable-next-line no-control-regex
 // Adopted from https://github.com/chalk/ansi-regex/blob/master/index.js
 // License: MIT, authors: @sindresorhus, Qix-, and arjunmehta
 // Matches all ansi escape code sequences in a string


### PR DESCRIPTION
Remove a comment disabling an ESLint rule that is not triggered by the
code anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline