### PR TITLE
repl: support hidden history file on Windows

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -164,10 +164,19 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       }
     }
 
-    fs.open(historyPath, 'w', onhandle);
+    fs.open(historyPath, 'r+', onhandle);
   }
 
   function onhandle(err, hnd) {
+    if (err) {
+      return ready(err);
+    }
+    fs.ftruncate(hnd, 0, (err) => {
+      return onftruncate(err, hnd);
+    });
+  }
+
+  function onftruncate(err, hnd) {
     if (err) {
       return ready(err);
     }

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -76,6 +76,8 @@ const oldHistoryPath = path.join(fixtures, 'old-repl-history-file.json');
 const enoentHistoryPath = path.join(fixtures, 'enoent-repl-history-file.json');
 const emptyHistoryPath = path.join(fixtures, '.empty-repl-history-file');
 const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
+const emptyHiddenHistoryPath = path.join(fixtures,
+                                         '.empty-hidden-repl-history-file');
 
 const tests = [
   {
@@ -162,6 +164,19 @@ const tests = [
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP],
     expected: [prompt, replFailedRead, prompt, replDisabled, prompt]
+  },
+  {
+    before: function before() {
+      if (common.isWindows) {
+        const execSync = require('child_process').execSync;
+        execSync(`ATTRIB +H "${emptyHiddenHistoryPath}"`, (err) => {
+          assert.ifError(err);
+        });
+      }
+    },
+    env: { NODE_REPL_HISTORY: emptyHiddenHistoryPath },
+    test: [UP],
+    expected: [prompt]
   },
   { // Make sure this is always the last test, since we change os.homedir()
     before: function before() {


### PR DESCRIPTION
On Windows when REPL history file has the hidden attribute node will fail when trying to open it in `w` mode. This changes the mode to `r+`. The file is guaranteed to exists because of earlier open call with `a+`.

Fixes: https://github.com/nodejs/node/issues/5261

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
repl
