### PR TITLE
Revert "src: exclude node_root_certs when use-def-ca-store"

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -143,11 +143,9 @@ static X509_NAME *cnnic_ev_name =
 
 static Mutex* mutexes;
 
-#if !defined(NODE_OPENSSL_CERT_STORE)
 const char* const root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
 };
-#endif
 
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
@@ -722,7 +720,6 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
-#if !defined(NODE_OPENSSL_CERT_STORE)
   if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));
@@ -735,7 +732,6 @@ static X509_STORE* NewRootCertStore() {
       root_certs_vector.push_back(x509);
     }
   }
-#endif
 
   X509_STORE* store = X509_STORE_new();
   if (ssl_openssl_cert_store) {


### PR DESCRIPTION
This reverts commit be98f2691736e10053b9826fce42b0ab50604da7.

The above commit prevented the functionality of --use-bundled-ca if
Node has been built using --openssl-use-def-ca-store, since there will
be no bundled ca included and no way to use them.

I only noticed this when trying to add // Flags: --use-bundled-ca to
test-tls-ccnic-whitelist.js to force it to use the bundled ca and allow
the test to pass.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src