### PR TITLE
assert.doesNotThrow, show error message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -546,7 +546,10 @@ function innerThrows(shouldThrow, block, expected, message) {
   } else if (actual !== undefined) {
     if (!expected || expectedException(actual, expected)) {
       details = message ? `: ${message}` : '.';
-      fail(actual, expected, `Got unwanted exception${details}`, fail);
+      fail(actual,
+           expected,
+           `Got unwanted exception${details}\n${actual.message}`,
+           fail);
     }
     throw actual;
   }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -468,6 +468,34 @@ assert.throws(() => {
 }, /Got unwanted exception: user message/,
               'a.doesNotThrow ignores user message');
 
+{
+  let threw = false;
+  try {
+    assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
+  } catch (e) {
+    threw = true;
+    common.expectsError({
+      code: 'ERR_ASSERTION',
+      message: /Got unwanted exception: user message\n\[object Object\]/
+    })(e);
+  }
+  assert.ok(threw);
+}
+
+{
+  let threw = false;
+  try {
+    assert.doesNotThrow(makeBlock(thrower, Error));
+  } catch (e) {
+    threw = true;
+    common.expectsError({
+      code: 'ERR_ASSERTION',
+      message: /Got unwanted exception\.\n\[object Object\]/
+    })(e);
+  }
+  assert.ok(threw);
+}
+
 // make sure that validating using constructor really works
 {
   let threw = false;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

As mentioned in #12079 `doesNotThrow` doesn't show actual error message but shows **Got unwanted error** which is not really helpful. As @mscdex said it will be better to show actual error message so this is what I have done here. `parallel/test-assert.js` also was changed a bit. 

I hope it will be helpful. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
