### PR TITLE
test,benchmark: enable minimal CI for http bench

### DIFF
--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -13,7 +13,8 @@ var common = require('../common.js');
 var bench = common.createBenchmark(main, {
   num: [1, 4, 8, 16],
   size: [1, 64, 256],
-  c: [100]
+  c: [100],
+  dur: [10]
 });
 
 function main(conf) {
@@ -33,7 +34,8 @@ function main(conf) {
 
   server.listen(common.PORT, function() {
     bench.http({
-      connections: conf.c
+      connections: conf.c,
+      duration: conf.dur
     }, function() {
       server.close();
     });

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -8,7 +8,8 @@ if (cluster.isMaster) {
     // unicode confuses ab on os x.
     type: ['bytes', 'buffer'],
     length: [4, 1024, 102400],
-    c: [50, 500]
+    c: [50, 500],
+    dur: [10]
   });
 } else {
   require('./_http_simple.js');
@@ -30,7 +31,8 @@ function main(conf) {
 
       bench.http({
         path: path,
-        connections: conf.c
+        connections: conf.c,
+        duration: conf.dur
       }, function() {
         w1.destroy();
         w2.destroy();

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -14,7 +14,8 @@ var bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   kb: [64, 128, 256, 1024],
   c: [100],
-  method: ['write', 'end']
+  method: ['write', 'end'],
+  dur: [10]
 });
 
 function main(conf) {
@@ -50,7 +51,8 @@ function main(conf) {
 
   server.listen(common.PORT, function() {
     bench.http({
-      connections: conf.c
+      connections: conf.c,
+      duration: conf.dur
     }, function() {
       server.close();
     });

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -8,7 +8,8 @@ var bench = common.createBenchmark(main, {
   length: [4, 1024, 102400],
   chunks: [0, 1, 4],  // chunks=0 means 'no chunked encoding'.
   c: [50, 500],
-  res: ['normal', 'setHeader', 'setHeaderWH']
+  res: ['normal', 'setHeader', 'setHeaderWH'],
+  dur: [10]
 });
 
 function main(conf) {
@@ -20,7 +21,8 @@ function main(conf) {
 
     bench.http({
       path: path,
-      connections: conf.c
+      connections: conf.c,
+      duration: conf.dur
     }, function() {
       server.close();
     });

--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for http benchmarks. This makes sure the benchmarks aren't
+// horribly broken but nothing more than that.
+
+// Because some http benchmarks use hardcoded ports, this should be in
+// sequential rather than parallel to make sure it does not conflict with tests
+// that choose random available ports.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const path = require('path');
+
+const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
+
+// Q: 😱 WHY SO MANY OPTIONS??!! 😱
+// A: `wrk` will not accept a duration shorter than 1 second, so all benchmarks
+//    that depend on `wrk` will run for as many seconds as they have
+//    combinations of options. By specifying just one option for `res` and
+//    `method` and so on, we make sure those benchmark files run, but only for
+//    a little more than one second each.
+const child = fork(runjs,
+                   ['--set', 'n=1',
+                    '--set', 'c=8',
+                    '--set', 'dur=1',
+                    '--set', 'size=1',
+                    '--set', 'num=1',
+                    '--set', 'bytes=32',
+                    '--set', 'method=write',
+                    '--set', 'type=asc',
+                    '--set', 'length=4',
+                    '--set', 'kb=64',
+                    '--set', 'res=normal',
+                    '--set', 'chunks=0',
+                    'http']);
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});


### PR DESCRIPTION
Enable minimal CI testing for http benchmarks. This required making the
duration of some benchmarks configurable. They had been defaulting to 10
seconds each.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
