### PR TITLE
benchmark: add final clean-up to module-loader.js

### DIFF
--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -35,6 +35,8 @@ function main(conf) {
     measureFull(n, conf.useCache === 'true');
   else
     measureDir(n, conf.useCache === 'true');
+
+  rmrf(tmpDirectory);
 }
 
 function measureFull(n, useCache) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
benchmark, module

Currently, `module-loader.js` cleans up its temp directory only before each benchmark run. So after the last run, a `tmp` directory with 50,000 subdirectories and 100,000 files remains in the `benchmark` directory. A second final clean-up does not add much more time to overall benchmark duration because it reduces the time for each next initialization, while `benchmark` directory remains clean after the last run.

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
