### PR TITLE
test: use dynamic port in test-cluster-bind-twice

### DIFF
--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -67,9 +67,8 @@ if (!id) {
 
 
   a.on('message', common.mustCall((m) => {
-    if (typeof m === 'object') return;
-    assert.strictEqual(m, 'READY');
-    b.send('START');
+    assert.strictEqual(m.msg, 'READY');
+    b.send({msg: 'START', port: m.port});
   }));
 
   b.on('message', common.mustCall((m) => {
@@ -81,10 +80,10 @@ if (!id) {
 } else if (id === 'one') {
   if (cluster.isMaster) return startWorker();
 
-  http.createServer(common.mustNotCall())
-    .listen(common.PORT, common.mustCall(() => {
-      process.send('READY');
-    }));
+  const server = http.createServer(common.mustNotCall());
+  server.listen(0, common.mustCall(() => {
+    process.send({msg: 'READY', port: server.address().port});
+  }));
 
   process.on('message', common.mustCall((m) => {
     if (m === 'QUIT') process.exit();
@@ -95,8 +94,8 @@ if (!id) {
   const server = http.createServer(common.mustNotCall());
   process.on('message', common.mustCall((m) => {
     if (m === 'QUIT') process.exit();
-    assert.strictEqual(m, 'START');
-    server.listen(common.PORT, common.mustNotCall());
+    assert.strictEqual(m.msg, 'START');
+    server.listen(m.port, common.mustNotCall());
     server.on('error', common.mustCall((e) => {
       assert.strictEqual(e.code, 'EADDRINUSE');
       process.send(e.code);


### PR DESCRIPTION
Remove common.PORT from test-cluster-bind-twice to eliminate possibility
that a dynamic port used in another test will collide with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test cluster