### PR TITLE
http_parser: assert on incoming argument's type

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -496,6 +496,7 @@ class Parser : public AsyncWrap {
   static void Consume(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.Holder());
+    CHECK(args[0]->IsExternal());
     Local<External> stream_obj = args[0].As<External>();
     StreamBase* stream = static_cast<StreamBase*>(stream_obj->Value());
     CHECK_NE(stream, nullptr);

--- a/test/abort/test-http-parser-consume.js
+++ b/test/abort/test-http-parser-consume.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const spawn = require('child_process').spawn;
+
+if (process.argv[2] === 'child') {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.end('hello');
+  }));
+
+  server.listen(0, common.mustCall((s) => {
+    const rr = http.get(
+      { port: server.address().port },
+      common.mustCall((d) => {
+        // This bad input (0) should abort the parser and the process
+        rr.parser.consume(0);
+        server.close();
+      }));
+  }));
+} else {
+  const child = spawn(process.execPath, [__filename, 'child'],
+                      { stdio: 'inherit' });
+  child.on('exit', common.mustCall((code, signal) => {
+    assert(common.nodeProcessAborted(code, signal),
+           'process should have aborted, but did not');
+  }));
+}


### PR DESCRIPTION
Unchecked argument conversion in Parser::Consume crashes node
in an slightly undesirable manner - 'unreachable code' in parser.

Make sure we validate the incoming type at the earliest point.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http_parser