### PR TITLE
buffer: stricter Buffer.isBuffer

### DIFF
--- a/benchmark/buffers/buffer-isbuffer.js
+++ b/benchmark/buffers/buffer-isbuffer.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const { Buffer } = require('buffer');
+
+function FakeBuffer() {}
+FakeBuffer.prototype = Object.create(Buffer.prototype);
+
+// Refs: https://github.com/nodejs/node/issues/9531#issuecomment-265611061
+class ExtensibleBuffer extends Buffer {
+  constructor() {
+    super(new ArrayBuffer(0), 0, 0);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+const inputs = {
+  primitive: false,
+  object: {},
+  fake: new FakeBuffer(),
+  subclassed: new ExtensibleBuffer(),
+  fastbuffer: Buffer.alloc(1),
+  slowbuffer: Buffer.allocUnsafeSlow(0),
+  uint8array: new Uint8Array(1)
+};
+
+const bench = common.createBenchmark(main, {
+  type: Object.keys(inputs),
+  n: [1e7]
+});
+
+function main(conf) {
+  const n = conf.n | 0;
+  const input = inputs[conf.type];
+
+  bench.start();
+  for (var i = 0; i < n; i++)
+    Buffer.isBuffer(input);
+  bench.end(n);
+}

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -645,7 +645,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     return true;
   }
 
-  if (!fromEnd && typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+  if (!fromEnd && typeof chunk !== 'string' && !Buffer.isBuffer(chunk)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
                                ['string', 'buffer']);
   }
@@ -743,7 +743,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
 
   var uncork;
   if (chunk) {
-    if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+    if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk)) {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
                                  ['string', 'buffer']);
     }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -420,7 +420,14 @@ function fromObject(obj) {
 // Static methods
 
 Buffer.isBuffer = function isBuffer(b) {
-  return b instanceof Buffer;
+  if (!isUint8Array(b))
+    return false;
+  // Subclassing Buffer is not officially supported currently, and actually
+  // subclassing it requires some awkward code that users are unlikely to do.
+  // Therefore prioritize the fast case over the full `instanceof`.
+  // Refs: https://github.com/nodejs/node/issues/9531#issuecomment-265611061
+  const proto = Object.getPrototypeOf(b);
+  return proto === Buffer.prototype || proto instanceof Buffer.prototype;
 };
 
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -567,7 +567,7 @@ Buffer.byteLength = byteLength;
 Object.defineProperty(Buffer.prototype, 'parent', {
   enumerable: true,
   get() {
-    if (!(this instanceof Buffer))
+    if (!Buffer.isBuffer(this))
       return undefined;
     return this.buffer;
   }
@@ -575,7 +575,7 @@ Object.defineProperty(Buffer.prototype, 'parent', {
 Object.defineProperty(Buffer.prototype, 'offset', {
   enumerable: true,
   get() {
-    if (!(this instanceof Buffer))
+    if (!Buffer.isBuffer(this))
       return undefined;
     return this.byteOffset;
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2198,7 +2198,7 @@ WriteStream.prototype.open = function() {
 
 
 WriteStream.prototype._write = function(data, encoding, cb) {
-  if (!(data instanceof Buffer))
+  if (!Buffer.isBuffer(data))
     return this.emit('error', new Error('Invalid data'));
 
   if (typeof this.fd !== 'number') {

--- a/lib/net.js
+++ b/lib/net.js
@@ -694,7 +694,7 @@ protoGetter('localPort', function localPort() {
 
 
 Socket.prototype.write = function(chunk, encoding, cb) {
-  if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
+  if (typeof chunk !== 'string' && !Buffer.isBuffer(chunk)) {
     throw new TypeError(
       'Invalid data, chunk must be a string or buffer, not ' + typeof chunk);
   }
@@ -752,7 +752,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
     if (err === 0) req._chunks = chunks;
   } else {
     var enc;
-    if (data instanceof Buffer) {
+    if (Buffer.isBuffer(data)) {
       enc = 'buffer';
     } else {
       enc = encoding;
@@ -821,7 +821,7 @@ protoGetter('bytesWritten', function bytesWritten() {
     return undefined;
 
   state.getBuffer().forEach(function(el) {
-    if (el.chunk instanceof Buffer)
+    if (Buffer.isBuffer(el.chunk))
       bytes += el.chunk.length;
     else
       bytes += Buffer.byteLength(el.chunk, el.encoding);
@@ -832,7 +832,7 @@ protoGetter('bytesWritten', function bytesWritten() {
     for (var i = 0; i < data.length; i++) {
       const chunk = data[i];
 
-      if (data.allBuffers || chunk instanceof Buffer)
+      if (data.allBuffers || Buffer.isBuffer(chunk))
         bytes += chunk.length;
       else
         bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -973,7 +973,7 @@ Interface.prototype._ttyWrite = function(s, key) {
         // falls through
 
       default:
-        if (s instanceof Buffer)
+        if (Buffer.isBuffer(s))
           s = s.toString('utf-8');
 
         if (s) {

--- a/test/parallel/test-buffer-isbuffer.js
+++ b/test/parallel/test-buffer-isbuffer.js
@@ -1,0 +1,31 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { Buffer } = require('buffer');
+
+const t = (val, exp) => assert.strictEqual(Buffer.isBuffer(val), exp);
+
+function FakeBuffer() {}
+FakeBuffer.prototype = Object.create(Buffer.prototype);
+
+class ExtensibleBuffer extends Buffer {
+  constructor() {
+    super(new ArrayBuffer(0), 0, 0);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+t(0, false);
+t(true, false);
+t('foo', false);
+t(Symbol(), false);
+t(null, false);
+t(undefined, false);
+t(() => {}, false);
+
+t({}, false);
+t(new Uint8Array(2), false);
+t(new FakeBuffer(), false);
+t(new ExtensibleBuffer(), true);
+t(Buffer.from('foo'), true);
+t(Buffer.allocUnsafeSlow(2), true);

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -96,6 +96,7 @@ assert.strictEqual(true, util.isPrimitive(NaN));
 assert.strictEqual(true, util.isPrimitive(Symbol('symbol')));
 
 // isBuffer
+assert.strictEqual(util.isBuffer, Buffer.isBuffer);
 assert.strictEqual(false, util.isBuffer('foo'));
 assert.strictEqual(true, util.isBuffer(Buffer.from('foo')));
 


### PR DESCRIPTION
Make "fake" Buffer subclasses whose instances are not valid Uint8Arrays fail the test.

Performance-wise, there are two options for this PR: one is to simply add an `isUint8Array` check and be done with it (w/o 88cf96b). It makes non-Buffers a lot faster, but Buffers slower:

```
                                                        improvement confidence      p.value
 buffers/buffer-isbuffer.js n=5000000 type="fake"          554.78 %        *** 3.206274e-20
 buffers/buffer-isbuffer.js n=5000000 type="fastbuffer"    -17.47 %        *** 1.807310e-11
 buffers/buffer-isbuffer.js n=5000000 type="object"        554.77 %        *** 1.516898e-38
 buffers/buffer-isbuffer.js n=5000000 type="primitive"     551.40 %        *** 2.627161e-22
 buffers/buffer-isbuffer.js n=5000000 type="slowbuffer"    -18.48 %        *** 1.807566e-06
 buffers/buffer-isbuffer.js n=5000000 type="uint8array"    -18.54 %        *** 4.267087e-11
```

Because of the decrease in performance of actual buffers, I exploited the fact that currently subclassing Buffer is not possible due to #4701, and only checked `[[Prototype]]` of the value itself (rather than going up the prototype chain as `instanceof` does). I can remove 88cf96b if it is deemed to be less future-proof but it does help out the performance a lot.

```
                                                        improvement confidence      p.value
 buffers/buffer-isbuffer.js n=5000000 type="fake"          556.85 %        *** 3.050148e-14
 buffers/buffer-isbuffer.js n=5000000 type="fastbuffer"    193.17 %        *** 7.663717e-17
 buffers/buffer-isbuffer.js n=5000000 type="object"        542.87 %        *** 2.297773e-15
 buffers/buffer-isbuffer.js n=5000000 type="primitive"     569.15 %        *** 1.922435e-17
 buffers/buffer-isbuffer.js n=5000000 type="slowbuffer"    191.37 %        *** 1.020681e-20
 buffers/buffer-isbuffer.js n=5000000 type="uint8array"    186.11 %        *** 3.797325e-13
```

Fixes: #11954

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
