### PR TITLE
(v6.x backport) events,test: fix TypeError in EventEmitter warning

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -257,8 +257,9 @@ function _addListener(target, type, listener, prepend) {
       if (m && m > 0 && existing.length > m) {
         existing.warned = true;
         const w = new Error('Possible EventEmitter memory leak detected. ' +
-                            `${existing.length} ${type} listeners added. ` +
-                            'Use emitter.setMaxListeners() to increase limit');
+                            `${existing.length} ${String(type)} listeners ` +
+                            'added. Use emitter.setMaxListeners() to ' +
+                            'increase limit');
         w.name = 'Warning';
         w.emitter = target;
         w.type = type;

--- a/test/parallel/test-event-emitter-check-listener-leaks.js
+++ b/test/parallel/test-event-emitter-check-listener-leaks.js
@@ -13,6 +13,14 @@ assert.ok(!e._events['default'].hasOwnProperty('warned'));
 e.on('default', function() {});
 assert.ok(e._events['default'].warned);
 
+// symbol
+const symbol = Symbol('symbol');
+e.setMaxListeners(1);
+e.on(symbol, function() {});
+assert.ok(!e._events[symbol].hasOwnProperty('warned'));
+e.on(symbol, function() {});
+assert.ok(e._events[symbol].hasOwnProperty('warned'));
+
 // specific
 e.setMaxListeners(5);
 for (let i = 0; i < 5; i++) {

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
@@ -14,9 +14,9 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'Warning');
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
-  assert.strictEqual(warning.type, 'event-type');
-  assert.ok(warning.message.includes('2 event-type listeners added.'));
+  assert.strictEqual(warning.type, null);
+  assert.ok(warning.message.includes('2 null listeners added.'));
 }));
 
-e.on('event-type', function() {});
-e.on('event-type', function() {});
+e.on(null, function() {});
+e.on(null, function() {});

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
@@ -6,6 +6,8 @@ const common = require('../common');
 const events = require('events');
 const assert = require('assert');
 
+const symbol = Symbol('symbol');
+
 const e = new events.EventEmitter();
 e.setMaxListeners(1);
 
@@ -14,9 +16,9 @@ process.on('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'Warning');
   assert.strictEqual(warning.emitter, e);
   assert.strictEqual(warning.count, 2);
-  assert.strictEqual(warning.type, 'event-type');
-  assert.ok(warning.message.includes('2 event-type listeners added.'));
+  assert.strictEqual(warning.type, symbol);
+  assert.ok(warning.message.includes('2 Symbol(symbol) listeners added.'));
 }));
 
-e.on('event-type', function() {});
-e.on('event-type', function() {});
+e.on(symbol, function() {});
+e.on(symbol, function() {});


### PR DESCRIPTION
Allows Symbol to be converted to String so it can be included in the
error.

Fixes: https://github.com/nodejs/node/issues/9003

Conflicts:
	lib/events.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, test
