### PR TITLE
events, doc: add type checking in defaultMaxListeners getter

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -262,7 +262,8 @@ By default, a maximum of `10` listeners can be registered for any single
 event. This limit can be changed for individual `EventEmitter` instances
 using the [`emitter.setMaxListeners(n)`][] method. To change the default
 for *all* `EventEmitter` instances, the `EventEmitter.defaultMaxListeners`
-property can be used.
+property can be used. If this value is not a positive number, a `TypeError`
+will be thrown.
 
 Take caution when setting the `EventEmitter.defaultMaxListeners` because the
 change effects *all* `EventEmitter` instances, including those created before

--- a/lib/events.js
+++ b/lib/events.js
@@ -56,6 +56,10 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
     // force global console to be compiled.
     // see https://github.com/nodejs/node/issues/4467
     console;
+    // check whether the input is a positive number (whose value is zero or
+    // greater and not a NaN).
+    if (typeof arg !== 'number' || arg < 0 || arg !== arg)
+      throw new TypeError('defaultMaxListeners must be a positive number');
     defaultMaxListeners = arg;
   }
 });

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -30,16 +30,13 @@ e.on('maxListeners', common.mustCall(function() {}));
 // Should not corrupt the 'maxListeners' queue.
 e.setMaxListeners(42);
 
-assert.throws(function() {
-  e.setMaxListeners(NaN);
-}, /^TypeError: "n" argument must be a positive number$/);
+const throwsObjs = [NaN, -1, 'and even this'];
 
-assert.throws(function() {
-  e.setMaxListeners(-1);
-}, /^TypeError: "n" argument must be a positive number$/);
-
-assert.throws(function() {
-  e.setMaxListeners('and even this');
-}, /^TypeError: "n" argument must be a positive number$/);
+for (const obj of throwsObjs) {
+  assert.throws(() => e.setMaxListeners(obj),
+                /^TypeError: "n" argument must be a positive number$/);
+  assert.throws(() => events.defaultMaxListeners = obj,
+                /^TypeError: defaultMaxListeners must be a positive number$/);
+}
 
 e.emit('maxListeners');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Since [`EventEmitter.defaultMaxListeners`](https://nodejs.org/dist/latest-v7.x/docs/api/events.html#events_eventemitter_defaultmaxlisteners)  and [`emitter.setMaxListeners(n)`](https://nodejs.org/dist/latest-v7.x/docs/api/events.html#events_emitter_setmaxlisteners_n) are both public APIs listed in the document, so it is reasonable to check `EventEmitter.defaultMaxListeners` getter's input like what `emitter.setMaxListeners(n)` does to avoid potential confusing results or error messages caused by some userland mistaken input, like:

```js
'use strict'
const E = require('events')

E.defaultMaxListeners = new Proxy({}, { get: () => {} })
let e = new E()
e.addListener('1', function () {})
e.addListener('1', function () {})
// output:
// events.js:260
//      if (m && m > 0 && existing.length > m) {
//                 ^
//
// TypeError: Cannot convert object to primitive value
//     at _addListener (events.js:260:18)
//     at EventEmitter.addListener (events.js:279:10)
//     at Object.<anonymous> (/Users/caiwei/workspace/benchmarks/index.js:7:3)
//     at Module._compile (module.js:571:32)
//     at Object.Module._extensions..js (module.js:580:10)
//     at Module.load (module.js:488:32)
//     at tryModuleLoad (module.js:447:12)
//     at Function.Module._load (module.js:439:3)
//     at Module.runMain (module.js:605:10)
//     at run (bootstrap_node.js:425:7)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [-] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [-] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
events, doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
