### PR TITLE
test: invalid chars in http client path

### DIFF
--- a/test/parallel/test-http-invalid-path-chars.js
+++ b/test/parallel/test-http-invalid-path-chars.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const expectedError = /^TypeError: Request path contains unescaped characters$/;
+const theExperimentallyDeterminedNumber = 39;
+
+function fail(path) {
+  assert.throws(() => {
+    http.request({ path }, common.fail);
+  }, expectedError);
+}
+
+for (let i = 0; i <= theExperimentallyDeterminedNumber; i++) {
+  const prefix = 'a'.repeat(i);
+  for (let i = 0; i <= 32; i++) {
+    fail(prefix + String.fromCodePoint(i));
+  }
+}


### PR DESCRIPTION
This test adds coverage for all the characters which are considered
invalid in a http path.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test http-client