### PR TITLE
test: add case for url.parse throwing a URIError

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -259,6 +259,10 @@ added: v0.1.25
 The `url.parse()` method takes a URL string, parses it, and returns a URL
 object.
 
+A `TypeError` is thrown if `urlString` is not a string.
+
+A `URIError` is thrown if the `auth` property is present but cannot be decoded.
+
 ## url.resolve(from, to)
 <!-- YAML
 added: v0.1.25

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -16,3 +16,5 @@ const url = require('url');
 ].forEach(function(val) {
   assert.throws(function() { url.parse(val); }, TypeError);
 });
+
+assert.throws(function() { url.parse('http://%E0%A4%A@fail'); }, /^URIError: URI malformed$/);


### PR DESCRIPTION
Hello, the `url.parse` function uses `decodeURIComponent`, which can throw a `URIError`, to parse the `auth` property of a URL. The example included here will test this path.

This PR also adds documentation on the possible errors that `url.parse` can throw. I'm happy to move this to a separate PR should this make things easier/cleaner.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
