### PR TITLE
docs: add info about serializable types for `querystring.stringify()`

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -101,6 +101,9 @@ added: v0.1.25
 The `querystring.stringify()` method produces a URL query string from a
 given `obj` by iterating through the object's "own properties".
 
+This method searializes the following types of values passed in `obj`: strings,
+finite numbers, booleans and arrays of the aforementioned types.
+
 For example:
 
 ```js

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -101,9 +101,9 @@ added: v0.1.25
 The `querystring.stringify()` method produces a URL query string from a
 given `obj` by iterating through the object's "own properties".
 
-This method serializes the following types of values passed in `obj`: strings,
-finite numbers, booleans and arrays of the aforementioned types.
-Any other input values will be coerced to empty strings
+It serializes the following types of values passed in `obj`:
+{String|Number|Boolean|String[]|Number[]|Boolean[]}
+Any other input values will be coerced to empty strings.
 
 For example:
 

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -101,8 +101,9 @@ added: v0.1.25
 The `querystring.stringify()` method produces a URL query string from a
 given `obj` by iterating through the object's "own properties".
 
-This method searializes the following types of values passed in `obj`: strings,
+This method serializes the following types of values passed in `obj`: strings,
 finite numbers, booleans and arrays of the aforementioned types.
+Any other input values will be coerced to empty strings
 
 For example:
 


### PR DESCRIPTION
querystring.stringify() doesn't serialize some values. Explicitly mention what values are serialized in the docs.

Fixes #12234 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
