### PR TITLE
Improve test-tls-key-mismatch.js

### DIFF
--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -29,6 +29,8 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const tls = require('tls');
 const fs = require('fs');
+const errorMessageRegex = new RegExp('^Error: error:0B080074:x509 ' +
+  'certificate routines:X509_check_private_key:key values mismatch$');
 
 const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
@@ -37,4 +39,4 @@ const options = {
 
 assert.throws(function() {
   tls.createSecureContext(options);
-});
+}, errorMessageRegex);


### PR DESCRIPTION
Improves `test/parallel/test-tls-key-mismatch.js` by providing a regex to validate the error message. 