### PR TITLE
test: increase coverage for buffer.js

### DIFF
--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -105,3 +105,41 @@ b.writeDoubleBE(11.11, 0, true);
     return true;
   });
 }
+
+{
+  // If byteOffset is not numeric, it defaults to 0.
+  const ab = new ArrayBuffer(10);
+  const expected = Buffer.from(ab, 0);
+  assert.deepStrictEqual(Buffer.from(ab, 'fhqwhgads'), expected);
+  assert.deepStrictEqual(Buffer.from(ab, NaN), expected);
+  assert.deepStrictEqual(Buffer.from(ab, {}), expected);
+  assert.deepStrictEqual(Buffer.from(ab, []), expected);
+
+  // If byteOffset can be converted to a number, it will be.
+  assert.deepStrictEqual(Buffer.from(ab, [1]), Buffer.from(ab, 1));
+
+  // If byteOffset is Infinity, throw.
+  assert.throws(
+    () => { Buffer.from(ab, Infinity); },
+    /^RangeError: 'offset' is out of bounds$/
+  );
+}
+
+{
+  // If length is not numeric, it defaults to 0.
+  const ab = new ArrayBuffer(10);
+  const expected = Buffer.from(ab, 0, 0);
+  assert.deepStrictEqual(Buffer.from(ab, 0, 'fhqwhgads'), expected);
+  assert.deepStrictEqual(Buffer.from(ab, 0, NaN), expected);
+  assert.deepStrictEqual(Buffer.from(ab, 0, {}), expected);
+  assert.deepStrictEqual(Buffer.from(ab, 0, []), expected);
+
+  // If length can be converted to a number, it will be.
+  assert.deepStrictEqual(Buffer.from(ab, 0, [1]), Buffer.from(ab, 0, 1));
+
+  //If length is Infinity, throw.
+  assert.throws(
+    () => { Buffer.from(ab, 0, Infinity); },
+    /^RangeError: 'length' is out of bounds$/
+  );
+}


### PR DESCRIPTION
Add coverage for non-numeric byteOffset and length when using
Buffer.from() with an ArrayBuffer.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test buffer