### PR TITLE
start inspect agent on SIGUSR2

### DIFF
--- a/test/parallel/test-signal-inspect.js
+++ b/test/parallel/test-signal-inspect.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const spawn = require('child_process').spawn;
+
+if (common.isWindows) {
+  // No way to send CTRL_C_EVENT to processes from JS right now.
+  common.skip('platform not supported');
+  return;
+}
+
+process.env.REPL_TEST_PPID = process.pid;
+const child = spawn(process.execPath, [
+    '-e',
+    'vm.runInThisContext("setInterval(() => console.log(\'miau\'), 1000);", ' +
+     '{ breakOnSigint: true });'
+]);
+
+child.stderr.once('data', common.mustCall((data) => {
+  child.stderr.once('data', common.mustCall((data) => {
+    const stdErr = data.toString('utf8');
+    assert.ok(
+      stdErr.includes('To start debugging, open the following URL in Chrome:'),
+      'Expected stdErr to contain "To start debugging,' +
+        `open the following URL in Chrome:", got ${stdErr}`
+    );
+
+    assert.ok(
+      stdErr.includes('chrome-devtools://devtools/bundled'),
+      'Expected stdErr to contain "chrome-devtools://devtools/bundled,' +
+         `got ${stdErr}`
+    );
+
+    process.kill(child.pid, 'SIGINT');
+  }));
+
+  const stdErr = data.toString('utf8');
+  assert.ok(
+    stdErr.includes('Starting inspector agent'),
+    `Expected stdErr to contain "Starting inspector agent", got ${stdErr}`
+  );
+}));
+
+child.stdout.once('data', () => {
+  process.kill(child.pid, 'SIGUSR2');
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
it should be possible to start v8 inspector for running process, similar to debug's signal SIGUSR1.
Sending SIGUSR2 starts the v8 inspector agent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
