### PR TITLE
doc: update link for landing PRs

### DIFF
--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -132,7 +132,7 @@ onboarding session.
 
 ## Landing PRs
 
-  * [See the Collaborator Guide: Technical HOWTO](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#technical-howto)
+  * [See the Collaborator Guide: Landing Pull Requests](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#landing-pull-requests)
 
 ## Exercise: Make a PR adding yourself to the README
 


### PR DESCRIPTION
The onboarding doc links to the "Technical How-to" portion of the
Collaborator's Guide for landing PRs. That section is a subsection of
the "Landing Pull Requests" portion of that document. By skipping the
main section header, important information is skipped, such as the part
about not using the merge button and descriptions of the metadata
required. Update the link to target the main section and not the
subsection.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc