### PR TITLE
v6.x backport: test: refactor several parallel/test-timer tests

### DIFF
--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -6,10 +6,8 @@ const assert = require('assert');
 // but immediates queued while processing the current queue should happen
 // on the next turn of the event loop.
 
-// in v0.10 hit should be 1, because we only process one cb per turn
-// in v0.11 and beyond it should be the exact same size of QUEUE
-// if we're letting things recursively add to the immediate QUEUE hit will be
-// > QUEUE
+// hit should be the exact same size of QUEUE, if we're letting things
+// recursively add to the immediate QUEUE hit will be > QUEUE
 
 let ticked = false;
 

--- a/test/parallel/test-timers-non-integer-delay.js
+++ b/test/parallel/test-timers-non-integer-delay.js
@@ -1,4 +1,6 @@
 'use strict';
+require('../common');
+
 /*
  * This test makes sure that non-integer timer delays do not make the process
  * hang. See https://github.com/joyent/node/issues/8065 and
@@ -14,8 +16,6 @@
  * expire correctly. 50 timers has always been more than enough to reproduce
  * it 100%.
  */
-
-require('../common');
 
 const TIMEOUT_DELAY = 1.1;
 const NB_TIMEOUTS_FIRED = 50;

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -1,8 +1,8 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const Timer = process.binding('timer_wrap').Timer;
 
+const Timer = process.binding('timer_wrap').Timer;
 const N = 30;
 
 let last_i = 0;

--- a/test/parallel/test-timers-uncaught-exception.js
+++ b/test/parallel/test-timers-uncaught-exception.js
@@ -1,40 +1,19 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
-let exceptions = 0;
-let timer1 = 0;
-let timer2 = 0;
+const errorMsg = 'BAM!';
 
 // the first timer throws...
-console.error('set first timer');
-setTimeout(function() {
-  console.error('first timer');
-  timer1++;
-  throw new Error('BAM!');
-}, 100);
+setTimeout(common.mustCall(function() {
+  throw new Error(errorMsg);
+}), 1);
 
 // ...but the second one should still run
-console.error('set second timer');
-setTimeout(function() {
-  console.error('second timer');
-  assert.strictEqual(timer1, 1);
-  timer2++;
-}, 100);
+setTimeout(common.mustCall(function() {}), 1);
 
 function uncaughtException(err) {
-  console.error('uncaught handler');
-  assert.strictEqual(err.message, 'BAM!');
-  exceptions++;
+  assert.strictEqual(err.message, errorMsg);
 }
-process.on('uncaughtException', uncaughtException);
 
-let exited = false;
-process.on('exit', function() {
-  assert(!exited);
-  exited = true;
-  process.removeListener('uncaughtException', uncaughtException);
-  assert.strictEqual(exceptions, 1);
-  assert.strictEqual(timer1, 1);
-  assert.strictEqual(timer2, 1);
-});
+process.on('uncaughtException', common.mustCall(uncaughtException));


### PR DESCRIPTION
Change var to const/let. Simplify test-timers-uncaught-exception.

PR-URL: https://github.com/nodejs/node/pull/10524
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>
Reviewed-By: Jeremiah Senkpiel <fishrock123@rocketmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Test

/cc @gibfahn 