### PR TITLE
test: add cctest for native URL class

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -611,6 +611,7 @@
         '<(OBJ_PATH)/node.<(OBJ_SUFFIX)',
         '<(OBJ_PATH)/node_buffer.<(OBJ_SUFFIX)',
         '<(OBJ_PATH)/node_i18n.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_url.<(OBJ_SUFFIX)',
         '<(OBJ_PATH)/debug-agent.<(OBJ_SUFFIX)',
         '<(OBJ_PATH)/util.<(OBJ_SUFFIX)',
         '<(OBJ_PATH)/string_bytes.<(OBJ_SUFFIX)',
@@ -637,6 +638,7 @@
 
       'sources': [
         'test/cctest/test_util.cc',
+        'test/cctest/test_url.cc'
       ],
 
       'sources!': [

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -492,7 +492,7 @@ enum url_error_cb_args {
 #define XX(name) name,
   ERR_ARGS(XX)
 #undef XX
-} url_error_cb_args;
+};
 
 static inline bool IsSpecial(std::string scheme) {
 #define XX(name, _) if (scheme == name) return true;

--- a/test/cctest/test_url.cc
+++ b/test/cctest/test_url.cc
@@ -1,0 +1,69 @@
+#include "node_url.h"
+#include "node_i18n.h"
+
+#include "gtest/gtest.h"
+
+using node::url::URL;
+
+class URLTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+#if defined(NODE_HAVE_I18N_SUPPORT)
+    std::string icu_data_dir;
+    node::i18n::InitializeICUDirectory(icu_data_dir);
+#endif
+  }
+
+  void TearDown() override {}
+};
+
+TEST_F(URLTest, Simple) {
+  URL simple("https://example.org:81/a/b/c?query#fragment");
+
+  EXPECT_EQ(simple.protocol(), "https:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.port(), 81);
+  EXPECT_EQ(simple.path(), "/a/b/c");
+  EXPECT_EQ(simple.query(), "query");
+  EXPECT_EQ(simple.fragment(), "fragment");
+}
+
+TEST_F(URLTest, Simple2) {
+  const char* input = "https://example.org:81/a/b/c?query#fragment";
+  URL simple(input, strlen(input));
+
+  EXPECT_EQ(simple.protocol(), "https:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.port(), 81);
+  EXPECT_EQ(simple.path(), "/a/b/c");
+  EXPECT_EQ(simple.query(), "query");
+  EXPECT_EQ(simple.fragment(), "fragment");
+}
+
+TEST_F(URLTest, Base1) {
+  URL base("http://example.org/foo/bar");
+  URL simple("../baz", &base);
+
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.path(), "/baz");
+}
+
+TEST_F(URLTest, Base2) {
+  URL simple("../baz", "http://example.org/foo/bar");
+
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.path(), "/baz");
+}
+
+TEST_F(URLTest, Base3) {
+  const char* input = "../baz";
+  const char* base = "http://example.org/foo/bar";
+
+  URL simple(input, strlen(input), base, strlen(base));
+
+  EXPECT_EQ(simple.protocol(), "http:");
+  EXPECT_EQ(simple.host(), "example.org");
+  EXPECT_EQ(simple.path(), "/baz");
+}


### PR DESCRIPTION
Adds a cctest for the new native URL class

Depends on: https://github.com/nodejs/node/pull/11801 and https://github.com/nodejs/node/pull/11956

/cc @bmeck @TimothyGu 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

url, test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
