### PR TITLE
doc, inspector: note that the host is optional

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -94,7 +94,7 @@ Follows `require()`'s module resolution
 rules. `module` may be either a path to a file, or a node module name.
 
 
-### `--inspect[=host:port]`
+### `--inspect[=[host:]port]`
 <!-- YAML
 added: v6.3.0
 -->
@@ -106,7 +106,7 @@ and profile Node.js instances. The tools attach to Node.js instances via a
 tcp port and communicate using the [Chrome Debugging Protocol][].
 
 
-### `--inspect-brk[=host:port]`
+### `--inspect-brk[=[host:]port]`
 <!-- YAML
 added: v7.6.0
 -->

--- a/doc/node.1
+++ b/doc/node.1
@@ -93,14 +93,14 @@ Preload the specified module at startup. Follows `require()`'s module resolution
 rules. \fImodule\fR may be either a path to a file, or a node module name.
 
 .TP
-.BR \-\-inspect \fI[=host:port]\fR
+.BR \-\-inspect \fI[=[host:]port]\fR
 Activate inspector on host:port. Default is 127.0.0.1:9229.
 
 V8 Inspector integration allows attaching Chrome DevTools and IDEs to Node.js
 instances for debugging and profiling. It uses the Chrome Debugging Protocol.
 
 .TP
-.BR \-\-inspect-brk \fI[=host:port]\fR
+.BR \-\-inspect-brk \fI[=[host:]port]\fR
 Activate inspector on host:port and break at start of user script.
 
 .TP

--- a/src/node.cc
+++ b/src/node.cc
@@ -3541,9 +3541,10 @@ static void PrintHelp() {
          "  -r, --require              module to preload (option can be "
          "repeated)\n"
 #if HAVE_INSPECTOR
-         "  --inspect[=host:port]      activate inspector on host:port\n"
+         "  --inspect[=[host:]port]    activate inspector on host:port\n"
          "                             (default: 127.0.0.1:9229)\n"
-         "  --inspect-brk[=host:port]  activate inspector on host:port\n"
+         "  --inspect-brk[=[host:]port]\n"
+         "                             activate inspector on host:port\n"
          "                             and break at start of user script\n"
 #endif
          "  --no-deprecation           silence deprecation warnings\n"


### PR DESCRIPTION
Document that `node --inspect=${port}` is also a viable option.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] ~tests and/or benchmarks are included~ There are already tests for this behaviour: [sequential/test-debugger-debug-brk.js](https://github.com/nodejs/node/blob/master/test/sequential/test-debugger-debug-brk.js) [inspector/test-inspector-ip-detection.js](https://github.com/nodejs/node/blob/master/test/inspector/test-inspector-ip-detection.js)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

_**EDIT:**_ CI: https://ci.nodejs.org/job/node-test-commit/8834/