### PR TITLE
errors: add space between error name and code

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -26,7 +26,7 @@ function makeNodeError(Base) {
     }
 
     get name() {
-      return `${super.name}[${this[kCode]}]`;
+      return `${super.name} [${this[kCode]}]`;
     }
 
     get code() {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -15,27 +15,27 @@ const err4 = new errors.Error('TEST_ERROR_2', 'abc', 'xyz');
 const err5 = new errors.Error('TEST_ERROR_1');
 
 assert(err1 instanceof Error);
-assert.strictEqual(err1.name, 'Error[TEST_ERROR_1]');
+assert.strictEqual(err1.name, 'Error [TEST_ERROR_1]');
 assert.strictEqual(err1.message, 'Error for testing purposes: test');
 assert.strictEqual(err1.code, 'TEST_ERROR_1');
 
 assert(err2 instanceof TypeError);
-assert.strictEqual(err2.name, 'TypeError[TEST_ERROR_1]');
+assert.strictEqual(err2.name, 'TypeError [TEST_ERROR_1]');
 assert.strictEqual(err2.message, 'Error for testing purposes: test');
 assert.strictEqual(err2.code, 'TEST_ERROR_1');
 
 assert(err3 instanceof RangeError);
-assert.strictEqual(err3.name, 'RangeError[TEST_ERROR_1]');
+assert.strictEqual(err3.name, 'RangeError [TEST_ERROR_1]');
 assert.strictEqual(err3.message, 'Error for testing purposes: test');
 assert.strictEqual(err3.code, 'TEST_ERROR_1');
 
 assert(err4 instanceof Error);
-assert.strictEqual(err4.name, 'Error[TEST_ERROR_2]');
+assert.strictEqual(err4.name, 'Error [TEST_ERROR_2]');
 assert.strictEqual(err4.message, 'abc xyz');
 assert.strictEqual(err4.code, 'TEST_ERROR_2');
 
 assert(err5 instanceof Error);
-assert.strictEqual(err5.name, 'Error[TEST_ERROR_1]');
+assert.strictEqual(err5.name, 'Error [TEST_ERROR_1]');
 assert.strictEqual(err5.message, 'Error for testing purposes: %s');
 assert.strictEqual(err5.code, 'TEST_ERROR_1');
 


### PR DESCRIPTION
`Error[CODE]` becomes `Error [CODE]`

Depends on: https://github.com/nodejs/node/pull/11220

/cc @Trott @evanlucas

(I'm not sure how to classify this on the semver scale since we have not actually used it yet)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

errors

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
