### PR TITLE
doc: drop PPC BE from supported platforms

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -40,7 +40,6 @@ Support is divided into three tiers:
 | Windows      | Tier 1       | >= Windows 7 or >= Windows2008R2 | x86, x64             |                  |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
-| GNU/Linux    | Tier 2       | kernel >= 4.2.0, glibc >= 2.19   | ppc64be              |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le              |                  |
 | AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be              |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |


### PR DESCRIPTION
We've discussed this with the Power team within IBM and have
agreement that we should drop Power Linux BE for Node version
8 as customers will be using Power Linux LE when using
Node.js going forward.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]
##### Affected core subsystem(s)
doc