### PR TITLE
doc: limit lines to 80 cols in internal README

### DIFF
--- a/lib/internal/readme.md
+++ b/lib/internal/readme.md
@@ -1,4 +1,6 @@
 # Internal Modules
 
-The modules in `lib/internal` are intended for internal use in Node.js core only, and are not accessible with `require()` from user modules.
-These are subject to change at **any** time. Reliance on these modules outside of core is **not supported** in any way.
+The modules in `lib/internal` are intended for internal use in Node.js core
+only, and are not accessible with `require()` from user modules. These are
+subject to change at **any** time. Reliance on these modules outside of core
+is **not supported** in any way.


### PR DESCRIPTION
We generally stick to 80 columns even in markdown files.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc