### PR TITLE
test: fix test-cli-syntax assertions on windows

### DIFF
--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -124,9 +124,10 @@ syntaxArgs.forEach(function(args) {
     const args = [checkFlag, evalFlag, 'foo'];
     const c = spawnSync(node, args, {encoding: 'utf8'});
 
-    assert.strictEqual(
-      c.stderr,
-      `${node}: either --check or --eval can be used, not both\n`
+    assert(
+      c.stderr.startsWith(
+        `${node}: either --check or --eval can be used, not both`
+      )
     );
 
     assert.strictEqual(c.status, 9, 'code === ' + c.status);


### PR DESCRIPTION
The test introduced in a5f91ab230c574d561780b6867d00f06fcc1e4de accidentally introduced failures on some windows builds. Update the assertion that was causing the failures.

Ref: https://github.com/nodejs/node/pull/11689

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
