### PR TITLE
n-api: investigate breakage

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
  * Experimental prototype for demonstrating VM agnostic and ABI stable API
  * for native modules to use instead of using Nan and V8 APIs directly.
  *
@@ -2162,7 +2162,7 @@ napi_status napi_instanceof(napi_env env,
 
   if (env->has_instance_available) {
     napi_value value, js_result, has_instance = nullptr;
-    napi_status status;
+    napi_status status = napi_ok;
     napi_valuetype value_type;
 
     // Get "Symbol" from the global object


### PR DESCRIPTION
~~Check to see If this will turn the CI green, that will mean that #12240 breaks on windows~~
Now the suspect is [lines L2186-L2187 in node_api.cc](https://github.com/nodejs/node/blob/8fbace163afbd61b5efc57cf94414be904bf0188/src/node_api.cc#L2186-L2187) 8fbace1/#12246.

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
n-api,test
