### PR TITLE
src: guard bundled_ca/openssl_ca with HAVE_OPENSSL

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3647,8 +3647,10 @@ static void ParseArgs(int* argc,
   const char** new_exec_argv = new const char*[nargs];
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
+#if HAVE_OPENSSL
   bool use_bundled_ca = false;
   bool use_openssl_ca = false;
+#endif  // HAVE_INSPECTOR
 
   for (unsigned int i = 0; i < nargs; ++i) {
     new_exec_argv[i] = nullptr;


### PR DESCRIPTION
Currently, the following warning will be reported when configuring
without-ssl:
```
../src/node.cc:3653:8: warning: unused variable 'use_bundled_ca'
[-Wunused-variable]
  bool use_bundled_ca = false;
       ^
../src/node.cc:3654:8: warning: unused variable 'use_openssl_ca'
[-Wunused-variable]
  bool use_openssl_ca = false;
       ^
```
I missed this when working on commit 8a7db9d4b5798679045d7a4f6f62243ba4be5b8c ("src: add --use-bundled-ca --use-openssl-ca check").

Refs: https://github.com/nodejs/node/pull/12087

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src