### PR TITLE
test: initialize platform in NodeTestFixture

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -79,6 +79,8 @@ class NodeTestFixture : public ::testing::Test {
   ArrayBufferAllocator allocator_;
   v8::Isolate* isolate_;
 
+  NodeTestFixture() : isolate_(nullptr), platform_(nullptr) {}
+
   virtual void SetUp() {
     platform_ = v8::platform::CreateDefaultPlatform();
     v8::V8::InitializePlatform(platform_);
@@ -88,6 +90,8 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void TearDown() {
+    isolate_->Dispose();
+    isolate_ = nullptr;
     v8::V8::ShutdownPlatform();
     delete platform_;
     platform_ = nullptr;


### PR DESCRIPTION
Calling TearDown() without Setup() first is not allowed, but
this should fix a coverity warning:

```
*** CID 166971:  Uninitialized members  (UNINIT_CTOR)
/test/cctest/node_test_fixture.h: 97 in NodeTestFixture::NodeTestFixture()()
91         v8::V8::ShutdownPlatform();
92         delete platform_;
93         platform_ = nullptr;
94       }
95
96      private:
>>>     CID 166971:  Uninitialized members  (UNINIT_CTOR)
>>>     The compiler-generated constructor for this class does not initialize "platform_".
97       v8::Platform* platform_;
98     };
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
