### PR TITLE
v7.x Backport - build: avoid passing kill empty input in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,14 +265,13 @@ test/addons/.buildstamp: config.gypi \
 # TODO(bnoordhuis) Force rebuild after gyp update.
 build-addons: $(NODE_EXE) test/addons/.buildstamp
 
-ifeq ($(OSTYPE),$(filter $(OSTYPE),darwin aix))
-  XARGS = xargs
-else
-  XARGS = xargs -r
-endif
 clear-stalled:
+	# Clean up any leftover processes but don't error if found.
 	ps awwx | grep Release/node | grep -v grep | cat
-	ps awwx | grep Release/node | grep -v grep | awk '{print $$1}' | $(XARGS) kill
+	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
+	if [ "$${PS_OUT}" ]; then \
+		echo $${PS_OUT} | xargs kill; \
+	fi
 
 test-gc: all test/gc/build/Release/binding.node
 	$(PYTHON) tools/test.py --mode=release gc
@@ -300,10 +299,11 @@ test-ci-js: | clear-stalled
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
-	# Clean up any leftover processes
-	PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
+	# Clean up any leftover processes, error if found.
+	ps awwx | grep Release/node | grep -v grep | cat
+	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
 	if [ "$${PS_OUT}" ]; then \
-		echo $${PS_OUT} | $(XARGS) kill; exit 1; \
+		echo $${PS_OUT} | xargs kill; exit 1; \
 	fi
 
 test-ci: LOGLEVEL := info
@@ -312,10 +312,11 @@ test-ci: | clear-stalled build-addons
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES) $(CI_JS_SUITES)
-	# Clean up any leftover processes
-	PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
+	# Clean up any leftover processes, error if found.
+	ps awwx | grep Release/node | grep -v grep | cat
+	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
 	if [ "$${PS_OUT}" ]; then \
-		echo $${PS_OUT} | $(XARGS) kill; exit 1; \
+		echo $${PS_OUT} | xargs kill; exit 1; \
 	fi
 
 test-release: test-build


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build