### PR TITLE
lib: make callback checks more strict

### DIFF
--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -266,7 +266,7 @@ Client.prototype._onResponse = function(res) {
     handled = true;
   }
 
-  if (cb) {
+  if (typeof cb === 'function') {
     this._reqCallbacks.splice(index, 1);
     handled = true;
 
@@ -1744,7 +1744,7 @@ Interface.prototype.trySpawn = function(cb) {
       self.killChild();
     });
 
-    if (cb) cb();
+    if (typeof cb === 'function') cb();
     self.resume();
   });
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -147,7 +147,7 @@ function ClientRequest(options, cb) {
   }
 
   self.path = options.path || '/';
-  if (cb) {
+  if (typeof cb === 'function') {
     self.once('response', cb);
   }
 
@@ -708,7 +708,7 @@ function _deferToConnect(method, arguments_, cb) {
 }
 
 ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
-  if (callback) this.once('timeout', callback);
+  if (typeof callback === 'function') this.once('timeout', callback);
 
   var self = this;
   function emitTimeout() {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -87,7 +87,7 @@ exports.IncomingMessage = IncomingMessage;
 
 
 IncomingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
-  if (callback)
+  if (typeof callback === 'function')
     this.on('timeout', callback);
   this.socket.setTimeout(msecs);
   return this;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -195,7 +195,7 @@ exports.OutgoingMessage = OutgoingMessage;
 
 OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 
-  if (callback) {
+  if (typeof callback === 'function') {
     this.on('timeout', callback);
   }
 
@@ -686,7 +686,7 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
 
 function writeAfterEndNT(self, err, callback) {
   self.emit('error', err);
-  if (callback) callback(err);
+  if (typeof callback === 'function') callback(err);
 }
 
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -284,7 +284,7 @@ util.inherits(Server, net.Server);
 
 Server.prototype.setTimeout = function setTimeout(msecs, callback) {
   this.timeout = msecs;
-  if (callback)
+  if (typeof callback === 'function')
     this.on('timeout', callback);
   return this;
 };

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -88,7 +88,7 @@ function afterTransform(stream, er, data) {
 
   var cb = ts.writecb;
 
-  if (!cb)
+  if (typeof cb !== 'function')
     return stream.emit('error', new Error('no writecb in Transform class'));
 
   ts.writechunk = null;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -538,7 +538,7 @@ function finishMaybe(stream, state) {
 function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
-  if (cb) {
+  if (typeof cb === 'function') {
     if (state.finished)
       process.nextTick(cb);
     else

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -345,7 +345,7 @@ tls_wrap.TLSWrap.prototype.close = function close(cb) {
         ssl._secureContext.context = null;
       }
     }
-    if (cb)
+    if (typeof cb === 'function')
       cb();
   };
 
@@ -556,7 +556,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
     this._rejectUnauthorized = rejectUnauthorized;
   }
   if (!this._handle.renegotiate()) {
-    if (callback) {
+    if (typeof callback === 'function') {
       process.nextTick(callback, new Error('Failed to renegotiate'));
     }
     return false;
@@ -565,7 +565,7 @@ TLSSocket.prototype.renegotiate = function(options, callback) {
   // Ensure that we'll cycle through internal openssl's state
   this.write('');
 
-  if (callback) {
+  if (typeof callback === 'function') {
     this.once('secure', function() {
       callback(null);
     });
@@ -1065,7 +1065,7 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
     requestOCSP: options.requestOCSP
   });
 
-  if (cb)
+  if (typeof cb === 'function')
     socket.once('secureConnect', cb);
 
   if (!options.socket) {

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -221,7 +221,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
       timeoutId = null;
     }
 
-    if (!callback) return;
+    if (typeof callback !== 'function') return;
 
     // merge chunks
     var stdout;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -596,7 +596,7 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
-  if (callback) {
+  if (typeof callback === 'function') {
     var next = function(er, ret) {
       if (ret)
         ret = ret.toString(encoding);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -425,7 +425,7 @@ function doSend(ex, self, ip, list, address, port, callback) {
   req.list = list;  // Keep reference alive.
   req.address = address;
   req.port = port;
-  if (callback) {
+  if (typeof callback === 'function') {
     req.callback = callback;
     req.oncomplete = afterSend;
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -304,7 +304,7 @@ fs.exists = function(path, callback) {
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
   function cb(err) {
-    if (callback) callback(err ? false : true);
+    if (typeof callback === 'function') callback(err ? false : true);
   }
 };
 
@@ -1990,7 +1990,7 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  if (cb)
+  if (typeof cb === 'function')
     this.once('close', cb);
 
   if (this.closed || typeof this.fd !== 'number') {

--- a/lib/net.js
+++ b/lib/net.js
@@ -356,13 +356,13 @@ Socket.prototype.listen = function() {
 Socket.prototype.setTimeout = function(msecs, callback) {
   if (msecs === 0) {
     timers.unenroll(this);
-    if (callback) {
+    if (typeof callback === 'function') {
       this.removeListener('timeout', callback);
     }
   } else {
     timers.enroll(this, msecs);
     timers._unrefActive(this);
-    if (callback) {
+    if (typeof callback === 'function') {
       this.once('timeout', callback);
     }
   }
@@ -501,7 +501,7 @@ Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');
 
   function fireErrorCallbacks(self) {
-    if (cb) cb(exception);
+    if (typeof cb === 'function') cb(exception);
     if (exception && !self._writableState.errorEmitted) {
       process.nextTick(emitErrorNT, self, exception);
       self._writableState.errorEmitted = true;
@@ -954,7 +954,7 @@ Socket.prototype.connect = function() {
     initSocketHandle(this);
   }
 
-  if (cb !== null) {
+  if (typeof cb === 'function') {
     this.once('connect', cb);
   }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -147,7 +147,7 @@ function flushCallback(level, strategy, callback) {
   if (!this._hadError) {
     this._level = level;
     this._strategy = strategy;
-    if (callback) callback();
+    if (typeof callback === 'function') callback();
   }
 }
 
@@ -275,13 +275,13 @@ class Zlib extends Transform {
     }
 
     if (ws.ended) {
-      if (callback)
+      if (typeof callback === 'function')
         process.nextTick(callback);
     } else if (ws.ending) {
-      if (callback)
+      if (typeof callback === 'function')
         this.once('end', callback);
     } else if (ws.needDrain) {
-      if (callback) {
+      if (typeof callback === 'function') {
         const drainHandler = () => this.flush(kind, callback);
         this.once('drain', drainHandler);
       }
@@ -452,7 +452,7 @@ class Zlib extends Transform {
 }
 
 function _close(engine, callback) {
-  if (callback)
+  if (typeof callback === 'function')
     process.nextTick(callback);
 
   // Caller may invoke .close after a zlib error (which will null _handle).


### PR DESCRIPTION
Many places in `lib/` check if a callback argument is truthy before using the callback. This doesn't make any guarantees that the callback is actually a function though. This commit replaces truthy checks with explicit `typeof` checks.

FWIW, my personal opinion is that we should throw in the cases where the callback is not a function, but people might find that too disruptive.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
lib
