### PR TITLE
test: fix coverity UNINIT_CTOR cctest warning

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -79,6 +79,10 @@ class NodeTestFixture : public ::testing::Test {
   ArrayBufferAllocator allocator_;
   v8::Isolate* isolate_;
 
+  ~NodeTestFixture() {
+    TearDown();
+  }
+
   virtual void SetUp() {
     platform_ = v8::platform::CreateDefaultPlatform();
     v8::V8::InitializePlatform(platform_);
@@ -88,13 +92,14 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void TearDown() {
+    if (platform_ == nullptr) return;
     v8::V8::ShutdownPlatform();
     delete platform_;
     platform_ = nullptr;
   }
 
  private:
-  v8::Platform* platform_;
+  v8::Platform* platform_ = nullptr;
 };
 
 #endif  // TEST_CCTEST_NODE_TEST_FIXTURE_H_


### PR DESCRIPTION
Explicitly initialize `platform_` to nullptr.  Coverity cannot divine
it is set and cleared by the Setup() and TearDown() methods.

cc @danbev

CI: https://ci.nodejs.org/job/node-test-pull-request/7373/