### PR TITLE
deps: cherry-pick 79aee39 from upstream v8

### DIFF
--- a/deps/v8/src/builtins/builtins-object.cc
+++ b/deps/v8/src/builtins/builtins-object.cc
@@ -300,10 +300,10 @@ void Builtins::Generate_ObjectProtoToString(CodeStubAssembler* assembler) {
   Node* context = assembler->Parameter(3);
 
   assembler->GotoIf(
-      assembler->Word32Equal(receiver, assembler->UndefinedConstant()),
+      assembler->WordEqual(receiver, assembler->UndefinedConstant()),
       &return_undefined);
 
-  assembler->GotoIf(assembler->Word32Equal(receiver, assembler->NullConstant()),
+  assembler->GotoIf(assembler->WordEqual(receiver, assembler->NullConstant()),
                     &return_null);
 
   assembler->GotoIf(assembler->WordIsSmi(receiver), &return_number);

--- a/deps/v8/test/mjsunit/regress/regress-crbug-664506.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-664506.js
@@ -1,0 +1,11 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-gc --predictable --random-seed=-1109634722
+
+gc();
+gc();
+assertEquals("[object Object]", Object.prototype.toString.call({}));
+gc();
+assertEquals("[object Array]", Object.prototype.toString.call([]));


### PR DESCRIPTION
This is a chery-pick if you consider reducing the context to -C2
a cherry-pick; WordIsSmi has been renamed to TaggedIsSmi upstream.

Original commit message:

    [builtins] Fix pointer comparison in ToString builtin.

    This fixes the bogus {Word32Equal} comparison in the ToString
    builtin implementing Object.prototype.toString to be a pointer-size
    {WordEqual} comparison instead. Comparing just the lower half-word
    is insufficient on 64-bit architectures.

    R=jgruber@chromium.org
    TEST=mjsunit/regress/regress-crbug-664506
    BUG=chromium:664506

    Review-Url: https://codereview.chromium.org/2496043003
    Cr-Commit-Position: refs/heads/master@{#40963}

Node CI: https://ci.nodejs.org/job/node-test-pull-request/7400/
V8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/647/