### PR TITLE
src: guard default_inspector_port

### DIFF
--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -9,7 +9,9 @@ namespace node {
 
 namespace {
 const int default_debugger_port = 5858;
+#if HAVE_INSPECTOR
 const int default_inspector_port = 9229;
+#endif  // HAVE_INSPECTOR
 
 inline std::string remove_brackets(const std::string& host) {
   if (!host.empty() && host.front() == '[' && host.back() == ']')


### PR DESCRIPTION
When configuring and building --without-ssl the following warning is
reported:
```
../src/node_debug_options.cc:12:11: warning: unused variable
'default_inspector_port' [-Wunused-const-variable]
const int default_inspector_port = 9229;
```
The commit adds a HAVE_INSPECTOR guard to this constant.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src