### PR TITLE
test: add second argument to assert.throws()

### DIFF
--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -31,7 +31,8 @@ assert.strictEqual(processUtil.getProxyDetails({}), undefined);
 // and the get function on the handler object defined above
 // is actually invoked.
 assert.throws(
-  () => util.inspect(proxyObj)
+  () => util.inspect(proxyObj),
+  /^Error: Getter should not be called$/
 );
 
 // Yo dawg, I heard you liked Proxy so I put a Proxy


### PR DESCRIPTION
Adds a second argument to the assert.throws() test to implicitly specify
expected error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
