### PR TITLE
(v7.x-backport) build: enable cctest to use generated objects

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,6 +38,8 @@
       ['OS == "win"', {
         'os_posix': 0,
         'v8_postmortem_support%': 'false',
+        'OBJ_DIR': '<(PRODUCT_DIR)/obj',
+        'V8_BASE': '<(PRODUCT_DIR)/lib/v8_libbase.lib',
       }, {
         'os_posix': 1,
         'v8_postmortem_support%': 'true',
@@ -51,8 +53,8 @@
             'OBJ_DIR': '<(PRODUCT_DIR)/obj',
             'V8_BASE': '<(PRODUCT_DIR)/obj/deps/v8/src/libv8_base.a',
           }, {
-            'OBJ_DIR': '<(PRODUCT_DIR)/obj.target',
-            'V8_BASE': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
+            'OBJ_DIR%': '<(PRODUCT_DIR)/obj.target',
+            'V8_BASE%': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
           }],
         ],
       }],

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -279,3 +279,65 @@ If you want to improve tests that have been imported this way, please send
 a PR to the upstream project first. When your proposed change is merged in
 the upstream project, send another PR here to update Node.js accordingly.
 Be sure to update the hash in the URL following `WPT Refs:`.
+
+## C++ Unit test
+C++ code can be tested using [Google Test][]. Most features in Node.js can be
+tested using the methods described previously in this document. But there are
+cases where these might not be enough, for example writing code for Node.js
+that will only be called when Node.js is embedded.
+
+### Adding a new test
+The unit test should be placed in `test/cctest` and be named with the prefix
+`test` followed by the name of unit being tested. For example, the code below
+would be placed in `test/cctest/test_env.cc`:
+
+```c++
+#include "gtest/gtest.h"
+#include "node_test_fixture.h"
+#include "env.h"
+#include "node.h"
+#include "v8.h"
+
+static bool called_cb = false;
+static void at_exit_callback(void* arg);
+
+class EnvTest : public NodeTestFixture { };
+
+TEST_F(EnvTest, RunAtExit) {
+  v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  node::IsolateData* isolateData = node::CreateIsolateData(isolate_, uv_default_loop());
+  Argv argv{"node", "-e", ";"};
+  auto env = Environment:CreateEnvironment(isolateData, context, 1, *argv, 2, *argv);
+  node::AtExit(at_exit_callback);
+  node::RunAtExit(env);
+  EXPECT_TRUE(called_cb);
+}
+
+static void at_exit_callback(void* arg) {
+  called_cb = true;
+}
+```
+
+Next add the test to the `sources` in the `cctest` target in node.gyp:
+```
+'sources': [
+  'test/cctest/test_env.cc',
+  ...
+],
+```
+The test can be executed by running the `cctest` target:
+```
+$ make cctest
+```
+
+### Node test fixture
+There is a [test fixture] named `node_test_fixture.h` which can be included by
+unit tests. The fixture takes care of setting up the Node.js environment
+and tearing it down after the tests have finished.
+
+It also contains a helper to create arguments to be passed into Node.js. It
+will depend on what is being tested if this is required or not.
+
+[Google Test]: https://github.com/google/googletest
+[Test fixture]: https://github.com/google/googletest/blob/master/googletest/docs/Primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests

--- a/node.gyp
+++ b/node.gyp
@@ -145,6 +145,10 @@
         'node_js2c#host',
       ],
 
+      'includes': [
+        'node.gypi'
+      ],
+
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
@@ -258,340 +262,6 @@
         'NODE_WANT_INTERNALS=1',
         # Warn when using deprecated V8 APIs.
         'V8_DEPRECATION_WARNINGS=1',
