### PR TITLE
benchmark: fix CLI arguments check in common.js

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -43,7 +43,7 @@ Benchmark.prototype._parseArgs = function(argv, configs) {
   // Parse configuration arguments
   for (const arg of argv) {
     const match = arg.match(/^(.+?)=([\s\S]*)$/);
-    if (!match || !match[1]) {
+    if (!match) {
       console.error('bad argument: ' + arg);
       process.exit(1);
     }


### PR DESCRIPTION
##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
benchmark

I can't think up any case when `match` is not `null` while `match[1]` is falsy here, as the first group does not use a quantifier that can end up in an empty string. ~So I suppose the `match[2]` is intended to prevent arguments like `n=`.~ However, I may miss something obvious.