### PR TITLE
test: pipe some error output if npm fails

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto) {
 }
 
 const path = require('path');
-const spawn = require('child_process').spawn;
+const exec = require('child_process').exec;
 const assert = require('assert');
 const fs = require('fs');
 
@@ -26,11 +26,6 @@ const npmPath = path.join(
   'npm-cli.js'
 );
 
-const args = [
-  npmPath,
-  'install'
-];
-
 const pkgContent = JSON.stringify({
   dependencies: {
     'package-name': common.fixturesDir + '/packages/main'
@@ -47,17 +42,22 @@ env['NPM_CONFIG_PREFIX'] = path.join(npmSandbox, 'npm-prefix');
 env['NPM_CONFIG_TMP'] = path.join(npmSandbox, 'npm-tmp');
 env['HOME'] = path.join(npmSandbox, 'home');
 
-const proc = spawn(process.execPath, args, {
+exec(`${process.execPath} ${npmPath} install`, {
   cwd: installDir,
   env: env
-});
+}, common.mustCall(handleExit));
 
-function handleExit(code, signalCode) {
+function handleExit(error, stdout, stderr) {
+  const code = error ? error.code : 0;
+  const signalCode = error ? error.signal : null;
+
+  if (code !== 0) {
+    process.stderr.write(stderr);
+  }
+
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
   assert.doesNotThrow(function() {
     fs.accessSync(installDir + '/node_modules/package-name');
   });
 }
-
-proc.on('exit', common.mustCall(handleExit));


### PR DESCRIPTION
This test now prints out some child error output if the npm child proc
fails, allowing us to debug easier.

Refs: https://github.com/nodejs/node/pull/12480

CI: https://ci.nodejs.org/job/node-test-pull-request/7485/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test