### PR TITLE
test: add internal/fs tests

### DIFF
--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -1,0 +1,66 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const SyncWriteStream = require('internal/fs').SyncWriteStream;
+
+common.refreshTmpDir();
+
+const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
+
+// Verify constructing the instance with defualt options.
+{
+  const stream = new SyncWriteStream(1);
+
+  assert.strictEqual(stream.fd, 1);
+  assert.strictEqual(stream.readable, false);
+  assert.strictEqual(stream.autoClose, true);
+  assert.strictEqual(stream.listenerCount('end'), 1);
+}
+
+// Verify constructing the instance with specified options.
+{
+  const stream = new SyncWriteStream(1, { autoClose: false });
+
+  assert.strictEqual(stream.fd, 1);
+  assert.strictEqual(stream.readable, false);
+  assert.strictEqual(stream.autoClose, false);
+  assert.strictEqual(stream.listenerCount('end'), 1);
+}
+
+// Verfiy that the file will be writen synchronously.
+{
+  const fd = fs.openSync(filename, 'w');
+  const stream = new SyncWriteStream(fd);
+  const chunk = Buffer.from('foo');
+
+  assert.strictEqual(stream._write(chunk, null, common.mustCall(1)), true);
+  assert.strictEqual(fs.readFileSync(filename).equals(chunk), true);
+}
+
+// Verify that the stream will unset the fd after destory().
+{
+  const fd = fs.openSync(filename, 'w');
+  const stream = new SyncWriteStream(fd);
+
+  stream.on('close', common.mustCall(3));
+
+  assert.strictEqual(stream.destroy(), true);
+  assert.strictEqual(stream.fd, null);
+  assert.strictEqual(stream.destroy(), true);
+  assert.strictEqual(stream.destroySoon(), true);
+}
+
+// Verfit that the 'end' event listener will also destroy the stream.
+{
+  const fd = fs.openSync(filename, 'w');
+  const stream = new SyncWriteStream(fd);
+
+  assert.strictEqual(stream.fd, fd);
+
+  stream.emit('end');
+  assert.strictEqual(stream.fd, null);
+}

--- a/test/parallel/test-internal-fs.js
+++ b/test/parallel/test-internal-fs.js
@@ -1,0 +1,10 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const fs = require('internal/fs');
+
+assert.doesNotThrow(() => fs.assertEncoding());
+assert.doesNotThrow(() => fs.assertEncoding('utf8'));
+assert.throws(() => fs.assertEncoding('foo'), /^Error: Unknown encoding: foo$/);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
- add tests of `internal/fs.js`
- increase coverage
- ~~move tests of `require(internal/fs).stringToFlags` in `test-fs-open-flags.js` to `test-internal-fs-string-to-flags.js` for a more accurate and findable filename~~

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->