### PR TITLE
Implement assert.isInstanceOf()

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -303,13 +303,15 @@ assert.ifError(new Error());
 
 ## assert.isInstanceOf(obj, constructor, message)
 <!-- YAML
-added: v7.8.1
+added: REPLACEME
 -->
 * `obj` {any}
 * `constructor` {function}
 * `message` {string}
 
-Throws an `AssertionError` if `obj` is not instance of constructor.
+Throws an `AssertionError` if `obj` is not instance of constructor. Tests
+whether an object has in its prototype chain the prototype property of a
+constructor.
 
 ```js
 const assert = require('assert');

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -301,6 +301,38 @@ assert.ifError(new Error());
 // Throws Error
 ```
 
+## assert.isInstanceOf(obj, constructor, message)
+<!-- YAML
+added: v7.8.1
+-->
+* `obj` {any}
+* `constructor` {function}
+* `message` {string}
+
+Throws an `AssertionError` if `obj` is not instance of constructor.
+
+```js
+const assert = require('assert');
+
+assert.isInstanceOf([ ], Array);
+// OK
+assert.isInstanceOf(new Array(), Array);
+// OK
+assert.isInstanceOf(new Constructor1(), Constructor1);
+// OK
+
+assert.isInstanceOf(null, Constructor1);
+// Throws AssertionError
+assert.isInstanceOf(undefined, Constructor1);
+// Throws AssertionError
+assert.isInstanceOf(1, Constructor1);
+// Throws AssertionError
+assert.isInstanceOf(true, Constructor1);
+// Throws AssertionError
+assert.isInstanceOf('hello', Constructor1);
+// Throws AssertionError
+```
+
 ## assert.notDeepEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -553,15 +553,6 @@ assert.isInstanceOf = function isInstanceOf(obj, constructor, message) {
   if (typeof constructor !== 'function') {
     throw new TypeError('Constructor must be a function');
   }
-  if (isNullOrNonObj(obj)) {
-    fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
-  }
-  if (constructor === Array) {
-    if (!Array.isArray(obj)) {
-      fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
-    }
-    return;
-  }
   if (!(obj instanceof constructor)) {
     fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -548,3 +548,21 @@ function doesNotThrow(block, /*optional*/error, /*optional*/message) {
 }
 
 assert.ifError = function ifError(err) { if (err) throw err; };
+
+assert.isInstanceOf = function isInstanceOf(obj, constructor, message) {
+  if (typeof constructor !== 'function') {
+    throw new TypeError('Constructor must be a function');
+  }
+  if (isNullOrNonObj(obj)) {
+    fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
+  }
+  if (constructor === Array) {
+    if (!Array.isArray(obj)) {
+      fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
+    }
+    return;
+  }
+  if (!(obj instanceof constructor)) {
+    fail(obj, constructor, message, 'instanceof', assert.isInstanceOf);
+  }
+};

--- a/test/parallel/test-assert-isinstanceof.js
+++ b/test/parallel/test-assert-isinstanceof.js
@@ -1,0 +1,41 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+function Constructor1() {}
+
+function Constructor2() {
+  Constructor1.call(this);
+}
+util.inherits(Constructor2, Constructor1);
+
+// First parameter must be an object instance
+assert.throws(() => assert.isInstanceOf(undefined, Constructor1),
+              assert.AssertionError);
+assert.throws(() => assert.isInstanceOf(null, Array),
+              assert.AssertionError);
+assert.throws(() => assert.isInstanceOf(null, Constructor1),
+              assert.AssertionError);
+assert.throws(() => assert.isInstanceOf(1, Constructor1),
+              assert.AssertionError);
+assert.throws(() => assert.isInstanceOf(true, Constructor1),
+              assert.AssertionError);
+assert.throws(() => assert.isInstanceOf(() => {}, Constructor1),
+              assert.AssertionError);
+// Second parameter must be a function
+assert.throws(() => assert.isInstanceOf([], null), TypeError);
+// Object must be an instance of
+assert.throws(() => assert.isInstanceOf({}, Constructor1),
+              assert.AssertionError);
+
+// Correct usage
+assert.doesNotThrow(() => assert.isInstanceOf(new Array(), Array));
+assert.doesNotThrow(() => assert.isInstanceOf([ ], Array));
+assert.doesNotThrow(() => assert.isInstanceOf([ 1 ], Array));
+assert.doesNotThrow(() => assert.isInstanceOf(new Constructor1(),
+                                              Constructor1));
+assert.doesNotThrow(() => assert.isInstanceOf(new Constructor2(),
+                                              Constructor1));
+assert.doesNotThrow(() => assert.isInstanceOf(new Constructor2(),
+                                              Constructor2));


### PR DESCRIPTION
Introduce `isInstanceOf(obj, constructor, message)` function in the assert module that validates
that the provided instance is an Object and it's an instance of the provided
constructor.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

assert

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
