### PR TITLE
test: fix compiler warning in n-api test

### DIFF
--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -40,7 +40,7 @@ napi_value Echo(napi_env env, napi_callback_info info) {
 
 napi_value New(napi_env env, napi_callback_info info) {
   napi_value _this;
-  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, NULL, &_this));
+  NAPI_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &_this, NULL));
 
   return _this;
 }


### PR DESCRIPTION
Missed in ca786c3734f6e23e34cd60f13e6bdaab033c5739. This does
not actually affect the outcome because returning `nullptr` or
`this` from a constructor has the same effect.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

test, n-api