### PR TITLE
src: add --use-bundled-ca --use-openssl-ca check

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3637,6 +3637,8 @@ static void ParseArgs(int* argc,
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
   const char** local_preload_modules = new const char*[nargs];
+  bool use_bundled_ca = false;
+  bool use_openssl_ca = false;
 
   for (unsigned int i = 0; i < nargs; ++i) {
     new_exec_argv[i] = nullptr;
@@ -3751,7 +3753,9 @@ static void ParseArgs(int* argc,
       default_cipher_list = arg + 18;
     } else if (strncmp(arg, "--use-openssl-ca", 16) == 0) {
       ssl_openssl_cert_store = true;
+      use_openssl_ca = true;
     } else if (strncmp(arg, "--use-bundled-ca", 16) == 0) {
+      use_bundled_ca = true;
       ssl_openssl_cert_store = false;
 #if NODE_FIPS_MODE
     } else if (strcmp(arg, "--enable-fips") == 0) {
@@ -3785,6 +3789,16 @@ static void ParseArgs(int* argc,
     new_exec_argc += args_consumed;
     index += args_consumed;
   }
+
+#if HAVE_OPENSSL
+  if (use_openssl_ca && use_bundled_ca) {
+    fprintf(stderr,
+            "%s: either --use-openssl-ca or --use-bundled-ca can be used, "
+            "not both\n",
+            argv[0]);
+    exit(9);
+  }
+#endif
 
   // Copy remaining arguments.
   const unsigned int args_left = nargs - index;

--- a/test/parallel/test-openssl-ca-options.js
+++ b/test/parallel/test-openssl-ca-options.js
@@ -1,0 +1,31 @@
+'use strict';
+// This test checks the usage of --use-bundled-ca and --use-openssl-ca arguments
+// to verify that both are not used at the same time.
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const assert = require('assert');
+const os = require('os');
+const childProcess = require('child_process');
+const result = childProcess.spawnSync(process.execPath, [
+                                      '--use-bundled-ca',
+                                      '--use-openssl-ca',
+                                      '-p', 'process.version'],
+                                      {encoding: 'utf8'});
+
+assert.strictEqual(result.stderr,
+                   process.execPath + ': either --use-openssl-ca or ' +
+                   '--use-bundled-ca can be used, not both' + os.EOL);
+assert.strictEqual(result.status, 9);
+
+const useBundledCA = childProcess.spawnSync(process.execPath, [
+                                            '--use-bundled-ca',
+                                            '-p', 'process.version']);
+assert.strictEqual(useBundledCA.status, 0);
+
+const useOpenSSLCA = childProcess.spawnSync(process.execPath, [
+                                            '--use-openssl-ca',
+                                            '-p', 'process.version']);
+assert.strictEqual(useOpenSSLCA.status, 0);


### PR DESCRIPTION
The --use-bundled-ca and --use-openssl-ca command line arguments are
mutually exclusive but can both be used on the same command line.

This commit adds a check if both options are used.

Fixes: https://github.com/nodejs/node/issues/12083

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
