### PR TITLE
benchmark: update obsolete information pointer

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -88,9 +88,9 @@ exports.run = function(options, callback) {
     benchmarker: exports.default_http_benchmarker
   }, options);
   if (!options.benchmarker) {
-    callback(new Error('Could not locate any of the required http ' +
-                       'benchmarkers. Check benchmark/README.md for further ' +
-                       'instructions.'));
+    callback(new Error('Could not locate required http benchmarker. See ' +
+                       'https://github.com/nodejs/node/blob/master/doc/guides/writing-and-running-benchmarks.md##http-benchmark-requirements ' +
+                       'for further instructions.'));
     return;
   }
   const benchmarker = benchmarkers[options.benchmarker];


### PR DESCRIPTION
A doc suggested in an error message is no longer the place to get the
information about required http benchmarkers. Update the error message
to point to the current location for the information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
