### PR TITLE
lib: use Object.create(null) directly

### DIFF
--- a/benchmark/es/map-bench.js
+++ b/benchmark/es/map-bench.js
@@ -4,7 +4,10 @@ const common = require('../common.js');
 const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
-  method: ['object', 'nullProtoObject', 'fakeMap', 'map'],
+  method: [
+    'object', 'nullProtoObject', 'nullProtoLiteralObject', 'storageObject',
+    'fakeMap', 'map'
+  ],
   millions: [1]
 });
 
@@ -24,6 +27,37 @@ function runObject(n) {
 
 function runNullProtoObject(n) {
   const m = Object.create(null);
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m['i' + i] = i;
+    m['s' + i] = String(i);
+    assert.strictEqual(String(m['i' + i]), m['s' + i]);
+    m['i' + i] = undefined;
+    m['s' + i] = undefined;
+  }
+  bench.end(n / 1e6);
+}
+
+function runNullProtoLiteralObject(n) {
+  const m = { __proto__: null };
+  var i = 0;
+  bench.start();
+  for (; i < n; i++) {
+    m['i' + i] = i;
+    m['s' + i] = String(i);
+    assert.strictEqual(String(m['i' + i]), m['s' + i]);
+    m['i' + i] = undefined;
+    m['s' + i] = undefined;
+  }
+  bench.end(n / 1e6);
+}
+
+function StorageObject() {}
+StorageObject.prototype = Object.create(null);
+
+function runStorageObject(n) {
+  const m = new StorageObject();
   var i = 0;
   bench.start();
   for (; i < n; i++) {
@@ -83,6 +117,12 @@ function main(conf) {
       break;
     case 'nullProtoObject':
       runNullProtoObject(n);
+      break;
+    case 'nullProtoLiteralObject':
+      runNullProtoLiteralObject(n);
+      break;
+    case 'storageObject':
+      runStorageObject(n);
       break;
     case 'fakeMap':
       runFakeMap(n);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -31,7 +31,6 @@ const common = require('_http_common');
 const checkIsHttpToken = common._checkIsHttpToken;
 const checkInvalidHeaderChar = common._checkInvalidHeaderChar;
 const outHeadersKey = require('internal/http').outHeadersKey;
-const StorageObject = require('internal/querystring').StorageObject;
 
 const CRLF = common.CRLF;
 const debug = common.debug;
@@ -143,7 +142,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
   get: function() {
     const headers = this[outHeadersKey];
     if (headers) {
-      const out = new StorageObject();
+      const out = Object.create(null);
       const keys = Object.keys(headers);
       for (var i = 0; i < keys.length; ++i) {
         const key = keys[i];
@@ -552,7 +551,7 @@ OutgoingMessage.prototype.getHeaderNames = function getHeaderNames() {
 // Returns a shallow copy of the current outgoing headers.
 OutgoingMessage.prototype.getHeaders = function getHeaders() {
   const headers = this[outHeadersKey];
-  const ret = new StorageObject();
+  const ret = Object.create(null);
   if (headers) {
     const keys = Object.keys(headers);
     for (var i = 0; i < keys.length; ++i) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -23,12 +23,6 @@
 
 var domain;
 
-// This constructor is used to store event handlers. Instantiating this is
-// faster than explicitly calling `Object.create(null)` to get a "clean" empty
-// object (tested with v8 v4.9).
-function EventHandlers() {}
-EventHandlers.prototype = Object.create(null);
-
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -71,7 +65,7 @@ EventEmitter.init = function() {
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
-    this._events = new EventHandlers();
+    this._events = Object.create(null);
     this._eventsCount = 0;
   }
 
@@ -241,7 +235,7 @@ function _addListener(target, type, listener, prepend) {
 
   events = target._events;
   if (!events) {
-    events = target._events = new EventHandlers();
+    events = target._events = Object.create(null);
     target._eventsCount = 0;
   } else {
     // To avoid recursion in the case that type === "newListener"! Before
@@ -356,7 +350,7 @@ EventEmitter.prototype.removeListener =
 
       if (list === listener || list.listener === listener) {
         if (--this._eventsCount === 0)
-          this._events = new EventHandlers();
+          this._events = Object.create(null);
         else {
           delete events[type];
           if (events.removeListener)
@@ -379,7 +373,7 @@ EventEmitter.prototype.removeListener =
         if (list.length === 1) {
           list[0] = undefined;
           if (--this._eventsCount === 0) {
-            this._events = new EventHandlers();
+            this._events = Object.create(null);
             return this;
           } else {
             delete events[type];
@@ -408,11 +402,11 @@ EventEmitter.prototype.removeAllListeners =
       // not listening for removeListener, no need to emit
       if (!events.removeListener) {
         if (arguments.length === 0) {
-          this._events = new EventHandlers();
+          this._events = Object.create(null);
           this._eventsCount = 0;
         } else if (events[type]) {
           if (--this._eventsCount === 0)
-            this._events = new EventHandlers();
+            this._events = Object.create(null);
           else
             delete events[type];
         }
@@ -428,7 +422,7 @@ EventEmitter.prototype.removeAllListeners =
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        this._events = new EventHandlers();
+        this._events = Object.create(null);
         this._eventsCount = 0;
         return this;
       }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -43,7 +43,6 @@ const internalUtil = require('internal/util');
 const assertEncoding = internalFS.assertEncoding;
 const stringToFlags = internalFS.stringToFlags;
 const getPathFromURL = internalURL.getPathFromURL;
-const { StorageObject } = require('internal/querystring');
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -1560,7 +1559,7 @@ if (isWindows) {
   nextPart = function nextPart(p, i) { return p.indexOf('/', i); };
 }
 
-const emptyObj = new StorageObject();
+const emptyObj = Object.create(null);
 fs.realpathSync = function realpathSync(p, options) {
   if (!options)
     options = emptyObj;
@@ -1580,8 +1579,8 @@ fs.realpathSync = function realpathSync(p, options) {
     return maybeCachedResult;
   }
 
-  const seenLinks = new StorageObject();
-  const knownHard = new StorageObject();
+  const seenLinks = Object.create(null);
+  const knownHard = Object.create(null);
   const original = p;
 
   // current character position in p
@@ -1700,8 +1699,8 @@ fs.realpath = function realpath(p, options, callback) {
     return;
   p = pathModule.resolve(p);
 
-  const seenLinks = new StorageObject();
-  const knownHard = new StorageObject();
+  const seenLinks = Object.create(null);
+  const knownHard = Object.create(null);
 
   // current character position in p
   var pos;

--- a/lib/internal/querystring.js
+++ b/lib/internal/querystring.js
@@ -23,13 +23,7 @@ const isHexTable = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0  // ... 256
 ];
 
-// Instantiating this is faster than explicitly calling `Object.create(null)`
-// to get a "clean" empty object (tested with v8 v4.9).
-function StorageObject() {}
-StorageObject.prototype = Object.create(null);
-
 module.exports = {
   hexTable,
-  isHexTable,
-  StorageObject
+  isHexTable
 };

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -3,8 +3,7 @@
 const util = require('util');
 const {
   hexTable,
-  isHexTable,
-  StorageObject
+  isHexTable
 } = require('internal/querystring');
 const binding = process.binding('url');
 const context = Symbol('context');
@@ -97,6 +96,26 @@ class TupleOrigin {
   }
 }
 
+// This class provides the internal state of a URL object. An instance of this
+// class is stored in every URL object and is accessed internally by setters
+// and getters. It roughly corresponds to the concept of a URL record in the
+// URL Standard, with a few differences. It is also the object transported to
+// the C++ binding.
+// Refs: https://url.spec.whatwg.org/#concept-url
+class URLContext {
+  constructor() {
+    this.flags = 0;
+    this.scheme = undefined;
+    this.username = undefined;
+    this.password = undefined;
+    this.host = undefined;
+    this.port = undefined;
+    this.path = [];
+    this.query = undefined;
+    this.fragment = undefined;
+  }
+}
+
 function onParseComplete(flags, protocol, username, password,
                          host, port, path, query, fragment) {
   if (flags & binding.URL_FLAGS_FAILED)
@@ -121,7 +140,7 @@ function onParseComplete(flags, protocol, username, password,
 // Reused by URL constructor and URL#href setter.
 function parse(url, input, base) {
   const base_context = base ? base[context] : undefined;
-  url[context] = new StorageObject();
+  url[context] = new URLContext();
   binding.parse(input.trim(), -1,
                 base_context, undefined,
                 onParseComplete.bind(url));

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -25,7 +25,6 @@
 
 const { Buffer } = require('buffer');
 const {
-  StorageObject,
   hexTable,
   isHexTable
 } = require('internal/querystring');
@@ -281,7 +280,7 @@ const defEqCodes = [61]; // =
 
 // Parse a key/val string.
 function parse(qs, sep, eq, options) {
-  const obj = new StorageObject();
+  const obj = Object.create(null);
 
   if (typeof qs !== 'string' || qs.length === 0) {
     return obj;

--- a/lib/url.js
+++ b/lib/url.js
@@ -23,7 +23,7 @@
 
 const { toASCII } = process.binding('config').hasIntl ?
   process.binding('icu') : require('punycode');
-const { StorageObject, hexTable } = require('internal/querystring');
+const { hexTable } = require('internal/querystring');
 const internalUrl = require('internal/url');
 exports.parse = urlParse;
 exports.resolve = urlResolve;
@@ -197,7 +197,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
         }
       } else if (parseQueryString) {
         this.search = '';
-        this.query = new StorageObject();
+        this.query = Object.create(null);
       }
       return this;
     }
@@ -390,7 +390,7 @@ Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
   } else if (parseQueryString) {
     // no query string, but parseQueryString still requested
     this.search = '';
-    this.query = new StorageObject();
+    this.query = Object.create(null);
   }
 
   var firstIdx = (questionIdx !== -1 &&


### PR DESCRIPTION
Since v8/v8@532c16eca071df3ec8eed394dcebb932ef584ee6 (included in v5.6), using `Object.create(null)` directly is now faster than using a constructor.

Refs: https://github.com/emberjs/ember.js/issues/15001
Refs: https://crrev.com/532c16eca071df3ec8eed394dcebb932ef584ee6

/cc @nodejs/v8 

<details><summary>querystring</summary>

```make
                                                                 improvement confidence      p.value
 querystring/querystring-parse.js n=100000 type="altspaces"           5.40 %          * 1.400406e-02
 querystring/querystring-parse.js n=100000 type="encodefake"          5.70 %            6.377693e-02
 querystring/querystring-parse.js n=100000 type="encodelast"          3.49 %            1.214386e-01
 querystring/querystring-parse.js n=100000 type="encodemany"          5.08 %          * 1.427018e-02
 querystring/querystring-parse.js n=100000 type="manyblankpairs"     -7.21 %         ** 1.152391e-03
 querystring/querystring-parse.js n=100000 type="manypairs"           8.53 %        *** 6.779383e-10
 querystring/querystring-parse.js n=100000 type="multicharsep"        6.11 %         ** 8.321237e-03
 querystring/querystring-parse.js n=100000 type="multivalue"         12.44 %         ** 1.668042e-03
 querystring/querystring-parse.js n=100000 type="multivaluemany"     19.43 %        *** 1.919249e-09
 querystring/querystring-parse.js n=100000 type="noencode"            6.23 %        *** 2.348627e-04
```
</details>

<details><summary>map-bench</summary>

```make
es/map-bench.js millions=3 method="object": 0.39794620430879774
es/map-bench.js millions=3 method="nullProtoObject": 0.41138972726767054
es/map-bench.js millions=3 method="nullProtoLiteralObject": 0.37403618701313923
es/map-bench.js millions=3 method="storageObject": 0.39906914551802625
es/map-bench.js millions=3 method="fakeMap": 0.3576056060343219
es/map-bench.js millions=3 method="map": 0.5858516350899148
```
</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
