### PR TITLE
inspector: proper WS URLs when bound to 0.0.0.0

### DIFF
--- a/test/inspector/test-inspector-ip-detection.js
+++ b/test/inspector/test-inspector-ip-detection.js
@@ -1,0 +1,52 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled && common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const helper = require('./inspector-helper.js');
+const os = require('os');
+
+const ip = pickIPv4Address();
+
+if (!ip) {
+  common.skip('No IP address found');
+  return;
+}
+
+function checkListResponse(instance, err, response) {
+  assert.ifError(err);
+  const res = response[0];
+  const wsUrl = res['webSocketDebuggerUrl'];
+  assert.ok(wsUrl);
+  const match = wsUrl.match(/^ws:\/\/(.*):9229\/(.*)/);
+  assert.strictEqual(ip, match[1]);
+  assert.strictEqual(res['id'], match[2]);
+  assert.strictEqual(ip, res['devtoolsFrontendUrl'].match(/.*ws=(.*):9229/)[1]);
+  instance.childInstanceDone = true;
+}
+
+function checkError(instance, error) {
+  // Some OSes will not allow us to connect
+  if (error.code === 'EHOSTUNREACH') {
+    common.skip('Unable to connect to self');
+  } else {
+    throw error;
+  }
+  instance.childInstanceDone = true;
+}
+
+function runTests(instance) {
+  instance
+    .testHttpResponse(ip, '/json/list', checkListResponse.bind(null, instance),
+                      checkError.bind(null, instance))
+    .kill();
+}
+
+function pickIPv4Address() {
+  for (const i of [].concat(...Object.values(os.networkInterfaces()))) {
+    if (i.family === 'IPv4' && i.address !== '127.0.0.1')
+      return i.address;
+  }
+}
+
+helper.startNodeForInspectorTest(runTests, '--inspect-brk=0.0.0.0');

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -208,12 +208,12 @@ function testWaitsForFrontendDisconnect(session, harness) {
 
 function runTests(harness) {
   harness
-    .testHttpResponse('/json', checkListResponse)
-    .testHttpResponse('/json/list', checkListResponse)
-    .testHttpResponse('/json/version', checkVersion)
-    .testHttpResponse('/json/activate', checkBadPath)
-    .testHttpResponse('/json/activate/boom', checkBadPath)
-    .testHttpResponse('/json/badpath', checkBadPath)
+    .testHttpResponse(null, '/json', checkListResponse)
+    .testHttpResponse(null, '/json/list', checkListResponse)
+    .testHttpResponse(null, '/json/version', checkVersion)
+    .testHttpResponse(null, '/json/activate', checkBadPath)
+    .testHttpResponse(null, '/json/activate/boom', checkBadPath)
+    .testHttpResponse(null, '/json/badpath', checkBadPath)
     .runFrontendSession([
       testNoUrlsWhenConnected,
       testBreakpointOnStart,


### PR DESCRIPTION
JSON target list response will now return appropriate IP address
for instances listening on 0.0.0.0.

Refs: https://github.com/nodejs/node/issues/11591
PR-URL: https://github.com/nodejs/node/pull/11755
Reviewed-By: James Snell <jasnell@gmail.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
inspector: IP is not obtained from the socket

This is a backport of https://github.com/nodejs/node/pull/11755. The only change is that the test now checks if common.skipIfInspectorDisabled exists before calling it.
