### PR TITLE
doc: upgrade Clang requirement to 3.4.2

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -62,7 +62,7 @@ Depending on host platform, the selection of toolchains may vary.
 #### Unix
 
 * GCC 4.8.5 or newer
-* Clang 3.4.1 or newer
+* Clang 3.4.2 or newer
 
 #### Windows
 
@@ -77,7 +77,7 @@ Depending on host platform, the selection of toolchains may vary.
 Prerequisites:
 
 * `gcc` and `g++` 4.8.5 or newer, or
-* `clang` and `clang++` 3.4.1 or newer
+* `clang` and `clang++` 3.4.2 or newer
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer
 

--- a/configure
+++ b/configure
@@ -617,8 +617,8 @@ def check_compiler(o):
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
   if not ok:
     warn('failed to autodetect C++ compiler version (CXX=%s)' % CXX)
-  elif clang_version < '3.4.0' if is_clang else gcc_version < '4.8.0':
-    warn('C++ compiler too old, need g++ 4.8 or clang++ 3.4 (CXX=%s)' % CXX)
+  elif clang_version < '3.4.2' if is_clang else gcc_version < '4.8.0':
+    warn('C++ compiler too old, need g++ 4.8 or clang++ 3.4.2 (CXX=%s)' % CXX)
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CC, 'c')
   if not ok:


### PR DESCRIPTION
Clang 3.4.1 has a bug that prevents compilation of V8.
As of Node.js 8.0.0 we stopped floating a workaround for this issue.

I don't have a test system to check if 3.4.2 is enough.

/cc @nodejs/build 

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)
