### PR TITLE
crypto: remove unused code in sign/verify

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -324,7 +324,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     }
   }
 
-  var ret = this._handle.sign(toBuf(key), null, passphrase, rsaPadding,
+  var ret = this._handle.sign(toBuf(key), passphrase, rsaPadding,
                               pssSaltLength);
 
   encoding = encoding || exports.DEFAULT_ENCODING;
@@ -374,7 +374,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     }
   }
 
-  return this._handle.verify(toBuf(key), toBuf(signature, sigEncoding), null,
+  return this._handle.verify(toBuf(key), toBuf(signature, sigEncoding),
                              rsaPadding, pssSaltLength);
 };
 


### PR DESCRIPTION
Removes unused code in `node_crypto.cc` in `Sign::SignFinal` and `Verify::VerifyFinal` as suggested by @addaleax [here](https://github.com/nodejs/node/pull/12164#discussion_r109395637).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto