### PR TITLE
Revert "Revert "repl: disable Ctrl+C support..."

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -322,7 +322,13 @@ function REPLServer(prompt,
     if (!err) {
       // Unset raw mode during evaluation so that Ctrl+C raises a signal.
       let previouslyInRawMode;
-      if (self.breakEvalOnSigint) {
+
+      // Temporarily disabled on Windows due to output problems that likely
+      // result from the raw mode switches here, see
+      // https://github.com/nodejs/node/issues/7837
+      // Setting NODE_REPL_CTRLC is meant as a temporary opt-in for debugging.
+      if (self.breakEvalOnSigint &&
+          (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn’t lead to aborting the process completely.
         utilBinding.startSigintWatchdog();
@@ -342,7 +348,8 @@ function REPLServer(prompt,
             result = script.runInContext(context, scriptOptions);
           }
         } finally {
-          if (self.breakEvalOnSigint) {
+          if (self.breakEvalOnSigint &&
+              (process.platform !== 'win32' || process.env.NODE_REPL_CTRLC)) {
             // Reset terminal mode to its previous value.
             self._setRawMode(previouslyInRawMode);
 


### PR DESCRIPTION
Full original message:

  Revert "repl: disable Ctrl+C support on win32 for now"

This reverts commit 1d400ea4843232c9c698b5d9b04e7a3df4635751.

Refs: https://github.com/nodejs/node/pull/8645
