### PR TITLE
assert: Add support for Map and Set in deepEqual

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -18,6 +18,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/12142
+    description: Sets and Maps are handled correctly.
   - version: v6.4.0, v4.7.1
     pr-url: https://github.com/nodejs/node/pull/8002
     description: Typed array slices are handled correctly now.
@@ -99,6 +102,9 @@ parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/12142
+    description: Sets and Maps are handled correctly.
   - version: v6.4.0, v4.7.1
     pr-url: https://github.com/nodejs/node/pull/8002
     description: Typed array slices are handled correctly now.

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -20,7 +20,7 @@ added: v0.1.21
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/12142
-    description: Sets and Maps are handled correctly.
+    description: Set and Map content is also compared
   - version: v6.4.0, v4.7.1
     pr-url: https://github.com/nodejs/node/pull/8002
     description: Typed array slices are handled correctly now.
@@ -104,7 +104,7 @@ added: v1.2.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/12142
-    description: Sets and Maps are handled correctly.
+    description: Set and Map content is also compared
   - version: v6.4.0, v4.7.1
     pr-url: https://github.com/nodejs/node/pull/8002
     description: Typed array slices are handled correctly now.
@@ -122,7 +122,8 @@ changes:
 Generally identical to `assert.deepEqual()` with three exceptions:
 
 1. Primitive values are compared using the [Strict Equality Comparison][]
-  ( `===` ).
+  ( `===` ). Set values and Map keys are compared using the [SameValueZero][]
+  comparison. (Which means they are free of the [Caveats][]).
 2. [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [Strict Equality Comparison][] too.
 3. [Type tags][Object.prototype.toString()] of objects should be the same.
@@ -155,21 +156,6 @@ assert.deepEqual(date, fakeDate);
 assert.deepStrictEqual(date, fakeDate);
 // AssertionError: 2017-03-11T14:25:31.849Z deepStrictEqual Date {}
 // Different type tags
-```
-
-An exception is made to the strict equality comparison rule for [`Map`][] keys
-and [`Set`][] items. These tests also inherit the rules of `Set.prototype.has`
-and `Map.prototype.has`, which differs from strict equality comparison in
-also allowing NaN to be considered equal to itself:
-
-```js
-assert.deepStrictEqual(NaN, NaN);
-// AssertionError: NaN deepStrictEqual NaN
-// because NaN !== NaN
-
-// But this is ok:
-assert.deepStrictEqual(new Set([NaN]), new Set([NaN]));
-assert.deepStrictEqual(new Map([[NaN, 1]]), new Map([[NaN, 1]]));
 ```
 
 If the values are not equal, an `AssertionError` is thrown with a `message`

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -40,7 +40,7 @@ Only [enumerable "own" properties][] are considered. The
 [`assert.deepEqual()`][] implementation does not test the
 [`[[Prototype]]`][prototype-spec] of objects, attached symbols, or
 non-enumerable properties — for such checks, consider using
-[assert.deepStrictEqual()][] instead. This can lead to some
+[`assert.deepStrictEqual()`][] instead. This can lead to some
 potentially surprising results. For example, the following example does not
 throw an `AssertionError` because the properties on the [`Error`][] object are
 not enumerable:
@@ -49,6 +49,9 @@ not enumerable:
 // WARNING: This does not throw an AssertionError!
 assert.deepEqual(Error('a'), Error('b'));
 ```
+
+An exception is made for [`Map`][] and [`Set`][]. Maps and Sets have their
+contained items compared too, as expected.
 
 "Deep" equality means that the enumerable "own" properties of child objects
 are evaluated also:
@@ -146,6 +149,21 @@ assert.deepEqual(date, fakeDate);
 assert.deepStrictEqual(date, fakeDate);
 // AssertionError: 2017-03-11T14:25:31.849Z deepStrictEqual Date {}
 // Different type tags
+```
+
+An exception is made to the strict equality comparison rule for [`Map`][] keys
+and [`Set`][] items. These tests also inherit the rules of `Set.prototype.has`
+and `Map.prototype.has`, which differs from strict equality comparison in
+also allowing NaN to be considered equal to itself:
+
+```js
+assert.deepStrictEqual(NaN, NaN);
+// AssertionError: NaN deepStrictEqual NaN
+// because NaN !== NaN
+
+// But this is ok:
+assert.deepStrictEqual(new Set([NaN]), new Set([NaN]));
+assert.deepStrictEqual(new Map([[NaN, 1]]), new Map([[NaN, 1]]));
 ```
 
 If the values are not equal, an `AssertionError` is thrown with a `message`
@@ -580,6 +598,8 @@ For more information, see
 [`TypeError`]: errors.html#errors_class_typeerror
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison
 [Strict Equality Comparison]: https://tc39.github.io/ecma262/#sec-strict-equality-comparison
+[`Map`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Map
+[`Set`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Set
 [`Object.is()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
 [SameValueZero]: https://tc39.github.io/ecma262/#sec-samevaluezero
 [prototype-spec]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -123,7 +123,7 @@ Generally identical to `assert.deepEqual()` with three exceptions:
 
 1. Primitive values are compared using the [Strict Equality Comparison][]
   ( `===` ). Set values and Map keys are compared using the [SameValueZero][]
-  comparison. (Which means they are free of the [Caveats][]).
+  comparison. (Which means they are free of the [caveats][]).
 2. [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [Strict Equality Comparison][] too.
 3. [Type tags][Object.prototype.toString()] of objects should be the same.
@@ -586,6 +586,7 @@ For more information, see
 [`assert.ok()`]: #assert_assert_ok_value_message
 [`assert.throws()`]: #assert_assert_throws_block_error_message
 [`Error`]: errors.html#errors_class_error
+[caveats]: #assert_caveats
 [`RegExp`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 [`TypeError`]: errors.html#errors_class_typeerror
 [Abstract Equality Comparison]: https://tc39.github.io/ecma262/#sec-abstract-equality-comparison

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -300,7 +300,7 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
 
   outer: for (const val1 of a) {
     if (!b.has(val1)) {
-      if (!strict || typeof val1 === 'object') {
+      if (!strict || (typeof val1 === 'object' && val1 !== null)) {
         // The value doesn't exist in the second set by reference, so we'll go
         // hunting for something thats deep-equal to it. Note that this is
         // O(n^2) complexity, and will get slower if large, very similar sets /
@@ -346,7 +346,7 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
     // Hunt for keys which are deep-equal to key1 in b. Just like setEquiv
     // above, this hunt makes this function O(n^2) when using objects and lists
     // as keys
-    if (!strict || typeof key1 === 'object') {
+    if (!strict || (typeof key1 === 'object' && key1 !== null)) {
       for (const [key2, item2] of b) {
         // Just for performance. We already checked these keys above.
         if (key2 === key1)

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -263,12 +263,6 @@ function _deepEqual(actual, expected, strict, memos) {
     }
   }
 
-  if (isSet(actual)) {
-    return isSet(expected) && setEquiv(actual, expected);
-  } else if (isSet(expected)) {
-    return false;
-  }
-
   // For all other Object pairs, including Array objects and Maps,
   // equivalence is determined by having:
   // a) The same number of owned enumerable properties
@@ -288,24 +282,82 @@ function _deepEqual(actual, expected, strict, memos) {
   memos.actual.push(actual);
   memos.expected.push(expected);
 
+
   return objEquiv(actual, expected, strict, memos);
 }
 
-function setEquiv(a, b) {
-  // This behaviour will work for any sets with contents that have
-  // strict-equality. That is, it will return false if the two sets contain
-  // equivalent objects that aren't reference-equal. We could support that, but
-  // it would require scanning each pairwise set of not strict-equal items,
-  // which is O(n^2), and would get exponentially worse if sets are nested. So
-  // for now we simply won't support deep equality checking set items or map
-  // keys.
+function setEquiv(a, b, strict, actualVisitedObjects) {
+  // This code currently returns false for this pair of sets:
+  //   assert.deepEqual(new Set(['1', 1]), new Set([1]))
+  //
+  // In theory, all the items in the first set have a corresponding == value in
+  // the second set, but the sets have different sizes. Should they be
+  // considered to be non-strict deep equal to one another? Its a silly case,
+  // and more evidence that deepStrictEqual should always be preferred over
+  // deepEqual. The implementation currently returns false, which is a simpler
+  // and faster implementation.
   if (a.size !== b.size)
     return false;
 
-  var val;
-  for (val of a) {
-    if (!b.has(val))
+  var val1, val2;
+  outer: for (val1 of a) {
+    if (!b.has(val1)) {
+      // The value doesn't exist in the second set by reference, so we'll go
+      // hunting for something thats deep-equal to it. Note that this is O(n^2)
+      // complexity, and will get slower if large, very similar sets / maps are
+      // nested inside. Unfortunately there's no real way around this.
+      for (val2 of b) {
+        if (_deepEqual(val1, val2, strict, actualVisitedObjects)) {
+          continue outer;
+        }
+      }
+
+      // Not found!
       return false;
+    }
+  }
+
+  return true;
+}
+
+function mapEquiv(a, b, strict, actualVisitedObjects) {
+  // Caveat: In non-strict mode, this implementation does not handle cases
+  // where maps contain two equivalent-but-not-reference-equal keys.
+  //
+  // For example, maps like this are currently considered not equivalent:
+  if (a.size !== b.size)
+    return false;
+
+  var key1, key2, item1, item2;
+  outer: for ([key1, item1] of a) {
+    // To be able to handle cases like:
+    //   Map([[1, 'a'], ['1', 'b']]) vs Map([['1', 'a'], [1, 'b']])
+    // or:
+    //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
+    // ... we need to consider *all* matching keys, not just the first we find.
+
+    // This check is not strictly necessary, but its here to improve
+    // performance of the common case when reference-equal keys exist (which
+    // includes all primitive valued keys).
+    if (b.has(key1)) {
+      if (_deepEqual(item1, b.get(key1), strict, actualVisitedObjects))
+        continue outer;
+    }
+
+    // Hunt for keys which are deep-equal to key1 in b. Just like setEquiv
+    // above, this hunt makes this function O(n^2).
+    for ([key2, item2] of b) {
+      // Just for performance. We already checked these keys above.
+      if (key2 === key1)
+        continue;
+
+      if (_deepEqual(key1, key2, strict, actualVisitedObjects) &&
+          _deepEqual(item1, item2, strict, actualVisitedObjects)) {
+        continue outer;
+      }
+    }
+
+    return false;
   }
 
   return true;
@@ -335,21 +387,18 @@ function objEquiv(a, b, strict, actualVisitedObjects) {
       return false;
   }
 
+  // Sets and maps don't have their entries accessable via normal object
+  // properties.
+  if (isSet(a)) {
+    if (!isSet(b) || !setEquiv(a, b, strict, actualVisitedObjects))
+      return false;
+  } else if (isSet(b)) {
+    return false;
+  }
+
   if (isMap(a)) {
-    if (!isMap(b))
+    if (!isMap(b) || !mapEquiv(a, b, strict, actualVisitedObjects))
       return false;
-
-    if (a.size !== b.size)
-      return false;
-
-    var item;
-    for ([key, item] of a) {
-      if (!b.has(key))
-        return false;
-
-      if (!_deepEqual(item, b.get(key), strict, actualVisitedObjects))
-        return false;
-    }
   } else if (isMap(b)) {
     return false;
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -338,7 +338,7 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
 
     // This check is not strictly necessary, but its here to improve
     // performance of the common case when reference-equal keys exist (which
-    // includes all primitive valued keys).
+    // includes all primitive-valued keys).
     if (b.has(key1)) {
       if (_deepEqual(item1, b.get(key1), strict, actualVisitedObjects))
         continue outer;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -161,6 +161,14 @@ function isArguments(tag) {
   return tag === '[object Arguments]';
 }
 
+function isMap(object) {
+  return object.constructor === Map;
+}
+
+function isSet(object) {
+  return object.constructor === Set;
+}
+
 function _deepEqual(actual, expected, strict, memos) {
   // All identical values are equivalent, as determined by ===.
   if (actual === expected) {
@@ -262,11 +270,18 @@ function _deepEqual(actual, expected, strict, memos) {
     }
   }
 
-  // For all other Object pairs, including Array objects,
+  if (isSet(actual)) {
+    return isSet(expected) && setEquiv(actual, expected);
+  } else if (isSet(expected)) {
+    return false;
+  }
+
+  // For all other Object pairs, including Array objects and Maps,
   // equivalence is determined by having:
   // a) The same number of owned enumerable properties
   // b) The same set of keys/indexes (although not necessarily the same order)
   // c) Equivalent values for every corresponding key/index
+  // d) For Maps, strict-equal keys mapping to deep-equal values
   // Note: this accounts for both named and indexed properties on Arrays.
 
   // Use memos to handle cycles.
@@ -281,6 +296,26 @@ function _deepEqual(actual, expected, strict, memos) {
   memos.expected.push(expected);
 
   return objEquiv(actual, expected, strict, memos);
+}
+
+function setEquiv(a, b) {
+  // This behaviour will work for any sets with contents that have
+  // strict-equality. That is, it will return false if the two sets contain
+  // equivalent objects that aren't reference-equal. We could support that, but
+  // it would require scanning each pairwise set of not strict-equal items,
+  // which is O(n^2), and would get exponentially worse if sets are nested. So
+  // for now we simply won't support deep equality checking set items or map
+  // keys.
+  if (a.size !== b.size)
+    return false;
+
+  var val;
+  for (val of a) {
+    if (!b.has(val))
+      return false;
+  }
+
+  return true;
 }
 
 function objEquiv(a, b, strict, actualVisitedObjects) {
@@ -305,6 +340,25 @@ function objEquiv(a, b, strict, actualVisitedObjects) {
   for (i = aKeys.length - 1; i >= 0; i--) {
     if (aKeys[i] !== bKeys[i])
       return false;
+  }
+
+  if (isMap(a)) {
+    if (!isMap(b))
+      return false;
+
+    if (a.size !== b.size)
+      return false;
+
+    var item;
+    for ([key, item] of a) {
+      if (!b.has(key))
+        return false;
+
+      if (!_deepEqual(item, b.get(key), strict, actualVisitedObjects))
+        return false;
+    }
+  } else if (isMap(b)) {
+    return false;
   }
 
   // The pair must have equivalent values for every corresponding key.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -387,7 +387,7 @@ function objEquiv(a, b, strict, actualVisitedObjects) {
       return false;
   }
 
-  // Sets and maps don't have their entries accessable via normal object
+  // Sets and maps don't have their entries accessible via normal object
   // properties.
   if (isSet(a)) {
     if (!isSet(b) || !setEquiv(a, b, strict, actualVisitedObjects))

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -285,15 +285,25 @@ function _deepEqual(actual, expected, strict, memos) {
   return objEquiv(actual, expected, strict, memos);
 }
 
-function setHasSimilarElement(set, val1, strict, actualVisitedObjects) {
+function setHasSimilarElement(set, val1, strict, memo) {
+  if (set.has(val1))
+    return true;
+
+  // In strict mode the only things which can match a primitive or a function
+  // will already be detected by set.has(val1).
+  if (strict && (util.isPrimitive(val1) || util.isFunction(val1)))
+    return false;
+
+  // Otherwise go looking.
   for (const val2 of set) {
-    if (_deepEqual(val1, val2, strict, actualVisitedObjects))
+    if (_deepEqual(val1, val2, strict, memo))
       return true;
   }
+
   return false;
 }
 
-function setEquiv(a, b, strict, actualVisitedObjects) {
+function setEquiv(a, b, strict, memo) {
   // This code currently returns false for this pair of sets:
   //   assert.deepEqual(new Set(['1', 1]), new Set([1]))
   //
@@ -310,9 +320,7 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
     // deep-equal to it. Note that this is O(n^2) complexity, and will get
     // slower if large, very similar sets / maps are nested inside.
     // Unfortunately there's no real way around this.
-    if (!b.has(val1)
-        && (!strict || (!util.isObject(val1) && !util.isFunction(val1)))
-        && !setHasSimilarElement(b, val1, strict, actualVisitedObjects)) {
+    if (!setHasSimilarElement(b, val1, strict, memo)) {
       return false;
     }
   }
@@ -320,7 +328,37 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
   return true;
 }
 
-function mapEquiv(a, b, strict, actualVisitedObjects) {
+function mapHasSimilarEntry(map, key1, item1, strict, memo) {
+  // To be able to handle cases like:
+  //   Map([[1, 'a'], ['1', 'b']]) vs Map([['1', 'a'], [1, 'b']])
+  // or:
+  //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
+  // ... we need to consider *all* matching keys, not just the first we find.
+
+  // This check is not strictly necessary. The loop performs this check, but
+  // doing it here improves performance of the common case when reference-equal
+  // keys exist (which includes all primitive-valued keys).
+  if (map.has(key1) && _deepEqual(item1, map.get(key1), strict, memo))
+    return true;
+
+  if (strict && (util.isPrimitive(key1) || util.isFunction(key1)))
+    return false;
+
+  for (const [key2, item2] of map) {
+    // This case is checked above.
+    if (key2 === key1)
+      continue;
+
+    if (_deepEqual(key1, key2, strict, memo) &&
+        _deepEqual(item1, item2, strict, memo)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function mapEquiv(a, b, strict, memo) {
   // Caveat: In non-strict mode, this implementation does not handle cases
   // where maps contain two equivalent-but-not-reference-equal keys.
   //
@@ -328,38 +366,11 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
   if (a.size !== b.size)
     return false;
 
-  outer: for (const [key1, item1] of a) {
-    // To be able to handle cases like:
-    //   Map([[1, 'a'], ['1', 'b']]) vs Map([['1', 'a'], [1, 'b']])
-    // or:
-    //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
-    // ... we need to consider *all* matching keys, not just the first we find.
-
-    // This check is not strictly necessary if we run the loop below, but it
-    // improves performance of the common case when reference-equal keys exist
-    // (which includes all primitive-valued keys).
-    if (b.has(key1)) {
-      if (_deepEqual(item1, b.get(key1), strict, actualVisitedObjects))
-        continue outer;
-    }
-
-    // Hunt for keys which are deep-equal to key1 in b. Just like setEquiv
-    // above, this hunt makes this function O(n^2) when using objects and lists
-    // as keys
-    if (!strict || (typeof key1 === 'object' && key1 !== null)) {
-      for (const [key2, item2] of b) {
-        // Just for performance. We already checked these keys above.
-        if (key2 === key1)
-          continue;
-
-        if (_deepEqual(key1, key2, strict, actualVisitedObjects) &&
-            _deepEqual(item1, item2, strict, actualVisitedObjects)) {
-          continue outer;
-        }
-      }
-    }
-
-    return false;
+  for (const [key1, item1] of a) {
+    // Just like setEquiv above, this hunt makes this function O(n^2) when
+    // using objects and lists as keys
+    if (!mapHasSimilarEntry(b, key1, item1, strict, memo))
+      return false;
   }
 
   return true;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -300,13 +300,15 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
 
   outer: for (const val1 of a) {
     if (!b.has(val1)) {
-      // The value doesn't exist in the second set by reference, so we'll go
-      // hunting for something thats deep-equal to it. Note that this is O(n^2)
-      // complexity, and will get slower if large, very similar sets / maps are
-      // nested inside. Unfortunately there's no real way around this.
-      for (const val2 of b) {
-        if (_deepEqual(val1, val2, strict, actualVisitedObjects)) {
-          continue outer;
+      if (!strict || typeof val1 === 'object') {
+        // The value doesn't exist in the second set by reference, so we'll go
+        // hunting for something thats deep-equal to it. Note that this is
+        // O(n^2) complexity, and will get slower if large, very similar sets /
+        // maps are nested inside. Unfortunately there's no real way around
+        // this.
+        for (const val2 of b) {
+          if (_deepEqual(val1, val2, strict, actualVisitedObjects))
+            continue outer;
         }
       }
 
@@ -333,24 +335,27 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
     //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
     // ... we need to consider *all* matching keys, not just the first we find.
 
-    // This check is not strictly necessary, but its here to improve
-    // performance of the common case when reference-equal keys exist (which
-    // includes all primitive-valued keys).
+    // This check is not strictly necessary if we run the loop below, but it
+    // improves performance of the common case when reference-equal keys exist
+    // (which includes all primitive-valued keys).
     if (b.has(key1)) {
       if (_deepEqual(item1, b.get(key1), strict, actualVisitedObjects))
         continue outer;
     }
 
     // Hunt for keys which are deep-equal to key1 in b. Just like setEquiv
-    // above, this hunt makes this function O(n^2).
-    for (const [key2, item2] of b) {
-      // Just for performance. We already checked these keys above.
-      if (key2 === key1)
-        continue;
+    // above, this hunt makes this function O(n^2) when using objects and lists
+    // as keys
+    if (!strict || typeof key1 === 'object') {
+      for (const [key2, item2] of b) {
+        // Just for performance. We already checked these keys above.
+        if (key2 === key1)
+          continue;
 
-      if (_deepEqual(key1, key2, strict, actualVisitedObjects) &&
-          _deepEqual(item1, item2, strict, actualVisitedObjects)) {
-        continue outer;
+        if (_deepEqual(key1, key2, strict, actualVisitedObjects) &&
+            _deepEqual(item1, item2, strict, actualVisitedObjects)) {
+          continue outer;
+        }
       }
     }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -23,6 +23,7 @@
 // UTILITY
 const compare = process.binding('buffer').compare;
 const util = require('util');
+const { isSet, isMap } = process.binding('util');
 const objectToString = require('internal/util').objectToString;
 const Buffer = require('buffer').Buffer;
 
@@ -159,14 +160,6 @@ function isFloatTypedArrayTag(tag) {
 
 function isArguments(tag) {
   return tag === '[object Arguments]';
-}
-
-function isMap(object) {
-  return object.constructor === Map;
-}
-
-function isSet(object) {
-  return object.constructor === Set;
 }
 
 function _deepEqual(actual, expected, strict, memos) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -268,7 +268,7 @@ function _deepEqual(actual, expected, strict, memos) {
   // a) The same number of owned enumerable properties
   // b) The same set of keys/indexes (although not necessarily the same order)
   // c) Equivalent values for every corresponding key/index
-  // d) For Maps, strict-equal keys mapping to deep-equal values
+  // d) For Sets and Maps, equal contents
   // Note: this accounts for both named and indexed properties on Arrays.
 
   // Use memos to handle cycles.
@@ -291,22 +291,20 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
   //   assert.deepEqual(new Set(['1', 1]), new Set([1]))
   //
   // In theory, all the items in the first set have a corresponding == value in
-  // the second set, but the sets have different sizes. Should they be
-  // considered to be non-strict deep equal to one another? Its a silly case,
+  // the second set, but the sets have different sizes. Its a silly case,
   // and more evidence that deepStrictEqual should always be preferred over
-  // deepEqual. The implementation currently returns false, which is a simpler
-  // and faster implementation.
+  // deepEqual. The implementation currently returns false, which is simpler
+  // and slightly faster.
   if (a.size !== b.size)
     return false;
 
-  var val1, val2;
-  outer: for (val1 of a) {
+  outer: for (const val1 of a) {
     if (!b.has(val1)) {
       // The value doesn't exist in the second set by reference, so we'll go
       // hunting for something thats deep-equal to it. Note that this is O(n^2)
       // complexity, and will get slower if large, very similar sets / maps are
       // nested inside. Unfortunately there's no real way around this.
-      for (val2 of b) {
+      for (const val2 of b) {
         if (_deepEqual(val1, val2, strict, actualVisitedObjects)) {
           continue outer;
         }
@@ -328,8 +326,7 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
   if (a.size !== b.size)
     return false;
 
-  var key1, key2, item1, item2;
-  outer: for ([key1, item1] of a) {
+  outer: for (const [key1, item1] of a) {
     // To be able to handle cases like:
     //   Map([[1, 'a'], ['1', 'b']]) vs Map([['1', 'a'], [1, 'b']])
     // or:
@@ -346,7 +343,7 @@ function mapEquiv(a, b, strict, actualVisitedObjects) {
 
     // Hunt for keys which are deep-equal to key1 in b. Just like setEquiv
     // above, this hunt makes this function O(n^2).
-    for ([key2, item2] of b) {
+    for (const [key2, item2] of b) {
       // Just for performance. We already checked these keys above.
       if (key2 === key1)
         continue;

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -282,8 +282,15 @@ function _deepEqual(actual, expected, strict, memos) {
   memos.actual.push(actual);
   memos.expected.push(expected);
 
-
   return objEquiv(actual, expected, strict, memos);
+}
+
+function setHasSimilarElement(set, val1, strict, actualVisitedObjects) {
+  for (const val2 of set) {
+    if (_deepEqual(val1, val2, strict, actualVisitedObjects))
+      return true;
+  }
+  return false;
 }
 
 function setEquiv(a, b, strict, actualVisitedObjects) {
@@ -293,26 +300,19 @@ function setEquiv(a, b, strict, actualVisitedObjects) {
   // In theory, all the items in the first set have a corresponding == value in
   // the second set, but the sets have different sizes. Its a silly case,
   // and more evidence that deepStrictEqual should always be preferred over
-  // deepEqual. The implementation currently returns false, which is simpler
-  // and slightly faster.
+  // deepEqual.
   if (a.size !== b.size)
     return false;
 
-  outer: for (const val1 of a) {
-    if (!b.has(val1)) {
-      if (!strict || (typeof val1 === 'object' && val1 !== null)) {
-        // The value doesn't exist in the second set by reference, so we'll go
-        // hunting for something thats deep-equal to it. Note that this is
-        // O(n^2) complexity, and will get slower if large, very similar sets /
-        // maps are nested inside. Unfortunately there's no real way around
-        // this.
-        for (const val2 of b) {
-          if (_deepEqual(val1, val2, strict, actualVisitedObjects))
-            continue outer;
-        }
-      }
-
-      // Not found!
+  for (const val1 of a) {
+    // If the value doesn't exist in the second set by reference, and its an
+    // object or an array we'll need to go hunting for something thats
+    // deep-equal to it. Note that this is O(n^2) complexity, and will get
+    // slower if large, very similar sets / maps are nested inside.
+    // Unfortunately there's no real way around this.
+    if (!b.has(val1)
+        && (!strict || (!util.isObject(val1) && !util.isFunction(val1)))
+        && !setHasSimilarElement(b, val1, strict, actualVisitedObjects)) {
       return false;
     }
   }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -107,4 +107,105 @@ for (const a of similar) {
   }
 }
 
+function assertDeepAndStrictEqual(a, b) {
+  assert.doesNotThrow(() => assert.deepEqual(a, b));
+  assert.doesNotThrow(() => assert.deepStrictEqual(a, b));
+
+  assert.doesNotThrow(() => assert.deepEqual(b, a));
+  assert.doesNotThrow(() => assert.deepStrictEqual(b, a));
+}
+
+function assertNotDeepOrStrict(a, b) {
+  assert.throws(() => assert.deepEqual(a, b));
+  assert.throws(() => assert.deepStrictEqual(a, b));
+
+  assert.throws(() => assert.deepEqual(b, a));
+  assert.throws(() => assert.deepStrictEqual(b, a));
+}
+
+// es6 Maps and Sets
+assertDeepAndStrictEqual(new Set(), new Set());
+assertDeepAndStrictEqual(new Map(), new Map());
+
+// deepEqual only works with primitive key values and reference-equal values in
+// sets and map keys avoid O(n^d) complexity (where d is depth)
+assertDeepAndStrictEqual(new Set([1, 2, 3]), new Set([1, 2, 3]));
+assertNotDeepOrStrict(new Set([1, 2, 3]), new Set([1, 2, 3, 4]));
+assertNotDeepOrStrict(new Set([1, 2, 3, 4]), new Set([1, 2, 3]));
+assertDeepAndStrictEqual(new Set(['1', '2', '3']), new Set(['1', '2', '3']));
+
+assertDeepAndStrictEqual(new Map([[1, 1], [2, 2]]), new Map([[1, 1], [2, 2]]));
+assertDeepAndStrictEqual(new Map([[1, 1], [2, 2]]), new Map([[2, 2], [1, 1]]));
+assertNotDeepOrStrict(new Map([[1, 1], [2, 2]]), new Map([[1, 2], [2, 1]]));
+
+assertNotDeepOrStrict(new Set([1]), [1]);
+assertNotDeepOrStrict(new Set(), []);
+assertNotDeepOrStrict(new Set(), {});
+
+assertNotDeepOrStrict(new Map([['a', 1]]), {a: 1});
+assertNotDeepOrStrict(new Map(), []);
+assertNotDeepOrStrict(new Map(), {});
+
+{
+  const values = [
+    123,
+    Infinity,
+    0,
+    null,
+    undefined,
+    false,
+    true,
+    {}, // Objects, lists and functions are ok if they're in by reference.
+    [],
+    () => {},
+  ];
+  assertDeepAndStrictEqual(new Set(values), new Set(values));
+  assertDeepAndStrictEqual(new Set(values), new Set(values.reverse()));
+
+  const mapValues = values.map((v) => [v, {a: 5}]);
+  assertDeepAndStrictEqual(new Map(mapValues), new Map(mapValues));
+  assertDeepAndStrictEqual(new Map(mapValues), new Map(mapValues.reverse()));
+}
+
+{
+  const s1 = new Set();
+  const s2 = new Set();
+  s1.add(1);
+  s1.add(2);
+  s2.add(2);
+  s2.add(1);
+  assertDeepAndStrictEqual(s1, s2);
+}
+
+{
+  const m1 = new Map();
+  const m2 = new Map();
+  const obj = {a: 5, b: 6};
+  m1.set(1, obj);
+  m1.set(2, 'hi');
+  m1.set(3, [1, 2, 3]);
+
+  m2.set(2, 'hi'); // different order
+  m2.set(1, obj);
+  m2.set(3, [1, 2, 3]); // deep equal, but not reference equal.
+
+  assertDeepAndStrictEqual(m1, m2);
+}
+
+{
+  const m1 = new Map();
+  const m2 = new Map();
+
+  // m1 contains itself.
+  m1.set(1, m1);
+  m2.set(1, new Map());
+
+  assertNotDeepOrStrict(m1, m2);
+}
+
+assert.deepEqual(new Map([[1, 1]]), new Map([[1, '1']]));
+assert.throws(() =>
+  assert.deepStrictEqual(new Map([[1, 1]]), new Map([[1, '1']]))
+);
+
 /* eslint-enable */

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -108,11 +108,11 @@ for (const a of similar) {
 }
 
 function assertDeepAndStrictEqual(a, b) {
-  assert.doesNotThrow(() => assert.deepEqual(a, b));
-  assert.doesNotThrow(() => assert.deepStrictEqual(a, b));
+  assert.deepEqual(a, b);
+  assert.deepStrictEqual(a, b);
 
-  assert.doesNotThrow(() => assert.deepEqual(b, a));
-  assert.doesNotThrow(() => assert.deepStrictEqual(b, a));
+  assert.deepEqual(b, a);
+  assert.deepStrictEqual(b, a);
 }
 
 function assertNotDeepOrStrict(a, b) {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -158,6 +158,8 @@ assertOnlyDeepEqual(new Set(['1']), new Set([1]));
 assertOnlyDeepEqual(new Map([['1', 'a']]), new Map([[1, 'a']]));
 assertOnlyDeepEqual(new Map([['a', '1']]), new Map([['a', 1]]));
 
+assertDeepAndStrictEqual(new Set([{}]), new Set([{}]));
+
 // This is an awful case, where a map contains multiple equivalent keys:
 assertOnlyDeepEqual(
   new Map([[1, 'a'], ['1', 'b']]),

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -245,4 +245,25 @@ assert.throws(() =>
   assertNotDeepOrStrict(m1, m2);
 }
 
+{
+  // Circular references.
+  const s1 = new Set();
+  s1.add(s1);
+  const s2 = new Set();
+  s2.add(s2);
+  assertDeepAndStrictEqual(s1, s2);
+
+  const m1 = new Map();
+  m1.set(2, m1);
+  const m2 = new Map();
+  m2.set(2, m2);
+  assertDeepAndStrictEqual(m1, m2);
+
+  const m3 = new Map();
+  m3.set(m3, 2);
+  const m4 = new Map();
+  m4.set(m4, 2);
+  assertDeepAndStrictEqual(m3, m4);
+}
+
 /* eslint-enable */


### PR DESCRIPTION
assert.deepEqual and assert.deepStrictEqual currently return true for
any pair of Maps and Sets regardless of content. This patch adds
support in deepEqual and deepStrictEqual to verify the contents of Maps
and Sets.

~~Unfortunately because there's no way to pairwise fetch set values or map
values which are equivalent but not reference-equal, this change
currently only supports reference equality checking in set values and
map keys. Equivalence checking could be done, but it would be an
O(n^2) operation, and worse, it would get slower exponentially if maps
and sets were nested.~~

**Update**: Based on conversation below, the implementation now incurs an O(n^2) cost if the sets or maps are not equal, because to be correct we need to check all pairs of values in sets, and all pairs of keys in a map. This may become exponentially more expensive with input which does deep equality checking on nested maps. But given these checks are almost always only done during testing, and on small objects its probably the right approach.

**Update 2**: Based on a clever suggestion by @TimothyGu the O(n^2) cost is now only paid when you're either in non-strict mode or when you're using set values & map keys which have typeof object.

Note that this change breaks compatibility with previous versions of
deepEqual and deepStrictEqual if consumers were depending on all maps
and sets to be seen as equivalent. The old behaviour was never
documented, but nevertheless there are certainly some tests out there somewhere
which depend on it.

Support had been stalled because the assert API was frozen, but assert was recently
unfrozen in [CTC#63](https://github.com/nodejs/CTC/issues/63)

Fixes: https://github.com/nodejs/node/issues/2309
Refs: https://github.com/substack/tape/issues/342
Refs: https://github.com/nodejs/node/pull/2315
Refs: https://github.com/nodejs/CTC/issues/63

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
- Assert

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines