### PR TITLE
test: complete coverage of lib/child_process.js

### DIFF
--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -1,9 +1,9 @@
 'use strict';
-
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
+const uv = process.binding('uv');
 
 const fixture = path.join(common.fixturesDir, 'exit.js');
 
@@ -18,4 +18,23 @@ const fixture = path.join(common.fixturesDir, 'exit.js');
       assert.strictEqual(e.code, 42);
     })
   );
+}
+
+{
+  // Verify that negative exit codes can be translated to UV error names.
+  const errorString = `Error: Command failed: ${process.execPath}`;
+  const code = -1;
+  const callback = common.mustCall((err, stdout, stderr) => {
+    assert.strictEqual(err.toString().trim(), errorString);
+    assert.strictEqual(err.code, uv.errname(code));
+    assert.strictEqual(err.killed, true);
+    assert.strictEqual(err.signal, null);
+    assert.strictEqual(err.cmd, process.execPath);
+    assert.strictEqual(stdout.trim(), '');
+    assert.strictEqual(stderr.trim(), '');
+  });
+  const child = execFile(process.execPath, callback);
+
+  child.kill();
+  child.emit('close', code, null);
 }


### PR DESCRIPTION
This commit adds a test which brings coverage of `lib/child_process.js` to 100%. It adds coverage for the call to [`uv.errname()` in `execFile()`'s `exithandler()` function](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/child_process.js#L249).

I haven't been able to hit this line of code completely naturally, but as shown in the test, it can be done with public APIs. So, there is a question of whether that line of code needs to exist. To execute that line:

- `exithandler()` must be [called for the first time](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/child_process.js#L217).
- A [callback must be provided](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/child_process.js#L225) to `execFile()`.
- [`ex` must not be set and `code` must be less than zero](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/child_process.js#L238-L249).

Out of the three call sites of `exithandler()`, the child process [`'close'` handler](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/child_process.js#L330) is the only one that does not set `ex`. The `'close'` event is [emitted once all of child processes streams have been closed](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/internal/child_process.js#L882). I find it unlikely that [all of the streams will be closed](https://github.com/nodejs/node/blob/2ced07ccaf7682b9ec8fb3bcc3dc8d2bb2798c61/lib/internal/child_process.js#L334-L336) before an error is emitted. That would make the code in question dead code. However, I'd like to avoid possibly breaking anyone, and it's technically possible to recreate the case, as shown in the test.

cc: @Trott 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test