### PR TITLE
test: remove common.PORT from test-cluster-basic

### DIFF
--- a/test/parallel/test-cluster-basic.js
+++ b/test/parallel/test-cluster-basic.js
@@ -35,10 +35,7 @@ function forEach(obj, fn) {
 
 
 if (cluster.isWorker) {
-  const http = require('http');
-  http.Server(function() {
-
-  }).listen(common.PORT, '127.0.0.1');
+  require('http').Server(common.noop).listen(0, '127.0.0.1');
 } else if (cluster.isMaster) {
 
   const checks = {
@@ -129,11 +126,15 @@ if (cluster.isWorker) {
 
         case 'listening':
           assert.strictEqual(arguments.length, 1);
-          const expect = { address: '127.0.0.1',
-                           port: common.PORT,
-                           addressType: 4,
-                           fd: undefined };
-          assert.deepStrictEqual(arguments[0], expect);
+          assert.strictEqual(Object.keys(arguments[0]).length, 4);
+          assert.strictEqual(arguments[0].address, '127.0.0.1');
+          assert.strictEqual(arguments[0].addressType, 4);
+          assert(arguments[0].hasOwnProperty('fd'));
+          assert.strictEqual(arguments[0].fd, undefined);
+          const port = arguments[0].port;
+          assert(Number.isInteger(port));
+          assert(port >= 1);
+          assert(port <= 65535);
           break;
 
         default:


### PR DESCRIPTION
Use of `common.PORT` in `parallel` tests is not completely safe (because
the same port can be previously assigned to another test running in
parallel if that test uses port `0` to get an arbitrary available port).

Remove `common.PORT` from test-cluster-basic.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test cluster