### PR TITLE
readline: rename `deDupeHistory` option

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -370,9 +370,9 @@ changes:
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
     `crlfDelay` will be coerced to `[100, 2000]` range.
-  * `deDupeHistory` {boolean} If `true`, when a new input line added to the
-    history list duplicates an older one, this removes the older line from the
-    list. Defaults to `false`.
+  * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
+    to the history list duplicates an older one, this removes the older line
+    from the list. Defaults to `false`.
 
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -60,7 +60,7 @@ function Interface(input, output, completer, terminal) {
 
   EventEmitter.call(this);
   var historySize;
-  var deDupeHistory = false;
+  var removeHistoryDuplicates = false;
   let crlfDelay;
   let prompt = '> ';
 
@@ -70,7 +70,7 @@ function Interface(input, output, completer, terminal) {
     completer = input.completer;
     terminal = input.terminal;
     historySize = input.historySize;
-    deDupeHistory = input.deDupeHistory;
+    removeHistoryDuplicates = input.removeHistoryDuplicates;
     if (input.prompt !== undefined) {
       prompt = input.prompt;
     }
@@ -103,7 +103,7 @@ function Interface(input, output, completer, terminal) {
   this.output = output;
   this.input = input;
   this.historySize = historySize;
-  this.deDupeHistory = !!deDupeHistory;
+  this.removeHistoryDuplicates = !!removeHistoryDuplicates;
   this.crlfDelay = Math.max(kMincrlfDelay,
                             Math.min(kMaxcrlfDelay, crlfDelay >>> 0));
 
@@ -281,7 +281,7 @@ Interface.prototype._addHistory = function() {
   if (this.line.trim().length === 0) return this.line;
 
   if (this.history.length === 0 || this.history[0] !== this.line) {
-    if (this.deDupeHistory) {
+    if (this.removeHistoryDuplicates) {
       // Remove older history line if identical to new one
       const dupIndex = this.history.indexOf(this.line);
       if (dupIndex !== -1) this.history.splice(dupIndex, 1);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -326,14 +326,14 @@ function isWarned(emitter) {
     return false;
   });
 
-  // duplicate lines are removed from history when `options.deDupeHistory`
-  // is `true`
+  // duplicate lines are removed from history when
+  // `options.removeHistoryDuplicates` is `true`
   fi = new FakeInput();
   rli = new readline.Interface({
     input: fi,
     output: fi,
     terminal: true,
-    deDupeHistory: true
+    removeHistoryDuplicates: true
   });
   expectedLines = ['foo', 'bar', 'baz', 'bar', 'bat', 'bat'];
   callCount = 0;
@@ -356,14 +356,14 @@ function isWarned(emitter) {
   assert.strictEqual(callCount, 0);
   rli.close();
 
-  // duplicate lines are not removed from history when `options.deDupeHistory`
-  // is `false`
+  // duplicate lines are not removed from history when
+  // `options.removeHistoryDuplicates` is `false`
   fi = new FakeInput();
   rli = new readline.Interface({
     input: fi,
     output: fi,
     terminal: true,
-    deDupeHistory: false
+    removeHistoryDuplicates: false
   });
   expectedLines = ['foo', 'bar', 'baz', 'bar', 'bat', 'bat'];
   callCount = 0;


### PR DESCRIPTION
Renames `options.deDupeHistory` → `options.removeHistoryDuplicates` for `readline.createInterface(options)`.

The option name `removeHistoryDuplicates` is preferable to the semantically identical name `deDupeHistory` because "dedupe" (short for "deduplication") is obscure and neologistic while `removeHistoryDuplicates` is clear, though verbose. See [this comment](https://github.com/nodejs/node/pull/2982#issuecomment-287578299) for more.

Updates tests and documentation for this option accordingly.

Refs: https://github.com/nodejs/node/pull/2982

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
`readline`

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines