### PR TITLE
crypto: add OPENSSL_NO_EC guard

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -31,6 +31,7 @@ var crypto = null;
 
 const binding = process.binding('crypto');
 const NativeSecureContext = binding.SecureContext;
+const opensslNoEC = !!process.binding('config').openssl_no_ec;
 
 function SecureContext(secureProtocol, secureOptions, context) {
   if (!(this instanceof SecureContext)) {
@@ -111,7 +112,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   else
     c.context.setCiphers(tls.DEFAULT_CIPHERS);
 
-  if (c.context.hasEC()) {
+  if (!opensslNoEC) {
     if (options.ecdhCurve === undefined)
       c.context.setECDHCurve(tls.DEFAULT_ECDH_CURVE);
     else if (options.ecdhCurve)

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -111,10 +111,12 @@ exports.createSecureContext = function createSecureContext(options, context) {
   else
     c.context.setCiphers(tls.DEFAULT_CIPHERS);
 
-  if (options.ecdhCurve === undefined)
-    c.context.setECDHCurve(tls.DEFAULT_ECDH_CURVE);
-  else if (options.ecdhCurve)
-    c.context.setECDHCurve(options.ecdhCurve);
+  if (c.context.hasEC()) {
+    if (options.ecdhCurve === undefined)
+      c.context.setECDHCurve(tls.DEFAULT_ECDH_CURVE);
+    else if (options.ecdhCurve)
+      c.context.setECDHCurve(options.ecdhCurve);
+  }
 
   if (options.dhparam) {
     const warning = c.context.setDHParam(options.dhparam);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -38,7 +38,7 @@ const getCurves = binding.getCurves;
 const getFipsCrypto = binding.getFipsCrypto;
 const setFipsCrypto = binding.setFipsCrypto;
 const timingSafeEqual = binding.timingSafeEqual;
-const hasEC = binding.hasEC;
+const opensslNoEC = !!process.binding('config').openssl_no_ec;
 
 const Buffer = require('buffer').Buffer;
 const kBufferMaxLength = require('buffer').kMaxLength;
@@ -567,11 +567,13 @@ function ECDH(curve) {
   this._handle = new binding.ECDH(curve);
 }
 
-if (hasEC()) {
-  exports.createECDH = function createECDH(curve) {
-    return new ECDH(curve);
-  };
-}
+exports.createECDH = function createECDH(curve) {
+  if (opensslNoEC) {
+    throw new Error(
+        'Node.js is not compiled with OpenSSL elliptic curve support.');
+  }
+  return new ECDH(curve);
+};
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
 ECDH.prototype.setPrivateKey = DiffieHellman.prototype.setPrivateKey;
@@ -781,11 +783,13 @@ exports.getHashes = internalUtil.cachedResult(
   () => internalUtil.filterDuplicateStrings(getHashes())
 );
 
-if (hasEC()) {
-  exports.getCurves = internalUtil.cachedResult(
-    () => internalUtil.filterDuplicateStrings(getCurves())
-  );
-}
+exports.getCurves = internalUtil.cachedResult(() => {
+  if (opensslNoEC) {
+    throw new Error(
+        'Node.js is not compiled with OpenSSL elliptic curve support.');
+  }
+  return internalUtil.filterDuplicateStrings(getCurves());
+});
 
 Object.defineProperty(exports, 'fips', {
   get: getFipsCrypto,
@@ -793,7 +797,6 @@ Object.defineProperty(exports, 'fips', {
 });
 
 exports.timingSafeEqual = timingSafeEqual;
-exports.hasEC = hasEC;
 
 // Legacy API
 Object.defineProperty(exports, 'createCredentials', {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -38,6 +38,7 @@ const getCurves = binding.getCurves;
 const getFipsCrypto = binding.getFipsCrypto;
 const setFipsCrypto = binding.setFipsCrypto;
 const timingSafeEqual = binding.timingSafeEqual;
+const hasEC = binding.hasEC;
 
 const Buffer = require('buffer').Buffer;
 const kBufferMaxLength = require('buffer').kMaxLength;
@@ -566,9 +567,11 @@ function ECDH(curve) {
   this._handle = new binding.ECDH(curve);
 }
 
-exports.createECDH = function createECDH(curve) {
-  return new ECDH(curve);
-};
+if (hasEC()) {
+  exports.createECDH = function createECDH(curve) {
+    return new ECDH(curve);
+  };
+}
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
 ECDH.prototype.setPrivateKey = DiffieHellman.prototype.setPrivateKey;
@@ -778,9 +781,11 @@ exports.getHashes = internalUtil.cachedResult(
   () => internalUtil.filterDuplicateStrings(getHashes())
 );
 
-exports.getCurves = internalUtil.cachedResult(
-  () => internalUtil.filterDuplicateStrings(getCurves())
-);
+if (hasEC()) {
+  exports.getCurves = internalUtil.cachedResult(
+    () => internalUtil.filterDuplicateStrings(getCurves())
+  );
+}
 
 Object.defineProperty(exports, 'fips', {
   get: getFipsCrypto,
@@ -788,6 +793,7 @@ Object.defineProperty(exports, 'fips', {
 });
 
 exports.timingSafeEqual = timingSafeEqual;
+exports.hasEC = hasEC;
 
 // Legacy API
 Object.defineProperty(exports, 'createCredentials', {

--- a/src/node.cc
+++ b/src/node.cc
@@ -201,6 +201,13 @@ bool force_fips_crypto = false;
 std::string openssl_config;  // NOLINT(runtime/string)
 #endif  // HAVE_OPENSSL
 
+bool config_openssl_ec =
+# if defined(OPENSSL_NO_EC)
+        false;
+# else
+        true;
+#endif
+
 // true if process warnings should be suppressed
 bool no_process_warnings = false;
 bool trace_warnings = false;

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -15,6 +15,8 @@ using v8::ReadOnly;
 using v8::String;
 using v8::Value;
 
+extern bool config_openssl_ec;
+
 // The config binding is used to provide an internal view of compile or runtime
 // config options that are required internally by lib/*.js code. This is an
 // alternative to dropping additional properties onto the process object as
@@ -64,6 +66,9 @@ static void InitConfig(Local<Object> target,
 
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
+
+  if (!config_openssl_ec)
+    READONLY_BOOLEAN_PROPERTY("openssl_no_ec");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -37,8 +37,10 @@
 #include <limits>
 
 #if HAVE_OPENSSL
-# include <openssl/ec.h>
 # include <openssl/ssl.h>
+# if !defined(OPENSSL_NO_EC)
+#  include <openssl/ec.h>
+# endif
 # ifndef OPENSSL_NO_ENGINE
 #  include <openssl/engine.h>
 # endif  // !OPENSSL_NO_ENGINE
@@ -49,7 +51,9 @@ namespace node {
 using v8::Local;
 using v8::Object;
 
-#if HAVE_OPENSSL
+#if defined(OPENSSL_NO_EC)
+const char* default_cipher_list = NO_EC_CIPHER_LIST_CORE;
+#elif HAVE_OPENSSL
 const char* default_cipher_list = DEFAULT_CIPHER_LIST_CORE;
 #endif
 
@@ -1012,12 +1016,14 @@ void DefineOpenSSLConstants(Local<Object> target) {
 #endif
 
 #if HAVE_OPENSSL
+# if !defined(OPENSSL_NO_EC)
   // NOTE: These are not defines
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_COMPRESSED);
 
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_UNCOMPRESSED);
 
   NODE_DEFINE_CONSTANT(target, POINT_CONVERSION_HYBRID);
+# endif
 #endif
 }
 
@@ -1172,7 +1178,11 @@ void DefineCryptoConstants(Local<Object> target) {
 #if HAVE_OPENSSL
   NODE_DEFINE_STRING_CONSTANT(target,
                               "defaultCoreCipherList",
+# if defined(OPENSSL_NO_EC)
+                              NO_EC_CIPHER_LIST_CORE);
+# else
                               DEFAULT_CIPHER_LIST_CORE);
+#endif
   NODE_DEFINE_STRING_CONSTANT(target,
                               "defaultCipherList",
                               default_cipher_list);

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -51,9 +51,7 @@ namespace node {
 using v8::Local;
 using v8::Object;
 
-#if defined(OPENSSL_NO_EC)
-const char* default_cipher_list = NO_EC_CIPHER_LIST_CORE;
-#elif HAVE_OPENSSL
+#if HAVE_OPENSSL
 const char* default_cipher_list = DEFAULT_CIPHER_LIST_CORE;
 #endif
 
@@ -1178,11 +1176,7 @@ void DefineCryptoConstants(Local<Object> target) {
 #if HAVE_OPENSSL
   NODE_DEFINE_STRING_CONSTANT(target,
                               "defaultCoreCipherList",
-# if defined(OPENSSL_NO_EC)
-                              NO_EC_CIPHER_LIST_CORE);
-# else
                               DEFAULT_CIPHER_LIST_CORE);
-#endif
   NODE_DEFINE_STRING_CONSTANT(target,
                               "defaultCipherList",
                               default_cipher_list);

--- a/src/node_constants.h
+++ b/src/node_constants.h
@@ -40,6 +40,20 @@
 #ifndef RSA_PSS_SALTLEN_AUTO
 #define RSA_PSS_SALTLEN_AUTO -2
 #endif
+#define NO_EC_CIPHER_LIST_CORE   "DHE-RSA-AES128-GCM-SHA256:"       \
+                                 "DHE-RSA-AES128-SHA256:"           \
+                                 "DHE-RSA-AES256-SHA384:"           \
+                                 "DHE-RSA-AES256-SHA256:"           \
+                                 "HIGH:"                            \
+                                 "!aNULL:"                          \
+                                 "!eNULL:"                          \
+                                 "!EXPORT:"                         \
+                                 "!DES:"                            \
+                                 "!RC4:"                            \
+                                 "!MD5:"                            \
+                                 "!PSK:"                            \
+                                 "!SRP:"                            \
+                                 "!CAMELLIA"
 
 #define DEFAULT_CIPHER_LIST_CORE "ECDHE-RSA-AES128-GCM-SHA256:"     \
                                  "ECDHE-ECDSA-AES128-GCM-SHA256:"   \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -310,7 +310,6 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethod(t, "addCRL", SecureContext::AddCRL);
   env->SetProtoMethod(t, "addRootCerts", SecureContext::AddRootCerts);
   env->SetProtoMethod(t, "setCiphers", SecureContext::SetCiphers);
-  env->SetProtoMethod(t, "hasEC", SecureContext::HasEC);
 #if !defined(OPENSSL_NO_ECDH)
   env->SetProtoMethod(t, "setECDHCurve", SecureContext::SetECDHCurve);
 #endif
@@ -899,15 +898,6 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
 
   const node::Utf8Value ciphers(args.GetIsolate(), args[0]);
   SSL_CTX_set_cipher_list(sc->ctx_, *ciphers);
-}
-
-
-void SecureContext::HasEC(const FunctionCallbackInfo<Value>& args) {
-#if defined(OPENSSL_NO_EC)
-  args.GetReturnValue().Set(false);
-#else
-  args.GetReturnValue().Set(true);
-#endif
 }
 
 
@@ -6228,7 +6218,6 @@ void InitCrypto(Local<Object> target,
   env->SetMethod(target, "getSSLCiphers", GetSSLCiphers);
   env->SetMethod(target, "getCiphers", GetCiphers);
   env->SetMethod(target, "getHashes", GetHashes);
-  env->SetMethod(target, "hasEC", SecureContext::HasEC);
 #if !defined(OPENSSL_NO_EC)
   env->SetMethod(target, "getCurves", GetCurves);
 #endif

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -39,8 +39,12 @@
 #include "v8.h"
 
 #include <openssl/ssl.h>
+#if !defined(OPENSSL_NO_EC)
 #include <openssl/ec.h>
+#endif
+#if !defined(OPENSSL_NO_ECDH)
 #include <openssl/ecdh.h>
+#endif
 #ifndef OPENSSL_NO_ENGINE
 # include <openssl/engine.h>
 #endif  // !OPENSSL_NO_ENGINE
@@ -98,6 +102,7 @@ class SecureContext : public BaseObject {
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
+  static void HasEC(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   SSL_CTX* ctx_;
   X509* cert_;
@@ -123,7 +128,9 @@ class SecureContext : public BaseObject {
   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCiphers(const v8::FunctionCallbackInfo<v8::Value>& args);
+#if !defined(OPENSSL_NO_EC)
   static void SetECDHCurve(const v8::FunctionCallbackInfo<v8::Value>& args);
+#endif
   static void SetDHParam(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetSessionIdContext(
@@ -708,6 +715,7 @@ class DiffieHellman : public BaseObject {
   DH* dh;
 };
 
+#if !defined(OPENSSL_NO_ECDH)
 class ECDH : public BaseObject {
  public:
   ~ECDH() override {
@@ -744,6 +752,7 @@ class ECDH : public BaseObject {
   EC_KEY* key_;
   const EC_GROUP* group_;
 };
+#endif
 
 bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -127,9 +127,7 @@ class SecureContext : public BaseObject {
   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCiphers(const v8::FunctionCallbackInfo<v8::Value>& args);
-#if !defined(OPENSSL_NO_EC)
   static void SetECDHCurve(const v8::FunctionCallbackInfo<v8::Value>& args);
-#endif
   static void SetDHParam(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetSessionIdContext(

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -102,7 +102,6 @@ class SecureContext : public BaseObject {
   }
 
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
-  static void HasEC(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   SSL_CTX* ctx_;
   X509* cert_;

--- a/test/README.md
+++ b/test/README.md
@@ -231,6 +231,11 @@ Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
 
 Checks for 'openssl'.
 
+### hasCryptoEC
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks for 'openssl elliptic curve support'.
+
 ### hasFipsCrypto
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 

--- a/test/common.js
+++ b/test/common.js
@@ -214,6 +214,12 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
   }
 });
 
+Object.defineProperty(exports, 'hasCryptoEC', {
+  get: function() {
+    return exports.hasCrypto && require('crypto').hasEC();
+  }
+});
+
 if (exports.isWindows) {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';
   if (process.env.TEST_THREAD_ID) {

--- a/test/common.js
+++ b/test/common.js
@@ -216,7 +216,7 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 
 Object.defineProperty(exports, 'hasCryptoEC', {
   get: function() {
-    return exports.hasCrypto && require('crypto').hasEC();
+    return process.binding('config').openssl_no_ec ? false : true;
   }
 });
 

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const common = require('../common');
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -174,6 +174,19 @@ assert.strictEqual(bad_dh.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 
 const availableCurves = new Set(crypto.getCurves());
+// Test ECDH
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
+  return;
+}
+const ecdh1 = crypto.createECDH('prime256v1');
+const ecdh2 = crypto.createECDH('prime256v1');
+key1 = ecdh1.generateKeys();
+key2 = ecdh2.generateKeys('hex');
+secret1 = ecdh1.computeSecret(key2, 'hex', 'base64');
+secret2 = ecdh2.computeSecret(key1, 'latin1', 'buffer');
+
+assert.strictEqual(secret1, secret2.toString('base64'));
 
 // Oakley curves do not clean up ERR stack, it was causing unexpected failure
 // when accessing other OpenSSL APIs afterwards.

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -22,8 +22,8 @@
 'use strict';
 const common = require('../common');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const common = require('../common');
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -21,8 +21,10 @@ assert.throws(() => tls.createSecureContext({key: 'dummykey', passphrase: 1}),
 assert.throws(() => tls.createServer({key: 'dummykey', passphrase: 1}),
               /TypeError: Pass phrase must be a string/);
 
-assert.throws(() => tls.createServer({ecdhCurve: 1}),
-              /TypeError: ECDH curve name must be a string/);
+if (common.hasCryptoEC) {
+  assert.throws(() => tls.createServer({ecdhCurve: 1}),
+                /TypeError: ECDH curve name must be a string/);
+}
 
 assert.throws(() => tls.createServer({handshakeTimeout: 'abcd'}),
               /TypeError: handshakeTimeout must be a number/);

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -81,18 +81,23 @@ function testDHE2048() {
 }
 
 function testECDHE256() {
-  test(256, 'ECDH', tls.DEFAULT_ECDH_CURVE, testECDHE512);
-  ntests++;
+  if (common.hasCryptoEC) {
+    console.log(common.hasCryptoEC);
+    test(256, 'ECDH', tls.DEFAULT_ECDH_CURVE, testECDHE512);
+    ntests++;
+  }
 }
 
 function testECDHE512() {
-  test(521, 'ECDH', 'secp521r1', null);
-  ntests++;
+  if (common.hasCryptoEC) {
+    test(521, 'ECDH', 'secp521r1', null);
+    ntests++;
+  }
 }
 
 testNOT_PFS();
 
 process.on('exit', function() {
   assert.strictEqual(ntests, nsuccess);
-  assert.strictEqual(ntests, 5);
+  assert.strictEqual(ntests, common.hasCryptoEC ? 5 : 3);
 });

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -24,8 +24,8 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -22,8 +22,8 @@
 'use strict';
 const common = require('../common');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 

--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -2,8 +2,8 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 const tls = require('tls');

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -23,8 +23,8 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 const tls = require('tls');

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -23,8 +23,8 @@
 const common = require('../common');
 const assert = require('assert');
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+if (!common.hasCryptoEC) {
+  common.skip('missing crypto/elliptic curve support');
   return;
 }
 const tls = require('tls');


### PR DESCRIPTION
It is possible configure OpenSSL with no elliptic curve support using:
$ ./Configure no-ec

When configuring Node and specifying the above version of OpenSSL
a number of funtions will not work as they expect to have elliptic
curve support (--shared-openssl).

This commit adds a guard to check the places where elliptic curve
functionality is used and reduces the JavaScript API so that these
functions are not exposed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
