### PR TITLE
n-api: fix -Wmismatched-tags compiler warning

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -22,8 +22,7 @@ napi_status napi_set_last_error(napi_env env, napi_status error_code,
                                 void* engine_reserved = nullptr);
 void napi_clear_last_error(napi_env env);
 
-class napi_env__ {
- public:
+struct napi_env__ {
   explicit napi_env__(v8::Isolate* _isolate): isolate(_isolate),
       has_instance_available(true), last_error() {}
   ~napi_env__() {


### PR DESCRIPTION
`napi_env__` was declared as a struct in one place and a class in
another.