### PR TITLE
doc: add single arg scenario for util.format

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -135,6 +135,13 @@ Each argument is converted to a string using `util.inspect()`.
 util.format(1, 2, 3); // '1 2 3'
 ```
 
+If only one argument is passed to `util.format()`, it is returned as it is
+without any formatting.
+
+```js
+util.format('%% %s'); // '%% %s'
+```
+
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0


### PR DESCRIPTION
Set the expected outcome of `util.format('%%')` to be `%%`
instead of `%`.

Fixes: #12362

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc