### PR TITLE
url: always show password for URL instances

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -206,8 +206,6 @@ class URL {
       throw new errors.TypeError('ERR_INVALID_THIS', 'URL');
     }
 
-    const ctx = this[context];
-
     if (typeof depth === 'number' && depth < 0)
       return opts.stylize('[Object]', 'special');
 
@@ -221,8 +219,7 @@ class URL {
     obj.origin = this.origin;
     obj.protocol = this.protocol;
     obj.username = this.username;
-    obj.password = (opts.showHidden || ctx.password === '') ?
-                     this.password : '--------';
+    obj.password = this.password;
     obj.host = this.host;
     obj.hostname = this.hostname;
     obj.port = this.port;

--- a/test/parallel/test-whatwg-url-inspect.js
+++ b/test/parallel/test-whatwg-url-inspect.js
@@ -21,7 +21,7 @@ assert.strictEqual(
   origin: 'https://host.name:8080',
   protocol: 'https:',
   username: 'username',
-  password: '--------',
+  password: 'password',
   host: 'host.name:8080',
   hostname: 'host.name',
   port: '8080',


### PR DESCRIPTION
This matches browser behavior.

CI: https://ci.nodejs.org/job/node-test-pull-request/7413/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* url
