### PR TITLE
test: added net.connect lookup type check

### DIFF
--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const expectedError = /^TypeError: "lookup" option should be a function$/;
+
+['foobar', 1, {}, []].forEach((input => { connectThrows(input); }))
+
+function connectThrows(input) {
+  var opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input,
+  };
+
+  assert.throws(function() {
+    net.connect(opts);
+  }, expectedError);
+}
+
+[() => {}].forEach((input => { connectDoesNotThrow(input); }))
+
+function connectDoesNotThrow(input) {
+  var opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input,
+  };
+
+  assert.doesNotThrow(function() {
+    net.connect(opts);
+  });
+}

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -5,10 +5,10 @@ const net = require('net');
 
 const expectedError = /^TypeError: "lookup" option should be a function$/;
 
-['foobar', 1, {}, []].forEach((input => { connectThrows(input); }))
+['foobar', 1, {}, []].forEach((input => connectThrows(input) ));
 
 function connectThrows(input) {
-  var opts = {
+  const opts = {
     host: 'localhost',
     port: common.PORT,
     lookup: input,
@@ -19,10 +19,10 @@ function connectThrows(input) {
   }, expectedError);
 }
 
-[() => {}].forEach((input => { connectDoesNotThrow(input); }))
+[() => {}].forEach((input => connectDoesNotThrow(input) ));
 
 function connectDoesNotThrow(input) {
-  var opts = {
+  const opts = {
     host: 'localhost',
     port: common.PORT,
     lookup: input,

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -5,7 +5,7 @@ const net = require('net');
 
 const expectedError = /^TypeError: "lookup" option should be a function$/;
 
-['foobar', 1, {}, []].forEach((input => connectThrows(input) ));
+['foobar', 1, {}, []].forEach(input => connectThrows(input));
 
 function connectThrows(input) {
   const opts = {
@@ -19,7 +19,7 @@ function connectThrows(input) {
   }, expectedError);
 }
 
-[() => {}].forEach((input => connectDoesNotThrow(input) ));
+[() => {}].forEach(input => connectDoesNotThrow(input));
 
 function connectDoesNotThrow(input) {
   const opts = {

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -5,13 +5,13 @@ const net = require('net');
 
 const expectedError = /^TypeError: "lookup" option should be a function$/;
 
-['foobar', 1, {}, []].forEach(input => connectThrows(input));
+['foobar', 1, {}, []].forEach((input) => connectThrows(input));
 
 function connectThrows(input) {
   const opts = {
     host: 'localhost',
     port: common.PORT,
-    lookup: input,
+    lookup: input
   };
 
   assert.throws(function() {
@@ -19,13 +19,13 @@ function connectThrows(input) {
   }, expectedError);
 }
 
-[() => {}].forEach(input => connectDoesNotThrow(input));
+[() => {}].forEach((input) => connectDoesNotThrow(input));
 
 function connectDoesNotThrow(input) {
   const opts = {
     host: 'localhost',
     port: common.PORT,
-    lookup: input,
+    lookup: input
   };
 
   assert.doesNotThrow(function() {


### PR DESCRIPTION
Check the options passed to the Socket connect function to validate
the type of the lookup property. It must be strictly a function.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
test net
