### PR TITLE
test, tools: add common.noop and common.mustNotCall lint rule

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -9,5 +9,6 @@ rules:
   # Custom rules in tools/eslint-rules
   prefer-assert-iferror: 2
   prefer-assert-methods: 2
+  prefer-common-mustnotcall: 2
   ## common module is mandatory in tests
   required-modules: [2, common]

--- a/test/README.md
+++ b/test/README.md
@@ -324,7 +324,7 @@ Gets IP of localhost
 
 Array of IPV6 hosts.
 
-### mustCall(fn[, expected])
+### mustCall([fn][, expected])
 * fn [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 * expected [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
 * return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
@@ -333,12 +333,26 @@ Returns a function that calls `fn`. If the returned function has not been called
 exactly `expected` number of times when the test is complete, then the test will
 fail.
 
+If `fn` is not provided, `common.noop` will be used.
+
 ### nodeProcessAborted(exitCode, signal)
 * `exitCode` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
 * `signal` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 
 Returns `true` if the exit code `exitCode` and/or signal name `signal` represent the exit code and/or signal name of a node process that aborted, `false` otherwise.
+
+### noop
+
+A non-op `Function` that can be used for a variety of scenarios.
+
+For instance,
+
+```js
+const common = require('../common');
+
+someAsyncAPI('foo', common.mustCall(common.noop));
+```
 
 ### opensslCli
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/test/addons/async-hello-world/test.js
+++ b/test/addons/async-hello-world/test.js
@@ -6,5 +6,5 @@ const binding = require(`./build/${common.buildType}/binding`);
 binding(5, common.mustCall(function(err, val) {
   assert.strictEqual(err, null);
   assert.strictEqual(val, 10);
-  process.nextTick(common.mustCall(function() {}));
+  process.nextTick(common.mustCall());
 }));

--- a/test/addons/heap-profiler/test.js
+++ b/test/addons/heap-profiler/test.js
@@ -5,7 +5,7 @@ const common = require('../../common');
 const binding = require(`./build/${common.buildType}/binding`);
 
 // Create an AsyncWrap object.
-const timer = setTimeout(function() {}, 1);
+const timer = setTimeout(common.noop, 1);
 timer.unref();
 
 // Stress-test the heap profiler.

--- a/test/common.js
+++ b/test/common.js
@@ -35,6 +35,9 @@ const execSync = require('child_process').execSync;
 const testRoot = process.env.NODE_TEST_DIR ?
                    fs.realpathSync(process.env.NODE_TEST_DIR) : __dirname;
 
+const noop = () => {};
+
+exports.noop = noop;
 exports.fixturesDir = path.join(__dirname, 'fixtures');
 exports.tmpDirName = 'tmp';
 // PORT should match the definition in test/testpy/__init__.py.
@@ -429,6 +432,13 @@ function runCallChecks(exitCode) {
 
 
 exports.mustCall = function(fn, expected) {
+  if (typeof fn === 'number') {
+    expected = fn;
+    fn = noop;
+  } else if (fn === undefined) {
+    fn = noop;
+  }
+
   if (expected === undefined)
     expected = 1;
   else if (typeof expected !== 'number')
@@ -525,9 +535,9 @@ util.inherits(ArrayStream, stream.Stream);
 exports.ArrayStream = ArrayStream;
 ArrayStream.prototype.readable = true;
 ArrayStream.prototype.writable = true;
-ArrayStream.prototype.pause = function() {};
-ArrayStream.prototype.resume = function() {};
-ArrayStream.prototype.write = function() {};
+ArrayStream.prototype.pause = noop;
+ArrayStream.prototype.resume = noop;
+ArrayStream.prototype.write = noop;
 
 // Returns true if the exit code "exitCode" and/or signal name "signal"
 // represent the exit code and/or signal name of a node process that aborted,

--- a/test/debugger/test-debugger-client.js
+++ b/test/debugger/test-debugger-client.js
@@ -150,7 +150,7 @@ addTest(function(client, done) {
 
 let connectCount = 0;
 const script = 'setTimeout(function() { console.log("blah"); });' +
-               'setInterval(function() {}, 1000000);';
+               'setInterval(common.noop, 1000000);';
 
 let nodeProcess;
 
@@ -193,7 +193,7 @@ function doTest(cb, done) {
         console.error('>>> connecting...');
         c.connect(debug.port);
         c.on('break', function() {
-          c.reqContinue(function() {});
+          c.reqContinue(common.noop);
         });
         c.on('ready', function() {
           connectCount++;

--- a/test/message/unhandled_promise_trace_warnings.js
+++ b/test/message/unhandled_promise_trace_warnings.js
@@ -1,5 +1,5 @@
 // Flags: --trace-warnings
 'use strict';
-require('../common');
+const common = require('../common');
 const p = Promise.reject(new Error('This was rejected'));
-setImmediate(() => p.catch(() => {}));
+setImmediate(() => p.catch(common.noop));

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const a = require('assert');
 
@@ -505,22 +505,22 @@ a.throws(makeBlock(a.deepEqual, args, []));
 // check messages from assert.throws()
 {
   assert.throws(
-    () => { a.throws(() => {}); },
+    () => { a.throws(common.noop); },
     /^AssertionError: Missing expected exception\.$/
   );
 
   assert.throws(
-    () => { a.throws(() => {}, TypeError); },
+    () => { a.throws(common.noop, TypeError); },
     /^AssertionError: Missing expected exception \(TypeError\)\.$/
   );
 
   assert.throws(
-    () => { a.throws(() => {}, 'fhqwhgads'); },
+    () => { a.throws(common.noop, 'fhqwhgads'); },
     /^AssertionError: Missing expected exception: fhqwhgads$/
   );
 
   assert.throws(
-    () => { a.throws(() => {}, TypeError, 'fhqwhgads'); },
+    () => { a.throws(common.noop, TypeError, 'fhqwhgads'); },
     /^AssertionError: Missing expected exception \(TypeError\): fhqwhgads$/
   );
 }

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -39,35 +39,33 @@ function init(id, provider) {
   keyList = keyList.filter((e) => e !== pkeys[provider]);
 }
 
-function noop() { }
-
 async_wrap.setupHooks({ init });
 
 async_wrap.enable();
 
 
-setTimeout(function() { }, 1);
+setTimeout(common.noop, 1);
 
-fs.stat(__filename, noop);
+fs.stat(__filename, common.noop);
 
 if (!common.isAix) {
   // fs-watch currently needs special configuration on AIX and we
   // want to improve under https://github.com/nodejs/node/issues/5085.
   // strip out fs watch related parts for now
-  fs.watchFile(__filename, noop);
+  fs.watchFile(__filename, common.noop);
   fs.unwatchFile(__filename);
   fs.watch(__filename).close();
 }
 
-dns.lookup('localhost', noop);
-dns.lookupService('::', 0, noop);
-dns.resolve('localhost', noop);
+dns.lookup('localhost', common.noop);
+dns.lookupService('::', 0, common.noop);
+dns.resolve('localhost', common.noop);
 
 new StreamWrap(new net.Socket());
 
 new (process.binding('tty_wrap').TTY)();
 
-crypto.randomBytes(1, noop);
+crypto.randomBytes(1, common.noop);
 
 common.refreshTmpDir();
 
@@ -75,14 +73,14 @@ net.createServer(function(c) {
   c.end();
   this.close();
 }).listen(common.PIPE, function() {
-  net.connect(common.PIPE, noop);
+  net.connect(common.PIPE, common.noop);
 });
 
 net.createServer(function(c) {
   c.end();
   this.close(checkTLS);
 }).listen(0, function() {
-  net.connect(this.address().port, noop);
+  net.connect(this.address().port, common.noop);
 });
 
 dgram.createSocket('udp4').bind(0, function() {
@@ -99,7 +97,7 @@ function checkTLS() {
     key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
     cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
   };
-  const server = tls.createServer(options, noop)
+  const server = tls.createServer(options, common.noop)
     .listen(0, function() {
       const connectOpts = { rejectUnauthorized: false };
       tls.connect(this.address().port, connectOpts, function() {

--- a/test/parallel/test-async-wrap-disabled-propagate-parent.js
+++ b/test/parallel/test-async-wrap-disabled-propagate-parent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
@@ -28,8 +28,6 @@ function init(uid, type, parentUid, parentHandle) {
   }
 }
 
-function noop() { }
-
 async_wrap.setupHooks({ init });
 async_wrap.enable();
 
@@ -41,7 +39,7 @@ const server = net.createServer(function(c) {
     this.close();
   });
 }).listen(0, function() {
-  net.connect(this.address().port, noop);
+  net.connect(this.address().port, common.noop);
 });
 
 async_wrap.disable();

--- a/test/parallel/test-async-wrap-propagate-parent.js
+++ b/test/parallel/test-async-wrap-propagate-parent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 const async_wrap = process.binding('async_wrap');
@@ -28,8 +28,6 @@ function init(uid, type, parentUid, parentHandle) {
   }
 }
 
-function noop() { }
-
 async_wrap.setupHooks({ init });
 async_wrap.enable();
 
@@ -41,7 +39,7 @@ const server = net.createServer(function(c) {
     this.close();
   });
 }).listen(0, function() {
-  net.connect(this.address().port, noop);
+  net.connect(this.address().port, common.noop);
 });
 
 

--- a/test/parallel/test-async-wrap-throw-from-callback.js
+++ b/test/parallel/test-async-wrap-throw-from-callback.js
@@ -43,7 +43,7 @@ if (typeof process.argv[2] === 'string') {
   d.on('error', common.mustNotCall());
   d.run(() => {
     // Using randomBytes because timers are not yet supported.
-    crypto.randomBytes(0, () => { });
+    crypto.randomBytes(0, common.noop);
   });
 
 } else {

--- a/test/parallel/test-async-wrap-throw-no-init.js
+++ b/test/parallel/test-async-wrap-throw-no-init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
 
@@ -17,9 +17,9 @@ assert.throws(function() {
 }, /init callback is not assigned to a function/);
 
 // Should not throw
-async_wrap.setupHooks({ init: () => {} });
+async_wrap.setupHooks({ init: common.noop });
 async_wrap.enable();
 
 assert.throws(function() {
-  async_wrap.setupHooks(() => {});
+  async_wrap.setupHooks(common.noop);
 }, /hooks should not be set while also enabled/);

--- a/test/parallel/test-async-wrap-uid.js
+++ b/test/parallel/test-async-wrap-uid.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const async_wrap = process.binding('async_wrap');
@@ -8,7 +8,7 @@ const async_wrap = process.binding('async_wrap');
 // Give the event loop time to clear out the final uv_close().
 let si_cntr = 3;
 process.on('beforeExit', () => {
-  if (--si_cntr > 0) setImmediate(() => {});
+  if (--si_cntr > 0) setImmediate(common.noop);
 });
 
 const storage = new Map();

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const Buffer = require('buffer').Buffer;
@@ -278,7 +278,7 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
 const expectedError =
   /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
 assert.throws(() => {
-  b.includes(() => {});
+  b.includes(common.noop);
 }, expectedError);
 assert.throws(() => {
   b.includes({});

--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
-  setTimeout(() => {}, common.platformTimeout(100));
+  setTimeout(common.noop, common.platformTimeout(100));
   return;
 }
 

--- a/test/parallel/test-child-process-disconnect.js
+++ b/test/parallel/test-child-process-disconnect.js
@@ -78,7 +78,7 @@ if (process.argv[2] === 'child') {
   }));
 
   // the process should also self terminate without using signals
-  child.on('exit', common.mustCall(function() {}));
+  child.on('exit', common.mustCall());
 
   // when child is listening
   child.on('message', function(obj) {

--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const fork = require('child_process').fork;
 
 if (process.argv[2] === 'child') {
@@ -29,7 +29,7 @@ if (process.argv[2] === 'child') {
 
   setTimeout(function() {
     console.log('child -> will this keep it alive?');
-    process.on('message', function() { });
+    process.on('message', common.noop);
   }, 400);
 
 } else {

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -25,9 +25,9 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 const cat = spawn(common.isWindows ? 'cmd' : 'cat');
 
-cat.stdout.on('end', common.mustCall(function() {}));
+cat.stdout.on('end', common.mustCall());
 cat.stderr.on('data', common.mustNotCall());
-cat.stderr.on('end', common.mustCall(function() {}));
+cat.stderr.on('end', common.mustCall());
 
 cat.on('exit', common.mustCall(function(code, signal) {
   assert.strictEqual(code, null);

--- a/test/parallel/test-child-process-send-type-error.js
+++ b/test/parallel/test-child-process-send-type-error.js
@@ -1,9 +1,7 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-
-function noop() {}
 
 function fail(proc, args) {
   assert.throws(() => {
@@ -22,4 +20,4 @@ fail(target, ['msg', null, 'foo']);
 fail(target, ['msg', null, 0]);
 fail(target, ['msg', null, NaN]);
 fail(target, ['msg', null, 1]);
-fail(target, ['msg', null, null, noop]);
+fail(target, ['msg', null, null, common.noop]);

--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -1,10 +1,10 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
-  setInterval(() => {}, 1000);
+  setInterval(common.noop, 1000);
 } else {
   const { SIGKILL } = process.binding('constants').os.signals;
 

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
-const noop = function() {};
 
 function pass(option, value) {
   // Run the command with the specified option. Since it's not a real command,
@@ -31,7 +30,7 @@ function fail(option, value, message) {
   fail('cwd', false, err);
   fail('cwd', [], err);
   fail('cwd', {}, err);
-  fail('cwd', noop, err);
+  fail('cwd', common.noop, err);
 }
 
 {
@@ -47,7 +46,7 @@ function fail(option, value, message) {
   fail('detached', __dirname, err);
   fail('detached', [], err);
   fail('detached', {}, err);
-  fail('detached', noop, err);
+  fail('detached', common.noop, err);
 }
 
 if (!common.isWindows) {
@@ -64,7 +63,7 @@ if (!common.isWindows) {
       fail('uid', false, err);
       fail('uid', [], err);
       fail('uid', {}, err);
-      fail('uid', noop, err);
+      fail('uid', common.noop, err);
       fail('uid', NaN, err);
       fail('uid', Infinity, err);
       fail('uid', 3.1, err);
@@ -85,7 +84,7 @@ if (!common.isWindows) {
       fail('gid', false, err);
       fail('gid', [], err);
       fail('gid', {}, err);
-      fail('gid', noop, err);
+      fail('gid', common.noop, err);
       fail('gid', NaN, err);
       fail('gid', Infinity, err);
       fail('gid', 3.1, err);
@@ -105,7 +104,7 @@ if (!common.isWindows) {
   fail('shell', 1, err);
   fail('shell', [], err);
   fail('shell', {}, err);
-  fail('shell', noop, err);
+  fail('shell', common.noop, err);
 }
 
 {
@@ -121,7 +120,7 @@ if (!common.isWindows) {
   fail('argv0', false, err);
   fail('argv0', [], err);
   fail('argv0', {}, err);
-  fail('argv0', noop, err);
+  fail('argv0', common.noop, err);
 }
 
 {
@@ -137,7 +136,7 @@ if (!common.isWindows) {
   fail('windowsVerbatimArguments', __dirname, err);
   fail('windowsVerbatimArguments', [], err);
   fail('windowsVerbatimArguments', {}, err);
-  fail('windowsVerbatimArguments', noop, err);
+  fail('windowsVerbatimArguments', common.noop, err);
 }
 
 {
@@ -154,7 +153,7 @@ if (!common.isWindows) {
   fail('timeout', __dirname, err);
   fail('timeout', [], err);
   fail('timeout', {}, err);
-  fail('timeout', noop, err);
+  fail('timeout', common.noop, err);
   fail('timeout', NaN, err);
   fail('timeout', Infinity, err);
   fail('timeout', 3.1, err);
@@ -179,7 +178,7 @@ if (!common.isWindows) {
   fail('maxBuffer', __dirname, err);
   fail('maxBuffer', [], err);
   fail('maxBuffer', {}, err);
-  fail('maxBuffer', noop, err);
+  fail('maxBuffer', common.noop, err);
 }
 
 {
@@ -198,5 +197,5 @@ if (!common.isWindows) {
   fail('killSignal', false, typeErr);
   fail('killSignal', [], typeErr);
   fail('killSignal', {}, typeErr);
-  fail('killSignal', noop, typeErr);
+  fail('killSignal', common.noop, typeErr);
 }

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -43,11 +43,11 @@ cat.stdout.on('data', function(chunk) {
   response += chunk;
 });
 
-cat.stdout.on('end', common.mustCall(function() {}));
+cat.stdout.on('end', common.mustCall());
 
 cat.stderr.on('data', common.mustNotCall());
 
-cat.stderr.on('end', common.mustCall(function() {}));
+cat.stderr.on('end', common.mustCall());
 
 cat.on('exit', common.mustCall(function(status) {
   assert.strictEqual(0, status);

--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -103,7 +103,7 @@ if (cluster.isWorker) {
   }));
 
   //Kill process when worker is killed
-  cluster.on('exit', common.mustCall(() => {}));
+  cluster.on('exit', common.mustCall());
 
   //Create worker
   const worker = cluster.fork();

--- a/test/parallel/test-cluster-disconnect-leak.js
+++ b/test/parallel/test-cluster-disconnect-leak.js
@@ -6,19 +6,17 @@ const common = require('../common');
 const net = require('net');
 const cluster = require('cluster');
 
-const noop = () => {};
-
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
 
   // This is the important part of the test: Confirm that `disconnect` fires.
-  worker.on('disconnect', common.mustCall(noop));
+  worker.on('disconnect', common.mustCall());
 
   // These are just some extra stuff we're checking for good measure...
-  worker.on('exit', common.mustCall(noop));
-  cluster.on('exit', common.mustCall(noop));
+  worker.on('exit', common.mustCall());
+  cluster.on('exit', common.mustCall());
 
   cluster.disconnect();
   return;

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -35,10 +35,10 @@ if (cluster.isMaster) {
   const worker = cluster.fork();
 
   // makes sure master is able to fork the worker
-  cluster.on('fork', common.mustCall(function() {}));
+  cluster.on('fork', common.mustCall());
 
   // makes sure the worker is ready
-  worker.on('online', common.mustCall(function() {}));
+  worker.on('online', common.mustCall());
 
   worker.on('message', common.mustCall(function(err) {
     // disconnect first, so that we will not leave zombies

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -38,7 +38,7 @@ if (cluster.isMaster) {
   worker.on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, 'DONE');
   }));
-  worker.on('exit', common.mustCall(() => {}));
+  worker.on('exit', common.mustCall());
   return;
 }
 

--- a/test/parallel/test-cluster-rr-domain-listen.js
+++ b/test/parallel/test-cluster-rr-domain-listen.js
@@ -29,10 +29,10 @@ const domain = require('domain');
 
 if (cluster.isWorker) {
   const d = domain.create();
-  d.run(function() { });
+  d.run(common.noop);
 
   const http = require('http');
-  http.Server(function() { }).listen(common.PORT, '127.0.0.1');
+  http.Server(common.noop).listen(common.PORT, '127.0.0.1');
 
 } else if (cluster.isMaster) {
 

--- a/test/parallel/test-cluster-setup-master-emit.js
+++ b/test/parallel/test-cluster-setup-master-emit.js
@@ -43,5 +43,5 @@ function emitAndCatch2(next) {
 }
 
 emitAndCatch(common.mustCall(function() {
-  emitAndCatch2(common.mustCall(function() {}));
+  emitAndCatch2(common.mustCall());
 }));

--- a/test/parallel/test-cluster-worker-destroy.js
+++ b/test/parallel/test-cluster-worker-destroy.js
@@ -38,8 +38,8 @@ if (cluster.isMaster) {
   worker2 = cluster.fork();
 
   [worker1, worker2].forEach(function(worker) {
-    worker.on('disconnect', common.mustCall(function() {}));
-    worker.on('exit', common.mustCall(function() {}));
+    worker.on('disconnect', common.mustCall());
+    worker.on('exit', common.mustCall());
   });
 } else {
   if (cluster.worker.id === 1) {

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -11,7 +11,7 @@ if (cluster.isWorker) {
   const server = net.createServer(function(socket) {
     // Wait for any data, then close connection
     socket.write('.');
-    socket.on('data', function discard() {});
+    socket.on('data', common.noop);
   }).listen(common.PORT, common.localhostIPv4);
 
   server.once('close', function() {
@@ -20,7 +20,7 @@ if (cluster.isWorker) {
 
   // Although not typical, the worker process can exit before the disconnect
   // event fires. Use this to keep the process open until the event has fired.
-  const keepOpen = setInterval(function() {}, 9999);
+  const keepOpen = setInterval(common.noop, 9999);
 
   // Check worker events and properties
   process.once('disconnect', function() {

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -43,7 +43,7 @@ assert.throws(() => {
 
 // Console constructor should throw if stderr exists but is not writable
 assert.throws(() => {
-  out.write = () => {};
+  out.write = common.noop;
   err.write = undefined;
   new Console(out, err);
 }, /^TypeError: Console expects writable stream instances$/);

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -98,7 +98,7 @@ assert.doesNotThrow(() => {
 });
 
 assert.throws(() => {
-  crypto.pbkdf2('password', 'salt', 8, 8, function() {});
+  crypto.pbkdf2('password', 'salt', 8, 8, common.noop);
 }, /^TypeError: The "digest" argument is required and must not be undefined$/);
 
 assert.throws(() => {

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -38,7 +38,7 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
 [crypto.randomBytes, crypto.pseudoRandomBytes].forEach(function(f) {
   [-1, undefined, null, false, true, {}, []].forEach(function(value) {
     assert.throws(function() { f(value); }, expectedErrorRegexp);
-    assert.throws(function() { f(value, function() {}); }, expectedErrorRegexp);
+    assert.throws(function() { f(value, common.noop); }, expectedErrorRegexp);
   });
 
   [0, 1, 2, 4, 16, 256, 1024].forEach(function(len) {

--- a/test/parallel/test-debug-brk.js
+++ b/test/parallel/test-debug-brk.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const spawn = require('child_process').spawn;
 
-let run = () => {};
+let run = common.noop;
 function test(extraArgs, stdoutPattern) {
   const next = run;
   run = () => {

--- a/test/parallel/test-dgram-bind-shared-ports.js
+++ b/test/parallel/test-dgram-bind-shared-ports.js
@@ -25,8 +25,6 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
-function noop() { }
-
 if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
@@ -51,8 +49,8 @@ if (cluster.isMaster) {
     });
   });
 } else {
-  const socket1 = dgram.createSocket('udp4', noop);
-  const socket2 = dgram.createSocket('udp4', noop);
+  const socket1 = dgram.createSocket('udp4', common.noop);
+  const socket2 = dgram.createSocket('udp4', common.noop);
 
   socket1.on('error', (err) => {
     // no errors expected

--- a/test/parallel/test-dgram-close-is-not-callback.js
+++ b/test/parallel/test-dgram-close-is-not-callback.js
@@ -11,4 +11,4 @@ socket.send(buf, 0, buf.length, common.PORT, 'localhost');
 // if close callback is not function, ignore the argument.
 socket.close('bad argument');
 
-socket.on('close', common.mustCall(function() {}));
+socket.on('close', common.mustCall());

--- a/test/parallel/test-dgram-close.js
+++ b/test/parallel/test-dgram-close.js
@@ -33,8 +33,8 @@ let socket = dgram.createSocket('udp4');
 const handle = socket._handle;
 
 socket.send(buf, 0, buf.length, common.PORT, 'localhost');
-assert.strictEqual(socket.close(common.mustCall(function() {})), socket);
-socket.on('close', common.mustCall(function() {}));
+assert.strictEqual(socket.close(common.mustCall()), socket);
+socket.on('close', common.mustCall());
 socket = null;
 
 // Verify that accessing handle after closure doesn't throw

--- a/test/parallel/test-dgram-oob-buffer.js
+++ b/test/parallel/test-dgram-oob-buffer.js
@@ -30,12 +30,11 @@ const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 const buf = Buffer.from([1, 2, 3, 4]);
 
-function ok() {}
-socket.send(buf, 0, 0, common.PORT, '127.0.0.1', ok); // useful? no
-socket.send(buf, 0, 4, common.PORT, '127.0.0.1', ok);
-socket.send(buf, 1, 3, common.PORT, '127.0.0.1', ok);
-socket.send(buf, 3, 1, common.PORT, '127.0.0.1', ok);
+socket.send(buf, 0, 0, common.PORT, '127.0.0.1', common.noop); // useful? no
+socket.send(buf, 0, 4, common.PORT, '127.0.0.1', common.noop);
+socket.send(buf, 1, 3, common.PORT, '127.0.0.1', common.noop);
+socket.send(buf, 3, 1, common.PORT, '127.0.0.1', common.noop);
 // Since length of zero means nothing, don't error despite OOB.
-socket.send(buf, 4, 0, common.PORT, '127.0.0.1', ok);
+socket.send(buf, 4, 0, common.PORT, '127.0.0.1', common.noop);
 
 socket.close();

--- a/test/parallel/test-dgram-send-empty-buffer.js
+++ b/test/parallel/test-dgram-send-empty-buffer.js
@@ -43,6 +43,6 @@ client.bind(0, common.mustCall(function() {
 
   const buf = Buffer.alloc(0);
   const interval = setInterval(function() {
-    client.send(buf, 0, 0, port, '127.0.0.1', common.mustCall(function() {}));
+    client.send(buf, 0, 0, port, '127.0.0.1', common.mustCall());
   }, 10);
 }));

--- a/test/parallel/test-dgram-udp4.js
+++ b/test/parallel/test-dgram-udp4.js
@@ -46,7 +46,7 @@ server.on('listening', common.mustCall(() => {
               message_to_send.length,
               port,
               'localhost');
-  client.on('close', common.mustCall(() => {}));
+  client.on('close', common.mustCall());
 }));
-server.on('close', common.mustCall(() => {}));
+server.on('close', common.mustCall());
 server.bind(0);

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -24,7 +24,7 @@ assert.throws(() => {
     hints: 100,
     family: 0,
     all: false
-  }, () => {});
+  }, common.noop);
 }, /^TypeError: Invalid argument: hints must use valid flags$/);
 
 assert.throws(() => {
@@ -32,7 +32,7 @@ assert.throws(() => {
     hints: 0,
     family: 20,
     all: false
-  }, () => {});
+  }, common.noop);
 }, /^TypeError: Invalid argument: family must be 4 or 6$/);
 
 assert.doesNotThrow(() => {

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const dns = require('dns');
@@ -54,8 +54,6 @@ assert.doesNotThrow(() => {
 
   dns.setServers(servers);
 });
-
-function noop() {}
 
 const goog = [
   '8.8.8.8',
@@ -93,7 +91,7 @@ assert.doesNotThrow(() => dns.setServers([]));
 assert.deepStrictEqual(dns.getServers(), []);
 
 assert.throws(() => {
-  dns.resolve('test.com', [], noop);
+  dns.resolve('test.com', [], common.noop);
 }, function(err) {
   return !(err instanceof TypeError);
 }, 'Unexpected error');
@@ -102,25 +100,25 @@ assert.throws(() => {
 const errorReg =
   /^TypeError: Invalid arguments: hostname must be a string or falsey$/;
 
-assert.throws(() => dns.lookup({}, noop), errorReg);
+assert.throws(() => dns.lookup({}, common.noop), errorReg);
 
-assert.throws(() => dns.lookup([], noop), errorReg);
+assert.throws(() => dns.lookup([], common.noop), errorReg);
 
-assert.throws(() => dns.lookup(true, noop), errorReg);
+assert.throws(() => dns.lookup(true, common.noop), errorReg);
 
-assert.throws(() => dns.lookup(1, noop), errorReg);
+assert.throws(() => dns.lookup(1, common.noop), errorReg);
 
-assert.throws(() => dns.lookup(noop, noop), errorReg);
+assert.throws(() => dns.lookup(common.noop, common.noop), errorReg);
 
-assert.doesNotThrow(() => dns.lookup('', noop));
+assert.doesNotThrow(() => dns.lookup('', common.noop));
 
-assert.doesNotThrow(() => dns.lookup(null, noop));
+assert.doesNotThrow(() => dns.lookup(null, common.noop));
 
-assert.doesNotThrow(() => dns.lookup(undefined, noop));
+assert.doesNotThrow(() => dns.lookup(undefined, common.noop));
 
-assert.doesNotThrow(() => dns.lookup(0, noop));
+assert.doesNotThrow(() => dns.lookup(0, common.noop));
 
-assert.doesNotThrow(() => dns.lookup(NaN, noop));
+assert.doesNotThrow(() => dns.lookup(NaN, common.noop));
 
 /*
  * Make sure that dns.lookup throws if hints does not represent a valid flag.
@@ -133,7 +131,7 @@ assert.doesNotThrow(() => dns.lookup(NaN, noop));
  */
 assert.throws(() => {
   dns.lookup('www.google.com', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
-             noop);
+             common.noop);
 }, /^TypeError: Invalid argument: hints must use valid flags$/);
 
 assert.throws(() => dns.lookup('www.google.com'),
@@ -142,49 +140,49 @@ assert.throws(() => dns.lookup('www.google.com'),
 assert.throws(() => dns.lookup('www.google.com', 4),
               /^TypeError: Invalid arguments: callback must be passed$/);
 
-assert.doesNotThrow(() => dns.lookup('www.google.com', 6, noop));
+assert.doesNotThrow(() => dns.lookup('www.google.com', 6, common.noop));
 
-assert.doesNotThrow(() => dns.lookup('www.google.com', {}, noop));
+assert.doesNotThrow(() => dns.lookup('www.google.com', {}, common.noop));
 
-assert.doesNotThrow(() => dns.lookup('', {family: 4, hints: 0}, noop));
+assert.doesNotThrow(() => dns.lookup('', {family: 4, hints: 0}, common.noop));
 
 assert.doesNotThrow(() => {
   dns.lookup('', {
     family: 6,
     hints: dns.ADDRCONFIG
-  }, noop);
+  }, common.noop);
 });
 
-assert.doesNotThrow(() => dns.lookup('', {hints: dns.V4MAPPED}, noop));
+assert.doesNotThrow(() => dns.lookup('', {hints: dns.V4MAPPED}, common.noop));
 
 assert.doesNotThrow(() => {
   dns.lookup('', {
     hints: dns.ADDRCONFIG | dns.V4MAPPED
-  }, noop);
+  }, common.noop);
 });
 
 assert.throws(() => dns.lookupService('0.0.0.0'),
               /^Error: Invalid arguments$/);
 
-assert.throws(() => dns.lookupService('fasdfdsaf', 0, noop),
+assert.throws(() => dns.lookupService('fasdfdsaf', 0, common.noop),
               /^TypeError: "host" argument needs to be a valid IP address$/);
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', '0', noop));
+assert.doesNotThrow(() => dns.lookupService('0.0.0.0', '0', common.noop));
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', 0, noop));
+assert.doesNotThrow(() => dns.lookupService('0.0.0.0', 0, common.noop));
 
-assert.throws(() => dns.lookupService('0.0.0.0', null, noop),
+assert.throws(() => dns.lookupService('0.0.0.0', null, common.noop),
               /^TypeError: "port" should be >= 0 and < 65536, got "null"$/);
 
 assert.throws(
-  () => dns.lookupService('0.0.0.0', undefined, noop),
+  () => dns.lookupService('0.0.0.0', undefined, common.noop),
   /^TypeError: "port" should be >= 0 and < 65536, got "undefined"$/
 );
 
-assert.throws(() => dns.lookupService('0.0.0.0', 65538, noop),
+assert.throws(() => dns.lookupService('0.0.0.0', 65538, common.noop),
               /^TypeError: "port" should be >= 0 and < 65536, got "65538"$/);
 
-assert.throws(() => dns.lookupService('0.0.0.0', 'test', noop),
+assert.throws(() => dns.lookupService('0.0.0.0', 'test', common.noop),
               /^TypeError: "port" should be >= 0 and < 65536, got "test"$/);
 
 assert.throws(() => dns.lookupService('0.0.0.0', 80, null),

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -37,7 +37,7 @@ global.domain = require('domain');
 
 // should not throw a 'TypeError: undefined is not a function' exception
 crypto.randomBytes(8);
-crypto.randomBytes(8, function() {});
+crypto.randomBytes(8, common.noop);
 crypto.pseudoRandomBytes(8);
-crypto.pseudoRandomBytes(8, function() {});
-crypto.pbkdf2('password', 'salt', 8, 8, 'sha1', function() {});
+crypto.pseudoRandomBytes(8, common.noop);
+crypto.pbkdf2('password', 'salt', 8, 8, 'sha1', common.noop);

--- a/test/parallel/test-domain-exit-dispose.js
+++ b/test/parallel/test-domain-exit-dispose.js
@@ -43,7 +43,7 @@ function err() {
   function err2() {
     // this timeout should never be called, since the domain gets
     // disposed when the error happens.
-    setTimeout(common.mustCall(() => {}, 0), 1);
+    setTimeout(common.mustNotCall(), 1);
 
     // this function doesn't exist, and throws an error as a result.
     err3(); // eslint-disable-line no-undef

--- a/test/parallel/test-domain-timers.js
+++ b/test/parallel/test-domain-timers.js
@@ -51,4 +51,4 @@ immediated.run(function() {
   });
 });
 
-const timeout = setTimeout(function() {}, 10 * 1000);
+const timeout = setTimeout(common.noop, 10 * 1000);

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -22,7 +22,7 @@
 'use strict';
 // Simple tests of most basic domain functionality.
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const domain = require('domain');
 const events = require('events');
@@ -261,7 +261,7 @@ const fst = fs.createReadStream('stream for nonexistent file');
 d.add(fst);
 expectCaught++;
 
-[42, null, , false, function() {}, 'string'].forEach(function(something) {
+[42, null, , false, common.noop, 'string'].forEach(function(something) {
   const d = new domain.Domain();
   d.run(function() {
     process.nextTick(function() {

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const events = require('events');
 
@@ -28,40 +29,40 @@ let e = new events.EventEmitter();
 
 // default
 for (let i = 0; i < 10; i++) {
-  e.on('default', function() {});
+  e.on('default', common.noop);
 }
 assert.ok(!e._events['default'].hasOwnProperty('warned'));
-e.on('default', function() {});
+e.on('default', common.noop);
 assert.ok(e._events['default'].warned);
 
 // symbol
 const symbol = Symbol('symbol');
 e.setMaxListeners(1);
-e.on(symbol, function() {});
+e.on(symbol, common.noop);
 assert.ok(!e._events[symbol].hasOwnProperty('warned'));
-e.on(symbol, function() {});
+e.on(symbol, common.noop);
 assert.ok(e._events[symbol].hasOwnProperty('warned'));
 
 // specific
 e.setMaxListeners(5);
 for (let i = 0; i < 5; i++) {
-  e.on('specific', function() {});
+  e.on('specific', common.noop);
 }
 assert.ok(!e._events['specific'].hasOwnProperty('warned'));
-e.on('specific', function() {});
+e.on('specific', common.noop);
 assert.ok(e._events['specific'].warned);
 
 // only one
 e.setMaxListeners(1);
-e.on('only one', function() {});
+e.on('only one', common.noop);
 assert.ok(!e._events['only one'].hasOwnProperty('warned'));
-e.on('only one', function() {});
+e.on('only one', common.noop);
 assert.ok(e._events['only one'].hasOwnProperty('warned'));
 
 // unlimited
 e.setMaxListeners(0);
 for (let i = 0; i < 1000; i++) {
-  e.on('unlimited', function() {});
+  e.on('unlimited', common.noop);
 }
 assert.ok(!e._events['unlimited'].hasOwnProperty('warned'));
 
@@ -70,26 +71,26 @@ events.EventEmitter.defaultMaxListeners = 42;
 e = new events.EventEmitter();
 
 for (let i = 0; i < 42; ++i) {
-  e.on('fortytwo', function() {});
+  e.on('fortytwo', common.noop);
 }
 assert.ok(!e._events['fortytwo'].hasOwnProperty('warned'));
-e.on('fortytwo', function() {});
+e.on('fortytwo', common.noop);
 assert.ok(e._events['fortytwo'].hasOwnProperty('warned'));
 delete e._events['fortytwo'].warned;
 
 events.EventEmitter.defaultMaxListeners = 44;
-e.on('fortytwo', function() {});
+e.on('fortytwo', common.noop);
 assert.ok(!e._events['fortytwo'].hasOwnProperty('warned'));
-e.on('fortytwo', function() {});
+e.on('fortytwo', common.noop);
 assert.ok(e._events['fortytwo'].hasOwnProperty('warned'));
 
 // but _maxListeners still has precedence over defaultMaxListeners
 events.EventEmitter.defaultMaxListeners = 42;
 e = new events.EventEmitter();
 e.setMaxListeners(1);
-e.on('uno', function() {});
+e.on('uno', common.noop);
 assert.ok(!e._events['uno'].hasOwnProperty('warned'));
-e.on('uno', function() {});
+e.on('uno', common.noop);
 assert.ok(e._events['uno'].hasOwnProperty('warned'));
 
 // chainable

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 
@@ -15,5 +15,5 @@ assert.strictEqual(emitter.getMaxListeners(), 3);
 
 // https://github.com/nodejs/node/issues/523 - second call should not throw.
 const recv = {};
-EventEmitter.prototype.on.call(recv, 'event', function() {});
-EventEmitter.prototype.on.call(recv, 'event', function() {});
+EventEmitter.prototype.on.call(recv, 'event', common.noop);
+EventEmitter.prototype.on.call(recv, 'event', common.noop);

--- a/test/parallel/test-event-emitter-listener-count.js
+++ b/test/parallel/test-event-emitter-listener-count.js
@@ -1,15 +1,15 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 
 const emitter = new EventEmitter();
-emitter.on('foo', function() {});
-emitter.on('foo', function() {});
-emitter.on('baz', function() {});
+emitter.on('foo', common.noop);
+emitter.on('foo', common.noop);
+emitter.on('baz', common.noop);
 // Allow any type
-emitter.on(123, function() {});
+emitter.on(123, common.noop);
 
 assert.strictEqual(EventEmitter.listenerCount(emitter, 'foo'), 2);
 assert.strictEqual(emitter.listenerCount('foo'), 2);

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
@@ -18,5 +18,5 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 null listeners added.'));
 }));
 
-e.on(null, function() {});
-e.on(null, function() {});
+e.on(null, common.noop);
+e.on(null, common.noop);

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
@@ -20,5 +20,5 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 Symbol(symbol) listeners added.'));
 }));
 
-e.on(symbol, function() {});
-e.on(symbol, function() {});
+e.on(symbol, common.noop);
+e.on(symbol, common.noop);

--- a/test/parallel/test-event-emitter-max-listeners-warning.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning.js
@@ -18,5 +18,5 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 event-type listeners added.'));
 }));
 
-e.on('event-type', function() {});
-e.on('event-type', function() {});
+e.on('event-type', common.noop);
+e.on('event-type', common.noop);

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const events = require('events');
 const e = new events.EventEmitter();
 
-e.on('maxListeners', common.mustCall(function() {}));
+e.on('maxListeners', common.mustCall());
 
 // Should not corrupt the 'maxListeners' queue.
 e.setMaxListeners(42);

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -26,7 +26,7 @@ const EventEmitter = require('events');
 
 const e = new EventEmitter();
 
-e.once('hello', common.mustCall(function(a, b) {}));
+e.once('hello', common.mustCall());
 
 e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
@@ -45,7 +45,7 @@ e.once('e', common.mustCall(function() {
   e.emit('e');
 }));
 
-e.once('e', common.mustCall(function() {}));
+e.once('e', common.mustCall());
 
 e.emit('e');
 

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -36,28 +36,26 @@ function expect(expected) {
   return common.mustCall(listener, expected.length);
 }
 
-function listener() {}
-
 {
   const ee = new events.EventEmitter();
-  ee.on('foo', listener);
-  ee.on('bar', listener);
-  ee.on('baz', listener);
-  ee.on('baz', listener);
+  ee.on('foo', common.noop);
+  ee.on('bar', common.noop);
+  ee.on('baz', common.noop);
+  ee.on('baz', common.noop);
   const fooListeners = ee.listeners('foo');
   const barListeners = ee.listeners('bar');
   const bazListeners = ee.listeners('baz');
   ee.on('removeListener', expect(['bar', 'baz', 'baz']));
   ee.removeAllListeners('bar');
   ee.removeAllListeners('baz');
-  assert.deepStrictEqual(ee.listeners('foo'), [listener]);
+  assert.deepStrictEqual(ee.listeners('foo'), [common.noop]);
   assert.deepStrictEqual(ee.listeners('bar'), []);
   assert.deepStrictEqual(ee.listeners('baz'), []);
   // After calling removeAllListeners(),
   // the old listeners array should stay unchanged.
-  assert.deepStrictEqual(fooListeners, [listener]);
-  assert.deepStrictEqual(barListeners, [listener]);
-  assert.deepStrictEqual(bazListeners, [listener, listener]);
+  assert.deepStrictEqual(fooListeners, [common.noop]);
+  assert.deepStrictEqual(barListeners, [common.noop]);
+  assert.deepStrictEqual(bazListeners, [common.noop, common.noop]);
   // After calling removeAllListeners(),
   // new listeners arrays is different from the old.
   assert.notStrictEqual(ee.listeners('bar'), barListeners);
@@ -66,8 +64,8 @@ function listener() {}
 
 {
   const ee = new events.EventEmitter();
-  ee.on('foo', listener);
-  ee.on('bar', listener);
+  ee.on('foo', common.noop);
+  ee.on('bar', common.noop);
   // Expect LIFO order
   ee.on('removeListener', expect(['foo', 'bar', 'removeListener']));
   ee.on('removeListener', expect(['foo', 'bar']));
@@ -78,7 +76,7 @@ function listener() {}
 
 {
   const ee = new events.EventEmitter();
-  ee.on('removeListener', listener);
+  ee.on('removeListener', common.noop);
   // Check for regression where removeAllListeners() throws when
   // there exists a 'removeListener' listener, but there exists
   // no listeners for the provided event type.
@@ -88,12 +86,12 @@ function listener() {}
 {
   const ee = new events.EventEmitter();
   let expectLength = 2;
-  ee.on('removeListener', function(name, listener) {
+  ee.on('removeListener', function(name, noop) {
     assert.strictEqual(expectLength--, this.listeners('baz').length);
   });
-  ee.on('baz', function() {});
-  ee.on('baz', function() {});
-  ee.on('baz', function() {});
+  ee.on('baz', common.noop);
+  ee.on('baz', common.noop);
+  ee.on('baz', common.noop);
   assert.strictEqual(ee.listeners('baz').length, expectLength + 1);
   ee.removeAllListeners('baz');
   assert.strictEqual(ee.listeners('baz').length, 0);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -112,7 +112,7 @@ function listener2() {}
   const listener3 = common.mustCall(() => {
     ee.removeListener('hello', listener4);
   }, 2);
-  const listener4 = common.mustCall(() => {});
+  const listener4 = common.mustCall();
 
   ee.on('hello', listener3);
   ee.on('hello', listener4);
@@ -140,7 +140,7 @@ function listener2() {}
 {
   const ee = new EventEmitter();
 
-  assert.deepStrictEqual(ee, ee.removeListener('foo', () => {}));
+  assert.deepStrictEqual(ee, ee.removeListener('foo', common.noop));
 }
 
 // Verify that the removed listener must be a function
@@ -152,7 +152,7 @@ assert.throws(() => {
 
 {
   const ee = new EventEmitter();
-  const listener = () => {};
+  const listener = common.noop;
   ee._events = undefined;
   const e = ee.removeListener('foo', listener);
   assert.strictEqual(e, ee);

--- a/test/parallel/test-event-emitter-special-event-names.js
+++ b/test/parallel/test-event-emitter-special-event-names.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events');
 const assert = require('assert');
 
 const ee = new EventEmitter();
-const handler = () => {};
+const handler = common.noop;
 
 assert.deepStrictEqual(ee.eventNames(), []);
 

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -34,7 +34,7 @@ function MyEE(cb) {
   EventEmitter.call(this);
 }
 
-const myee = new MyEE(common.mustCall(function() {}));
+const myee = new MyEE(common.mustCall());
 
 
 util.inherits(ErrorEE, EventEmitter);
@@ -62,6 +62,6 @@ MyEE2.prototype = new EventEmitter();
 const ee1 = new MyEE2();
 const ee2 = new MyEE2();
 
-ee1.on('x', function() {});
+ee1.on('x', common.noop);
 
 assert.strictEqual(ee2.listenerCount('x'), 0);

--- a/test/parallel/test-event-emitter-symbols.js
+++ b/test/parallel/test-event-emitter-symbols.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 
 const ee = new EventEmitter();
 const foo = Symbol('foo');
-const listener = common.mustCall(function() {});
+const listener = common.mustCall();
 
 ee.on(foo, listener);
 assert.deepStrictEqual(ee.listeners(foo), [listener]);

--- a/test/parallel/test-events-list.js
+++ b/test/parallel/test-events-list.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events');
 const assert = require('assert');
 
 const EE = new EventEmitter();
+// Do not use common.noop here, these need to be separate listener functions
 const m = () => {};
 EE.on('foo', () => {});
 assert.deepStrictEqual(['foo'], EE.eventNames());

--- a/test/parallel/test-fs-assert-encoding-error.js
+++ b/test/parallel/test-fs-assert-encoding-error.js
@@ -1,14 +1,13 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
 const options = 'test';
-const noop = () => {};
 const unknownEncodingMessage = /^Error: Unknown encoding: test$/;
 
 assert.throws(() => {
-  fs.readFile('path', options, noop);
+  fs.readFile('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -16,7 +15,7 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.readdir('path', options, noop);
+  fs.readdir('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -24,7 +23,7 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.readlink('path', options, noop);
+  fs.readlink('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -32,7 +31,7 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.writeFile('path', 'data', options, noop);
+  fs.writeFile('path', 'data', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -40,7 +39,7 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.appendFile('path', 'data', options, noop);
+  fs.appendFile('path', 'data', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -48,11 +47,11 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.watch('path', options, noop);
+  fs.watch('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.realpath('path', options, noop);
+  fs.realpath('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {
@@ -60,7 +59,7 @@ assert.throws(() => {
 }, unknownEncodingMessage);
 
 assert.throws(() => {
-  fs.mkdtemp('path', options, noop);
+  fs.mkdtemp('path', options, common.noop);
 }, unknownEncodingMessage);
 
 assert.throws(() => {

--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -33,11 +33,9 @@ fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
 
   const read = fs.createReadStream(emptyFile, { fd });
 
-  read.once('data', () => {
-    common.fail('data event should not emit');
-  });
+  read.once('data', common.mustNotCall('data event should not emit'));
 
-  read.once('end', common.mustCall(function endEvent1() {}));
+  read.once('end', common.mustCall());
 }));
 
 fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
@@ -48,13 +46,9 @@ fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
 
   read.pause();
 
-  read.once('data', () => {
-    common.fail('data event should not emit');
-  });
+  read.once('data', common.mustNotCall('data event should not emit'));
 
-  read.once('end', function endEvent2() {
-    common.fail('end event should not emit');
-  });
+  read.once('end', common.mustNotCall('end event should not emit'));
 
   setTimeout(common.mustCall(() => {
     assert.strictEqual(read.isPaused(), true);

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -12,7 +12,7 @@ function test(cb) {
 }
 
 // Verify the case where a callback function is provided
-assert.doesNotThrow(test(function() {}));
+assert.doesNotThrow(test(common.noop));
 
 process.once('warning', common.mustCall((warning) => {
   assert.strictEqual(

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -77,4 +77,4 @@ common.refreshTmpDir();
 
 // Keep the event loop alive so the async mkdir() requests
 // have a chance to run (since they don't ref the event loop).
-process.nextTick(function() {});
+process.nextTick(common.noop);

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -63,12 +63,14 @@ if (!common.isAix) {
   // https://github.com/nodejs/node/issues/5085 is fixed
   {
     let watch;
-    assert.doesNotThrow(() => watch = fs.watch(__filename, options, () => {}));
+    assert.doesNotThrow(() => {
+      watch = fs.watch(__filename, options, common.noop);
+    });
     watch.close();
   }
 
   {
-    assert.doesNotThrow(() => fs.watchFile(__filename, options, () => {}));
+    assert.doesNotThrow(() => fs.watchFile(__filename, options, common.noop));
     fs.unwatchFile(__filename);
   }
 }

--- a/test/parallel/test-fs-read-file-assert-encoding.js
+++ b/test/parallel/test-fs-read-file-assert-encoding.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../common');
 
+const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
@@ -8,6 +8,6 @@ const encoding = 'foo-8';
 const filename = 'bar.txt';
 
 assert.throws(
-  fs.readFile.bind(fs, filename, { encoding }, () => {}),
+  fs.readFile.bind(fs, filename, { encoding }, common.noop),
   new RegExp(`Error: Unknown encoding: ${encoding}$`)
 );

--- a/test/parallel/test-fs-read-stream-double-close.js
+++ b/test/parallel/test-fs-read-stream-double-close.js
@@ -5,7 +5,5 @@ const fs = require('fs');
 
 const s = fs.createReadStream(__filename);
 
-s.close(common.mustCall(noop));
-s.close(common.mustCall(noop));
-
-function noop() {}
+s.close(common.mustCall());
+s.close(common.mustCall());

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -39,7 +39,7 @@ let paused = false;
   });
 
 
-  file.on('end', common.mustCall(function() {}));
+  file.on('end', common.mustCall());
 
 
   file.on('close', common.mustCall(function() {
@@ -139,7 +139,7 @@ let paused = false;
   let file7 =
     fs.createReadStream(rangeFile, Object.create({autoClose: false }));
   assert.strictEqual(file7.autoClose, false);
-  file7.on('data', function() {});
+  file7.on('data', common.noop);
   file7.on('end', common.mustCall(function() {
     process.nextTick(common.mustCall(function() {
       assert(!file7.closed);
@@ -169,8 +169,8 @@ let paused = false;
 {
   const options = Object.create({fd: 13337, autoClose: false});
   const file8 = fs.createReadStream(null, options);
-  file8.on('data', function() {});
-  file8.on('error', common.mustCall(function() {}));
+  file8.on('data', common.noop);
+  file8.on('error', common.mustCall());
   process.on('exit', function() {
     assert(!file8.closed);
     assert(!file8.destroyed);
@@ -181,8 +181,8 @@ let paused = false;
 // Make sure stream is destroyed when file does not exist.
 {
   const file9 = fs.createReadStream('/path/to/file/that/does/not/exist');
-  file9.on('data', function() {});
-  file9.on('error', common.mustCall(function() {}));
+  file9.on('data', common.noop);
+  file9.on('error', common.mustCall());
 
   process.on('exit', function() {
     assert(!file9.closed);

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -159,7 +159,7 @@ pauseRes.pause();
 pauseRes.resume();
 
 let file7 = fs.createReadStream(rangeFile, {autoClose: false });
-file7.on('data', function() {});
+file7.on('data', common.noop);
 file7.on('end', function() {
   process.nextTick(function() {
     assert(!file7.closed);
@@ -182,13 +182,13 @@ function file7Next() {
 
 // Just to make sure autoClose won't close the stream because of error.
 const file8 = fs.createReadStream(null, {fd: 13337, autoClose: false });
-file8.on('data', function() {});
-file8.on('error', common.mustCall(function() {}));
+file8.on('data', common.noop);
+file8.on('error', common.mustCall());
 
 // Make sure stream is destroyed when file does not exist.
 const file9 = fs.createReadStream('/path/to/file/that/does/not/exist');
-file9.on('data', function() {});
-file9.on('error', common.mustCall(function() {}));
+file9.on('data', common.noop);
+file9.on('error', common.mustCall());
 
 process.on('exit', function() {
   assert(file7.closed);

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -13,7 +13,7 @@ assert.throws(() => {
           expected.length,
           0,
           'utf-8',
-          () => {});
+          common.noop);
 }, /Second argument needs to be a buffer/);
 
 assert.throws(() => {

--- a/test/parallel/test-fs-watch-stop-async.js
+++ b/test/parallel/test-fs-watch-stop-async.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const watch = fs.watchFile(__filename, () => {});
+const watch = fs.watchFile(__filename, common.noop);
 let triggered;
 const listener = common.mustCall(() => {
   triggered = true;

--- a/test/parallel/test-fs-watch-stop-sync.js
+++ b/test/parallel/test-fs-watch-stop-sync.js
@@ -1,9 +1,10 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const watch = fs.watchFile(__filename, () => {});
+const watch = fs.watchFile(__filename, common.noop);
 watch.once('stop', assert.fail);  // Should not trigger.
 watch.stop();
 watch.removeListener('stop', assert.fail);

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -15,7 +15,7 @@ assert.throws(function() {
 }, /"watchFile\(\)" requires a listener function/);
 
 assert.throws(function() {
-  fs.watchFile(new Object(), function() {});
+  fs.watchFile(new Object(), common.noop);
 }, /Path must be a string/);
 
 const enoentFile = path.join(common.tmpDir, 'non-existent-file');

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -8,7 +8,5 @@ common.refreshTmpDir();
 
 const s = fs.createWriteStream(path.join(common.tmpDir, 'rw'));
 
-s.close(common.mustCall(noop));
-s.close(common.mustCall(noop));
-
-function noop() {}
+s.close(common.mustCall());
+s.close(common.mustCall());

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -31,7 +31,7 @@ common.refreshTmpDir();
   const file = path.join(common.tmpDir, 'write-end-test0.txt');
   const stream = fs.createWriteStream(file);
   stream.end();
-  stream.on('close', common.mustCall(function() { }));
+  stream.on('close', common.mustCall());
 }
 
 {

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -35,8 +35,8 @@ const old_default = EventEmitter.defaultMaxListeners;
 EventEmitter.defaultMaxListeners = 1;
 
 const e = new EventEmitter();
-e.on('hello', () => {});
-e.on('hello', () => {});
+e.on('hello', common.noop);
+e.on('hello', common.noop);
 
 // TODO: Figure out how to validate console. Currently,
 // there is no obvious way of validating that console

--- a/test/parallel/test-handle-wrap-close-abort.js
+++ b/test/parallel/test-handle-wrap-close-abort.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 
-process.on('uncaughtException', common.mustCall(function() {}, 2));
+process.on('uncaughtException', common.mustCall(2));
 
 setTimeout(function() {
   process.nextTick(function() {

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -87,7 +87,7 @@ const strictEqual = require('assert').strictEqual;
 // tcp
 {
   const net = require('net');
-  const server = net.createServer(() => {}).listen(0);
+  const server = net.createServer(common.noop).listen(0);
   strictEqual(Object.getPrototypeOf(server._handle).hasOwnProperty('hasRef'),
               true, 'tcp_wrap: hasRef() missing');
   strictEqual(server._handle.hasRef(),
@@ -112,7 +112,7 @@ const strictEqual = require('assert').strictEqual;
 
 // timers
 {
-  const timer = setTimeout(() => {}, 500);
+  const timer = setTimeout(common.noop, 500);
   timer.unref();
   strictEqual(Object.getPrototypeOf(timer._handle).hasOwnProperty('hasRef'),
               true, 'timer_wrap: hasRef() missing');

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -59,6 +59,6 @@ server.listen(0, common.mustCall(function() {
     });
 
     // it would be nice if this worked:
-    res.on('close', common.mustCall(function() {}));
+    res.on('close', common.mustCall());
   }));
 }));

--- a/test/parallel/test-http-client-aborted-event.js
+++ b/test/parallel/test-http-client-aborted-event.js
@@ -13,6 +13,6 @@ server.listen(0, common.mustCall(function() {
     headers: { connection: 'keep-alive' }
   }, common.mustCall(function(res) {
     server.close();
-    res.on('aborted', common.mustCall(function() {}));
+    res.on('aborted', common.mustCall());
   }));
 }));

--- a/test/parallel/test-http-client-defaults.js
+++ b/test/parallel/test-http-client-defaults.js
@@ -1,24 +1,23 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const ClientRequest = require('http').ClientRequest;
 
-function noop() {}
-
 {
-  const req = new ClientRequest({ createConnection: noop });
+  const req = new ClientRequest({ createConnection: common.noop });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }
 
 {
-  const req = new ClientRequest({ method: '', createConnection: noop });
+  const req = new ClientRequest({ method: '', createConnection: common.noop });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }
 
 {
-  const req = new ClientRequest({ path: '', createConnection: noop });
+  const req = new ClientRequest({ path: '', createConnection: common.noop });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -33,7 +33,7 @@ server.listen(0, common.mustCall(function() {
     path: 'example.com:443'
   }, common.mustNotCall());
 
-  req.on('close', common.mustCall(function() { }));
+  req.on('close', common.mustCall());
 
   req.on('connect', common.mustCall(function(res, socket, firstBodyChunk) {
     console.error('Client got CONNECT request');

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -49,7 +49,7 @@ server.listen(0, common.mustCall(function() {
     path: 'google.com:443'
   }, common.mustNotCall());
 
-  req.on('close', common.mustCall(() => {}));
+  req.on('close', common.mustCall());
 
   req.on('connect', common.mustCall((res, socket, firstBodyChunk) => {
     // Make sure this request got removed from the pool.

--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -49,4 +49,4 @@ server.listen(0, common.mustCall(() => {
   }
 }));
 
-process.on('uncaughtException', common.mustCall(() => {}, 10));
+process.on('uncaughtException', common.mustCall(10));

--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const net = require('net');
 const http = require('http');
 
@@ -28,7 +29,7 @@ const http = require('http');
 // It is separate from test-http-malformed-request.js because it is only
 // reproduceable on the first packet on the first connection to a server.
 
-const server = http.createServer(function(req, res) {});
+const server = http.createServer(common.noop);
 server.listen(0);
 
 server.on('listening', function() {

--- a/test/parallel/test-http-invalidheaderfield.js
+++ b/test/parallel/test-http-invalidheaderfield.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 const http = require('http');
@@ -28,7 +29,7 @@ server.listen(0, function() {
         port: server.address().port,
         headers: {'testing 123': 123}
       };
-      http.get(options, function() {});
+      http.get(options, common.noop);
     },
     function(err) {
       ee.emit('done');

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -4,7 +4,7 @@
 
 // Flags: --expose_gc
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const HTTPParser = process.binding('http_parser').HTTPParser;
 
@@ -39,7 +39,7 @@ function demoBug(part1, part2) {
     console.log('url', info.url);
   };
 
-  parser[kOnBody] = function(b, start, len) { };
+  parser[kOnBody] = common.noop;
 
   parser[kOnMessageComplete] = function() {
     messagesComplete++;

--- a/test/parallel/test-http-pause-resume-one-end.js
+++ b/test/parallel/test-http-pause-resume-one-end.js
@@ -43,6 +43,6 @@ server.listen(0, common.mustCall(function() {
       });
     }));
 
-    res.on('end', common.mustCall(function() {}));
+    res.on('end', common.mustCall());
   }));
 }));

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -46,7 +46,7 @@ function parent() {
     res.end();
   });
 
-  server.on('connection', common.mustCall(function(conn) {}));
+  server.on('connection', common.mustCall());
 
   server.listen(0, function() {
     const spawn = require('child_process').spawn;

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -25,5 +25,5 @@ server.listen(0, () => {
     // close the connection without returning any data.
     common.fail('no data should be returned by the server');
   });
-  client.on('end', common.mustCall(() => {}));
+  client.on('end', common.mustCall());
 });

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -52,7 +52,7 @@ test(function serverTimeout(cb) {
     // just do nothing, we should get a timeout event.
   });
   server.listen(common.mustCall(function() {
-    http.get({ port: server.address().port }).on('error', function() {});
+    http.get({ port: server.address().port }).on('error', common.noop);
   }));
   const s = server.setTimeout(50, function(socket) {
     caughtTimeout = true;
@@ -81,7 +81,7 @@ test(function serverRequestTimeout(cb) {
   server.listen(common.mustCall(function() {
     const port = server.address().port;
     const req = http.request({ port: port, method: 'POST' });
-    req.on('error', function() {});
+    req.on('error', common.noop);
     req.write('Hello');
     // req is in progress
   }));
@@ -104,7 +104,7 @@ test(function serverResponseTimeout(cb) {
   });
   server.listen(common.mustCall(function() {
     const port = server.address().port;
-    http.get({ port: port }).on('error', function() {});
+    http.get({ port: port }).on('error', common.noop);
   }));
 });
 
@@ -132,7 +132,7 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
   });
   server.listen(common.mustCall(function() {
     const port = server.address().port;
-    http.get({ port: port }).on('error', function() {});
+    http.get({ port: port }).on('error', common.noop);
   }));
 });
 

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 
 const util = require('util');
@@ -37,7 +38,7 @@ function createTestServer() {
 }
 
 function testServer() {
-  http.Server.call(this, function() {});
+  http.Server.call(this, common.noop);
 
   this.on('connection', function() {
     requests_recv++;

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -31,7 +31,7 @@ server.on('connection', function(connection) {
 });
 
 function shutdown() {
-  server.close(common.mustCall(function() {}));
+  server.close(common.mustCall());
 
   for (const key in connections) {
     connections[key].destroy();
@@ -49,7 +49,7 @@ server.listen(0, function() {
   };
 
   const req = https.request(requestOptions, function(res) {
-    res.on('data', function(d) {});
+    res.on('data', common.noop);
     setImmediate(shutdown);
   });
   req.end();

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -69,7 +69,7 @@ test(function serverTimeout(cb) {
     https.get({
       port: this.address().port,
       rejectUnauthorized: false
-    }).on('error', function() {});
+    }).on('error', common.noop);
   }));
 });
 
@@ -90,7 +90,7 @@ test(function serverRequestTimeout(cb) {
       method: 'POST',
       rejectUnauthorized: false
     });
-    req.on('error', function() {});
+    req.on('error', common.noop);
     req.write('Hello');
     // req is in progress
   });
@@ -111,7 +111,7 @@ test(function serverResponseTimeout(cb) {
     https.get({
       port: this.address().port,
       rejectUnauthorized: false
-    }).on('error', function() {});
+    }).on('error', common.noop);
   });
 });
 
@@ -119,7 +119,7 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
   function handler(req, res) {
     // just do nothing, we should get a timeout event.
     req.setTimeout(50, common.mustNotCall());
-    res.on('timeout', common.mustCall(function(socket) {}));
+    res.on('timeout', common.mustCall());
   }
   const server = https.createServer(serverOptions, common.mustCall(handler));
   server.on('timeout', function(socket) {
@@ -131,7 +131,7 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
     https.get({
       port: this.address().port,
       rejectUnauthorized: false
-    }).on('error', function() {});
+    }).on('error', common.noop);
   });
 });
 

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -58,7 +58,7 @@ server_http.listen(0, function() {
   });
   // These methods should exist on the request and get passed down to the socket
   req.setNoDelay(true);
-  req.setTimeout(1000, function() { });
+  req.setTimeout(1000, common.noop);
   req.setSocketKeepAlive(true, 1000);
   req.end();
 });
@@ -82,7 +82,7 @@ server_https.listen(0, function() {
   });
   // These methods should exist on the request and get passed down to the socket
   req.setNoDelay(true);
-  req.setTimeout(1000, function() { });
+  req.setTimeout(1000, common.noop);
   req.setSocketKeepAlive(true, 1000);
   req.end();
 });

--- a/test/parallel/test-instanceof.js
+++ b/test/parallel/test-instanceof.js
@@ -1,10 +1,11 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 
 
 // Regression test for instanceof, see
 // https://github.com/nodejs/node/issues/7592
-const F = () => {};
+const F = common.noop;
 F.prototype = {};
 assert(Object.create(F.prototype) instanceof F);

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -36,7 +36,7 @@ let localhostTries = 10;
 
 const server = net.createServer({allowHalfOpen: true}, function(socket) {
   socket.resume();
-  socket.on('end', common.mustCall(function() {}));
+  socket.on('end', common.mustCall());
   socket.end();
 });
 

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -159,7 +159,8 @@ function syncFailToConnect(port, regexp, optOnly) {
 }
 
 function canConnect(port) {
-  const noop = () => common.mustCall(function() {});
+  const noop = () => common.mustCall();
+
   // connect(port, cb) and connect(port)
   const portArgBlocks = doConnect([port], noop);
   for (const block of portArgBlocks) {

--- a/test/parallel/test-net-listen-close-server-callback-is-not-function.js
+++ b/test/parallel/test-net-listen-close-server-callback-is-not-function.js
@@ -4,7 +4,7 @@ const net = require('net');
 
 const server = net.createServer(common.mustNotCall());
 
-server.on('close', common.mustCall(function() {}));
+server.on('close', common.mustCall());
 
 server.listen(0, common.mustNotCall());
 

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -26,4 +26,4 @@ const net = require('net');
 const server = net.createServer(function(socket) {
 });
 server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCESS or EADDRNOTAVAIL
-server.on('error', common.mustCall(function(error) {}));
+server.on('error', common.mustCall());

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -1,10 +1,9 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
-
-function noop() {}
 
 if (cluster.isMaster) {
   const worker1 = cluster.fork();
@@ -21,7 +20,7 @@ if (cluster.isMaster) {
     });
   });
 } else {
-  const server = net.createServer(noop);
+  const server = net.createServer(common.noop);
 
   server.on('error', function(err) {
     process.send(err.code);

--- a/test/parallel/test-net-listen-shared-ports.js
+++ b/test/parallel/test-net-listen-shared-ports.js
@@ -25,8 +25,6 @@ const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 
-function noop() {}
-
 if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
@@ -41,8 +39,8 @@ if (cluster.isMaster) {
     });
   });
 } else {
-  const server1 = net.createServer(noop);
-  const server2 = net.createServer(noop);
+  const server1 = net.createServer(common.noop);
+  const server2 = net.createServer(common.noop);
 
   server1.on('error', function(err) {
     // no errors expected

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -19,7 +19,7 @@ function connectThrows(input) {
   }, expectedError);
 }
 
-[() => {}].forEach((input) => connectDoesNotThrow(input));
+connectDoesNotThrow(common.noop);
 
 function connectDoesNotThrow(input) {
   const opts = {

--- a/test/parallel/test-net-server-bind.js
+++ b/test/parallel/test-net-server-bind.js
@@ -7,7 +7,7 @@ const net = require('net');
 // With only a callback, server should get a port assigned by the OS
 
 let address0;
-const server0 = net.createServer(function(socket) { });
+const server0 = net.createServer(common.noop);
 
 server0.listen(function() {
   address0 = server0.address();
@@ -20,7 +20,7 @@ server0.listen(function() {
 
 let address1;
 let connectionKey1;
-const server1 = net.createServer(function(socket) { });
+const server1 = net.createServer(common.noop);
 
 server1.listen(common.PORT);
 
@@ -35,7 +35,7 @@ setTimeout(function() {
 // Callback to listen()
 
 let address2;
-const server2 = net.createServer(function(socket) { });
+const server2 = net.createServer(common.noop);
 
 server2.listen(common.PORT + 1, function() {
   address2 = server2.address();
@@ -47,7 +47,7 @@ server2.listen(common.PORT + 1, function() {
 // Backlog argument
 
 let address3;
-const server3 = net.createServer(function(socket) { });
+const server3 = net.createServer(common.noop);
 
 server3.listen(common.PORT + 2, '0.0.0.0', 127, function() {
   address3 = server3.address();
@@ -59,7 +59,7 @@ server3.listen(common.PORT + 2, '0.0.0.0', 127, function() {
 // Backlog argument without host argument
 
 let address4;
-const server4 = net.createServer(function(socket) { });
+const server4 = net.createServer(common.noop);
 
 server4.listen(common.PORT + 3, 127, function() {
   address4 = server4.address();

--- a/test/parallel/test-net-socket-destroy-twice.js
+++ b/test/parallel/test-net-socket-destroy-twice.js
@@ -29,4 +29,4 @@ conn.on('error', common.mustCall(function() {
   conn.destroy();
 }));
 
-conn.on('close', common.mustCall(function() {}));
+conn.on('close', common.mustCall());

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -25,10 +25,9 @@ const net = require('net');
 const assert = require('assert');
 
 // Verify that invalid delays throw
-const noop = function() {};
 const s = new net.Socket();
 const nonNumericDelays = [
-  '100', true, false, undefined, null, '', {}, noop, []
+  '100', true, false, undefined, null, '', {}, common.noop, []
 ];
 const badRangeDelays = [-0.001, -1, -Infinity, Infinity, NaN];
 const validDelays = [0, 0.001, 1, 1e6];
@@ -36,19 +35,19 @@ const validDelays = [0, 0.001, 1, 1e6];
 
 for (let i = 0; i < nonNumericDelays.length; i++) {
   assert.throws(function() {
-    s.setTimeout(nonNumericDelays[i], noop);
+    s.setTimeout(nonNumericDelays[i], common.noop);
   }, TypeError);
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
   assert.throws(function() {
-    s.setTimeout(badRangeDelays[i], noop);
+    s.setTimeout(badRangeDelays[i], common.noop);
   }, RangeError);
 }
 
 for (let i = 0; i < validDelays.length; i++) {
   assert.doesNotThrow(function() {
-    s.setTimeout(validDelays[i], noop);
+    s.setTimeout(validDelays[i], common.noop);
   });
 }
 

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -53,7 +54,7 @@ const server = net.createServer(function(socket) {
   });
 
   for (let i = 0; i < N; ++i) {
-    socket.write(buf, function() { });
+    socket.write(buf, common.noop);
   }
   socket.end();
 

--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -33,7 +33,7 @@ const server = net.createServer(common.mustCall(function(socket) {
 
   setTimeout(common.mustCall(function() {
     console.error('about to try to write');
-    socket.write('test', common.mustCall(function(e) {}));
+    socket.write('test', common.mustCall());
   }), 250);
 }));
 

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -25,15 +25,15 @@ const assert = require('assert');
 
 process.nextTick(common.mustCall(function() {
   process.nextTick(common.mustCall(function() {
-    process.nextTick(common.mustCall(function() {}));
+    process.nextTick(common.mustCall());
   }));
 }));
 
 setTimeout(common.mustCall(function() {
-  process.nextTick(common.mustCall(function() {}));
+  process.nextTick(common.mustCall());
 }), 50);
 
-process.nextTick(common.mustCall(function() {}));
+process.nextTick(common.mustCall());
 
 const obj = {};
 

--- a/test/parallel/test-no-enter-tickcallback.js
+++ b/test/parallel/test-no-enter-tickcallback.js
@@ -27,6 +27,6 @@ setImmediate(common.mustCall(() => {
   require('domain');
   setImmediate(common.mustCall(() => setImmediate(common.mustCall(() => {
     allsGood = true;
-    process.nextTick(() => {});
+    process.nextTick(common.noop);
   }))));
 }));

--- a/test/parallel/test-process-getactiverequests.js
+++ b/test/parallel/test-process-getactiverequests.js
@@ -1,10 +1,10 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
 for (let i = 0; i < 12; i++)
-  fs.open(__filename, 'r', function() { });
+  fs.open(__filename, 'r', common.noop);
 
 assert.strictEqual(12, process._getActiveRequests().length);

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -31,7 +31,7 @@ for (let i = 0; i < N; ++i) {
   process.nextTick(common.mustCall(cb));
 }
 
-process.on('uncaughtException', common.mustCall(function() {}, N));
+process.on('uncaughtException', common.mustCall(N));
 
 process.on('exit', function() {
   process.removeAllListeners('uncaughtException');

--- a/test/parallel/test-promises-warning-on-unhandled-rejection.js
+++ b/test/parallel/test-promises-warning-on-unhandled-rejection.js
@@ -26,4 +26,4 @@ process.on('warning', common.mustCall((warning) => {
 }, 3));
 
 const p = Promise.reject('This was rejected');
-setImmediate(common.mustCall(() => p.catch(() => {})));
+setImmediate(common.mustCall(() => p.catch(common.noop)));

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -34,10 +34,10 @@ function FakeInput() {
   EventEmitter.call(this);
 }
 inherits(FakeInput, EventEmitter);
-FakeInput.prototype.resume = function() {};
-FakeInput.prototype.pause = function() {};
-FakeInput.prototype.write = function() {};
-FakeInput.prototype.end = function() {};
+FakeInput.prototype.resume = common.noop;
+FakeInput.prototype.pause = common.noop;
+FakeInput.prototype.write = common.noop;
+FakeInput.prototype.end = common.noop;
 
 function isWarned(emitter) {
   for (const name in emitter) {
@@ -566,7 +566,7 @@ function isWarned(emitter) {
     });
 
     const rl = readline.createInterface({
-      input: new Readable({ read: () => {} }),
+      input: new Readable({ read: common.noop }),
       output: output,
       prompt: '$ ',
       terminal: terminal

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -298,7 +298,7 @@ const runKeyIntervalTests = [
     { name: 'escape', sequence: '\x1b', meta: true },
     { name: 'escape', sequence: '\x1b', meta: true }
   ])
-].reverse().reduce((acc, fn) => fn(acc), () => {});
+].reverse().reduce((acc, fn) => fn(acc), common.noop);
 
 // run key interval tests one after another
 runKeyIntervalTests();

--- a/test/parallel/test-regress-GH-4948.js
+++ b/test/parallel/test-regress-GH-4948.js
@@ -1,7 +1,7 @@
 'use strict';
 // https://github.com/joyent/node/issues/4948
 
-require('../common');
+const common = require('../common');
 const http = require('http');
 
 let reqCount = 0;
@@ -22,10 +22,10 @@ const server = http.createServer(function(serverReq, serverRes) {
     serverRes.end();
 
     // required for test to fail
-    res.on('data', function(data) { });
+    res.on('data', common.noop);
 
   });
-  r.on('error', function(e) {});
+  r.on('error', common.noop);
   r.end();
 
   serverRes.write('some data');

--- a/test/parallel/test-regress-GH-5051.js
+++ b/test/parallel/test-regress-GH-5051.js
@@ -5,7 +5,7 @@ const agent = require('http').globalAgent;
 
 // small stub just so we can call addRequest directly
 const req = {
-  getHeader: function() {}
+  getHeader: common.noop
 };
 
 agent.maxSockets = 0;

--- a/test/parallel/test-repl-.save.load.js
+++ b/test/parallel/test-repl-.save.load.js
@@ -98,7 +98,7 @@ putIn.write = function(data) {
   // make sure I get a failed to load message and not some crazy error
   assert.strictEqual(data, 'Failed to load:' + loadFile + '\n');
   // eat me to avoid work
-  putIn.write = function() {};
+  putIn.write = common.noop;
 };
 putIn.run(['.load ' + loadFile]);
 
@@ -107,7 +107,7 @@ loadFile = common.tmpDir;
 putIn.write = function(data) {
   assert.strictEqual(data, 'Failed to load:' + loadFile +
                      ' is not a valid file\n');
-  putIn.write = function() {};
+  putIn.write = common.noop;
 };
 putIn.run(['.load ' + loadFile]);
 
@@ -123,7 +123,7 @@ putIn.write = function(data) {
   // make sure I get a failed to save message and not some other error
   assert.strictEqual(data, 'Failed to save:' + invalidFileName + '\n');
   // reset to no-op
-  putIn.write = function() {};
+  putIn.write = common.noop;
 };
 
 // save it to a file

--- a/test/parallel/test-repl-function-definition-edge-case.js
+++ b/test/parallel/test-repl-function-definition-edge-case.js
@@ -19,7 +19,7 @@ assert.strictEqual(got, expected);
 
 function initRepl() {
   const input = new stream();
-  input.write = input.pause = input.resume = () => {};
+  input.write = input.pause = input.resume = common.noop;
   input.readable = true;
 
   const output = new stream();

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -19,7 +19,7 @@ const Duplex = require('stream').Duplex;
 // and mode 600.
 
 const stream = new Duplex();
-stream.pause = stream.resume = function() {};
+stream.pause = stream.resume = common.noop;
 // ends immediately
 stream._read = function() {
   this.push(null);

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -64,7 +64,7 @@ function testAutoMode() {
 
 function initRepl(mode) {
   const input = new Stream();
-  input.write = input.pause = input.resume = function() {};
+  input.write = input.pause = input.resume = common.noop;
   input.readable = true;
 
   const output = new Stream();

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 
-common.ArrayStream.prototype.write = function(msg) {};
+common.ArrayStream.prototype.write = common.noop;
 
 const putIn = new common.ArrayStream();
 const testMe = repl.start('', putIn);

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -30,7 +30,7 @@ if (common.isWindows) {
 
 console.log('process.pid: ' + process.pid);
 
-process.on('SIGUSR1', common.mustCall(function() {}));
+process.on('SIGUSR1', common.mustCall());
 
 process.on('SIGUSR1', common.mustCall(function() {
   setTimeout(function() {
@@ -52,5 +52,5 @@ setInterval(function() {
 // has been previously registered, and `process.listeners(SIGNAL).length === 1`
 process.on('SIGHUP', common.mustNotCall());
 process.removeAllListeners('SIGHUP');
-process.on('SIGHUP', common.mustCall(function() {}));
+process.on('SIGHUP', common.mustCall());
 process.kill(process.pid, 'SIGHUP');

--- a/test/parallel/test-stdout-close-unref.js
+++ b/test/parallel/test-stdout-close-unref.js
@@ -27,7 +27,7 @@ if (process.argv[2] === 'child') {
   process.stdin.resume();
   process.stdin._handle.close();
   process.stdin._handle.unref();  // Should not segfault.
-  process.stdin.on('error', common.mustCall(function(err) {}));
+  process.stdin.on('error', common.mustCall());
   return;
 }
 

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -45,7 +45,7 @@ const checkTLS = common.mustCall(function checkTLS() {
     key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
     cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
   };
-  const server = tls.createServer(options, () => {})
+  const server = tls.createServer(options, common.noop)
     .listen(0, function() {
       const connectOpts = { rejectUnauthorized: false };
       tls.connect(this.address().port, connectOpts, function() {
@@ -56,7 +56,7 @@ const checkTLS = common.mustCall(function checkTLS() {
 });
 
 const checkTCP = common.mustCall(function checkTCP() {
-  net.createServer(() => {}).listen(0, function() {
+  net.createServer(common.noop).listen(0, function() {
     this.close(checkTLS);
   });
 });

--- a/test/parallel/test-stream-big-push.js
+++ b/test/parallel/test-stream-big-push.js
@@ -49,7 +49,7 @@ function _read() {
 
 r._read = common.mustCall(_read, 3);
 
-r.on('end', common.mustCall(function() {}));
+r.on('end', common.mustCall());
 
 // push some data in to start.
 // we've never gotten any read event at this point.

--- a/test/parallel/test-stream-decoder-objectmode.js
+++ b/test/parallel/test-stream-decoder-objectmode.js
@@ -1,10 +1,11 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: () => {},
+  read: common.noop,
   encoding: 'utf16le',
   objectMode: true
 });

--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -18,9 +18,9 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const Duplex = require('stream').Transform;
 
@@ -38,7 +38,7 @@ stream._write = (obj, _, cb) => {
   cb();
 };
 
-stream._read = () => {};
+stream._read = common.noop;
 
 stream.on('data', (obj) => {
   read = obj;

--- a/test/parallel/test-stream-end-paused.js
+++ b/test/parallel/test-stream-end-paused.js
@@ -40,7 +40,7 @@ stream.on('data', function() {
 stream.pause();
 
 setTimeout(common.mustCall(function() {
-  stream.on('end', common.mustCall(function() {}));
+  stream.on('end', common.mustCall());
   stream.resume();
 }), 1);
 

--- a/test/parallel/test-stream-events-prepend.js
+++ b/test/parallel/test-stream-events-prepend.js
@@ -23,7 +23,7 @@ Readable.prototype._read = function() {
 };
 
 const w = new Writable();
-w.on('pipe', common.mustCall(function() {}));
+w.on('pipe', common.mustCall());
 
 const r = new Readable();
 r.pipe(w);

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -63,11 +63,11 @@ const piper = new TestReadable();
 piper.read();
 
 setTimeout(common.mustCall(function() {
-  ender.on('end', common.mustCall(function() {}));
+  ender.on('end', common.mustCall());
   const c = ender.read();
   assert.strictEqual(c, null);
 
   const w = new TestWritable();
-  w.on('finish', common.mustCall(function() {}));
+  w.on('finish', common.mustCall());
   piper.pipe(w);
 }), 1);

--- a/test/parallel/test-stream-pipe-await-drain.js
+++ b/test/parallel/test-stream-pipe-await-drain.js
@@ -15,7 +15,7 @@ const writer3 = new stream.Writable();
 // See: https://github.com/nodejs/node/issues/5820
 const buffer = Buffer.allocUnsafe(560000);
 
-reader._read = function(n) {};
+reader._read = common.noop;
 
 writer1._write = common.mustCall(function(chunk, encoding, cb) {
   this.emit('chunk-received');

--- a/test/parallel/test-stream-pipe-cleanup-pause.js
+++ b/test/parallel/test-stream-pipe-cleanup-pause.js
@@ -11,7 +11,7 @@ const writer2 = new stream.Writable();
 // See: https://github.com/nodejs/node/issues/2323
 const buffer = Buffer.allocUnsafe(560000);
 
-reader._read = function(n) {};
+reader._read = common.noop;
 
 writer1._write = common.mustCall(function(chunk, encoding, cb) {
   this.emit('chunk-received');

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -100,11 +100,11 @@ const Stream = require('stream').Stream;
     }), 1);
   });
 
-  w.on('error', common.mustCall(function() {}));
-  w._write = function() {};
+  w.on('error', common.mustCall());
+  w._write = common.noop;
 
   r.pipe(w);
   // Removing some OTHER random listener should not do anything
-  w.removeListener('error', function() {});
+  w.removeListener('error', common.noop);
   removed = true;
 }

--- a/test/parallel/test-stream-pipe-multiple-pipes.js
+++ b/test/parallel/test-stream-pipe-multiple-pipes.js
@@ -4,7 +4,7 @@ const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: () => {}
+  read: common.noop
 });
 
 const writables = [];
@@ -18,7 +18,7 @@ for (let i = 0; i < 5; i++) {
   });
   target.output = [];
 
-  target.on('pipe', common.mustCall(() => {}));
+  target.on('pipe', common.mustCall());
   readable.pipe(target);
 
 
@@ -35,7 +35,7 @@ process.nextTick(common.mustCall(() => {
   for (const target of writables) {
     assert.deepStrictEqual(target.output, [input]);
 
-    target.on('unpipe', common.mustCall(() => {}));
+    target.on('unpipe', common.mustCall());
     readable.unpipe(target);
   }
 

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -4,15 +4,15 @@ const assert = require('assert');
 
 const { Readable, Writable } = require('stream');
 
-const source = Readable({read: () => {}});
-const dest1 = Writable({write: () => {}});
-const dest2 = Writable({write: () => {}});
+const source = Readable({read: common.noop});
+const dest1 = Writable({write: common.noop});
+const dest2 = Writable({write: common.noop});
 
 source.pipe(dest1);
 source.pipe(dest2);
 
-dest1.on('unpipe', common.mustCall(() => {}));
-dest2.on('unpipe', common.mustCall(() => {}));
+dest1.on('unpipe', common.mustCall());
+dest2.on('unpipe', common.mustCall());
 
 assert.strictEqual(source._readableState.pipes[0], dest1);
 assert.strictEqual(source._readableState.pipes[1], dest2);

--- a/test/parallel/test-stream-pipe-without-listenerCount.js
+++ b/test/parallel/test-stream-pipe-without-listenerCount.js
@@ -12,8 +12,6 @@ w.on('pipe', function() {
   r.emit('error', new Error('Readable Error'));
   w.emit('error', new Error('Writable Error'));
 });
-r.on('error', common.mustCall(noop));
-w.on('error', common.mustCall(noop));
+r.on('error', common.mustCall());
+w.on('error', common.mustCall());
 r.pipe(w);
-
-function noop() {}

--- a/test/parallel/test-stream-readable-emittedReadable.js
+++ b/test/parallel/test-stream-readable-emittedReadable.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Readable = require('stream').Readable;
 
 const readable = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 // Initialized to false.
@@ -37,7 +37,7 @@ process.nextTick(common.mustCall(() => {
 }));
 
 const noRead = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 noRead.on('readable', common.mustCall(() => {
@@ -52,7 +52,7 @@ noRead.push('foo');
 noRead.push(null);
 
 const flowing = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 flowing.on('data', common.mustCall(() => {

--- a/test/parallel/test-stream-readable-event.js
+++ b/test/parallel/test-stream-readable-event.js
@@ -40,7 +40,7 @@ const Readable = require('stream').Readable;
   setTimeout(function() {
     // we're testing what we think we are
     assert(!r._readableState.reading);
-    r.on('readable', common.mustCall(function() {}));
+    r.on('readable', common.mustCall());
   }, 1);
 }
 
@@ -52,7 +52,7 @@ const Readable = require('stream').Readable;
     highWaterMark: 3
   });
 
-  r._read = common.mustCall(function(n) {});
+  r._read = common.mustCall();
 
   // This triggers a 'readable' event, which is lost.
   r.push(Buffer.from('bl'));
@@ -60,7 +60,7 @@ const Readable = require('stream').Readable;
   setTimeout(function() {
     // assert we're testing what we think we are
     assert(r._readableState.reading);
-    r.on('readable', common.mustCall(function() {}));
+    r.on('readable', common.mustCall());
   }, 1);
 }
 
@@ -80,6 +80,6 @@ const Readable = require('stream').Readable;
   setTimeout(function() {
     // assert we're testing what we think we are
     assert(!r._readableState.reading);
-    r.on('readable', common.mustCall(function() {}));
+    r.on('readable', common.mustCall());
   }, 1);
 }

--- a/test/parallel/test-stream-readable-invalid-chunk.js
+++ b/test/parallel/test-stream-readable-invalid-chunk.js
@@ -1,10 +1,11 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: () => {}
+  read: common.noop
 });
 
 assert.throws(() => readable.push([]), /Invalid non-string\/buffer chunk/);

--- a/test/parallel/test-stream-readable-needReadable.js
+++ b/test/parallel/test-stream-readable-needReadable.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Readable = require('stream').Readable;
 
 const readable = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 // Initialized to false.
@@ -28,7 +28,7 @@ readable.on('end', common.mustCall(() => {
 }));
 
 const asyncReadable = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 asyncReadable.on('readable', common.mustCall(() => {
@@ -51,7 +51,7 @@ process.nextTick(common.mustCall(() => {
 }));
 
 const flowing = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 // Notice this must be above the on('data') call.
@@ -69,7 +69,7 @@ flowing.on('data', common.mustCall(function(data) {
 }, 3));
 
 const slowProducer = new Readable({
-  read: () => {}
+  read: common.noop
 });
 
 slowProducer.on('readable', common.mustCall(() => {

--- a/test/parallel/test-stream-readableListening-state.js
+++ b/test/parallel/test-stream-readableListening-state.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const stream = require('stream');
 
 const r = new stream.Readable({
-  read: () => {}
+  read: common.noop
 });
 
 // readableListening state should start in `false`.
@@ -19,7 +19,7 @@ r.on('readable', common.mustCall(() => {
 r.push(Buffer.from('Testing readableListening state'));
 
 const r2 = new stream.Readable({
-  read: () => {}
+  read: common.noop
 });
 
 // readableListening state should start in `false`.

--- a/test/parallel/test-stream-wrap.js
+++ b/test/parallel/test-stream-wrap.js
@@ -28,4 +28,4 @@ function testShutdown(callback) {
   req.handle.shutdown(req);
 }
 
-testShutdown(common.mustCall(function() {}));
+testShutdown(common.mustCall());

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
 const assert = require('assert');
@@ -75,7 +76,7 @@ function toArray(callback) {
 
 function fromArray(list) {
   const r = new Readable({ objectMode: true });
-  r._read = noop;
+  r._read = common.noop;
   list.forEach(function(chunk) {
     r.push(chunk);
   });
@@ -83,8 +84,6 @@ function fromArray(list) {
 
   return r;
 }
-
-function noop() {}
 
 test('can read objects from stream', function(t) {
   const r = fromArray([{ one: '1'}, { two: '2' }]);
@@ -165,7 +164,7 @@ test('can read strings as objects', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = noop;
+  r._read = common.noop;
   const list = ['one', 'two', 'three'];
   list.forEach(function(str) {
     r.push(str);
@@ -183,7 +182,7 @@ test('read(0) for object streams', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = noop;
+  r._read = common.noop;
 
   r.push('foobar');
   r.push(null);
@@ -199,7 +198,7 @@ test('falsey values', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = noop;
+  r._read = common.noop;
 
   r.push(false);
   r.push(0);
@@ -250,7 +249,7 @@ test('high watermark push', function(t) {
     highWaterMark: 6,
     objectMode: true
   });
-  r._read = function(n) {};
+  r._read = common.noop;
   for (let i = 0; i < 6; i++) {
     const bool = r.push(i);
     assert.strictEqual(bool, i !== 5);

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -20,8 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
 
+const common = require('../common');
 const util = require('util');
 const stream = require('stream');
 
@@ -50,7 +50,7 @@ Write.prototype._write = function(buffer, encoding, cb) {
 const read = new Read();
 const write = new Write();
 
-write.once('error', function(err) {});
+write.once('error', common.noop);
 write.once('alldone', function(err) {
   console.log('ok');
 });

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -41,6 +41,6 @@ r.on('readable', function onReadable() {
   r.read(N * 2);
 });
 
-r.on('end', common.mustCall(function() {}));
+r.on('end', common.mustCall());
 
 r.read(0);

--- a/test/parallel/test-stream2-readable-legacy-drain.js
+++ b/test/parallel/test-stream2-readable-legacy-drain.js
@@ -33,7 +33,7 @@ r._read = function(n) {
   return r.push(++reads === N ? null : Buffer.allocUnsafe(1));
 };
 
-r.on('end', common.mustCall(function() {}));
+r.on('end', common.mustCall());
 
 const w = new Stream();
 w.writable = true;
@@ -50,7 +50,7 @@ function drain() {
   w.emit('drain');
 }
 
-w.end = common.mustCall(function() {});
+w.end = common.mustCall();
 
 // Just for kicks, let's mess with the drain count.
 // This verifies that even if it gets negative in the

--- a/test/parallel/test-stream2-readable-non-empty-end.js
+++ b/test/parallel/test-stream2-readable-non-empty-end.js
@@ -61,7 +61,7 @@ test.read(0);
 function next() {
   // now let's make 'end' happen
   test.removeListener('end', thrower);
-  test.on('end', common.mustCall(function() {}));
+  test.on('end', common.mustCall());
 
   // one to get the last byte
   let r = test.read();

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -26,13 +26,13 @@ const Readable = require('_stream_readable');
 const EE = require('events').EventEmitter;
 
 const oldStream = new EE();
-oldStream.pause = function() {};
-oldStream.resume = function() {};
+oldStream.pause = common.noop;
+oldStream.resume = common.noop;
 
 const newStream = new Readable().wrap(oldStream);
 
 newStream
-  .on('readable', function() {})
-  .on('end', common.mustCall(function() {}));
+  .on('readable', common.noop)
+  .on('end', common.mustCall());
 
 oldStream.emit('end');

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -33,7 +33,7 @@ function runTest(highWaterMark, objectMode, produce) {
                            objectMode: objectMode });
   assert.strictEqual(r, r.wrap(old));
 
-  r.on('end', common.mustCall(function() {}));
+  r.on('end', common.mustCall());
 
   old.pause = function() {
     old.emit('pause');

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const W = require('_stream_writable');
 const D = require('_stream_duplex');
 const assert = require('assert');
@@ -304,7 +305,7 @@ test('encoding should be ignored for buffers', function(t) {
 
 test('writables are not pipable', function(t) {
   const w = new W();
-  w._write = function() {};
+  w._write = common.noop;
   let gotError = false;
   w.on('error', function() {
     gotError = true;
@@ -316,8 +317,8 @@ test('writables are not pipable', function(t) {
 
 test('duplexes are pipable', function(t) {
   const d = new D();
-  d._read = function() {};
-  d._write = function() {};
+  d._read = common.noop;
+  d._write = common.noop;
   let gotError = false;
   d.on('error', function() {
     gotError = true;
@@ -329,7 +330,7 @@ test('duplexes are pipable', function(t) {
 
 test('end(chunk) two times is an error', function(t) {
   const w = new W();
-  w._write = function() {};
+  w._write = common.noop;
   let gotError = false;
   w.on('error', function(er) {
     gotError = true;

--- a/test/parallel/test-timer-close.js
+++ b/test/parallel/test-timer-close.js
@@ -7,5 +7,5 @@ const common = require('../common');
 const Timer = process.binding('timer_wrap').Timer;
 const t = new Timer();
 
-t.close(common.mustCall(function() {}));
+t.close(common.mustCall());
 t.close(common.mustNotCall());

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -30,7 +30,7 @@ setTimeout(common.mustCall(function() {
 }), 1);
 
 // ...but the second one should still run
-setTimeout(common.mustCall(function() {}), 1);
+setTimeout(common.mustCall(), 1);
 
 function uncaughtException(err) {
   assert.strictEqual(err.message, errorMsg);

--- a/test/parallel/test-timers-unenroll-unref-interval.js
+++ b/test/parallel/test-timers-unenroll-unref-interval.js
@@ -45,5 +45,5 @@ const timers = require('timers');
 // another. Any problems will occur when the second
 // should be called but before it is able to be.
 setTimeout(common.mustCall(() => {
-  setTimeout(common.mustCall(() => {}), 1);
+  setTimeout(common.mustCall(), 1);
 }), 1);

--- a/test/parallel/test-timers-unref-call.js
+++ b/test/parallel/test-timers-unref-call.js
@@ -1,11 +1,12 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 
 const Timer = process.binding('timer_wrap').Timer;
 Timer.now = function() { return ++Timer.now.ticks; };
 Timer.now.ticks = 0;
 
-const t = setInterval(function() {}, 1);
+const t = setInterval(common.noop, 1);
 const o = { _idleStart: 0, _idleTimeout: 1 };
 t.unref.call(o);
 

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -29,4 +29,4 @@ timers.enroll(foo, 50);
 timers._unrefActive(foo);
 
 // Keep the process open.
-setTimeout(function() {}, 100);
+setTimeout(common.noop, 100);

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 
 let interval_fired = false;
@@ -34,11 +35,11 @@ const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
 assert.doesNotThrow(function() {
-  setTimeout(function() {}, 10).unref().ref().unref();
+  setTimeout(common.noop, 10).unref().ref().unref();
 }, 'ref and unref are chainable');
 
 assert.doesNotThrow(function() {
-  setInterval(function() {}, 10).unref().ref().unref();
+  setInterval(common.noop, 10).unref().ref().unref();
 }, 'ref and unref are chainable');
 
 setInterval(function() {
@@ -77,7 +78,7 @@ setInterval(function() {
 
 // Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
 {
-  const t = setInterval(function() {}, 1);
+  const t = setInterval(common.noop, 1);
   process.nextTick(t.unref.bind({}));
   process.nextTick(t.unref.bind(t));
 }

--- a/test/parallel/test-timers-unrefed-in-beforeexit.js
+++ b/test/parallel/test-timers-unrefed-in-beforeexit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 let once = 0;
@@ -9,7 +9,7 @@ process.on('beforeExit', () => {
   if (once > 1)
     throw new RangeError('beforeExit should only have been called once!');
 
-  setTimeout(() => {}, 1).unref();
+  setTimeout(common.noop, 1).unref();
   once++;
 });
 

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -26,7 +26,7 @@ const assert = require('assert');
 // https://github.com/joyent/node/issues/2079 - zero timeout drops extra args
 {
   setTimeout(common.mustCall(f), 0, 'foo', 'bar', 'baz');
-  setTimeout(function() {}, 0);
+  setTimeout(common.noop, 0);
 
   function f(a, b, c) {
     assert.strictEqual(a, 'foo');

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -77,5 +77,5 @@ setTimeout(common.mustCall(function() {
 }), 2);
 
 // Test 10 ms timeout separately.
-setTimeout(common.mustCall(function() {}), 10);
+setTimeout(common.mustCall(), 10);
 setInterval(common.mustCall(function() { clearInterval(this); }), 10);

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -63,5 +63,5 @@ function test(cert, key, cb) {
 }
 
 test(cert, key, common.mustCall(function() {
-  test(Buffer.from(cert), Buffer.from(key), common.mustCall(function() {}));
+  test(Buffer.from(cert), Buffer.from(key), common.mustCall());
 }));

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -18,7 +18,7 @@ const server = tls.createServer({
 }).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, common.mustNotCall());
 
-  c.on('error', common.mustCall(function(err) {}));
+  c.on('error', common.mustCall());
 
   c.on('close', common.mustCall(function(err) {
     assert.ok(err);

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -39,8 +39,8 @@ const options = {
 
 const server = tls.Server(options, common.mustCall(function(socket) {
   if (++serverConnected === 2) {
-    server.close(common.mustCall(function() {}));
-    server.on('close', common.mustCall(function() {}));
+    server.close(common.mustCall());
+    server.on('close', common.mustCall());
   }
 }, 2));
 

--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -40,7 +40,7 @@ const path = require('path');
   const options = {cert: cert, key: key, port: common.PORT};
   const conn = tls.connect(options, common.mustNotCall());
 
-  conn.on('error', common.mustCall(function() {}));
+  conn.on('error', common.mustCall());
 }
 
 // SSL_accept/SSL_connect error handling
@@ -55,5 +55,5 @@ const path = require('path');
     ciphers: 'rick-128-roll'
   }, common.mustNotCall());
 
-  conn.on('error', common.mustCall(function() {}));
+  conn.on('error', common.mustCall());
 }

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -23,7 +23,7 @@ const server = net.createServer(common.mustCall(function(c) {
       secureContext: tls.createSecureContext(options)
     });
 
-    s.on('_tlsError', common.mustCall(function() {}));
+    s.on('_tlsError', common.mustCall());
 
     s.on('close', function() {
       server.close();

--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 if (process.env.CHILD) {
   const copts = {
     port: process.env.PORT,
-    checkServerIdentity: function() {},
+    checkServerIdentity: common.noop,
   };
   const client = tls.connect(copts, function() {
     client.end('hi');

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -39,8 +39,7 @@ const options = {
   honorCipherOrder: true
 };
 
-const server = tls.createServer(options,
-                                common.mustCall(function(cleartextStream) {}));
+const server = tls.createServer(options, common.mustCall());
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
   const client = tls.connect({

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -42,7 +42,7 @@ const server = tls.createServer({
     c._write('world!', null, function() {
       c.destroy();
     });
-    c._write(' gosh', null, function() {});
+    c._write(' gosh', null, common.noop);
   });
 
   server.close();

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -60,14 +60,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'passphrase',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: rawKey,
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -75,7 +75,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   // Buffer[]
   tls.connect({
@@ -84,14 +84,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'passphrase',
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [rawKey],
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -99,7 +99,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: [cert],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   // string
   tls.connect({
@@ -108,14 +108,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'passphrase',
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: rawKey.toString(),
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -123,7 +123,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert.toString(),
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   // String[]
   tls.connect({
@@ -132,14 +132,14 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'passphrase',
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [rawKey.toString()],
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -147,7 +147,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: [cert.toString()],
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   // Object[]
   tls.connect({
@@ -155,7 +155,7 @@ server.listen(0, common.mustCall(function() {
     key: [{pem: passKey, passphrase: 'passphrase'}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -163,7 +163,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -171,28 +171,28 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'passphrase',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [{pem: passKey.toString(), passphrase: 'passphrase'}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [{pem: rawKey, passphrase: 'ignored'}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [{pem: rawKey.toString(), passphrase: 'ignored'}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -200,7 +200,7 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
@@ -208,21 +208,21 @@ server.listen(0, common.mustCall(function() {
     passphrase: 'ignored',
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [{pem: rawKey}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 
   tls.connect({
     port: this.address().port,
     key: [{pem: rawKey.toString()}],
     cert: cert,
     rejectUnauthorized: false
-  }, common.mustCall(function() {}));
+  }, common.mustCall());
 })).unref();
 
 // Missing passphrase

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -36,4 +36,4 @@ function test(ca, next) {
 
 const array = [ca1, ca2];
 const string = ca1 + '\n' + ca2;
-test(array, () => test(string, () => {}));
+test(array, () => test(string, common.noop));

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -781,9 +781,9 @@ if (typeof Symbol !== 'undefined') {
   const rejected = Promise.reject(3);
   assert.strictEqual(util.inspect(rejected), 'Promise { <rejected> 3 }');
   // squelch UnhandledPromiseRejection
-  rejected.catch(() => {});
+  rejected.catch(common.noop);
 
-  const pending = new Promise(() => {});
+  const pending = new Promise(common.noop);
   assert.strictEqual(util.inspect(pending), 'Promise { <pending> }');
 
   const promiseWithProperty = Promise.resolve('foo');
@@ -880,7 +880,7 @@ if (typeof Symbol !== 'undefined') {
                      'SetSubclass { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
                      'MapSubclass { \'foo\' => 42 }');
-  assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
+  assert.strictEqual(util.inspect(new PromiseSubclass(common.noop)),
                      'PromiseSubclass { <pending> }');
 }
 

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -44,7 +44,7 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(onceHandlerCalled, 0);
 
   // Keep the process alive for a while so that the second SIGINT can be caught.
-  const timeout = setTimeout(() => {}, 1000);
+  const timeout = setTimeout(common.noop, 1000);
 
   let afterHandlerCalled = 0;
 

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -23,7 +23,7 @@ const failureTests = tests.filter((test) => test.failure).concat([
   { input: null },
   { input: new Date() },
   { input: new RegExp() },
-  { input: () => {} }
+  { input: common.noop }
 ]);
 
 for (const test of failureTests) {

--- a/test/parallel/test-zlib-close-after-write.js
+++ b/test/parallel/test-zlib-close-after-write.js
@@ -26,5 +26,5 @@ const zlib = require('zlib');
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.write(out);
-  unzip.close(common.mustCall(function() {}));
+  unzip.close(common.mustCall());
 }));

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -26,6 +26,6 @@ const zlib = require('zlib');
 
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
-  unzip.close(common.mustCall(function() {}));
+  unzip.close(common.mustCall());
   assert.throws(() => unzip.write(out), /^Error: zlib binding closed$/);
 }));

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -34,6 +34,6 @@ gz.on('data', function(c) {
 gz.on('end', common.mustCall(function() {
   assert.strictEqual(received, 20);
 }));
-gz.on('finish', common.mustCall(function() {}));
+gz.on('finish', common.mustCall());
 gz.write(emptyBuffer);
 gz.end();

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 
 const { TTY, isTTY } = process.binding('tty_wrap');
 const strictEqual = require('assert').strictEqual;
@@ -8,7 +9,7 @@ strictEqual(isTTY(0), true, 'fd 0 is not a TTY');
 
 const handle = new TTY(0);
 handle.readStart();
-handle.onread = () => {};
+handle.onread = common.noop;
 
 function isHandleActive(handle) {
   return process._getActiveHandles().some((active) => active === handle);

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -31,8 +31,8 @@ const server = net.createServer(function(socket) {
 server.on('listening', common.mustCall(function() {
   const client = http.createClient(common.PORT);
 
-  client.on('error', common.mustCall(function(err) {}));
-  client.on('end', common.mustCall(function() {}));
+  client.on('error', common.mustCall());
+  client.on('end', common.mustCall());
 
   const request = client.request('GET', '/', {'host': 'localhost'});
   request.end();

--- a/test/pummel/test-stream2-basic.js
+++ b/test/pummel/test-stream2-basic.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+
+const common = require('../common');
 const R = require('_stream_readable');
 const assert = require('assert');
 
@@ -321,10 +322,8 @@ test('multipipe', function(t) {
 });
 
 test('back pressure respected', function(t) {
-  function noop() {}
-
   const r = new R({ objectMode: true });
-  r._read = noop;
+  r._read = common.noop;
   let counter = 0;
   r.push(['one']);
   r.push(['two']);
@@ -342,7 +341,7 @@ test('back pressure respected', function(t) {
       r.pipe(w3);
     });
   };
-  w1.end = noop;
+  w1.end = common.noop;
 
   r.pipe(w1);
 
@@ -368,7 +367,7 @@ test('back pressure respected', function(t) {
 
     return false;
   };
-  w2.end = noop;
+  w2.end = common.noop;
 
   const w3 = new R();
   w3.write = function(chunk) {
@@ -401,7 +400,7 @@ test('read(0) for ended streams', function(t) {
   const r = new R();
   let written = false;
   let ended = false;
-  r._read = function(n) {};
+  r._read = common.noop;
 
   r.push(Buffer.from('foo'));
   r.push(null);
@@ -472,7 +471,7 @@ test('adding readable triggers data flow', function(t) {
 
 test('chainable', function(t) {
   const r = new R();
-  r._read = function() {};
+  r._read = common.noop;
   const r2 = r.setEncoding('utf8').pause().resume().pause();
   t.equal(r, r2);
   t.end();

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -45,7 +45,7 @@ if (process.argv[2] !== 'child') {
   // the only thing keeping this worker alive will be IPC. This is important,
   // because it means a worker with no parent will have no referenced handles,
   // thus no work to do, and will exit immediately, preventing process leaks.
-  process.on('message', function() {});
+  process.on('message', common.noop);
 
   const server = net.createServer((c) => {
     process.once('message', function(msg) {

--- a/test/sequential/test-debug-host-port.js
+++ b/test/sequential/test-debug-host-port.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-let run = () => {};
+let run = common.noop;
 function test(args, needle) {
   const next = run;
   run = () => {

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -129,7 +129,7 @@ fs.watch(__filename, {persistent: false}, function() {
 // https://github.com/joyent/node/issues/6690
 let oldhandle;
 assert.throws(function() {
-  const w = fs.watch(__filename, function(event, filename) { });
+  const w = fs.watch(__filename, common.noop);
   oldhandle = w._handle;
   w._handle = { close: w._handle.close };
   w.close();
@@ -137,7 +137,7 @@ assert.throws(function() {
 oldhandle.close(); // clean up
 
 assert.throws(function() {
-  const w = fs.watchFile(__filename, {persistent: false}, function() {});
+  const w = fs.watchFile(__filename, {persistent: false}, common.noop);
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -78,13 +78,13 @@ function parent() {
 
   wrap(s.stderr, process.stderr, 'SERVER 2>');
   wrap(s.stdout, process.stdout, 'SERVER 1>');
-  s.on('exit', common.mustCall(function(c) {}));
+  s.on('exit', common.mustCall(common.noop));
 
   s.stdout.once('data', common.mustCall(function() {
     c = spawn(node, [__filename, 'client']);
     wrap(c.stderr, process.stderr, 'CLIENT 2>');
     wrap(c.stdout, process.stdout, 'CLIENT 1>');
-    c.on('exit', common.mustCall(function(c) {}));
+    c.on('exit', common.mustCall(common.noop));
   }));
 
   function wrap(inp, out, w) {

--- a/test/sequential/test-pipe.js
+++ b/test/sequential/test-pipe.js
@@ -49,7 +49,7 @@ const web = http.Server(common.mustCall((req, res) => {
   const socket = net.Stream();
   socket.connect(tcpPort);
 
-  socket.on('connect', common.mustCall(() => {}));
+  socket.on('connect', common.mustCall());
 
   req.pipe(socket);
 

--- a/tools/eslint-rules/prefer-common-mustnotcall.js
+++ b/tools/eslint-rules/prefer-common-mustnotcall.js
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Prefer common.mustNotCall(msg) over common.mustCall(fn, 0)
+ * @author James M Snell <jasnell@gmail.com>
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const msg = 'Please use common.mustNotCall(msg) instead of ' +
+            'common.mustCall(fn, 0) or common.mustCall(0).';
+
+function isCommonMustCall(node) {
+  return node &&
+         node.callee &&
+         node.callee.object &&
+         node.callee.object.name === 'common' &&
+         node.callee.property &&
+         node.callee.property.name === 'mustCall';
+}
+
+function isArgZero(argument) {
+  return argument &&
+         typeof argument.value === 'number' &&
+         argument.value === 0;
+}
+
+module.exports = function(context) {
+  return {
+    CallExpression(node) {
+      if (isCommonMustCall(node) &&
+          (isArgZero(node.arguments[0]) ||  //  catch common.mustCall(0)
+           isArgZero(node.arguments[1]))) { //  catch common.mustCall(fn, 0)
+        context.report(node, msg);
+      }
+    }
+  };
+};


### PR DESCRIPTION
Throughout the tests, creation of non-op functions is fairly extensive, and it is not uncommon to find `common.mustCall(() => {})` or `common.mustCall(function() {})`, or `noop = () => {};` type declarations throughout.

This PR introduces a `common.noop` non-op function that is used as an alternative to redeclaring nonops all the time.

The `common.mustCall()` method is also modified such that the `fn` argument defaults to `common.noop` if `undefined`, making it unnecessary to pass in a function when a nonop is needed.

There were also a couple of places where `common.mustCall(fn, 0)` was used to identify a function that should not be called. These are replace with `common.mustNotCall()` and a lint rule is added.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

test, tools

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
