### PR TITLE
module: standardize strip shebang behaviour

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -447,8 +447,10 @@
     const vm = NativeModule.require('vm');
     const internalModule = NativeModule.require('internal/module');
 
-    // remove shebang and BOM
-    source = internalModule.stripBOM(source.replace(/^#!.*/, ''));
+    // remove Shebang
+    source = internalModule.stripShebang(source);
+    // remove BOM
+    source = internalModule.stripBOM(source);
     // wrap it
     source = Module.wrap(source);
     // compile the script, this will throw if it fails

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -3,6 +3,7 @@
 exports = module.exports = {
   makeRequireFunction,
   stripBOM,
+  stripShebang,
   addBuiltinLibsToObject
 };
 
@@ -46,6 +47,40 @@ function makeRequireFunction(mod) {
 function stripBOM(content) {
   if (content.charCodeAt(0) === 0xFEFF) {
     content = content.slice(1);
+  }
+  return content;
+}
+
+/**
+ * Find end of shebang line and slice it off
+ */
+function stripShebang(content) {
+  // Remove shebang
+  var contLen = content.length;
+  if (contLen >= 2) {
+    if (content.charCodeAt(0) === 35/*#*/ &&
+        content.charCodeAt(1) === 33/*!*/) {
+      if (contLen === 2) {
+        // Exact match
+        content = '';
+      } else {
+        // Find end of shebang line and slice it off
+        var i = 2;
+        for (; i < contLen; ++i) {
+          var code = content.charCodeAt(i);
+          if (code === 10/*\n*/ || code === 13/*\r*/)
+            break;
+        }
+        if (i === contLen)
+          content = '';
+        else {
+          // Note that this actually includes the newline character(s) in the
+          // new output. This duplicates the behavior of the regular expression
+          // that was previously used to replace the shebang line
+          content = content.slice(i);
+        }
+      }
+    }
   }
   return content;
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -537,33 +537,8 @@ var resolvedArgv;
 // the file.
 // Returns exception, if any.
 Module.prototype._compile = function(content, filename) {
-  // Remove shebang
-  var contLen = content.length;
-  if (contLen >= 2) {
-    if (content.charCodeAt(0) === 35/*#*/ &&
-        content.charCodeAt(1) === 33/*!*/) {
-      if (contLen === 2) {
-        // Exact match
-        content = '';
-      } else {
-        // Find end of shebang line and slice it off
-        var i = 2;
-        for (; i < contLen; ++i) {
-          var code = content.charCodeAt(i);
-          if (code === 10/*\n*/ || code === 13/*\r*/)
-            break;
-        }
-        if (i === contLen)
-          content = '';
-        else {
-          // Note that this actually includes the newline character(s) in the
-          // new output. This duplicates the behavior of the regular expression
-          // that was previously used to replace the shebang line
-          content = content.slice(i);
-        }
-      }
-    }
-  }
+
+  content = internalModule.stripShebang(content);
 
   // create wrapper function
   var wrapper = Module.wrap(content);


### PR DESCRIPTION
When loading a module, Node needs to finds the end of a shebang comment by searching for a ````\r```` or ````\n```` character. This behaviour is now standardized into a dedicated internal module function

Refs: https://github.com/nodejs/node/issues/12180

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
module
