### PR TITLE
benchmark: improve cli error message

### DIFF
--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -88,6 +88,8 @@ CLI.prototype.benchmarks = function() {
   const filter = this.optional.filter || false;
 
   for (const category of this.items) {
+    if (benchmarks[category] === undefined)
+      continue;
     for (const scripts of benchmarks[category]) {
       if (filter && scripts.lastIndexOf(filter) === -1) continue;
 

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -35,7 +35,7 @@ const runs = cli.optional.runs ? parseInt(cli.optional.runs, 10) : 30;
 const benchmarks = cli.benchmarks();
 
 if (benchmarks.length === 0) {
-  console.error('no benchmarks found');
+  console.error('No benchmarks found');
   process.exitCode = 1;
   return;
 }


### PR DESCRIPTION
When no matching benchmark files are found, a more sensible error is thrown now.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* benchmark
