### PR TITLE
n-api: Update property attrs enum to match JS spec

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,4 +1,4 @@
-﻿/******************************************************************************
+/******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -44,8 +44,7 @@ static inline v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
     // V8 requires the ReadOnly attribute to match nonexistence of a setter.
     attribute_flags |= (descriptor->setter == nullptr ?
       v8::PropertyAttribute::ReadOnly : v8::PropertyAttribute::None);
-  }
-  else if ((descriptor->attributes & napi_writable) == 0) {
+  } else if ((descriptor->attributes & napi_writable) == 0) {
     attribute_flags |= v8::PropertyAttribute::ReadOnly;
   }
 

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -25,13 +25,13 @@ typedef void (*napi_finalize)(napi_env env,
 
 typedef enum {
   napi_default = 0,
-  napi_read_only = 1 << 0,
-  napi_dont_enum = 1 << 1,
-  napi_dont_delete = 1 << 2,
+  napi_writable = 1 << 0,
+  napi_enumerable = 1 << 1,
+  napi_configurable = 1 << 2,
 
   // Used with napi_define_class to distinguish static properties
   // from instance properties. Ignored by napi_define_properties.
-  napi_static_property = 1 << 10,
+  napi_static = 1 << 10,
 } napi_property_attributes;
 
 typedef struct {

--- a/test/addons-napi/test_constructor/test.js
+++ b/test/addons-napi/test_constructor/test.js
@@ -17,7 +17,7 @@ assert.throws(() => { test_object.readonlyValue = 3; });
 
 assert.ok(test_object.hiddenValue);
 
-// All properties except 'hiddenValue' should be enumerable.
+// Properties with napi_enumerable attribute should be enumerable.
 const propertyNames = [];
 for (const name in test_object) {
   propertyNames.push(name);
@@ -26,3 +26,17 @@ assert.ok(propertyNames.indexOf('echo') >= 0);
 assert.ok(propertyNames.indexOf('readwriteValue') >= 0);
 assert.ok(propertyNames.indexOf('readonlyValue') >= 0);
 assert.ok(propertyNames.indexOf('hiddenValue') < 0);
+assert.ok(propertyNames.indexOf('readwriteAccessor1') < 0);
+assert.ok(propertyNames.indexOf('readwriteAccessor2') < 0);
+assert.ok(propertyNames.indexOf('readonlyAccessor1') < 0);
+assert.ok(propertyNames.indexOf('readonlyAccessor2') < 0);
+
+// The napi_writable attribute should be ignored for accessors.
+test_object.readwriteAccessor1 = 1;
+assert.strictEqual(test_object.readwriteAccessor1, 1);
+assert.strictEqual(test_object.readonlyAccessor1, 1);
+assert.throws(() => { test_object.readonlyAccessor1 = 3; });
+test_object.readwriteAccessor2 = 2;
+assert.strictEqual(test_object.readwriteAccessor2, 2);
+assert.strictEqual(test_object.readonlyAccessor2, 2);
+assert.throws(() => { test_object.readonlyAccessor2 = 3; });

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -83,10 +83,13 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
 
   napi_property_descriptor properties[] = {
       { "echo", Echo, 0, 0, 0, napi_enumerable, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_enumerable, 0},
       { "readwriteValue", 0, 0, 0, number, napi_enumerable | napi_writable, 0 },
       { "readonlyValue", 0, 0, 0, number, napi_enumerable, 0},
       { "hiddenValue", 0, 0, 0, number, napi_default, 0},
+      { "readwriteAccessor1", 0, GetValue, SetValue, 0, napi_default, 0},
+      { "readwriteAccessor2", 0, GetValue, SetValue, 0, napi_writable, 0},
+      { "readonlyAccessor1", 0, GetValue, NULL, 0, napi_default, 0},
+      { "readonlyAccessor2", 0, GetValue, NULL, 0, napi_writable, 0},
   };
 
   napi_value cons;

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -82,11 +82,11 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   if (status != napi_ok) return;
 
   napi_property_descriptor properties[] = {
-      { "echo", Echo, 0, 0, 0, napi_default, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_default, 0},
-      { "readwriteValue", 0, 0, 0, number, napi_default, 0 },
-      { "readonlyValue", 0, 0, 0, number, napi_read_only, 0},
-      { "hiddenValue", 0, 0, 0, number, napi_read_only | napi_dont_enum, 0},
+      { "echo", Echo, 0, 0, 0, napi_enumerable, 0 },
+      { "accessorValue", 0, GetValue, SetValue, 0, napi_enumerable, 0},
+      { "readwriteValue", 0, 0, 0, number, napi_enumerable | napi_writable, 0 },
+      { "readonlyValue", 0, 0, 0, number, napi_enumerable, 0},
+      { "hiddenValue", 0, 0, 0, number, napi_default, 0},
   };
 
   napi_value cons;

--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -16,7 +16,7 @@ assert.throws(() => { test_object.readonlyValue = 3; });
 
 assert.ok(test_object.hiddenValue);
 
-// All properties except 'hiddenValue' should be enumerable.
+// Properties with napi_enumerable attribute should be enumerable.
 const propertyNames = [];
 for (const name in test_object) {
   propertyNames.push(name);
@@ -25,3 +25,17 @@ assert.ok(propertyNames.indexOf('echo') >= 0);
 assert.ok(propertyNames.indexOf('readwriteValue') >= 0);
 assert.ok(propertyNames.indexOf('readonlyValue') >= 0);
 assert.ok(propertyNames.indexOf('hiddenValue') < 0);
+assert.ok(propertyNames.indexOf('readwriteAccessor1') < 0);
+assert.ok(propertyNames.indexOf('readwriteAccessor2') < 0);
+assert.ok(propertyNames.indexOf('readonlyAccessor1') < 0);
+assert.ok(propertyNames.indexOf('readonlyAccessor2') < 0);
+
+// The napi_writable attribute should be ignored for accessors.
+test_object.readwriteAccessor1 = 1;
+assert.strictEqual(test_object.readwriteAccessor1, 1);
+assert.strictEqual(test_object.readonlyAccessor1, 1);
+assert.throws(() => { test_object.readonlyAccessor1 = 3; });
+test_object.readwriteAccessor2 = 2;
+assert.strictEqual(test_object.readwriteAccessor2, 2);
+assert.strictEqual(test_object.readonlyAccessor2, 2);
+assert.throws(() => { test_object.readonlyAccessor2 = 3; });

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -70,11 +70,11 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   if (status != napi_ok) return;
 
   napi_property_descriptor properties[] = {
-      { "echo", Echo, 0, 0, 0, napi_default, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_default, 0 },
-      { "readwriteValue", 0, 0, 0, number, napi_default, 0 },
-      { "readonlyValue", 0, 0, 0, number, napi_read_only, 0 },
-      { "hiddenValue", 0, 0, 0, number, napi_read_only | napi_dont_enum, 0 },
+      { "echo", Echo, 0, 0, 0, napi_enumerable, 0 },
+      { "accessorValue", 0, GetValue, SetValue, 0, napi_enumerable, 0},
+      { "readwriteValue", 0, 0, 0, number, napi_enumerable | napi_writable, 0 },
+      { "readonlyValue", 0, 0, 0, number, napi_enumerable, 0},
+      { "hiddenValue", 0, 0, 0, number, napi_default, 0},
   };
 
   status = napi_define_properties(

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -71,10 +71,13 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
 
   napi_property_descriptor properties[] = {
       { "echo", Echo, 0, 0, 0, napi_enumerable, 0 },
-      { "accessorValue", 0, GetValue, SetValue, 0, napi_enumerable, 0},
       { "readwriteValue", 0, 0, 0, number, napi_enumerable | napi_writable, 0 },
       { "readonlyValue", 0, 0, 0, number, napi_enumerable, 0},
       { "hiddenValue", 0, 0, 0, number, napi_default, 0},
+      { "readwriteAccessor1", 0, GetValue, SetValue, 0, napi_default, 0},
+      { "readwriteAccessor2", 0, GetValue, SetValue, 0, napi_writable, 0},
+      { "readonlyAccessor1", 0, GetValue, NULL, 0, napi_default, 0},
+      { "readonlyAccessor2", 0, GetValue, NULL, 0, napi_writable, 0},
   };
 
   status = napi_define_properties(


### PR DESCRIPTION
The `napi_property_attributes` enum used names and values from
`v8::PropertyAttribute`, but those negative flag names were outdated
along with the default behavior of a property being writable,
enumerable, and configurable unless otherwise specified. To match the
ES5 standard property descriptor those attributes should be positive
flags and should default to false unless otherwise specified.

Fixes: https://github.com/nodejs/abi-stable-node/issues/221

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
N-API

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
