### PR TITLE
tests: remove common.PORT from shared,master,rr tests

### DIFF
--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -31,7 +31,7 @@ if (cluster.isWorker) {
   const http = require('http');
   http.Server(() => {
 
-  }).listen(common.PORT, '127.0.0.1');
+  }).listen(0, '127.0.0.1');
 
 } else if (process.argv[2] === 'cluster') {
 

--- a/test/parallel/test-cluster-master-kill.js
+++ b/test/parallel/test-cluster-master-kill.js
@@ -28,7 +28,7 @@ if (cluster.isWorker) {
 
   // keep the worker alive
   const http = require('http');
-  http.Server().listen(common.PORT, '127.0.0.1');
+  http.Server().listen(0, '127.0.0.1');
 
 } else if (process.argv[2] === 'cluster') {
 

--- a/test/parallel/test-cluster-net-send.js
+++ b/test/parallel/test-cluster-net-send.js
@@ -67,8 +67,8 @@ if (process.argv[2] !== 'child') {
     socketConnected();
   });
 
-  server.listen(common.PORT, function() {
-    socket = net.connect(common.PORT, '127.0.0.1', socketConnected);
+  server.listen(0, function() {
+    socket = net.connect(server.address().port, '127.0.0.1', socketConnected);
   });
 
   process.on('disconnect', function() {

--- a/test/parallel/test-cluster-rr-domain-listen.js
+++ b/test/parallel/test-cluster-rr-domain-listen.js
@@ -32,7 +32,7 @@ if (cluster.isWorker) {
   d.run(common.noop);
 
   const http = require('http');
-  http.Server(common.noop).listen(common.PORT, '127.0.0.1');
+  http.Server(common.noop).listen(0, '127.0.0.1');
 
 } else if (cluster.isMaster) {
 

--- a/test/parallel/test-cluster-rr-ref.js
+++ b/test/parallel/test-cluster-rr-ref.js
@@ -10,7 +10,7 @@ if (cluster.isMaster) {
   });
 } else {
   const server = net.createServer(common.mustNotCall());
-  server.listen(common.PORT, function() {
+  server.listen(0, function() {
     server.unref();
     server.ref();
     server.close(function() {

--- a/test/parallel/test-cluster-shared-leak.js
+++ b/test/parallel/test-cluster-shared-leak.js
@@ -13,10 +13,10 @@ if (cluster.isMaster) {
   let conn, worker2;
 
   const worker1 = cluster.fork();
-  worker1.on('message', common.mustCall(function() {
+  worker1.on('listening', common.mustCall(function(address) {
     worker2 = cluster.fork();
     worker2.on('online', function() {
-      conn = net.connect(common.PORT, common.mustCall(function() {
+      conn = net.connect(address.port, common.mustCall(function() {
         worker1.disconnect();
         worker2.disconnect();
       }));
@@ -48,6 +48,4 @@ const server = net.createServer(function(c) {
   c.end('bye');
 });
 
-server.listen(common.PORT, function() {
-  process.send('listening');
-});
+server.listen(0);

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -55,7 +55,7 @@ if (cluster.isMaster) {
       success = true;
     });
 
-  }).listen(common.PORT, function() {
+  }).listen(0, function() {
     const port = this.address().port;
 
     worker = cluster.fork()


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/12376
PR_URL: https://github.com/nodejs/node/pull/12451

Tests updated:
 * test/parallel/test-cluster-shared-leak.js
 * test/parallel/test-cluster-master-error.js
 * test/parallel/test-cluster-master-kill.js
 * test/parallel/test-cluster-net-send.js
 * test/parallel/test-cluster-rr-domain-listen.js
 * test/parallel/test-cluster-rr-ref.js
 * test/parallel/test-cluster-worker-no-exit.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test