### PR TITLE
src: remove explicit UTF-8 validity check in url

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -15,11 +15,6 @@
 #include <stdio.h>
 #include <cmath>
 
-#if defined(NODE_HAVE_I18N_SUPPORT)
-#include <unicode/utf8.h>
-#include <unicode/utf.h>
-#endif
-
 #define UNICODE_REPLACEMENT_CHARACTER 0xFFFD
 
 namespace node {
@@ -113,21 +108,6 @@ namespace url {
     output->assign(*buf, buf.length());
     return true;
   }
-
-  // Unfortunately there's not really a better way to do this.
-  // Iterate through each encoded codepoint and verify that
-  // it is a valid unicode codepoint.
-  static bool IsValidUTF8(std::string* input) {
-    const char* p = input->c_str();
-    int32_t len = input->length();
-    for (int32_t i = 0; i < len;) {
-      UChar32 c;
-      U8_NEXT_UNSAFE(p, i, c);
-      if (!U_IS_UNICODE_CHAR(c))
-        return false;
-    }
-    return true;
-  }
 #else
   // Intentional non-ops if ICU is not present.
   static bool ToUnicode(std::string* input, std::string* output) {
@@ -137,10 +117,6 @@ namespace url {
 
   static bool ToASCII(std::string* input, std::string* output) {
     *output = *input;
-    return true;
-  }
-
-  static bool IsValidUTF8(std::string* input) {
     return true;
   }
 #endif
@@ -393,12 +369,6 @@ namespace url {
 
     // First, we have to percent decode
     if (PercentDecode(input, length, &decoded) < 0)
-      goto end;
-
-    // If there are any invalid UTF8 byte sequences, we have to fail.
-    // Unfortunately this means iterating through the string and checking
-    // each decoded codepoint.
-    if (!IsValidUTF8(&decoded))
       goto end;
 
     // Then we have to punycode toASCII


### PR DESCRIPTION
This step was never part of the URL Standard's host parser algorithm, and is rendered unnecessary after errors from `ToASCII` are no longer ignored.

Refs: c2a302c50b37876663393711 "src: do not ignore IDNA conversion error"
Refs: https://url.spec.whatwg.org/#concept-host-parser

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, url