### PR TITLE
doc: missing _ in Writable ES6 examples

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1219,7 +1219,7 @@ For example:
 const Writable = require('stream').Writable;
 
 const myWritable = new Writable({
-  write(chunk, encoding, callback) {
+  _write(chunk, encoding, callback) {
     // ...
   }
 });
@@ -1284,10 +1284,10 @@ Or, using the Simplified Constructor approach:
 const Writable = require('stream').Writable;
 
 const myWritable = new Writable({
-  write(chunk, encoding, callback) {
+  _write(chunk, encoding, callback) {
     // ...
   },
-  writev(chunks, callback) {
+  _writev(chunks, callback) {
     // ...
   }
 });
@@ -1373,7 +1373,7 @@ predictable handling of errors.
 const Writable = require('stream').Writable;
 
 const myWritable = new Writable({
-  write(chunk, encoding, callback) {
+  _write(chunk, encoding, callback) {
     if (chunk.toString().indexOf('a') >= 0) {
       callback(new Error('chunk is invalid'));
     } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Stream implementers need to implement `_write`/`_writev` rather than `write`/`writev`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
