### PR TITLE
(v7.x backport) test: add arrow functions to test-util-inspect

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -9,7 +9,9 @@ assert.strictEqual(util.inspect(false), 'false');
 assert.strictEqual(util.inspect(''), "''");
 assert.strictEqual(util.inspect('hello'), "'hello'");
 assert.strictEqual(util.inspect(function() {}), '[Function]');
+assert.strictEqual(util.inspect(() => {}), '[Function]');
 assert.strictEqual(util.inspect(async function() {}), '[AsyncFunction]');
+assert.strictEqual(util.inspect(async () => {}), '[AsyncFunction]');
 assert.strictEqual(util.inspect(function*() {}), '[Function]');
 assert.strictEqual(util.inspect(undefined), 'undefined');
 assert.strictEqual(util.inspect(null), 'null');
@@ -30,7 +32,10 @@ assert.strictEqual(util.inspect([1, [2, 3]]), '[ 1, [ 2, 3 ] ]');
 assert.strictEqual(util.inspect({}), '{}');
 assert.strictEqual(util.inspect({a: 1}), '{ a: 1 }');
 assert.strictEqual(util.inspect({a: function() {}}), '{ a: [Function: a] }');
+assert.strictEqual(util.inspect({a: () => {}}), '{ a: [Function: a] }');
 assert.strictEqual(util.inspect({a: async function() {}}),
+                   '{ a: [AsyncFunction: a] }');
+assert.strictEqual(util.inspect({a: async () => {}}),
                    '{ a: [AsyncFunction: a] }');
 assert.strictEqual(util.inspect({a: function*() {}}),
                    '{ a: [Function: a] }');


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/11781 to v7.x

/cc @italoacasas @cjihrig

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
