### PR TITLE
test: minor fixups for REPL eval tests

### DIFF
--- a/test/parallel/test-repl-empty.js
+++ b/test/parallel/test-repl-empty.js
@@ -9,7 +9,7 @@ const repl = require('repl');
   const options = {
     eval: common.mustCall((cmd, context) => {
       // Assertions here will not cause the test to exit with an error code
-      // so set a boolean that is checked in process.on('exit',...) instead.
+      // so set a boolean that is checked later instead.
       evalCalledWithExpectedArgs = (cmd === '\n');
     })
   };
@@ -23,7 +23,5 @@ const repl = require('repl');
     r.write('.exit\n');
   }
 
-  process.on('exit', () => {
-    assert(evalCalledWithExpectedArgs);
-  });
+  assert(evalCalledWithExpectedArgs);
 }

--- a/test/parallel/test-repl-eval.js
+++ b/test/parallel/test-repl-eval.js
@@ -9,7 +9,7 @@ const repl = require('repl');
   const options = {
     eval: common.mustCall((cmd, context) => {
       // Assertions here will not cause the test to exit with an error code
-      // so set a boolean that is checked in process.on('exit',...) instead.
+      // so set a boolean that is checked later instead.
       evalCalledWithExpectedArgs = (cmd === 'function f() {}\n' &&
                                     context.foo === 'bar');
     })
@@ -29,7 +29,5 @@ const repl = require('repl');
     r.write('.exit\n');
   }
 
-  process.on('exit', () => {
-    assert(evalCalledWithExpectedArgs);
-  });
+  assert(evalCalledWithExpectedArgs);
 }


### PR DESCRIPTION
The `process.on("exit")` event handlers are unnecessary, so it’s okay
to drop them.

Ref: https://github.com/nodejs/node/pull/11871

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

test,repl

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
