### PR TITLE
test: console.log removed from test-net-localport

### DIFF
--- a/test/parallel/test-net-localport.js
+++ b/test/parallel/test-net-localport.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const net = require('net');
 
 const server = net.createServer(function(socket) {
-  console.log(socket.remotePort);
   assert.strictEqual(socket.remotePort, common.PORT);
   socket.end();
   socket.on('close', function() {


### PR DESCRIPTION
There seems to be an unecessary console log
happening in a test.


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
