### PR TITLE
src: use std::string for trace enabled_categories

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -173,7 +173,7 @@ static node_module* modlist_builtin;
 static node_module* modlist_linked;
 static node_module* modlist_addon;
 static bool trace_enabled = false;
-static const char* trace_enabled_categories = nullptr;
+static std::string trace_enabled_categories;  // NOLINT(runtime/string)
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
 // Path to ICU data (for i18n / Intl)

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -10,10 +10,11 @@ namespace node {
 namespace tracing {
 
 using v8::platform::tracing::TraceConfig;
+using std::string;
 
 Agent::Agent() {}
 
-void Agent::Start(v8::Platform* platform, const char* enabled_categories) {
+void Agent::Start(v8::Platform* platform, const string& enabled_categories) {
   platform_ = platform;
 
   int err = uv_loop_init(&tracing_loop_);
@@ -26,7 +27,7 @@ void Agent::Start(v8::Platform* platform, const char* enabled_categories) {
   tracing_controller_ = new TracingController();
 
   TraceConfig* trace_config = new TraceConfig();
-  if (enabled_categories) {
+  if (!enabled_categories.empty()) {
     std::stringstream category_list(enabled_categories);
     while (category_list.good()) {
       std::string category;

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -12,7 +12,7 @@ namespace tracing {
 class Agent {
  public:
   explicit Agent();
-  void Start(v8::Platform* platform, const char* enabled_categories);
+  void Start(v8::Platform* platform, const std::string& enabled_categories);
   void Stop();
 
  private:


### PR DESCRIPTION
A std::string manages its own memory, so using one removes the  implicit
assumption that the argv vector passed to node will never be
deallocated. Also, the enabled_categories are used to construct a
std::stringstream, so its simpler to use the standard library
consistently.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
src
