### PR TITLE
build: disable -O3 for C++ coverage

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -325,7 +325,8 @@
                    '-O0' ],
        'cflags': [ '--coverage',
                    '-g',
-                   '-O0' ]
+                   '-O0' ],
+       'cflags!': [ '-O3' ]
     }],
     [ 'OS=="sunos"', {
       'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],


### PR DESCRIPTION
The `cflags` for `--coverage` included `-O0` so far, but that was
overridden by a later `-O3`. Resolve that by adding
`'cflags!': [ '-O3' ]` and increase coverage accuracy.

CI: https://ci.nodejs.org/job/node-test-commit/9087/

/cc @mhdawson @CurryKitten 