### PR TITLE
doc: minor improvements in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,11 +26,10 @@ Support is divided into three tiers:
   the broader community.
 * **Tier 2**: Full test coverage but more limited maintenance,
   often provided by the vendor of the platform.
-* **Experimental**: Known to compile but not necessarily reliably or with
-  a full passing test suite. These are often working to be promoted to Tier
-  2 but are not quite ready. There is at least one individual actively
-  providing maintenance and the team is striving to broaden quality and
-  reliability of support.
+* **Experimental**: May not compile reliably or test suite may not pass.
+  These are often working to be promoted to Tier 2 but are not quite ready.
+  There is at least one individual actively providing maintenance and the team
+  is striving to broaden quality and reliability of support.
 
 ### Supported platforms
 
@@ -96,7 +95,7 @@ to avoid popups asking to accept incoming network connections when running tests
 $ sudo ./tools/macosx-firewall.sh
 ```
 Running this script will add rules for the executable `node` in the out
-directory and the symbolic `node` link in the projects root directory.
+directory and the symbolic `node` link in the project's root directory.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo
@@ -121,7 +120,7 @@ and not a newer version.
 
 To run the tests:
 
-```console
+```
 $ make test
 ```
 
@@ -206,9 +205,9 @@ in the current continuous integration environment. The participation of people
 dedicated and determined to improve Android building, testing, and support is
 encouraged.
 
-Be sure you have downloaded and extracted [Android NDK]
-(https://developer.android.com/tools/sdk/ndk/index.html)
-before in a folder. Then run:
+Be sure you have downloaded and extracted
+[Android NDK](https://developer.android.com/tools/sdk/ndk/index.html) before in
+a folder. Then run:
 
 ```console
 $ ./android-configure /path/to/your/android-ndk
@@ -350,6 +349,6 @@ and [user guide](https://openssl.org/docs/fips/UserGuide-2.0.pdf).
 6. Get into Node.js checkout folder
 7. `./configure --openssl-fips=/path/to/openssl-fips/installdir`
    For example on ubuntu 12 the installation directory was
-   /usr/local/ssl/fips-2.0
+   `/usr/local/ssl/fips-2.0`
 8. Build Node.js with `make -j`
-9. Verify with `node -p "process.versions.openssl"` (`1.0.2a-fips`)
+9. Verify with `node -p "process.versions.openssl"` (for example `1.0.2a-fips`)


### PR DESCRIPTION
1. necessarily reliably => necessarily reliable
2. projects root directory => project's root directory
3. remove `console` highlighting, as `test` alone is highlighted
4. fix broken link for Android NDK
5. highlight the directory location `/usr/local/ssl/fips-2.0`
6. remove expected output for `process.versions.openssl` as the version
   displayed is not mentioned in the document

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

---

cc @mhdawson 
