### PR TITLE
test: add test-benchmark-crypto

### DIFF
--- a/test/parallel/test-benchmark-crypto.js
+++ b/test/parallel/test-benchmark-crypto.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+if (common.hasFipsCrypto) {
+  common.skip('some benchmarks are FIPS-incompatible');
+  return;
+}
+
+// Minimal test for crypto benchmarks. This makes sure the benchmarks aren't
+// horribly broken but nothing more than that.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const path = require('path');
+
+const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
+const argv = ['--set', 'n=1',
+              '--set', 'writes=1',
+              '--set', 'len=1',
+              '--set', 'api=stream',
+              '--set', 'out=buffer',
+              '--set', 'keylen=1024',
+              '--set', 'type=buf',
+              'crypto'];
+
+const child = fork(runjs, argv, {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});


### PR DESCRIPTION
Add minimal test for crypto benchmarks. It makes sure that they can run
without returning an error code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test benchmark crypto