### PR TITLE
crypto: Handle exceptions in hmac/hash.digest

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -100,7 +100,8 @@ Hash.prototype.update = function update(data, encoding) {
 
 Hash.prototype.digest = function digest(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  return this._handle.digest(outputEncoding);
+  // Explicit conversion for backward compatibility
+  return this._handle.digest(String(outputEncoding));
 };
 
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -101,7 +101,7 @@ Hash.prototype.update = function update(data, encoding) {
 Hash.prototype.digest = function digest(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
   // Explicit conversion for backward compatibility
-  return this._handle.digest(String(outputEncoding));
+  return this._handle.digest(`${outputEncoding}`);
 };
 
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -100,7 +100,7 @@ Hash.prototype.update = function update(data, encoding) {
 
 Hash.prototype.digest = function digest(outputEncoding) {
   outputEncoding = outputEncoding || exports.DEFAULT_ENCODING;
-  // Explicit conversion for backward compatibility
+  // Explicit conversion for backward compatibility.
   return this._handle.digest(`${outputEncoding}`);
 };
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1481,6 +1481,8 @@ enum encoding ParseEncoding(const char* encoding,
 enum encoding ParseEncoding(Isolate* isolate,
                             Local<Value> encoding_v,
                             enum encoding default_encoding) {
+  CHECK(!encoding_v.IsEmpty());
+
   if (!encoding_v->IsString())
     return default_encoding;
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3797,9 +3797,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {
-    encoding = ParseEncoding(env->isolate(),
-                             args[0]->ToString(env->isolate()),
-                             BUFFER);
+    encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
   unsigned char* md_value = nullptr;
@@ -3921,9 +3919,7 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {
-    encoding = ParseEncoding(env->isolate(),
-                             args[0]->ToString(env->isolate()),
-                             BUFFER);
+    encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
   unsigned char md_value[EVP_MAX_MD_SIZE];
@@ -4201,10 +4197,8 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
 
   unsigned int len = args.Length();
   enum encoding encoding = BUFFER;
-  if (len >= 2 && args[1]->IsString()) {
-    encoding = ParseEncoding(env->isolate(),
-                             args[1]->ToString(env->isolate()),
-                             BUFFER);
+  if (len >= 2) {
+    encoding = ParseEncoding(env->isolate(), args[1], BUFFER);
   }
 
   node::Utf8Value passphrase(env->isolate(), args[2]);
@@ -4452,9 +4446,7 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
 
   enum encoding encoding = UTF8;
   if (args.Length() >= 3) {
-    encoding = ParseEncoding(env->isolate(),
-                             args[2]->ToString(env->isolate()),
-                             UTF8);
+    encoding = ParseEncoding(env->isolate(), args[2], UTF8);
   }
 
   ssize_t hlen = StringBytes::Size(env->isolate(), args[1], encoding);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3797,6 +3797,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {
+    CHECK(args[0]->IsString());
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
@@ -3919,6 +3920,7 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
 
   enum encoding encoding = BUFFER;
   if (args.Length() >= 1) {
+    CHECK(args[0]->IsString());
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 

--- a/test/parallel/test-regress-GH-9819.js
+++ b/test/parallel/test-regress-GH-9819.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const execFile = require('child_process').execFile;
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+const setup = 'const enc = { toString: () => { throw new Error("xyz"); } };';
+
+const scripts = [
+  'crypto.createHash("sha256").digest(enc)',
+  'crypto.createHmac("sha256", "msg").digest(enc)'
+];
+
+scripts.forEach((script) => {
+  const node = process.execPath;
+  const code = setup + ';' + script;
+  execFile(node, [ '-e', code ], common.mustCall((err, stdout, stderr) => {
+    assert(stderr.includes('Error: xyz'), 'digest crashes');
+  }));
+});


### PR DESCRIPTION
`Hash.digest()` and `Hmac.digest()` lead to a segmentation fault if an error was thrown while converting the encoding parameter to a string, see #9819. As discussed there, we could alternatively handle errors in `crypto.cc` or drop support for `toString()` (which is consistent with other core APIs, see #9819 again).

Fixes: https://github.com/nodejs/node/issues/9819

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
crypto

---

I prepared a regression test as well but refrained from committing it as it might promote the use of `toString()` for the encoding parameter, which we might decide not to support in the future.

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
