### PR TITLE
url: add ToObject method to native URL class

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -54,6 +54,8 @@
 
     _process.setupRawDebug();
 
+    // Ensure setURLConstructor() is called before the native
+    // URL::ToObject() method is used.
     NativeModule.require('internal/url');
 
     Object.defineProperty(process, 'argv0', {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -54,6 +54,8 @@
 
     _process.setupRawDebug();
 
+    NativeModule.require('internal/url');
+
     Object.defineProperty(process, 'argv0', {
       enumerable: true,
       configurable: false,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1400,6 +1400,33 @@ function getPathFromURL(path) {
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
 }
 
+function NativeURL(ctx) {
+  this[context] = ctx;
+}
+util.inherits(NativeURL, URL);
+
+function constructUrl(flags, protocol, username, password,
+                      host, port, path, query, fragment) {
+  var ctx = new URLContext();
+  ctx.flags = flags;
+  ctx.scheme = protocol;
+  ctx.username = username;
+  ctx.password = password;
+  ctx.port = port;
+  ctx.path = path;
+  ctx.query = query;
+  ctx.fragment = fragment;
+  ctx.host = host;
+  const url = new NativeURL(ctx);
+  if (!url[searchParams]) { // invoked from URL constructor
+    url[searchParams] = new URLSearchParams();
+    url[searchParams][context] = this;
+  }
+  initSearchParams(url[searchParams], query);
+  return url;
+}
+binding.setURLConstructor(constructUrl);
+
 module.exports = {
   toUSVString,
   getPathFromURL,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1403,7 +1403,7 @@ function getPathFromURL(path) {
 function NativeURL(ctx) {
   this[context] = ctx;
 }
-util.inherits(NativeURL, URL);
+NativeURL.prototype = URL.prototype;
 
 function constructUrl(flags, protocol, username, password,
                       host, port, path, query, fragment) {
@@ -1418,10 +1418,8 @@ function constructUrl(flags, protocol, username, password,
   ctx.fragment = fragment;
   ctx.host = host;
   const url = new NativeURL(ctx);
-  if (!url[searchParams]) { // invoked from URL constructor
-    url[searchParams] = new URLSearchParams();
-    url[searchParams][context] = this;
-  }
+  url[searchParams] = new URLSearchParams();
+  url[searchParams][context] = url;
   initSearchParams(url[searchParams], query);
   return url;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -269,6 +269,7 @@ namespace node {
   V(tls_wrap_constructor_template, v8::FunctionTemplate)                      \
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \
+  V(url_constructor_function, v8::Function)                                   \
   V(write_wrap_constructor_function, v8::Function)                            \
 
 class Environment;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,10 +4,17 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
+#include "env.h"
+#include "env-inl.h"
+
 #include <string>
 
 namespace node {
 namespace url {
+
+using v8::MaybeLocal;
+using v8::Value;
+
 
 #define BIT_AT(a, i)                                                          \
   (!!((unsigned int) (a)[(unsigned int) (i) >> 3] &                           \
@@ -618,6 +625,8 @@ class URL {
     }
     return ret;
   }
+
+  MaybeLocal<Value> ToObject(Environment* env);
 
  private:
   struct url_data context_;

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -12,7 +12,7 @@
 namespace node {
 namespace url {
 
-using v8::MaybeLocal;
+using v8::Local;
 using v8::Value;
 
 
@@ -626,7 +626,7 @@ class URL {
     return ret;
   }
 
-  MaybeLocal<Value> ToObject(Environment* env);
+  const Local<Value> ToObject(Environment* env) const;
 
  private:
   struct url_data context_;


### PR DESCRIPTION
Provides a factory method to convert a native URL class into a JS URL object.

```c++
Environment* env = ...

URL url("http://example.org/a/b/c?query#fragment");

MaybeLocal<Value> val = url.ToObject(env);
```

(Including a test for this is a bit difficult at the current time.)

/cc @bmeck

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

url

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
