### PR TITLE
doc: remove superfluous sample assert code

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -12,22 +12,7 @@ added: v0.5.9
 * `value` {any}
 * `message` {any}
 
-An alias of [`assert.ok()`][] .
-
-```js
-const assert = require('assert');
-
-assert(true);
-// OK
-assert(1);
-// OK
-assert(false);
-// throws "AssertionError: false == true"
-assert(0);
-// throws "AssertionError: 0 == true"
-assert(false, 'it\'s false');
-// throws "AssertionError: it's false"
-```
+An alias of [`assert.ok()`][].
 
 ## assert.deepEqual(actual, expected[, message])
 <!-- YAML


### PR DESCRIPTION
Remove superfluous sample code. Since `assert()` is documented as an
alias of `assert.ok()` and nothing more, the sample code for
`assert.ok()` is sufficient.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc assert