### PR TITLE
doc: response.write ignores body in some cases

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1161,6 +1161,10 @@ it will switch to implicit header mode and flush the implicit headers.
 This sends a chunk of the response body. This method may
 be called multiple times to provide successive parts of the body.
 
+Note that in the `http` module, the response body is omitted when the
+request is a HEAD request. Similarly, the `204` and `304` responses
+_must not_ include a message body.
+
 `chunk` can be a string or a buffer. If `chunk` is a string,
 the second parameter specifies how to encode it into a byte stream.
 By default the `encoding` is `'utf8'`. `callback` will be called when this chunk


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/8057

Hi guys. I hope it is ok to take a stalled PR (https://github.com/nodejs/node/pull/8992) and finally close the issue. 

Please feel free to close it, if it is something wrong. 

What is done here, is updated doc for `http` and `response.write` in particular with information that `body` is ignored in case of HEAD request.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, http