### PR TITLE
node: warn if cwd is inaccessible during bootstrap

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -374,6 +374,9 @@
       threw = false;
     } finally {
       if (threw) {
+        process.emitWarning('The current working directory was inaccessible.' +
+                            '\nFalling back to the executable\'s directory.',
+                            'BootstrapInaccessibleCwdWarning');
         // getcwd(3) can fail if the current working directory has been deleted.
         // Fall back to the directory name of the (absolute) executable path.
         // It's not really correct but what are the alternatives?


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
bootstrap

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

This was added/fixed in https://github.com/nodejs/node/commit/2c6f79c08cba4e7adee9de2283c7d08cf977adcb and seems like it could be quite confusing, so... maybe we should warn? ¯\\\_(ツ)\_/¯

I don't really know how to trigger this though, so no test... for now?

cc @bnoordhuis, maybe this isn't a good idea, idk.