### PR TITLE
test: correct the assertion for the ES6 object properties

### DIFF
--- a/test/known_issues/test-vm-getters.js
+++ b/test/known_issues/test-vm-getters.js
@@ -16,4 +16,9 @@ const context = vm.createContext(sandbox);
 const code = 'Object.getOwnPropertyDescriptor(this, "prop");';
 const result = vm.runInContext(code, context);
 
-assert.strictEqual(result, descriptor);
+// Ref: https://github.com/nodejs/node/issues/11803
+
+assert.deepStrictEqual(Object.keys(result), Object.keys(descriptor));
+for (const prop of Object.keys(result)) {
+  assert.strictEqual(result[prop], descriptor[prop]);
+}


### PR DESCRIPTION
test: fix assertion in a vm test

Prototypes are not strict equal when they are
from different contexts.  Therefore, assert.strictEqual() 
fails for objects that are created in different 
contexts, e.g. in vm.runInContext().

Instead of expecting the prototypes to be equal, 
only check the properties of the objects for equality.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test