### PR TITLE
util: show External values explicitly in inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -466,6 +466,9 @@ function formatValue(ctx, value, recurseTimes) {
       return `${constructor.name}` +
              ` { byteLength: ${formatNumber(ctx, value.byteLength)} }`;
     }
+    if (binding.isExternal(value)) {
+      return ctx.stylize('[External]', 'special');
+    }
   }
 
   var base = '';

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -22,6 +22,7 @@ using v8::Value;
   V(isArrayBuffer, IsArrayBuffer)                                             \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
+  V(isExternal, IsExternal)                                                   \
   V(isMap, IsMap)                                                             \
   V(isMapIterator, IsMapIterator)                                             \
   V(isPromise, IsPromise)                                                     \

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -82,6 +82,9 @@ assert.strictEqual(util.inspect(Object.assign(new String('hello'),
                    { [Symbol('foo')]: 123 }), { showHidden: true }),
                    '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }');
 
+assert.strictEqual(util.inspect(process.stdin._handle._externalStream),
+                   '[External]');
+
 {
   const regexp = /regexp/;
   regexp.aprop = 42;


### PR DESCRIPTION
Display `v8::External` values as `[External]` rather than `{}`
which makes them look like objects.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

util

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
