### PR TITLE
doc: increase Buffer.concat() documentation

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -755,6 +755,10 @@ in `list`. This however causes an additional loop to be executed in order to
 calculate the `totalLength`, so it is faster to provide the length explicitly if
 it is already known.
 
+If `totalLength` is provided, it is coerced to an unsigned integer. If the
+combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
+truncated to `totalLength`.
+
 Example: Create a single `Buffer` from a list of three `Buffer` instances
 
 ```js


### PR DESCRIPTION
This commit adds documentation for two edge cases in
`Buffer.concat()`. Those cases are:

- `totalLength` is specified, but is not an integer.
- The combined buffer length is greater than `totalLength`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
doc

Fixes: https://github.com/nodejs/node/issues/11605