### PR TITLE
build: add checks for openssl configure options

### DIFF
--- a/configure
+++ b/configure
@@ -977,8 +977,18 @@ def configure_openssl(o):
 
 
   if options.without_ssl:
+    if options.shared_openssl:
+      withoutSSLError('--shared-openssl')
+    if options.openssl_no_asm:
+      withoutSSLError('--openssl-no-asm')
+    if options.openssl_fips:
+      withoutSSLError('--openssl-fips')
     return
   configure_library('openssl', o)
+
+def withoutSSLError(option):
+  print('Error: --without-ssl is incompatible with %s' % option)
+  exit(1);
 
 
 def configure_static(o):

--- a/configure
+++ b/configure
@@ -988,7 +988,7 @@ def configure_openssl(o):
 
 def withoutSSLError(option):
   print('Error: --without-ssl is incompatible with %s' % option)
-  exit(1);
+  exit(1)
 
 
 def configure_static(o):

--- a/configure
+++ b/configure
@@ -977,18 +977,18 @@ def configure_openssl(o):
 
 
   if options.without_ssl:
+    def without_ssl_error(option):
+      print('Error: --without-ssl is incompatible with %s' % option)
+      exit(1)
     if options.shared_openssl:
-      withoutSSLError('--shared-openssl')
+      without_ssl_error('--shared-openssl')
     if options.openssl_no_asm:
-      withoutSSLError('--openssl-no-asm')
+      without_ssl_error('--openssl-no-asm')
     if options.openssl_fips:
-      withoutSSLError('--openssl-fips')
+      without_ssl_error('--openssl-fips')
     return
   configure_library('openssl', o)
 
-def withoutSSLError(option):
-  print('Error: --without-ssl is incompatible with %s' % option)
-  exit(1)
 
 
 def configure_static(o):

--- a/configure
+++ b/configure
@@ -990,7 +990,6 @@ def configure_openssl(o):
   configure_library('openssl', o)
 
 
-
 def configure_static(o):
   if options.fully_static or options.partly_static:
     if flavor == 'mac':


### PR DESCRIPTION
Currently it is possible to configure using --without-ssl and
--shared-openssl/--openssl-no-asm/openssl-fips without an error
occuring.

The commit add check for these combinations:
```console
$ ./configure --without-ssl --shared-openssl
Error: --without-ssl is incompatible with --shared-openssl
```
```console
$ ./configure --without-ssl --openssl-no-asm
Error: --without-ssl is incompatible with --openssl-no-asm
```

```console
$ ./configure --without-ssl --openssl-fips=dummy
Error: --without-ssl is incompatible with --openssl-fips
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
