### PR TITLE
deps: update node-inspect to v1.11.2

### DIFF
--- a/deps/node-inspect/CHANGELOG.md
+++ b/deps/node-inspect/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.11.2
+
+* [`42e0cd1`](https://github.com/nodejs/node-inspect/commit/42e0cd111d89ed09faba1c0ec45089b0b44de011) **fix:** look for generic hint text
+
+
 ### 1.11.1
 
 * Prefer --inspect-brk over --debug-brk - **[@ofrobots](https://github.com/ofrobots)** [#43](https://github.com/nodejs/node-inspect/pull/43)

--- a/deps/node-inspect/CHANGELOG.md
+++ b/deps/node-inspect/CHANGELOG.md
@@ -1,3 +1,24 @@
+### 1.11.1
+
+* Prefer --inspect-brk over --debug-brk - **[@ofrobots](https://github.com/ofrobots)** [#43](https://github.com/nodejs/node-inspect/pull/43)
+  - [`2c1ed27`](https://github.com/nodejs/node-inspect/commit/2c1ed27ee44d9aebb3c5ac50039abae8166a54e3) **fix:** use --inspect-brk with Node 8+
+
+
+### 1.11.0
+
+* doc: add profile and heap to help - **[@joshgav](https://github.com/joshgav)** [#39](https://github.com/nodejs/node-inspect/pull/39)
+  - [`f64c920`](https://github.com/nodejs/node-inspect/commit/f64c9205bd8382289660aa677d3ac192a9c81fd5) **doc:** add profile and heap to help
+* Update test suite to pass on latest nightly - **[@jkrems](https://github.com/jkrems)** [#36](https://github.com/nodejs/node-inspect/pull/36)
+  - [`41148d7`](https://github.com/nodejs/node-inspect/commit/41148d74a2d563eea3b7ad5463622b6b9fd4c46e) **test:** Remove outdated test
+  - [`2c224c5`](https://github.com/nodejs/node-inspect/commit/2c224c551619e386e80fc3154cc14562cac063b9) **test:** Accept any kind of "break"
+  - [`22bf349`](https://github.com/nodejs/node-inspect/commit/22bf349bc86d7bf6fd449791c9d1e7eaf66c2681) **test:** Adjust for v8 5.7
+  - [`6ce8c16`](https://github.com/nodejs/node-inspect/commit/6ce8c165c45a491bea8cfb3c67d2ae80e7c34dcb) **test:** Revert to old assertions
+* Verify custom port support - **[@jkrems](https://github.com/jkrems)** [#41](https://github.com/nodejs/node-inspect/pull/41)
+  - [`e3a489f`](https://github.com/nodejs/node-inspect/commit/e3a489f23b089d3d57a25d5efe40daf06de63e23) **test:** custom port
+* Support for debugging a pid - **[@jkrems](https://github.com/jkrems)** [#37](https://github.com/nodejs/node-inspect/pull/37)
+  - [`4179506`](https://github.com/nodejs/node-inspect/commit/4179506a4d546bac2c93b2a7ff491b1fa4494fd9) **feat:** Support for debugging a pid
+
+
 ### 1.10.6
 
 * chore: Fix usage text for embedded mode - **[@addaleax](https://github.com/addaleax)** [#20](https://github.com/nodejs/node-inspect/pull/20)

--- a/deps/node-inspect/CONTRIBUTING.md
+++ b/deps/node-inspect/CONTRIBUTING.md
@@ -179,3 +179,4 @@ A simple bug fix:
 ```
 fix: Handle multi-byte characters in search logic
 ```
+

--- a/deps/node-inspect/lib/_inspect.js
+++ b/deps/node-inspect/lib/_inspect.js
@@ -110,7 +110,7 @@ function runScript(script, scriptArgs, inspectHost, inspectPort, childPrint) {
         let output = '';
         function waitForListenHint(text) {
           output += text;
-          if (/chrome-devtools:\/\//.test(output)) {
+          if (/Debugger listening on/.test(output)) {
             child.stderr.removeListener('data', waitForListenHint);
             resolve(child);
           }

--- a/deps/node-inspect/lib/_inspect.js
+++ b/deps/node-inspect/lib/_inspect.js
@@ -42,7 +42,7 @@ const [ InspectClient, createRepl ] =
 
 const debuglog = util.debuglog('inspect');
 
-const DEBUG_PORT_PATTERN = /^--(?:debug|inspect)-port=(\d+)$/;
+const DEBUG_PORT_PATTERN = /^--(?:debug|inspect)(?:-port|-brk)?=(\d{1,5})$/;
 function getDefaultPort() {
   for (const arg of process.execArgv) {
     const match = arg.match(DEBUG_PORT_PATTERN);
@@ -51,54 +51,6 @@ function getDefaultPort() {
     }
   }
   return 9229;
-}
-
-function runScript(script, scriptArgs, inspectPort, childPrint) {
-  return new Promise((resolve) => {
-    const needDebugBrk = process.version.match(/^v(6|7)\./);
-    const args = (needDebugBrk ?
-                      ['--inspect', `--debug-brk=${inspectPort}`] :
-                      [`--inspect-brk=${inspectPort}`])
-                     .concat([script], scriptArgs);
-    const child = spawn(process.execPath, args);
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', childPrint);
-    child.stderr.on('data', childPrint);
-
-    let output = '';
-    function waitForListenHint(text) {
-      output += text;
-      if (/chrome-devtools:\/\//.test(output)) {
-        child.stderr.removeListener('data', waitForListenHint);
-        resolve(child);
-      }
-    }
-
-    child.stderr.on('data', waitForListenHint);
-  });
-}
-
-function createAgentProxy(domain, client) {
-  const agent = new EventEmitter();
-  agent.then = (...args) => {
-    // TODO: potentially fetch the protocol and pretty-print it here.
-    const descriptor = {
-      [util.inspect.custom](depth, { stylize }) {
-        return stylize(`[Agent ${domain}]`, 'special');
-      },
-    };
-    return Promise.resolve(descriptor).then(...args);
-  };
-
-  return new Proxy(agent, {
-    get(target, name) {
-      if (name in target) return target[name];
-      return function callVirtualMethod(params) {
-        return client.callMethod(`${domain}.${name}`, params);
-      };
-    },
-  });
 }
 
 function portIsFree(host, port, timeout = 2000) {
@@ -140,6 +92,57 @@ function portIsFree(host, port, timeout = 2000) {
   });
 }
 
+function runScript(script, scriptArgs, inspectHost, inspectPort, childPrint) {
+  return portIsFree(inspectHost, inspectPort)
+    .then(() => {
+      return new Promise((resolve) => {
+        const needDebugBrk = process.version.match(/^v(6|7)\./);
+        const args = (needDebugBrk ?
+                          ['--inspect', `--debug-brk=${inspectPort}`] :
+                          [`--inspect-brk=${inspectPort}`])
+                         .concat([script], scriptArgs);
+        const child = spawn(process.execPath, args);
+        child.stdout.setEncoding('utf8');
+        child.stderr.setEncoding('utf8');
+        child.stdout.on('data', childPrint);
+        child.stderr.on('data', childPrint);
+
+        let output = '';
+        function waitForListenHint(text) {
+          output += text;
+          if (/chrome-devtools:\/\//.test(output)) {
+            child.stderr.removeListener('data', waitForListenHint);
+            resolve(child);
+          }
+        }
+
+        child.stderr.on('data', waitForListenHint);
+      });
+    });
+}
+
+function createAgentProxy(domain, client) {
+  const agent = new EventEmitter();
+  agent.then = (...args) => {
+    // TODO: potentially fetch the protocol and pretty-print it here.
+    const descriptor = {
+      [util.inspect.custom](depth, { stylize }) {
+        return stylize(`[Agent ${domain}]`, 'special');
+      },
+    };
+    return Promise.resolve(descriptor).then(...args);
+  };
+
+  return new Proxy(agent, {
+    get(target, name) {
+      if (name in target) return target[name];
+      return function callVirtualMethod(params) {
+        return client.callMethod(`${domain}.${name}`, params);
+      };
+    },
+  });
+}
+
 class NodeInspector {
   constructor(options, stdin, stdout) {
     this.options = options;
@@ -153,6 +156,7 @@ class NodeInspector {
       this._runScript = runScript.bind(null,
                                        options.script,
                                        options.scriptArgs,
+                                       options.host,
                                        options.port,
                                        this.childPrint.bind(this));
     } else {
@@ -221,12 +225,7 @@ class NodeInspector {
     this.killChild();
     const { host, port } = this.options;
 
-    const runOncePortIsFree = () => {
-      return portIsFree(host, port)
-        .then(() => this._runScript());
-    };
-
-    return runOncePortIsFree().then((child) => {
+    return this._runScript().then((child) => {
       this.child = child;
 
       let connectionAttempts = 0;
@@ -296,6 +295,7 @@ function parseArgv([target, ...args]) {
 
   const hostMatch = target.match(/^([^:]+):(\d+)$/);
   const portMatch = target.match(/^--port=(\d+)$/);
+
   if (hostMatch) {
     // Connecting to remote debugger
     // `node-inspect localhost:9229`
@@ -304,16 +304,31 @@ function parseArgv([target, ...args]) {
     isRemote = true;
     script = null;
   } else if (portMatch) {
-    // Start debugger on custom port
-    // `node debug --port=8058 app.js`
+    // start debugee on custom port
+    // `node inspect --port=9230 script.js`
     port = parseInt(portMatch[1], 10);
     script = args[0];
     scriptArgs = args.slice(1);
+  } else if (args.length === 1 && /^\d+$/.test(args[0]) && target === '-p') {
+    // Start debugger against a given pid
+    const pid = parseInt(args[0], 10);
+    try {
+      process._debugProcess(pid);
+    } catch (e) {
+      if (e.code === 'ESRCH') {
+        /* eslint-disable no-console */
+        console.error(`Target process: ${pid} doesn't exist.`);
+        /* eslint-enable no-console */
+        process.exit(1);
+      }
+      throw e;
+    }
+    script = null;
+    isRemote = true;
   }
 
   return {
-    host, port,
-    isRemote, script, scriptArgs,
+    host, port, isRemote, script, scriptArgs,
   };
 }
 
@@ -328,6 +343,7 @@ function startInspect(argv = process.argv.slice(2),
 
     console.error(`Usage: ${invokedAs} script.js`);
     console.error(`       ${invokedAs} <host>:<port>`);
+    console.error(`       ${invokedAs} -p <pid>`);
     process.exit(1);
   }
 

--- a/deps/node-inspect/lib/internal/inspect_repl.js
+++ b/deps/node-inspect/lib/internal/inspect_repl.js
@@ -67,6 +67,15 @@ repl                  Enter a debug repl that works like exec
 
 scripts               List application scripts that are currently loaded
 scripts(true)         List all scripts (including node-internals)
+
+profile               Start CPU profiling session.
+profileEnd            Stop current CPU profiling session.
+profiles              Array of completed CPU profiling sessions.
+profiles[n].save(filepath = 'node.cpuprofile')
+                      Save CPU profiling session to disk as JSON.
+
+takeHeapSnapshot(filepath = 'node.heapsnapshot')
+                      Take a heap snapshot and save to disk as JSON.
 `.trim();
 
 const FUNCTION_NAME_PATTERN = /^(?:function\*? )?([^(\s]+)\(/;

--- a/deps/node-inspect/package.json
+++ b/deps/node-inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-inspect",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Node Inspect",
   "license": "MIT",
   "main": "lib/_inspect.js",

--- a/deps/node-inspect/package.json
+++ b/deps/node-inspect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-inspect",
-  "version": "1.10.6",
+  "version": "1.11.1",
   "description": "Node Inspect",
   "license": "MIT",
   "main": "lib/_inspect.js",
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "pretest": "eslint --rulesdir=tools/eslint-rules lib test",
-    "test": "tap \"test/**/*.test.js\"",
+    "test": "tap test",
     "posttest": "nlm verify"
   },
   "nlm": {

--- a/deps/node-inspect/test/cli/backtrace.test.js
+++ b/deps/node-inspect/test/cli/backtrace.test.js
@@ -14,7 +14,7 @@ test('display and navigate backtrace', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('c'))
     .then(() => cli.command('bt'))

--- a/deps/node-inspect/test/cli/break.test.js
+++ b/deps/node-inspect/test/cli/break.test.js
@@ -14,7 +14,7 @@ test('stepping through breakpoints', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
@@ -132,7 +132,7 @@ test('sb before loading file', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("other.js", 3)'))
     .then(() => {
@@ -161,7 +161,7 @@ test('clearBreakpoint', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("break.js", 3)'))
     .then(() => cli.command('sb("break.js", 9)'))

--- a/deps/node-inspect/test/cli/exceptions.test.js
+++ b/deps/node-inspect/test/cli/exceptions.test.js
@@ -14,17 +14,19 @@ test('break on (uncaught) exceptions', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })
     // making sure it will die by default:
     .then(() => cli.command('c'))
-    .then(() => cli.waitFor(/disconnect/))
+    // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore
+    .then(() => cli.waitFor(/disconnect|FATAL ERROR/))
 
     // Next run: With `breakOnException` it pauses in both places
     .then(() => cli.stepCommand('r'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })
@@ -41,6 +43,7 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: With `breakOnUncaught` it only pauses on the 2nd exception
     .then(() => cli.command('breakOnUncaught'))
     .then(() => cli.stepCommand('r')) // also, the setting survives the restart
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })
@@ -52,11 +55,13 @@ test('break on (uncaught) exceptions', (t) => {
     // Next run: Back to the initial state! It should die again.
     .then(() => cli.command('breakOnNone'))
     .then(() => cli.stepCommand('r'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })
     .then(() => cli.command('c'))
-    .then(() => cli.waitFor(/disconnect/))
+    // TODO: Remove FATAL ERROR once node doesn't show a FATAL ERROR anymore
+    .then(() => cli.waitFor(/disconnect|FATAL ERROR/))
 
     .then(() => cli.quit())
     .then(null, onFatal);

--- a/deps/node-inspect/test/cli/exec.test.js
+++ b/deps/node-inspect/test/cli/exec.test.js
@@ -11,7 +11,7 @@ test('examples/alive.js', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('exec [typeof heartbeat, typeof process.exit]'))
     .then(() => {
@@ -60,7 +60,7 @@ test('exec .scope', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('c'))
     .then(() => cli.command('exec .scope'))

--- a/deps/node-inspect/test/cli/help.test.js
+++ b/deps/node-inspect/test/cli/help.test.js
@@ -11,7 +11,7 @@ test('examples/empty.js', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('help'))
     .then(() => {

--- a/deps/node-inspect/test/cli/launch.test.js
+++ b/deps/node-inspect/test/cli/launch.test.js
@@ -5,17 +5,38 @@ const { test } = require('tap');
 
 const startCLI = require('./start-cli');
 
-test('examples/empty.js', (t) => {
-  const script = Path.join('examples', 'empty.js');
-  const cli = startCLI([script]);
+test('custom port', (t) => {
+  const CUSTOM_PORT = '9230';
+  const script = Path.join('examples', 'three-lines.js');
 
-  return cli.waitFor(/break/)
+  const cli = startCLI([`--port=${CUSTOM_PORT}`, script]);
+
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(cli.output, 'debug>', 'prints a prompt');
       t.match(
         cli.output,
-        '< Debugger listening on port 9229',
+        new RegExp(`< Debugger listening on [^\n]*${CUSTOM_PORT}`),
+        'forwards child output');
+    })
+    .then(() => cli.quit())
+    .then((code) => {
+      t.equal(code, 0, 'exits with success');
+    });
+});
+
+test('examples/three-lines.js', (t) => {
+  const script = Path.join('examples', 'three-lines.js');
+  const cli = startCLI([script]);
+
+  return cli.waitForInitialBreak()
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(cli.output, 'debug>', 'prints a prompt');
+      t.match(
+        cli.output,
+        /< Debugger listening on [^\n]*9229/,
         'forwards child output');
     })
     .then(() => cli.command('["hello", "world"].join(" ")'))
@@ -45,7 +66,7 @@ test('run after quit / restart', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('n'))
     .then(() => {
@@ -72,6 +93,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, 'Use `run` to start the app again');
     })
     .then(() => cli.stepCommand('run'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(
@@ -87,6 +109,7 @@ test('run after quit / restart', (t) => {
         'steps to the 2nd line');
     })
     .then(() => cli.stepCommand('restart'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(
         cli.output,
@@ -100,6 +123,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, 'Use `run` to start the app again');
     })
     .then(() => cli.stepCommand('run'))
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(

--- a/deps/node-inspect/test/cli/low-level.test.js
+++ b/deps/node-inspect/test/cli/low-level.test.js
@@ -4,15 +4,15 @@ const { test } = require('tap');
 const startCLI = require('./start-cli');
 
 test('Debugger agent direct access', (t) => {
-  const cli = startCLI(['examples/empty.js']);
-  const scriptPattern = /^\* (\d+): examples(?:\/|\\)empty.js/;
+  const cli = startCLI(['examples/three-lines.js']);
+  const scriptPattern = /^\* (\d+): examples(?:\/|\\)three-lines.js/;
 
   function onFatal(error) {
     cli.quit();
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('scripts'))
     .then(() => {
@@ -24,7 +24,10 @@ test('Debugger agent direct access', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /scriptSource: '\(function \([^)]+\) \{ \\n}\);'/);
+        /scriptSource: '\(function \(/);
+      t.match(
+        cli.output,
+        /let x = 1;/);
     })
     .then(() => cli.quit())
     .then(null, onFatal);

--- a/deps/node-inspect/test/cli/pid.test.js
+++ b/deps/node-inspect/test/cli/pid.test.js
@@ -1,0 +1,52 @@
+'use strict';
+const { spawn } = require('child_process');
+const Path = require('path');
+
+const { test } = require('tap');
+
+const startCLI = require('./start-cli');
+
+function launchTarget(...args) {
+  const childProc = spawn(process.execPath, args);
+  return Promise.resolve(childProc);
+}
+
+// process.debugPort is our proxy for "the version of node used to run this
+// test suite doesn't support SIGUSR1 for enabling --inspect for a process".
+const defaultsToOldProtocol = process.debugPort === 5858;
+
+test('examples/alive.js', { skip: defaultsToOldProtocol }, (t) => {
+  const script = Path.join('examples', 'alive.js');
+  let cli = null;
+  let target = null;
+
+  function cleanup(error) {
+    if (cli) {
+      cli.quit();
+      cli = null;
+    }
+    if (target) {
+      target.kill();
+      target = null;
+    }
+    if (error) throw error;
+  }
+
+  return launchTarget(script)
+    .then((childProc) => {
+      target = childProc;
+      cli = startCLI(['-p', `${target.pid}`]);
+      return cli.waitForPrompt();
+    })
+    .then(() => cli.command('sb("alive.js", 3)'))
+    .then(() => cli.waitFor(/break/))
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(
+        cli.output,
+        '> 3   ++x;',
+        'marks the 3rd line');
+    })
+    .then(() => cleanup())
+    .then(null, cleanup);
+});

--- a/deps/node-inspect/test/cli/preserve-breaks.test.js
+++ b/deps/node-inspect/test/cli/preserve-breaks.test.js
@@ -14,7 +14,7 @@ test('run after quit / restart', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('breakpoints'))
     .then(() => {
@@ -33,8 +33,7 @@ test('run after quit / restart', (t) => {
       t.match(cli.output, `break in ${script}:3`);
     })
     .then(() => cli.command('restart'))
-    .then(() => cli.waitFor([/break in examples/, /breakpoints restored/]))
-    .then(() => cli.waitForPrompt())
+    .then(() => cli.waitForInitialBreak())
     .then(() => {
       t.match(cli.output, `break in ${script}:1`);
     })

--- a/deps/node-inspect/test/cli/profile.test.js
+++ b/deps/node-inspect/test/cli/profile.test.js
@@ -15,7 +15,7 @@ test('profiles', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('exec console.profile()'))
     .then(() => {

--- a/deps/node-inspect/test/cli/scripts.test.js
+++ b/deps/node-inspect/test/cli/scripts.test.js
@@ -6,7 +6,7 @@ const { test } = require('tap');
 const startCLI = require('./start-cli');
 
 test('list scripts', (t) => {
-  const script = Path.join('examples', 'empty.js');
+  const script = Path.join('examples', 'three-lines.js');
   const cli = startCLI([script]);
 
   function onFatal(error) {
@@ -14,13 +14,13 @@ test('list scripts', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('scripts'))
     .then(() => {
       t.match(
         cli.output,
-        /^\* \d+: examples(?:\/|\\)empty\.js/,
+        /^\* \d+: examples(?:\/|\\)three-lines\.js/,
         'lists the user script');
       t.notMatch(
         cli.output,
@@ -31,7 +31,7 @@ test('list scripts', (t) => {
     .then(() => {
       t.match(
         cli.output,
-        /\* \d+: examples(?:\/|\\)empty\.js/,
+        /\* \d+: examples(?:\/|\\)three-lines\.js/,
         'lists the user script');
       t.match(
         cli.output,

--- a/deps/node-inspect/test/cli/use-strict.test.js
+++ b/deps/node-inspect/test/cli/use-strict.test.js
@@ -14,7 +14,7 @@ test('for whiles that starts with strict directive', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => {
       t.match(

--- a/deps/node-inspect/test/cli/watchers.test.js
+++ b/deps/node-inspect/test/cli/watchers.test.js
@@ -11,7 +11,7 @@ test('stepping through breakpoints', (t) => {
     throw error;
   }
 
-  return cli.waitFor(/break/)
+  return cli.waitForInitialBreak()
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('watch("x")'))
     .then(() => cli.command('watch("\\"Hello\\"")'))

--- a/deps/node-inspect/test/node-inspect.test.js
+++ b/deps/node-inspect/test/node-inspect.test.js
@@ -1,9 +1,0 @@
-'use strict';
-const tap = require('tap');
-
-const nodeInspect = require('../');
-
-tap.equal(
-  9229,
-  nodeInspect.port,
-  'Uses the --inspect default port');


### PR DESCRIPTION
This updates the bundled `node-inspect` to 1.11.2, including https://github.com/nodejs/node-inspect/pull/43 which was previously cherry-picked in https://github.com/nodejs/node/pull/11441.

#### Highlights

* Support for debugging a pid (`node inspect -p <pid>`)
* Fixes to support latest master changes
* Memory & CPU profiling added to help text

Compare: https://github.com/nodejs/node-inspect/compare/v1.10.6...v1.11.2

#### Rendered Changelog

> ### 1.11.2
>
> * [`42e0cd1`](https://github.com/nodejs/node-inspect/commit/42e0cd111d89ed09faba1c0ec45089b0b44de011) **fix:** look for generic hint text
>
>
> ### 1.11.1
> 
> * Prefer --inspect-brk over --debug-brk - **[@ofrobots](https://github.com/ofrobots)** [#43](https://github.com/nodejs/node-inspect/pull/43)
>   - [`2c1ed27`](https://github.com/nodejs/node-inspect/commit/2c1ed27ee44d9aebb3c5ac50039abae8166a54e3) **fix:** use --inspect-brk with Node 8+
> 
> 
> ### 1.11.0
> 
> * doc: add profile and heap to help - **[@joshgav](https://github.com/joshgav)** [#39](https://github.com/nodejs/node-inspect/pull/39)
>   - [`f64c920`](https://github.com/nodejs/node-inspect/commit/f64c9205bd8382289660aa677d3ac192a9c81fd5) **doc:** add profile and heap to help
> * Update test suite to pass on latest nightly - **[@jkrems](https://github.com/jkrems)** [#36](https://github.com/nodejs/node-inspect/pull/36)
>   - [`41148d7`](https://github.com/nodejs/node-inspect/commit/41148d74a2d563eea3b7ad5463622b6b9fd4c46e) **test:** Remove outdated test
>   - [`2c224c5`](https://github.com/nodejs/node-inspect/commit/2c224c551619e386e80fc3154cc14562cac063b9) **test:** Accept any kind of "break"
>   - [`22bf349`](https://github.com/nodejs/node-inspect/commit/22bf349bc86d7bf6fd449791c9d1e7eaf66c2681) **test:** Adjust for v8 5.7
>   - [`6ce8c16`](https://github.com/nodejs/node-inspect/commit/6ce8c165c45a491bea8cfb3c67d2ae80e7c34dcb) **test:** Revert to old assertions
> * Verify custom port support - **[@jkrems](https://github.com/jkrems)** [#41](https://github.com/nodejs/node-inspect/pull/41)
>   - [`e3a489f`](https://github.com/nodejs/node-inspect/commit/e3a489f23b089d3d57a25d5efe40daf06de63e23) **test:** custom port
> * Support for debugging a pid - **[@jkrems](https://github.com/jkrems)** [#37](https://github.com/nodejs/node-inspect/pull/37)
>   - [`4179506`](https://github.com/nodejs/node-inspect/commit/4179506a4d546bac2c93b2a7ff491b1fa4494fd9) **feat:** Support for debugging a pid

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` and `make test-node-inspect` pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

deps