### PR TITLE
src: allow inspector to be run on ephemeral port

### DIFF
--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -22,7 +22,8 @@ int parse_and_validate_port(const std::string& port) {
   char* endptr;
   errno = 0;
   const long result = strtol(port.c_str(), &endptr, 10);  // NOLINT(runtime/int)
-  if (errno != 0 || *endptr != '\0'|| result < 1024 || result > 65535) {
+  if (errno != 0 || *endptr != '\0' ||
+     (result != 0 && (result < 1024 || result > 65535))) {
     fprintf(stderr, "Debug port must be in range 1024 to 65535.\n");
     exit(12);
   }

--- a/test/parallel/test-inspector-ephemeral-port.js
+++ b/test/parallel/test-inspector-ephemeral-port.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// Check that inspector can run on an ephemeral port.
+
+const assert = require('assert');
+const exec = require('child_process').exec;
+
+const printA = require.resolve('../fixtures/printA.js');
+const cmd = [
+  process.execPath,
+  '--inspect=0',
+  printA,
+].join(' ');
+
+exec(cmd, common.mustCall(function(err, _, stderr) {
+  assert.ifError(err);
+  const port1 = Number(stderr.match(/Debugger listening on port (\d+)/)[1]);
+  const port2 = Number(stderr.match(/chrome-devtools.*:(\d+)/)[1]);
+  assert.strictEqual(port1, port2);
+  assert(port1 > 0);
+}));


### PR DESCRIPTION
Its impossible to know in general whether any specific port will be
available or not, so its quite useful to run the inspector on an
ephemeral port, chosen by the operating system from its free ports.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
