### PR TITLE
doc: adding note regarding http.get options

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1530,6 +1530,7 @@ added: v0.3.6
 
 * `options` {Object | string} Accepts the same `options` as
   [`http.request()`][], with the `method` always set to `GET`.
+  Properties that are inherited from the prototype are ignored.
 * `callback` {Function}
 * Returns: {http.ClientRequest}
 


### PR DESCRIPTION
This addresses #12092. Adds a note to `doc/api/http.md` that clarifies that `options` 
doesn't include the prototype. 

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc