### PR TITLE
tools,lib: enable strict equality lint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -34,6 +34,7 @@ rules:
   # Best Practices
   # http://eslint.org/docs/rules/#best-practices
   dot-location: [2, property]
+  eqeqeq: [2, smart]
   no-fallthrough: 2
   no-global-assign: 2
   no-multi-spaces: 2

--- a/lib/_debugger.js
+++ b/lib/_debugger.js
@@ -1391,6 +1391,7 @@ Interface.prototype.setBreakpoint = function(script, line,
     };
   } else {
     // setBreakpoint('scriptname')
+    // eslint-disable-next-line eqeqeq
     if (script != +script && !this.client.scripts[script]) {
       var scripts = this.client.scripts;
       for (var id in scripts) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -112,6 +112,7 @@ assert.ok = ok;
 // assert.equal(actual, expected, message_opt);
 /* eslint-disable no-restricted-properties */
 assert.equal = function equal(actual, expected, message) {
+  // eslint-disable-next-line eqeqeq
   if (actual != expected) fail(actual, expected, message, '==', assert.equal);
 };
 
@@ -120,6 +121,7 @@ assert.equal = function equal(actual, expected, message) {
 // assert.notEqual(actual, expected, message_opt);
 
 assert.notEqual = function notEqual(actual, expected, message) {
+  // eslint-disable-next-line eqeqeq
   if (actual == expected) {
     fail(actual, expected, message, '!=', assert.notEqual);
   }
@@ -176,6 +178,7 @@ function _deepEqual(actual, expected, strict, memos) {
   // (determined by typeof value !== 'object'),
   // or null, equivalence is determined by === or ==.
   if (isNullOrNonObj(actual) && isNullOrNonObj(expected)) {
+    // eslint-disable-next-line eqeqeq
     return strict ? actual === expected : actual == expected;
   }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -192,6 +192,7 @@ Buffer.allocUnsafeSlow = function(size) {
 // If --zero-fill-buffers command line argument is set, a zero-filled
 // buffer is returned.
 function SlowBuffer(length) {
+  // eslint-disable-next-line eqeqeq
   if (+length != length)
     length = 0;
   assertSize(+length);
@@ -306,7 +307,7 @@ function fromObject(obj) {
     return b;
   }
 
-  if (obj != undefined) {
+  if (obj != null) {
     if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
       if (typeof obj.length !== 'number' || obj.length !== obj.length) {
         return new FastBuffer();

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1161,6 +1161,7 @@ fs.chownSync = function(path, uid, gid) {
 
 // converts Date or number to a fractional UNIX timestamp
 function toUnixTimestamp(time) {
+  // eslint-disable-next-line eqeqeq
   if (typeof time === 'string' && +time == time) {
     return +time;
   }

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -169,6 +169,7 @@ function setupKillAndExit() {
   process.kill = function(pid, sig) {
     var err;
 
+    // eslint-disable-next-line eqeqeq
     if (pid != (pid | 0)) {
       throw new TypeError('invalid pid');
     }

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1365,7 +1365,7 @@ function getPathFromURLPosix(url) {
 }
 
 function getPathFromURL(path) {
-  if (path == undefined || !path[searchParams] ||
+  if (path == null || !path[searchParams] ||
       !path[searchParams][searchParams]) {
     return path;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -179,9 +179,10 @@ function Socket(options) {
   } else if (options.fd !== undefined) {
     this._handle = createHandle(options.fd);
     this._handle.open(options.fd);
-    // options.fd can be string (since it user-defined),
+    // options.fd can be string (since it is user-defined),
     // so changing this to === would be semver-major
     // See: https://github.com/nodejs/node/pull/11513
+    // eslint-disable-next-line eqeqeq
     if ((options.fd == 1 || options.fd == 2) &&
         (this._handle instanceof Pipe) &&
         process.platform === 'win32') {
@@ -748,7 +749,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
 
   // If it was entirely flushed, we can write some more right now.
   // However, if more is left in the queue, then wait until that clears.
-  if (req.async && this._handle.writeQueueSize != 0)
+  if (req.async && this._handle.writeQueueSize !== 0)
     req.cb = cb;
   else
     cb();


### PR DESCRIPTION
Enablie a lint rule to require `===` and `!==` instead of `==` and `!=`
except in some well-defined cases:

* comparing against `null` as a shorthand for also checking for
  `undefined`
* comparing the result of `typeof`
* comparing literal values

In cases where `==` or `!=` are being used as optimizations, use an
ESLint comment to disable the `eqeqeq` rule for that line explicitly. I
rather like this because it's a signal that the usage is intentional and
not a mistake.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools lib