### PR TITLE
test: improve test coverage for n-api

### DIFF
--- a/test/addons-napi/test_handle_scope/binding.gyp
+++ b/test/addons-napi/test_handle_scope/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_handle_scope",
+      "sources": [ "test_handle_scope.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_handle_scope/test.js
+++ b/test/addons-napi/test_handle_scope/test.js
@@ -1,0 +1,10 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+// testing handle scope api calls
+const test_handle_scope =
+    require(`./build/${common.buildType}/test_handle_scope`);
+
+test_handle_scope.NewScope();
+assert.ok(test_handle_scope.NewScopeEscape() instanceof Object);

--- a/test/addons-napi/test_handle_scope/test.js
+++ b/test/addons-napi/test_handle_scope/test.js
@@ -3,8 +3,8 @@ const common = require('../../common');
 const assert = require('assert');
 
 // testing handle scope api calls
-const test_handle_scope =
+const testHandleScope =
     require(`./build/${common.buildType}/test_handle_scope`);
 
-test_handle_scope.NewScope();
-assert.ok(test_handle_scope.NewScopeEscape() instanceof Object);
+testHandleScope.NewScope();
+assert.ok(testHandleScope.NewScopeEscape() instanceof Object);

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -1,0 +1,42 @@
+#include <node_api.h>
+#include "../common.h"
+#include <string.h>
+
+// these tests validate the handle scope functions in the normal 
+// flow.  Forcing gc behaviour to fully validate they are doing
+// the right right thing would be quite hard so we keep it
+// simple for now.
+
+napi_value NewScope(napi_env env, napi_callback_info info) {
+  napi_handle_scope scope;
+  napi_value output = NULL;
+
+  NAPI_CALL(env, napi_open_handle_scope(env, &scope));
+  NAPI_CALL(env, napi_create_object(env, &output));
+  NAPI_CALL(env, napi_close_handle_scope(env, scope));
+  return NULL;
+}
+
+napi_value NewScopeEscape(napi_env env, napi_callback_info info) {
+  napi_escapable_handle_scope scope;
+  napi_value output = NULL;
+  napi_value escapee = NULL;
+
+  NAPI_CALL(env, napi_open_escapable_handle_scope(env, &scope));
+  NAPI_CALL(env, napi_create_object(env, &output));
+  NAPI_CALL(env, napi_escape_handle(env, scope, output, &escapee));
+  NAPI_CALL(env, napi_close_escapable_handle_scope(env, scope));
+  return escapee;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("NewScope", NewScope),
+    DECLARE_NAPI_PROPERTY("NewScopeEscape", NewScopeEscape),
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(properties) / sizeof(*properties), properties));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
Add basic tests for handle scopes as code coverage
reports that we are not covering these with the existing
tests.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]
##### Affected core subsystem(s)
test, n-api