### PR TITLE
v6.x: backport V8 fixes for parser bugs

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 96
+#define V8_PATCH_LEVEL 97
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 97
+#define V8_PATCH_LEVEL 98
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 95
+#define V8_PATCH_LEVEL 96
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/ast/ast-value-factory.h
+++ b/deps/v8/src/ast/ast-value-factory.h
@@ -257,6 +257,7 @@ class AstValue : public ZoneObject {
   F(eval, "eval")                               \
   F(function, "function")                       \
   F(get_space, "get ")                          \
+  F(length, "length")                           \
   F(let, "let")                                 \
   F(native, "native")                           \
   F(new_target, ".new.target")                  \

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -1400,11 +1400,14 @@ typename ParserBase<Traits>::ExpressionT ParserBase<Traits>::ParseExpression(
   //   AssignmentExpression
   //   Expression ',' AssignmentExpression
 
-  ExpressionClassifier binding_classifier(this);
-  ExpressionT result =
-      this->ParseAssignmentExpression(accept_IN, &binding_classifier, CHECK_OK);
-  classifier->Accumulate(&binding_classifier,
-                         ExpressionClassifier::AllProductions);
+  ExpressionT result = this->EmptyExpression();
+  {
+    ExpressionClassifier binding_classifier(this);
+    result = this->ParseAssignmentExpression(accept_IN, &binding_classifier,
+                                             CHECK_OK);
+    classifier->Accumulate(&binding_classifier,
+                           ExpressionClassifier::AllProductions);
+  }
   bool is_simple_parameter_list = this->IsIdentifier(result);
   bool seen_rest = false;
   while (peek() == Token::COMMA) {

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -1307,8 +1307,11 @@ ParserBase<Traits>::ParsePrimaryExpression(ExpressionClassifier* classifier,
                                           MessageTemplate::kUnexpectedToken,
                                           Token::String(Token::ELLIPSIS));
         classifier->RecordNonSimpleParameter();
-        ExpressionT expr =
-            this->ParseAssignmentExpression(true, classifier, CHECK_OK);
+        ExpressionClassifier binding_classifier(this);
+        ExpressionT expr = this->ParseAssignmentExpression(
+            true, &binding_classifier, CHECK_OK);
+        classifier->Accumulate(&binding_classifier,
+                               ExpressionClassifier::AllProductions);
         if (!this->IsIdentifier(expr) && !IsValidPattern(expr)) {
           classifier->RecordArrowFormalParametersError(
               Scanner::Location(ellipsis_pos, scanner()->location().end_pos),

--- a/deps/v8/src/runtime/runtime-object.cc
+++ b/deps/v8/src/runtime/runtime-object.cc
@@ -543,6 +543,7 @@ RUNTIME_FUNCTION(Runtime_AppendElement) {
 
   CONVERT_ARG_HANDLE_CHECKED(JSArray, array, 0);
   CONVERT_ARG_HANDLE_CHECKED(Object, value, 1);
+  CHECK(!value->IsTheHole());
 
   uint32_t index;
   CHECK(array->length()->ToArrayIndex(&index));

--- a/deps/v8/test/mjsunit/harmony/regress/regress-crbug-621111.js
+++ b/deps/v8/test/mjsunit/harmony/regress/regress-crbug-621111.js
@@ -1,0 +1,6 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+(y = 1[1, [...[]]]) => 1;   // will core dump, if not fixed
+(y = 1[1, [...[]]]) => {};  // will core dump, if not fixed

--- a/deps/v8/test/mjsunit/harmony/regress/regress-crbug-621496.js
+++ b/deps/v8/test/mjsunit/harmony/regress/regress-crbug-621496.js
@@ -1,0 +1,7 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+(function testIllegalSpreadAsSingleArrowParameter() {
+  assertThrows("(...[42]) => 42)", SyntaxError)  // will core dump, if not fixed
+})();

--- a/deps/v8/test/mjsunit/regress/regress-crbug-644215.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-644215.js
@@ -1,0 +1,13 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+var arr = [...[],,];
+assertTrue(%HasFastHoleyElements(arr));
+assertEquals(1, arr.length);
+assertFalse(arr.hasOwnProperty(0));
+assertEquals(undefined, arr[0]);
+// Should not crash.
+assertThrows(() => arr[0][0], TypeError);


### PR DESCRIPTION
This PR includes three fixes related to spread syntax.
One of the bugs was introduced in 6.10.1 and can be easily encountered in projects using istanbul.

Refs: https://github.com/nodejs/node/issues/11977

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

V8

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
