### PR TITLE
net: refactor onSlaveClose in Server.close

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1539,13 +1539,6 @@ Server.prototype.getConnections = function(cb) {
 
 
 Server.prototype.close = function(cb) {
-  function onSlaveClose() {
-    if (--left !== 0) return;
-
-    self._connections = 0;
-    self._emitCloseIfDrained();
-  }
-
   if (typeof cb === 'function') {
     if (!this._handle) {
       this.once('close', function close() {
@@ -1562,8 +1555,13 @@ Server.prototype.close = function(cb) {
   }
 
   if (this._usingSlaves) {
-    var self = this;
     var left = this._slaves.length;
+    const onSlaveClose = () => {
+      if (--left !== 0) return;
+
+      this._connections = 0;
+      this._emitCloseIfDrained();
+    };
 
     // Increment connections to be sure that, even if all sockets will be closed
     // during polling of slaves, `close` event will be emitted only once.


### PR DESCRIPTION
Refactors onSlaveClose in Server.close to be an arrow function,
removes need for `self = this` and moves it down to make code
more readable.

`make bench-net` before and after (don't see any significant change):
https://gist.github.com/claudiorodriguez/b3b9483c05bd6c21626c9bcd0bfa7897

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net