### PR TITLE
tests: remove common.PORT from cluster send tests

### DIFF
--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -23,7 +23,7 @@
 // Testing mutual send of handles: from master to worker, and from worker to
 // master.
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -40,14 +40,15 @@ if (cluster.isMaster) {
     worker.send('handle', socket);
   });
 
-  server.listen(common.PORT, function() {
-    worker.send('listen');
+  server.listen(0, function() {
+    worker.send({message: 'listen', port: server.address().port});
   });
 } else {
   process.on('message', function(msg, handle) {
-    if (msg === 'listen') {
-      const client1 = net.connect({ host: 'localhost', port: common.PORT });
-      const client2 = net.connect({ host: 'localhost', port: common.PORT });
+    if (msg.message && msg.message === 'listen') {
+      assert(msg.port);
+      const client1 = net.connect({ host: 'localhost', port: msg.port });
+      const client2 = net.connect({ host: 'localhost', port: msg.port });
       let waiting = 2;
       client1.on('close', onclose);
       client2.on('close', onclose);

--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -45,8 +45,11 @@ if (cluster.isMaster) {
     process.send('send-handle-2', socket);
   });
 
-  server.listen(common.PORT, function() {
-    const client = net.connect({ host: 'localhost', port: common.PORT });
+  server.listen(0, function() {
+    const client = net.connect({
+      host: 'localhost',
+      port: server.address().port
+    });
     client.on('close', common.mustCall(() => { cluster.worker.disconnect(); }));
     setTimeout(function() { client.end(); }, 50);
   }).on('error', function(e) {


### PR DESCRIPTION
Remove common.PORT from test-cluster-send-deadlock and
test-cluster-send-handle-twice to reduce possibility that
a dynamic port used in another test will collide with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
