### PR TITLE
doc: make docs available offline w/ServiceWorker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ endif
 DOCS_ANALYTICS ?=
 
 apidoc_sources = $(wildcard doc/api/*.md)
-apidocs_html = $(apidoc_dirs) $(apiassets) $(addprefix out/,$(apidoc_sources:.md=.html))
+apidocs_html = $(apidoc_dirs) $(apiassets) out/doc/api/service_worker.js $(addprefix out/,$(apidoc_sources:.md=.html))
 apidocs_json = $(apidoc_dirs) $(apiassets) $(addprefix out/,$(apidoc_sources:.md=.json))
 
 apidoc_dirs = out/doc out/doc/api/ out/doc/api/assets
@@ -465,6 +465,9 @@ $(apidoc_dirs):
 
 out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets/
 	cp $< $@
+
+out/doc/api/service_worker.js:
+	cp out/doc/api/assets/service_worker.js out/doc/api/service_worker.js
 
 out/doc/%: doc/%
 	cp -r $< $@

--- a/doc/api/_toc.md
+++ b/doc/api/_toc.md
@@ -47,5 +47,6 @@
 
 <div class="line"></div>
 
+* <a href="#" data-js-handler="offline-docs">Make available offline</a>
 * [GitHub Repo & Issue Tracker](https://github.com/nodejs/node)
 * [Mailing List](http://groups.google.com/group/nodejs)

--- a/doc/api_assets/offline_docs.js
+++ b/doc/api_assets/offline_docs.js
@@ -1,0 +1,78 @@
+const staticAssets = [
+  'assets/style.css',
+  'assets/sh.css',
+  'assets/sh_main.js',
+  'assets/sh_javascript.min.js',
+  'assets/offline_docs.js',
+  'all.html'
+]
+
+function findVersionFromUrl() {
+  const matches = window.location.pathname.match(/v\d+\.\d+\.\d+/)
+  return matches && matches[0]
+}
+
+function isLocalDocURL(url) {
+  return !url.startsWith('http')
+}
+
+function isLocalDevelopment() {
+  return window.location.host.includes('localhost')
+}
+
+function findUrlsToAllDocLinks() {
+  const linkElements = Array.from(document.querySelectorAll('#column2 a'))
+  const urls = linkElements.map(elem => elem.attributes.href.value)
+
+  return urls.filter(isLocalDocURL)
+}
+
+function removePreviousFeedbacks(parent) {
+  parent.querySelectorAll('[data-js-feedback]').forEach(element => element.remove())
+}
+
+function cacheDocs(event) {
+  event.preventDefault()
+
+  const nodeVersion = findVersionFromUrl()
+  const docUrls = findUrlsToAllDocLinks()
+  const urls = staticAssets.concat(docUrls)
+  const display = (text) => () => displayTextBelow(event.target, text)
+
+  if (nodeVersion || isLocalDevelopment()) {
+    removePreviousFeedbacks(event.target.parentNode)
+
+    caches.open('v1')
+      .then(cache => cache.addAll(urls))
+      .then(display(`✓ docs for ${nodeVersion} are now available while offline.`),
+            display('An error occured while downloading docs, probably already offline?'))
+  }
+}
+
+function cacheDocsElemOnClick(fn) {
+  const elements = Array.from(document.querySelectorAll('[data-js-handler="offline-docs"]'))
+
+  elements.forEach(elem => elem.addEventListener('click', fn))
+}
+
+function displayNoSwSupport(event) {
+  displayTextBelow(event.target, 'Sorry, your browser do not have support for making docs offline yet :(')
+}
+
+function displayTextBelow(element, text) {
+  const feedbackElem = document.createElement('p')
+  feedbackElem.textContent = text
+  feedbackElem.setAttribute('data-js-feedback', '1')
+  feedbackElem.style.color = 'white'
+  feedbackElem.style.fontStyle = 'italic'
+  feedbackElem.style.marginTop = '10px'
+
+  element.parentNode.appendChild(feedbackElem)
+}
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service_worker.js')
+  cacheDocsElemOnClick(cacheDocs)
+} else {
+  cacheDocsElemOnClick(displayNoSwSupport)
+}

--- a/doc/api_assets/service_worker.js
+++ b/doc/api_assets/service_worker.js
@@ -1,0 +1,19 @@
+function activateWorkerImmediately(event) {
+  event.waitUntil(self.skipWaiting())
+}
+
+function becomeAvailableToAllPages(event) {
+  event.waitUntil(self.clients.claim())
+}
+
+function cachedResponseOrDoRequest(event) {
+  event.respondWith(
+    caches.open('v1')
+      .then(cache => caches.match(event.request))
+      .then(cachedResponse => cachedResponse || fetch(event.request))
+  )
+}
+
+self.addEventListener('install', activateWorkerImmediately)
+self.addEventListener('activate', becomeAvailableToAllPages)
+self.addEventListener('fetch', cachedResponseOrDoRequest)

--- a/doc/template.html
+++ b/doc/template.html
@@ -45,6 +45,7 @@
   <script src="assets/sh_main.js"></script>
   <script src="assets/sh_javascript.min.js"></script>
   <script>highlight(undefined, undefined, 'pre');</script>
+  <script src="assets/offline_docs.js"></script>
   <!-- __TRACKING__ -->
 </body>
 </html>


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
doc

This is work in progress that I'm putting out here for public scrutiny.

I've been wanting to get my feet wet with ServiceWorkers for a while, so here's my first pet project. Since I've been bother by docs not being available on spotty connection while commuting or where there is no connection at all, I decided our docs would be nice to have available at all times.

**How it works:**

1. ServiceWorker is registered immediately when visiting any doc page
2. When visitor clicks the "Make available offline" link
3. JavaScript finds all the relevant doc pages URLs, fetches the content and puts it into the ServiceWorker cache

To avoid caching docs too eagerly in step 2, I've put in a small check that ensure the docs currently displayed are for an exact version, not `latest-v6.x` or similar.

At the moment Firefox, Opera and Crome has ServiceWorker support, fingers crossed more will get support in the not too distant future: http://caniuse.com/#feat=serviceworkers

Got lots of inspiration from this cookbook: https://jakearchibald.com/2014/offline-cookbook/#on-background-sync

<img width="234" alt="screen shot 2017-04-13 at 12 59 03" src="https://cloud.githubusercontent.com/assets/1231635/25002614/a4ea20f6-204b-11e7-9f7f-a7ce53d4efac.png">

<img width="233" alt="screen shot 2017-04-13 at 12 58 46" src="https://cloud.githubusercontent.com/assets/1231635/25002617/a840de52-204b-11e7-8bb6-4ad1e1ecea0d.png">

Any thoughts?

/cc @nodejs/documentation 