### PR TITLE
doc: add statement about support for dependencies

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,6 +72,11 @@ Depending on host platform, the selection of toolchains may vary.
 * Building native add-ons: Visual Studio 2013 or Visual C++ Build Tools 2015
   or newer
 
+### Shared libraries & dependencies
+
+Node.js intends to support building against shared representations of
+dependencies found in the [*deps*](./deps/) directory.
+
 ## Building Node.js on supported platforms
 
 ### Unix / OS X

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ the binary verification command above.
 ## Building Node.js
 
 See [BUILDING.md](BUILDING.md) for instructions on how to build
-Node.js from source.
+Node.js from source along with a list of officially supported platforms.
 
 ## Security
 


### PR DESCRIPTION
- In the review of https://github.com/nodejs/node/pull/11872 we
pulled out the discussion of supporting dependencies.  This
PR adds back that statement.
- Update README.md to indicatte BUILDING.md contains the list
of supported platforms. ( I missed this part in the original PR)


##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc
