### PR TITLE
buffer: various performance improvements

### DIFF
--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -2,7 +2,7 @@
 var common = require('../common');
 
 var bench = common.createBenchmark(main, {
-  encoding: ['utf8', 'base64'],
+  encoding: ['utf8', 'base64', 'buffer'],
   len: [1, 2, 4, 16, 64, 256], // x16
   n: [5e6]
 });
@@ -21,21 +21,27 @@ function main(conf) {
   var encoding = conf.encoding;
 
   var strings = [];
-  for (var string of chars) {
-    // Strings must be built differently, depending on encoding
-    var data = buildString(string, len);
-    if (encoding === 'utf8') {
-      strings.push(data);
-    } else if (encoding === 'base64') {
-      // Base64 strings will be much longer than their UTF8 counterparts
-      strings.push(Buffer.from(data, 'utf8').toString('base64'));
+  var results;
+  if (encoding === 'buffer') {
+    strings = [ Buffer.alloc(len * 16, 'a') ];
+    results = [ len * 16 ];
+  } else {
+    for (var string of chars) {
+      // Strings must be built differently, depending on encoding
+      var data = buildString(string, len);
+      if (encoding === 'utf8') {
+        strings.push(data);
+      } else if (encoding === 'base64') {
+        // Base64 strings will be much longer than their UTF8 counterparts
+        strings.push(Buffer.from(data, 'utf8').toString('base64'));
+      }
     }
-  }
 
-  // Check the result to ensure it is *properly* optimized
-  var results = strings.map(function(val) {
-    return Buffer.byteLength(val, encoding);
-  });
+    // Check the result to ensure it is *properly* optimized
+    results = strings.map(function(val) {
+      return Buffer.byteLength(val, encoding);
+    });
+  }
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/buffers/buffer-from.js
+++ b/benchmark/buffers/buffer-from.js
@@ -10,11 +10,12 @@ const bench = common.createBenchmark(main, {
     'buffer',
     'uint8array',
     'string',
+    'string-utf8',
     'string-base64',
     'object'
   ],
   len: [10, 2048],
-  n: [1024]
+  n: [2048]
 });
 
 function main(conf) {
@@ -72,6 +73,13 @@ function main(conf) {
       bench.start();
       for (i = 0; i < n * 1024; i++) {
         Buffer.from(str);
+      }
+      bench.end(n);
+      break;
+    case 'string-utf8':
+      bench.start();
+      for (i = 0; i < n * 1024; i++) {
+        Buffer.from(str, 'utf8');
       }
       bench.end(n);
       break;

--- a/benchmark/buffers/buffer-tostring.js
+++ b/benchmark/buffers/buffer-tostring.js
@@ -3,25 +3,47 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  arg: ['true', 'false'],
+  encoding: ['', 'utf8', 'ascii', 'latin1', 'binary', 'hex', 'UCS-2'],
+  args: [0, 1, 2, 3],
   len: [0, 1, 64, 1024],
   n: [1e7]
 });
 
 function main(conf) {
-  const arg = conf.arg === 'true';
+  var encoding = conf.encoding;
+  const args = conf.args | 0;
   const len = conf.len | 0;
   const n = conf.n | 0;
   const buf = Buffer.alloc(len, 42);
 
+  if (encoding.length === 0)
+    encoding = undefined;
+
   var i;
-  bench.start();
-  if (arg) {
-    for (i = 0; i < n; i += 1)
-      buf.toString('utf8');
-  } else {
-    for (i = 0; i < n; i += 1)
-      buf.toString();
+  switch (args) {
+    case 1:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding);
+      bench.end(n);
+      break;
+    case 2:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding, 0);
+      bench.end(n);
+      break;
+    case 3:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString(encoding, 0, len);
+      bench.end(n);
+      break;
+    default:
+      bench.start();
+      for (i = 0; i < n; i += 1)
+        buf.toString();
+      bench.end(n);
+      break;
   }
-  bench.end(n);
 }

--- a/benchmark/buffers/buffer-write-string.js
+++ b/benchmark/buffers/buffer-write-string.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  encoding: [
+    '', 'utf8', 'ascii', 'hex', 'UCS-2', 'utf16le', 'latin1', 'binary'
+  ],
+  args: [ '', 'offset', 'offset+length' ],
+  len: [10, 2048],
+  n: [1e7]
+});
+
+function main(conf) {
+  const len = +conf.len;
+  const n = +conf.n;
+  const encoding = conf.encoding;
+  const args = conf.args;
+
+  const string = 'a'.repeat(len);
+  const buf = Buffer.allocUnsafe(len);
+
+  var i;
+
+  switch (args) {
+    case 'offset':
+      if (encoding) {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string, 0, encoding);
+        }
+        bench.end(n);
+      } else {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string, 0);
+        }
+        bench.end(n);
+      }
+      break;
+    case 'offset+length':
+      if (encoding) {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string, 0, buf.length, encoding);
+        }
+        bench.end(n);
+      } else {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string, 0, buf.length);
+        }
+        bench.end(n);
+      }
+      break;
+    default:
+      if (encoding) {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string, encoding);
+        }
+        bench.end(n);
+      } else {
+        bench.start();
+        for (i = 0; i < n; ++i) {
+          buf.write(string);
+        }
+        bench.end(n);
+      }
+  }
+}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -483,82 +483,85 @@ Object.defineProperty(Buffer.prototype, 'offset', {
 });
 
 
-function slowToString(buf, encoding, start, end) {
-  var loweredCase = false;
-
-  // No need to verify that "buf.length <= MAX_UINT32" since it's a read-only
-  // property of a typed array.
-
-  // This behaves neither like String nor Uint8Array in that we set start/end
-  // to their upper/lower bounds if the value passed is out of range.
-  // undefined is handled specially as per ECMA-262 6th Edition,
-  // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
-  if (start === undefined || start < 0)
-    start = 0;
-  // Return early if start > buf.length. Done here to prevent potential uint32
-  // coercion fail below.
-  if (start > buf.length)
-    return '';
-
-  if (end === undefined || end > buf.length)
-    end = buf.length;
-
-  if (end <= 0)
-    return '';
-
-  // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
-  end >>>= 0;
-  start >>>= 0;
-
-  if (end <= start)
-    return '';
-
-  if (encoding === undefined) encoding = 'utf8';
-
-  while (true) {
-    switch (encoding) {
-      case 'hex':
-        return buf.hexSlice(start, end);
-
-      case 'utf8':
-      case 'utf-8':
-        return buf.utf8Slice(start, end);
-
-      case 'ascii':
-        return buf.asciiSlice(start, end);
-
-      case 'latin1':
-      case 'binary':
+function stringSlice(buf, encoding, start, end) {
+  if (encoding === undefined) return buf.utf8Slice(start, end);
+  encoding += '';
+  switch (encoding.length) {
+    case 4:
+      if (encoding === 'utf8') return buf.utf8Slice(start, end);
+      if (encoding === 'ucs2') return buf.ucs2Slice(start, end);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf8') return buf.utf8Slice(start, end);
+      if (encoding === 'ucs2') return buf.ucs2Slice(start, end);
+      break;
+    case 5:
+      if (encoding === 'utf-8') return buf.utf8Slice(start, end);
+      if (encoding === 'ascii') return buf.asciiSlice(start, end);
+      if (encoding === 'ucs-2') return buf.ucs2Slice(start, end);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf-8') return buf.utf8Slice(start, end);
+      if (encoding === 'ascii') return buf.asciiSlice(start, end);
+      if (encoding === 'ucs-2') return buf.ucs2Slice(start, end);
+      break;
+    case 6:
+      if (encoding === 'latin1' || encoding === 'binary')
         return buf.latin1Slice(start, end);
-
-      case 'base64':
-        return buf.base64Slice(start, end);
-
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
+      if (encoding === 'base64') return buf.base64Slice(start, end);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'latin1' || encoding === 'binary')
+        return buf.latin1Slice(start, end);
+      if (encoding === 'base64') return buf.base64Slice(start, end);
+      break;
+    case 3:
+      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
+        return buf.hexSlice(start, end);
+      break;
+    case 7:
+      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
         return buf.ucs2Slice(start, end);
-
-      default:
-        if (loweredCase)
-          throw new TypeError('Unknown encoding: ' + encoding);
-        encoding = (encoding + '').toLowerCase();
-        loweredCase = true;
-    }
+      break;
+    case 8:
+      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
+        return buf.ucs2Slice(start, end);
+      break;
   }
+  throw new TypeError('Unknown encoding: ' + encoding);
 }
+
 
 Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
   return binding.copy(this, target, targetStart, sourceStart, sourceEnd);
 };
 
+// No need to verify that "buf.length <= MAX_UINT32" since it's a read-only
+// property of a typed array.
+// This behaves neither like String nor Uint8Array in that we set start/end
+// to their upper/lower bounds if the value passed is out of range.
 Buffer.prototype.toString = function(encoding, start, end) {
-  let result;
+  var result;
   if (arguments.length === 0) {
     result = this.utf8Slice(0, this.length);
   } else {
-    result = slowToString(this, encoding, start, end);
+    const len = this.length;
+    if (len === 0)
+      return '';
+
+    if (!start || start < 0)
+      start = 0;
+    else if (start >= len)
+      return '';
+
+    if (end === undefined || end > len)
+      end = len;
+    else if (end <= 0)
+      return '';
+
+    start |= 0;
+    end |= 0;
+
+    if (end <= start)
+      return '';
+    result = stringSlice(this, encoding, start, end);
   }
   if (result === undefined)
     throw new Error('"toString()" failed');

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -786,9 +786,7 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
 Buffer.prototype.write = function(string, offset, length, encoding) {
   // Buffer#write(string);
   if (offset === undefined) {
-    encoding = 'utf8';
-    length = this.length;
-    offset = 0;
+    return this.utf8Write(string, 0, this.length);
 
   // Buffer#write(string, encoding)
   } else if (length === undefined && typeof offset === 'string') {
@@ -801,12 +799,17 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
     offset = offset >>> 0;
     if (isFinite(length)) {
       length = length >>> 0;
-      if (encoding === undefined)
-        encoding = 'utf8';
     } else {
       encoding = length;
       length = undefined;
     }
+
+    var remaining = this.length - offset;
+    if (length === undefined || length > remaining)
+      length = remaining;
+
+    if (string.length > 0 && (length < 0 || offset < 0))
+      throw new RangeError('Attempt to write outside buffer bounds');
   } else {
     // if someone is still calling the obsolete form of write(), tell them.
     // we don't want eg buf.write("foo", "utf8", 10) to silently turn into
@@ -815,50 +818,51 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
                     'is no longer supported');
   }
 
-  var remaining = this.length - offset;
-  if (length === undefined || length > remaining)
-    length = remaining;
+  if (!encoding) return this.utf8Write(string, offset, length);
 
-  if (string.length > 0 && (length < 0 || offset < 0))
-    throw new RangeError('Attempt to write outside buffer bounds');
-
-  if (!encoding)
-    encoding = 'utf8';
-
-  var loweredCase = false;
-  for (;;) {
-    switch (encoding) {
-      case 'hex':
-        return this.hexWrite(string, offset, length);
-
-      case 'utf8':
-      case 'utf-8':
-        return this.utf8Write(string, offset, length);
-
-      case 'ascii':
-        return this.asciiWrite(string, offset, length);
-
-      case 'latin1':
-      case 'binary':
-        return this.latin1Write(string, offset, length);
-
-      case 'base64':
-        // Warning: maxLength not taken into account in base64Write
-        return this.base64Write(string, offset, length);
-
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
+  encoding += '';
+  switch (encoding.length) {
+    case 4:
+      if (encoding === 'utf8') return this.utf8Write(string, offset, length);
+      if (encoding === 'ucs2') return this.ucs2Write(string, offset, length);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf8') return this.utf8Write(string, offset, length);
+      if (encoding === 'ucs2') return this.ucs2Write(string, offset, length);
+      break;
+    case 5:
+      if (encoding === 'utf-8') return this.utf8Write(string, offset, length);
+      if (encoding === 'ascii') return this.asciiWrite(string, offset, length);
+      if (encoding === 'ucs-2') return this.ucs2Write(string, offset, length);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf-8') return this.utf8Write(string, offset, length);
+      if (encoding === 'ascii') return this.asciiWrite(string, offset, length);
+      if (encoding === 'ucs-2') return this.ucs2Write(string, offset, length);
+      break;
+    case 7:
+      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
         return this.ucs2Write(string, offset, length);
-
-      default:
-        if (loweredCase)
-          throw new TypeError('Unknown encoding: ' + encoding);
-        encoding = ('' + encoding).toLowerCase();
-        loweredCase = true;
-    }
+      break;
+    case 8:
+      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
+        return this.ucs2Write(string, offset, length);
+      break;
+    case 6:
+      if (encoding === 'latin1' || encoding === 'binary')
+        return this.latin1Write(string, offset, length);
+      if (encoding === 'base64')
+        return this.base64Write(string, offset, length);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'latin1' || encoding === 'binary')
+        return this.latin1Write(string, offset, length);
+      if (encoding === 'base64')
+        return this.base64Write(string, offset, length);
+      break;
+    case 3:
+      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
+        return this.hexWrite(string, offset, length);
+      break;
   }
+  throw new TypeError('Unknown encoding: ' + encoding);
 };
 
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,8 +23,7 @@
 
 const binding = process.binding('buffer');
 const { compare: compare_, compareOffset } = binding;
-const { isArrayBuffer, isSharedArrayBuffer, isUint8Array } =
-    process.binding('util');
+const { isAnyArrayBuffer, isUint8Array } = process.binding('util');
 const bindingObj = {};
 const internalUtil = require('internal/util');
 
@@ -116,16 +115,19 @@ function Buffer(arg, encodingOrOffset, length) {
  * Buffer.from(arrayBuffer[, byteOffset[, length]])
  **/
 Buffer.from = function(value, encodingOrOffset, length) {
-  if (typeof value === 'number')
-    throw new TypeError('"value" argument must not be a number');
-
-  if (isArrayBuffer(value) || isSharedArrayBuffer(value))
-    return fromArrayBuffer(value, encodingOrOffset, length);
-
   if (typeof value === 'string')
     return fromString(value, encodingOrOffset);
 
-  return fromObject(value);
+  if (isAnyArrayBuffer(value))
+    return fromArrayBuffer(value, encodingOrOffset, length);
+
+  var b = fromObject(value);
+  if (b)
+    return b;
+
+  if (typeof value === 'number')
+    throw new TypeError('"value" argument must not be a number');
+  throw new TypeError(kFromErrorMsg);
 };
 
 Object.setPrototypeOf(Buffer, Uint8Array);
@@ -218,16 +220,19 @@ function allocate(size) {
 
 
 function fromString(string, encoding) {
-  if (typeof encoding !== 'string' || encoding === '')
+  var length;
+  if (typeof encoding !== 'string' || encoding.length === 0) {
     encoding = 'utf8';
-
-  if (!Buffer.isEncoding(encoding))
-    throw new TypeError('"encoding" must be a valid string encoding');
-
-  if (string.length === 0)
-    return new FastBuffer();
-
-  var length = byteLength(string, encoding);
+    if (string.length === 0)
+      return new FastBuffer();
+    length = binding.byteLengthUtf8(string);
+  } else {
+    length = byteLength(string, encoding, true);
+    if (length === -1)
+      throw new TypeError('"encoding" must be a valid string encoding');
+    if (string.length === 0)
+      return new FastBuffer();
+  }
 
   if (length >= (Buffer.poolSize >>> 1))
     return binding.createFromString(string, encoding);
@@ -235,7 +240,7 @@ function fromString(string, encoding) {
   if (length > (poolSize - poolOffset))
     createPool();
   var b = new FastBuffer(allocPool, poolOffset, length);
-  var actual = b.write(string, encoding);
+  const actual = b.write(string, encoding);
   if (actual !== length) {
     // byteLength() may overestimate. That's a rare case, though.
     b = new FastBuffer(allocPool, poolOffset, actual);
@@ -255,8 +260,14 @@ function fromArrayLike(obj) {
 
 function fromArrayBuffer(obj, byteOffset, length) {
   // convert byteOffset to integer
-  byteOffset = +byteOffset;
-  byteOffset = byteOffset ? Math.trunc(byteOffset) : 0;
+  if (byteOffset === undefined) {
+    byteOffset = 0;
+  } else {
+    byteOffset = +byteOffset;
+    // check for NaN
+    if (byteOffset !== byteOffset)
+      byteOffset = 0;
+  }
 
   const maxLength = obj.byteLength - byteOffset;
 
@@ -268,11 +279,17 @@ function fromArrayBuffer(obj, byteOffset, length) {
   } else {
     // convert length to non-negative integer
     length = +length;
-    length = length ? Math.trunc(length) : 0;
-    length = length <= 0 ? 0 : Math.min(length, Number.MAX_SAFE_INTEGER);
-
-    if (length > maxLength)
-      throw new RangeError("'length' is out of bounds");
+    // Check for NaN
+    if (length !== length) {
+      length = 0;
+    } else if (length > 0) {
+      length = (length < Number.MAX_SAFE_INTEGER ?
+                length : Number.MAX_SAFE_INTEGER);
+      if (length > maxLength)
+        throw new RangeError("'length' is out of bounds");
+    } else {
+      length = 0;
+    }
   }
 
   return new FastBuffer(obj, byteOffset, length);
@@ -289,9 +306,8 @@ function fromObject(obj) {
     return b;
   }
 
-  if (obj) {
-    if (obj.length !== undefined || isArrayBuffer(obj.buffer) ||
-        isSharedArrayBuffer(obj.buffer)) {
+  if (obj != undefined) {
+    if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
       if (typeof obj.length !== 'number' || obj.length !== obj.length) {
         return new FastBuffer();
       }
@@ -302,8 +318,6 @@ function fromObject(obj) {
       return fromArrayLike(obj.data);
     }
   }
-
-  throw new TypeError(kFromErrorMsg);
 }
 
 
@@ -388,53 +402,63 @@ function base64ByteLength(str, bytes) {
 
 function byteLength(string, encoding) {
   if (typeof string !== 'string') {
-    if (ArrayBuffer.isView(string) || isArrayBuffer(string) ||
-        isSharedArrayBuffer(string)) {
+    if (ArrayBuffer.isView(string) || isAnyArrayBuffer(string)) {
       return string.byteLength;
     }
 
     throw new TypeError('"string" must be a string, Buffer, or ArrayBuffer');
   }
 
-  var len = string.length;
-  if (len === 0)
+  const len = string.length;
+  const mustMatch = (arguments.length > 2 && arguments[2] === true);
+  if (!mustMatch && len === 0)
     return 0;
 
-  // Use a for loop to avoid recursion
-  var loweredCase = false;
-  for (;;) {
-    switch (encoding) {
-      case 'ascii':
-      case 'latin1':
-      case 'binary':
-        return len;
+  if (!encoding)
+    return (mustMatch ? -1 : binding.byteLengthUtf8(string));
 
-      case 'utf8':
-      case 'utf-8':
-      case undefined:
-        return binding.byteLengthUtf8(string);
-
-      case 'ucs2':
-      case 'ucs-2':
-      case 'utf16le':
-      case 'utf-16le':
+  encoding += '';
+  switch (encoding.length) {
+    case 4:
+      if (encoding === 'utf8') return binding.byteLengthUtf8(string);
+      if (encoding === 'ucs2') return len * 2;
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf8') return binding.byteLengthUtf8(string);
+      if (encoding === 'ucs2') return len * 2;
+      break;
+    case 5:
+      if (encoding === 'utf-8') return binding.byteLengthUtf8(string);
+      if (encoding === 'ascii') return len;
+      if (encoding === 'ucs-2') return len * 2;
+      encoding = encoding.toLowerCase();
+      if (encoding === 'utf-8') return binding.byteLengthUtf8(string);
+      if (encoding === 'ascii') return len;
+      if (encoding === 'ucs-2') return len * 2;
+      break;
+    case 7:
+      if (encoding === 'utf16le' || encoding.toLowerCase() === 'utf16le')
         return len * 2;
-
-      case 'hex':
+      break;
+    case 8:
+      if (encoding === 'utf-16le' || encoding.toLowerCase() === 'utf-16le')
+        return len * 2;
+      break;
+    case 6:
+      if (encoding === 'latin1' || encoding === 'binary') return len;
+      if (encoding === 'base64') return base64ByteLength(string, len);
+      encoding = encoding.toLowerCase();
+      if (encoding === 'latin1' || encoding === 'binary') return len;
+      if (encoding === 'base64') return base64ByteLength(string, len);
+      break;
+    case 3:
+      if (encoding === 'hex' || encoding.toLowerCase() === 'hex')
         return len >>> 1;
-
-      case 'base64':
-        return base64ByteLength(string, len);
-
-      default:
-        // The C++ binding defaulted to UTF8, we should too.
-        if (loweredCase)
-          return binding.byteLengthUtf8(string);
-
-        encoding = ('' + encoding).toLowerCase();
-        loweredCase = true;
-    }
+      break;
   }
+  if (mustMatch)
+    throw new TypeError('Unknown encoding: ' + encoding);
+  else
+    return binding.byteLengthUtf8(string);
 }
 
 Buffer.byteLength = byteLength;

--- a/lib/util.js
+++ b/lib/util.js
@@ -452,7 +452,7 @@ function formatValue(ctx, value, recurseTimes) {
     // Fast path for ArrayBuffer and SharedArrayBuffer.
     // Can't do the same for DataView because it has a non-primitive
     // .buffer property that we need to recurse for.
-    if (binding.isArrayBuffer(value) || binding.isSharedArrayBuffer(value)) {
+    if (binding.isAnyArrayBuffer(value)) {
       return `${constructor.name}` +
              ` { byteLength: ${formatNumber(ctx, value.byteLength)} }`;
     }
@@ -494,8 +494,7 @@ function formatValue(ctx, value, recurseTimes) {
       keys.unshift('size');
     empty = value.size === 0;
     formatter = formatMap;
-  } else if (binding.isArrayBuffer(value) ||
-             binding.isSharedArrayBuffer(value)) {
+  } else if (binding.isAnyArrayBuffer(value)) {
     braces = ['{', '}'];
     keys.unshift('byteLength');
     visibleKeys.byteLength = true;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -20,7 +20,6 @@ using v8::Value;
 
 
 #define VALUE_METHOD_MAP(V)                                                   \
-  V(isArrayBuffer, IsArrayBuffer)                                             \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
   V(isExternal, IsExternal)                                                   \
@@ -30,7 +29,6 @@ using v8::Value;
   V(isRegExp, IsRegExp)                                                       \
   V(isSet, IsSet)                                                             \
   V(isSetIterator, IsSetIterator)                                             \
-  V(isSharedArrayBuffer, IsSharedArrayBuffer)                                 \
   V(isTypedArray, IsTypedArray)                                               \
   V(isUint8Array, IsUint8Array)
 
@@ -43,6 +41,12 @@ using v8::Value;
 
   VALUE_METHOD_MAP(V)
 #undef V
+
+static void IsAnyArrayBuffer(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(1, args.Length());
+  args.GetReturnValue().Set(
+    args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer());
+}
 
 static void GetPromiseDetails(const FunctionCallbackInfo<Value>& args) {
   // Return undefined if it's not a Promise.
@@ -150,6 +154,8 @@ void Initialize(Local<Object> target,
 #define V(lcname, ucname) env->SetMethod(target, #lcname, ucname);
   VALUE_METHOD_MAP(V)
 #undef V
+
+  env->SetMethod(target, "isAnyArrayBuffer", IsAnyArrayBuffer);
 
 #define V(name, _)                                                            \
   target->Set(context,                                                        \


### PR DESCRIPTION
Various performance improvements for a few different `buffer` methods. Here are some results:

<details>

```
                                                                                           improvement confidence      p.value
 buffers/buffer-bytelength.js n=50000000 len=1 encoding="base64"                              51.44 %        *** 1.050242e-53
 buffers/buffer-bytelength.js n=50000000 len=1 encoding="buffer"                               1.42 %         ** 6.738195e-03
 buffers/buffer-bytelength.js n=50000000 len=1 encoding="utf8"                                 7.56 %        *** 5.018577e-22
 buffers/buffer-from.js n=8192 len=10 source="array"                                           6.60 %        *** 1.457931e-18
 buffers/buffer-from.js n=8192 len=10 source="arraybuffer-middle"                              1.07 %            2.401741e-01
 buffers/buffer-from.js n=8192 len=10 source="arraybuffer"                                     1.89 %         ** 7.543607e-03
 buffers/buffer-from.js n=8192 len=10 source="buffer"                                          3.30 %            7.008235e-02
 buffers/buffer-from.js n=8192 len=10 source="object"                                          6.92 %        *** 1.504947e-09
 buffers/buffer-from.js n=8192 len=10 source="string-base64"                                  12.71 %        *** 6.389098e-06
 buffers/buffer-from.js n=8192 len=10 source="string-utf8"                                     4.45 %          * 4.777047e-02
 buffers/buffer-from.js n=8192 len=10 source="string"                                         11.63 %        *** 1.350708e-09
 buffers/buffer-from.js n=8192 len=10 source="uint8array"                                      0.86 %            6.221473e-01
 buffers/buffer-from.js n=2048 len=2048 source="array"                                         0.61 %        *** 8.664083e-05
 buffers/buffer-from.js n=2048 len=2048 source="arraybuffer-middle"                            0.33 %            7.338223e-01
 buffers/buffer-from.js n=2048 len=2048 source="arraybuffer"                                   3.30 %          * 1.755731e-02
 buffers/buffer-from.js n=2048 len=2048 source="buffer"                                        3.02 %        *** 6.629900e-04
 buffers/buffer-from.js n=2048 len=2048 source="object"                                        5.65 %        *** 1.659545e-12
 buffers/buffer-from.js n=2048 len=2048 source="string-base64"                                 2.93 %        *** 1.243836e-06
 buffers/buffer-from.js n=2048 len=2048 source="string-utf8"                                   2.60 %        *** 3.548890e-04
 buffers/buffer-from.js n=2048 len=2048 source="string"                                        5.24 %        *** 7.227091e-11
 buffers/buffer-from.js n=2048 len=2048 source="uint8array"                                   -0.27 %            7.524947e-01
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding=""                              260.76 %        *** 3.130638e-38
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="ascii"                         268.52 %        *** 3.255707e-31
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="binary"                        269.05 %        *** 3.730882e-30
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="hex"                           266.61 %        *** 1.917714e-25
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="latin1"                        264.17 %        *** 9.225369e-32
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="UCS-2"                         267.50 %        *** 1.460693e-30
 buffers/buffer-tostring.js n=90000000 len=0 args=1 encoding="utf8"                          263.34 %        *** 4.274071e-31
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding=""                               0.87 %            3.249672e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="ascii"                          0.02 %            9.922721e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="binary"                        -2.22 %            3.026759e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="hex"                           -0.19 %            9.182579e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="latin1"                        -0.52 %            7.138981e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="UCS-2"                         -1.10 %            5.829493e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=0 encoding="utf8"                          -1.14 %            3.478206e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding=""                               2.81 %        *** 2.749400e-04
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="ascii"                          7.05 %        *** 2.932016e-09
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="binary"                        10.10 %        *** 5.688044e-18
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="hex"                           -0.28 %            8.461152e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="latin1"                         7.96 %        *** 6.284652e-06
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="UCS-2"                         19.49 %        *** 5.979844e-33
 buffers/buffer-tostring.js n=40000000 len=64 args=1 encoding="utf8"                           2.95 %         ** 4.455376e-03
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding=""                               3.08 %          * 3.739954e-02
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="ascii"                          6.73 %        *** 2.516403e-07
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="binary"                         9.05 %        *** 1.497619e-13
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="hex"                            0.12 %            9.239700e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="latin1"                        11.31 %        *** 8.922726e-22
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="UCS-2"                         20.40 %        *** 1.096930e-27
 buffers/buffer-tostring.js n=40000000 len=64 args=2 encoding="utf8"                           0.90 %            6.442258e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding=""                               2.98 %        *** 3.235235e-05
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="ascii"                          4.20 %          * 1.458188e-02
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="binary"                         6.50 %        *** 7.378602e-05
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="hex"                            0.71 %            5.972208e-01
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="latin1"                         7.37 %        *** 7.379083e-09
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="UCS-2"                         19.33 %        *** 9.793473e-20
 buffers/buffer-tostring.js n=40000000 len=64 args=3 encoding="utf8"                           2.71 %         ** 1.348332e-03
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding=""                          7.34 %        *** 3.834387e-14
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="ascii"                     4.91 %        *** 2.537762e-06
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="binary"                    8.11 %        *** 2.907588e-06
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="hex"                      -0.77 %            5.734921e-01
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="latin1"                    9.29 %        *** 8.819301e-06
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="UCS-2"                    18.52 %        *** 1.116642e-33
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="utf16le"                  22.72 %        *** 8.339782e-16
 buffers/buffer-write-string.js n=10000000 len=10 args="" encoding="utf8"                      3.93 %         ** 3.174114e-03
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding=""                    4.34 %        *** 1.837325e-05
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="ascii"               3.82 %         ** 4.578509e-03
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="binary"              3.02 %            6.567071e-02
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="hex"                -1.59 %            3.640330e-01
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="latin1"              4.95 %        *** 4.968388e-06
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="UCS-2"              13.52 %        *** 4.838675e-15
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="utf16le"            14.72 %        *** 1.318866e-14
 buffers/buffer-write-string.js n=10000000 len=10 args="offset" encoding="utf8"                1.99 %            1.325214e-01
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding=""             4.62 %         ** 7.720895e-03
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="ascii"        5.90 %        *** 5.690321e-06
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="binary"       4.24 %        *** 1.967408e-05
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="hex"          1.22 %            1.347244e-01
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="latin1"       5.61 %        *** 4.559969e-04
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="UCS-2"       14.97 %        *** 1.388892e-15
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="utf16le"     13.35 %        *** 1.915156e-10
 buffers/buffer-write-string.js n=10000000 len=10 args="offset+length" encoding="utf8"         1.63 %            1.468564e-01
```

</details>
<br/>

I've decided *not* to mark this as semver-major despite changes such as `.toString()` now returning early when `buf.length === 0`, in which case it won't validate the encoding name. The reason being there are already similar short-circuits being done in that method depending on the values of `start` and `end`.

As far as I know there shouldn't be any other semver-major-like changes.

CI: https://ci.nodejs.org/job/node-test-pull-request/7352/

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* buffer