### PR TITLE
doc: fix process.stdout fd number

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1552,7 +1552,7 @@ must call `process.stdin.resume()` to read from it. Note also that calling
 * {Stream}
 
 The `process.stdout` property returns a [Writable][] stream connected to
-`stdout` (fd `2`).
+`stdout` (fd `1`).
 
 For example, to copy process.stdin to process.stdout:
 


### PR DESCRIPTION
Trivial fix.

It should be 1 for the stdout fd number.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
