### PR TITLE
[DO NOT LAND] src: invalidate Utf8/TwoByteValue upon error

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -352,6 +352,8 @@ function normalizeSpawnArguments(file, args, options) {
 
   if (Array.isArray(args)) {
     args = args.slice(0);
+    for (var i = 0; i < args.length; i++)
+      args[i] = `${args[i]}`;
   } else if (args !== undefined &&
              (args === null || typeof args !== 'object')) {
     throw new TypeError('Incorrect value of args option');

--- a/src/env.cc
+++ b/src/env.cc
@@ -127,7 +127,8 @@ void Environment::PrintSyncTrace() const {
     const int column = stack_frame->GetColumn();
 
     if (stack_frame->IsEval()) {
-      if (stack_frame->GetScriptId() == Message::kNoScriptIdInfo) {
+      if (script_name.IsInvalidated() ||
+          stack_frame->GetScriptId() == Message::kNoScriptIdInfo) {
         fprintf(stderr, "    at [eval]:%i:%i\n", line_number, column);
       } else {
         fprintf(stderr,
@@ -139,13 +140,16 @@ void Environment::PrintSyncTrace() const {
       break;
     }
 
-    if (fn_name_s.length() == 0) {
-      fprintf(stderr, "    at %s:%i:%i\n", *script_name, line_number, column);
+    if (fn_name_s.IsInvalidated() || fn_name_s.length() == 0) {
+      fprintf(stderr,
+              "    at %s:%i:%i\n",
+              script_name.IsInvalidated() ? "<anonymous>" : *script_name,
+              line_number, column);
     } else {
       fprintf(stderr,
               "    at %s (%s:%i:%i)\n",
               *fn_name_s,
-              *script_name,
+              script_name.IsInvalidated() ? "<anonymous>" : *script_name,
               line_number,
               column);
     }

--- a/src/node.cc
+++ b/src/node.cc
@@ -1485,6 +1485,8 @@ enum encoding ParseEncoding(Isolate* isolate,
     return default_encoding;
 
   node::Utf8Value encoding(isolate, encoding_v);
+  if (encoding.IsInvalidated())
+    return default_encoding;
 
   return ParseEncoding(*encoding, default_encoding);
 }
@@ -1555,10 +1557,14 @@ void AppendExceptionLine(Environment* env,
 
   // Print (filename):(line number): (message).
   node::Utf8Value filename(env->isolate(), message->GetScriptResourceName());
+  if (filename.IsInvalidated())
+    return;
   const char* filename_string = *filename;
   int linenum = message->GetLineNumber();
   // Print line of source code.
   node::Utf8Value sourceline(env->isolate(), message->GetSourceLine());
+  if (sourceline.IsInvalidated())
+    return;
   const char* sourceline_string = *sourceline;
 
   // Because of how node modules work, all scripts are wrapped with a
@@ -1667,6 +1673,10 @@ static void ReportException(Environment* env,
   }
 
   node::Utf8Value trace(env->isolate(), trace_value);
+  if (trace.IsInvalidated()) {
+    // Something is wrong; abort.
+    return;
+  }
 
   // range errors have a trace member set to undefined
   if (trace.length() > 0 && !trace_value->IsUndefined()) {
@@ -1674,6 +1684,7 @@ static void ReportException(Environment* env,
       PrintErrorString("%s\n", *trace);
     } else {
       node::Utf8Value arrow_string(env->isolate(), arrow);
+      CHECK(!arrow_string.IsInvalidated());
       PrintErrorString("%s\n%s\n", *arrow_string, *trace);
     }
   } else {
@@ -1699,17 +1710,25 @@ static void ReportException(Environment* env,
       PrintErrorString("%s\n", *message ? *message :
                                           "<toString() threw exception>");
     } else {
-      node::Utf8Value name_string(env->isolate(), name);
-      node::Utf8Value message_string(env->isolate(), message);
+      const char* name_string = "<toString() threw exception>";
+      node::Utf8Value name_val(env->isolate(), name);
+      if (!name_val.IsInvalidated())
+        name_string = *name_val;
+
+      const char* message_string = "<toString() threw exception>";
+      node::Utf8Value message_val(env->isolate(), message);
+      if (!message_val.IsInvalidated())
+        message_string = *message_val;
 
       if (arrow.IsEmpty() || !arrow->IsString() || decorated) {
-        PrintErrorString("%s: %s\n", *name_string, *message_string);
+        PrintErrorString("%s: %s\n", name_string, message_string);
       } else {
-        node::Utf8Value arrow_string(env->isolate(), arrow);
+        node::Utf8Value arrow_val(env->isolate(), arrow);
+        CHECK(!arrow_val.IsInvalidated());
         PrintErrorString("%s\n%s: %s\n",
-                         *arrow_string,
-                         *name_string,
-                         *message_string);
+                         *arrow_val,
+                         name_string,
+                         message_string);
       }
     }
   }
@@ -1858,6 +1877,8 @@ static void Chdir(const FunctionCallbackInfo<Value>& args) {
   }
 
   node::Utf8Value path(args.GetIsolate(), args[0]);
+  CHECK(!path.IsInvalidated());
+
   int err = uv_chdir(*path);
   if (err) {
     return env->ThrowUVException(err, "uv_chdir");
@@ -1904,6 +1925,7 @@ static void Umask(const FunctionCallbackInfo<Value>& args) {
     } else {
       oct = 0;
       node::Utf8Value str(env->isolate(), args[0]);
+      CHECK(!str.IsInvalidated());
 
       // Parse the octal string.
       for (size_t i = 0; i < str.length(); i++) {
@@ -2011,6 +2033,8 @@ static uid_t uid_by_name(Isolate* isolate, Local<Value> value) {
     return static_cast<uid_t>(value->Uint32Value());
   } else {
     node::Utf8Value name(isolate, value);
+    if (name.IsInvalidated())
+      return uid_not_found;
     return uid_by_name(*name);
   }
 }
@@ -2021,6 +2045,8 @@ static gid_t gid_by_name(Isolate* isolate, Local<Value> value) {
     return static_cast<gid_t>(value->Uint32Value());
   } else {
     node::Utf8Value name(isolate, value);
+    if (name.IsInvalidated())
+      return gid_not_found;
     return gid_by_name(*name);
   }
 }
@@ -2206,6 +2232,9 @@ static void InitGroups(const FunctionCallbackInfo<Value>& args) {
   }
 
   node::Utf8Value arg0(env->isolate(), args[0]);
+  if (arg0.IsInvalidated())
+    return;
+
   gid_t extra_group;
   bool must_free;
   char* user;
@@ -2437,6 +2466,8 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> module = args[0]->ToObject(env->isolate());  // Cast
   node::Utf8Value filename(env->isolate(), args[1]);  // Cast
+  if (filename.IsInvalidated())
+    return;
   const bool is_dlopen_error = uv_dlopen(*filename, &lib);
 
   // Objects containing v14 or later modules will have registered themselves
@@ -2643,6 +2674,8 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> module = args[0]->ToString(env->isolate());
   node::Utf8Value module_v(env->isolate(), module);
+  if (module_v.IsInvalidated())
+    return;
 
   Local<Object> cache = env->binding_cache_object();
   Local<Object> exports;
@@ -2695,6 +2728,8 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args.GetIsolate());
 
   Local<String> module_name = args[0]->ToString(env->isolate());
+  if (module_name.IsEmpty())
+    return;
 
   Local<Object> cache = env->binding_cache_object();
   Local<Value> exports_v = cache->Get(module_name);
@@ -2703,6 +2738,7 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(exports_v.As<Object>());
 
   node::Utf8Value module_name_v(env->isolate(), module_name);
+  CHECK(!module_name_v.IsInvalidated());
   node_module* mod = get_linked_module(*module_name_v);
 
   if (mod == nullptr) {
@@ -2748,6 +2784,8 @@ static void ProcessTitleSetter(Local<Name> property,
                                Local<Value> value,
                                const PropertyCallbackInfo<void>& info) {
   node::Utf8Value title(info.GetIsolate(), value);
+  if (title.IsInvalidated())
+    return;
   // TODO(piscisaureus): protect with a lock
   uv_set_process_title(*title);
 }
@@ -2761,12 +2799,14 @@ static void EnvGetter(Local<Name> property,
   }
 #ifdef __POSIX__
   node::Utf8Value key(isolate, property);
+  CHECK(!key.IsInvalidated());
   const char* val = getenv(*key);
   if (val) {
     return info.GetReturnValue().Set(String::NewFromUtf8(isolate, val));
   }
 #else  // _WIN32
   node::TwoByteValue key(isolate, property);
+  CHECK(!key.IsInvalidated());
   WCHAR buffer[32767];  // The maximum size allowed for environment variables.
   DWORD result = GetEnvironmentVariableW(reinterpret_cast<WCHAR*>(*key),
                                          buffer,
@@ -2789,11 +2829,19 @@ static void EnvSetter(Local<Name> property,
                       const PropertyCallbackInfo<Value>& info) {
 #ifdef __POSIX__
   node::Utf8Value key(info.GetIsolate(), property);
+  if (key.IsInvalidated())
+    return;
   node::Utf8Value val(info.GetIsolate(), value);
+  if (val.IsInvalidated())
+    return;
   setenv(*key, *val, 1);
 #else  // _WIN32
   node::TwoByteValue key(info.GetIsolate(), property);
+  if (key.IsInvalidated())
+    return;
   node::TwoByteValue val(info.GetIsolate(), value);
+  if (val.IsInvalidated())
+    return;
   WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
   // Environment variables that start with '=' are read-only.
   if (key_ptr[0] != L'=') {
@@ -2811,10 +2859,12 @@ static void EnvQuery(Local<Name> property,
   if (property->IsString()) {
 #ifdef __POSIX__
     node::Utf8Value key(info.GetIsolate(), property);
+    CHECK(!key.IsInvalidated());
     if (getenv(*key))
       rc = 0;
 #else  // _WIN32
     node::TwoByteValue key(info.GetIsolate(), property);
+    CHECK(!key.IsInvalidated());
     WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
     if (GetEnvironmentVariableW(key_ptr, nullptr, 0) > 0 ||
         GetLastError() == ERROR_SUCCESS) {
@@ -2838,9 +2888,11 @@ static void EnvDeleter(Local<Name> property,
   if (property->IsString()) {
 #ifdef __POSIX__
     node::Utf8Value key(info.GetIsolate(), property);
+    CHECK(!key.IsInvalidated());
     unsetenv(*key);
 #else
     node::TwoByteValue key(info.GetIsolate(), property);
+    CHECK(!key.IsInvalidated());
     WCHAR* key_ptr = reinterpret_cast<WCHAR*>(*key);
     SetEnvironmentVariableW(key_ptr, nullptr);
 #endif
@@ -3441,6 +3493,7 @@ static void RawDebug(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
   node::Utf8Value message(args.GetIsolate(), args[0]);
+  CHECK(!message.IsInvalidated());
   PrintErrorString("%s\n", *message);
   fflush(stderr);
 }

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -401,6 +401,7 @@ static void GetVersion(const FunctionCallbackInfo<Value>& args) {
     CHECK_GE(args.Length(), 1);
     CHECK(args[0]->IsString());
     Utf8Value val(env->isolate(), args[0]);
+    CHECK(!val.IsInvalidated());
     UErrorCode status = U_ZERO_ERROR;
     char buf[U_MAX_VERSION_STRING_LENGTH] = "";  // Possible output buffer.
     const char* versionString = GetVersion(*val, buf, &status);
@@ -513,6 +514,7 @@ static void ToUnicode(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
   Utf8Value val(env->isolate(), args[0]);
+  CHECK(!val.IsInvalidated());
   // optional arg
   bool lenient = args[1]->BooleanValue(env->context()).FromJust();
 
@@ -535,6 +537,7 @@ static void ToASCII(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
   Utf8Value val(env->isolate(), args[0]);
+  CHECK(!val.IsInvalidated());
   // optional arg
   bool lenient = args[1]->BooleanValue(env->context()).FromJust();
 
@@ -609,6 +612,8 @@ static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
   }
 
   TwoByteValue value(env->isolate(), args[0]);
+  if (value.IsInvalidated())
+    return;
   // reinterpret_cast is required by windows to compile
   UChar* str = reinterpret_cast<UChar*>(*value);
   static_assert(sizeof(*str) == sizeof(**value),

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -41,7 +41,8 @@ using v8::Value;
   {                                                                           \
     Local<Value> val = GET(env, obj, #name);                                  \
     if (val->IsString()) {                                                    \
-      Utf8Value value(env->isolate(), val.As<String>());                      \
+      Utf8Value value(env->isolate(), val);                                   \
+      CHECK(!value.IsInvalidated());                                          \
       data->name = *value;                                                    \
       data->flags |= flag;                                                    \
     }                                                                         \
@@ -509,7 +510,8 @@ namespace url {
     for (int32_t n = 0; n < len; n++) {
       Local<Value> val = ary->Get(env->context(), n).ToLocalChecked();
       if (val->IsString()) {
-        Utf8Value value(env->isolate(), val.As<String>());
+        Utf8Value value(env->isolate(), val);
+        CHECK(!value.IsInvalidated());
         vec->push_back(std::string(*value, value.length()));
       }
     }
@@ -562,6 +564,7 @@ namespace url {
     Local<Value> scheme = GET(env, context_obj, "scheme");
     if (scheme->IsString()) {
       Utf8Value value(env->isolate(), scheme);
+      CHECK(!value.IsInvalidated());
       context->scheme.assign(*value, value.length());
     }
     Local<Value> port = GET(env, context_obj, "port");
@@ -1297,7 +1300,6 @@ namespace url {
   static void Parse(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK_GE(args.Length(), 5);
-    CHECK(args[0]->IsString());
     CHECK(args[2]->IsUndefined() ||
           args[2]->IsNull() ||
           args[2]->IsObject());
@@ -1306,6 +1308,7 @@ namespace url {
           args[3]->IsObject());
     CHECK(args[4]->IsFunction());
     Utf8Value input(env->isolate(), args[0]);
+    CHECK(!input.IsInvalidated());
     enum url_parse_state state_override = kUnknownState;
     if (args[1]->IsNumber()) {
       state_override = static_cast<enum url_parse_state>(
@@ -1323,8 +1326,8 @@ namespace url {
   static void EncodeAuthSet(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK_GE(args.Length(), 1);
-    CHECK(args[0]->IsString());
     Utf8Value value(env->isolate(), args[0]);
+    CHECK(!value.IsInvalidated());
     std::string output;
     const size_t len = value.length();
     output.reserve(len);
@@ -1341,10 +1344,10 @@ namespace url {
   static void ToUSVString(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK_GE(args.Length(), 2);
-    CHECK(args[0]->IsString());
     CHECK(args[1]->IsNumber());
 
     TwoByteValue value(env->isolate(), args[0]);
+    CHECK(!value.IsInvalidated());
     const size_t n = value.length();
 
     const int64_t start = args[1]->IntegerValue(env->context()).FromJust();
@@ -1376,8 +1379,8 @@ namespace url {
   static void DomainToASCII(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK_GE(args.Length(), 1);
-    CHECK(args[0]->IsString());
     Utf8Value value(env->isolate(), args[0]);
+    CHECK(!value.IsInvalidated());
 
     url_host host{{""}, HOST_TYPE_DOMAIN};
     ParseHost(&host, *value, value.length());
@@ -1396,8 +1399,8 @@ namespace url {
   static void DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK_GE(args.Length(), 1);
-    CHECK(args[0]->IsString());
     Utf8Value value(env->isolate(), args[0]);
+    CHECK(!value.IsInvalidated());
 
     url_host host{{""}, HOST_TYPE_DOMAIN};
     ParseHost(&host, *value, value.length(), true);

--- a/src/util.cc
+++ b/src/util.cc
@@ -37,8 +37,10 @@ static void MakeUtf8String(Isolate* isolate,
                            Local<Value> value,
                            T* target) {
   Local<String> string = value->ToString(isolate);
-  if (string.IsEmpty())
+  if (string.IsEmpty()) {
+    target->Invalidate();
     return;
+  }
 
   const size_t storage = StringBytes::StorageSize(isolate, string, UTF8) + 1;
   target->AllocateSufficientStorage(storage);
@@ -49,8 +51,10 @@ static void MakeUtf8String(Isolate* isolate,
 }
 
 Utf8Value::Utf8Value(Isolate* isolate, Local<Value> value) {
-  if (value.IsEmpty())
+  if (value.IsEmpty()) {
+    Invalidate();
     return;
+  }
 
   MakeUtf8String(isolate, value, this);
 }
@@ -58,12 +62,15 @@ Utf8Value::Utf8Value(Isolate* isolate, Local<Value> value) {
 
 TwoByteValue::TwoByteValue(Isolate* isolate, Local<Value> value) {
   if (value.IsEmpty()) {
+    Invalidate();
     return;
   }
 
   Local<String> string = value->ToString(isolate);
-  if (string.IsEmpty())
+  if (string.IsEmpty()) {
+    Invalidate();
     return;
+  }
 
   // Allocate enough space to include the null terminator
   const size_t storage = string->Length() + 1;

--- a/src/util.h
+++ b/src/util.h
@@ -419,17 +419,29 @@ class MaybeStackBuffer {
 
 class Utf8Value : public MaybeStackBuffer<char> {
  public:
-  explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  explicit Utf8Value(v8::Local<v8::Context> context,
+                     v8::Local<v8::Value> value);
+  explicit Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value)
+      : Utf8Value(isolate->GetCurrentContext(), value) {
+  }
 };
 
 class TwoByteValue : public MaybeStackBuffer<uint16_t> {
  public:
-  explicit TwoByteValue(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  explicit TwoByteValue(v8::Local<v8::Context> context,
+                        v8::Local<v8::Value> value);
+  explicit TwoByteValue(v8::Isolate* isolate, v8::Local<v8::Value> value)
+      : TwoByteValue(isolate->GetCurrentContext(), value) {
+  }
 };
 
 class BufferValue : public MaybeStackBuffer<char> {
  public:
-  explicit BufferValue(v8::Isolate* isolate, v8::Local<v8::Value> value);
+  explicit BufferValue(v8::Local<v8::Context> context,
+                       v8::Local<v8::Value> value);
+  explicit BufferValue(v8::Isolate* isolate, v8::Local<v8::Value> value)
+      : BufferValue(isolate->GetCurrentContext(), value) {
+  }
 };
 
 #define THROW_AND_RETURN_UNLESS_BUFFER(env, obj)                            \

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -200,3 +200,34 @@ if (!common.isWindows) {
   fail('killSignal', {}, typeErr);
   fail('killSignal', noop, typeErr);
 }
+
+{
+  // Validate the args argument
+  const err = /^TypeError: Incorrect value of args option$/;
+
+  function pass(value) {
+    // Run the command with the specified option. Since it's not a real command,
+    // spawnSync() should run successfully but return an ENOENT error.
+    const child = spawnSync('not_a_real_command', value);
+    assert.strictEqual(child.error.code, 'ENOENT');
+  }
+
+  function fail(value, message = err) {
+    assert.throws(() => {
+      spawnSync('not_a_real_command', value);
+    }, message);
+  }
+
+  pass([]);
+  pass(['a']);
+  pass({}); // in which case the args argument is actually options
+  pass(undefined);
+  fail(null);
+  fail('a');
+  fail(42);
+  fail(false);
+  fail(Symbol());
+  fail([Symbol()], /^TypeError: Cannot convert a Symbol value to a string$/);
+  fail([{ toString() { throw new TypeError('stringifier'); } }],
+       /^TypeError: stringifier$/);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

So far all of the changes are semver-patch. Plans to replace certain usage of `Utf8Value` with `BufferValue` are semver-minor and have not been done yet.

- [ ] `cares_wrap.cc`
- [x] `env.cc`
- [x] `node.cc`
- [ ] `node_buffer.cc`
- [ ] `node_crypto.cc`
- [ ] `node_dtrace.cc`
- [ ] `node_file.cc`
- [x] `node_i18n.cc`
- [ ] `node_lttng.cc`
- [ ] `node_stat_watcher.cc`
- [x] `node_url.cc`
- [ ] `pipe_wrap.cc`
- [ ] `process_wrap.cc`
- [ ] `tcp_wrap.cc`
- [ ] `tls_wrap.cc`
- [ ] `udp_wrap.cc`

Fixes: https://github.com/nodejs/node/issues/9819
Fixes: https://github.com/nodejs/node/issues/9820

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
