### PR TITLE
n-api: fix coverity scan report

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2602,6 +2602,7 @@ class Work {
     _data(data),
     _execute(execute),
     _complete(complete) {
+    memset(&_request, 0, sizeof(_request));
     _request.data = this;
   }
 


### PR DESCRIPTION
Coverity was reporting _request.work_req as not being initialized.
Add memset to ensure all of _request is initialized.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
n-api