### PR TITLE
fs: (+/-)Infinity and NaN invalid unixtimestamp

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1880,8 +1880,7 @@ follow these rules:
   returns milliseconds, so it should be divided by 1000 before passing it in.
 - If the value is a numeric string like `'123456789'`, the value will get
   converted to the corresponding number.
-- If the value is `NaN` or `Infinity`, the value will get converted to
-  `Date.now() / 1000`.
+- If the value is `NaN`, `Infinity` or `-Infinity`, an Error will be thrown.
 
 ## fs.utimesSync(path, atime, mtime)
 <!-- YAML

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1165,8 +1165,8 @@ function toUnixTimestamp(time) {
   if (typeof time === 'string' && +time == time) {
     return +time;
   }
-  if (typeof time === 'number') {
-    if (!Number.isFinite(time) || time < 0) {
+  if (Number.isFinite(time)) {
+    if (time < 0) {
       return Date.now() / 1000;
     }
     return time;

--- a/test/parallel/test-fs-timestamp-parsing-error.js
+++ b/test/parallel/test-fs-timestamp-parsing-error.js
@@ -1,9 +1,9 @@
 'use strict';
 require('../common');
-const assert = require('assert');
 const fs = require('fs');
+const assert = require('assert');
 
-[undefined, null, []].forEach((input) => {
+[Infinity, -Infinity, NaN].forEach((input) => {
   assert.throws(() => fs._toUnixTimestamp(input),
                 new RegExp('^Error: Cannot parse time: ' + input + '$'));
 });
@@ -11,6 +11,7 @@ const fs = require('fs');
 assert.throws(() => fs._toUnixTimestamp({}),
               /^Error: Cannot parse time: \[object Object\]$/);
 
-[1, '1', Date.now(), -1, '-1', Infinity].forEach((input) => {
+const okInputs = [1, -1, '1', '-1', Date.now()];
+okInputs.forEach((input) => {
   assert.doesNotThrow(() => fs._toUnixTimestamp(input));
 });

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -143,17 +143,15 @@ function testIt(atime, mtime, callback) {
 const stats = fs.statSync(__filename);
 
 // run tests
-const runTest = common.mustCall(testIt, 6);
+const runTest = common.mustCall(testIt, 5);
 
 runTest(new Date('1982-09-10 13:37'), new Date('1982-09-10 13:37'), function() {
   runTest(new Date(), new Date(), function() {
     runTest(123456.789, 123456.789, function() {
       runTest(stats.mtime, stats.mtime, function() {
-        runTest(NaN, Infinity, function() {
-          runTest('123456', -1, common.mustCall(function() {
-            // done
-          }));
-        });
+        runTest('123456', -1, common.mustCall(function() {
+          // done
+        }));
       });
     });
   });


### PR DESCRIPTION
Infinity and NaN are currently considered valid input when generating a
unix time stamp but are defaulted arbitrarly to Date.now()/1000. This
PR removes this behaviour and throw an exception like all the other
invalid input types.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
fs