### PR TITLE
benchmark: fix fs\bench-realpathSync.js

### DIFF
--- a/benchmark/fs/bench-realpathSync.js
+++ b/benchmark/fs/bench-realpathSync.js
@@ -3,6 +3,8 @@
 const common = require('../common');
 const fs = require('fs');
 const path = require('path');
+
+process.chdir(__dirname);
 const resolved_path = path.resolve(__dirname, '../../lib/');
 const relative_path = path.relative(__dirname, '../../lib/');
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
benchmark, fs

`fs\bench-realpathSync.js` runs safely only if its `cwd` is its `__dirname`. In other cases, it throws `ENOENT: no such file or directory`. This commit makes it callable from any place (including being a part of the `fs` suite launched from any directory).

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines