### PR TITLE
doc: fix fs.read arg type and setImmediate desc

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1415,7 +1415,7 @@ changes:
 -->
 
 * `fd` {integer}
-* `buffer` {string|Buffer|Uint8Array}
+* `buffer` {Buffer|Uint8Array}
 * `offset` {integer}
 * `length` {integer}
 * `position` {integer}

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -75,9 +75,7 @@ added: v0.9.1
 * `...args` {any} Optional arguments to pass when the `callback` is called.
 
 Schedules the "immediate" execution of the `callback` after I/O events'
-callbacks and before timers created using [`setTimeout()`][] and
-[`setInterval()`][] are triggered. Returns an `Immediate` for use with
-[`clearImmediate()`][].
+callbacks. Returns an `Immediate` for use with [`clearImmediate()`][].
 
 When multiple calls to `setImmediate()` are made, the `callback` functions are
 queued for execution in the order in which they are created. The entire callback


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

doc

##### Description of change

About fs.read's 2nd argument, I think string is invalid.
https://github.com/nodejs/node/blob/v6.x-staging/src/node_file.cc#L1247-L1248

```
$cat fs_invalid_read_arg.js
const fs = require('fs');
fs.open('./fs_invalid_read_arg.js', 'r', (err, fd) => {
  const buffer = ''; // About 2nd argument, string is error. Buffer.alloc(1024) is ok.
  fs.read(fd, buffer, 0, 1024, 0, (err, byteRead, buffer) => {
    console.log('ok');
  })
});

$node fs_invalid_read_arg.js
fs.js:129
    throw new Error('Unknown encoding: ' + encoding);
    ^

Error: Unknown encoding: 1048576
    at assertEncoding (fs.js:129:11)
    at Object.fs.read (fs.js:654:5)
    at fs.open (/Users/daiki/workspace/fs_invalid_read_arg.js:5:6)
    at FSReqWrap.oncomplete (fs.js:123:15)
```


And also, about setImmediate, the timing of the execution is after timers in Event Loop of over v0.9, though it is correct in Event Loop under v0.8.
So, I deleted the description because the timing depended on Nodejs version.