### PR TITLE
tests: remove common.PORT from cluster worker wait server close

### DIFF
--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -12,7 +12,7 @@ if (cluster.isWorker) {
     // Wait for any data, then close connection
     socket.write('.');
     socket.on('data', common.noop);
-  }).listen(common.PORT, common.localhostIPv4);
+  }).listen(0, common.localhostIPv4);
 
   server.once('close', function() {
     serverClosed = true;
@@ -33,8 +33,8 @@ if (cluster.isWorker) {
   const worker = cluster.fork();
 
   // Disconnect worker when it is ready
-  worker.once('listening', function() {
-    const socket = net.createConnection(common.PORT, common.localhostIPv4);
+  worker.once('listening', function(address) {
+    const socket = net.createConnection(address.port, common.localhostIPv4);
 
     socket.on('connect', function() {
       socket.on('data', function() {


### PR DESCRIPTION
Remove common.PORT from test-cluster-worker-wait-server-close
possibility that a dynamic port used in another test will collide
with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
