### PR TITLE
zlib: remove unused declaration

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -66,9 +66,6 @@ enum node_zlib_mode {
 #define GZIP_HEADER_ID1 0x1f
 #define GZIP_HEADER_ID2 0x8b
 
-void InitZlib(v8::Local<v8::Object> target);
-
-
 /**
  * Deflate/Inflate
  */


### PR DESCRIPTION
Overlooked in https://github.com/nodejs/node/pull/12366. Removing this
removes a compiler warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

src/zlib

Also trivial enough that I would say this doesn’t need to wait 48 hours.