### PR TITLE
doc: update OS level support for AIX

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -42,7 +42,7 @@ Support is divided into three tiers:
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 4.2.0, glibc >= 2.19   | ppc64be              |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le              |                  |
-| AIX          | Tier 2       | >= 6.1 TL09                      | ppc64be              |                  |
+| AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be              |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |
 | macOS        | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |


### PR DESCRIPTION
Update OS level supprot for AIX.  Based on discussions
with the AIX team we've have decided that the minimum
support level should be 7.1. This is because support
for AIX 6.1 will likely end during the lifespan of
the upcoming Node version 8 release.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
doc
