### PR TITLE
tests: remove common.PORT from cluster-worker-disconnect-on-error

### DIFF
--- a/test/parallel/test-cluster-worker-disconnect-on-error.js
+++ b/test/parallel/test-cluster-worker-disconnect-on-error.js
@@ -2,19 +2,32 @@
 const common = require('../common');
 const http = require('http');
 const cluster = require('cluster');
+const assert = require('assert');
 
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 const server = http.createServer();
 if (cluster.isMaster) {
-  server.listen(common.PORT);
-  const worker = cluster.fork();
+  let worker;
+
+  server.listen(0, common.mustCall((error) => {
+    assert.ifError(error);
+    assert(worker);
+
+    worker.send({port: server.address().port});
+  }));
+
+  worker = cluster.fork();
   worker.on('exit', common.mustCall(() => {
     server.close();
   }));
 } else {
-  server.listen(common.PORT);
-  server.on('error', common.mustCall((e) => {
-    cluster.worker.disconnect();
+  process.on('message', common.mustCall((msg) => {
+    assert(msg.port);
+
+    server.listen(msg.port);
+    server.on('error', common.mustCall((e) => {
+      cluster.worker.disconnect();
+    }));
   }));
 }


### PR DESCRIPTION
Remove common.PORT from test-cluster-worker-disconnect-on-error
possibility that a dynamic port used in another test will collide
with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
