### PR TITLE
tests: remove common.PORT from cluster worker disconnect, exit and kill

### DIFF
--- a/test/parallel/test-cluster-worker-disconnect.js
+++ b/test/parallel/test-cluster-worker-disconnect.js
@@ -28,7 +28,7 @@ if (cluster.isWorker) {
   const http = require('http');
   http.Server(() => {
 
-  }).listen(common.PORT, '127.0.0.1');
+  }).listen(0, '127.0.0.1');
   const worker = cluster.worker;
   assert.strictEqual(worker.exitedAfterDisconnect, worker.suicide);
 

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -40,7 +40,7 @@ if (cluster.isWorker) {
   server.once('listening', common.mustCall(() => {
     process.exit(EXIT_CODE);
   }));
-  server.listen(common.PORT, '127.0.0.1');
+  server.listen(0, '127.0.0.1');
 
 } else if (cluster.isMaster) {
 

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -36,7 +36,7 @@ if (cluster.isWorker) {
   const server = http.Server(() => { });
 
   server.once('listening', common.mustCall(() => { }));
-  server.listen(common.PORT, '127.0.0.1');
+  server.listen(0, '127.0.0.1');
 
 } else if (cluster.isMaster) {
 


### PR DESCRIPTION
Migrate the following test files away from common.PORT:
- test-cluster-worker-disconnect.js
- test-cluster-worker-exit.js
- test-cluster-worker-kill.js

Ref: https://github.com/nodejs/node/issues/12376

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
