### PR TITLE
url: clean up WHATWG URL origin generation

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -34,26 +34,15 @@ function toUSVString(val) {
   return binding.toUSVString(str, match.index);
 }
 
-const kOpaqueOrigin = {
-  toString() {
-    return 'null';
-  }
-};
+// Refs: https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque
+const kOpaqueOrigin = 'null';
 
-class TupleOrigin {
-  constructor(scheme, host, port, domain = null) {
-    this.scheme = scheme;
-    this.host = host;
-    this.port = port;
-    this.domain = domain;
-  }
-
-  // https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin
-  // https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin
-  toString(unicode = true) {
-    const unicodeHost = unicode ? domainToUnicode(this.host) : this.host;
-    return `${this.scheme}://${unicodeHost}${this.port == null ? '' : `:${this.port}`}`;
-  }
+// Refs:
+// - https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin
+// - https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin
+function serializeTupleOrigin(scheme, host, port, unicode = true) {
+  const unicodeHost = unicode ? domainToUnicode(host) : host;
+  return `${scheme}//${unicodeHost}${port == null ? '' : `:${port}`}`;
 }
 
 // This class provides the internal state of a URL object. An instance of this
@@ -319,7 +308,27 @@ Object.defineProperties(URL.prototype, {
     enumerable: true,
     configurable: true,
     get() {
-      return originFor(this).toString();
+      // Refs: https://url.spec.whatwg.org/#concept-url-origin
+      const ctx = this[context];
+      switch (ctx.scheme) {
+        case 'blob:':
+          if (ctx.path.length > 0) {
+            try {
+              return (new URL(ctx.path[0])).origin;
+            } catch (err) {
+              // fall through... do nothing
+            }
+          }
+          return kOpaqueOrigin;
+        case 'ftp:':
+        case 'gopher:':
+        case 'http:':
+        case 'https:':
+        case 'ws:':
+        case 'wss:':
+          return serializeTupleOrigin(ctx.scheme, ctx.host, ctx.port);
+      }
+      return kOpaqueOrigin;
     }
   },
   protocol: {
@@ -1235,32 +1244,6 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParamsIterator', {
     return `${this[Symbol.toStringTag]} {${outputStr} }`;
   }
 });
-
-function originFor(url) {
-  const protocol = url.protocol;
-  switch (protocol) {
-    case 'blob:':
-      if (url[context].path.length > 0) {
-        try {
-          return (new URL(url[context].path[0])).origin;
-        } catch (err) {
-          // fall through... do nothing
-        }
-      }
-      return kOpaqueOrigin;
-    case 'ftp:':
-    case 'gopher:':
-    case 'http:':
-    case 'https:':
-    case 'ws:':
-    case 'wss:':
-      return new TupleOrigin(protocol.slice(0, -1),
-                             url[context].host,
-                             url[context].port,
-                             null);
-  }
-  return kOpaqueOrigin;
-}
 
 function domainToASCII(domain) {
   if (arguments.length < 1)

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -15,10 +15,6 @@ const os = require('os');
 
 const isWindows = process.platform === 'win32';
 
-const kScheme = Symbol('scheme');
-const kHost = Symbol('host');
-const kPort = Symbol('port');
-const kDomain = Symbol('domain');
 const kFormat = Symbol('format');
 
 // https://tc39.github.io/ecma262/#sec-%iteratorprototype%-object
@@ -38,61 +34,25 @@ function toUSVString(val) {
   return binding.toUSVString(str, match.index);
 }
 
-class OpaqueOrigin {
+const kOpaqueOrigin = {
   toString() {
     return 'null';
   }
-
-  get effectiveDomain() {
-    return this;
-  }
-}
+};
 
 class TupleOrigin {
-  constructor(scheme, host, port, domain) {
-    this[kScheme] = scheme;
-    this[kHost] = host;
-    this[kPort] = port;
-    this[kDomain] = domain;
+  constructor(scheme, host, port, domain = null) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.domain = domain;
   }
 
-  get scheme() {
-    return this[kScheme];
-  }
-
-  get host() {
-    return this[kHost];
-  }
-
-  get port() {
-    return this[kPort];
-  }
-
-  get domain() {
-    return this[kDomain];
-  }
-
-  get effectiveDomain() {
-    return this[kDomain] || this[kHost];
-  }
-
-  // https://url.spec.whatwg.org/#dom-url-origin
+  // https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin
+  // https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin
   toString(unicode = true) {
-    var result = this[kScheme];
-    result += '://';
-    result += unicode ? domainToUnicode(this[kHost]) : this[kHost];
-    if (this[kPort] !== undefined && this[kPort] !== null)
-      result += `:${this[kPort]}`;
-    return result;
-  }
-
-  [util.inspect.custom]() {
-    return `TupleOrigin {
-      scheme: ${this[kScheme]},
-      host: ${this[kHost]},
-      port: ${this[kPort]},
-      domain: ${this[kDomain]}
-    }`;
+    const unicodeHost = unicode ? domainToUnicode(this.host) : this.host;
+    return `${this.scheme}://${unicodeHost}${this.port == null ? '' : `:${this.port}`}`;
   }
 }
 
@@ -1276,39 +1236,30 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParamsIterator', {
   }
 });
 
-function originFor(url, base) {
-  if (url != undefined &&
-      (!url[searchParams] || !url[searchParams][searchParams])) {
-    url = new URL(url, base);
-  }
-  var origin;
+function originFor(url) {
   const protocol = url.protocol;
   switch (protocol) {
     case 'blob:':
-      if (url[context].path && url[context].path.length > 0) {
+      if (url[context].path.length > 0) {
         try {
           return (new URL(url[context].path[0])).origin;
         } catch (err) {
           // fall through... do nothing
         }
       }
-      origin = new OpaqueOrigin();
-      break;
+      return kOpaqueOrigin;
     case 'ftp:':
     case 'gopher:':
     case 'http:':
     case 'https:':
     case 'ws:':
     case 'wss:':
-      origin = new TupleOrigin(protocol.slice(0, -1),
-                               url[context].host,
-                               url[context].port,
-                               null);
-      break;
-    default:
-      origin = new OpaqueOrigin();
+      return new TupleOrigin(protocol.slice(0, -1),
+                             url[context].host,
+                             url[context].port,
+                             null);
   }
-  return origin;
+  return kOpaqueOrigin;
 }
 
 function domainToASCII(domain) {


### PR DESCRIPTION
- Directly generate serialized string instead of going through class construction + `toString()`
- Use template string literals

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url