### PR TITLE
src, buffer: do not segfault on out-of-range index

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -184,7 +184,7 @@ inline MUST_USE_RESULT bool ParseArrayIndex(Local<Value> arg,
   // Check that the result fits in a size_t.
   const uint64_t kSizeMax = static_cast<uint64_t>(static_cast<size_t>(-1));
   // coverity[pointless_expression]
-  if (static_cast<uint64_t>(tmp_i) > kSizeMax)
+  if (static_cast<uint64_t>(tmp_i) > kSizeMax - needed)
     return false;
 
   *ret = static_cast<size_t>(tmp_i);

--- a/test/parallel/test-buffer-write-noassert.js
+++ b/test/parallel/test-buffer-write-noassert.js
@@ -4,6 +4,8 @@ const assert = require('assert');
 
 // testing buffer write functions
 
+const outOfRange = /^RangeError: (?:Index )?out of range(?: index)?$/;
+
 function write(funx, args, result, res) {
   {
     const buf = Buffer.alloc(9);
@@ -11,14 +13,8 @@ function write(funx, args, result, res) {
     assert.deepStrictEqual(buf, res);
   }
 
-  {
-    const invalidArgs = Array.from(args);
-    invalidArgs[1] = -1;
-    assert.throws(
-      () => Buffer.alloc(9)[funx](...invalidArgs),
-      /^RangeError: (?:Index )?out of range(?: index)?$/
-    );
-  }
+  writeInvalidOffset(-1);
+  writeInvalidOffset(9);
 
   if (!/Int/.test(funx)) {
     assert.throws(
@@ -33,6 +29,15 @@ function write(funx, args, result, res) {
     assert.deepStrictEqual(buf2, res);
   }
 
+  function writeInvalidOffset(offset) {
+    const newArgs = Array.from(args);
+    newArgs[1] = offset;
+    assert.throws(() => Buffer.alloc(9)[funx](...newArgs), outOfRange);
+
+    const buf = Buffer.alloc(9);
+    buf[funx](...newArgs, true);
+    assert.deepStrictEqual(buf, Buffer.alloc(9));
+  }
 }
 
 write('writeInt8', [1, 0], 1, Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 0]));
@@ -53,3 +58,45 @@ write('writeDoubleBE', [1, 1], 9, Buffer.from([0, 63, 240, 0, 0, 0, 0, 0, 0]));
 write('writeDoubleLE', [1, 1], 9, Buffer.from([0, 0, 0, 0, 0, 0, 0, 240, 63]));
 write('writeFloatBE', [1, 1], 5, Buffer.from([0, 63, 128, 0, 0, 0, 0, 0, 0]));
 write('writeFloatLE', [1, 1], 5, Buffer.from([0, 0, 0, 128, 63, 0, 0, 0, 0]));
+
+function writePartial(funx, args, result, res) {
+  assert.throws(() => Buffer.alloc(9)[funx](...args), outOfRange);
+  const buf = Buffer.alloc(9);
+  assert.strictEqual(buf[funx](...args, true), result);
+  assert.deepStrictEqual(buf, res);
+}
+
+// Test partial writes (cases where the buffer isn't large enough to hold the
+// entire value, but is large enough to hold parts of it).
+writePartial('writeIntBE', [0x0eadbeef, 6, 4], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0x0e, 0xad, 0xbe]));
+writePartial('writeIntLE', [0x0eadbeef, 6, 4], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xef, 0xbe, 0xad]));
+writePartial('writeInt16BE', [0x1234, 8], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0x12]));
+writePartial('writeInt16LE', [0x1234, 8], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0x34]));
+writePartial('writeInt32BE', [0x0eadbeef, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0x0e, 0xad, 0xbe]));
+writePartial('writeInt32LE', [0x0eadbeef, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xef, 0xbe, 0xad]));
+writePartial('writeUIntBE', [0xdeadbeef, 6, 4], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xde, 0xad, 0xbe]));
+writePartial('writeUIntLE', [0xdeadbeef, 6, 4], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xef, 0xbe, 0xad]));
+writePartial('writeUInt16BE', [0x1234, 8], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0x12]));
+writePartial('writeUInt16LE', [0x1234, 8], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0x34]));
+writePartial('writeUInt32BE', [0xdeadbeef, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xde, 0xad, 0xbe]));
+writePartial('writeUInt32LE', [0xdeadbeef, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0xef, 0xbe, 0xad]));
+writePartial('writeDoubleBE', [1, 2], 10,
+             Buffer.from([0, 0, 63, 240, 0, 0, 0, 0, 0]));
+writePartial('writeDoubleLE', [1, 2], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 240]));
+writePartial('writeFloatBE', [1, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 63, 128, 0]));
+writePartial('writeFloatLE', [1, 6], 10,
+             Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 128]));


### PR DESCRIPTION
Also add test cases for partial writes and invalid indices.

Fixes: https://github.com/nodejs/node/issues/8724

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, buffer

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
