### PR TITLE
src: only block SIGUSR1 when HAVE_INSPECTOR

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4074,10 +4074,12 @@ static void DebugEnd(const FunctionCallbackInfo<Value>& args) {
 
 inline void PlatformInit() {
 #ifdef __POSIX__
+#if HAVE_INSPECTOR
   sigset_t sigmask;
   sigemptyset(&sigmask);
   sigaddset(&sigmask, SIGUSR1);
   const int err = pthread_sigmask(SIG_SETMASK, &sigmask, nullptr);
+#endif  // HAVE_INSPECTOR
 
   // Make sure file descriptors 0-2 are valid before we start logging anything.
   for (int fd = STDIN_FILENO; fd <= STDERR_FILENO; fd += 1) {
@@ -4092,7 +4094,9 @@ inline void PlatformInit() {
       ABORT();
   }
 
+#if HAVE_INSPECTOR
   CHECK_EQ(err, 0);
+#endif  // HAVE_INSPECTOR
 
 #ifndef NODE_SHARED_MODE
   // Restore signal dispositions, the parent process may have changed them.


### PR DESCRIPTION
I'm currently seeing a timeout error for test-signal-handler.js on
macosx when using the following configuration:

./configure --debug --without-ssl && make -j8 test

--without-ssl implies that there will be no inspector but the signal
SIGUSR1 is blocked in PlatformInit just the same. But in this case
never unblocked which is causing the signal to never be delivered to
the handlers in test-signal-handler.js and it loops until it times out.

Not sure if this is the best way of fixing this but hopefully more eyes
on this will help.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src