### PR TITLE
src: use std::list for at_exit_functions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -84,6 +84,7 @@
 
 #include <string>
 #include <vector>
+#include <list>
 
 #if defined(NODE_HAVE_I18N_SUPPORT)
 #include <unicode/uvernum.h>
@@ -4263,34 +4264,24 @@ void Init(int* argc,
 
 
 struct AtExitCallback {
-  AtExitCallback* next_;
   void (*cb_)(void* arg);
   void* arg_;
 };
 
-static AtExitCallback* at_exit_functions_;
+static std::list<AtExitCallback> at_exit_functions;
 
 
 // TODO(bnoordhuis) Turn into per-context event.
 void RunAtExit(Environment* env) {
-  AtExitCallback* p = at_exit_functions_;
-  at_exit_functions_ = nullptr;
-
-  while (p) {
-    AtExitCallback* q = p->next_;
-    p->cb_(p->arg_);
-    delete p;
-    p = q;
+  for (AtExitCallback at_exit : at_exit_functions) {
+    at_exit.cb_(at_exit.arg_);
   }
+  at_exit_functions.clear();
 }
 
 
 void AtExit(void (*cb)(void* arg), void* arg) {
-  AtExitCallback* p = new AtExitCallback;
-  p->cb_ = cb;
-  p->arg_ = arg;
-  p->next_ = at_exit_functions_;
-  at_exit_functions_ = p;
+  at_exit_functions.push_back(AtExitCallback{cb, arg});
 }
 
 


### PR DESCRIPTION
This change was suggested by bnoordhuis in the following comment:
https://github.com/nodejs/node/pull/9163#discussion_r84264628

Not including any tests as this is covered by test/addons/at-exit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src