### PR TITLE
test: use JSON.stringify to trigger stack overflow

### DIFF
--- a/test/message/stack_overflow.js
+++ b/test/message/stack_overflow.js
@@ -26,10 +26,12 @@ Error.stackTraceLimit = 0;
 
 console.error('before');
 
-// stack overflow
-function stackOverflow() {
-  stackOverflow();
+// Trigger stack overflow by stringifying a deeply nested array.
+let array = [];
+for (let i = 0; i < 100000; i++) {
+  array = [ array ];
 }
-stackOverflow();
+
+JSON.stringify(array);
 
 console.error('after');

--- a/test/message/stack_overflow.out
+++ b/test/message/stack_overflow.out
@@ -1,6 +1,6 @@
 before
-
 *test*message*stack_overflow.js:*
-function stackOverflow() {
-                      ^
+JSON.stringify(array);
+     ^
+
 RangeError: Maximum call stack size exceeded


### PR DESCRIPTION
V8's interpreter performs stack checks both at the call site and at the
function entry. A recursive function could therefore trigger stack
overflow at two different source locations. Instead of recursion, call
JSON.stringify on a deeply nested array.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
