### PR TITLE
Migrate cluster tests from common.PORT

### DIFF
--- a/test/parallel/test-cluster-disconnect-leak.js
+++ b/test/parallel/test-cluster-disconnect-leak.js
@@ -24,4 +24,4 @@ if (cluster.isMaster) {
 
 const server = net.createServer();
 
-server.listen(common.PORT);
+server.listen(0);

--- a/test/parallel/test-cluster-disconnect-race.js
+++ b/test/parallel/test-cluster-disconnect-race.js
@@ -34,6 +34,6 @@ if (cluster.isMaster) {
 
 const server = net.createServer();
 
-server.listen(common.PORT, function() {
+server.listen(0, function() {
   process.send('listening');
 });

--- a/test/parallel/test-cluster-process-disconnect.js
+++ b/test/parallel/test-cluster-process-disconnect.js
@@ -12,7 +12,7 @@ if (cluster.isMaster) {
 } else {
   const net = require('net');
   const server = net.createServer();
-  server.listen(common.PORT, common.mustCall(() => {
+  server.listen(0, common.mustCall(() => {
     process.disconnect();
   }));
 }


### PR DESCRIPTION
Migrate the following test files away from `common.PORT`:
* test-cluster-disconnect-leak.js
* test-cluster-disconnect-race.js
* test-cluster-process-disconnect.js

Ref: #12376 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests