### PR TITLE
errors: remove needless lazyAssert 

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -6,16 +6,11 @@
 // value statically and permanently identifies the error. While the error
 // message may change, the code should not.
 
+const assert = require('assert');
 const kCode = Symbol('code');
 const messages = new Map();
 
-var assert, util;
-function lazyAssert() {
-  if (!assert)
-    assert = require('assert');
-  return assert;
-}
-
+var util;
 function lazyUtil() {
   if (!util)
     util = require('util');
@@ -41,7 +36,6 @@ function makeNodeError(Base) {
 }
 
 function message(key, args) {
-  const assert = lazyAssert();
   assert.strictEqual(typeof key, 'string');
   const util = lazyUtil();
   const msg = messages.get(key);
@@ -60,7 +54,6 @@ function message(key, args) {
 // Utility function for registering the error codes. Only used here. Exported
 // *only* to allow for testing.
 function E(sym, val) {
-  const assert = lazyAssert();
   assert(messages.has(sym) === false, `Error symbol: ${sym} was already used.`);
   messages.set(sym, typeof val === 'function' ? val : String(val));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Since now the `lazyAssert()` function will be called in `E()` and `E()` will be called suddenly at the end of the script, so there is no need to require the `assert` module lazily any more.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors