### PR TITLE
test: extended test to makeCallback cb type check

### DIFF
--- a/test/parallel/test-fs-makeStatsCallback.js
+++ b/test/parallel/test-fs-makeStatsCallback.js
@@ -4,27 +4,26 @@ const assert = require('assert');
 const fs = require('fs');
 const cbTypeError = /^TypeError: "callback" argument must be a function$/;
 const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
-
-const { sep } = require('path');
 const warn = 'Calling an asynchronous function without callback is deprecated.';
 
-common.refreshTmpDir();
-
-function testMakeCallback(cb) {
+function testMakeStatsCallback(cb) {
   return function() {
-    // fs.mkdtemp() calls makeCallback() on its third argument
-    fs.mkdtemp(`${common.tmpDir}${sep}`, {}, cb);
+    // fs.stat() calls makeStatsCallback() on its second argument
+    fs.stat(__filename, cb);
   };
 }
 
 common.expectWarning('DeprecationWarning', warn);
 
+// Verify the case where a callback function is provided
+assert.doesNotThrow(testMakeStatsCallback(common.noop));
+
 // Passing undefined/nothing calls rethrow() internally, which emits a warning
-assert.doesNotThrow(testMakeCallback());
+assert.doesNotThrow(testMakeStatsCallback());
 
 function invalidCallbackThrowsTests() {
   callbackThrowValues.forEach((value) => {
-    assert.throws(testMakeCallback(value), cbTypeError);
+    assert.throws(testMakeStatsCallback(value), cbTypeError);
   });
 }
 


### PR DESCRIPTION
makeCallback and makeStatsCallback are both tested intedependently.

Fixes: https://github.com/nodejs/node/issues/12136

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test, fs
