### PR TITLE
repl: Empty command should be sent to eval function

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -422,12 +422,6 @@ function REPLServer(prompt,
           return;
         }
       }
-    } else {
-      // Print a new line when hitting enter.
-      if (!self.bufferedCommand) {
-        finish(null);
-        return;
-      }
     }
 
     const evalCmd = self.bufferedCommand + cmd + '\n';

--- a/test/parallel/test-repl-empty.js
+++ b/test/parallel/test-repl-empty.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+{
+  let evalCalledWithExpectedArgs = false;
+
+  const options = {
+    eval: common.mustCall((cmd, context) => {
+      // Assertions here will not cause the test to exit with an error code
+      // so set a boolean that is checked in process.on('exit',...) instead.
+      evalCalledWithExpectedArgs = (cmd === '\n');
+    })
+  };
+
+  const r = repl.start(options);
+
+  try {
+    // Empty strings should be sent to the repl's eval function
+    r.write('\n');
+  } finally {
+    r.write('.exit\n');
+  }
+
+  process.on('exit', () => {
+    assert(evalCalledWithExpectedArgs);
+  });
+}


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/nodejs/node/pull/6171

The command line debugger relies on the previous behavior. This adds a regression test and restores it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl