### PR TITLE
meta: move the Code of Conduct to TSC repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,55 +1,5 @@
 # Code of Conduct
 
-## Conduct
-
-* We are committed to providing a friendly, safe and welcoming
-  environment for all, regardless of level of experience, gender
-  identity and expression, sexual orientation, disability,
-  personal appearance, body size, race, ethnicity, age, religion,
-  nationality, or other similar characteristic.
-* Please avoid using overtly sexual nicknames or other nicknames that
-  might detract from a friendly, safe and welcoming environment for
-  all.
-* Please be kind and courteous. There's no need to be mean or rude.
-* Respect that some individuals and cultures consider the casual use of
-  profanity and sexualized language offensive and off-putting.
-* Respect that people have differences of opinion and that every
-  design or implementation choice carries a trade-off and numerous
-  costs. There is seldom a right answer.
-* Please keep unstructured critique to a minimum. If you have solid
-  ideas you want to experiment with, make a fork and see how it works.
-* We will exclude you from interaction if you insult, demean or harass
-  anyone. That is not welcome behavior. We interpret the term
-  "harassment" as including the definition in the [Citizen Code of
-  Conduct](http://citizencodeofconduct.org/); if you have any lack of
-  clarity about what might be included in that concept, please read
-  their definition. In particular, we don't tolerate behavior that
-  excludes people in socially marginalized groups.
-* Private harassment is also unacceptable. No matter who you are, if
-  you feel you have been or are being harassed or made uncomfortable
-  by a community member, please contact one of the channel ops or any
-  of the TSC members immediately with a capture (log, photo, email) of
-  the harassment if possible. Whether you're a regular contributor or
-  a newcomer, we care about making this community a safe place for you
-  and we've got your back.
-* Likewise any spamming, trolling, flaming, baiting or other
-  attention-stealing behavior is not welcome.
-* Avoid the use of personal pronouns in code comments or
-  documentation. There is no need to address persons when explaining
-  code (e.g. "When the developer").
-
-## Contact
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by:
-
-* Emailing [report@nodejs.org](mailto:report@nodejs.org) (this will email all TSC members)
-* Contacting [individual TSC members](https://nodejs.org/en/foundation/tsc/#current-members-of-the-technical-steering-committee).
-
-## Moderation
-See the TSC's [moderation policy](https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md) for details about moderation.
-
-## Attribution
-
-This Code of Conduct is adapted from [Rust's wonderful
-CoC](http://www.rust-lang.org/conduct.html) as well as the
-[Contributor Covenant v1.3.0](http://contributor-covenant.org/version/1/3/0/).
+The Node.js Code of Conduct document has moved to
+https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md. Please update
+links to this document accordingly.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ open source libraries in the world.
 The Node.js project is supported by the
 [Node.js Foundation](https://nodejs.org/en/foundation/). Contributions,
 policies, and releases are managed under an
-[open governance model](./GOVERNANCE.md). We are also bound by a
-[Code of Conduct](./CODE_OF_CONDUCT.md).
+[open governance model](./GOVERNANCE.md).
+
+**This project is bound by a [Code of Conduct][].**
 
 If you need help using or installing Node.js, please use the
 [nodejs/help](https://github.com/nodejs/help) issue tracker.
@@ -447,3 +448,4 @@ Information on the current Node.js Working Groups can be found in the
 [Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
 [#node.js on chat.freenode.net]: https://webchat.freenode.net?channels=node.js&uio=d4
 [#node-dev on chat.freenode.net]: https://webchat.freenode.net?channels=node-dev&uio=d4
+[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Per the discussion and decision on the last TSC call. Moves the the Code of Conduct to the TSC repository.

https://github.com/nodejs/TSC/pull/232 should land first.

Requires @nodejs/tsc signoff. 

Refs: https://github.com/nodejs/TSC/issues/224
Refs: https://github.com/nodejs/TSC/pull/232

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

meta

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
