### PR TITLE
buffer: remove error for malformatted hex string

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -615,9 +615,6 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
       enc == UTF8 ? str_obj->Utf8Length() :
       enc == UCS2 ? str_obj->Length() * sizeof(uint16_t) : str_obj->Length();
 
-  if (enc == HEX && str_length  % 2 != 0)
-    return env->ThrowTypeError("Invalid hex string");
-
   if (str_length == 0)
     return;
 
@@ -684,9 +681,6 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowTypeError("Argument must be a string");
 
   Local<String> str = args[0]->ToString(env->isolate());
-
-  if (encoding == HEX && str->Length() % 2 != 0)
-    return env->ThrowTypeError("Invalid hex string");
 
   size_t offset;
   size_t max_length;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -510,11 +510,13 @@ assert.strictEqual(Buffer.from('=bad'.repeat(1e4), 'base64').length, 0);
   }
 }
 
-// Test single hex character throws TypeError
-// - https://github.com/nodejs/node/issues/6770
-assert.throws(() => Buffer.from('A', 'hex'), TypeError);
+// Test single hex character is discarded.
+assert.strictEqual(Buffer.from('A', 'hex').length, 0);
 
-// Test single base64 char encodes as 0
+// Test that if a trailing character is discarded, rest of string is processed.
+assert.deepStrictEqual(Buffer.from('Abx', 'hex'), Buffer.from('Ab', 'hex'));
+
+// Test single base64 char encodes as 0.
 assert.strictEqual(Buffer.from('A', 'base64').length, 0);
 
 

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -132,11 +132,21 @@ testBufs('c8a26161', 8, 1, 'hex');
 testBufs('61c8b462c8b563c8b6', 4, -1, 'hex');
 testBufs('61c8b462c8b563c8b6', 4, 1, 'hex');
 testBufs('61c8b462c8b563c8b6', 12, 1, 'hex');
-// Make sure this operation doesn't go on forever
-buf1.fill('yKJh', 'hex');
-assert.throws(() =>
-      buf1.fill('\u0222', 'hex'), /^TypeError: Invalid hex string$/);
 
+{
+  const buf = Buffer.allocUnsafe(SIZE);
+  assert.doesNotThrow(() => {
+    // Make sure this operation doesn't go on forever.
+    buf.fill('yKJh', 'hex');
+  });
+}
+
+{
+  const buf = Buffer.allocUnsafe(SIZE);
+  assert.doesNotThrow(() => {
+    buf.fill('\u0222', 'hex');
+  });
+}
 
 // BASE64
 testBufs('YWJj', 'ucs2');


### PR DESCRIPTION
Improve accuracy of the error message when a hex string of an incorrect
length is send to .write() or .fill().

Fixes: https://github.com/nodejs/node/issues/3770

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
