### PR TITLE
lib: remove an unnecessary coverage check

### DIFF
--- a/lib/internal/process/write-coverage.js
+++ b/lib/internal/process/write-coverage.js
@@ -5,12 +5,10 @@ const fs = require('fs');
 const mkdirSync = fs.mkdirSync;
 const writeFileSync = fs.writeFileSync;
 
-var isWritingCoverage = false;
 function writeCoverage() {
-  if (isWritingCoverage || !global.__coverage__) {
+  if (!global.__coverage__) {
     return;
   }
-  isWritingCoverage = true;
 
   const dirname = path.join(path.dirname(process.execPath), '.coverage');
   const filename = `coverage-${process.pid}-${Date.now()}.json`;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
coverage

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

Fixes: https://github.com/nodejs/node/issues/11445
Refs: f65a48fc8f89071dc326e4d84646b5cbcfa8eca7

Based on @addaleax's [comment here](https://github.com/nodejs/node/issues/11445#issuecomment-280765078).

## Before (coverage.nodejs.org, `master`)

<img width="785" alt="screen shot 2017-03-24 at 12 15 20 pm" src="https://cloud.githubusercontent.com/assets/1093990/24303643/23f5275c-108d-11e7-9bfc-ab522985411b.png">

## After

<img width="792" alt="screen shot 2017-03-24 at 12 15 27 pm" src="https://cloud.githubusercontent.com/assets/1093990/24303654/2c60f074-108d-11e7-9669-53c82781c0e7.png">

And the specific `process._exiting` lines that f65a48fc8f89071dc326e4d84646b5cbcfa8eca7 was supposed to hit are indeed hit with this change:

<img width="583" alt="screen shot 2017-03-24 at 12 25 52 pm" src="https://cloud.githubusercontent.com/assets/1093990/24303688/42095f24-108d-11e7-9330-27a8d1f6c9b2.png">

cc @addaleax, @mhdawson @CurryKitten 
