### PR TITLE
test: add crypto check to crypto-lazy-transform

### DIFF
--- a/test/parallel/test-crypto-lazy-transform-writable.js
+++ b/test/parallel/test-crypto-lazy-transform-writable.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 const assert = require('assert');
 const crypto = require('crypto');
 const Stream = require('stream');


### PR DESCRIPTION
When configuring `--without-ssl` test-crypto-lazy-transform-writable.js
fails with the following error:
```
Path: parallel/test-crypto-lazy-transform-writable
internal/util.js:83
    throw new Error('Node.js is not compiled with openssl crypto
support');
    ^

Error: Node.js is not compiled with openssl crypto support
    at Object.exports.assertCrypto (internal/util.js:83:11)
    at crypto.js:28:14
    at NativeModule.compile (bootstrap_node.js:557:7)
    at Function.NativeModule.require (bootstrap_node.js:500:18)
    at Function.Module._load (module.js:446:25)
    at Module.require (module.js:526:17)
    at require (internal/module.js:19:18)
    at Object.<anonymous>
(/Users/danielbevenius/work/nodejs/node/test/parallel/test-crypto-lazy-transform-writable.js:5:16)
    at Module._compile (module.js:607:30)
    at Object.Module._extensions..js (module.js:618:10)
Command: out/Release/node
/Users/danielbevenius/work/nodejs/node/test/parallel/test-crypto-lazy-transform-writable.js
[01:29|% 100|+ 1461|-   1]: Done
make: *** [test] Error 1
```
This commit add a hasCrypto check like other crypto tests do.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test