### PR TITLE
doc: fix formatting in onboarding-extras

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -13,11 +13,11 @@
 | `lib/{crypto,tls,https}` | @nodejs/crypto |
 | `lib/dgram` | @cjihrig, @mcollina |
 | `lib/domains` | @misterdjules |
-| `lib/fs`, `src/{fs|file}` | @nodejs/fs |
+| `lib/fs`, `src/{fs,file}` | @nodejs/fs |
 | `lib/internal/url`, `src/node_url` | @nodejs/url |
 | `lib/{_}http{*}` | @nodejs/http |
 | `lib/net` | @bnoordhuis, @indutny, @nodejs/streams |
-| `lib/{_}stream{s|*}` | @nodejs/streams |
+| `lib/{_}stream{*}` | @nodejs/streams |
 | `lib/repl` | @addaleax, @fishrock123 |
 | `lib/timers` | @fishrock123, @misterdjules |
 | `lib/util` | @bnoordhuis, @cjihrig, @evanlucas |


### PR DESCRIPTION
Use of extra `|` breaks markdown table rendering. Fix it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
