### PR TITLE
napi: break dep between v8 and napi attributes

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -26,7 +26,7 @@ napi_env JsEnvFromV8Isolate(v8::Isolate* isolate) {
 }
 
 // convert from n-api property attributes to v8::PropertyAttribute
-v8::PropertyAttribute V8PropertyAttributesFromAttributes(
+static inline v8::PropertyAttribute V8PropertyAttributesFromAttributes(
     napi_property_attributes attributes) {
   unsigned int attribute_flags = v8::None;
   if (attributes & napi_read_only) {

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -741,8 +741,19 @@ napi_status napi_define_class(napi_env env,
     v8::Local<v8::String> property_name;
     CHECK_NEW_FROM_UTF8(isolate, property_name, p->utf8name);
 
+    // convert the properties from NAPI to v8 format
+    unsigned int attribute_flags = v8::None;
+    if ((p->attributes & napi_read_only)) {
+      attribute_flags |= v8::ReadOnly;
+    }
+    if ((p->attributes & napi_dont_enum)) {
+      attribute_flags |= v8::DontEnum;
+    }
+    if ((p->attributes & napi_dont_delete)) {
+      attribute_flags |= v8::DontDelete;
+    }
     v8::PropertyAttribute attributes =
-        static_cast<v8::PropertyAttribute>(p->attributes);
+        static_cast<v8::PropertyAttribute>(attribute_flags);
 
     // This code is similar to that in napi_define_property(); the
     // difference is it applies to a template instead of an object.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -25,6 +25,22 @@ napi_env JsEnvFromV8Isolate(v8::Isolate* isolate) {
   return reinterpret_cast<napi_env>(isolate);
 }
 
+// convert from n-api property attributes to v8::PropertyAttribute
+v8::PropertyAttribute V8PropertyAttributesFromAttributes(
+    napi_property_attributes attributes) {
+  unsigned int attribute_flags = v8::None;
+  if (attributes & napi_read_only) {
+    attribute_flags |= v8::ReadOnly;
+  }
+  if (attributes & napi_dont_enum) {
+    attribute_flags |= v8::DontEnum;
+  }
+  if (attributes & napi_dont_delete) {
+    attribute_flags |= v8::DontDelete;
+  }
+  return static_cast<v8::PropertyAttribute>(attribute_flags);
+}
+
 v8::Isolate* V8IsolateFromJsEnv(napi_env e) {
   return reinterpret_cast<v8::Isolate*>(e);
 }
@@ -740,20 +756,8 @@ napi_status napi_define_class(napi_env env,
 
     v8::Local<v8::String> property_name;
     CHECK_NEW_FROM_UTF8(isolate, property_name, p->utf8name);
-
-    // convert the properties from NAPI to v8 format
-    unsigned int attribute_flags = v8::None;
-    if ((p->attributes & napi_read_only)) {
-      attribute_flags |= v8::ReadOnly;
-    }
-    if ((p->attributes & napi_dont_enum)) {
-      attribute_flags |= v8::DontEnum;
-    }
-    if ((p->attributes & napi_dont_delete)) {
-      attribute_flags |= v8::DontDelete;
-    }
     v8::PropertyAttribute attributes =
-        static_cast<v8::PropertyAttribute>(attribute_flags);
+        v8impl::V8PropertyAttributesFromAttributes(p->attributes);
 
     // This code is similar to that in napi_define_property(); the
     // difference is it applies to a template instead of an object.
@@ -1062,8 +1066,9 @@ napi_status napi_define_properties(napi_env env,
     v8::Local<v8::Name> name;
     CHECK_NEW_FROM_UTF8(isolate, name, p->utf8name);
 
-    v8::PropertyAttribute attributes = static_cast<v8::PropertyAttribute>(
-        p->attributes & ~napi_static_property);
+    v8::PropertyAttribute attributes =
+        v8impl::V8PropertyAttributesFromAttributes(
+            (napi_property_attributes)(p->attributes & ~napi_static_property));
 
     if (p->method) {
       v8::Local<v8::Object> cbdata =


### PR DESCRIPTION
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
napi

The v8 napi implementation had been depending on a one-to-one
relationship between v8 and napi v8 property attributes.
Remove this dependency and fix coverity scan issue
165845 related to mixing enums.