### PR TITLE
test: testing validity of prefix in mkdtempSync

### DIFF
--- a/test/parallel/test-mkdtemp-sync-prefix-check.js
+++ b/test/parallel/test-mkdtemp-sync-prefix-check.js
@@ -1,0 +1,13 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+const assertValues = [undefined, null, 0, true, false, 1];
+
+assertValues.forEach((assertValue) => {
+  assert.throws(
+    () => fs.mkdtempSync(assertValue, {}),
+    /^TypeError: filename prefix is required$/
+  );
+});


### PR DESCRIPTION
This test is checking for the validity of the path used as parameter
for mkdtempSync

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test fs
