### PR TITLE
test: use dynamic port in test-cluster-dgram-reuse

### DIFF
--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -37,4 +37,4 @@ function close() {
 }
 
 for (let i = 0; i < 2; i++)
-  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(common.PORT, next);
+  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(0, next);

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -36,5 +36,12 @@ function close() {
     cluster.worker.disconnect();
 }
 
-for (let i = 0; i < 2; i++)
-  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(0, next);
+// Creates the first socket
+const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+// Let the OS assign a random port to the first socket
+socket.bind(0, function() {
+  // Creates the second socket using the same port from the previous one
+  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(socket.address().port, next);
+  // Call next for the first socket
+  next.call(this);
+});

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -41,7 +41,8 @@ const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
 // Let the OS assign a random port to the first socket
 socket.bind(0, function() {
   // Creates the second socket using the same port from the previous one
-  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(socket.address().port, next);
+  dgram.createSocket({ type: 'udp4', reuseAddr: true })
+    .bind(socket.address().port, next);
   // Call next for the first socket
   next.call(this);
 });

--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -39,10 +39,10 @@ function close() {
 // Creates the first socket
 const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
 // Let the OS assign a random port to the first socket
-socket.bind(0, function() {
+socket.bind(0, common.mustCall(function() {
   // Creates the second socket using the same port from the previous one
   dgram.createSocket({ type: 'udp4', reuseAddr: true })
     .bind(socket.address().port, next);
   // Call next for the first socket
   next.call(this);
-});
+}));


### PR DESCRIPTION
Use of common.PORT in parallel tests is not completely safe (because
the same port can be previously assigned to another test running in
parallel if that test uses port 0 to get an arbitrary available port).

Remove common.PORT from test-cluster-dgram-reuse.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test cluster
