### PR TITLE
v7.x backport: tools: ignore URLs in line length linting

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -97,7 +97,7 @@ rules:
   key-spacing: [2, {mode: minimum}]
   keyword-spacing: 2
   linebreak-style: [2, unix]
-  max-len: [2, 80, 2]
+  max-len: [2, {code: 80, ignoreUrls: true, tabWidth: 2}]
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -236,11 +236,9 @@ function Server(requestListener) {
     this.on('request', requestListener);
   }
 
-  /* eslint-disable max-len */
   // Similar option to this. Too lazy to write my own docs.
   // http://www.squid-cache.org/Doc/config/half_closed_clients/
   // http://wiki.squid-cache.org/SquidFaq/InnerWorkings#What_is_a_half-closed_filedescriptor.3F
-  /* eslint-enable max-len */
   this.httpAllowHalfOpen = false;
 
   this.on('connection', connectionListener);

--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -49,7 +49,6 @@ if (process.argv[2] === 'you-are-the-child') {
 delete process.env.NON_EXISTING_VARIABLE;
 assert.strictEqual(true, delete process.env.NON_EXISTING_VARIABLE);
 
-/* eslint-disable max-len */
 /* For the moment we are not going to support setting the timezone via the
  * environment variables. The problem is that various V8 platform backends
  * deal with timezone in different ways. The windows platform backend caches
@@ -66,7 +65,6 @@ date = new Date('Fri, 10 Sep 1982 03:15:00 GMT');
 assert.strictEqual(3, date.getUTCHours());
 assert.strictEqual(5, date.getHours());
 */
-/* eslint-enable max-len */
 
 // Environment variables should be case-insensitive on Windows, and
 // case-sensitive on other platforms.


### PR DESCRIPTION
This is a backport of #11890.

Where inclusion of a lengthy URL causes a line to exceed 80 characters
in our code base, do not report the line length as a linting error.

PR-URL: https://github.com/nodejs/node/pull/11890
Reviewed-By: Michaël Zasso <targos@protonmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
