### PR TITLE
benchmark: remove v8ForceOptimization calls

### DIFF
--- a/benchmark/url/whatwg-url-idna.js
+++ b/benchmark/url/whatwg-url-idna.js
@@ -37,8 +37,6 @@ function main(conf) {
   const input = inputs[conf.input][to];
   const method = to === 'ascii' ? domainToASCII : domainToUnicode;
 
-  common.v8ForceOptimization(method, input);
-
   bench.start();
   for (var i = 0; i < n; i++) {
     method(input);

--- a/benchmark/vm/run-in-context.js
+++ b/benchmark/vm/run-in-context.js
@@ -23,8 +23,6 @@ function main(conf) {
 
   const contextifiedSandbox = vm.createContext();
 
-  common.v8ForceOptimization(vm.runInContext,
-                             '0', contextifiedSandbox, options);
   bench.start();
   for (; i < n; i++)
     vm.runInContext('0', contextifiedSandbox, options);

--- a/benchmark/vm/run-in-this-context.js
+++ b/benchmark/vm/run-in-this-context.js
@@ -21,7 +21,6 @@ function main(conf) {
 
   var i = 0;
 
-  common.v8ForceOptimization(vm.runInThisContext, '0', options);
   bench.start();
   for (; i < n; i++)
     vm.runInThisContext('0', options);


### PR DESCRIPTION
#9615 removed common.v8ForceOptimization along with most of the calls to it but these were left behind. This removes common.v8ForceOptimization calls from url and vm benchmark
files. 

Fixes: https://github.com/nodejs/node/issues/11895

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
