### PR TITLE
doc: run tests before landing changes

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -444,6 +444,10 @@ commit logs, ensure that they are properly formatted, and add
 * The commit message text must conform to the
 [commit message guidelines](./CONTRIBUTING.md#step-3-commit).
 
+Run tests (`make -j4 test` or `vcbuild test`). Even though there was a
+successful continuous integration run, other changes may have landed on master
+since then, so running the tests one last time locally is a good practice.
+
 Time to push it:
 
 ```text
@@ -461,11 +465,6 @@ landing your own contributions.
 your pull request shows the purple merged status then you should still
 add the "Landed in <commit hash>..<commit hash>" comment if you added
 multiple commits.
-
-* `./configure && make -j8 test`
-  * `-j8` builds node in parallel with 8 threads. Adjust to the number
-  of cores or processor-level threads your processor has (or slightly
-  more) for best results.
 
 ### I Just Made a Mistake
 


### PR DESCRIPTION
The Collaborator Guide suggests running tests after pushing changes to
the main repository. Tests should be run before then so move the
instructions earlier.

Instructions are also simplified and re-written to not exclude Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc