### PR TITLE
src: exclude node_root_certs when use-def-ca-store

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -141,9 +141,11 @@ static X509_NAME *cnnic_ev_name =
 
 static Mutex* mutexes;
 
+#if !defined(NODE_OPENSSL_CERT_STORE)
 const char* const root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
 };
+#endif
 
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
@@ -718,6 +720,7 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
+#if !defined(NODE_OPENSSL_CERT_STORE)
   if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));
@@ -730,6 +733,7 @@ static X509_STORE* NewRootCertStore() {
       root_certs_vector.push_back(x509);
     }
   }
+#endif
 
   X509_STORE* store = X509_STORE_new();
   if (ssl_openssl_cert_store) {


### PR DESCRIPTION
When configuring node with --openssl-use-def-ca-store the root certs
from OpenSSL should be used and not the ones in src/node_root_certs.h.
I noticed that src/node_root_certs.h is still included even when
using --openssl-use-def-ca-store.

This commit adds check and does not include node_root_certs.h if
--openssl-use-def-ca-store is specified.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
