### PR TITLE
test: fix allocUnsafe uninitialized buffer check

### DIFF
--- a/test/parallel/test-buffer-bindingobj-no-zerofill.js
+++ b/test/parallel/test-buffer-bindingobj-no-zerofill.js
@@ -44,7 +44,7 @@ const monkeyPatchedBuffer = require('../../lib/buffer');
 // possible that a segment of memory is already zeroed out, so try again and
 // again until we succeed or we time out.
 let uninitialized = buffer.Buffer.allocUnsafe(1024);
-while (uninitialized.some((val) => val !== 0))
+while (uninitialized.every((val) => val === 0))
   uninitialized = buffer.Buffer.allocUnsafe(1024);
 
 // On monkeypatched buffer, zeroFill property is undefined. allocUnsafe() should


### PR DESCRIPTION
Fixes parallel/test-buffer-bindingobj-no-zerofill to properly check
that buffers created with `Buffer.allocUnsafe()` are not zero-filled.

The test introduced in #11706 passes even if the buffer has been
zero-filled and fails if none of the buffer values are zero.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

test