### PR TITLE
crypto: only try to set FIPS mode if different

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6021,11 +6021,14 @@ void GetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
 void SetFipsCrypto(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 #ifdef NODE_FIPS_MODE
-  bool mode = args[0]->BooleanValue();
+  const bool enabled = FIPS_mode();
+  const bool enable = args[0]->BooleanValue();
+  if (enable == enabled)
+    return;  // No action needed.
   if (force_fips_crypto) {
     return env->ThrowError(
         "Cannot set FIPS mode, it was forced with --force-fips at startup.");
-  } else if (!FIPS_mode_set(mode)) {
+  } else if (!FIPS_mode_set(enable)) {
     unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
     return ThrowCryptoError(env, err);
   }

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -212,6 +212,15 @@ testHelper(
   'require("crypto").fips = false',
   process.env);
 
+// --force-fips makes setFipsCrypto enable a no-op (FIPS stays on)
+testHelper(
+  compiledWithFips() ? 'stdout' : 'stderr',
+  ['--force-fips'],
+  compiledWithFips() ? FIPS_ENABLED : OPTION_ERROR_STRING,
+  '(require("crypto").fips = true,' +
+  'require("crypto").fips)',
+  process.env);
+
 // --force-fips and --enable-fips order does not matter
 testHelper(
   'stderr',


### PR DESCRIPTION
Turning FIPS mode on (or off) when it's already on (or off) should be a
no-op, not an error.

Fixes: https://github.com/nodejs/node/issues/11849

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
crypto (FIPS)

Patch shamelessly stolen from @bnoordhuis [here](https://github.com/nodejs/node/issues/11849#issuecomment-287129742). PR'd to remind myself to test this properly.

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
