### PR TITLE
tls: fix SecurePair external memory reporting

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3245,11 +3245,7 @@ void Connection::Start(const FunctionCallbackInfo<Value>& args) {
 void Connection::Close(const FunctionCallbackInfo<Value>& args) {
   Connection* conn;
   ASSIGN_OR_RETURN_UNWRAP(&conn, args.Holder());
-
-  if (conn->ssl_ != nullptr) {
-    SSL_free(conn->ssl_);
-    conn->ssl_ = nullptr;
-  }
+  conn->DestroySSL();
 }
 
 


### PR DESCRIPTION
Ensure that AdjustAmountOfExternalAllocatedMemory() is called when
the SecurePair is destroyed.  Not doing so is not an actual memory
leak but it makes `process.memoryUsage().external` wildly inaccurate
and can cause performance problems due to excessive garbage collection.