### PR TITLE
test: changed equality comparison to identity operator

### DIFF
--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -139,7 +139,7 @@ const modSize = 1024;
                              padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
                              saltLength: verifySaltLength
                            }, s4);
-          const saltLengthCorrect = getEffectiveSaltLength(signSaltLength) ==
+          const saltLengthCorrect = getEffectiveSaltLength(signSaltLength) ===
                                     getEffectiveSaltLength(verifySaltLength);
           assert.strictEqual(verified, saltLengthCorrect, 'verify (PSS)');
         });


### PR DESCRIPTION
test: changed equality comparison to identity operator

Changed the equality comparison from == to identity operator ===

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines]

