### PR TITLE
debugger: fix debugger failure when passing commands with non-latin symbols

### DIFF
--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -97,7 +97,7 @@ function Client(agent, socket) {
   // Parse incoming data
   this.state = 'headers';
   this.headers = {};
-  this.buffer = new Buffer(0);
+  this.buffer = Buffer.alloc(0);
   socket.pipe(this);
 
   this.on('data', this.onCommand);
@@ -150,7 +150,8 @@ Client.prototype._transform = function _transform(data, enc, cb) {
       if (Buffer.byteLength(this.buffer, 'utf8') < len)
         break;
 
-      this.push(new Command(this.headers, this.buffer.slice(0, len).toString('utf8')));
+      this.push(new Command(this.headers,
+        this.buffer.slice(0, len).toString('utf8')));
       this.state = 'headers';
       this.buffer = this.buffer.slice(len);
       this.headers = {};

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -146,12 +146,17 @@ Client.prototype._transform = function _transform(data, enc, cb) {
         return this.destroy('Expected content-length');
 
       len = len | 0;
-      if (Buffer.byteLength(this.buffer) < len)
+      var bufLength = Buffer.byteLength(this.buffer, 'utf8');
+      if (bufLength < len)
         break;
 
-      this.push(new Command(this.headers, this.buffer.slice(0, len)));
+      var buf = Buffer.allocUnsafe(bufLength);
+      buf.write(this.buffer, 0, bufLength, 'utf8');
+      var body = buf.slice(0, len).toString('utf8');
+
+      this.push(new Command(this.headers, body));
       this.state = 'headers';
-      this.buffer = this.buffer.slice(len);
+      this.buffer = buf.slice(len).toString('utf8');
       this.headers = {};
     }
   }

--- a/lib/_debug_agent.js
+++ b/lib/_debug_agent.js
@@ -97,7 +97,7 @@ function Client(agent, socket) {
   // Parse incoming data
   this.state = 'headers';
   this.headers = {};
-  this.buffer = '';
+  this.buffer = new Buffer(0);
   socket.pipe(this);
 
   this.on('data', this.onCommand);
@@ -117,7 +117,7 @@ Client.prototype.destroy = function destroy(msg) {
 Client.prototype._transform = function _transform(data, enc, cb) {
   cb();
 
-  this.buffer += data;
+  this.buffer = Buffer.concat([this.buffer, data]);
 
   while (true) {
     if (this.state === 'headers') {
@@ -125,7 +125,8 @@ Client.prototype._transform = function _transform(data, enc, cb) {
       if (!this.buffer.includes('\r\n'))
         break;
 
-      if (this.buffer.startsWith('\r\n')) {
+      var bufString = this.buffer.toString('utf8');
+      if (bufString.startsWith('\r\n')) {
         this.buffer = this.buffer.slice(2);
         this.state = 'body';
         continue;
@@ -133,30 +134,25 @@ Client.prototype._transform = function _transform(data, enc, cb) {
 
       // Match:
       //   Header-name: header-value\r\n
-      var match = this.buffer.match(/^([^:\s\r\n]+)\s*:\s*([^\s\r\n]+)\r\n/);
+      var match = bufString.match(/^([^:\s\r\n]+)\s*:\s*([^\s\r\n]+)\r\n/);
       if (!match)
         return this.destroy('Expected header, but failed to parse it');
 
       this.headers[match[1].toLowerCase()] = match[2];
 
-      this.buffer = this.buffer.slice(match[0].length);
+      this.buffer = this.buffer.slice(Buffer.byteLength(match[0], 'utf8'));
     } else {
       var len = this.headers['content-length'];
       if (len === undefined)
         return this.destroy('Expected content-length');
 
       len = len | 0;
-      var bufLength = Buffer.byteLength(this.buffer, 'utf8');
-      if (bufLength < len)
+      if (Buffer.byteLength(this.buffer, 'utf8') < len)
         break;
 
-      var buf = Buffer.allocUnsafe(bufLength);
-      buf.write(this.buffer, 0, bufLength, 'utf8');
-      var body = buf.slice(0, len).toString('utf8');
-
-      this.push(new Command(this.headers, body));
+      this.push(new Command(this.headers, this.buffer.slice(0, len).toString('utf8')));
       this.state = 'headers';
-      this.buffer = buf.slice(len).toString('utf8');
+      this.buffer = this.buffer.slice(len);
       this.headers = {};
     }
   }


### PR DESCRIPTION
Debug agent incorrectly used Content-Length and cut Content-Length symbols  instead of Content-Length bytes from debugger protocol messages. This causes incorrect command body extraction and parsing that leads to debugger disconnection.

I use to fix the issue code similar to https://github.com/nodejs/node/blob/master/lib/_debugger.js#L136
This fixes debugger problem mistakenly reported here https://github.com/Microsoft/vscode/issues/17389

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
debugger
