### PR TITLE
doc: Stream 'finish' event string interpolation fix

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -281,7 +281,7 @@ has been called, and all data has been flushed to the underlying system.
 ```js
 const writer = getWritableStreamSomehow();
 for (var i = 0; i < 100; i ++) {
-  writer.write('hello, #${i}!\n');
+  writer.write(`hello, #${i}!\n`);
 }
 writer.end('This is the end\n');
 writer.on('finish', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] documentation is changed or added
- [x ] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines

##### Description of change

String interpolation in the docs in the `Stream 'finish'` event example does not use back ticks `.