### PR TITLE
src: ensure that fd 0-2 are valid on windows

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4213,6 +4213,16 @@ inline void PlatformInit() {
     } while (min + 1 < max);
   }
 #endif  // __POSIX__
+#ifdef _WIN32
+  for (int fd = 0; fd <= 2; ++fd) {
+    auto handle = (HANDLE) _get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE ||
+        GetFileType(handle) == FILE_TYPE_UNKNOWN) {
+      if (_close(fd) || fd != _open("nul", _O_RDWR))
+        ABORT();
+    }
+  }
+#endif  // _WIN32
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4215,10 +4215,11 @@ inline void PlatformInit() {
 #endif  // __POSIX__
 #ifdef _WIN32
   for (int fd = 0; fd <= 2; ++fd) {
-    auto handle = (HANDLE) _get_osfhandle(fd);
+    auto handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
     if (handle == INVALID_HANDLE_VALUE ||
         GetFileType(handle) == FILE_TYPE_UNKNOWN) {
-      if (_close(fd) || fd != _open("nul", _O_RDWR))
+      _close(fd);
+      if (fd != _open("nul", _O_RDWR))
         ABORT();
     }
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -4218,6 +4218,8 @@ inline void PlatformInit() {
     auto handle = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
     if (handle == INVALID_HANDLE_VALUE ||
         GetFileType(handle) == FILE_TYPE_UNKNOWN) {
+      // Ignore _close result. If it fails or not depends on used Windows
+      // version. We will just check _open result.
       _close(fd);
       if (fd != _open("nul", _O_RDWR))
         ABORT();

--- a/test/fixtures/spawn_closed_stdio.py
+++ b/test/fixtures/spawn_closed_stdio.py
@@ -4,5 +4,5 @@ import subprocess
 os.close(0)
 os.close(1)
 os.close(2)
-exit_code = subprocess.call(sys.argv[1:4], shell=False)
+exit_code = subprocess.call(sys.argv[1:], shell=False)
 sys.exit(exit_code)

--- a/test/fixtures/spawn_closed_stdio.py
+++ b/test/fixtures/spawn_closed_stdio.py
@@ -4,6 +4,5 @@ import subprocess
 os.close(0)
 os.close(1)
 os.close(2)
-cmd = sys.argv[1] + ' -e "process.stdin; process.stdout; process.stderr;"'
-exit_code = subprocess.call(cmd, shell=False)
+exit_code = subprocess.call(sys.argv[1:4], shell=False)
 sys.exit(exit_code)

--- a/test/fixtures/spawn_closed_stdio.py
+++ b/test/fixtures/spawn_closed_stdio.py
@@ -1,0 +1,9 @@
+import os
+import sys
+import subprocess
+os.close(0)
+os.close(1)
+os.close(2)
+cmd = sys.argv[1] + ' -e "process.stdin; process.stdout; process.stderr;"'
+exit_code = subprocess.call(cmd, shell=False)
+sys.exit(exit_code)

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -10,7 +10,7 @@ if (common.isWindows) {
     process.stdin;
     process.stdout;
     process.stderr;
-    process.exit(0);
+    return;
   }
   const python = process.env.PYTHON || 'python';
   const script = path.join(common.fixturesDir, 'spawn_closed_stdio.py');

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -3,9 +3,16 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
+const path = require('path');
 
 if (common.isWindows) {
-  common.skip('platform not supported.');
+  const python = process.env.PYTHON || 'python';
+  const script = path.join(__dirname, '..', 'fixtures',
+                           'spawn_closed_stdio.py');
+  const proc = spawn(python, [ script, process.execPath ]);
+  proc.on('exit', common.mustCall(function(exitCode) {
+    assert.strictEqual(exitCode, 0);
+  }));
   return;
 }
 

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -6,10 +6,15 @@ const fs = require('fs');
 const path = require('path');
 
 if (common.isWindows) {
+  if (process.argv[2] === 'child') {
+    process.stdin;
+    process.stdout;
+    process.stderr;
+    process.exit(0);
+  }
   const python = process.env.PYTHON || 'python';
-  const script = path.join(__dirname, '..', 'fixtures',
-                           'spawn_closed_stdio.py');
-  const proc = spawn(python, [ script, process.execPath ]);
+  const script = path.join(common.fixturesDir, 'spawn_closed_stdio.py');
+  const proc = spawn(python, [script, process.execPath, __filename, 'child']);
   proc.on('exit', common.mustCall(function(exitCode) {
     assert.strictEqual(exitCode, 0);
   }));


### PR DESCRIPTION
Check that `stdin`, `stdout` and `stderr` are valid file descriptors on Windows. If not, reopen them with `nul` file.

This is a port of https://github.com/nodejs/node/pull/875 for Windows.

Fixes: https://github.com/nodejs/node/issues/11656

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
src
