### PR TITLE
build: always use V8_ENABLE_CHECKS in debug mode

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -76,7 +76,7 @@
         'variables': {
           'v8_enable_handle_zapping': 1,
         },
-        'defines': [ 'DEBUG', '_DEBUG' ],
+        'defines': [ 'DEBUG', '_DEBUG', 'V8_ENABLE_CHECKS' ],
         'cflags': [ '-g', '-O0' ],
         'conditions': [
           ['target_arch=="x64"', {


### PR DESCRIPTION
Define `V8_ENABLE_CHECKS` in `common.gypi` for the debug mode.
Without this, these checks would only be present in the object files
generated from the V8 build, and so for inline functions in v8.h
multiple different definitions could be generated, where one definition
includes the check and the other does not.

Refs: https://github.com/nodejs/node/pull/11975#discussion_r108005423

/cc @jasongin @bnoordhuis @danbev 