-      ],
-
-
-      'conditions': [
-        [ 'node_shared=="false"', {
-          'msvs_settings': {
-            'VCManifestTool': {
-              'EmbedManifest': 'true',
-              'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
-            }
-          },
-        }, {
-          'defines': [
-            'NODE_SHARED_MODE',
-          ],
-          'conditions': [
-            [ 'node_module_version!="" and OS!="win"', {
-              'product_extension': '<(shlib_suffix)',
-            }]
-          ],
-        }],
-        [ 'node_enable_d8=="true"', {
-          'dependencies': [ 'deps/v8/src/d8.gyp:d8' ],
-        }],
-        [ 'node_use_bundled_v8=="true"', {
-          'dependencies': [
-            'deps/v8/src/v8.gyp:v8',
-            'deps/v8/src/v8.gyp:v8_libplatform'
-          ],
-        }],
-        [ 'node_use_v8_platform=="true"', {
-          'defines': [
-            'NODE_USE_V8_PLATFORM=1',
-          ],
-        }, {
-          'defines': [
-            'NODE_USE_V8_PLATFORM=0',
-          ],
-        }],
-        [ 'node_tag!=""', {
-          'defines': [ 'NODE_TAG="<(node_tag)"' ],
-        }],
-        [ 'node_v8_options!=""', {
-          'defines': [ 'NODE_V8_OPTIONS="<(node_v8_options)"'],
-        }],
-        # No node_main.cc for anything except executable
-        [ 'node_target_type!="executable"', {
-          'sources!': [
-            'src/node_main.cc',
-          ],
-        }],
-        [ 'node_release_urlbase!=""', {
-          'defines': [
-            'NODE_RELEASE_URLBASE="<(node_release_urlbase)"',
-          ]
-        }],
-        [ 'v8_enable_i18n_support==1', {
-          'defines': [ 'NODE_HAVE_I18N_SUPPORT=1' ],
-          'dependencies': [
-            '<(icu_gyp_path):icui18n',
-            '<(icu_gyp_path):icuuc',
-          ],
-          'conditions': [
-            [ 'icu_small=="true"', {
-              'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
-          }]],
-        }],
-        [ 'node_use_bundled_v8=="true" and \
-           node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
-           target_arch=="ia32" or target_arch=="x32")', {
-          'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
-          'dependencies': [
-            'deps/v8/src/third_party/vtune/v8vtune.gyp:v8_vtune'
-          ],
-        }],
-        [ 'v8_inspector=="true"', {
-          'defines': [
-            'HAVE_INSPECTOR=1',
-          ],
-          'sources': [
-            'src/inspector_agent.cc',
-            'src/inspector_socket.cc',
-            'src/inspector_socket_server.cc',
-            'src/inspector_agent.h',
-            'src/inspector_socket.h',
-            'src/inspector_socket_server.h',
-          ],
-          'dependencies': [
-            'deps/v8_inspector/src/inspector/inspector.gyp:standalone_inspector',
-            'v8_inspector_compress_protocol_json#host',
-          ],
-          'include_dirs': [
-            'deps/v8_inspector/include',
-            '<(SHARED_INTERMEDIATE_DIR)/include', # for inspector
-            '<(SHARED_INTERMEDIATE_DIR)',
-          ],
-        }, {
-          'defines': [ 'HAVE_INSPECTOR=0' ]
-        }],
-        [ 'node_use_openssl=="true"', {
-          'defines': [ 'HAVE_OPENSSL=1' ],
-          'sources': [
-            'src/node_crypto.cc',
-            'src/node_crypto_bio.cc',
-            'src/node_crypto_clienthello.cc',
-            'src/node_crypto.h',
-            'src/node_crypto_bio.h',
-            'src/node_crypto_clienthello.h',
-            'src/tls_wrap.cc',
-            'src/tls_wrap.h'
-          ],
-          'conditions': [
-            ['openssl_fips != ""', {
-              'defines': [ 'NODE_FIPS_MODE' ],
-            }],
-            [ 'node_shared_openssl=="false"', {
-              'dependencies': [
-                './deps/openssl/openssl.gyp:openssl',
-
-                # For tests
-                './deps/openssl/openssl.gyp:openssl-cli',
-              ],
-              # Do not let unused OpenSSL symbols to slip away
-              'conditions': [
-                # -force_load or --whole-archive are not applicable for
-                # the static library
-                [ 'node_target_type!="static_library"', {
-                  'xcode_settings': {
-                    'OTHER_LDFLAGS': [
-                      '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
-                    ],
-                  },
-                  'conditions': [
-                    ['OS in "linux freebsd" and node_shared=="false"', {
-                      'ldflags': [
-                        '-Wl,--whole-archive,'
-                            '<(OBJ_DIR)/deps/openssl/'
-                            '<(OPENSSL_PRODUCT)',
-                        '-Wl,--no-whole-archive',
-                      ],
-                    }],
-                    # openssl.def is based on zlib.def, zlib symbols
-                    # are always exported.
-                    ['use_openssl_def==1', {
-                      'sources': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
-                    }],
-                    ['OS=="win" and use_openssl_def==0', {
-                      'sources': ['deps/zlib/win32/zlib.def'],
-                    }],
-                  ],
-                }],
-              ],
-            }]]
-        }, {
-          'defines': [ 'HAVE_OPENSSL=0' ]
-        }],
-        [ 'node_use_dtrace=="true"', {
-          'defines': [ 'HAVE_DTRACE=1' ],
-          'dependencies': [
-            'node_dtrace_header',
-            'specialize_node_d',
-          ],
-          'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
-
-          #
-          # DTrace is supported on linux, solaris, mac, and bsd.  There are
-          # three object files associated with DTrace support, but they're
-          # not all used all the time:
-          #
-          #   node_dtrace.o           all configurations
-          #   node_dtrace_ustack.o    not supported on mac and linux
-          #   node_dtrace_provider.o  All except OS X.  "dtrace -G" is not
-          #                           used on OS X.
-          #
-          # Note that node_dtrace_provider.cc and node_dtrace_ustack.cc do not
-          # actually exist.  They're listed here to trick GYP into linking the
-          # corresponding object files into the final "node" executable.  These
-          # object files are generated by "dtrace -G" using custom actions
-          # below, and the GYP-generated Makefiles will properly build them when
-          # needed.
-          #
-          'sources': [ 'src/node_dtrace.cc' ],
-          'conditions': [
-            [ 'OS=="linux"', {
-              'sources': [
-                '<(SHARED_INTERMEDIATE_DIR)/node_dtrace_provider.o'
-              ],
-            }],
-            [ 'OS!="mac" and OS!="linux"', {
-              'sources': [
-                'src/node_dtrace_ustack.cc',
-                'src/node_dtrace_provider.cc',
-              ]
-            }
-          ] ]
-        } ],
-        [ 'node_use_lttng=="true"', {
-          'defines': [ 'HAVE_LTTNG=1' ],
-          'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
-          'libraries': [ '-llttng-ust' ],
-          'sources': [
-            'src/node_lttng.cc'
-          ],
-        } ],
-        [ 'node_use_etw=="true"', {
-          'defines': [ 'HAVE_ETW=1' ],
-          'dependencies': [ 'node_etw' ],
-          'sources': [
-            'src/node_win32_etw_provider.h',
-            'src/node_win32_etw_provider-inl.h',
-            'src/node_win32_etw_provider.cc',
-            'src/node_dtrace.cc',
-            'tools/msvs/genfiles/node_etw_provider.h',
-            'tools/msvs/genfiles/node_etw_provider.rc',
-          ]
-        } ],
-        [ 'node_use_perfctr=="true"', {
-          'defines': [ 'HAVE_PERFCTR=1' ],
-          'dependencies': [ 'node_perfctr' ],
-          'sources': [
-            'src/node_win32_perfctr_provider.h',
-            'src/node_win32_perfctr_provider.cc',
-            'src/node_counters.cc',
-            'src/node_counters.h',
-            'tools/msvs/genfiles/node_perfctr_provider.rc',
-          ]
-        } ],
-        [ 'node_no_browser_globals=="true"', {
-          'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
-        } ],
-        [ 'node_use_bundled_v8=="true" and v8_postmortem_support=="true"', {
-          'dependencies': [ 'deps/v8/src/v8.gyp:postmortem-metadata' ],
-          'conditions': [
-            # -force_load is not applicable for the static library
-            [ 'node_target_type!="static_library"', {
-              'xcode_settings': {
-                'OTHER_LDFLAGS': [
-                  '-Wl,-force_load,<(V8_BASE)',
-                ],
-              },
-            }],
-          ],
-        }],
-        [ 'node_shared_zlib=="false"', {
-          'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
-        }],
-
-        [ 'node_shared_http_parser=="false"', {
-          'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
-        }],
-
-        [ 'node_shared_cares=="false"', {
-          'dependencies': [ 'deps/cares/cares.gyp:cares' ],
-        }],
-
-        [ 'node_shared_libuv=="false"', {
-          'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
-        }],
-
-        [ 'OS=="win"', {
-          'sources': [
-            'src/backtrace_win32.cc',
-            'src/res/node.rc',
-          ],
-          'defines!': [
-            'NODE_PLATFORM="win"',
-          ],
-          'defines': [
-            'FD_SETSIZE=1024',
-            # we need to use node's preferred "win32" rather than gyp's preferred "win"
-            'NODE_PLATFORM="win32"',
-            '_UNICODE=1',
-          ],
-          'libraries': [ '-lpsapi.lib' ]
-        }, { # POSIX
-          'defines': [ '__POSIX__' ],
-          'sources': [ 'src/backtrace_posix.cc' ],
-        }],
-        [ 'OS=="mac"', {
-          # linking Corefoundation is needed since certain OSX debugging tools
-          # like Instruments require it for some features
-          'libraries': [ '-framework CoreFoundation' ],
-          'defines!': [
-            'NODE_PLATFORM="mac"',
-          ],
-          'defines': [
-            # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
-            'NODE_PLATFORM="darwin"',
-          ],
-        }],
-        [ 'OS=="freebsd"', {
-          'libraries': [
-            '-lutil',
-            '-lkvm',
-          ],
-        }],
-        [ 'OS=="aix"', {
-          'defines': [
-            '_LINUX_SOURCE_COMPAT',
-          ],
-        }],
-        [ 'OS=="solaris"', {
-          'libraries': [
-            '-lkstat',
-            '-lumem',
-          ],
-          'defines!': [
-            'NODE_PLATFORM="solaris"',
-          ],
-          'defines': [
-            # we need to use node's preferred "sunos"
-            # rather than gyp's preferred "solaris"
-            'NODE_PLATFORM="sunos"',
-          ],
-        }],
-        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="false"', {
-          'ldflags': [ '-Wl,-z,noexecstack',
-                       '-Wl,--whole-archive <(V8_BASE)',
-                       '-Wl,--no-whole-archive' ]
-        }],
-        [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="true"', {
-          'ldflags': [ '-Wl,-z,noexecstack',
-                       '-Wl,--whole-archive <(V8_BASE)',
-                       '-Wl,--no-whole-archive',
-                       '--coverage',
-                       '-g',
-                       '-O0' ],
-           'cflags': [ '--coverage',
-                       '-g',
-                       '-O0' ]
-        }],
-        [ 'OS=="sunos"', {
-          'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
-        }],
       ],
     },
     {
@@ -890,12 +560,70 @@
     {
       'target_name': 'cctest',
       'type': 'executable',
-      'dependencies': [ 'deps/gtest/gtest.gyp:gtest' ],
+
+      'dependencies': [
+        '<(node_core_target_name)',
+        'deps/gtest/gtest.gyp:gtest',
+        'node_js2c#host',
+        'node_dtrace_header',
+        'node_dtrace_ustack',
+        'node_dtrace_provider',
+      ],
+
+      'variables': {
+        'OBJ_PATH': '<(OBJ_DIR)/node/src',
+        'OBJ_GEN_PATH': '<(OBJ_DIR)/node/gen',
+        'OBJ_TRACING_PATH': '<(OBJ_DIR)/node/src/tracing',
+        'OBJ_SUFFIX': 'o',
+        'conditions': [
+          ['OS=="win"', {
+            'OBJ_PATH': '<(OBJ_DIR)/node',
+            'OBJ_GEN_PATH': '<(OBJ_DIR)/node',
+            'OBJ_TRACING_PATH': '<(OBJ_DIR)/node',
+            'OBJ_SUFFIX': 'obj',
+          }],
+          ['OS=="aix"', {
+            'OBJ_PATH': '<(OBJ_DIR)/node_base/src',
+            'OBJ_GEN_PATH': '<(OBJ_DIR)/node_base/gen',
+            'OBJ_TRACING_PATH': '<(OBJ_DIR)/node_base/src/tracing',
+          }],
+         ],
+       },
+
+      'includes': [
+        'node.gypi'
+      ],
+
       'include_dirs': [
         'src',
+        'tools/msvs/genfiles',
         'deps/v8/include',
-        '<(SHARED_INTERMEDIATE_DIR)'
+        'deps/cares/include',
+        'deps/uv/include',
+        '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
       ],
+
+      'libraries': [
+        '<(OBJ_GEN_PATH)/node_javascript.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_debug_options.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/async-wrap.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/env.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_buffer.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_i18n.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/debug-agent.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/util.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/string_bytes.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/string_search.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/stream_base.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_constants.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)/node_revert.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)/agent.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)/node_trace_buffer.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)/node_trace_writer.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)/trace_event.<(OBJ_SUFFIX)',
+      ],
+
       'defines': [
         # gtest's ASSERT macros conflict with our own.
         'GTEST_DONT_DEFINE_ASSERT_EQ=1',
@@ -906,24 +634,18 @@
         'GTEST_DONT_DEFINE_ASSERT_NE=1',
         'NODE_WANT_INTERNALS=1',
       ],
+
       'sources': [
-        'test/cctest/util.cc',
+        'test/cctest/test_util.cc',
+      ],
+
+      'sources!': [
+        'src/node_main.cc'
       ],
 
       'conditions': [
         ['v8_inspector=="true"', {
-          'defines': [
-            'HAVE_INSPECTOR=1',
-          ],
-          'dependencies': [
-            'v8_inspector_compress_protocol_json#host'
-          ],
-          'include_dirs': [
-            '<(SHARED_INTERMEDIATE_DIR)'
-          ],
           'sources': [
-            'src/inspector_socket.cc',
-            'src/inspector_socket_server.cc',
             'test/cctest/test_inspector_socket.cc',
             'test/cctest/test_inspector_socket_server.cc'
           ],
@@ -955,11 +677,18 @@
             'deps/v8/src/v8.gyp:v8_libplatform',
           ],
         }],
-        [ 'node_use_bundled_v8=="true"', {
-          'dependencies': [
-            'deps/v8/src/v8.gyp:v8',
-            'deps/v8/src/v8.gyp:v8_libplatform'
+        [ 'node_use_dtrace=="true" and OS!="mac" and OS!="linux"', {
+          'copies': [{
+            'destination': '<(OBJ_DIR)/cctest/src',
+            'files': [
+              '<(OBJ_PATH)/node_dtrace_ustack.<(OBJ_SUFFIX)',
+              '<(OBJ_PATH)/node_dtrace_provider.<(OBJ_SUFFIX)',
+              '<(OBJ_PATH)/node_dtrace.<(OBJ_SUFFIX)',
+            ]},
           ],
+        }],
+        ['OS=="solaris"', {
+          'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
         }],
       ]
     }

--- a/node.gypi
+++ b/node.gypi
@@ -1,0 +1,334 @@
+{
+  'conditions': [
+    [ 'node_shared=="false"', {
+      'msvs_settings': {
+        'VCManifestTool': {
+          'EmbedManifest': 'true',
+          'AdditionalManifestFiles': 'src/res/node.exe.extra.manifest'
+        }
+      },
+    }, {
+      'defines': [
+        'NODE_SHARED_MODE',
+      ],
+      'conditions': [
+        [ 'node_module_version!="" and OS!="win"', {
+          'product_extension': '<(shlib_suffix)',
+        }]
+      ],
+    }],
+    [ 'node_enable_d8=="true"', {
+      'dependencies': [ 'deps/v8/src/d8.gyp:d8' ],
+    }],
+    [ 'node_use_bundled_v8=="true"', {
+      'dependencies': [
+        'deps/v8/src/v8.gyp:v8',
+        'deps/v8/src/v8.gyp:v8_libplatform'
+      ],
+    }],
+    [ 'node_use_v8_platform=="true"', {
+      'defines': [
+        'NODE_USE_V8_PLATFORM=1',
+      ],
+    }, {
+      'defines': [
+        'NODE_USE_V8_PLATFORM=0',
+      ],
+    }],
+    [ 'node_tag!=""', {
+      'defines': [ 'NODE_TAG="<(node_tag)"' ],
+    }],
+    [ 'node_v8_options!=""', {
+      'defines': [ 'NODE_V8_OPTIONS="<(node_v8_options)"'],
+    }],
+    # No node_main.cc for anything except executable
+    [ 'node_target_type!="executable"', {
+      'sources!': [
+        'src/node_main.cc',
+      ],
+    }],
+    [ 'node_release_urlbase!=""', {
+      'defines': [
+        'NODE_RELEASE_URLBASE="<(node_release_urlbase)"',
+      ]
+    }],
+    [ 'v8_enable_i18n_support==1', {
+      'defines': [ 'NODE_HAVE_I18N_SUPPORT=1' ],
+      'dependencies': [
+        '<(icu_gyp_path):icui18n',
+        '<(icu_gyp_path):icuuc',
+      ],
+      'conditions': [
+        [ 'icu_small=="true"', {
+          'defines': [ 'NODE_HAVE_SMALL_ICU=1' ],
+      }]],
+    }],
+    [ 'node_use_bundled_v8=="true" and \
+        node_enable_v8_vtunejit=="true" and (target_arch=="x64" or \
+        target_arch=="ia32" or target_arch=="x32")', {
+      'defines': [ 'NODE_ENABLE_VTUNE_PROFILING' ],
+      'dependencies': [
+        'deps/v8/src/third_party/vtune/v8vtune.gyp:v8_vtune'
+      ],
+    }],
+    [ 'v8_inspector=="true"', {
+      'defines': [
+        'HAVE_INSPECTOR=1',
+      ],
+      'sources': [
+        'src/inspector_agent.cc',
+        'src/inspector_socket.cc',
+        'src/inspector_socket_server.cc',
+        'src/inspector_agent.h',
+        'src/inspector_socket.h',
+        'src/inspector_socket_server.h',
+      ],
+      'dependencies': [
+        'deps/v8_inspector/src/inspector/inspector.gyp:standalone_inspector',
+        'v8_inspector_compress_protocol_json#host',
+      ],
+      'include_dirs': [
+        'deps/v8_inspector/include',
+        '<(SHARED_INTERMEDIATE_DIR)/include', # for inspector
+        '<(SHARED_INTERMEDIATE_DIR)',
+      ],
+    }, {
+      'defines': [ 'HAVE_INSPECTOR=0' ]
+    }],
+    [ 'node_use_openssl=="true"', {
+      'defines': [ 'HAVE_OPENSSL=1' ],
+      'sources': [
+        'src/node_crypto.cc',
+        'src/node_crypto_bio.cc',
+        'src/node_crypto_clienthello.cc',
+        'src/node_crypto.h',
+        'src/node_crypto_bio.h',
+        'src/node_crypto_clienthello.h',
+        'src/tls_wrap.cc',
+        'src/tls_wrap.h'
+      ],
+      'conditions': [
+        ['openssl_fips != ""', {
+          'defines': [ 'NODE_FIPS_MODE' ],
+        }],
+        [ 'node_shared_openssl=="false"', {
+          'dependencies': [
+            './deps/openssl/openssl.gyp:openssl',
+
+            # For tests
+            './deps/openssl/openssl.gyp:openssl-cli',
+          ],
+          # Do not let unused OpenSSL symbols to slip away
+          'conditions': [
+            # -force_load or --whole-archive are not applicable for
+            # the static library
+            [ 'node_target_type!="static_library"', {
+              'xcode_settings': {
+                'OTHER_LDFLAGS': [
+                  '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
+                ],
+              },
+              'conditions': [
+                ['OS in "linux freebsd" and node_shared=="false"', {
+                  'ldflags': [
+                    '-Wl,--whole-archive,'
+                        '<(OBJ_DIR)/deps/openssl/'
+                        '<(OPENSSL_PRODUCT)',
+                    '-Wl,--no-whole-archive',
+                  ],
+                }],
+                # openssl.def is based on zlib.def, zlib symbols
+                # are always exported.
+                ['use_openssl_def==1', {
+                  'sources': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
+                }],
+                ['OS=="win" and use_openssl_def==0', {
+                  'sources': ['deps/zlib/win32/zlib.def'],
+                }],
+              ],
+            }],
+          ],
+        }]]
+    }, {
+      'defines': [ 'HAVE_OPENSSL=0' ]
+    }],
+    [ 'node_use_dtrace=="true"', {
+      'defines': [ 'HAVE_DTRACE=1' ],
+      'dependencies': [
+        'node_dtrace_header',
+        'specialize_node_d',
+      ],
+      'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
+
+      #
+      # DTrace is supported on linux, solaris, mac, and bsd.  There are
+      # three object files associated with DTrace support, but they're
+      # not all used all the time:
+      #
+      #   node_dtrace.o           all configurations
+      #   node_dtrace_ustack.o    not supported on mac and linux
+      #   node_dtrace_provider.o  All except OS X.  "dtrace -G" is not
+      #                           used on OS X.
+      #
+      # Note that node_dtrace_provider.cc and node_dtrace_ustack.cc do not
+      # actually exist.  They're listed here to trick GYP into linking the
+      # corresponding object files into the final "node" executable.  These
+      # object files are generated by "dtrace -G" using custom actions
+      # below, and the GYP-generated Makefiles will properly build them when
+      # needed.
+      #
+      'sources': [ 'src/node_dtrace.cc' ],
+      'conditions': [
+        [ 'OS=="linux"', {
+          'sources': [
+            '<(SHARED_INTERMEDIATE_DIR)/node_dtrace_provider.o'
+          ],
+        }],
+        [ 'OS!="mac" and OS!="linux"', {
+          'sources': [
+            'src/node_dtrace_ustack.cc',
+            'src/node_dtrace_provider.cc',
+          ]
+        }
+      ] ]
+    } ],
+    [ 'node_use_lttng=="true"', {
+      'defines': [ 'HAVE_LTTNG=1' ],
+      'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
+      'libraries': [ '-llttng-ust' ],
+      'sources': [
+        'src/node_lttng.cc'
+      ],
+    } ],
+    [ 'node_use_etw=="true"', {
+      'defines': [ 'HAVE_ETW=1' ],
+      'dependencies': [ 'node_etw' ],
+      'sources': [
+        'src/node_win32_etw_provider.h',
+        'src/node_win32_etw_provider-inl.h',
+        'src/node_win32_etw_provider.cc',
+        'src/node_dtrace.cc',
+        'tools/msvs/genfiles/node_etw_provider.h',
+        'tools/msvs/genfiles/node_etw_provider.rc',
+      ]
+    } ],
+    [ 'node_use_perfctr=="true"', {
+      'defines': [ 'HAVE_PERFCTR=1' ],
+      'dependencies': [ 'node_perfctr' ],
+      'sources': [
+        'src/node_win32_perfctr_provider.h',
+        'src/node_win32_perfctr_provider.cc',
+        'src/node_counters.cc',
+        'src/node_counters.h',
+        'tools/msvs/genfiles/node_perfctr_provider.rc',
+      ]
+    } ],
+    [ 'node_no_browser_globals=="true"', {
+      'defines': [ 'NODE_NO_BROWSER_GLOBALS' ],
+    } ],
+    [ 'node_use_bundled_v8=="true" and v8_postmortem_support=="true"', {
+      'dependencies': [ 'deps/v8/src/v8.gyp:postmortem-metadata' ],
+      'conditions': [
+        # -force_load is not applicable for the static library
+        [ 'node_target_type!="static_library"', {
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(V8_BASE)',
+            ],
+          },
+        }],
+      ],
+    }],
+    [ 'node_shared_zlib=="false"', {
+      'dependencies': [ 'deps/zlib/zlib.gyp:zlib' ],
+    }],
+
+    [ 'node_shared_http_parser=="false"', {
+      'dependencies': [ 'deps/http_parser/http_parser.gyp:http_parser' ],
+    }],
+
+    [ 'node_shared_cares=="false"', {
+      'dependencies': [ 'deps/cares/cares.gyp:cares' ],
+    }],
+
+    [ 'node_shared_libuv=="false"', {
+      'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
+    }],
+
+    [ 'OS=="win"', {
+      'sources': [
+        'src/backtrace_win32.cc',
+        'src/res/node.rc',
+      ],
+      'defines!': [
+        'NODE_PLATFORM="win"',
+      ],
+      'defines': [
+        'FD_SETSIZE=1024',
+        # we need to use node's preferred "win32" rather than gyp's preferred "win"
+        'NODE_PLATFORM="win32"',
+        '_UNICODE=1',
+      ],
+      'libraries': [ '-lpsapi.lib' ]
+    }, { # POSIX
+      'defines': [ '__POSIX__' ],
+      'sources': [ 'src/backtrace_posix.cc' ],
+    }],
+    [ 'OS=="mac"', {
+      # linking Corefoundation is needed since certain OSX debugging tools
+      # like Instruments require it for some features
+      'libraries': [ '-framework CoreFoundation' ],
+      'defines!': [
+        'NODE_PLATFORM="mac"',
+      ],
+      'defines': [
+        # we need to use node's preferred "darwin" rather than gyp's preferred "mac"
+        'NODE_PLATFORM="darwin"',
+      ],
+    }],
+    [ 'OS=="freebsd"', {
+      'libraries': [
+        '-lutil',
+        '-lkvm',
+      ],
+    }],
+    [ 'OS=="aix"', {
+      'defines': [
+        '_LINUX_SOURCE_COMPAT',
+      ],
+    }],
+    [ 'OS=="solaris"', {
+      'libraries': [
+        '-lkstat',
+        '-lumem',
+      ],
+      'defines!': [
+        'NODE_PLATFORM="solaris"',
+      ],
+      'defines': [
+        # we need to use node's preferred "sunos"
+        # rather than gyp's preferred "solaris"
+        'NODE_PLATFORM="sunos"',
+      ],
+    }],
+    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="false"', {
+      'ldflags': [ '-Wl,-z,noexecstack',
+                    '-Wl,--whole-archive <(V8_BASE)',
+                    '-Wl,--no-whole-archive' ]
+    }],
+    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false" and coverage=="true"', {
+      'ldflags': [ '-Wl,-z,noexecstack',
+                    '-Wl,--whole-archive <(V8_BASE)',
+                    '-Wl,--no-whole-archive',
+                    '--coverage',
+                    '-g',
+                    '-O0' ],
+        'cflags': [ '--coverage',
+                    '-g',
+                    '-O0' ]
+    }],
+    [ 'OS=="sunos"', {
+      'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
+    }],
+  ],
+}

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -1,0 +1,2 @@
+#include <stdlib.h>
+#include "node_test_fixture.h"

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -1,0 +1,85 @@
+#ifndef TEST_CCTEST_NODE_TEST_FIXTURE_H_
+#define TEST_CCTEST_NODE_TEST_FIXTURE_H_
+
+#include <stdlib.h>
+#include "gtest/gtest.h"
+#include "node.h"
+#include "env.h"
+#include "v8.h"
+#include "libplatform/libplatform.h"
+
+using node::Environment;
+using node::IsolateData;
+using node::CreateIsolateData;
+using node::CreateEnvironment;
+using node::AtExit;
+using node::RunAtExit;
+
+class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+ public:
+  virtual void* Allocate(size_t length) {
+    return AllocateUninitialized(length);
+  }
+
+  virtual void* AllocateUninitialized(size_t length) {
+    return calloc(length, sizeof(int));
+  }
+
+  virtual void Free(void* data, size_t) {
+    free(data);
+  }
+};
+
+struct Argv {
+ public:
+  Argv(const char* prog, const char* arg1, const char* arg2) {
+    int prog_len = strlen(prog) + 1;
+    int arg1_len = strlen(arg1) + 1;
+    int arg2_len = strlen(arg2) + 1;
+    argv_ = static_cast<char**>(malloc(3 * sizeof(char*)));
+    argv_[0] = static_cast<char*>(malloc(prog_len + arg1_len + arg2_len));
+    snprintf(argv_[0], prog_len, "%s", prog);
+    snprintf(argv_[0] + prog_len, arg1_len, "%s", arg1);
+    snprintf(argv_[0] + prog_len + arg1_len, arg2_len, "%s", arg2);
+    argv_[1] = argv_[0] + prog_len + 1;
+    argv_[2] = argv_[0] + prog_len + arg1_len + 1;
+  }
+
+  ~Argv() {
+    free(argv_[0]);
+    free(argv_);
+  }
+
+  char** operator *() const {
+    return argv_;
+  }
+
+ private:
+  char** argv_;
+};
+
+class NodeTestFixture : public ::testing::Test {
+ protected:
+  v8::Isolate::CreateParams params_;
+  ArrayBufferAllocator allocator_;
+  v8::Isolate* isolate_;
+
+  virtual void SetUp() {
+    platform_ = v8::platform::CreateDefaultPlatform();
+    v8::V8::InitializePlatform(platform_);
+    v8::V8::Initialize();
+    params_.array_buffer_allocator = &allocator_;
+    isolate_ = v8::Isolate::New(params_);
+  }
+
+  virtual void TearDown() {
+    v8::V8::ShutdownPlatform();
+    delete platform_;
+    platform_ = nullptr;
+  }
+
+ private:
+  v8::Platform* platform_;
+};
+
+#endif  // TEST_CCTEST_NODE_TEST_FIXTURE_H_

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -90,10 +90,6 @@ TEST(UtilTest, ToLower) {
   EXPECT_EQ('a', ToLower('A'));
 }
 
-namespace node {
-  void LowMemoryNotification() {}
-}
-
 #define TEST_AND_FREE(expression)                                             \
   do {                                                                        \
     auto pointer = expression;                                                \

--- a/tools/gyp/pylib/gyp/generator/make.py
+++ b/tools/gyp/pylib/gyp/generator/make.py
@@ -147,7 +147,7 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
 # special "figure out circular dependencies" flags around the entire
 # input list during linking.
 quiet_cmd_link = LINK($(TOOLSET)) $@
-cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ -Wl,--start-group $(LD_INPUTS) -Wl,--end-group $(LIBS)
+cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ -Wl,--start-group $(LD_INPUTS) $(LIBS) -Wl,--end-group
 
 # We support two kinds of shared objects (.so):
 # 1) shared_library, which is just bundling together many dependent libraries


### PR DESCRIPTION
Backport https://github.com/nodejs/node/pull/11956 to v7.x. PRs https://github.com/nodejs/node/pull/12042 and https://github.com/nodejs/node/pull/12238 (both labeled as "backport-to-v7.x") depend on it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
build, doc
