### PR TITLE
Revert "Make a noble effort at setting OS_CODE correctly."

### DIFF
--- a/deps/zlib/zutil.h
+++ b/deps/zlib/zutil.h
@@ -100,38 +100,28 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 #ifdef AMIGA
-#  define OS_CODE  1
+#  define OS_CODE  0x01
 #endif
 
 #if defined(VAXC) || defined(VMS)
-#  define OS_CODE  2
+#  define OS_CODE  0x02
 #  define F_OPEN(name, mode) \
      fopen((name), (mode), "mbc=60", "ctx=stm", "rfm=fix", "mrs=512")
 #endif
 
-#ifdef __370__
-#  if __TARGET_LIB__ < 0x20000000
-#    define OS_CODE 4
-#  elif __TARGET_LIB__ < 0x40000000
-#    define OS_CODE 11
-#  else
-#    define OS_CODE 8
-#  endif
-#endif
-
 #if defined(ATARI) || defined(atarist)
-#  define OS_CODE  5
+#  define OS_CODE  0x05
 #endif
 
 #ifdef OS2
-#  define OS_CODE  6
+#  define OS_CODE  0x06
 #  if defined(M_I86) && !defined(Z_SOLO)
 #    include <malloc.h>
 #  endif
 #endif
 
 #if defined(MACOS) || defined(TARGET_OS_MAC)
-#  define OS_CODE  7
+#  define OS_CODE  0x07
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
@@ -143,24 +133,18 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#ifdef __acorn
-#  define OS_CODE 13
+#ifdef TOPS20
+#  define OS_CODE  0x0a
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
-#  define OS_CODE  10
+#ifdef WIN32
+#  ifndef __CYGWIN__  /* Cygwin is Unix, not Win32 */
+#    define OS_CODE  0x0b
+#  endif
 #endif
 
-#ifdef _BEOS_
-#  define OS_CODE  16
-#endif
-
-#ifdef __TOS_OS400__
-#  define OS_CODE 18
-#endif
-
-#ifdef __APPLE__
-#  define OS_CODE 19
+#ifdef __50SERIES /* Prime/PRIMOS */
+#  define OS_CODE  0x0f
 #endif
 
 #if defined(_BEOS_) || defined(RISCOS)
@@ -195,7 +179,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
         /* common defaults */
 
 #ifndef OS_CODE
-#  define OS_CODE  3     /* assume Unix */
+#  define OS_CODE  0x03  /* assume Unix */
 #endif
 
 #ifndef F_OPEN

--- a/test/parallel/test-zlib-oscode.js
+++ b/test/parallel/test-zlib-oscode.js
@@ -14,7 +14,7 @@ if (process.platform !== 'linux' && process.platform !== 'darwin')
 const assert = require('assert');
 const zlib = require('zlib');
 
-const expected = "1f8b0800000000000003ab00008316dc8c01000000";
+const expected = '1f8b0800000000000003ab00008316dc8c01000000';
 const options = {strategy: zlib.Z_DEFAULT_STRATEGY};
 
 zlib.gzip('x', options, common.mustCall(function(err, compressed) {

--- a/test/parallel/test-zlib-oscode.js
+++ b/test/parallel/test-zlib-oscode.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+
+// Assert that the zlib output on MacOS and Linux is identical to what it was
+// before the zlib 1.2.11 update. The change was in an unused 'OS code' in the
+// header, so is not dependent on the size or content of the data encrypted.
+// The test doesn't apply to non-MacOS/Linux platforms, they already had unique
+// OS codes prior to the zlib update.
+
+if (process.platform !== 'linux' && process.platform !== 'darwin')
+  return common.skip('test applies only to Mac and Linux');
+
+const assert = require('assert');
+const zlib = require('zlib');
+
+const expected = "1f8b0800000000000003ab00008316dc8c01000000";
+const options = {strategy: zlib.Z_DEFAULT_STRATEGY};
+
+zlib.gzip('x', options, common.mustCall(function(err, compressed) {
+  assert.strictEqual(compressed.toString('hex'), expected);
+}));


### PR DESCRIPTION
Revert change to the OS_CODE in the zlib header made in zlib 1.2.11. It
changes the binary format of the compressed data on MacOS. This has been
found to cause problems for test suites that used to be passing in 4.x
and 6.x, and that had assertions based on the expect compressed output.

Refs: https://github.com/madler/zlib/commit/ce12c5cd00628bf8f680c98123a369974d32df15

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
