### PR TITLE
build: make build-addons execute parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,7 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
 test: all
-	$(MAKE) build-addons
-	$(MAKE) build-addons-napi
+	$(MAKE) build-addons build-addons-napi
 	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
 		addons addons-napi doctool inspector known_issues message pseudo-tty parallel sequential


### PR DESCRIPTION
Currently the building of addons and addons-napi are done sequentially
but could be done in parallel which this commit tries to address.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
