### PR TITLE
test: fix flaky test-child-process-exec-timeout

### DIFF
--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -18,7 +18,13 @@ const cmd = `${process.execPath} ${__filename} child`;
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {
   assert.strictEqual(err.killed, true);
   assert.strictEqual(err.code, null);
-  assert.strictEqual(err.signal, 'SIGTERM');
+  // At least starting with Darwin Kernel Version 16.4.0, sending a SIGTERM to a
+  // process that is still starting up kills it with SIGKILL instead of SIGTERM.
+  // See: https://github.com/libuv/libuv/issues/1226
+  if (common.isOSX)
+    assert.ok(err.signal === 'SIGTERM' || err.signal === 'SIGKILL');
+  else
+    assert.strictEqual(err.signal, 'SIGTERM');
   assert.strictEqual(err.cmd, cmd);
   assert.strictEqual(stdout.trim(), '');
   assert.strictEqual(stderr.trim(), '');


### PR DESCRIPTION
At least starting with Darwin Kernel Version 16.4.0, sending a SIGTERM
to a process that is still starting up kills it with SIGKILL instead of
SIGTERM.

Refs: https://github.com/libuv/libuv/issues/1226


Relevant backtrace:

```
=== release test-child-process-exec-timeout ===                    
Path: parallel/test-child-process-exec-timeout
assert.js:81
  throw new assert.AssertionError({
  ^
AssertionError: 'SIGKILL' === 'SIGTERM'
    at cp.exec.common.mustCall (/Users/sgimeno/node/node/test/parallel/test-child-process-exec-timeout.js:21:10)
    at /Users/sgimeno/node/node/test/common.js:461:15
    at ChildProcess.exithandler (child_process.js:253:5)
    at emitTwo (events.js:125:13)
    at ChildProcess.emit (events.js:213:7)
    at maybeClose (internal/child_process.js:893:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:219:5)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines