### PR TITLE
domain: support promises

### DIFF
--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -1,4 +1,11 @@
 # Domain
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/12489
+    description: Handlers for `Promise`s are now invoked in the domain in which
+                 the first promise of a chain was created.
+-->
 
 > Stability: 0 - Deprecated
 

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -451,6 +451,50 @@ d.run(() => {
 In this example, the `d.on('error')` handler will be triggered, rather
 than crashing the program.
 
+## Domains and Promises
+
+As of Node REPLACEME, the handlers of Promises are run inside the domain in
+which the call to `.then` or `.catch` itself was made:
+
+```js
+const d1 = domain.create();
+const d2 = domain.create();
+
+let p;
+d1.run(() => {
+  p = Promise.resolve(42);
+});
+
+d2.run(() => {
+  p.then((v) => {
+    // running in d2
+  });
+});
+```
+
+If you need to run that callback in a specific domain, you can use
+[`domain.bind(callback)`][]:
+
+```js
+const d1 = domain.create();
+const d2 = domain.create();
+
+let p;
+d1.run(() => {
+  p = Promise.resolve(42);
+});
+
+d2.run(() => {
+  p.then(p.domain.bind((v) => {
+    // running in d1
+  }));
+});
+```
+
+Note that domains will not interfere with the error handling mechanisms for
+Promises, i.e. no `error` event will be emitted for unhandled Promise
+rejections.
+
 [`domain.add(emitter)`]: #domain_domain_add_emitter
 [`domain.bind(callback)`]: #domain_domain_bind_callback
 [`domain.dispose()`]: #domain_domain_dispose

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -472,8 +472,7 @@ d2.run(() => {
 });
 ```
 
-If you need to run that callback in a specific domain, you can use
-[`domain.bind(callback)`][]:
+A callback may be bound to a specific domain using [`domain.bind(callback)`][]:
 
 ```js
 const d1 = domain.create();

--- a/src/env.h
+++ b/src/env.h
@@ -35,6 +35,7 @@
 #include "util.h"
 #include "uv.h"
 #include "v8.h"
+#include "node.h"
 
 #include <list>
 #include <stdint.h>
@@ -572,6 +573,8 @@ class Environment {
 
   static const int kContextEmbedderDataIndex = NODE_CONTEXT_EMBEDDER_DATA_INDEX;
 
+  void AddPromiseHook(promise_hook_func fn, void* arg);
+
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
@@ -619,6 +622,16 @@ class Environment {
     void* arg_;
   };
   std::list<AtExitCallback> at_exit_functions_;
+
+  struct PromiseHookCallback {
+    promise_hook_func cb_;
+    void* arg_;
+  };
+  std::vector<PromiseHookCallback> promise_hooks_;
+
+  static void EnvPromiseHook(v8::PromiseHookType type,
+                             v8::Local<v8::Promise> promise,
+                             v8::Local<v8::Value> parent);
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1232,6 +1232,12 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 }  // anonymous namespace
 
 
+void AddPromiseHook(v8::Isolate* isolate, promise_hook_func fn, void* arg) {
+  Environment* env = Environment::GetCurrent(isolate);
+  env->AddPromiseHook(fn, arg);
+}
+
+
 Local<Value> MakeCallback(Environment* env,
                           Local<Value> recv,
                           const Local<Function> callback,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1117,14 +1117,15 @@ bool ShouldAbortOnUncaughtException(Isolate* isolate) {
 void PromiseHook(PromiseHookType type,
                  Local<Promise> promise,
                  Local<Value> parent) {
-  Environment* env = Environment::GetCurrent(Isolate::GetCurrent());
-  Local<Context> context = env->context();
+  Local<Context> context = promise->CreationContext();
+  Environment* env = Environment::GetCurrent(context);
 
   if (type == PromiseHookType::kResolve) return;
   if (type == PromiseHookType::kInit && env->in_domain()) {
     promise->Set(context,
                  env->domain_string(),
-                 env->domain_array()->Get(0)).FromJust();
+                 env->domain_array()->Get(context,
+                                          0).ToLocalChecked()).FromJust();
     return;
   }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -142,6 +142,7 @@ using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::Promise;
+using v8::PromiseHookType;
 using v8::PromiseRejectMessage;
 using v8::PropertyCallbackInfo;
 using v8::ScriptOrigin;
@@ -1113,6 +1114,56 @@ bool ShouldAbortOnUncaughtException(Isolate* isolate) {
 }
 
 
+void PromiseHook(PromiseHookType type,
+                 Local<Promise> promise,
+                 Local<Value> parent) {
+  Environment* env = Environment::GetCurrent(Isolate::GetCurrent());
+  Local<Context> context = env->context();
+
+  if (type == PromiseHookType::kResolve) return;
+  if (type == PromiseHookType::kInit && env->in_domain()) {
+    promise->Set(context,
+                 env->domain_string(),
+                 env->domain_array()->Get(0)).FromJust();
+    return;
+  }
+
+  // Loosely based on node::MakeCallback().
+  Local<Value> domain_v =
+      promise->Get(context, env->domain_string()).ToLocalChecked();
+  if (!domain_v->IsObject())
+    return;
+
+  Local<Object> domain = domain_v.As<Object>();
+  if (domain->Get(context, env->disposed_string())
+          .ToLocalChecked()->IsTrue()) {
+    return;
+  }
+
+  if (type == PromiseHookType::kBefore) {
+    Local<Value> enter_v =
+        domain->Get(context, env->enter_string()).ToLocalChecked();
+    if (enter_v->IsFunction()) {
+      if (enter_v.As<Function>()->Call(context, domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::PromiseHook",
+                   "domain enter callback threw, please report this "
+                   "as a bug in Node.js");
+      }
+    }
+  } else {
+    Local<Value> exit_v =
+        domain->Get(context, env->exit_string()).ToLocalChecked();
+    if (exit_v->IsFunction()) {
+      if (exit_v.As<Function>()->Call(context, domain, 0, nullptr).IsEmpty()) {
+        FatalError("node::MakeCallback",
+                   "domain exit callback threw, please report this "
+                   "as a bug in Node.js");
+      }
+    }
+  }
+}
+
+
 void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -1151,6 +1202,8 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
 
   Local<ArrayBuffer> array_buffer =
       ArrayBuffer::New(env->isolate(), fields, sizeof(*fields) * fields_count);
+
+  env->isolate()->SetPromiseHook(PromiseHook);
 
   args.GetReturnValue().Set(Uint32Array::New(array_buffer, 0, fields_count));
 }

--- a/src/node.h
+++ b/src/node.h
@@ -517,6 +517,17 @@ NODE_EXTERN void AtExit(void (*cb)(void* arg), void* arg = 0);
  */
 NODE_EXTERN void AtExit(Environment* env, void (*cb)(void* arg), void* arg = 0);
 
+typedef void (*promise_hook_func) (v8::PromiseHookType type,
+                                   v8::Local<v8::Promise> promise,
+                                   v8::Local<v8::Value> parent,
+                                   void* arg);
+
+/* Registers an additional v8::PromiseHook wrapper. This API exists because V8
+ * itself supports only a single PromiseHook. */
+NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
+                                promise_hook_func fn,
+                                void* arg);
+
 }  // namespace node
 
 #endif  // SRC_NODE_H_

--- a/test/common.js
+++ b/test/common.js
@@ -678,5 +678,6 @@ exports.getArrayBufferViews = function getArrayBufferViews(buf) {
 
 // Crash the process on unhandled rejections.
 exports.crashOnUnhandledRejection = function() {
-  process.on('unhandledRejection', (err) => setImmediate(() => { throw err; }));
+  process.on('unhandledRejection',
+             (err) => process.nextTick(() => { throw err; }));
 };

--- a/test/common.js
+++ b/test/common.js
@@ -675,3 +675,8 @@ exports.getArrayBufferViews = function getArrayBufferViews(buf) {
   }
   return out;
 };
+
+// Crash the process on unhandled rejections.
+exports.crashOnUnhandledRejection = function() {
+  process.on('unhandledRejection', (err) => setImmediate(() => { throw err; }));
+};

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -2,26 +2,127 @@
 const common = require('../common');
 const assert = require('assert');
 const domain = require('domain');
+const fs = require('fs');
 const vm = require('vm');
 
 common.crashOnUnhandledRejection();
 
-const d = domain.create();
+{
+  const d = domain.create();
 
-d.run(common.mustCall(() => {
-  Promise.resolve().then(common.mustCall(() => {
-    assert.strictEqual(process.domain, d);
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));
   }));
-}));
+}
 
