### PR TITLE
benchmark: replace [].join() with ''.repeat()

### DIFF
--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -40,11 +40,11 @@ function main(conf) {
   var encoding;
   switch (conf.type) {
     case 'asc':
-      message = new Array(conf.len + 1).join('a');
+      message = 'a'.repeat(conf.len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = new Array(conf.len / 2 + 1).join('ü');
+      message = 'ü'.repeat(conf.len / 2);
       encoding = 'utf8';
       break;
     case 'buf':

--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -25,11 +25,11 @@ function main(conf) {
   var encoding;
   switch (conf.type) {
     case 'asc':
-      message = new Array(conf.len + 1).join('a');
+      message = 'a'.repeat(conf.len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = new Array(conf.len / 2 + 1).join('ü');
+      message = 'ü'.repeat(conf.len / 2);
       encoding = 'utf8';
       break;
     case 'buf':

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -24,11 +24,11 @@ function main(conf) {
   var encoding;
   switch (conf.type) {
     case 'asc':
-      message = new Array(conf.len + 1).join('a');
+      message = 'a'.repeat(conf.len);
       encoding = 'ascii';
       break;
     case 'utf':
-      message = new Array(conf.len / 2 + 1).join('ü');
+      message = 'ü'.repeat(conf.len / 2);
       encoding = 'utf8';
       break;
     case 'buf':

--- a/benchmark/es/string-repeat.js
+++ b/benchmark/es/string-repeat.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common.js');
+
+const configs = {
+  n: [1e3],
+  mode: ['Array', 'repeat'],
+  encoding: ['ascii', 'utf8'],
+  size: [1e1, 1e3, 1e6],
+};
+
+const bench = common.createBenchmark(main, configs);
+
+function main(conf) {
+  const n = +conf.n;
+  const size = +conf.size;
+  const character = conf.encoding === 'ascii' ? 'a' : '\ud83d\udc0e'; // '🐎'
+
+  let str;
+
+  if (conf.mode === 'Array') {
+    bench.start();
+    for (let i = 0; i < n; i++)
+      str = new Array(size + 1).join(character);
+    bench.end(n);
+  } else {
+    bench.start();
+    for (let i = 0; i < n; i++)
+      str = character.repeat(size);
+    bench.end(n);
+  }
+
+  assert.strictEqual([...str].length, size);
+}

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -24,11 +24,11 @@ function main(conf) {
       chunk = Buffer.alloc(size, 'b');
       break;
     case 'asc':
-      chunk = new Array(size + 1).join('a');
+      chunk = 'a'.repeat(size);
       encoding = 'ascii';
       break;
     case 'utf':
-      chunk = new Array(Math.ceil(size / 2) + 1).join('ü');
+      chunk = 'ü'.repeat(Math.ceil(size / 2));
       encoding = 'utf8';
       break;
     default:

--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -23,10 +23,10 @@ function main(conf) {
       break;
     case 'utf':
       encoding = 'utf8';
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
-      chunk = new Array(len + 1).join('a');
+      chunk = 'a'.repeat(len);
       break;
   }
 

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -26,10 +26,10 @@ function main(conf) {
       chunk = Buffer.alloc(len, 'x');
       break;
     case 'utf':
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
-      chunk = new Array(len + 1).join('a');
+      chunk = 'a'.repeat(len);
       break;
   }
 

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -27,11 +27,11 @@ function main(conf) {
       break;
     case 'utf':
       encoding = 'utf8';
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
       encoding = 'ascii';
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -27,11 +27,11 @@ function main(conf) {
       break;
     case 'utf':
       encoding = 'utf8';
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
       encoding = 'ascii';
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -27,11 +27,11 @@ function main(conf) {
       break;
     case 'utf':
       encoding = 'utf8';
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
       encoding = 'ascii';
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -27,11 +27,11 @@ function main(conf) {
       break;
     case 'utf':
       encoding = 'utf8';
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
       encoding = 'ascii';
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -83,10 +83,10 @@ function client() {
       chunk = Buffer.alloc(len, 'x');
       break;
     case 'utf':
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -80,10 +80,10 @@ function client() {
       chunk = Buffer.alloc(len, 'x');
       break;
     case 'utf':
-      chunk = new Array(len / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(len / 2);
       break;
     case 'asc':
-      chunk = new Array(len + 1).join('x');
+      chunk = 'x'.repeat(len);
       break;
     default:
       throw new Error('invalid type: ' + type);

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -54,10 +54,10 @@ function server() {
         chunk = Buffer.alloc(len, 'x');
         break;
       case 'utf':
-        chunk = new Array(len / 2 + 1).join('ü');
+        chunk = 'ü'.repeat(len / 2);
         break;
       case 'asc':
-        chunk = new Array(len + 1).join('x');
+        chunk = 'x'.repeat(len);
         break;
       default:
         throw new Error('invalid type: ' + type);

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -26,11 +26,11 @@ function main(conf) {
       chunk = Buffer.alloc(size, 'b');
       break;
     case 'asc':
-      chunk = new Array(size + 1).join('a');
+      chunk = 'a'.repeat(size);
       encoding = 'ascii';
       break;
     case 'utf':
-      chunk = new Array(size / 2 + 1).join('ü');
+      chunk = 'ü'.repeat(size / 2);
       encoding = 'utf8';
       break;
     default:


### PR DESCRIPTION
##### Checklist
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
benchmark

This change is mostly for readability as the edited fragments are not performance-wise concerned. However, a benchmark to compare both ways of long string creation is added to be on the safe side.

Results of the added benchmark with the last `node.8.0.0-nightly20170402`
```
es\string-repeat.js size=10 encoding="ascii" mode="Array" n=1000: 290,692.60419876396
es\string-repeat.js size=1000 encoding="ascii" mode="Array" n=1000: 102,836.05382685862
es\string-repeat.js size=1000000 encoding="ascii" mode="Array" n=1000: 135.32093280569134

es\string-repeat.js size=10 encoding="utf8" mode="Array" n=1000: 288,349.3871854649
es\string-repeat.js size=1000 encoding="utf8" mode="Array" n=1000: 94,707.65121331392
es\string-repeat.js size=1000000 encoding="utf8" mode="Array" n=1000: 115.63063143181027

es\string-repeat.js size=10 encoding="ascii" mode="repeat" n=1000: 1,551,397.8094262932
es\string-repeat.js size=1000 encoding="ascii" mode="repeat" n=1000: 695,483.8063550529
es\string-repeat.js size=1000000 encoding="ascii" mode="repeat" n=1000: 467,033.2877975878

es\string-repeat.js size=10 encoding="utf8" mode="repeat" n=1000: 1,659,899.8084475622
es\string-repeat.js size=1000 encoding="utf8" mode="repeat" n=1000: 661,734.5385725063
es\string-repeat.js size=1000000 encoding="utf8" mode="repeat" n=1000: 455,820.924368369
```
[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
