### PR TITLE
doc: use GH issue/PR shorthand in commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,13 +132,13 @@ Check the output of `git log --oneline files_that_you_changed` to find out
 what subsystem (or subsystems) your changes touch.
 
 If your patch fixes an open issue, you can add a reference to it at the end
-of the log. Use the `Fixes:` prefix and the full issue URL. For other references
-use `Refs:`. For example:
+of the log. Use the `Fixes:` prefix and the GitHub issue number. For other
+references use `Refs:`. For example:
 
 ```txt
-Fixes: https://github.com/nodejs/node/issues/1337
+Fixes: #1337
 Refs: http://eslint.org/docs/rules/space-in-parens.html
-Refs: https://github.com/nodejs/node/pull/3615
+Refs: #3615
 ```
 
 ### Step 4: Rebase


### PR DESCRIPTION
Most commits seem to use GitHub shorthand to refer to an issue or PR, rather than using the full URL.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc