### PR TITLE
buffer: remove unneeded eslint-disable comment

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable require-buffer */
 'use strict';
 
 const binding = process.binding('buffer');


### PR DESCRIPTION
lib/buffer.js uses a function declaration for `Buffer`. So it never
uses an instance of `Buffer` in the global scope. Therefore the
disabling of the `require-buffer` custom rule is not needed. Remove the
comment.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer tools

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
