### PR TITLE
test: fix flaky child-process-exec-kill-throws

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,9 +7,6 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
-# See https://github.com/nodejs/node/issues/12053, this test may be exposing a
-# genuine bug with kill() on Windows.
-test-child-process-exec-kill-throws : PASS,FLAKY
 
 [$system==linux]
 

--- a/test/parallel/test-child-process-exec-kill-throws.js
+++ b/test/parallel/test-child-process-exec-kill-throws.js
@@ -3,12 +3,13 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const internalCp = require('internal/child_process');
 
 if (process.argv[2] === 'child') {
-  // Keep the process alive and printing to stdout.
-  setInterval(() => { console.log('foo'); }, 1);
+  // Since maxBuffer is 0, this should trigger an error.
+  console.log('foo');
 } else {
+  const internalCp = require('internal/child_process');
+
   // Monkey patch ChildProcess#kill() to kill the process and then throw.
   const kill = internalCp.ChildProcess.prototype.kill;
 
@@ -21,7 +22,7 @@ if (process.argv[2] === 'child') {
   const options = { maxBuffer: 0 };
   const child = cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
     // Verify that if ChildProcess#kill() throws, the error is reported.
-    assert(/^Error: mock error$/.test(err));
+    assert.strictEqual(err.message, 'mock error', err);
     assert.strictEqual(stdout, '');
     assert.strictEqual(stderr, '');
     assert.strictEqual(child.killed, true);


### PR DESCRIPTION
This is a fix for test-child-process-exec-kill-throws which is currently
flaky on Windows.

A bug in the test was causing the child process to fail for reasons
other than those intended by the test. Instead of failing for exceeding
the `maxBuffer` setting, the test was failing because it was trying to
load `internal/child_process` without being passed the
`expose-internals` flag. Move that module to where only the parent
process (which gets the flag) loads it.

Additionally, improve an assertion message to help debug problems like
this.

Fixes: https://github.com/nodejs/node/issues/12053

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process


[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
