### PR TITLE
test: add --use-bundled-ca to tls-cnnic-whitelist

### DIFF
--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -1,3 +1,4 @@
+// Flags: --use-bundled-ca
 'use strict';
 const common = require('../common');
 


### PR DESCRIPTION
If configued with --openssl-use-def-ca-store --shared-openssl the
following error might be thrown:
```console
assert.js:86
  throw new assert.AssertionError({
  ^
AssertionError: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' === 'CERT_REVOKED'
    at TLSSocket.client.on.common.mustCall
(/Users/danielbevenius/work/nodejs/node/test/parallel/test-tls-cnnic-whitelist.js:71:14)
    at TLSSocket.<anonymous>
(/Users/danielbevenius/work/nodejs/node/test/common.js:461:15)
    at emitOne (events.js:115:13)
    at TLSSocket.emit (events.js:210:7)
    at emitErrorNT (net.js:1305:8)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
```
In this case the CA's used will be the ones shipped with OpenSSL. For
tests though we should be able to specify --use-bundled-ca as a fix for
the above error, but this functionality was broken by me in commit
be98f2691736e10053b9826fce42b0ab50604da7 ("src: exclude node_root_certs when use-def-ca-store").

That commit removed the abilty to use --use-bundled-ca if the build was
configured --openssl-use-def-ca-store. That commit will be reverted by https://github.com/nodejs/node/pull/12391.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test