### PR TITLE
http: make OutgoingMessage look like it is a Writable

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -23,6 +23,7 @@
 
 const assert = require('assert').ok;
 const Stream = require('stream');
+const { Writable } = Stream;
 const timers = require('timers');
 const util = require('util');
 const internalUtil = require('internal/util');
@@ -117,9 +118,29 @@ function OutgoingMessage() {
   this[outHeadersKey] = null;
 
   this._onPendingData = null;
+
+  this._corked = 0;
 }
 util.inherits(OutgoingMessage, Stream);
 
+Object.defineProperty(OutgoingMessage.prototype, '_writableState', {
+  get() {
+    var state = new Writable.WritableState();
+    Object.defineProperty(this, '_writableState', {
+      value: state,
+      configurable: false,
+      enumerable: false
+    });
+    return state;
+  },
+  enumerable: false
+});
+
+Object.defineProperty(OutgoingMessage.prototype, '_write', {
+  value() {}, // empty function
+  configurable: false,
+  enumerable: false
+});
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   get: function() {
@@ -286,6 +307,35 @@ OutgoingMessage.prototype._buffer = function _buffer(data, encoding, callback) {
   if (typeof this._onPendingData === 'function')
     this._onPendingData(data.length);
   return false;
+};
+
+
+function connectionCork(conn) {
+  conn.cork();
+}
+
+
+OutgoingMessage.prototype.cork = function cork() {
+  this._corked++;
+  if (!this.connection) {
+    this.once('connection', connectionCork);
+  } else {
+    this.connection.cork();
+  }
+};
+
+
+OutgoingMessage.prototype.uncork = function uncork() {
+  if (!this._corked)
+    return;
+
+  this._corked--;
+
+  if (!this.connection) {
+    this.once('connection', connectionCorkNT);
+  } else {
+    this.connection.uncork();
+  }
 };
 
 
@@ -790,6 +840,11 @@ OutgoingMessage.prototype.end = function end(data, encoding, callback) {
 
   if (this.connection && data)
     this.connection.uncork();
+
+  // end fully uncorks
+  for (var i = 0; i < this._corked; i++) {
+    this.uncork();
+  }
 
   this.finished = true;
 

--- a/test/parallel/test-http-outgoing-writable.js
+++ b/test/parallel/test-http-outgoing-writable.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const Stream = require('stream');
+const { Writable } = Stream;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  assert(res instanceof Stream, 'the response must be an instance of Stream');
+  assert(res instanceof Writable,
+         'the response must be an instance of Writable');
+  assert.strictEqual(typeof res._write, 'function', '_write is a function');
+  res.end();
+  server.close();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const req = http.get(server.address());
+  assert(req instanceof Writable,
+         'the request must be an instance of Writable');
+  assert.strictEqual(typeof req._write, 'function', '_write is a function');
+}));

--- a/test/parallel/test-http-response-cork-end.js
+++ b/test/parallel/test-http-response-cork-end.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let serverRes;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  serverRes = res;
+  res.writeHead(200);
+  res.write('hello ');
+
+  setImmediate(() => {
+    res.cork();
+  });
+}));
+
+server.listen(0, (err) => {
+  assert.ifError(err);
+
+  const req = http.request(server.address());
+  req.end();
+
+  req.on('response', common.mustCall((res) => {
+    assert.strictEqual(res.statusCode, 200);
+
+    res.setEncoding('utf8');
+    res.once('data', common.mustCall((chunk) => {
+      assert.strictEqual(chunk, 'hello ');
+    }));
+
+    setTimeout(() => {
+      assert(serverRes);
+
+      res.once('data', common.mustCall((data) => {
+        assert.strictEqual(data, 'world');
+        serverRes.end();
+        server.close();
+      }));
+
+      serverRes.end('world');
+    }, common.platformTimeout(100));
+  }));
+});

--- a/test/parallel/test-http-response-cork-uncork.js
+++ b/test/parallel/test-http-response-cork-uncork.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let serverRes;
+
+const server = http.createServer(common.mustCall((req, res) => {
+  serverRes = res;
+  res.writeHead(200);
+  res.write('hello ');
+
+  setImmediate(() => {
+    res.cork();
+    res.write('world');
+  });
+}));
+
+server.listen(0, (err) => {
+  assert.ifError(err);
+
+  const req = http.request(server.address());
+  req.end();
+
+  req.on('response', common.mustCall((res) => {
+    assert.strictEqual(res.statusCode, 200);
+
+    res.setEncoding('utf8');
+    res.once('data', common.mustCall((chunk) => {
+      assert.strictEqual(chunk, 'hello ');
+    }));
+
+    setTimeout(() => {
+      assert(serverRes);
+      serverRes.uncork();
+
+      res.once('data', common.mustCall((data) => {
+        assert.strictEqual(data, 'world');
+        serverRes.end();
+        server.close();
+      }));
+    }, common.platformTimeout(100));
+  }));
+});


### PR DESCRIPTION
For performance reasons OutgoingMessage is not a Writable. However,
for end-users expects it to be a Writable.

@sindresorhus @addaleax please check. Maybe there is a smarter way of doing this.
It piggybacks on the same mechanism we used to support `stream instanceof Duplex`.

The downside of this approach is that we have a `WritableState` that is completely meaningless.
It adds `cork()` and `uncork()` to  `OutgoingMessage`, using the underlining connection.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

http, stream