### PR TITLE
doc: deprecate vm.runInDebugContext

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -590,6 +590,16 @@ Type: Runtime
 `node debug` corresponds to the legacy CLI debugger which has been replaced with
 a V8-inspector based CLI debugger available through `node inspect`.
 
+<a id="DEP0069"></a>
+### DEP0069: vm.runInDebugContext(string)
+
+Type: Documentation-only
+
+The DebugContext will be removed in V8 soon and will not be available in Node
+10+.
+
+*Note*: DebugContext was an experimental API.
+
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -313,6 +313,8 @@ console.log(util.inspect(sandbox));
 added: v0.11.14
 -->
 
+> Stability: 0 - Deprecated. An alternative is in development.
+
 * `code` {string} The JavaScript code to compile and run.
 
 The `vm.runInDebugContext()` method compiles and executes `code` inside the V8


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src, debugger

---

Per https://github.com/nodejs/diagnostics/blob/master/wg-meetings/2017-03-23.md#3-deprecate-vmrunindebugcontext-api:

> vm.runInDebugContext will go away at end of 2017, so we should deprecate now in preparation for Node 10 (April 2018).

@jasnell should this be included in 8.0.0? Sorry it's late...

cc @ofrobots @eugeneo