### PR TITLE
deps: fix async await desugaring in V8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 372
-#define V8_PATCH_LEVEL 42
+#define V8_PATCH_LEVEL 43
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -411,12 +411,21 @@ class ParserBase {
     }
 
     void set_promise_variable(typename Types::Variable* variable) {
-      DCHECK(variable != NULL);
+      DCHECK_NOT_NULL(variable);
       DCHECK(IsAsyncFunction(kind()));
       promise_variable_ = variable;
     }
     typename Types::Variable* promise_variable() const {
       return promise_variable_;
+    }
+
+    void set_async_return_variable(typename Types::Variable* variable) {
+      DCHECK_NOT_NULL(variable);
+      DCHECK(IsAsyncFunction(kind()));
+      async_return_variable_ = variable;
+    }
+    typename Types::Variable* async_return_variable() const {
+      return async_return_variable_;
     }
 
     const ZoneList<DestructuringAssignment>&
@@ -488,6 +497,8 @@ class ParserBase {
     // For async functions, this variable holds a temporary for the Promise
     // being created as output of the async function.
     Variable* promise_variable_;
+    Variable* async_return_variable_;
+    Variable* is_rejection_variable_;
 
     FunctionState** function_state_stack_;
     FunctionState* outer_function_state_;
@@ -1468,6 +1479,8 @@ ParserBase<Impl>::FunctionState::FunctionState(
       expected_property_count_(0),
       generator_object_variable_(nullptr),
       promise_variable_(nullptr),
+      async_return_variable_(nullptr),
+      is_rejection_variable_(nullptr),
       function_state_stack_(function_state_stack),
       outer_function_state_(*function_state_stack),
       destructuring_assignments_to_rewrite_(16, scope->zone()),

--- a/deps/v8/src/parsing/parser.h
+++ b/deps/v8/src/parsing/parser.h
@@ -491,6 +491,7 @@ class Parser : public ParserBase<Parser> {
   Block* BuildParameterInitializationBlock(
       const ParserFormalParameters& parameters, bool* ok);
   Block* BuildRejectPromiseOnException(Block* block, bool* ok);
+  Block* BuildRejectPromiseOnExceptionForParameters(Block* block);
 
   // Consumes the ending }.
   ZoneList<Statement*>* ParseEagerFunctionBody(
@@ -576,9 +577,10 @@ class Parser : public ParserBase<Parser> {
 
   Expression* BuildInitialYield(int pos, FunctionKind kind);
   Expression* BuildCreateJSGeneratorObject(int pos, FunctionKind kind);
-  Expression* BuildResolvePromise(Expression* value, int pos);
-  Expression* BuildRejectPromise(Expression* value, int pos);
+  Expression* BuildResolvePromise();
+  Expression* BuildRejectPromise(Variable* value);
   Variable* PromiseVariable();
+  Variable* AsyncReturnVariable();
 
   // Generic AST generator for throwing errors from compiled code.
   Expression* NewThrowError(Runtime::FunctionId function_id,
@@ -983,8 +985,7 @@ class Parser : public ParserBase<Parser> {
     auto* init_block = BuildParameterInitializationBlock(parameters, ok);
     if (!*ok) return;
     if (is_async) {
-      init_block = BuildRejectPromiseOnException(init_block, ok);
-      if (!*ok) return;
+      init_block = BuildRejectPromiseOnExceptionForParameters(init_block);
     }
     if (init_block != nullptr) body->Add(init_block, zone());
   }

--- a/deps/v8/test/mjsunit/regress/regress-5896.js
+++ b/deps/v8/test/mjsunit/regress/regress-5896.js
@@ -1,0 +1,14 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// Flags: --allow-natives-syntax
+async function foo() {
+  try {
+    return 1;
+  } finally {
+    return Promise.resolve().then(() => { return 2; });
+  }
+}
+foo()
+  .then(value => { found = value; assertEquals(2, value) })
+  .catch((e) => { %AbortJS(''+e); });


### PR DESCRIPTION
This is a backport of https://codereview.chromium.org/2672313003/. The
patch did not land in V8 because it was superseded by another one but it
is much easier to backport to V8 5.5, was reviewed and passed tests.

Original commit message:

    [async await] Fix async function desugaring

    Previously we rewrote the return statement in an async function from
    `return expr;` to `return %ResolvePromise(.promise, expr),
    .promise`. This can lead to incorrect behavior in the presence of try-finally.

    This patch stores the `expr` of the return statement in a temporary
    variable, resolves and returns the promise at the end of the finally
    block.

    BUG=v8:5896

Fixes: https://github.com/nodejs/node/issues/11960

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
V8