### PR TITLE
benchmark: readStart only after completion

### DIFF
--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -97,8 +97,6 @@ function client() {
   if (err)
     fail(err, 'connect');
 
-  clientHandle.readStart();
-
   clientHandle.onread = function(nread, buffer) {
     if (nread < 0)
       fail(nread, 'read');
@@ -111,6 +109,8 @@ function client() {
       fail(err, 'connect');
 
     bench.start();
+
+    clientHandle.readStart();
 
     setTimeout(function() {
       // multiply by 2 since we're sending it first one way


### PR DESCRIPTION
fix #11972 
On windows apparently it's meaningful to call `readStart` only after connection completion.
(makes sense on POSIX as well, and causes no regressions)

##### Checklist

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
benchmarks
