### PR TITLE
doc: correct info in child_process.md

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1132,7 +1132,7 @@ added: v0.1.90
 A `Readable Stream` that represents the child process's `stderr`.
 
 If the child was spawned with `stdio[2]` set to anything other than `'pipe'`,
-then this will be `undefined`.
+then this will be `null`.
 
 `child.stderr` is an alias for `child.stdio[2]`. Both properties will refer to
 the same value.
@@ -1150,7 +1150,7 @@ A `Writable Stream` that represents the child process's `stdin`.
 continue until this stream has been closed via `end()`.*
 
 If the child was spawned with `stdio[0]` set to anything other than `'pipe'`,
-then this will be `undefined`.
+then this will be `null`.
 
 `child.stdin` is an alias for `child.stdio[0]`. Both properties will refer to
 the same value.
@@ -1205,7 +1205,7 @@ added: v0.1.90
 A `Readable Stream` that represents the child process's `stdout`.
 
 If the child was spawned with `stdio[1]` set to anything other than `'pipe'`,
-then this will be `undefined`.
+then this will be `null`.
 
 `child.stdout` is an alias for `child.stdio[1]`. Both properties will refer
 to the same value.


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc, child_process

`child.stderr`, `child.stdin`, and `child.stdout` are `null`, not `undefined`, if the relevant `stdio` properties are set to anything other than 'pipe':
```js
console.log(
  require('child_process').spawn(
    'echo', { stdio: ['ignore', 'ignore', 'ignore'] }
  )
);
```
```
ChildProcess {
  domain: null,
  _events: {},
  _eventsCount: 0,
  _maxListeners: undefined,
  _closesNeeded: 1,
  _closesGot: 0,
  connected: false,
  signalCode: null,
  exitCode: null,
  killed: false,
  spawnfile: 'echo',
  _handle: Process { owner: [Circular], onexit: [Function], pid: 4252 },
  spawnargs: [ 'echo' ],
  pid: 4252,
  stdin: null,
  stdout: null,
  stderr: null,
  stdio: [ null, null, null ] }
```
The relevant test [checks `null` values](https://github.com/nodejs/node/blob/master/test/parallel/test-child-process-stdio.js#L26-L36).

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
