### PR TITLE
napi: supress invalid coverity leak message

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2274,6 +2274,10 @@ napi_status napi_create_external_buffer(napi_env env,
 
   *result = v8impl::JsValueFromV8LocalValue(maybe.ToLocalChecked());
   return GET_RETURN_STATUS();
+  // Tell coverity that 'finalizer' should not be freed when we return
+  // as it will be deleted when the buffer to which it is associated
+  // is finalized.
+  // coverity[leaked_storage]
 }
 
 napi_status napi_create_buffer_copy(napi_env env,


### PR DESCRIPTION
Coverity was complaining that finalizer was being
leaked in this method, however it should be
freed when the buffer is finalized so I believe
the message is invalid.

I don't think we can test this locally, but based on
some googling and looking were the same comment
is used in src/node.cc I think this should do the trick.

Add the required comments to suppress the warning.

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
napi
