### PR TITLE
Fix building on Windows x86

### DIFF
--- a/deps/v8/src/v8.gyp
+++ b/deps/v8/src/v8.gyp
@@ -1741,7 +1741,7 @@
           # When building Official, the .lib is too large and exceeds the 2G
           # limit. This breaks it into multiple pieces to avoid the limit.
           # See http://crbug.com/485155.
-          'msvs_shard': 4,
+          'msvs_shard': 10,
         }],
         ['component=="shared_library"', {
           'defines': [

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -190,9 +190,11 @@ echo Project files generated.
 if defined nobuild goto sign
 
 @rem Build the sln with msbuild.
+set "msbcpu=/m:2"
+if "%NUMBER_OF_PROCESSORS%"=="1" set "msbcpu=/m:1"
 set "msbplatform=Win32"
 if "%target_arch%"=="x64" set "msbplatform=x64"
-msbuild node.sln /m /t:%target% /p:Configuration=%config% /p:Platform=%msbplatform% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
+msbuild node.sln %msbcpu% /t:%target% /p:Configuration=%config% /p:Platform=%msbplatform% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 if errorlevel 1 goto exit
 if "%target%" == "Clean" goto exit
 


### PR DESCRIPTION
Building on Windows x86 has been broken on master since the update of V8 to 5.7 (https://github.com/nodejs/node/issues/11752, https://github.com/nodejs/v8/issues/4, https://github.com/nodejs/build/issues/669). This was not detected at the time because the CI matrix does not include a 32 bit build (which I plan to add after this lands).

When building V8 with Gyp, the library `v8_base` is divided into several shards because [its size exceeds the limit](https://github.com/nodejs/node/blob/2d039ffa29e4c4366a1028555b71cb36b7129fb1/deps/v8/src/v8.gyp#L1741-L1744). For each shard, a single `cl.exe` invocation is used to compile all `.cc` files into `.obj` files. In this invocation, some functions from `runtime.cc` are not getting compiled into `runtime.obj`. Using `cl.exe` with all the same arguments but to compile only `runtime.cc` compiles all functions as expected. I was not yet able to determine what set of files interferes, but none of the other files compiled alone with `runtime.cc` causes the problem. This seems to happens only when a big set of files (>110) is compiled simultaneously.

This might have passed unnoticed in V8 upstream because ninja compiles every source file one at a time.

This PR increases the number of shards to divide v8_base into. This increases the number of calls to `cl.exe` but decreases the number of files compiled each time.

Fixes: https://github.com/nodejs/v8/issues/4

cc @nodejs/v8 @jasnell 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

Deps, V8, build, Windows.