### PR TITLE
src: use option parser for expose_internals

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -510,11 +510,9 @@
     return NativeModule._source.hasOwnProperty(id);
   };
 
-  const EXPOSE_INTERNALS = process.execArgv.some(function(arg) {
-    return arg.match(/^--expose[-_]internals$/);
-  });
+  const config = process.binding('config');
 
-  if (EXPOSE_INTERNALS) {
+  if (config.exposeInternals) {
     NativeModule.nonInternalExists = NativeModule.exists;
 
     NativeModule.isInternal = function(id) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -3277,6 +3277,7 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "_forceRepl", True(env->isolate()));
   }
 
+  // -r, --require
   if (!preload_modules.empty()) {
     Local<Array> array = Array::New(env->isolate());
     for (unsigned int i = 0; i < preload_modules.size(); ++i) {
@@ -3296,10 +3297,12 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "noDeprecation", True(env->isolate()));
   }
 
+  // --no-warnings
   if (no_process_warnings) {
     READONLY_PROPERTY(process, "noProcessWarnings", True(env->isolate()));
   }
 
+  // --trace-warnings
   if (trace_warnings) {
     READONLY_PROPERTY(process, "traceProcessWarnings", True(env->isolate()));
   }

--- a/src/node.cc
+++ b/src/node.cc
@@ -214,6 +214,12 @@ bool config_preserve_symlinks = false;
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
 std::string config_warning_file;  // NOLINT(runtime/string)
 
+// Set in node.cc by ParseArgs when --expose-internals or --expose_internals is
+// used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/internal/bootstrap_node.js
+bool config_expose_internals = false;
+
 bool v8_initialized = false;
 
 // process-relative uptime base, initialized at start-up
@@ -3787,7 +3793,7 @@ static void ParseArgs(int* argc,
 #endif
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
-      // consumed in js
+      config_expose_internals = true;
     } else if (strcmp(arg, "--") == 0) {
       index += 1;
       break;

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -58,6 +58,9 @@ void InitConfig(Local<Object> target,
                                                 .ToLocalChecked();
     target->DefineOwnProperty(env->context(), name, value).FromJust();
   }
+
+  if (config_expose_internals)
+    READONLY_BOOLEAN_PROPERTY("exposeInternals");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -65,6 +65,12 @@ extern std::string openssl_config;
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
 
+// Set in node.cc by ParseArgs when --expose-internals or --expose_internals is
+// used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/internal/bootstrap_node.js
+extern bool config_expose_internals;
+
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
 // Used to redirect warning output to a file rather than sending
 // it to stderr.

--- a/test/parallel/test-internal-modules-expose.js
+++ b/test/parallel/test-internal-modules-expose.js
@@ -3,5 +3,9 @@
 
 require('../common');
 const assert = require('assert');
+const config = process.binding('config');
+
+console.log(config, process.argv);
 
 assert.strictEqual(typeof require('internal/freelist').FreeList, 'function');
+assert.strictEqual(config.exposeInternals, true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

bootstrap_node.js was directly parsing process.execArgv to see if
internals should be exposed, even though the argv was already parsed by
node. This is unusual and unnecessary, change it to set the option value
from the parser onto the process object, as is done for the other CLI
options.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
src
