### PR TITLE
doc: modernize and fix code examples in modules.md

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -20,7 +20,7 @@ directory as `foo.js`.
 Here are the contents of `circle.js`:
 
 ```js
-const PI = Math.PI;
+const { PI } = Math;
 
 exports.area = (r) => PI * r * r;
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -59,7 +59,7 @@ module.exports = (width) => {
 };
 ```
 
-The module system is implemented in the `require("module")` module.
+The module system is implemented in the `require('module')` module.
 
 ## Accessing the main module
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -22,7 +22,7 @@ Here are the contents of `circle.js`:
 ```js
 const { PI } = Math;
 
-exports.area = (r) => PI * r * r;
+exports.area = (r) => PI * r ** 2;
 
 exports.circumference = (r) => 2 * PI * r;
 ```
@@ -54,7 +54,7 @@ The `square` module is defined in `square.js`:
 // assigning to exports will not modify module, must use module.exports
 module.exports = (width) => {
   return {
-    area: () => width * width
+    area: () => width ** 2
   };
 };
 ```

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -565,7 +565,7 @@ To illustrate the behavior, imagine this hypothetical implementation of
 `require()`, which is quite similar to what is actually done by `require()`:
 
 ```js
-function require(...) {
+function require(/* ... */) {
   const module = { exports: {} };
   ((module, exports) => {
     // Your module code here. In this example, define a function.

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -44,7 +44,7 @@ Below, `bar.js` makes use of the `square` module, which exports a constructor:
 
 ```js
 const square = require('./square.js');
-var mySquare = square(2);
+const mySquare = square(2);
 console.log(`The area of my square is ${mySquare.area()}`);
 ```
 
@@ -566,7 +566,7 @@ To illustrate the behavior, imagine this hypothetical implementation of
 
 ```js
 function require(...) {
-  var module = { exports: {} };
+  const module = { exports: {} };
   ((module, exports) => {
     // Your module code here. In this example, define a function.
     function some_func() {};

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -56,7 +56,7 @@ module.exports = (width) => {
   return {
     area: () => width * width
   };
-}
+};
 ```
 
 The module system is implemented in the `require("module")` module.
@@ -569,7 +569,7 @@ function require(...) {
   const module = { exports: {} };
   ((module, exports) => {
     // Your module code here. In this example, define a function.
-    function some_func() {};
+    function some_func() {}
     exports = some_func;
     // At this point, exports is no longer a shortcut to module.exports, and
     // this module will still export an empty default object.

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -569,12 +569,12 @@ function require(/* ... */) {
   const module = { exports: {} };
   ((module, exports) => {
     // Your module code here. In this example, define a function.
-    function some_func() {}
-    exports = some_func;
+    function someFunc() {}
+    exports = someFunc;
     // At this point, exports is no longer a shortcut to module.exports, and
     // this module will still export an empty default object.
-    module.exports = some_func;
-    // At this point, the module will now export some_func, instead of the
+    module.exports = someFunc;
+    // At this point, the module will now export someFunc, instead of the
     // default object.
   })(module, module.exports);
   return module.exports;

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -142,7 +142,7 @@ To get the exact filename that will be loaded when `require()` is called, use
 the `require.resolve()` function.
 
 Putting together all of the above, here is the high-level algorithm
-in pseudocode of what require.resolve does:
+in pseudocode of what `require.resolve()` does:
 
 ```txt
 require(X) from module at path Y


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc, modules

* Replace `var` by `const`.
* Fix semicolons.
* Add missing code marks.
* Unify quotes.
* Comment out ellipsis.
* Use object destructuring.
* Use exponentiation operator.
* Replace snake_case by camelCase.



[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