-d.run(common.mustCall(() => {
-  Promise.resolve().then(() => {}).then(() => {}).then(common.mustCall(() => {
-    assert.strictEqual(process.domain, d);
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(() => {}).then(() => {}).then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));
   }));
-}));
+}
 
-d.run(common.mustCall(() => {
-  vm.runInNewContext(`Promise.resolve().then(common.mustCall(() => {
-    assert.strictEqual(process.domain, d);
-  }));`, { common, assert, process, d });
-}));
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    vm.runInNewContext(`Promise.resolve().then(common.mustCall(() => {
+      assert.strictEqual(process.domain, d);
+    }));`, { common, assert, process, d });
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.then(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d2);
+      assert.strictEqual(p.domain, d1);
+    }));
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.then(p.domain.bind(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d1);
+      assert.strictEqual(p.domain, d1);
+    })));
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.resolve(42);
+  }));
+
+  d1.run(common.mustCall(() => {
+    d2.run(common.mustCall(() => {
+      p.then(common.mustCall((v) => {
+        assert.strictEqual(process.domain, d2);
+        assert.strictEqual(p.domain, d1);
+      }));
+    }));
+  }));
+}
+
+{
+  const d1 = domain.create();
+  const d2 = domain.create();
+  let p;
+  d1.run(common.mustCall(() => {
+    p = Promise.reject(new Error('foobar'));
+  }));
+
+  d2.run(common.mustCall(() => {
+    p.catch(common.mustCall((v) => {
+      assert.strictEqual(process.domain, d2);
+      assert.strictEqual(p.domain, d1);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      setTimeout(common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }), 0);
+    }));
+  }));
+}
+
+{
+  const d = domain.create();
+
+  d.run(common.mustCall(() => {
+    Promise.resolve().then(common.mustCall(() => {
+      fs.readFile(__filename, common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }));
+    }));
+  }));
+}

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -1,0 +1,12 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+const d = domain.create();
+
+d.run(common.mustCall(() => {
+  Promise.resolve().then(common.mustCall(() => {
+    assert.strictEqual(process.domain, d);
+  }));
+}));

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -13,6 +13,12 @@ d.run(common.mustCall(() => {
 }));
 
 d.run(common.mustCall(() => {
+  Promise.resolve().then(() => {}).then(() => {}).then(common.mustCall(() => {
+    assert.strictEqual(process.domain, d);
+  }));
+}));
+
+d.run(common.mustCall(() => {
   vm.runInNewContext(`Promise.resolve().then(common.mustCall(() => {
     assert.strictEqual(process.domain, d);
   }));`, { common, assert, process, d });

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -4,6 +4,8 @@ const assert = require('assert');
 const domain = require('domain');
 const vm = require('vm');
 
+common.crashOnUnhandledRejection();
+
 const d = domain.create();
 
 d.run(common.mustCall(() => {

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const domain = require('domain');
+const vm = require('vm');
 
 const d = domain.create();
 
@@ -9,4 +10,10 @@ d.run(common.mustCall(() => {
   Promise.resolve().then(common.mustCall(() => {
     assert.strictEqual(process.domain, d);
   }));
+}));
+
+d.run(common.mustCall(() => {
+  vm.runInNewContext(`Promise.resolve().then(common.mustCall(() => {
+    assert.strictEqual(process.domain, d);
+  }));`, { common, assert, process, d });
 }));


### PR DESCRIPTION
Not entirely convinced this should happen, but @misterdjules brought it up and I thought one might as well give it a try. ¯\\\_(ツ)_/¯ Take a look, and let me know what you think.

Aside: It seems like a V8 design bug that `Isolate::SetPromiseHook()`/`PromiseHook()` don’t take a `void* data` opaque, does anybody agree? I’d probably like to change that in V8 then. (Also, same question for `Isolate::SetPromiseRejectCallback()`… am I missing something? This can’t be intentional, right?)

/cc @nodejs/diagnostics and fyi @ORESoftware

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included ~~(somewhat? I guess?)~~
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

domain