### PR TITLE
[napi] properly initialize and check status (#12279)

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2162,7 +2162,7 @@ napi_status napi_instanceof(napi_env env,
 
   if (env->has_instance_available) {
     napi_value value, js_result, has_instance = nullptr;
-    napi_status status;
+    napi_status status = napi_generic_failure;
     napi_valuetype value_type;
 
     // Get "Symbol" from the global object
@@ -2185,14 +2185,12 @@ napi_status napi_instanceof(napi_env env,
         if (value_type == napi_symbol) {
           env->has_instance.Reset(env->isolate,
               v8impl::V8LocalValueFromJsValue(value));
-          if (status != napi_ok) return status;
           has_instance = value;
         }
       }
     } else {
       has_instance = v8impl::JsValueFromV8LocalValue(
           v8::Local<v8::Value>::New(env->isolate, env->has_instance));
-      if (status != napi_ok) return status;
     }
 
     if (has_instance) {


### PR DESCRIPTION
Initialize status to napi_generic_failure and only check it after
having made an actual N-API call.

This fixes up 8fbace163afbd61b5efc57cf94414be904bf0188.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api