### PR TITLE
vm: use SetterCallback to set func declarations

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -432,7 +432,17 @@ class ContextifyContext {
     // false for vmResult.x = 5 where vmResult = vm.runInContext();
     bool is_contextual_store = ctx->global_proxy() != args.This();
 
-    if (!is_declared && args.ShouldThrowOnError() && is_contextual_store)
+    // Indicator to not return before setting (undeclared) function declarations
+    // on the sandbox in strict mode, i.e. args.ShouldThrowOnError() = true.
+    // True for 'function f() {}', 'this.f = function() {}',
+    // 'var f = function()'.
+    // In effect only for 'function f() {}' because
+    // var f = function(), is_declared = true
+    // this.f = function() {}, is_contextual_store = false.
+    bool is_function = value->IsFunction();
+
+    if (!is_declared && args.ShouldThrowOnError() && is_contextual_store &&
+    !is_function)
       return;
 
     ctx->sandbox()->Set(property, value);


### PR DESCRIPTION
Currently, when in strict mode, function 
declarations are copied on the sandbox by 
CopyProperties(), which is not necessary 
because  GlobalPropertySetterCallback now 
also intercepts function declarations.

Current version will break when CopyProperties() 
is removed. This change maintains the behavior,
letting GlobalPropertySetterCallback do the task.

This is a preparation step for the removal 
of CopyProperties().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
vm

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

