### PR TITLE
test: do not use `more` command on Windows

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -376,23 +376,11 @@ Path to the 'root' directory. either `/` or `c:\\` (windows)
 
 Logs '1..0 # Skipped: ' + `msg`
 
-### spawnCat(options)
-* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-Platform normalizes the `cat` command.
-
 ### spawnPwd(options)
 * `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 * return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 
 Platform normalizes the `pwd` command.
-
-### spawnSyncCat(options)
-* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-Synchronous version of `spawnCat`.
 
 ### spawnSyncPwd(options)
 * `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)

--- a/test/common.js
+++ b/test/common.js
@@ -261,28 +261,6 @@ exports.ddCommand = function(filename, kilobytes) {
 };
 
 
-exports.spawnCat = function(options) {
-  const spawn = require('child_process').spawn;
-
-  if (exports.isWindows) {
-    return spawn('more', [], options);
-  } else {
-    return spawn('cat', [], options);
-  }
-};
-
-
-exports.spawnSyncCat = function(options) {
-  const spawnSync = require('child_process').spawnSync;
-
-  if (exports.isWindows) {
-    return spawnSync('more', [], options);
-  } else {
-    return spawnSync('cat', [], options);
-  }
-};
-
-
 exports.spawnPwd = function(options) {
   const spawn = require('child_process').spawn;
 

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -34,7 +34,7 @@ echo.on('close', common.mustCall((code, signal) => {
 }));
 
 // Verify that shell features can be used
-const cmd = common.isWindows ? 'echo bar | more' : 'echo bar | cat';
+const cmd = 'echo bar | cat';
 const command = cp.spawn(cmd, {
   encoding: 'utf8',
   shell: true

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -23,7 +23,7 @@ assert.strictEqual(echo.args[echo.args.length - 1].replace(/"/g, ''),
 assert.strictEqual(echo.stdout.toString().trim(), 'foo');
 
 // Verify that shell features can be used
-const cmd = common.isWindows ? 'echo bar | more' : 'echo bar | cat';
+const cmd = 'echo bar | cat';
 const command = cp.spawnSync(cmd, {shell: true});
 
 assert.strictEqual(command.stdout.toString().trim(), 'bar');

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 
 const spawn = require('child_process').spawn;
 
-const cat = spawn(common.isWindows ? 'more' : 'cat');
+const cat = spawn('cat');
 cat.stdin.write('hello');
 cat.stdin.write(' ');
 cat.stdin.write('world');
@@ -54,9 +54,5 @@ cat.on('exit', common.mustCall(function(status) {
 }));
 
 cat.on('close', common.mustCall(function() {
-  if (common.isWindows) {
-    assert.strictEqual('hello world\r\n', response);
-  } else {
-    assert.strictEqual('hello world', response);
-  }
+  assert.strictEqual('hello world', response);
 }));

--- a/test/parallel/test-child-process-stdio-inherit.js
+++ b/test/parallel/test-child-process-stdio-inherit.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
@@ -52,5 +52,5 @@ function grandparent() {
 
 function parent() {
   // should not immediately exit.
-  common.spawnCat({ stdio: 'inherit' });
+  spawn('cat', [], { stdio: 'inherit' });
 }

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const spawnSync = require('child_process').spawnSync;
 
 let options = {stdio: ['pipe']};
 let child = common.spawnPwd(options);
@@ -36,7 +37,7 @@ assert.strictEqual(child.stdout, null);
 assert.strictEqual(child.stderr, null);
 
 options = {stdio: 'ignore'};
-child = common.spawnSyncCat(options);
+child = spawnSync('cat', [], options);
 assert.deepStrictEqual(options, {stdio: 'ignore'});
 
 assert.throws(() => {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test

Fixes: https://github.com/nodejs/node/issues/11469

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
