### PR TITLE
test: fix parallel/test-setproctitle.js on alpine

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -14,7 +14,7 @@ const path = require('path');
 // The title shouldn't be too long; libuv's uv_set_process_title() out of
 // security considerations no longer overwrites envp, only argv, so the
 // maximum title length is possibly quite short.
-let title = 'testme';
+let title = 'test';
 
 assert.notStrictEqual(process.title, title);
 process.title = title;
@@ -25,7 +25,13 @@ if (common.isWindows) {
   return common.skip('Windows does not have "ps" utility');
 }
 
-exec(`ps -p ${process.pid} -o args=`, function callback(error, stdout, stderr) {
+// To pass this test on alpine, since Busybox `ps` does not
+// support `-p` switch, use `ps -o` and `grep` instead.
+const cmd = common.isLinux ?
+            `ps -o pid,args | grep '${process.pid} ${title}' | grep -v grep` :
+            `ps -p ${process.pid} -o args=`;
+
+exec(cmd, common.mustCall((error, stdout, stderr) => {
   assert.ifError(error);
   assert.strictEqual(stderr, '');
 
@@ -34,5 +40,5 @@ exec(`ps -p ${process.pid} -o args=`, function callback(error, stdout, stderr) {
     title += ` (${path.basename(process.execPath)})`;
 
   // omitting trailing whitespace and \n
-  assert.strictEqual(stdout.replace(/\s+$/, ''), title);
-});
+  assert.strictEqual(stdout.replace(/\s+$/, '').endsWith(title), true);
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Fixes: #12399 

As mentioned in the ref issue, since Busybox `ps` does not support `-p` switch,  using `ps -o` and `grep` instead to get the process title and then check it.

The `title` variable in this test script was also renamed  from `'testme'` to `'test'`, because it seems that on alpine if trying to set the process title to a string whose length is >=5 like `'abcde'`, it will become `{abcde} abcd` in `ps` output:

```
> docker run -it node:alpine
> process.title = 'abcde'
'abcde'
> child_process.execSync('ps').toString().split('\n')
[ 'PID   USER     TIME   COMMAND',
  '    1 root       0:00 {abcde} abcd',
  '   20 root       0:00 /bin/sh -c ps',
  '   21 root       0:00 ps',
  '' ]
```

```
> docker run -it node:alpine
> process.title = 'abcd'
'abcd'
> child_process.execSync('ps').toString().split('\n')
[ 'PID   USER     TIME   COMMAND',
  '    1 root       0:00 abcd',
  '   20 root       0:00 /bin/sh -c ps',
  '   21 root       0:00 ps',
  '' ]
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->