### PR TITLE
src: do not join an uninitialized thread

### DIFF
--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -182,8 +182,11 @@ bool InspectorIo::Start() {
 }
 
 void InspectorIo::Stop() {
+  if (State::kNew == state_)
+    return;
   int err = uv_thread_join(&thread_);
   CHECK_EQ(err, 0);
+  state_ = State::kNew;
 }
 
 bool InspectorIo::IsConnected() {


### PR DESCRIPTION
A uv_thread_t/pthread_t cannot be initialized to an explicitly invalid
value, access to it must be guarded by some state tracking.

Attempt to fix

```
*** CID 166790:  Uninitialized members  (UNINIT_CTOR)
/src/inspector_io.cc: 167 in node::inspector::InspectorIo::InspectorIo(node::Environment *, v8::Platform *, const std::basic_string<char, std::char_traits<char>, std::allocator<char>>&, const node::DebugOptions &)()
161                                platform_(platform), dispatching_messages_(false),
162                                session_id_(0), script_name_(path) {
163       CHECK_EQ(0, uv_async_init(env->event_loop(), &main_thread_req_,
164                                 InspectorIo::MainThreadAsyncCb));
165       uv_unref(reinterpret_cast<uv_handle_t*>(&main_thread_req_));
166       CHECK_EQ(0, uv_sem_init(&start_sem_, 0));
>>>     CID 166790:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "thread_" is not initialized in this constructor nor in any functions that it calls.
167     }
168
169     bool InspectorIo::Start() {
170       CHECK_EQ(uv_thread_create(&thread_, InspectorIo::ThreadCbIO, this), 0);
171       uv_sem_wait(&start_sem_);
172
```

Though I may need some lint markup as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


/to @bnoordhuis @eugeneo 