### PR TITLE
doc: path functions ignore trailing slashes

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -68,7 +68,8 @@ changes:
 * Returns: {string}
 
 The `path.basename()` methods returns the last portion of a `path`, similar to
-the Unix `basename` command.
+the Unix `basename` command. Conforming to Posix standards, trailing `/`
+characters are not counted as part of the pathname.
 
 For example:
 
@@ -128,7 +129,8 @@ changes:
 * Returns: {string}
 
 The `path.dirname()` method returns the directory name of a `path`, similar to
-the Unix `dirname` command.
+the Unix `dirname` command. Conforming to Posix standards, trailing `/`
+characters are not counted as part of the pathname.
 
 For example:
 
@@ -347,7 +349,8 @@ added: v0.11.15
 * Returns: {Object}
 
 The `path.parse()` method returns an object whose properties represent
-significant elements of the `path`.
+significant elements of the `path`. Note that trailing `/` characters are not
+counted as part of the pathname and therefore ignored.
 
 The returned object will have the following properties:
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -68,8 +68,8 @@ changes:
 * Returns: {string}
 
 The `path.basename()` methods returns the last portion of a `path`, similar to
-the Unix `basename` command. Conforming to Posix standards, trailing `/`
-characters are not counted as part of the pathname.
+the Unix `basename` command. Trailing `/` (and `\\` on Windows) characters are
+ignored.
 
 For example:
 
@@ -129,8 +129,8 @@ changes:
 * Returns: {string}
 
 The `path.dirname()` method returns the directory name of a `path`, similar to
-the Unix `dirname` command. Conforming to Posix standards, trailing `/`
-characters are not counted as part of the pathname.
+the Unix `dirname` command. Trailing `/` (and `\\` on Windows) characters are
+ignored.
 
 For example:
 
@@ -349,8 +349,8 @@ added: v0.11.15
 * Returns: {Object}
 
 The `path.parse()` method returns an object whose properties represent
-significant elements of the `path`. Note that trailing `/` characters are not
-counted as part of the pathname and therefore ignored.
+significant elements of the `path`. Trailing `/` (and `\\` on Windows)
+characters are ignored.
 
 The returned object will have the following properties:
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -68,8 +68,8 @@ changes:
 * Returns: {string}
 
 The `path.basename()` methods returns the last portion of a `path`, similar to
-the Unix `basename` command. Trailing `/` (and `\\` on Windows) characters are
-ignored.
+the Unix `basename` command. Trailing directory separators are ignored, see
+[`path.sep`][].
 
 For example:
 
@@ -129,8 +129,8 @@ changes:
 * Returns: {string}
 
 The `path.dirname()` method returns the directory name of a `path`, similar to
-the Unix `dirname` command. Trailing `/` (and `\\` on Windows) characters are
-ignored.
+the Unix `dirname` command. Trailing directory separators are ignored, see
+[`path.sep`][].
 
 For example:
 
@@ -349,8 +349,8 @@ added: v0.11.15
 * Returns: {Object}
 
 The `path.parse()` method returns an object whose properties represent
-significant elements of the `path`. Trailing `/` (and `\\` on Windows)
-characters are ignored.
+significant elements of the `path`. Trailing directory separators are ignored,
+see [`path.sep`][].
 
 The returned object will have the following properties:
 
@@ -526,6 +526,11 @@ On Windows:
 // Returns: ['foo', 'bar', 'baz']
 ```
 
+*Note*: On Windows, both the forward slash (`/`) and backward slash (`\`) are
+accepted as path segment separators; however, if separators are to be added by
+Windows-specific implementations of the `path` methods, only the backward slash
+(`\`) will be used.
+
 ## path.win32
 <!-- YAML
 added: v0.11.15
@@ -536,11 +541,8 @@ added: v0.11.15
 The `path.win32` property provides access to Windows-specific implementations
 of the `path` methods.
 
-*Note*: On Windows, both the forward slash (`/`) and backward slash (`\`)
-characters are accepted as path delimiters; however, only the backward slash
-(`\`) will be used in return values.
-
 [`path.posix`]: #path_path_posix
+[`path.sep`]: #path_path_sep
 [`path.win32`]: #path_path_win32
 [`path.parse()`]: #path_path_parse_path
 [`TypeError`]: errors.html#errors_class_typeerror

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -527,9 +527,8 @@ On Windows:
 ```
 
 *Note*: On Windows, both the forward slash (`/`) and backward slash (`\`) are
-accepted as path segment separators; however, if separators are to be added by
-Windows-specific implementations of the `path` methods, only the backward slash
-(`\`) will be used.
+accepted as path segment separators; however, the `path` methods only add
+backward slashes (`\`).
 
 ## path.win32
 <!-- YAML


### PR DESCRIPTION
Add notes about path.parse(), path.basename() and path.dirname() ignoring trailing slashes as suggested by @bnoordhuis at #6229.

Refs: https://github.com/nodejs/node/issues/6229

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
