### PR TITLE
build: don't test addons-napi twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ test-ci: | clear-stalled build-addons build-addons-napi
 	out/Release/cctest --gtest_output=tap:cctest.tap
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
-		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES) addons-napi $(CI_JS_SUITES)
+		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES) $(CI_JS_SUITES)
 	# Clean up any leftover processes, error if found.
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \


### PR DESCRIPTION
The addons-napi testsuite [is already included in $(CI_NATIVE_SUITES)](https://github.com/nodejs/node/blob/master/Makefile#L322), so
we don't need to manually specify it in the test-ci target as well.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

CI: https://ci.nodejs.org/job/node-test-commit/8866/ _**EDIT:**_ Windows failed
CI 2: https://ci.nodejs.org/job/node-test-commit/8867/
CI 3: https://ci.nodejs.org/job/node-test-commit/8939/
CI 4: https://ci.nodejs.org/job/node-test-commit/8984/