### PR TITLE
build: make configure print statements consistent

### DIFF
--- a/configure
+++ b/configure
@@ -1045,15 +1045,15 @@ def configure_intl(o):
         if nodedownload.candownload(auto_downloads, "icu"):
           nodedownload.retrievefile(url, targetfile)
       else:
-        print(' Re-using existing %s' % targetfile)
+        print('Re-using existing %s' % targetfile)
       if os.path.isfile(targetfile):
         sys.stdout.write(' Checking file integrity with MD5:\r')
         gotmd5 = nodedownload.md5sum(targetfile)
-        print(' MD5:      %s  %s' % (gotmd5, targetfile))
+        print('MD5:      %s  %s' % (gotmd5, targetfile))
         if (md5 == gotmd5):
           return targetfile
         else:
-          print(' Expected: %s      *MISMATCH*' % md5)
+          print('Expected: %s      *MISMATCH*' % md5)
           print('\n ** Corrupted ZIP? Delete %s to retry download.\n' % targetfile)
     return None
   icu_config = {
@@ -1191,7 +1191,7 @@ def configure_intl(o):
         os.rename(tmp_icu, icu_full_path)
         shutil.rmtree(icu_tmp_path)
       else:
-        print(' Error: --with-icu-source=%s did not result in an "icu" dir.' % \
+        print('Error: --with-icu-source=%s did not result in an "icu" dir.' % \
                with_icu_source)
         shutil.rmtree(icu_tmp_path)
         sys.exit(1)
@@ -1207,8 +1207,8 @@ def configure_intl(o):
     if localzip:
       nodedownload.unpack(localzip, icu_parent_path)
   if not os.path.isdir(icu_full_path):
-    print(' Cannot build Intl without ICU in %s.' % icu_full_path)
-    print(' (Fix, or disable with "--with-intl=none" )')
+    print('Cannot build Intl without ICU in %s.' % icu_full_path)
+    print('(Fix, or disable with "--with-intl=none" )')
     sys.exit(1)
   else:
     print('* Using ICU in %s' % icu_full_path)
@@ -1216,7 +1216,7 @@ def configure_intl(o):
   # uvernum.h contains it as a #define.
   uvernum_h = os.path.join(icu_full_path, 'source/common/unicode/uvernum.h')
   if not os.path.isfile(uvernum_h):
-    print(' Error: could not load %s - is ICU installed?' % uvernum_h)
+    print('Error: could not load %s - is ICU installed?' % uvernum_h)
     sys.exit(1)
   icu_ver_major = None
   matchVerExp = r'^\s*#define\s+U_ICU_VERSION_SHORT\s+"([^"]*)".*'
@@ -1226,7 +1226,7 @@ def configure_intl(o):
     if m:
       icu_ver_major = m.group(1)
   if not icu_ver_major:
-    print(' Could not read U_ICU_VERSION_SHORT version from %s' % uvernum_h)
+    print('Could not read U_ICU_VERSION_SHORT version from %s' % uvernum_h)
     sys.exit(1)
   icu_endianness = sys.byteorder[0];
   o['variables']['icu_ver_major'] = icu_ver_major
@@ -1253,8 +1253,8 @@ def configure_intl(o):
   # this is the icudt*.dat file which node will be using (platform endianness)
   o['variables']['icu_data_file'] = icu_data_file
   if not os.path.isfile(icu_data_path):
-    print(' Error: ICU prebuilt data file %s does not exist.' % icu_data_path)
-    print(' See the README.md.')
+    print('Error: ICU prebuilt data file %s does not exist.' % icu_data_path)
+    print('See the README.md.')
     # .. and we're not about to build it from .gyp!
     sys.exit(1)
   # map from variable name to subdirs

--- a/configure
+++ b/configure
@@ -1047,7 +1047,7 @@ def configure_intl(o):
       else:
         print('Re-using existing %s' % targetfile)
       if os.path.isfile(targetfile):
-        sys.stdout.write(' Checking file integrity with MD5:\r')
+        sys.stdout.write('Checking file integrity with MD5:\r')
         gotmd5 = nodedownload.md5sum(targetfile)
         print('MD5:      %s  %s' % (gotmd5, targetfile))
         if (md5 == gotmd5):

--- a/configure
+++ b/configure
@@ -1047,7 +1047,7 @@ def configure_intl(o):
       else:
         print('Re-using existing %s' % targetfile)
       if os.path.isfile(targetfile):
-        sys.stdout.write('Checking file integrity with MD5:\r')
+        print('Checking file integrity with MD5:\r')
         gotmd5 = nodedownload.md5sum(targetfile)
         print('MD5:      %s  %s' % (gotmd5, targetfile))
         if (md5 == gotmd5):


### PR DESCRIPTION
I noticed that few of the print statements in configure have a leading
space with is not consistent with the rest of the file. Not sure if
this intentional or not so creating this commit just to bring it up
just in case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
