### PR TITLE
buffer: use slightly faster NaN check

### DIFF
--- a/benchmark/buffers/buffer-indexof-number.js
+++ b/benchmark/buffers/buffer-indexof-number.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common.js');
+const fs = require('fs');
+const path = require('path');
+
+const bench = common.createBenchmark(main, {
+  value: ['@'.charCodeAt(0)],
+  n: [1e7]
+});
+
+function main(conf) {
+  const n = +conf.n;
+  const search = +conf.value;
+  const aliceBuffer = fs.readFileSync(
+    path.resolve(__dirname, '../fixtures/alice.html')
+  );
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    aliceBuffer.indexOf(search, 0, undefined);
+  }
+  bench.end(n);
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -659,7 +659,8 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   // Coerce to Number. Values like null and [] become 0.
   byteOffset = +byteOffset;
   // If the offset is undefined, "foo", {}, coerces to NaN, search whole buffer.
-  if (Number.isNaN(byteOffset)) {
+  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
+  if (byteOffset !== byteOffset) {
     byteOffset = dir ? 0 : (buffer.length - 1);
   }
   dir = !!dir;  // Cast to bool.
@@ -882,7 +883,8 @@ function adjustOffset(offset, length) {
   // Use Math.trunc() to convert offset to an integer value that can be larger
   // than an Int32. Hence, don't use offset | 0 or similar techniques.
   offset = Math.trunc(offset);
-  if (offset === 0 || Number.isNaN(offset)) {
+  // `x !== x`-style conditionals are a faster form of `isNaN(x)`
+  if (offset === 0 || offset !== offset) {
     return 0;
   } else if (offset < 0) {
     offset += length;


### PR DESCRIPTION
Performance results:
```
                                                       improvement confidence      p.value
 buffers/buffer-indexof-number.js n=10000000 value=64      3.59 %        *** 5.794893e-21
 buffers/buffer-slice.js n=8192 type="fast"                6.66 %        *** 1.325662e-23
 buffers/buffer-slice.js n=8192 type="slow"                7.45 %        *** 5.384460e-23
```

CI: https://ci.nodejs.org/job/node-test-pull-request/7287/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* buffer
