### PR TITLE
test: performance - remove Popen(shell=True) on windows

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -617,7 +617,6 @@ def RunProcess(context, timeout, args, **rest):
   pty_out = rest.pop('pty_out')
 
   process = subprocess.Popen(
-    shell = utils.IsWindows(),
     args = popen_args,
     **rest
   )


### PR DESCRIPTION
not needed according to official python docs - https://docs.python.org/2/library/subprocess.html#index-2

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test,tools,windows