### PR TITLE
module: check env NODE_PRELOAD for preload modules

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -411,8 +411,38 @@
 
   // Load preload modules
   function preloadModules() {
-    if (process._preload_modules) {
-      NativeModule.require('module')._preloadModules(process._preload_modules);
+    var allPreloads = process._preload_modules;
+    var isSetUidRoot = false;
+
+    if (process.platform !== 'win32') {
+      isSetUidRoot = process.getuid() !== process.geteuid() ||
+        process.getgid() !== process.getegid();
+    }
+
+    if (!isSetUidRoot && process.env.NODE_PRELOAD) {
+      const path = NativeModule.require('path');
+
+      const addPreload = (nmDir, preloads) => {
+        const addNmDir = (m) => {
+          return path.isAbsolute(m) ? m : path.join(nmDir, m);
+        };
+
+        if (preloads && preloads.length > 0) {
+          preloads = preloads.map((m) => addNmDir(m.trim()))
+              .filter((m) => (m.length > nmDir.length && m.startsWith(nmDir)));
+
+          if (preloads.length > 0) {
+            allPreloads = (allPreloads || []).concat(preloads);
+          }
+        }
+      };
+
+      const globalNm = path.join(process.argv[0], '../../lib/node_modules/');
+      addPreload(globalNm, process.env.NODE_PRELOAD.split(path.delimiter));
+    }
+
+    if (allPreloads) {
+      NativeModule.require('module')._preloadModules(allPreloads);
     }
   }
 


### PR DESCRIPTION
Adds a new feature that checks the environment variable NODE_PRELOAD
that should be a : (or ; on windows) delimited string of modules inside
the global node_modules dir to preload, the same as those that can be
specified by the -r command line option except this is limited to
global node_modules. 

Each module can be the absolute path of the module or just the name
of the module under the global node_modules dir.

Implements https://github.com/nodejs/node/issues/11853

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
