### PR TITLE
src: add missing "http_parser.h" include

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -54,6 +54,7 @@
 #include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
+#include "http_parser.h"
 #include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "string_bytes.h"

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -20,3 +20,11 @@ expected_keys.sort();
 const actual_keys = Object.keys(process.versions).sort();
 
 assert.deepStrictEqual(actual_keys, expected_keys);
+
+assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.ares));
+assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.http_parser));
+assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.node));
+assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.uv));
+assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.zlib));
+assert(/^\d+\.\d+\.\d+\.\d+$/.test(process.versions.v8));
+assert(/^\d+$/.test(process.versions.modules));


### PR DESCRIPTION
In 9d522225e7907b6cf631975b34f586984f698e33 the indirect "http_parser.h"
include was removed, which made `NODE_STRINGIFY()` fail silently for the
http parser version in `process.versions`.

Ref: https://github.com/nodejs/node/pull/12366
Fixes: https://github.com/nodejs/node/issues/12463

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

src/process.versions

CI: https://ci.nodejs.org/job/node-test-commit/9161/