### PR TITLE
buffer: zero fill Buffer(num) by default

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -54,8 +54,8 @@ differently based on what arguments are provided:
 * Passing a number as the first argument to `Buffer()` (e.g. `new Buffer(10)`),
   allocates a new `Buffer` object of the specified size. Prior to Node.js 8.0.0,
   the memory allocated for such `Buffer` instances is *not* initialized and
-  *can contain sensitive data*. Such `Buffer` instances *must* be initialized
-  *manually* by using either [`buf.fill(0)`][`buf.fill()`] or by writing to the
+  *can contain sensitive data*. Such `Buffer` instances *must* be subsequently
+  initialized by using either [`buf.fill(0)`][`buf.fill()`] or by writing to the
   `Buffer` completely. While this behavior is *intentional* to improve
   performance, development experience has demonstrated that a more explicit
   distinction is required between creating a fast-but-uninitialized `Buffer`
@@ -452,7 +452,7 @@ A zero-length `Buffer` will be created if `size` is 0.
 
 Prior to Node.js 8.0.0, the underlying memory for `Buffer` instances
 created in this way is *not initialized*. The contents of a newly created
-`Buffer` are unknown and *could contain sensitive data*. Use
+`Buffer` are unknown and *may contain sensitive data*. Use
 [`Buffer.alloc(size)`][`Buffer.alloc()`] instead to initialize a `Buffer`
 to zeroes.
 
@@ -461,7 +461,7 @@ Example:
 ```js
 const buf = new Buffer(10);
 
-// Prints: (contents may vary): <Buffer 00 00 00 00 00 00 00 00 00 00>
+// Prints: <Buffer 00 00 00 00 00 00 00 00 00 00>
 console.log(buf);
 ```
 
@@ -2597,7 +2597,7 @@ Allocates a new `Buffer` of `size` bytes.  If the `size` is larger than
 A zero-length `Buffer` will be created if `size` is 0.
 
 The underlying memory for `SlowBuffer` instances is *not initialized*. The
-contents of a newly created `SlowBuffer` are unknown and could contain
+contents of a newly created `SlowBuffer` are unknown and may contain
 sensitive data. Use [`buf.fill(0)`][`buf.fill()`] to initialize a `SlowBuffer` to zeroes.
 
 Example:

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -52,13 +52,16 @@ In versions of Node.js prior to v6, `Buffer` instances were created using the
 differently based on what arguments are provided:
 
 * Passing a number as the first argument to `Buffer()` (e.g. `new Buffer(10)`),
-  allocates a new `Buffer` object of the specified size. The memory allocated
-  for such `Buffer` instances is *not* initialized and *can contain sensitive
-  data*. Such `Buffer` instances *must* be initialized *manually* by using either
-  [`buf.fill(0)`][`buf.fill()`] or by writing to the `Buffer` completely. While
-  this behavior is *intentional* to improve performance, development experience
-  has demonstrated that a more explicit distinction is required between creating
-  a fast-but-uninitialized `Buffer` versus creating a slower-but-safer `Buffer`.
+  allocates a new `Buffer` object of the specified size. Prior to Node.js 8.0.0,
+  the memory allocated for such `Buffer` instances is *not* initialized and
+  *can contain sensitive data*. Such `Buffer` instances *must* be initialized
+  *manually* by using either [`buf.fill(0)`][`buf.fill()`] or by writing to the
+  `Buffer` completely. While this behavior is *intentional* to improve
+  performance, development experience has demonstrated that a more explicit
+  distinction is required between creating a fast-but-uninitialized `Buffer`
+  versus creating a slower-but-safer `Buffer`. Starting in Node.js 8.0.0,
+  `Buffer(num)` and `new Buffer(num)` will return a `Buffer` with initialized
+  memory.
 * Passing a string, array, or `Buffer` as the first argument copies the
   passed object's data into the `Buffer`.
 * Passing an [`ArrayBuffer`] returns a `Buffer` that shares allocated memory with
@@ -427,6 +430,9 @@ console.log(buf2.toString());
 <!-- YAML
 deprecated: v6.0.0
 changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12141
+    description: new Buffer(size) will return zero-filled memory by default.
   - version: v7.2.1
     pr-url: https://github.com/nodejs/node/pull/9529
     description: Calling this constructor no longer emits a deprecation warning.
@@ -444,22 +450,18 @@ Allocates a new `Buffer` of `size` bytes.  If the `size` is larger than
 [`buffer.kMaxLength`] or smaller than 0, a [`RangeError`] will be thrown.
 A zero-length `Buffer` will be created if `size` is 0.
 
-Unlike [`ArrayBuffers`][`ArrayBuffer`], the underlying memory for `Buffer` instances
-created in this way is *not initialized*. The contents of a newly created `Buffer`
-are unknown and *could contain sensitive data*. Use
-[`Buffer.alloc(size)`][`Buffer.alloc()`] instead to initialize a `Buffer` to zeroes.
+Prior to Node.js 8.0.0, the underlying memory for `Buffer` instances
+created in this way is *not initialized*. The contents of a newly created
+`Buffer` are unknown and *could contain sensitive data*. Use
+[`Buffer.alloc(size)`][`Buffer.alloc()`] instead to initialize a `Buffer`
+to zeroes.
 
 Example:
 
 ```js
 const buf = new Buffer(10);
 
-// Prints: (contents may vary): <Buffer 48 21 4b 00 00 00 00 00 30 dd>
-console.log(buf);
-
-buf.fill(0);
-
-// Prints: <Buffer 00 00 00 00 00 00 00 00 00 00>
+// Prints: (contents may vary): <Buffer 00 00 00 00 00 00 00 00 00 00>
 console.log(buf);
 ```
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -102,7 +102,7 @@ function Buffer(arg, encodingOrOffset, length) {
         'If encoding is specified then the first argument must be a string'
       );
     }
-    return Buffer.allocUnsafe(arg);
+    return Buffer.alloc(arg);
   }
   return Buffer.from(arg, encodingOrOffset, length);
 }

--- a/test/parallel/test-buffer-zero-fill.js
+++ b/test/parallel/test-buffer-zero-fill.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const Buffer = require('buffer').Buffer;
+
+const buf1 = Buffer(100);
+const buf2 = new Buffer(100);
+
+let n = 0;
+
+for (n = 0; n < buf1.length; n++)
+  assert.strictEqual(buf1[n], 0);
+
+for (n = 0; n < buf2.length; n++)
+  assert.strictEqual(buf2[n], 0);

--- a/test/parallel/test-buffer-zero-fill.js
+++ b/test/parallel/test-buffer-zero-fill.js
@@ -7,10 +7,8 @@ const Buffer = require('buffer').Buffer;
 const buf1 = Buffer(100);
 const buf2 = new Buffer(100);
 
-let n = 0;
-
-for (n = 0; n < buf1.length; n++)
+for (let n = 0; n < buf1.length; n++)
   assert.strictEqual(buf1[n], 0);
 
-for (n = 0; n < buf2.length; n++)
+for (let n = 0; n < buf2.length; n++)
   assert.strictEqual(buf2[n], 0);


### PR DESCRIPTION
Zero-fill `Buffer(num)` and `new Buffer(num)` by default.

Refs: https://github.com/nodejs/CTC/issues/89

@nodejs/ctc 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

buffer

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
