### PR TITLE
deps: cherry-pick 09de996 from V8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 6
 #define V8_BUILD_NUMBER 326
-#define V8_PATCH_LEVEL 56
+#define V8_PATCH_LEVEL 57
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -5008,7 +5008,7 @@ typename ParserBase<Impl>::StatementT ParserBase<Impl>::ParseSwitchStatement(
 
   {
     BlockState cases_block_state(zone(), &scope_state_);
-    cases_block_state.set_start_position(scanner()->location().beg_pos);
+    cases_block_state.set_start_position(switch_pos);
     cases_block_state.SetNonlinear();
     typename Types::Target target(this, switch_statement);
 

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -1729,6 +1729,10 @@ Statement* Parser::RewriteSwitchStatement(Expression* tag,
   Block* cases_block = factory()->NewBlock(NULL, 1, false, kNoSourcePosition);
   cases_block->statements()->Add(switch_statement, zone());
   cases_block->set_scope(scope);
+  DCHECK_IMPLIES(scope != nullptr,
+                 switch_statement->position() >= scope->start_position());
+  DCHECK_IMPLIES(scope != nullptr,
+                 switch_statement->position() < scope->end_position());
   switch_block->statements()->Add(cases_block, zone());
   return switch_block;
 }

--- a/deps/v8/test/debugger/regress/regress-6085.js
+++ b/deps/v8/test/debugger/regress/regress-6085.js
@@ -1,0 +1,49 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+function* serialize() {
+  debugger;
+  switch (0) {
+    case 0:
+      let x = 1;
+      return x;  // Check scopes
+  }
+}
+
+let exception = null;
+let step_count = 0;
+let scopes_checked = false;
+
+function listener(event, exec_state, event_data, data) {
+  if (event != Debug.DebugEvent.Break) return;
+  try {
+    if (exec_state.frame().sourceLineText().includes("Check scopes")) {
+      let expected = [ debug.ScopeType.Block,
+                       debug.ScopeType.Local,
+                       debug.ScopeType.Script,
+                       debug.ScopeType.Global ];
+      for (let i = 0; i < exec_state.frame().scopeCount(); i++) {
+        assertEquals(expected[i], exec_state.frame().scope(i).scopeType());
+      }
+      scopes_checked = true;
+    }
+    if (step_count++ < 3) exec_state.prepareStep(Debug.StepAction.StepNext);
+  } catch (e) {
+    exception = e;
+    print(e, e.stack);
+  }
+}
+
+
+
+let Debug = debug.Debug;
+Debug.setListener(listener);
+
+let gen = serialize();
+gen.next();
+
+Debug.setListener(null);
+assertNull(exception);
+assertEquals(4, step_count);
+assertTrue(scopes_checked);


### PR DESCRIPTION
Original commit message:

    [debugger] fix switch block source positions.

    The switch statement itself is part of the switch block.
    However, the source position of the statement is outside of
    the block. This leads to confusion for the debugger, if the
    switch block pushes a block context: the current context is
    a block context, but the scope analysis based on the current
    source position tells the debugger that we should be outside
    the scope, so we should have the function context.

    R=marja@chromium.org
    BUG=v8:6085
    Review-Url: https://codereview.chromium.org/2744213003
    Cr-Commit-Position: refs/heads/master@{#43744}
    Committed: https://chromium.googlesource.com/v8/v8/+/09de9969ccb9bc3bbd667788afad665b309d02f5


Fixes: https://github.com/nodejs/node/issues/11746

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps, v8

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

/cc @nodejs/v8 

The test in https://github.com/nodejs/node/issues/11746
 does not crash with this fix anymore. But since it's a V8 fix, I think we don't need an extra regression test here. 