### PR TITLE
benchmark: avoid TurboFan deopt in arrays bench

### DIFF
--- a/benchmark/arrays/var-int.js
+++ b/benchmark/arrays/var-int.js
@@ -27,9 +27,13 @@ function main(conf) {
   bench.start();
   var arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
+    run();
+  }
+  bench.end(n);
+
+  function run() {
     for (var j = 0, k = arr.length; j < k; ++j) {
       arr[j] = (j ^ k) & 127;
     }
   }
-  bench.end(n);
 }

--- a/benchmark/arrays/zero-float.js
+++ b/benchmark/arrays/zero-float.js
@@ -27,9 +27,13 @@ function main(conf) {
   bench.start();
   var arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
+    run();
+  }
+  bench.end(n);
+
+  function run() {
     for (var j = 0, k = arr.length; j < k; ++j) {
       arr[j] = 0.0;
     }
   }
-  bench.end(n);
 }

--- a/benchmark/arrays/zero-int.js
+++ b/benchmark/arrays/zero-int.js
@@ -27,9 +27,13 @@ function main(conf) {
   bench.start();
   var arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
+    run();
+  }
+  bench.end(n);
+
+  function run() {
     for (var j = 0, k = arr.length; j < k; ++j) {
       arr[j] = 0;
     }
   }
-  bench.end(n);
 }


### PR DESCRIPTION
Something unidentified at the moment is causing the arrays benchmarks to
deopt when run with the TurboFan compiler. Refactor the test to use an
inner function that can be correctly optimized by TurboFan and
Crankshaft.
I think this change also makes the benchmarks generally better. I will optimize the `run` function instead of the whole `main` that is run only once anyway.

Refs: https://github.com/nodejs/node/issues/11851#issuecomment-287106714

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

benchmark

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
