### PR TITLE
assert.fail() accept a single argument or two arguments 

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -110,9 +110,6 @@ rules:
   }, {
     selector: "ThrowStatement > CallExpression[callee.name=/Error$/]",
     message: "Use new keyword when throwing an Error."
-    }, {
-    selector: "CallExpression[callee.object.name='assert'][callee.property.name='fail'][arguments.length=1]",
-    message: "assert.fail() message should be third argument"
     }]
   no-tabs: 2
   no-trailing-spaces: 2

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -256,6 +256,7 @@ If the values are not equal, an `AssertionError` is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
+## assert.fail(message)
 ## assert.fail(actual, expected, message, operator)
 <!-- YAML
 added: v0.1.21
@@ -263,7 +264,7 @@ added: v0.1.21
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
-* `operator` {string}
+* `operator` {string} (default: '!=')
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`.
@@ -277,6 +278,12 @@ assert.fail(1, 2, undefined, '>');
 
 assert.fail(1, 2, 'whoops', '>');
 // AssertionError: whoops
+
+assert.fail('boom');
+// AssertionError: boom
+
+assert.fail('a', 'b');
+// AssertionError: 'a' != 'b'
 ```
 
 ## assert.ifError(value)

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -79,6 +79,10 @@ function getMessage(self) {
 // display purposes.
 
 function fail(actual, expected, message, operator, stackStartFunction) {
+  if (arguments.length === 1)
+    message = actual;
+  if (arguments.length === 2)
+    operator = '!=';
   throw new assert.AssertionError({
     message: message,
     actual: actual,

--- a/test/README.md
+++ b/test/README.md
@@ -246,12 +246,6 @@ Checks whether `IPv6` is supported on this platform.
 
 Checks if there are multiple localhosts available.
 
-### fail(msg)
-* `msg` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Throws an `AssertionError` with `msg`
-
 ### fileExists(pathname)
 * pathname [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/test/common.js
+++ b/test/common.js
@@ -404,7 +404,7 @@ process.on('exit', function() {
   if (!exports.globalCheck) return;
   const leaked = leakedGlobals();
   if (leaked.length > 0) {
-    fail(`Unexpected global(s) found: ${leaked.join(', ')}`);
+    assert.fail(`Unexpected global(s) found: ${leaked.join(', ')}`);
   }
 });
 
@@ -507,14 +507,9 @@ exports.canCreateSymLink = function() {
   return true;
 };
 
-function fail(msg) {
-  assert.fail(null, null, msg);
-}
-exports.fail = fail;
-
 exports.mustNotCall = function(msg) {
   return function mustNotCall() {
-    fail(msg || 'function should not have been called');
+    assert.fail(msg || 'function should not have been called');
   };
 };
 
@@ -627,7 +622,7 @@ exports.WPT = {
   },
   assert_array_equals: assert.deepStrictEqual,
   assert_unreached(desc) {
-    assert.fail(undefined, undefined, `Reached unreachable code: ${desc}`);
+    assert.fail(`Reached unreachable code: ${desc}`);
   }
 };
 

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -217,7 +217,7 @@ TestSession.prototype.sendInspectorCommands = function(commands) {
         for (const id in this.messages_) {
           s += id + ', ';
         }
-        common.fail('Messages without response: ' +
+        assert.fail('Messages without response: ' +
                     s.substring(0, s.length - 2));
       }, TIMEOUT);
     });

--- a/test/internet/test-dgram-send-cb-quelches-error.js
+++ b/test/internet/test-dgram-send-cb-quelches-error.js
@@ -28,7 +28,7 @@ function callbackOnly(err) {
 }
 
 function onEvent(err) {
-  common.fail('Error should not be emitted if there is callback');
+  assert.fail('Error should not be emitted if there is callback');
 }
 
 function onError(err) {

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -453,7 +453,7 @@ TEST(function test_lookup_all_mixed(done) {
       else if (isIPv6(ip.address))
         assert.strictEqual(ip.family, 6);
       else
-        common.fail('unexpected IP address');
+        assert.fail('unexpected IP address');
     });
 
     done();

--- a/test/internet/test-tls-add-ca-cert.js
+++ b/test/internet/test-tls-add-ca-cert.js
@@ -38,7 +38,7 @@ tls.connect(opts, fail).on('error', common.mustCall((err) => {
 }));
 
 function fail() {
-  common.fail('should fail to connect');
+  assert.fail('should fail to connect');
 }
 
 // New secure contexts have the well-known root CAs.

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+// no args
+assert.throws(
+  () => { assert.fail(); },
+  /^AssertionError: undefined undefined undefined$/
+);
+
+// one arg = message
+assert.throws(
+  () => { assert.fail('custom message'); },
+  /^AssertionError: custom message$/
+);
+
+// two args only, operator defaults to '!='
+assert.throws(
+  () => { assert.fail('first', 'second'); },
+  /^AssertionError: 'first' != 'second'$/
+);
+
+// three args
+assert.throws(
+  () => { assert.fail('ignored', 'ignored', 'another custom message'); },
+  /^AssertionError: another custom message$/
+);
+
+// no third arg (but a fourth arg)
+assert.throws(
+  () => { assert.fail('first', 'second', undefined, 'operator'); },
+  /^AssertionError: 'first' operator 'second'$/
+);

--- a/test/parallel/test-beforeexit-event-exit.js
+++ b/test/parallel/test-beforeexit-event-exit.js
@@ -20,10 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
+const assert = require('assert');
 
 process.on('beforeExit', function() {
-  common.fail('exit should not allow this to occur');
+  assert.fail('exit should not allow this to occur');
 });
 
 process.exit();

--- a/test/parallel/test-child-process-fork-and-spawn.js
+++ b/test/parallel/test-child-process-fork-and-spawn.js
@@ -37,7 +37,7 @@ switch (process.argv[2] || '') {
   case 'spawn':
     break;
   default:
-    common.fail();
+    assert.fail();
 }
 
 function checkExit(statusCode) {

--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -42,7 +42,7 @@ if (process.argv[2] === 'child') {
 
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', function(data) {
-    common.fail(`Unexpected parent stderr: ${data}`);
+    assert.fail(`Unexpected parent stderr: ${data}`);
   });
 
   // check if we receive both 'hello' at start and 'goodbye' at end

--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -51,7 +51,7 @@ if (cluster.isMaster) {
     setTimeout(function() { client.end(); }, 50);
   }).on('error', function(e) {
     console.error(e);
-    common.fail('server.listen failed');
+    assert.fail('server.listen failed');
     cluster.worker.disconnect();
   });
 }

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -40,8 +40,8 @@ assert.throws(function() {
 }, /^TypeError: Invalid expected value: \/foo\/$/);
 
 
-// common.fail() tests
+// assert.fail() tests
 assert.throws(
-  () => { common.fail('fhqwhgads'); },
+  () => { assert.fail('fhqwhgads'); },
   /^AssertionError: fhqwhgads$/
 );

--- a/test/parallel/test-dgram-address.js
+++ b/test/parallel/test-dgram-address.js
@@ -41,7 +41,7 @@ const dgram = require('dgram');
 
   socket.on('error', (err) => {
     socket.close();
-    common.fail(`Unexpected error on udp4 socket. ${err.toString()}`);
+    assert.fail(`Unexpected error on udp4 socket. ${err.toString()}`);
   });
 
   socket.bind(0, common.localhostIPv4);
@@ -65,7 +65,7 @@ if (common.hasIPv6) {
 
   socket.on('error', (err) => {
     socket.close();
-    common.fail(`Unexpected error on udp6 socket. ${err.toString()}`);
+    assert.fail(`Unexpected error on udp6 socket. ${err.toString()}`);
   });
 
   socket.bind(0, localhost);

--- a/test/parallel/test-dgram-implicit-bind-failure.js
+++ b/test/parallel/test-dgram-implicit-bind-failure.js
@@ -40,7 +40,7 @@ socket.on('error', (err) => {
     return;
   }
 
-  common.fail(`Unexpected error: ${err}`);
+  assert.fail(`Unexpected error: ${err}`);
 });
 
 // Initiate a few send() operations, which will fail.

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -9,6 +9,7 @@
  */
 
 const common = require('../common');
+const assert = require('assert');
 const domain = require('domain');
 const child_process = require('child_process');
 
@@ -183,14 +184,14 @@ if (process.argv[2] === 'child') {
       test.expectedMessages.forEach(function(expectedMessage) {
         if (test.messagesReceived === undefined ||
           test.messagesReceived.indexOf(expectedMessage) === -1)
-          common.fail('test ' + test.fn.name + ' should have sent message: ' +
+          assert.fail('test ' + test.fn.name + ' should have sent message: ' +
                       expectedMessage + ' but didn\'t');
       });
 
       if (test.messagesReceived) {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (test.expectedMessages.indexOf(receivedMessage) === -1) {
-            common.fail('test ' + test.fn.name +
+            assert.fail('test ' + test.fn.name +
                         ' should not have sent message: ' + receivedMessage +
                         ' but did');
           }

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -53,9 +53,9 @@ const EventEmitter = require('events');
   });
 
   ee.on('hello', hello);
-  ee.once('foo', common.fail);
+  ee.once('foo', assert.fail);
   assert.deepStrictEqual(['hello', 'foo'], events_new_listener_emitted);
-  assert.deepStrictEqual([hello, common.fail], listeners_new_listener_emitted);
+  assert.deepStrictEqual([hello, assert.fail], listeners_new_listener_emitted);
 
   ee.emit('hello', 'a', 'b');
 }

--- a/test/parallel/test-event-emitter-listeners-side-effects.js
+++ b/test/parallel/test-event-emitter-listeners-side-effects.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const EventEmitter = require('events').EventEmitter;
@@ -35,12 +35,12 @@ assert.strictEqual(fl.length, 0);
 assert(!(e._events instanceof Object));
 assert.deepStrictEqual(Object.keys(e._events), []);
 
-e.on('foo', common.fail);
+e.on('foo', assert.fail);
 fl = e.listeners('foo');
-assert.strictEqual(e._events.foo, common.fail);
+assert.strictEqual(e._events.foo, assert.fail);
 assert(Array.isArray(fl));
 assert.strictEqual(fl.length, 1);
-assert.strictEqual(fl[0], common.fail);
+assert.strictEqual(fl[0], assert.fail);
 
 e.listeners('bar');
 
@@ -49,12 +49,12 @@ fl = e.listeners('foo');
 
 assert(Array.isArray(e._events.foo));
 assert.strictEqual(e._events.foo.length, 2);
-assert.strictEqual(e._events.foo[0], common.fail);
+assert.strictEqual(e._events.foo[0], assert.fail);
 assert.strictEqual(e._events.foo[1], assert.ok);
 
 assert(Array.isArray(fl));
 assert.strictEqual(fl.length, 2);
-assert.strictEqual(fl[0], common.fail);
+assert.strictEqual(fl[0], assert.fail);
 assert.strictEqual(fl[1], assert.ok);
 
 console.log('ok');

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -34,7 +34,7 @@ e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 
 const remove = function() {
-  common.fail('once->foo should not be emitted');
+  assert.fail('once->foo should not be emitted');
 };
 
 e.once('foo', remove);

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -70,11 +70,11 @@ function listener2() {}
   const ee = new EventEmitter();
 
   function remove1() {
-    common.fail('remove1 should not have been called');
+    assert.fail('remove1 should not have been called');
   }
 
   function remove2() {
-    common.fail('remove2 should not have been called');
+    assert.fail('remove2 should not have been called');
   }
 
   ee.on('removeListener', common.mustCall(function(name, cb) {

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 
 process.on('uncaughtException', function(err) {
   console.log('Caught exception: ' + err);
@@ -32,4 +33,4 @@ setTimeout(common.mustCall(function() {
 
 // Intentionally cause an exception, but don't catch it.
 nonexistentFunc(); // eslint-disable-line no-undef
-common.fail('This will not run.');
+assert.fail('This will not run.');

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -95,10 +95,10 @@ check(fs.symlink, fs.symlinkSync, fileUrl, 'foobar');
 check(fs.symlink, fs.symlinkSync, 'foobar', fileUrl);
 check(fs.truncate, fs.truncateSync, fileUrl);
 check(fs.unlink, fs.unlinkSync, fileUrl);
-check(null, fs.unwatchFile, fileUrl, common.fail);
+check(null, fs.unwatchFile, fileUrl, assert.fail);
 check(fs.utimes, fs.utimesSync, fileUrl, 0, 0);
-check(null, fs.watch, fileUrl, common.fail);
-check(null, fs.watchFile, fileUrl, common.fail);
+check(null, fs.watch, fileUrl, assert.fail);
+check(null, fs.watchFile, fileUrl, assert.fail);
 check(fs.writeFile, fs.writeFileSync, fileUrl, 'abc');
 
 check(fs.access, fs.accessSync, fileUrl2);
@@ -123,10 +123,10 @@ check(fs.symlink, fs.symlinkSync, fileUrl2, 'foobar');
 check(fs.symlink, fs.symlinkSync, 'foobar', fileUrl2);
 check(fs.truncate, fs.truncateSync, fileUrl2);
 check(fs.unlink, fs.unlinkSync, fileUrl2);
-check(null, fs.unwatchFile, fileUrl2, common.fail);
+check(null, fs.unwatchFile, fileUrl2, assert.fail);
 check(fs.utimes, fs.utimesSync, fileUrl2, 0, 0);
-check(null, fs.watch, fileUrl2, common.fail);
-check(null, fs.watchFile, fileUrl2, common.fail);
+check(null, fs.watch, fileUrl2, assert.fail);
+check(null, fs.watchFile, fileUrl2, assert.fail);
 check(fs.writeFile, fs.writeFileSync, fileUrl2, 'abc');
 
 // an 'error' for exists means that it doesn't exist.

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -62,7 +62,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   try {
     stats = fs.fstatSync(fd);
   } catch (err) {
-    common.fail(err);
+    assert.fail(err);
   }
   if (stats) {
     console.dir(stats);

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -44,7 +44,7 @@ common.refreshTmpDir();
   const stream = fs.createWriteStream(file);
 
   stream.on('drain', function() {
-    common.fail('\'drain\' event must not be emitted before ' +
+    assert.fail('\'drain\' event must not be emitted before ' +
                 'stream.write() has been called at least once.');
   });
   stream.destroy();

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -26,7 +26,7 @@ process.stderr.write = (data) => {
   if (write_calls === 0)
     assert.ok(data.match(leak_warning));
   else
-    common.fail('stderr.write should be called only once');
+    assert.fail('stderr.write should be called only once');
 
   write_calls++;
 };

--- a/test/parallel/test-http-createConnection.js
+++ b/test/parallel/test-http-createConnection.js
@@ -42,7 +42,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
           res.resume();
           fn = common.mustCall(createConnectionError);
           http.get({ createConnection: fn }, function(res) {
-            common.fail('Unexpected response callback');
+            assert.fail('Unexpected response callback');
           }).on('error', common.mustCall(function(err) {
             assert.strictEqual(err.message, 'Could not create socket');
             server.close();

--- a/test/parallel/test-http-invalid-path-chars.js
+++ b/test/parallel/test-http-invalid-path-chars.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 
@@ -8,7 +8,7 @@ const theExperimentallyDeterminedNumber = 39;
 
 function fail(path) {
   assert.throws(() => {
-    http.request({ path }, common.fail);
+    http.request({ path }, assert.fail);
   }, expectedError);
 }
 

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 const http = require('http');
 
 const invalidLocalAddress = '1.2.3.4';
@@ -43,7 +44,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    common.fail('unexpectedly got response from server');
+    assert.fail('unexpectedly got response from server');
   }).on('error', common.mustCall(function(e) {
     console.log('client got error: ' + e.message);
     server.close();

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -127,7 +127,7 @@ const s = http.createServer(common.mustCall((req, res) => {
       break;
 
     default:
-      common.fail('Unknown test');
+      assert.fail('Unknown test');
   }
 
   res.statusCode = 201;
@@ -174,7 +174,7 @@ function nextTest() {
         break;
 
       default:
-        common.fail('Unknown test');
+        assert.fail('Unknown test');
     }
 
     response.setEncoding('utf8');

--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -19,7 +19,7 @@ const server = http.createServer((req, res) => {
       res.writeHead(200, {'content-length': [1, 2]});
       break;
     default:
-      common.fail('should never get here');
+      assert.fail('should never get here');
   }
   res.end('ok');
 });
@@ -35,7 +35,7 @@ server.listen(0, common.mustCall(() => {
     http.get(
       {port: server.address().port, headers: {'x-num': n}},
       (res) => {
-        common.fail('client allowed multiple content-length headers.');
+        assert.fail('client allowed multiple content-length headers.');
       }
     ).on('error', common.mustCall((err) => {
       assert(/^Parse Error/.test(err.message));

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const http = require('http');
 const net = require('net');
 const url = require('url');
@@ -38,7 +38,7 @@ const server = http.createServer((req, res) => {
       test(res, 200, {'foo': y});
       break;
     default:
-      common.fail('should not get to here.');
+      assert.fail('should not get to here.');
   }
   if (count === 3)
     server.close();

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
@@ -44,7 +44,7 @@ testCases.findByPath = function(path) {
     return testCase.path === path;
   });
   if (matching.length === 0) {
-    common.fail(`failed to find test case with path ${path}`);
+    assert.fail(`failed to find test case with path ${path}`);
   }
   return matching[0];
 };

--- a/test/parallel/test-http-server-reject-chunked-with-content-length.js
+++ b/test/parallel/test-http-server-reject-chunked-with-content-length.js
@@ -23,7 +23,7 @@ server.listen(0, () => {
   client.on('data', (data) => {
     // Should not get to this point because the server should simply
     // close the connection without returning any data.
-    common.fail('no data should be returned by the server');
+    assert.fail('no data should be returned by the server');
   });
   client.on('end', common.mustCall());
 });

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -66,7 +66,7 @@ server.listen(common.PIPE, common.mustCall(function() {
   }));
 
   req.on('error', function(e) {
-    common.fail(e.stack);
+    assert.fail(e.stack);
   });
 
   req.end();

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 const fs = require('fs');
 
 if (!common.hasCrypto) {
@@ -54,7 +55,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
     method: 'GET',
     localAddress: invalidLocalAddress
   }, function(res) {
-    common.fail('unexpectedly got response from server');
+    assert.fail('unexpectedly got response from server');
   }).on('error', common.mustCall(function(e) {
     console.log('client got error: ' + e.message);
     server.close();

--- a/test/parallel/test-net-error-twice.js
+++ b/test/parallel/test-net-error-twice.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -41,7 +41,7 @@ const srv = net.createServer(function onConnection(conn) {
   conn.on('error', function(err) {
     errs.push(err);
     if (errs.length > 1 && errs[0] === errs[1])
-      common.fail('Should not emit the same error twice');
+      assert.fail('Should not emit the same error twice');
   });
   conn.on('close', function() {
     srv.unref();

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -56,7 +56,7 @@ if (common.isWindows) {
 }
 
 const notSocketClient = net.createConnection(emptyTxt, function() {
-  common.fail('connection callback should not run');
+  assert.fail('connection callback should not run');
 });
 
 notSocketClient.on('error', common.mustCall(function(err) {
@@ -67,7 +67,7 @@ notSocketClient.on('error', common.mustCall(function(err) {
 
 // Trying to connect to not-existing socket should result in ENOENT error
 const noEntSocketClient = net.createConnection('no-ent-file', function() {
-  common.fail('connection to non-existent socket, callback should not run');
+  assert.fail('connection to non-existent socket, callback should not run');
 });
 
 noEntSocketClient.on('error', common.mustCall(function(err) {
@@ -84,7 +84,7 @@ if (!common.isWindows && process.getuid() !== 0) {
     fs.chmodSync(common.PIPE, 0);
 
     const accessClient = net.createConnection(common.PIPE, function() {
-      common.fail('connection should get EACCES, callback should not run');
+      assert.fail('connection should get EACCES, callback should not run');
     });
 
     accessClient.on('error', common.mustCall(function(err) {

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const net = require('net');
@@ -86,5 +86,5 @@ process.on('exit', function() {
 
 process.on('unhandledRejection', function() {
   console.error('promise rejected');
-  common.fail('A promise in the chain rejected');
+  assert.fail('A promise in the chain rejected');
 });

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -31,7 +31,7 @@ let server1Sock;
 const server1ConnHandler = function(socket) {
   socket.on('data', function(data) {
     if (stopped) {
-      common.fail('data event should not have happened yet');
+      assert.fail('data event should not have happened yet');
     }
 
     assert.strictEqual(data.toString(), msg, 'invalid data received');

--- a/test/parallel/test-net-write-slow.js
+++ b/test/parallel/test-net-write-slow.js
@@ -34,7 +34,7 @@ const server = net.createServer(function(socket) {
   socket.setNoDelay();
   socket.setTimeout(9999);
   socket.on('timeout', function() {
-    common.fail(`flushed: ${flushed}, received: ${received}/${SIZE * N}`);
+    assert.fail(`flushed: ${flushed}, received: ${received}/${SIZE * N}`);
   });
 
   for (let i = 0; i < N; ++i) {

--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 process.on('exit', () => {
   assert.strictEqual(process._exiting, true, 'process._exiting was not set!');
 
   process.nextTick(() => {
-    common.fail('process is exiting, should not be called.');
+    assert.fail('process is exiting, should not be called.');
   });
 });
 

--- a/test/parallel/test-process-exit-from-before-exit.js
+++ b/test/parallel/test-process-exit-from-before-exit.js
@@ -21,9 +21,10 @@
 
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 
 process.on('beforeExit', common.mustCall(function() {
   setTimeout(common.mustNotCall(), 5);
   process.exit(0);  // Should execute immediately even if we schedule new work.
-  common.fail();
+  assert.fail();
 }));

--- a/test/parallel/test-process-no-deprecation.js
+++ b/test/parallel/test-process-no-deprecation.js
@@ -10,7 +10,7 @@ process.noDeprecation = true;
 const assert = require('assert');
 
 function listener() {
-  common.fail('received unexpected warning');
+  assert.fail('received unexpected warning');
 }
 
 process.addListener('warning', listener);

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const domain = require('domain');
 
@@ -164,7 +164,7 @@ asyncTest('Catching a promise rejection after setImmediate is not' +
   });
   _reject(e);
   setImmediate(function() {
-    promise.then(common.fail, function() {});
+    promise.then(assert.fail, function() {});
   });
 });
 
@@ -176,7 +176,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the' +
     assert.strictEqual(e2, reason);
     assert.strictEqual(promise2, promise);
   });
-  const promise2 = Promise.reject(e).then(common.fail, function(reason) {
+  const promise2 = Promise.reject(e).then(assert.fail, function(reason) {
     assert.strictEqual(e, reason);
     throw e2;
   });
@@ -205,7 +205,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the ' +
     setTimeout(function() {
       reject(e);
     }, 1);
-  }).then(common.fail, function(reason) {
+  }).then(assert.fail, function(reason) {
     assert.strictEqual(e, reason);
     throw e2;
   });
@@ -224,7 +224,7 @@ asyncTest('When re-throwing new errors in a promise catch, only the re-thrown' +
     setTimeout(function() {
       reject(e);
       process.nextTick(function() {
-        promise2 = promise.then(common.fail, function(reason) {
+        promise2 = promise.then(assert.fail, function(reason) {
           assert.strictEqual(e, reason);
           throw e2;
         });
@@ -240,7 +240,7 @@ asyncTest(
   function(done) {
     const e = new Error();
     onUnhandledFail(done);
-    Promise.reject(e).then(common.fail, function() {});
+    Promise.reject(e).then(assert.fail, function() {});
   }
 );
 
@@ -252,7 +252,7 @@ asyncTest(
     onUnhandledFail(done);
     new Promise(function(_, reject) {
       reject(e);
-    }).then(common.fail, function() {});
+    }).then(assert.fail, function() {});
   }
 );
 
@@ -262,7 +262,7 @@ asyncTest('Attaching a promise catch in a process.nextTick is soon enough to' +
   onUnhandledFail(done);
   const promise = Promise.reject(e);
   process.nextTick(function() {
-    promise.then(common.fail, function() {});
+    promise.then(assert.fail, function() {});
   });
 });
 
@@ -274,7 +274,7 @@ asyncTest('Attaching a promise catch in a process.nextTick is soon enough to' +
     reject(e);
   });
   process.nextTick(function() {
-    promise.then(common.fail, function() {});
+    promise.then(assert.fail, function() {});
   });
 });
 
@@ -305,7 +305,7 @@ asyncTest('catching a promise which is asynchronously rejected (via' +
         reject(e);
       }, 1);
     });
-  }).then(common.fail, function(reason) {
+  }).then(assert.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -316,7 +316,7 @@ asyncTest('Catching a rejected promise derived from throwing in a' +
   onUnhandledFail(done);
   Promise.resolve().then(function() {
     throw e;
-  }).then(common.fail, function(reason) {
+  }).then(assert.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -328,7 +328,7 @@ asyncTest('Catching a rejected promise derived from returning a' +
   onUnhandledFail(done);
   Promise.resolve().then(function() {
     return Promise.reject(e);
-  }).then(common.fail, function(reason) {
+  }).then(assert.fail, function(reason) {
     assert.strictEqual(e, reason);
   });
 });
@@ -382,7 +382,7 @@ asyncTest('Catching the Promise.all() of a collection that includes a' +
           'rejected promise prevents unhandledRejection', function(done) {
   const e = new Error();
   onUnhandledFail(done);
-  Promise.all([Promise.reject(e)]).then(common.fail, function() {});
+  Promise.all([Promise.reject(e)]).then(assert.fail, function() {});
 });
 
 asyncTest(
@@ -398,7 +398,7 @@ asyncTest(
     });
     p = Promise.all([p]);
     process.nextTick(function() {
-      p.then(common.fail, function() {});
+      p.then(assert.fail, function() {});
     });
   }
 );
@@ -434,7 +434,7 @@ asyncTest('Waiting setTimeout(, 10) to catch a promise causes an' +
     throw e;
   });
   setTimeout(function() {
-    thePromise.then(common.fail, function(reason) {
+    thePromise.then(assert.fail, function(reason) {
       assert.strictEqual(e, reason);
     });
   }, 10);

--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -39,7 +39,7 @@ if (!process.argv[2]) {
 
   const comspec = process.env['comspec'];
   if (!comspec || comspec.length === 0) {
-    common.fail('Failed to get COMSPEC');
+    assert.fail('Failed to get COMSPEC');
   }
 
   const args = ['/c', process.execPath, __filename, 'child',

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const R = require('_stream_readable');
 const W = require('_stream_writable');
 const assert = require('assert');
@@ -53,5 +53,5 @@ src.on('end', function() {
 src.pipe(dst);
 
 const timeout = setTimeout(function() {
-  common.fail('timed out waiting for _write');
+  assert.fail('timed out waiting for _write');
 }, 100);

--- a/test/parallel/test-tls-econnreset.js
+++ b/test/parallel/test-tls-econnreset.js
@@ -71,7 +71,7 @@ let clientError = null;
 let connectError = null;
 
 const server = tls.createServer({ ca: ca, cert: cert, key: key }, () => {
-  common.fail('should be unreachable');
+  assert.fail('should be unreachable');
 }).on('tlsClientError', function(err, conn) {
   assert(!clientError && conn);
   clientError = err;

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -22,7 +22,7 @@ const options = {
 };
 
 const server = tls.createServer(options, (c) => {
-  common.fail('Should not be called');
+  assert.fail('Should not be called');
 }).on('tlsClientError', common.mustCall((err, c) => {
   assert(/SSL_use_certificate:passed a null parameter/i.test(err.message));
   server.close();

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -140,7 +140,7 @@ function doTest(testOptions, callback) {
             spawnClient();
             return;
           }
-          common.fail(`code: ${code}, signal: ${signal}, output: ${err}`);
+          assert.fail(`code: ${code}, signal: ${signal}, output: ${err}`);
         }
         assert.strictEqual(code, 0);
         server.close(common.mustCall(function() {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -239,7 +239,7 @@ for (const showHidden of [true, false]) {
       {visible: {value: 1, enumerable: true}, hidden: {value: 2}}), true);
   if (out !== '{ [hidden]: 2, visible: 1 }' &&
       out !== '{ visible: 1, [hidden]: 2 }') {
-    common.fail(`unexpected value for out ${out}`);
+    assert.fail(`unexpected value for out ${out}`);
   }
 }
 
@@ -251,7 +251,7 @@ for (const showHidden of [true, false]) {
                                            hidden: {value: 'secret'}}), true);
   if (out !== "{ [hidden]: 'secret', name: 'Tim' }" &&
       out !== "{ name: 'Tim', [hidden]: 'secret' }") {
-    common.fail(`unexpected value for out ${out}`);
+    assert.fail(`unexpected value for out ${out}`);
   }
 }
 

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -31,7 +31,7 @@ assert.throws(function() {
 }, /SyntaxError/);
 
 assert.throws(function() {
-  vm.runInDebugContext({ toString: common.fail });
+  vm.runInDebugContext({ toString: assert.fail });
 }, /AssertionError/);
 
 assert.throws(function() {

--- a/test/parallel/test-vm-syntax-error-message.js
+++ b/test/parallel/test-vm-syntax-error-message.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 
@@ -12,7 +12,7 @@ const p = child_process.spawn(process.execPath, [
 ]);
 
 p.stderr.on('data', function(data) {
-  common.fail(`Unexpected stderr data: ${data}`);
+  assert.fail(`Unexpected stderr data: ${data}`);
 });
 
 let output = '';

--- a/test/parallel/test-vm-syntax-error-stderr.js
+++ b/test/parallel/test-vm-syntax-error-stderr.js
@@ -13,7 +13,7 @@ const p = child_process.spawn(process.execPath, [
 ]);
 
 p.stdout.on('data', function(data) {
-  common.fail('Unexpected stdout data: ' + data);
+  assert.fail('Unexpected stdout data: ' + data);
 });
 
 let output = '';


### PR DESCRIPTION
First commit:

    assert.fail() has two possible function signatures, both of which are
    not intuitive. It virtually guarantees that people who try to use
    assert.fail() without carefully reading the docs will end up using it
    incorrectly.
    
    This change maintains backwards compatibility with the two valid uses
    (arguments 1 2 and 4 supplied but argument 3 falsy, and argument 3
    supplied but arguments 1 2 and 4 all falsy) but also adds the far more
    intuitive first-argument-only and first-two-arguments-only
    possibilities.
    
    assert.fail('boom');
    // AssertionError: boom
    
    assert.fail('a', 'b');
    // AssertionError: 'a' != 'b'

Second commit: Remove lint rule that flags use of assert.fail() with a single argument.

Third commit: Remove common.fail() in tests since assert.fail() with a single argument works as expected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
