### PR TITLE
Revert "benchmark: fix CLI arguments check in common.js"

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -42,8 +42,8 @@ Benchmark.prototype._parseArgs = function(argv, configs) {
   const extraOptions = {};
   // Parse configuration arguments
   for (const arg of argv) {
-    const match = arg.match(/^(.+?)=([\s\S]+)$/);
-    if (!match) {
+    const match = arg.match(/^(.+?)=([\s\S]*)$/);
+    if (!match || !match[1]) {
       console.error('bad argument: ' + arg);
       process.exit(1);
     }


### PR DESCRIPTION
Ugh. I goofed. I landed https://github.com/nodejs/node/pull/12429, then realized it never went through CI and it breaks one of the tests in sequential. 

This reverts commit e34f8e1444d1e52f4501ccc289cdb83da93e48f0.

Need to get this landed quickly so we unbreak CI

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

test, benchmark