### PR TITLE
test: Skip intl-no-icu-data test when not (Intl and smallICU)

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -607,6 +607,12 @@ Object.defineProperty(exports, 'hasIntl', {
   }
 });
 
+Object.defineProperty(exports, 'hasSmallICU', {
+  get: function() {
+    return process.binding('config').hasSmallICU;
+  }
+});
+
 // https://github.com/w3c/testharness.js/blob/master/testharness.js
 exports.WPT = {
   test: (fn, desc) => {

--- a/test/parallel/test-intl-no-icu-data.js
+++ b/test/parallel/test-intl-no-icu-data.js
@@ -1,8 +1,12 @@
 // Flags: --icu-data-dir=test/fixtures/empty/
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const config = process.binding('config');
 
+if (!(common.hasIntl && common.hasSmallICU)) {
+  common.skip('not (Intl AND SmallICU)');
+  return;
+}
 assert.deepStrictEqual(Intl.NumberFormat.supportedLocalesOf('en'), []);
 assert.strictEqual(config.icuDataDir, 'test/fixtures/empty/');


### PR DESCRIPTION
The --icu-data-dir flag applies only when the code was originally
compiled with --with-intl=small-icu.  Skip the test in all other cases

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

test

Fixes: https://github.com/nodejs/node/issues/12198
