### PR TITLE
tests: remove common.PORT from client abort

### DIFF
--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -35,7 +35,7 @@ const path = require('path');
 const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
 const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-const conn = tls.connect({cert, key, port: common.PORT}, common.mustNotCall());
+const conn = tls.connect({cert, key, port: 0}, common.mustNotCall());
 conn.on('error', function() {
 });
 assert.doesNotThrow(function() {

--- a/test/parallel/test-tls-client-abort2.js
+++ b/test/parallel/test-tls-client-abort2.js
@@ -29,7 +29,7 @@ if (!common.hasCrypto) {
 }
 const tls = require('tls');
 
-const conn = tls.connect(common.PORT, common.mustNotCall());
+const conn = tls.connect(0, common.mustNotCall());
 conn.on('error', common.mustCall(function() {
   assert.doesNotThrow(function() {
     conn.destroy();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Refs: #12376

Tests updated:
- [x] test/parallel/test-tls-client-abort.js
- [x] test/parallel/test-tls-client-abort2.js

I wonder if I could do the same in these files:

- test/parallel/test-tls-client-default-ciphers.js
- test/parallel/test-tls-connect.js
- test/parallel/test-tls-ticket-cluster.js

If changing `common.PORT` to 0 isn't the case, what else?

cc/ @Trott 


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tests