### PR TITLE
buffer: remove unreachable code

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -228,8 +228,6 @@ function fromString(string, encoding) {
     length = binding.byteLengthUtf8(string);
   } else {
     length = byteLength(string, encoding, true);
-    if (length === -1)
-      throw new TypeError('"encoding" must be a valid string encoding');
     if (string.length === 0)
       return new FastBuffer();
   }


### PR DESCRIPTION
46f202 introduced changes that cause a previously reachable error
condition to be unreachable. Remove the code.

The error condition checks that `byteLength()` doesn't return -1. But
that will only happen if `byteLength()` receives an encoding that is
falsy. However the call to `byteLength()` is in an `else` block that is
only reachable if `encoding` is a string with a length greater than 0.
So `byteLength()` will never return `-1` in this situation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer