### PR TITLE
util: add util.promisify()

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -214,6 +214,23 @@ child runs longer than `timeout` milliseconds.
 *Note: Unlike the exec(3) POSIX system call, `child_process.exec()` does not
 replace the existing process and uses a shell to execute the command.*
 
+If this method is invoked as its [`util.promisify()`][]ed version, it returns
+a Promise for an object with `stdout` and `stderr` properties.
+
+For example:
+
+```js
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+async function lsExample() {
+  const {stdout, stderr} = await exec('ls');
+  console.log('stdout:', stdout);
+  console.log('stderr:', stderr);
+}
+lsExample();
+```
+
 ### child_process.execFile(file[, args][, options][, callback])
 <!-- YAML
 added: v0.1.91
@@ -262,6 +279,19 @@ the output as UTF-8 and pass strings to the callback. The `encoding` option
 can be used to specify the character encoding used to decode the stdout and
 stderr output. If `encoding` is `'buffer'`, or an unrecognized character
 encoding, `Buffer` objects will be passed to the callback instead.
+
+If this method is invoked as its [`util.promisify()`][]ed version, it returns
+a Promise for an object with `stdout` and `stderr` properties.
+
+```js
+const util = require('util');
+const execFile = util.promisify(require('child_process').execFile);
+async function getVersion() {
+  const {stdout} = await execFile('node', ['--version']);
+  console.log(stdout);
+}
+getVersion();
+```
 
 ### child_process.fork(modulePath[, args][, options])
 <!-- YAML
@@ -1269,4 +1299,5 @@ to `stdout` although there are only 4 characters.
 [`process.on('message')`]: process.html#process_event_message
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
 [`stdio`]: #child_process_options_stdio
+[`util.promisify()`]: util.html#util_util_promisify_original
 [synchronous counterparts]: #child_process_synchronous_process_creation

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -123,6 +123,10 @@ dns.lookup('example.com', options, (err, addresses) =>
 // addresses: [{"address":"2606:2800:220:1:248:1893:25c8:1946","family":6}]
 ```
 
+If this method is invoked as its [`util.promisify()`][]ed version, and `all`
+is not set to `true`, it returns a Promise for an object with `address` and
+`family` properties.
+
 ### Supported getaddrinfo flags
 
 The following flags can be passed as hints to [`dns.lookup()`][].
@@ -162,6 +166,9 @@ dns.lookupService('127.0.0.1', 22, (err, hostname, service) => {
   // Prints: localhost ssh
 });
 ```
+
+If this method is invoked as its [`util.promisify()`][]ed version, it returns a
+Promise for an object with `hostname` and `service` properties.
 
 ## dns.resolve(hostname[, rrtype], callback)
 <!-- YAML
@@ -528,3 +535,4 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [Implementation considerations section]: #dns_implementation_considerations
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags
 [the official libuv documentation]: http://docs.libuv.org/en/latest/threadpool.html
+[`util.promisify()`]: util.html#util_util_promisify_original

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1612,6 +1612,9 @@ If `position` is `null`, data will be read from the current file position.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 
+If this method is invoked as its [`util.promisify()`][]ed version, it returns
+a Promise for an object with `bytesRead` and `buffer` properties.
+
 ## fs.readdir(path[, options], callback)
 <!-- YAML
 added: v0.1.8
@@ -2393,8 +2396,11 @@ an integer specifying the number of bytes to write.
 should be written. If `typeof position !== 'number'`, the data will be written
 at the current position. See pwrite(2).
 
-The callback will be given three arguments `(err, written, buffer)` where
-`written` specifies how many _bytes_ were written from `buffer`.
+The callback will be given three arguments `(err, bytesWritten, buffer)` where
+`bytesWritten` specifies how many _bytes_ were written from `buffer`.
+
+If this method is invoked as its [`util.promisify()`][]ed version, it returns
+a Promise for an object with `bytesWritten` and `buffer` properties.
 
 Note that it is unsafe to use `fs.write` multiple times on the same file
 without waiting for the callback. For this scenario,
@@ -2810,6 +2816,7 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`net.Socket`]: net.html#net_class_net_socket
 [`stat()`]: fs.html#fs_fs_stat_path_callback
 [`util.inspect(stats)`]: util.html#util_util_inspect_object_options
+[`util.promisify()`]: util.html#util_util_promisify_original
 [Caveats]: #fs_caveats
 [Common System Errors]: errors.html#errors_common_system_errors
 [FS Constants]: #fs_fs_constants_1

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -85,6 +85,27 @@ next event loop iteration.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
+*Note*: This method has a custom variant for promises that is available using
+[`util.promisify()`][]:
+
+```js
+const util = require('util');
+const setImmediatePromise = util.promisify(setImmediate);
+
+setImmediatePromise('foobar').then((value) => {
+  // value === 'foobar' (passing values is optional)
+  // This is executed after all I/O callbacks.
+});
+
+// or with async function
+async function timerExample() {
+  console.log('Before I/O callbacks');
+  await setImmediatePromise();
+  console.log('After I/O callbacks');
+}
+timerExample();
+```
+
 ### setInterval(callback, delay[, ...args])
 <!-- YAML
 added: v0.0.1
@@ -126,11 +147,27 @@ will be set to `1`.
 
 If `callback` is not a function, a [`TypeError`][] will be thrown.
 
+*Note*: This method has a custom variant for promises that is available using
+[`util.promisify()`][]:
+
+```js
+const util = require('util');
+const setTimeoutPromise = util.promisify(setTimeout);
+
+setTimeoutPromise(40, 'foobar').then((value) => {
+  // value === 'foobar' (passing values is optional)
+  // This is executed after about 40 milliseconds.
+});
+```
+
 ## Cancelling Timers
 
 The [`setImmediate()`][], [`setInterval()`][], and [`setTimeout()`][] methods
 each return objects that represent the scheduled timers. These can be used to
 cancel the timer and prevent it from triggering.
+
+It is not possible to cancel timers that were created using the promisified
+variants of [`setImmediate()`][], [`setTimeout()`][].
 
 ### clearImmediate(immediate)
 <!-- YAML
@@ -168,4 +205,5 @@ Cancels a `Timeout` object created by [`setTimeout()`][].
 [`setImmediate()`]: timers.html#timers_setimmediate_callback_args
 [`setInterval()`]: timers.html#timers_setinterval_callback_delay_args
 [`setTimeout()`]: timers.html#timers_settimeout_callback_delay_args
+[`util.promisify()`]: util.html#util_util_promisify_original
 [the Node.js Event Loop]: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -399,6 +399,86 @@ util.inspect.defaultOptions.maxArrayLength = null;
 console.log(arr); // logs the full array
 ```
 
+## util.promisify(original)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `original` {Function}
+
+Takes a function following the common Node.js callback style, i.e. taking a
+`(err, value) => ...` callback as the last argument, and returns a version
+that returns promises.
+
+For example:
+
+```js
+const util = require('util');
+const fs = require('fs');
+
+const stat = util.promisify(fs.stat);
+stat('.').then((stats) => {
+  // Do something with `stats`
+}).catch((error) => {
+  // Handle the error.
+});
+```
+
+Or, equivalently using `async function`s:
+
+```js
+const util = require('util');
+const fs = require('fs');
+
+const stat = util.promisify(fs.stat);
+
+async function callStat() {
+  const stats = await stat('.');
+  console.log(`This directory is owned by ${stats.uid}`);
+}
+```
+
+If there is an `original[util.promisify.custom]` property present, `promisify`
+will return its value, see [Custom promisified functions][].
+
+`promisify()` assumes that `original` is a function taking a callback as its
+final argument in all cases, and the returned function will result in undefined
+behaviour if it does not.
+
+### Custom promisified functions
+
+Using the `util.promisify.custom` symbol one can override the return value of
+[`util.promisify()`][]:
+
+```js
+const util = require('util');
+
+function doSomething(foo, callback) {
+  // ...
+}
+
+doSomething[util.promisify.custom] = function(foo) {
+  return getPromiseSomehow();
+};
+
+const promisified = util.promisify(doSomething);
+console.log(promisified === doSomething[util.promisify.custom]);
+  // prints 'true'
+```
+
+This can be useful for cases where the original function does not follow the
+standard format of taking an error-first callback as the last argument.
+
+### util.promisify.custom
+<!-- YAML
+added: REPLACEME
+-->
+
+* {symbol}
+
+A Symbol that can be used to declare custom promisified variants of functions,
+see [Custom promisified functions][].
+
 ## Deprecated APIs
 
 The following APIs have been deprecated and should no longer be used. Existing
@@ -878,7 +958,9 @@ Deprecated predecessor of `console.log`.
 [`console.error()`]: console.html#console_console_error_data_args
 [`console.log()`]: console.html#console_console_log_data_args
 [`util.inspect()`]: #util_util_inspect_object_options
+[`util.promisify()`]: #util_util_promisify_original
 [Custom inspection functions on Objects]: #util_custom_inspection_functions_on_objects
 [Customizing `util.inspect` colors]: #util_customizing_util_inspect_colors
+[Custom promisified functions]: #util_custom_promisified_functions
 [constructor]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/constructor
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -22,7 +22,9 @@
 'use strict';
 
 const util = require('util');
-const { deprecate, convertToValidSignal } = require('internal/util');
+const {
+  deprecate, convertToValidSignal, customPromisifyArgs
+} = require('internal/util');
 const debug = util.debuglog('child_process');
 
 const uv = process.binding('uv');
@@ -137,6 +139,9 @@ exports.exec = function(command /*, options, callback*/) {
                           opts.options,
                           opts.callback);
 };
+
+Object.defineProperty(exports.exec, customPromisifyArgs,
+                      { value: ['stdout', 'stderr'], enumerable: false });
 
 
 exports.execFile = function(file /*, args, options, callback*/) {
@@ -332,6 +337,9 @@ exports.execFile = function(file /*, args, options, callback*/) {
 
   return child;
 };
+
+Object.defineProperty(exports.execFile, customPromisifyArgs,
+                      { value: ['stdout', 'stderr'], enumerable: false });
 
 const _deprecatedCustomFds = deprecate(
   function deprecateCustomFds(options) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -26,6 +26,7 @@ const util = require('util');
 const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
 const internalNet = require('internal/net');
+const { customPromisifyArgs } = require('internal/util');
 
 const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
 const GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
@@ -189,6 +190,9 @@ function lookup(hostname, options, callback) {
   return req;
 }
 
+Object.defineProperty(lookup, customPromisifyArgs,
+                      { value: ['address', 'family'], enumerable: false });
+
 
 function onlookupservice(err, host, service) {
   if (err)
@@ -227,6 +231,9 @@ function lookupService(host, port, callback) {
   callback.immediately = true;
   return req;
 }
+
+Object.defineProperty(lookupService, customPromisifyArgs,
+                      { value: ['hostname', 'service'], enumerable: false });
 
 
 function onresolve(err, result, ttls) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -656,6 +656,9 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
   binding.read(fd, buffer, offset, length, position, req);
 };
 
+Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
+                      { value: ['bytesRead', 'buffer'], enumerable: false });
+
 fs.readSync = function(fd, buffer, offset, length, position) {
   if (length === 0) {
     return 0;
@@ -705,6 +708,9 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
   callback = maybeCallback(position);
   return binding.writeString(fd, buffer, offset, length, req);
 };
+
+Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
+                      { value: ['bytesWritten', 'buffer'], enumerable: false });
 
 // usage:
 //  fs.writeSync(fd, buffer[, offset[, length[, position]]]);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -4,6 +4,8 @@ const errors = require('internal/errors');
 const binding = process.binding('util');
 const signals = process.binding('constants').os.signals;
 
+const { createPromise, promiseResolve, promiseReject } = binding;
+
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
 const noCrypto = !process.versions.openssl;
@@ -217,3 +219,62 @@ module.exports = exports = {
   // default isEncoding implementation, just in case userland overrides it.
   kIsEncodingSymbol: Symbol('node.isEncoding')
 };
+
+const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
+const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
+
+function promisify(orig) {
+  if (typeof orig !== 'function') {
+    const errors = require('internal/errors');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'function');
+  }
+
+  if (orig[kCustomPromisifiedSymbol]) {
+    const fn = orig[kCustomPromisifiedSymbol];
+    if (typeof fn !== 'function') {
+      throw new TypeError('The [util.promisify.custom] property must be ' +
+                          'a function');
+    }
+    Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+      value: fn, enumerable: false, writable: false, configurable: true
+    });
+    return fn;
+  }
+
+  // Names to create an object from in case the callback receives multiple
+  // arguments, e.g. ['stdout', 'stderr'] for child_process.exec.
+  const argumentNames = orig[kCustomPromisifyArgsSymbol];
+
+  function fn(...args) {
+    const promise = createPromise();
+    try {
+      orig.call(this, ...args, (err, ...values) => {
+        if (err) {
+          promiseReject(promise, err);
+        } else if (argumentNames !== undefined && values.length > 1) {
+          const obj = {};
+          for (var i = 0; i < argumentNames.length; i++)
+            obj[argumentNames[i]] = values[i];
+          promiseResolve(promise, obj);
+        } else {
+          promiseResolve(promise, values[0]);
+        }
+      });
+    } catch (err) {
+      promiseReject(promise, err);
+    }
+    return promise;
+  }
+
+  Object.setPrototypeOf(fn, Object.getPrototypeOf(orig));
+
+  Object.defineProperty(fn, kCustomPromisifiedSymbol, {
+    value: fn, enumerable: false, writable: false, configurable: true
+  });
+  return Object.defineProperties(fn, Object.getOwnPropertyDescriptors(orig));
+}
+
+promisify.custom = kCustomPromisifiedSymbol;
+
+exports.promisify = promisify;
+exports.customPromisifyArgs = kCustomPromisifyArgsSymbol;

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -23,6 +23,8 @@
 
 const TimerWrap = process.binding('timer_wrap').Timer;
 const L = require('internal/linkedlist');
+const internalUtil = require('internal/util');
+const { createPromise, promiseResolve } = process.binding('util');
 const assert = require('assert');
 const util = require('util');
 const debug = util.debuglog('timer');
@@ -364,7 +366,7 @@ exports.enroll = function(item, msecs) {
  */
 
 
-exports.setTimeout = function(callback, after, arg1, arg2, arg3) {
+function setTimeout(callback, after, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -383,7 +385,15 @@ exports.setTimeout = function(callback, after, arg1, arg2, arg3) {
   }
 
   return createSingleTimeout(callback, after, args);
+}
+
+setTimeout[internalUtil.promisify.custom] = function(after, value) {
+  const promise = createPromise();
+  createSingleTimeout(promise, after, [value]);
+  return promise;
 };
+
+exports.setTimeout = setTimeout;
 
 function createSingleTimeout(callback, after, args) {
   after *= 1; // coalesce to number or NaN
@@ -403,6 +413,8 @@ function createSingleTimeout(callback, after, args) {
 function ontimeout(timer) {
   var args = timer._timerArgs;
   var callback = timer._onTimeout;
+  if (typeof callback !== 'function')
+    return promiseResolve(callback, args[0]);
   if (!args)
     callback.call(timer);
   else {
@@ -687,6 +699,8 @@ function tryOnImmediate(immediate, oldTail) {
 function runCallback(timer) {
   const argv = timer._argv;
   const argc = argv ? argv.length : 0;
+  if (typeof timer._callback !== 'function')
+    return promiseResolve(timer._callback, argv[0]);
   switch (argc) {
     // fast-path callbacks with 0-3 arguments
     case 0:
@@ -715,7 +729,7 @@ function Immediate() {
   this.domain = process.domain;
 }
 
-exports.setImmediate = function(callback, arg1, arg2, arg3) {
+function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -740,7 +754,15 @@ exports.setImmediate = function(callback, arg1, arg2, arg3) {
       break;
   }
   return createImmediate(args, callback);
+}
+
+setImmediate[internalUtil.promisify.custom] = function(value) {
+  const promise = createPromise();
+  createImmediate([value], promise);
+  return promise;
 };
+
+exports.setImmediate = setImmediate;
 
 function createImmediate(args, callback) {
   // declaring it `const immediate` causes v6.0.0 to deoptimize this function

--- a/lib/util.js
+++ b/lib/util.js
@@ -1057,3 +1057,5 @@ exports._exceptionWithHostPort = function(err,
 // process.versions needs a custom function as some values are lazy-evaluated.
 process.versions[exports.inspect.custom] =
   (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));
+
+exports.promisify = internalUtil.promisify;

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -21,6 +21,7 @@ using v8::Value;
 
 
 #define VALUE_METHOD_MAP(V)                                                   \
+  V(isAsyncFunction, IsAsyncFunction)                                         \
   V(isDataView, IsDataView)                                                   \
   V(isDate, IsDate)                                                           \
   V(isExternal, IsExternal)                                                   \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -12,6 +12,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Integer;
 using v8::Local;
+using v8::Maybe;
 using v8::Object;
 using v8::Private;
 using v8::Promise;
@@ -147,6 +148,36 @@ void WatchdogHasPendingSigint(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+void CreatePromise(const FunctionCallbackInfo<Value>& args) {
+  Local<Context> context = args.GetIsolate()->GetCurrentContext();
+  auto maybe_resolver = Promise::Resolver::New(context);
+  if (!maybe_resolver.IsEmpty())
+    args.GetReturnValue().Set(maybe_resolver.ToLocalChecked());
+}
+
+
+void PromiseResolve(const FunctionCallbackInfo<Value>& args) {
+  Local<Context> context = args.GetIsolate()->GetCurrentContext();
+  Local<Value> promise = args[0];
+  CHECK(promise->IsPromise());
+  if (promise.As<Promise>()->State() != Promise::kPending) return;
+  Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();  // sic
+  Maybe<bool> ret = resolver->Resolve(context, args[1]);
+  args.GetReturnValue().Set(ret.FromMaybe(false));
+}
+
+
+void PromiseReject(const FunctionCallbackInfo<Value>& args) {
+  Local<Context> context = args.GetIsolate()->GetCurrentContext();
+  Local<Value> promise = args[0];
+  CHECK(promise->IsPromise());
+  if (promise.As<Promise>()->State() != Promise::kPending) return;
+  Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();  // sic
+  Maybe<bool> ret = resolver->Reject(context, args[1]);
+  args.GetReturnValue().Set(ret.FromMaybe(false));
+}
+
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context) {
@@ -192,6 +223,10 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "startSigintWatchdog", StartSigintWatchdog);
   env->SetMethod(target, "stopSigintWatchdog", StopSigintWatchdog);
   env->SetMethod(target, "watchdogHasPendingSigint", WatchdogHasPendingSigint);
+
+  env->SetMethod(target, "createPromise", CreatePromise);
+  env->SetMethod(target, "promiseResolve", PromiseResolve);
+  env->SetMethod(target, "promiseReject", PromiseReject);
 }
 
 }  // namespace util

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -3,7 +3,10 @@ const common = require('../common');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
+const util = require('util');
 const isIPv4 = net.isIPv4;
+
+common.crashOnUnhandledRejection();
 
 let running = false;
 const queue = [];
@@ -183,4 +186,14 @@ TEST(function test_lookupservice_ip_ipv4(done) {
   );
 
   checkWrap(req);
+});
+
+TEST(function test_lookupservice_ip_ipv4_promise(done) {
+  util.promisify(dns.lookupService)('127.0.0.1', 80)
+    .then(common.mustCall(({hostname, service}) => {
+      assert.strictEqual(typeof hostname, 'string');
+      assert(hostname.length > 0);
+      assert(['http', 'www', '80'].includes(service));
+      done();
+    }));
 });

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -28,6 +28,8 @@ const isIPv4 = net.isIPv4;
 const isIPv6 = net.isIPv6;
 const util = require('util');
 
+common.crashOnUnhandledRejection();
+
 let expected = 0;
 let completed = 0;
 let running = false;
@@ -425,6 +427,32 @@ TEST(function test_lookup_ip_all(done) {
   });
 
   checkWrap(req);
+});
+
+
+TEST(function test_lookup_ip_all_promise(done) {
+  const req = util.promisify(dns.lookup)('127.0.0.1', {all: true})
+    .then(function(ips) {
+      assert.ok(Array.isArray(ips));
+      assert.ok(ips.length > 0);
+      assert.strictEqual(ips[0].address, '127.0.0.1');
+      assert.strictEqual(ips[0].family, 4);
+
+      done();
+    });
+
+  checkWrap(req);
+});
+
+
+TEST(function test_lookup_ip_promise(done) {
+  util.promisify(dns.lookup)('127.0.0.1')
+    .then(function({ address, family }) {
+      assert.strictEqual(address, '127.0.0.1');
+      assert.strictEqual(family, 4);
+
+      done();
+    });
 });
 
 

--- a/test/parallel/test-child-process-promisified.js
+++ b/test/parallel/test-child-process-promisified.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const { promisify } = require('util');
+
+common.crashOnUnhandledRejection();
+
+const exec = promisify(child_process.exec);
+const execFile = promisify(child_process.execFile);
+
+{
+  exec(`${process.execPath} -p 42`).then(common.mustCall((obj) => {
+    assert.deepStrictEqual(obj, { stdout: '42\n', stderr: '' });
+  }));
+}
+
+{
+  execFile(process.execPath, ['-p', '42']).then(common.mustCall((obj) => {
+    assert.deepStrictEqual(obj, { stdout: '42\n', stderr: '' });
+  }));
+}
+
+{
+  exec('doesntexist').catch(common.mustCall((err) => {
+    assert(err.message.includes('doesntexist'));
+  }));
+}
+
+{
+  execFile('doesntexist', ['-p', '42']).catch(common.mustCall((err) => {
+    assert(err.message.includes('doesntexist'));
+  }));
+}

--- a/test/parallel/test-fs-promisified.js
+++ b/test/parallel/test-fs-promisified.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+
+common.crashOnUnhandledRejection();
+
+const read = promisify(fs.read);
+const write = promisify(fs.write);
+
+{
+  const fd = fs.openSync(__filename, 'r');
+  read(fd, Buffer.alloc(1024), 0, 1024, null).then(common.mustCall((obj) => {
+    assert.strictEqual(typeof obj.bytesRead, 'number');
+    assert(obj.buffer instanceof Buffer);
+    fs.closeSync(fd);
+  }));
+}
+
+common.refreshTmpDir();
+{
+  const filename = path.join(common.tmpDir, 'write-promise.txt');
+  const fd = fs.openSync(filename, 'w');
+  write(fd, Buffer.from('foobar')).then(common.mustCall((obj) => {
+    assert.strictEqual(typeof obj.bytesWritten, 'number');
+    assert.strictEqual(obj.buffer.toString(), 'foobar');
+    fs.closeSync(fd);
+  }));
+}

--- a/test/parallel/test-promise-internal-creation.js
+++ b/test/parallel/test-promise-internal-creation.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const {
+  createPromise, promiseResolve, promiseReject
+} = process.binding('util');
+const { inspect } = require('util');
+
+common.crashOnUnhandledRejection();
+
+{
+  const promise = createPromise();
+  assert.strictEqual(inspect(promise), 'Promise { <pending> }');
+  promiseResolve(promise, 42);
+  assert.strictEqual(inspect(promise), 'Promise { 42 }');
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, 42);
+  }));
+}
+
+{
+  const promise = createPromise();
+  const error = new Error('foobar');
+  promiseReject(promise, error);
+  assert(inspect(promise).includes('<rejected> Error: foobar'));
+  promise.catch(common.mustCall((value) => {
+    assert.strictEqual(value, error);
+  }));
+}
+
+{
+  const promise = createPromise();
+  const error = new Error('foobar');
+  promiseReject(promise, error);
+  assert(inspect(promise).includes('<rejected> Error: foobar'));
+  promiseResolve(promise, 42);
+  assert(inspect(promise).includes('<rejected> Error: foobar'));
+  promise.catch(common.mustCall((value) => {
+    assert.strictEqual(value, error);
+  }));
+}

--- a/test/parallel/test-timers-promisified.js
+++ b/test/parallel/test-timers-promisified.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const timers = require('timers');
+const { promisify } = require('util');
+
+/* eslint-disable no-restricted-syntax */
+
+common.crashOnUnhandledRejection();
+
+const setTimeout = promisify(timers.setTimeout);
+const setImmediate = promisify(timers.setImmediate);
+
+{
+  const promise = setTimeout(1);
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}
+
+{
+  const promise = setTimeout(1, 'foobar');
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, 'foobar');
+  }));
+}
+
+{
+  const promise = setImmediate();
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}
+
+{
+  const promise = setImmediate('foobar');
+  promise.then(common.mustCall((value) => {
+    assert.strictEqual(value, 'foobar');
+  }));
+}

--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -1,0 +1,76 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { promisify } = require('util');
+
+common.crashOnUnhandledRejection();
+
+const stat = promisify(fs.stat);
+
+{
+  const promise = stat(__filename);
+  assert(promise instanceof Promise);
+  promise.then(common.mustCall((value) => {
+    assert.deepStrictEqual(value, fs.statSync(__filename));
+  }));
+}
+
+{
+  const promise = stat('/dontexist');
+  promise.catch(common.mustCall((error) => {
+    assert(error.message.includes('ENOENT: no such file or directory, stat'));
+  }));
+}
+
+{
+  function fn() {}
+  function promisifedFn() {}
+  fn[promisify.custom] = promisifedFn;
+  assert.strictEqual(promisify(fn), promisifedFn);
+  assert.strictEqual(promisify(promisify(fn)), promisifedFn);
+}
+
+{
+  function fn() {}
+  fn[promisify.custom] = 42;
+  assert.throws(
+      () => promisify(fn),
+      (err) => err instanceof TypeError &&
+                err.message === 'The [util.promisify.custom] property must ' +
+                                'be a function');
+}
+
+{
+  const fn = vm.runInNewContext('(function() {})');
+  assert.notStrictEqual(Object.getPrototypeOf(promisify(fn)),
+                        Function.prototype);
+}
+
+{
+  function fn(callback) {
+    callback(null, 'foo', 'bar');
+  }
+  promisify(fn)().then(common.mustCall((value) => {
+    assert.deepStrictEqual(value, 'foo');
+  }));
+}
+
+{
+  function fn(callback) {
+    callback(null);
+  }
+  promisify(fn)().then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}
+
+{
+  function fn(callback) {
+    callback();
+  }
+  promisify(fn)().then(common.mustCall((value) => {
+    assert.strictEqual(value, undefined);
+  }));
+}


### PR DESCRIPTION
See nodejs/CTC#12 for discussion/background. I would say that that thread is a better place for general discussion, and I prefer it if comments here would be kept to what is directly relevant for this PR.

CI: https://ci.nodejs.org/job/node-test-commit/9143/

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

util, timers

#### Original commit descriptions

##### util: add internal bindings for promise handling

Add methods for creating, resolving and rejecting promises using the V8 C++ API that does not require creation of extra `resolve` and `reject` functions to `process.binding('util')`.

##### util: add util.promisify()

Add `util.promisify(function)` for creating promisified functions.

Fixes: nodejs/CTC#12

##### timers: add promisify support

Add support for `util.promisify(setTimeout)` and `util.promisify(setImmediate)` as a proof-of-concept implementation. ~~`clearTimeout()` and `clearImmediate()` resolve the promise immediately instead of rejecting it; that might be the most opinionated choice about this.~~

/cc @chrisdickinson @benjamingr @Fishrock123 @nodejs/ctc

edit: [CTC voting comment](https://github.com/nodejs/node/pull/12442#issuecomment-299158319)