### PR TITLE
util: use `[Array]` for deeply nested arrays

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -586,6 +586,8 @@ function formatValue(ctx, value, recurseTimes) {
   if (recurseTimes < 0) {
     if (isRegExp(value)) {
       return ctx.stylize(RegExp.prototype.toString.call(value), 'regexp');
+    } else if (Array.isArray(value)) {
+      return ctx.stylize('[Array]', 'special');
     } else {
       return ctx.stylize('[Object]', 'special');
     }

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -47,13 +47,13 @@ const expected1 = 'Proxy [ {}, {} ]';
 const expected2 = 'Proxy [ Proxy [ {}, {} ], {} ]';
 const expected3 = 'Proxy [ Proxy [ Proxy [ {}, {} ], {} ], Proxy [ {}, {} ] ]';
 const expected4 = 'Proxy [ Proxy [ {}, {} ], Proxy [ Proxy [ {}, {} ], {} ] ]';
-const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], {} ],' +
+const expected5 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], {} ],' +
                   ' Proxy [ {}, {} ] ],\n  Proxy [ Proxy [ {}, {} ]' +
-                  ', Proxy [ Proxy [Object], {} ] ] ]';
-const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Object], Proxy [Object]' +
-                  ' ],\n    Proxy [ Proxy [Object], Proxy [Object] ] ],\n' +
-                  '  Proxy [ Proxy [ Proxy [Object], Proxy [Object] ],\n' +
-                  '    Proxy [ Proxy [Object], Proxy [Object] ] ] ]';
+                  ', Proxy [ Proxy [Array], {} ] ] ]';
+const expected6 = 'Proxy [ Proxy [ Proxy [ Proxy [Array], Proxy [Array]' +
+                  ' ],\n    Proxy [ Proxy [Array], Proxy [Array] ] ],\n' +
+                  '  Proxy [ Proxy [ Proxy [Array], Proxy [Array] ],\n' +
+                  '    Proxy [ Proxy [Array], Proxy [Array] ] ] ]';
 assert.strictEqual(util.inspect(proxy1, opts), expected1);
 assert.strictEqual(util.inspect(proxy2, opts), expected2);
 assert.strictEqual(util.inspect(proxy3, opts), expected3);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -72,6 +72,8 @@ assert.strictEqual(util.inspect({'a': {'b': { 'c': 2}}}, false, 0),
                    '{ a: [Object] }');
 assert.strictEqual(util.inspect({'a': {'b': { 'c': 2}}}, false, 1),
                    '{ a: { b: [Object] } }');
+assert.strictEqual(util.inspect({'a': {'b': ['c']}}, false, 1),
+                   '{ a: { b: [Array] } }');
 assert.strictEqual(util.inspect(Object.create({},
   {visible: {value: 1, enumerable: true}, hidden: {value: 2}})),
                    '{ visible: 1 }'


### PR DESCRIPTION
Prefer `[Array]` over `[Object]` because the latter is confusing.

~~I may be mistaken but I think this was brought up somewhere a few weeks ago (?) – I couldn’t find anything, but if somebody has a `Fixes:` tag I’ll happily ad it, and if this is a duplicate, I’ll happily close the PR. :)~~

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

util

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
