### PR TITLE
doc: document the performance team

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -27,6 +27,7 @@
 | `test/*` | @nodejs/testing |
 | `tools/eslint`, `.eslintrc` | @not-an-aardvark, @silverwind, @trott |
 | async_hooks | @nodejs/diagnostics |
+| performance | @nodejs/performance |
 | upgrading V8 | @nodejs/v8, @nodejs/post-mortem |
 | upgrading npm | @fishrock123, @MylesBorins |
 | upgrading c-ares | @jbergstroem |


### PR DESCRIPTION
Can be cc'ed with `@nodejs/performance`.

I added some people: @mscdex @vsemozhetbyt @joyeecheung @TimothyGu @lpinca

If anyone else wants to join and be cc/ed on issues, feel free to request access (or remove yourself if you don't want to be on the team).

[Link to team](https://github.com/orgs/nodejs/teams/performance)

Refs: https://github.com/nodejs/node/pull/12194#issuecomment-291477258

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
