### PR TITLE
check uv_async_t wasn't already close

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -404,7 +404,10 @@ AgentImpl::~AgentImpl() {
   auto close_cb = [](uv_handle_t* handle) {
     delete reinterpret_cast<uv_async_t*>(handle);
   };
-  uv_close(reinterpret_cast<uv_handle_t*>(data_written_), close_cb);
+  if(!uv_is_closing()){
+    uv_close(reinterpret_cast<uv_handle_t*>(data_written_), close_cb);
+  }
+    
   data_written_ = nullptr;
 }
 

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -404,7 +404,7 @@ AgentImpl::~AgentImpl() {
   auto close_cb = [](uv_handle_t* handle) {
     delete reinterpret_cast<uv_async_t*>(handle);
   };
-  if(!uv_is_closing()){
+  if(!uv_is_closing(data_written_)){
     uv_close(reinterpret_cast<uv_handle_t*>(data_written_), close_cb);
   }
     


### PR DESCRIPTION
When embedding nodejs into another project. Developer have the possibility to provide there own ``uv_loop`` structure and can walk through its handler and close it.

``AgentImpl::~AgentImpl()`` should verify if ``data_written_`` async handler wasn't already close.