### PR TITLE
crypto: make LazyTransform compabile with Streams1

### DIFF
--- a/lib/internal/streams/lazy_transform.js
+++ b/lib/internal/streams/lazy_transform.js
@@ -11,6 +11,8 @@ module.exports = LazyTransform;
 
 function LazyTransform(options) {
   this._options = options;
+  this.writable = true;
+  this.readable = true;
 }
 util.inherits(LazyTransform, stream.Transform);
 

--- a/test/parallel/test-crypto-lazy-transform-writable.js
+++ b/test/parallel/test-crypto-lazy-transform-writable.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const crypto = require('crypto');
+const Stream = require('stream');
+const util = require('util');
+
+const hasher1 = crypto.createHash('sha256');
+const hasher2 = crypto.createHash('sha256');
+
+// Calculate the expected result.
+hasher1.write(Buffer.from('hello world'));
+hasher1.end();
+
+const expected = hasher1.read().toString('hex');
+
+function OldStream() {
+  Stream.call(this);
+
+  this.readable = true;
+}
+util.inherits(OldStream, Stream);
+
+const stream = new OldStream();
+
+stream.pipe(hasher2).on('finish', common.mustCall(function() {
+  const hash = hasher2.read().toString('hex');
+  assert.strictEqual(expected, hash);
+}));
+
+stream.emit('data', Buffer.from('hello'));
+stream.emit('data', Buffer.from(' world'));
+stream.emit('end');


### PR DESCRIPTION
Makes LazyTransform writable by Streams1 by assigning .writable = true
before the actual classes are loaded.

Fixes: https://github.com/nodejs/node/issues/12269

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

crypto, streams