### PR TITLE
build: run cpplint even if jslint failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -885,7 +885,11 @@ cpplint:
 	@$(PYTHON) tools/check-imports.py
 
 ifneq ("","$(wildcard tools/eslint/lib/eslint.js)")
-lint: jslint cpplint
+lint:
+	EXIT_STATUS=0 ; \
+	$(MAKE) jslint || EXIT_STATUS=$$? ; \
+	$(MAKE) cpplint || EXIT_STATUS=$$? ; \
+	exit $$EXIT_STATUS
 CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+
 lint-ci: jslint-ci cpplint
 	@if ! ( grep -IEqrs "$(CONFLICT_RE)" benchmark deps doc lib src test tools ) \


### PR DESCRIPTION
As it mentioned in #12082 issue, it would be good to execute `cpplint` even if `jslint` failed. As far as I can see it should help to get both lint errors from both checks at once, which is good. 

as @mscdex mentioned in the issue, there is `vcbuild.bat` that should be updated also with something similar, but I have huuuuge troubles with it. Could somebody help me please with this file or point me to the correct direction. I see that I can check the `%errorlevel%`variable but currently I do not see the way how can I pass it from `cpplint` to `jslint` "target". 

Thank you

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build