### PR TITLE
doc: consolidate -j information for make

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
-- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
+- [ ] `make test` (UNIX), or `vcbuild test` (Windows) passes
 - [ ] tests and/or benchmarks are included
 - [ ] documentation is changed or added
 - [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -99,20 +99,29 @@ directory and the symbolic `node` link in the project's root directory.
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo
 
+
+For faster builds:
+
+When running the various `make` commands specified in the build steps below,
+using the `-j4` command line flag will cause it to run 4 processes concurrently.
+This may significantly reduce build time. The number after `-j` can be changed
+to suit the number of processor cores on your machine. If you run into problems
+running `make` with concurrency, try running it without the `-j4` flag. See the
+[GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html)
+for more information.
+
+Alternatively, you can achieve the same effect by setting `make` as an alias for
+`make -j4` or by setting your `MAKEFLAGS` environment variable to include `-j4`.
+
+
 To build Node.js:
 
 ```console
 $ ./configure
-$ make -j4
+$ make
 ```
 
-Running `make` with the `-j4` flag will cause it to run 4 compilation jobs
-concurrently which may significantly reduce build time. The number after `-j`
-can be changed to best suit the number of processor cores on your machine. If
-you run into problems running `make` with concurrency, try running it without
-the `-j4` flag. See the
-[GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html)
-for more information.
+
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
 and not a newer version.
@@ -349,5 +358,5 @@ and [user guide](https://openssl.org/docs/fips/UserGuide-2.0.pdf).
 7. `./configure --openssl-fips=/path/to/openssl-fips/installdir`
    For example on ubuntu 12 the installation directory was
    `/usr/local/ssl/fips-2.0`
-8. Build Node.js with `make -j`
+8. Build Node.js with `make`
 9. Verify with `node -p "process.versions.openssl"` (for example `1.0.2a-fips`)

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -462,7 +462,7 @@ your pull request shows the purple merged status then you should still
 add the "Landed in <commit hash>..<commit hash>" comment if you added
 multiple commits.
 
-* `./configure && make -j8 test`
+* `./configure && make test`
   * `-j8` builds node in parallel with 8 threads. Adjust to the number
   of cores or processor-level threads your processor has (or slightly
   more) for best results.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ to see how they should be structured can also help.
 To run the tests on Unix / macOS:
 
 ```text
-$ ./configure && make -j4 test
+$ ./configure && make test
 ```
 
 Windows:
@@ -194,7 +194,7 @@ You can run tests directly with node:
 $ ./node ./test/parallel/test-stream2-transform.js
 ```
 
-Remember to recompile with `make -j4` in between test runs if you change
+Remember to recompile with `make` in between test runs if you change
 core modules.
 
 ### Step 6: Push

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -75,7 +75,7 @@ Please use these when possible / appropriate
   * major vs. everything else: run last versions tests against this version, if they pass, **probably** minor or patch
   * A breaking change helper ([full source](https://gist.github.com/chrisdickinson/ba532fa0e4e243fb7b44)):
   ```sh
-  git checkout $(git show -s --pretty='%T' $(git show-ref -d $(git describe --abbrev=0) | tail -n1 | awk '{print $1}')) -- test; make -j4 test
+  git checkout $(git show -s --pretty='%T' $(git show-ref -d $(git describe --abbrev=0) | tail -n1 | awk '{print $1}')) -- test; make test
   ```
 
 


### PR DESCRIPTION
Our docs contain a mixture of `make -j4`, `make -j8`, and `make` without
a `-j` option at all.

Standardize on not specifying a `-j` option, but include information in
`BUILDING.md` (where people are likely to be looking the first time they
build Node.js) about setting `-j`, including the possibility of using
`MAKEFLAGS`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build doc meta