### PR TITLE
v8: fix stack overflow in recursive method 

### DIFF
--- a/deps/v8/src/crankshaft/hydrogen-gvn.cc
+++ b/deps/v8/src/crankshaft/hydrogen-gvn.cc
@@ -5,6 +5,8 @@
 #include "src/crankshaft/hydrogen-gvn.h"
 
 #include "src/crankshaft/hydrogen.h"
+#include "src/list.h"
+#include "src/list-inl.h"
 #include "src/v8.h"
 
 namespace v8 {
@@ -650,19 +652,23 @@ SideEffects
 HGlobalValueNumberingPhase::CollectSideEffectsOnPathsToDominatedBlock(
     HBasicBlock* dominator, HBasicBlock* dominated) {
   SideEffects side_effects;
-  for (int i = 0; i < dominated->predecessors()->length(); ++i) {
-    HBasicBlock* block = dominated->predecessors()->at(i);
-    if (dominator->block_id() < block->block_id() &&
-        block->block_id() < dominated->block_id() &&
-        !visited_on_paths_.Contains(block->block_id())) {
-      visited_on_paths_.Add(block->block_id());
-      side_effects.Add(block_side_effects_[block->block_id()]);
-      if (block->IsLoopHeader()) {
-        side_effects.Add(loop_side_effects_[block->block_id()]);
+  List<HBasicBlock*> blocks;
+  for (;;) {
+    for (int i = 0; i < dominated->predecessors()->length(); ++i) {
+      HBasicBlock* block = dominated->predecessors()->at(i);
+      if (dominator->block_id() < block->block_id() &&
+          block->block_id() < dominated->block_id() &&
+          !visited_on_paths_.Contains(block->block_id())) {
+        visited_on_paths_.Add(block->block_id());
+        side_effects.Add(block_side_effects_[block->block_id()]);
+        if (block->IsLoopHeader()) {
+          side_effects.Add(loop_side_effects_[block->block_id()]);
+        }
+        blocks.Add(block);
       }
-      side_effects.Add(CollectSideEffectsOnPathsToDominatedBlock(
-          dominator, block));
     }
+    if (blocks.is_empty()) break;
+    dominated = blocks.RemoveLast();
   }
   return side_effects;
 }


### PR DESCRIPTION
HGlobalValueNumberingPhase::CollectSideEffectsOnPathsToDominatedBlock()
used to self-recurse before this commit, causing stack overflows on
systems with small stack sizes.  Make it non-recursive by storing
intermediate results in a heap-allocated list.

The first commit is the obvious way to implement it, the second commit optimizes a bit.

Switching to heap allocations might in theory have performance implications but, as a data point, it doesn't seem to affect the running time of the node.js test suite.

V8 CI (1st commit): https://ci.nodejs.org/job/node-test-commit-v8-linux/651/ (green)
V8 CI (2nd commit): https://ci.nodejs.org/job/node-test-commit-v8-linux/652/ (green)
V8 CI (3rd commit): https://ci.nodejs.org/job/node-test-commit-v8-linux/653/
Node CI (2nd commit): https://ci.nodejs.org/job/node-test-pull-request/7439/
Node CI (3rd commit): https://ci.nodejs.org/job/node-test-pull-request/7466/

See https://github.com/nodejs/node/issues/11991.