### PR TITLE
test: fix broken tests in test-buffer-includes

### DIFF
--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -155,14 +155,12 @@ assert(mixedByteStringUcs2.includes('bc', 0, 'ucs2'));
 assert(mixedByteStringUcs2.includes('\u03a3', 0, 'ucs2'));
 assert(!mixedByteStringUcs2.includes('\u0396', 0, 'ucs2'));
 
-assert(
-    6, mixedByteStringUcs2.includes(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
-assert(
-    10, mixedByteStringUcs2.includes(Buffer.from('\u03a3', 'ucs2'),
-                                     0, 'ucs2'));
-assert(
-    -1, mixedByteStringUcs2.includes(Buffer.from('\u0396', 'ucs2'),
-                                     0, 'ucs2'));
+assert.ok(
+    mixedByteStringUcs2.includes(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
+assert.ok(
+    mixedByteStringUcs2.includes(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'));
+assert.ok(
+    !mixedByteStringUcs2.includes(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'));
 
 twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 
@@ -266,12 +264,12 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
 
     const patternBufferUcs2 =
         allCharsBufferUcs2.slice(index, index + length);
-    assert(
-        index, allCharsBufferUcs2.includes(patternBufferUcs2, 0, 'ucs2'));
+    assert.ok(
+        allCharsBufferUcs2.includes(patternBufferUcs2, 0, 'ucs2'));
 
     const patternStringUcs2 = patternBufferUcs2.toString('ucs2');
-    assert(
-        index, allCharsBufferUcs2.includes(patternStringUcs2, 0, 'ucs2'));
+    assert.ok(
+        allCharsBufferUcs2.includes(patternStringUcs2, 0, 'ucs2'));
   }
 }
 


### PR DESCRIPTION
Some of the tests for `buffer.includes()` functionality introduced in https://github.com/nodejs/node/pull/3567 have been broken in a way that caused them to always pass regardless of the result of the tested method.

This behavior was caused by two reasons:

 * These tests were written as though `buffer.includes()` was supposed to return the same value that `buffer.indexOf()` does, i.e., used indices or -1 as expected return values instead of true and false.
 * `assert()` was used as the assertion function to do that instead of `assert.strictEqual()`.

Thus `assert()` was called with a non-zero number as the first argument effectively causing these tests to pass.

This commit changes the tests to use `assert.ok()` and `assert.ifError()` and removes redundant indices.

Refs: https://github.com/nodejs/node/pull/3567

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
