### PR TITLE
test: skip irrelevant test on Windows

### DIFF
--- a/test/known_issues/known_issues.status
+++ b/test/known_issues/known_issues.status
@@ -8,6 +8,7 @@ prefix known_issues
 
 [$system==win32]
 test-stdout-buffer-flush-on-exit: SKIP
+test-cluster-disconnect-handles: SKIP
 
 [$system==linux]
 


### PR DESCRIPTION
Skip test-cluster-disconnect-handles on Windows.
    
Refs: https://github.com/nodejs/node/pull/12197#issuecomment-292228866

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test