### PR TITLE
benchmark: harmonize progress bar and stderr output

### DIFF
--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -104,7 +104,7 @@ class BenchmarkProgress {
           `| ${fraction(completedFiles, scheduledFiles)} files ` +
           `| ${fraction(completedRunsForFile, runsPerFile)} runs ` +
           `| ${fraction(completedConfig, scheduledConfig)} configs]` +
-          `: ${caption}`;
+          `: ${caption} `;
   }
 
   updateProgress(finished) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
benchmark

`_benchmark_progress.js` does not work well with stderr output:

1. It sticks together with error messages which throw and abort runs. See [this comment](https://github.com/nodejs/node/pull/11904#issuecomment-287477565) for an example.

2. It still sticks together with error messages which do not throw and do not abort runs. At that, it starts to duplicate with each such message. For example, there is [`misc/function_call` ](https://github.com/nodejs/node/tree/master/benchmark/misc/function_call) which [calls](https://github.com/nodejs/node/blob/master/benchmark/misc/function_call/index.js#L10-L19) `console.error()` most of the time the `misc` suite is launched. So the output is something like this:

```
compare.js --old ... --new ... --filter function_call misc > bm.csv

misc/function_call.js Binding failed to load
[00:00:02|%   1| 0/1 files |  1/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
[00:00:02|%   3| 0/1 files |  2/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
[00:00:03|%   5| 0/1 files |  3/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
[00:00:04|%   6| 0/1 files |  4/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
[00:00:04|%   8| 0/1 files |  5/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
...
[00:00:37|%  98| 0/1 files | 59/60 runs | 0/0 configs]: misc\function_callmisc/function_call.js Binding failed to load
[00:00:37|% 100| 1/1 files | 60/60 runs | 0/0 configs]: Done
```
Till some drastic solution is applied, this commit just adds a space in the end of the bar for minimal readability. So the abovementioned output could be at least something like this:
```
compare.js --old ... --new ... --filter function_call misc > bm.csv

misc/function_call.js Binding failed to load
[00:00:02|%   1| 0/1 files |  1/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
[00:00:02|%   3| 0/1 files |  2/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
[00:00:03|%   5| 0/1 files |  3/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
[00:00:03|%   6| 0/1 files |  4/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
[00:00:04|%   8| 0/1 files |  5/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
...
[00:00:36|%  98| 0/1 files | 59/60 runs | 0/0 configs]: misc\function_call misc/function_call.js Binding failed to load
[00:00:37|% 100| 1/1 files | 60/60 runs | 0/0 configs]: Done
```

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
