### PR TITLE
cluster: fix debugging port collision

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -115,7 +115,7 @@ function createWorkerProcess(id, env) {
 
   for (var i = 0; i < execArgv.length; i++) {
     const match = execArgv[i].match(
-      /^(--inspect|--inspect-(brk|port)|--debug|--debug-(brk|port))(=\d+)?$/
+      /^(--inspect|--inspect-(brk|port)|--debug|--debug-(brk|port))(=.*)?$/
     );
 
     if (match) {
@@ -124,7 +124,7 @@ function createWorkerProcess(id, env) {
         ++debugPortOffset;
       }
 
-      execArgv[i] = match[1] + '=' + debugPort;
+      execArgv[i] = match[1] + '=' + process._debugHostname + ':' + debugPort;
     }
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3361,6 +3361,11 @@ void SetupProcessObject(Environment* env,
                              DebugPortSetter,
                              env->as_external()).FromJust());
 
+  READONLY_PROPERTY(process,
+                    "_debugHostname",
+                    OneByteString(env->isolate(),
+                    debug_options.host_name().c_str()));
+
   // define various internal methods
   env->SetMethod(process,
                  "_startProfilerIdleNotifier",

--- a/test/parallel/test-cluster-inspector-debug-port.js
+++ b/test/parallel/test-cluster-inspector-debug-port.js
@@ -28,6 +28,7 @@ if (cluster.isMaster) {
   fork(4, ['--inspect', `--debug-port=${debuggerPort}`]);
   fork(5, [`--inspect-port=${debuggerPort}`]);
   fork(6, ['--inspect', `--inspect-port=${debuggerPort}`]);
+  fork(7, [`--inspect=${common.localhostIPv4}:${debuggerPort}`]);
 } else {
   const hasDebugArg = process.execArgv.some(function(arg) {
     return /inspect/.test(arg);


### PR DESCRIPTION
Fixing an issue that giving a debugging option including a hostname
stop the cluster worker by EADDRINUSE.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, cluster, test
