### PR TITLE
stream_base,tls_wrap: notify on destruct

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -399,12 +399,6 @@ TLSSocket.prototype._wrapHandle = function(wrap) {
     res = null;
   });
 
-  if (wrap) {
-    wrap.on('close', function() {
-      res.onStreamClose();
-    });
-  }
-
   return res;
 };
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -85,6 +85,7 @@ TLSWrap::TLSWrap(Environment* env,
   stream_->set_after_write_cb({ OnAfterWriteImpl, this });
   stream_->set_alloc_cb({ OnAllocImpl, this });
   stream_->set_read_cb({ OnReadImpl, this });
+  stream_->set_destruct_cb({ OnDestructImpl, this });
 
   set_alloc_cb({ OnAllocSelf, this });
   set_read_cb({ OnReadSelf, this });
@@ -684,6 +685,12 @@ void TLSWrap::OnReadImpl(ssize_t nread,
                          void* ctx) {
   TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
   wrap->DoRead(nread, buf, pending);
+}
+
+
+void TLSWrap::OnDestructImpl(void* ctx) {
+  TLSWrap* wrap = static_cast<TLSWrap*>(ctx);
+  wrap->clear_stream();
 }
 
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -815,14 +815,6 @@ void TLSWrap::EnableSessionCallbacks(
 }
 
 
-void TLSWrap::OnStreamClose(const FunctionCallbackInfo<Value>& args) {
-  TLSWrap* wrap;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-
-  wrap->stream_ = nullptr;
-}
-
-
 void TLSWrap::DestroySSL(const FunctionCallbackInfo<Value>& args) {
   TLSWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
@@ -953,7 +945,6 @@ void TLSWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "enableSessionCallbacks", EnableSessionCallbacks);
   env->SetProtoMethod(t, "destroySSL", DestroySSL);
   env->SetProtoMethod(t, "enableCertCb", EnableCertCb);
-  env->SetProtoMethod(t, "onStreamClose", OnStreamClose);
 
   StreamBase::AddMethods<TLSWrap>(env, t, StreamBase::kFlagHasWritev);
   SSLWrap<TLSWrap>::AddMethods(env, t);

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -75,6 +75,8 @@ class TLSWrap : public AsyncWrap,
 
   size_t self_size() const override { return sizeof(*this); }
 
+  void clear_stream() { stream_ = nullptr; }
+
  protected:
   static const int kClearOutChunkSize = 16384;
 
@@ -142,6 +144,7 @@ class TLSWrap : public AsyncWrap,
                          const uv_buf_t* buf,
                          uv_handle_type pending,
                          void* ctx);
+  static void OnDestructImpl(void* ctx);
 
   void DoRead(ssize_t nread, const uv_buf_t* buf, uv_handle_type pending);
 

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -161,7 +161,6 @@ class TLSWrap : public AsyncWrap,
   static void EnableCertCb(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DestroySSL(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void OnStreamClose(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   static void GetServername(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-tls-retain-handle-no-abort.js
+++ b/test/parallel/test-tls-retain-handle-no-abort.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const tls = require('tls');
+const fs = require('fs');
+const util = require('util');
+
+const sent = 'hello world';
+const serverOptions = {
+  isServer: true,
+  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+};
+
+let ssl = null;
+
+process.on('exit', function() {
+  assert.ok(ssl !== null);
+  // If the internal pointer to stream_ isn't cleared properly then this
+  // will abort.
+  util.inspect(ssl);
+});
+
+const server = tls.createServer(serverOptions, function(s) {
+  s.on('data', function() { });
+  s.on('end', function() {
+    server.close();
+    s.destroy();
+  });
+}).listen(0, function() {
+  const c = new tls.TLSSocket();
+  ssl = c.ssl;
+  c.connect(this.address().port, function() {
+    c.end(sent);
+  });
+});


### PR DESCRIPTION
Classes like `TLSWrap` are given a pointer to a `StreamBase` instance;
stored on the private member `TLSWrap::stream_`. Unfortunately the
lifetime of `stream_` is not reported to the `TLSWrap` instance and if
free'd will leave an invalid pointer; which can still be accessed by the
`TLSWrap` instance. Causing the application to segfault if accessed.

Give `StreamBase` a destruct callback to notify when the class is being
cleaned up. Use this in `TLSWrap` to set `stream_ = nullptr`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
stream_base, tls_wrap

CI: https://ci.nodejs.org/job/node-test-commit/8575/
