### PR TITLE
util: refactor format method.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -59,6 +59,16 @@ function tryStringify(arg) {
   }
 }
 
+function getFormatFn(code) {
+  switch (code) {
+    case 100/*'d'*/: return Number;
+    case 105/*'i'*/: return parseInt;
+    case 102/*'f'*/: return parseFloat;
+    case 106/*'j'*/: return JSON.stringify;
+    case 115/*'s'*/: return String;
+  }
+}
+
 exports.format = function(f) {
   if (typeof f !== 'string') {
     const objects = new Array(arguments.length);
@@ -75,56 +85,26 @@ exports.format = function(f) {
   var str = '';
   var a = 1;
   var lastPos = 0;
-  for (var i = 0; i < f.length;) {
+  var i = 0;
+  while (i < f.length) {
     if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      switch (f.charCodeAt(i + 1)) {
-        case 100: // 'd'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += Number(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 105: // 'i'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += parseInt(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 102: // 'f'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += parseFloat(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 106: // 'j'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += tryStringify(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 115: // 's'
-          if (a >= argLen)
-            break;
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += String(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        case 37: // '%'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += '%';
-          lastPos = i = i + 2;
-          continue;
+      if (f.charCodeAt(i + 1) === 37) {
+        if (lastPos < i)
+          str += f.slice(lastPos, i);
+        str += '%';
+        lastPos = i = i + 2;
+        continue;
       }
+      if (a < argLen) {
+        var fn = getFormatFn(f.charCodeAt(i + 1));
+        if (fn) {
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += fn(arguments[a++]);
+          lastPos = i = i + 2;
+          continue;
+        }
+      }      
     }
     ++i;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -74,39 +74,39 @@ exports.format = function(f) {
   var a = 1;
   var lastPos = 0;
   for (var i = 0; i < f.length;) {
-    if (f.charCodeAt(i) === 37/*'%'*/ && f.length > i + 1) {
-      if (f.charCodeAt(i + 1) !== 37 && a >= arguments.length) {
+    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
+      if (f.charCodeAt(i + 1) !== 37/*'%'*/ && a >= arguments.length) {
         ++i;
         continue;
       }
       switch (f.charCodeAt(i + 1)) {
         case 100: // 'd'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += Number(arguments[a++]);
           break;
         case 105: // 'i'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += parseInt(arguments[a++]);
           break;
         case 102: // 'f'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += parseFloat(arguments[a++]);
           break;
         case 106: // 'j'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += tryStringify(arguments[a++]);
           break;
         case 115: // 's'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += String(arguments[a++]);
           break;
         case 37: // '%'
-          if (i > lastPos)
+          if (lastPos < i)
             str += f.slice(lastPos, i);
           str += '%';
           break;
@@ -130,6 +130,7 @@ exports.format = function(f) {
   }
   return str;
 };
+
 
 exports.deprecate = internalUtil.deprecate;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -68,33 +68,51 @@ exports.format = function(f) {
     return objects.join(' ');
   }
 
-  var argLen = arguments.length;
-
-  if (argLen === 1) return f;
+  if (arguments.length === 1) return f;
 
   var str = '';
   var a = 1;
   var lastPos = 0;
-  var i = 0;
-  var value;
-  while (i < f.length) {
-    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      if (f.charCodeAt(i + 1) === 37 || a < argLen) {
-        switch (f.charCodeAt(i + 1)) {
-          case 100/*'d'*/: value = Number(arguments[a++]); break;
-          case 105/*'i'*/: value = parseInt(arguments[a++]); break;
-          case 102/*'f'*/: value = parseFloat(arguments[a++]); break;
-          case 106/*'j'*/: value = tryStringify(arguments[a++]); break;
-          case 115/*'s'*/: value = String(arguments[a++]); break;
-          case 37/*'%'*/: value = '%'; break;
-          default: ++i; continue;
-        }
-        if (lastPos < i)
-          str += f.slice(lastPos, i);
-        str += value;
-        lastPos = i = i + 2;
+  for (var i = 0; i < f.length;) {
+    if (f.charCodeAt(i) === 37/*'%'*/ && f.length > i + 1) {
+      if (f.charCodeAt(i + 1) !== 37 && a >= arguments.length) {
+        ++i;
         continue;
       }
+      switch (f.charCodeAt(i + 1)) {
+        case 100: // 'd'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += Number(arguments[a++]);
+          break;
+        case 105: // 'i'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += parseInt(arguments[a++]);
+          break;
+        case 102: // 'f'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += parseFloat(arguments[a++]);
+          break;
+        case 106: // 'j'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += tryStringify(arguments[a++]);
+          break;
+        case 115: // 's'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += String(arguments[a++]);
+          break;
+        case 37: // '%'
+          if (i > lastPos)
+            str += f.slice(lastPos, i);
+          str += '%';
+          break;
+      }
+      lastPos = i = i +2;
+      continue;
     }
     ++i;
   }
@@ -102,7 +120,7 @@ exports.format = function(f) {
     str = f;
   else if (lastPos < f.length)
     str += f.slice(lastPos);
-  while (a < argLen) {
+  while (a < arguments.length) {
     const x = arguments[a++];
     if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
       str += ' ' + x;

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ function getFormatFn(code) {
     case 100/*'d'*/: return Number;
     case 105/*'i'*/: return parseInt;
     case 102/*'f'*/: return parseFloat;
-    case 106/*'j'*/: return JSON.stringify;
+    case 106/*'j'*/: return tryStringify;
     case 115/*'s'*/: return String;
   }
 }
@@ -104,7 +104,7 @@ exports.format = function(f) {
           lastPos = i = i + 2;
           continue;
         }
-      }      
+      }
     }
     ++i;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,8 +79,8 @@ exports.format = function(f) {
   var value;
   while (i < f.length) {
     if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      if (f.charCodeAt(i+1) === 37 || a < argLen) {
-        switch (f.charCodeAt(i+1)) {
+      if (f.charCodeAt(i + 1) === 37 || a < argLen) {
+        switch (f.charCodeAt(i + 1)) {
           case 100/*'d'*/: value = Number(arguments[a++]); break;
           case 105/*'i'*/: value = parseInt(arguments[a++]); break;
           case 102/*'f'*/: value = parseFloat(arguments[a++]); break;

--- a/lib/util.js
+++ b/lib/util.js
@@ -111,7 +111,7 @@ exports.format = function(f) {
           str += '%';
           break;
       }
-      lastPos = i = i +2;
+      lastPos = i = i + 2;
       continue;
     }
     ++i;

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,16 +59,6 @@ function tryStringify(arg) {
   }
 }
 
-function getFormatFn(code) {
-  switch (code) {
-    case 100/*'d'*/: return Number;
-    case 105/*'i'*/: return parseInt;
-    case 102/*'f'*/: return parseFloat;
-    case 106/*'j'*/: return tryStringify;
-    case 115/*'s'*/: return String;
-  }
-}
-
 exports.format = function(f) {
   if (typeof f !== 'string') {
     const objects = new Array(arguments.length);
@@ -86,24 +76,24 @@ exports.format = function(f) {
   var a = 1;
   var lastPos = 0;
   var i = 0;
+  var value;
   while (i < f.length) {
     if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      if (f.charCodeAt(i + 1) === 37) {
+      if (f.charCodeAt(i+1) === 37 || a < argLen) {
+        switch (f.charCodeAt(i+1)) {
+          case 100/*'d'*/: value = Number(arguments[a++]); break;
+          case 105/*'i'*/: value = parseInt(arguments[a++]); break;
+          case 102/*'f'*/: value = parseFloat(arguments[a++]); break;
+          case 106/*'j'*/: value = tryStringify(arguments[a++]); break;
+          case 115/*'s'*/: value = String(arguments[a++]); break;
+          case 37/*'%'*/: value = '%'; break;
+          default: ++i; continue;
+        }
         if (lastPos < i)
           str += f.slice(lastPos, i);
-        str += '%';
+        str += value;
         lastPos = i = i + 2;
         continue;
-      }
-      if (a < argLen) {
-        var fn = getFormatFn(f.charCodeAt(i + 1));
-        if (fn) {
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
-          str += fn(arguments[a++]);
-          lastPos = i = i + 2;
-          continue;
-        }
       }
     }
     ++i;
@@ -122,7 +112,6 @@ exports.format = function(f) {
   }
   return str;
 };
-
 
 exports.deprecate = internalUtil.deprecate;
 

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -96,6 +96,8 @@ assert.strictEqual(util.format('%%s%s', 'foo'), '%sfoo');
 assert.strictEqual(util.format('%s:%s'), '%s:%s');
 assert.strictEqual(util.format('%s:%s', undefined), 'undefined:%s');
 assert.strictEqual(util.format('%s:%s', 'foo'), 'foo:%s');
+assert.strictEqual(util.format('%s:%i', 'foo'), 'foo:%i');
+assert.strictEqual(util.format('%s:%f', 'foo'), 'foo:%f');
 assert.strictEqual(util.format('%s:%s', 'foo', 'bar'), 'foo:bar');
 assert.strictEqual(util.format('%s:%s', 'foo', 'bar', 'baz'), 'foo:bar baz');
 assert.strictEqual(util.format('%%%s%%', 'hi'), '%hi%');
@@ -104,9 +106,16 @@ assert.strictEqual(util.format('%sbc%%def', 'a'), 'abc%def');
 assert.strictEqual(util.format('%d:%d', 12, 30), '12:30');
 assert.strictEqual(util.format('%d:%d', 12), '12:%d');
 assert.strictEqual(util.format('%d:%d'), '%d:%d');
+assert.strictEqual(util.format('%i:%i', 12, 30), '12:30');
+assert.strictEqual(util.format('%i:%i', 12), '12:%i');
+assert.strictEqual(util.format('%i:%i'), '%i:%i');
+assert.strictEqual(util.format('%f:%f', 12, 30), '12:30');
+assert.strictEqual(util.format('%f:%f', 12), '12:%f');
+assert.strictEqual(util.format('%f:%f'), '%f:%f');
 assert.strictEqual(util.format('o: %j, a: %j', {}, []), 'o: {}, a: []');
 assert.strictEqual(util.format('o: %j, a: %j', {}), 'o: {}, a: %j');
 assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
+
 
 {
   const o = {};

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -116,7 +116,6 @@ assert.strictEqual(util.format('o: %j, a: %j', {}, []), 'o: {}, a: []');
 assert.strictEqual(util.format('o: %j, a: %j', {}), 'o: {}, a: %j');
 assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
 
-
 {
   const o = {};
   o.o = o;


### PR DESCRIPTION
Method format refactored to make it more maintenable, replacing the
switch by a function factory, that returns the appropiated function
given the character (d, i , f, j, s).

Also, performance when formatting an string that contains several
consecutive % symbols is improved. The test:
```
const numSamples = 10000000;
const strPercents = '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%s%%%%%%%%%%%%%%%%%i%%%%%%%%%%%%%%%%%%%%%%%%%%';
var s;
console.time('Percents');
for (let i = 0; i < numSamples; i++) {
  s = util.format(strPercents, 'test', 12);
}
console.timeEnd('Percents');
```
Original time:   28399.708ms
After refactor:  23763.788ms
Improved: 16%

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
