### PR TITLE
test: fix flaky test-tls-socket-close

### DIFF
--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -10,7 +10,6 @@ const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
 
 let tlsSocket;
-let interval;
 // tls server
 const tlsServer = tls.createServer({ cert, key }, (socket) => {
   tlsSocket = socket;
@@ -18,7 +17,6 @@ const tlsServer = tls.createServer({ cert, key }, (socket) => {
     assert.strictEqual(error.code, 'EINVAL');
     tlsServer.close();
     netServer.close();
-    clearInterval(interval);
   }));
 });
 

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -40,7 +40,7 @@ const netServer = net.createServer((socket) => {
       // this breaks if TLSSocket is already managing the socket:
       netSocket.destroy();
       const interval = setInterval(() => {
-        // Checking this way allows us to do the right at a time that causes a
+        // Checking this way allows us to do the write at a time that causes a
         // segmentation fault (not always, but often) in Node.js 7.7.3 and
         // earlier. If we instead, for example, wait on the `close` event, then
         // it will not segmentation fault, which is what this test is all about.

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -39,7 +39,7 @@ const netServer = net.createServer((socket) => {
       assert(tlsSocket);
       // this breaks if TLSSocket is already managing the socket:
       netSocket.destroy();
-      netSocket.on('close', () => { tlsSocket.write('bar'); });
+      const interval = setTimeout(() => { tlsSocket.write('bar'); }, 2);
     }));
   }));
 }));

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -10,6 +10,7 @@ const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
 const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
 
 let tlsSocket;
+let interval;
 // tls server
 const tlsServer = tls.createServer({ cert, key }, (socket) => {
   tlsSocket = socket;
@@ -17,6 +18,7 @@ const tlsServer = tls.createServer({ cert, key }, (socket) => {
     assert.strictEqual(error.code, 'EINVAL');
     tlsServer.close();
     netServer.close();
+    clearInterval(interval);
   }));
 });
 
@@ -39,7 +41,7 @@ const netServer = net.createServer((socket) => {
       assert(tlsSocket);
       // this breaks if TLSSocket is already managing the socket:
       netSocket.destroy();
-      setTimeout(() => { tlsSocket.write('bar'); }, 2);
+      netSocket.on('close', () => { tlsSocket.write('bar'); });
     }));
   }));
 }));

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -39,7 +39,7 @@ const netServer = net.createServer((socket) => {
       assert(tlsSocket);
       // this breaks if TLSSocket is already managing the socket:
       netSocket.destroy();
-      const interval = setTimeout(() => { tlsSocket.write('bar'); }, 2);
+      setTimeout(() => { tlsSocket.write('bar'); }, 2);
     }));
   }));
 }));


### PR DESCRIPTION
Replace timer/timeout race with event-based ordering, eliminating test
flakiness.

Fixes: https://github.com/nodejs/node/issues/11912

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls
