### PR TITLE
doc: fix fs properties for file permissions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -464,7 +464,7 @@ changes:
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} default = `'utf8'`
-  * `mode` {integer} default = `0o666`
+  * `mode` {integer} default = `0666`
   * `flag` {string} default = `'a'`
 * `callback` {Function}
 
@@ -507,7 +507,7 @@ changes:
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} default = `'utf8'`
-  * `mode` {integer} default = `0o666`
+  * `mode` {integer} default = `0666`
   * `flag` {string} default = `'a'`
 
 The synchronous version of [`fs.appendFile()`][]. Returns `undefined`.
@@ -634,7 +634,7 @@ default value of 64 kb for the same parameter.
   flags: 'r',
   encoding: null,
   fd: null,
-  mode: 0o666,
+  mode: 0666,
   autoClose: true
 }
 ```
@@ -700,7 +700,7 @@ Returns a new [`WriteStream`][] object. (See [Writable Stream][]).
   flags: 'w',
   defaultEncoding: 'utf8',
   fd: null,
-  mode: 0o666,
+  mode: 0666,
   autoClose: true
 }
 ```
@@ -1209,7 +1209,7 @@ changes:
 * `callback` {Function}
 
 Asynchronous mkdir(2). No arguments other than a possible exception are given
-to the completion callback. `mode` defaults to `0o777`.
+to the completion callback. `mode` defaults to `0777`.
 
 ## fs.mkdirSync(path[, mode])
 <!-- YAML
@@ -2158,7 +2158,7 @@ changes:
 * `data` {string|Buffer|Uint8Array}
 * `options` {Object|string}
   * `encoding` {string|null} default = `'utf8'`
-  * `mode` {integer} default = `0o666`
+  * `mode` {integer} default = `0666`
   * `flag` {string} default = `'w'`
 * `callback` {Function}
 
@@ -2208,7 +2208,7 @@ changes:
 * `data` {string|Buffer|Uint8Array}
 * `options` {Object|string}
   * `encoding` {string|null} default = `'utf8'`
-  * `mode` {integer} default = `0o666`
+  * `mode` {integer} default = `0666`
   * `flag` {string} default = `'w'`
 
 The synchronous version of [`fs.writeFile()`][]. Returns `undefined`.


### PR DESCRIPTION
File permissions just contain numbers so I changed `0o777` to `0777` and `0o666` to `0666`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
