### PR TITLE
url: show input in parse error message

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -99,8 +99,6 @@ class TupleOrigin {
 
 function onParseComplete(flags, protocol, username, password,
                          host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    throw new TypeError('Invalid URL');
   var ctx = this[context];
   ctx.flags = flags;
   ctx.scheme = protocol;
@@ -118,19 +116,23 @@ function onParseComplete(flags, protocol, username, password,
   initSearchParams(this[searchParams], query);
 }
 
+function onParseError(flags, input) {
+  const error = new TypeError('Invalid URL: ' + input);
+  error.input = input;
+  throw error;
+}
+
 // Reused by URL constructor and URL#href setter.
 function parse(url, input, base) {
   const base_context = base ? base[context] : undefined;
   url[context] = new StorageObject();
   binding.parse(input.trim(), -1,
                 base_context, undefined,
-                onParseComplete.bind(url));
+                onParseComplete.bind(url), onParseError);
 }
 
 function onParseProtocolComplete(flags, protocol, username, password,
                                  host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const newIsSpecial = (flags & binding.URL_FLAGS_SPECIAL) !== 0;
   const s = this[special];
   const ctx = this[context];
@@ -159,8 +161,6 @@ function onParseProtocolComplete(flags, protocol, username, password,
 
 function onParseHostComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const ctx = this[context];
   if (host) {
     ctx.host = host;
@@ -174,8 +174,6 @@ function onParseHostComplete(flags, protocol, username, password,
 
 function onParseHostnameComplete(flags, protocol, username, password,
                                  host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const ctx = this[context];
   if (host) {
     ctx.host = host;
@@ -187,15 +185,11 @@ function onParseHostnameComplete(flags, protocol, username, password,
 
 function onParsePortComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   this[context].port = port;
 }
 
 function onParsePathComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const ctx = this[context];
   if (path) {
     ctx.path = path;
@@ -207,16 +201,12 @@ function onParsePathComplete(flags, protocol, username, password,
 
 function onParseSearchComplete(flags, protocol, username, password,
                                host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const ctx = this[context];
   ctx.query = query;
 }
 
 function onParseHashComplete(flags, protocol, username, password,
                              host, port, path, query, fragment) {
-  if (flags & binding.URL_FLAGS_FAILED)
-    return;
   const ctx = this[context];
   if (fragment) {
     ctx.fragment = fragment;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -463,6 +463,10 @@ static inline void PercentDecode(const char* input,
   XX(ARG_QUERY)                                                               \
   XX(ARG_FRAGMENT)
 
+#define ERR_ARGS(XX)                                                          \
+  XX(ERR_ARG_FLAGS)                                                           \
+  XX(ERR_ARG_INPUT)                                                           \
+
 static const char kEOL = -1;
 
 enum url_parse_state {
@@ -483,6 +487,12 @@ enum url_cb_args {
   ARGS(XX)
 #undef XX
 };
+
+enum url_error_cb_args {
+#define XX(name) name,
+  ERR_ARGS(XX)
+#undef XX
+} url_error_cb_args;
 
 static inline bool IsSpecial(std::string scheme) {
 #define XX(name, _) if (scheme == name) return true;

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -13,15 +13,30 @@ if (!common.hasIntl) {
 
 // Tests below are not from WPT.
 const tests = require(path.join(common.fixturesDir, 'url-tests'));
+const failureTests = tests.filter((test) => test.failure).concat([
+  { input: '' },
+  { input: 'test' },
+  { input: undefined },
+  { input: 0 },
+  { input: true },
+  { input: false },
+  { input: null },
+  { input: new Date() },
+  { input: new RegExp() },
+  { input: () => {} }
+]);
 
-for (const test of tests) {
-  if (typeof test === 'string')
-    continue;
-
-  if (test.failure) {
-    assert.throws(() => new URL(test.input, test.base),
-                  /^TypeError: Invalid URL$/);
-  }
+for (const test of failureTests) {
+  assert.throws(
+    () => new URL(test.input, test.base),
+    (error) => {
+      // The input could be processed, so we don't do strict matching here
+      const match = (error + '').match(/^TypeError: Invalid URL: (.*)$/);
+      if (!match) {
+        return false;
+      }
+      return error.input === match[1];
+    });
 }
 
 const additional_tests = require(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Show the input in URL parse errors so it's easier to debug

Before

```
> new URL('test')
TypeError: Invalid URL
```

After

```
> new URL('test')
TypeError: Invalid URL: test
```

Also put the error handling in another callback of `binding.parse()`, if it is unspecified, nothing will be done.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url

@nodejs/url 
