### PR TITLE
url: update the processing in the scheme state.

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -133,6 +133,13 @@ function onParseProtocolComplete(flags, protocol, username, password,
   if ((s && !newIsSpecial) || (!s && newIsSpecial)) {
     return;
   }
+  if (protocol === 'file:' &&
+    (ctx.username || ctx.password || ctx.port !== undefined)) {
+    return;
+  }
+  if (ctx.scheme === 'file:' && !ctx.host) {
+    return;
+  }
   if (newIsSpecial) {
     ctx.flags |= binding.URL_FLAGS_SPECIAL;
   } else {

--- a/test/fixtures/url-setter-tests.json
+++ b/test/fixtures/url-setter-tests.json
@@ -112,6 +112,55 @@
             }
         },
         {
+            "href": "gopher://example.net:1234",
+            "new_value": "file",
+            "expected": {
+                "href": "gopher://example.net:1234/",
+                "protocol": "gopher:"
+            }
+        },
+        {
+            "href": "wss://x:x@example.net:1234",
+            "new_value": "file",
+            "expected": {
+                "href": "wss://x:x@example.net:1234/",
+                "protocol": "wss:"
+            }
+        },
+        {
+            "comment": "Can’t switch from file URL with no host",
+            "href": "file://localhost/",
+            "new_value": "http",
+            "expected": {
+                "href": "file:///",
+                "protocol": "file:"
+            }
+        },
+        {
+            "href": "file:///test",
+            "new_value": "gopher",
+            "expected": {
+                "href": "file:///test",
+                "protocol": "file:"
+            }
+        },
+        {
+            "href": "file:",
+            "new_value": "wss",
+            "expected": {
+                "href": "file:///",
+                "protocol": "file:"
+            }
+        },
+        {
+            "href": "file://hi/path",
+            "new_value": "s",
+            "expected": {
+                "href": "file://hi/path",
+                "protocol": "file:"
+            }
+        },
+        {
             "href": "https://example.net",
             "new_value": "s",
             "expected": {


### PR DESCRIPTION
Fix https://github.com/nodejs/node/issues/11785. I've updated the processing in the scheme state to follow the specification and synchronized `url-setter-tests` with upstream.
+ Related lines in the spec:
https://github.com/whatwg/url/blob/a8ed8d2aefeec1e742490d08844c3d91a87e77fb/url.bs#L1493-L1508

While I was testing added tests, I noticed that the current state machine of Node.js doesn't parse URL correctly for `pathname`. For example:
```js
var url = new URL('ssh://example.net')
url.pathname
// expected: //example.net
// actual: '/'
```

So I got rid of the following test for this time.
```json
{
  "href": "ssh://example.net",
  "new_value": "file",
  "expected": {
    "href": "ssh://example.net",
    "protocol": "ssh:"
  }
},
```

I will work on it later.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
url, test
