### PR TITLE
benchmark: use object literal shorthands

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -230,7 +230,7 @@ Benchmark.prototype.report = function(rate, elapsed) {
   sendResult({
     name: this.name,
     conf: this.config,
-    rate: rate,
+    rate,
     time: elapsed[0] + elapsed[1] / 1e9,
     type: 'report'
   });

--- a/benchmark/es/object-shorthands.js
+++ b/benchmark/es/object-shorthands.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common.js');
+
+const configs = {
+  n: [1e4],
+  mode: ['full', 'short'],
+  subject: ['properties', 'methods'],
+};
+
+const bench = common.createBenchmark(main, configs);
+
+function main(conf) {
+  const n = +conf.n;
+
+  let obj;
+
+  if (conf.mode === 'properties') {
+    const a = 'a';
+    const b = 1;
+    const c = {};
+    const d = () => {};
+
+    if (conf.mode === 'full') {
+      bench.start();
+      for (let i = 0; i < n; i++)
+        obj = { a: a, b: b, c: c, d: d };
+      bench.end(n);
+    } else {
+      bench.start();
+      for (let i = 0; i < n; i++)
+        obj = { a, b, c, d };
+      bench.end(n);
+    }
+  } else {
+    if (conf.mode === 'full') {
+      bench.start();
+      for (let i = 0; i < n; i++)
+        obj = {
+          a: function a() {},
+          b: function b() {},
+          c: function c() {},
+          d: function d() {},
+        };
+      bench.end(n);
+    } else {
+      bench.start();
+      for (let i = 0; i < n; i++)
+        obj = {
+          a() {},
+          b() {},
+          c() {},
+          d() {},
+        };
+      bench.end(n);
+    }
+  }
+
+  return obj;
+}

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -40,7 +40,7 @@ function runTest() {
   assert(fs.statSync(filename).size === filesize);
   var rs = fs.createReadStream(filename, {
     highWaterMark: size,
-    encoding: encoding
+    encoding
   });
 
   rs.on('open', function() {

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -29,7 +29,7 @@ function main(conf) {
       var path = '/' + conf.type + '/' + conf.length;
 
       bench.http({
-        path: path,
+        path,
         connections: conf.c
       }, function() {
         w1.destroy();

--- a/benchmark/http/create-clientrequest.js
+++ b/benchmark/http/create-clientrequest.js
@@ -13,7 +13,7 @@ function main(conf) {
   var n = +conf.n;
 
   var path = '/'.repeat(pathlen);
-  var opts = { path: path, createConnection: function() {} };
+  var opts = { path, createConnection() {} };
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -19,7 +19,7 @@ function main(conf) {
                conf.res;
 
     bench.http({
-      path: path,
+      path,
       connections: conf.c
     }, function() {
       server.close();

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -23,7 +23,7 @@ function main(conf) {
   for (var i = 0; i < conf.type.length * 10; i += 1)
     fn({}, process.env);
 
-  var obj = new Proxy({}, { set: function(a, b, c) { return true; } });
+  var obj = new Proxy({}, { set(a, b, c) { return true; } });
 
   bench.start();
   for (var j = 0; j < n; j += 1)

--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -26,10 +26,10 @@ load('navier-stokes.js');
 const benchmark_name = path.join('misc', 'v8-bench.js');
 const times = {};
 global.BenchmarkSuite.RunSuites({
-  NotifyStart: function(name) {
+  NotifyStart(name) {
     times[name] = process.hrtime();
   },
-  NotifyResult: function(name, result) {
+  NotifyResult(name, result) {
     const elapsed = process.hrtime(times[name]);
     common.sendResult({
       name: benchmark_name,
@@ -40,10 +40,10 @@ global.BenchmarkSuite.RunSuites({
       time: elapsed[0] + elapsed[1] / 1e9
     });
   },
-  NotifyError: function(name, error) {
+  NotifyError(name, error) {
     console.error(name + ': ' + error);
   },
-  NotifyScore: function(score) {
+  NotifyScore(score) {
     common.sendResult({
       name: benchmark_name,
       conf: {


### PR DESCRIPTION
##### Checklist
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
benchmark

For extra precaution, a benchmark to compare full and short notation is also added. It shows no significant degradation, if any could be with this change.

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
