### PR TITLE
test: buffer should always be stringified

### DIFF
--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that writeSync does support inputs which
+// are then correctly converted into string buffers.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(common.tmpDir, 'test_buffer_type');
+const v = [true, false, 0, 1, Infinity, common.noop, {}, [], undefined, null];
+
+common.refreshTmpDir();
+
+v.forEach((value) => {
+  const fd = fs.openSync(filePath, 'w');
+  fs.writeSync(fd, value);
+  assert.strictEqual(fs.readFileSync(filePath).toString(), value + '');
+});


### PR DESCRIPTION
This test makes sure that independently of the buffer type, the input
is always stringify and generates a valid input.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test fs
