### PR TITLE
tools: ignore URLs in line length linting

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -97,7 +97,7 @@ rules:
   key-spacing: [2, {mode: minimum}]
   keyword-spacing: 2
   linebreak-style: [2, unix]
-  max-len: [2, 80, 2]
+  max-len: [2, {code: 80, ignoreUrls: true, tabWidth: 2}]
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -150,10 +150,9 @@ function _addHeaderLines(headers, n) {
 // TODO: perhaps http_parser could be returning both raw and lowercased versions
 // of known header names to avoid us having to call toLowerCase() for those
 // headers.
-/* eslint-disable max-len */
+
 // 'array' header list is taken from:
 // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
-/* eslint-enable max-len */
 function matchKnownFields(field) {
   var low = false;
   while (true) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -265,11 +265,9 @@ function Server(requestListener) {
     this.on('request', requestListener);
   }
 
-  /* eslint-disable max-len */
   // Similar option to this. Too lazy to write my own docs.
   // http://www.squid-cache.org/Doc/config/half_closed_clients/
   // http://wiki.squid-cache.org/SquidFaq/InnerWorkings#What_is_a_half-closed_filedescriptor.3F
-  /* eslint-enable max-len */
   this.httpAllowHalfOpen = false;
 
   this.on('connection', connectionListener);

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -70,7 +70,6 @@ if (process.argv[2] === 'you-are-the-child') {
 delete process.env.NON_EXISTING_VARIABLE;
 assert.strictEqual(true, delete process.env.NON_EXISTING_VARIABLE);
 
-/* eslint-disable max-len */
 /* For the moment we are not going to support setting the timezone via the
  * environment variables. The problem is that various V8 platform backends
  * deal with timezone in different ways. The windows platform backend caches
@@ -87,7 +86,6 @@ date = new Date('Fri, 10 Sep 1982 03:15:00 GMT');
 assert.strictEqual(3, date.getUTCHours());
 assert.strictEqual(5, date.getHours());
 */
-/* eslint-enable max-len */
 
 // Environment variables should be case-insensitive on Windows, and
 // case-sensitive on other platforms.

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 'use strict';
 require('../common');
 const assert = require('assert');
@@ -272,8 +271,7 @@ const parseTests = {
   },
 
   'http://user:pass@mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=': {
-    href: 'http://user:pass@mt0.google.com/vt/lyrs=m@114???' +
-          '&hl=en&src=api&x=2&y=2&z=3&s=',
+    href: 'http://user:pass@mt0.google.com/vt/lyrs=m@114???&hl=en&src=api&x=2&y=2&z=3&s=',
     protocol: 'http:',
     slashes: true,
     host: 'mt0.google.com',
@@ -842,7 +840,7 @@ const parseTests = {
     hostname: 'a.b',
     hash: null,
     pathname: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E',
-    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
+    path: '/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz', // eslint-disable-line max-len
     search: '?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     query: 'mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz',
     href: 'http://a.b/%09bc%0Adr%0Def%20g%22hq%27j%3Ckl%3E?mn%5Cop%5Eq=r%6099%7Bst%7Cuv%7Dwz'


### PR DESCRIPTION
Where inclusion of a lengthy URL causes a line to exceed 80 characters
in our code base, do not report the line length as a linting error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools