### PR TITLE
test: add test for child_process.execFile()

### DIFF
--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const execFile = require('child_process').execFile;
+const path = require('path');
+
+const fixture = path.join(common.fixturesDir, 'exit.js');
+
+{
+  execFile(
+    process.execPath,
+    [fixture, 42],
+    common.mustCall((e) => {
+      // Check that arguments are included in message
+      assert.strictEqual(e.message.trim(),
+                         `Command failed: ${process.execPath} ${fixture} 42`);
+      assert.strictEqual(e.code, 42);
+    })
+  );
+}


### PR DESCRIPTION
While `child_process.execFile()` gets called in places in the test
suite, there are no explicit test for it and there are parts of the
implementation that are not covered by tests. This adds a minimal test
that increases (but does not complete) coverage for the implementation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process
