### PR TITLE
test: add RegExp second argument to assert.throws

### DIFF
--- a/test/addons/make-callback-recurse/test.js
+++ b/test/addons/make-callback-recurse/test.js
@@ -15,7 +15,7 @@ assert.throws(function() {
   makeCallback({}, function() {
     throw new Error('hi from domain error');
   });
-});
+}, /^Error: hi from domain error$/);
 
 
 // Check the execution order of the nextTickQueue and MicrotaskQueue in


### PR DESCRIPTION
Add a regular expression argument to assert.throws(Function, RegExp)
in test/addons/make-callback-recurse/test.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines