### PR TITLE
build: make linter targets silent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -854,10 +854,12 @@ bench: bench-net bench-http bench-fs bench-tls
 bench-ci: bench
 
 jslint:
+	@echo "Running JS linter..."
 	$(NODE) tools/eslint/bin/eslint.js --cache --rulesdir=tools/eslint-rules \
 	  benchmark lib test tools
 
 jslint-ci:
+	@echo "Running JS linter..."
 	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
 		benchmark lib test tools
 
@@ -884,12 +886,13 @@ CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard \
 	))
 
 cpplint:
+	@echo "Running C++ linter..."
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)
 	@$(PYTHON) tools/check-imports.py
 
 ifneq ("","$(wildcard tools/eslint/lib/eslint.js)")
 lint:
-	EXIT_STATUS=0 ; \
+	@EXIT_STATUS=0 ; \
 	$(MAKE) jslint || EXIT_STATUS=$$? ; \
 	$(MAKE) cpplint || EXIT_STATUS=$$? ; \
 	exit $$EXIT_STATUS


### PR DESCRIPTION
The linter targets are printing the commands they execute on screen.
This patch reduces the noise by not printing the commands.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

build

--

cc @nodejs/build 