### PR TITLE
buffer: fix backwards incompatibility

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -455,10 +455,7 @@ function byteLength(string, encoding) {
         return len >>> 1;
       break;
   }
-  if (mustMatch)
-    throw new TypeError('Unknown encoding: ' + encoding);
-  else
-    return binding.byteLengthUtf8(string);
+  return (mustMatch ? -1 : binding.byteLengthUtf8(string));
 }
 
 Buffer.byteLength = byteLength;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -885,7 +885,8 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 }
 
 // Regression test for #5482: should throw but not assert in C++ land.
-assert.throws(() => Buffer.from('', 'buffer'), TypeError);
+assert.throws(() => Buffer.from('', 'buffer'),
+              /^TypeError: "encoding" must be a valid string encoding$/);
 
 // Regression test for #6111. Constructing a buffer from another buffer
 // should a) work, and b) not corrupt the source buffer.


### PR DESCRIPTION
4a86803f6 introduced a backwards incompatibility by accident and was not caught due to an existing test that wasn't strict enough.

This commit fixes both the backwards incompatibility and the test.

This changes does not affect performance.

CI: https://ci.nodejs.org/job/node-test-pull-request/7424/

/cc @Trott 

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* buffer
