### PR TITLE
v8: fix offsets for TypedArray deserialization

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -177,7 +177,8 @@ class DefaultDeserializer extends Deserializer {
     } else {
       // Copy to an aligned buffer first.
       const copy = Buffer.allocUnsafe(byteLength);
-      bufferBinding.copy(this.buffer, copy, 0, offset, offset + byteLength);
+      bufferBinding.copy(this.buffer, copy, 0,
+                         byteOffset, byteOffset + byteLength);
       return new ctor(copy.buffer,
                       copy.byteOffset,
                       byteLength / BYTES_PER_ELEMENT);

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -118,3 +118,11 @@ const objects = [
   assert.deepStrictEqual(buf, ser.releaseBuffer());
   assert.strictEqual(des.getWireFormatVersion(), 0x0d);
 }
+
+{
+  // Unaligned Uint16Array read, with padding in the underlying array buffer.
+  const buf = Buffer.from('0'.repeat(64) + 'ff0d5c0404addeefbe', 'hex')
+      .slice(32);
+  assert.deepStrictEqual(v8.deserialize(buf),
+                         new Uint16Array([0xdead, 0xbeef]));
+}

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -121,8 +121,9 @@ const objects = [
 
 {
   // Unaligned Uint16Array read, with padding in the underlying array buffer.
-  const buf = Buffer.from('0'.repeat(64) + 'ff0d5c0404addeefbe', 'hex')
-      .slice(32);
+  let buf = Buffer.alloc(32 + 9);
+  buf.write('ff0d5c0404addeefbe', 32, 'hex');
+  buf = buf.slice(32);
   assert.deepStrictEqual(v8.deserialize(buf),
                          new Uint16Array([0xdead, 0xbeef]));
 }


### PR DESCRIPTION
Fix the offset calculation for deserializing TypedArrays that are
not aligned in their original buffer.

Since `byteOffset` refers to the offset into the source `Buffer`
instance, not its underlying `ArrayBuffer`, that is what should
be passed to `buffer.copy`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
v8

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
