### PR TITLE
test: add minimal test for net benchmarks

### DIFF
--- a/test/sequential/test-benchmark-net.js
+++ b/test/sequential/test-benchmark-net.js
@@ -1,0 +1,22 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for net benchmarks. This makes sure the benchmarks aren't
+// horribly broken but nothing more than that.
+
+// Because the net benchmarks use hardcoded ports, this should be in sequential
+// rather than parallel to make sure it does not conflict with tests that choose
+// random available ports.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const path = require('path');
+
+const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
+
+const child = fork(runjs, ['--set', 'dur=0', 'net']);
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});


### PR DESCRIPTION
Currently, benchmark code is not exercised at all in CI. This adds a
minimal test for net benchmarks. If this is deemed acceptable, similar
minimal tests for other benchmarks can be written. Additionally, as
issues and edge cases are uncovered, checks for them can be added.

/cc @Fishrock123 Is this kinda sorta what you had in mind?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark net

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
