### PR TITLE
lib: Use regex to compare error message

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -38,7 +38,7 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
-const CIRCULAR_ERROR_MESSAGE = 'Converting circular structure to JSON';
+const CIRCULAR_ERROR_MESSAGE = /Circular/i;
 
 var Debug;
 
@@ -46,7 +46,7 @@ function tryStringify(arg) {
   try {
     return JSON.stringify(arg);
   } catch (err) {
-    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
+    if (err.name === 'TypeError' && err.message.match(CIRCULAR_ERROR_MESSAGE))
       return '[Circular]';
     throw err;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,7 +53,7 @@ function tryStringify(arg) {
         CIRCULAR_ERROR_MESSAGE = err.message;
       }
     }
-    if (err.name === 'TypeError' && err.message.match(CIRCULAR_ERROR_MESSAGE))
+    if (err.name === 'TypeError' && err.message === CIRCULAR_ERROR_MESSAGE)
       return '[Circular]';
     throw err;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,14 +38,21 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
-const CIRCULAR_ERROR_MESSAGE = /Circular/i;
-
+var CIRCULAR_ERROR_MESSAGE;
 var Debug;
 
 function tryStringify(arg) {
   try {
     return JSON.stringify(arg);
   } catch (err) {
+    // Populate the circular error message lazily
+    if (!CIRCULAR_ERROR_MESSAGE) {
+      try {
+        const a = {}; a.a = a; JSON.stringify(a);
+      } catch (err) {
+        CIRCULAR_ERROR_MESSAGE = err.message;
+      }
+    }
     if (err.name === 'TypeError' && err.message.match(CIRCULAR_ERROR_MESSAGE))
       return '[Circular]';
     throw err;


### PR DESCRIPTION
To make node Engine Agnostic, use better comparison method for error
message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib
