### PR TITLE
test: fix global.PORT in dgram-cluster-test-1

### DIFF
--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -28,25 +28,37 @@ const assert = require('assert');
 const cluster = require('cluster');
 const dgram = require('dgram');
 
+function getPort(cb) {
+  const s = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+  s.bind(0, () => {
+    const port = s.address().port;
+    s.close();
+    cb(null, port);
+  });
+}
 
 if (common.isWindows) {
   common.skip('dgram clustering is currently not supported ' +
-              'on windows.');
+    'on windows.');
   return;
 }
 
-if (cluster.isMaster)
-  master();
-else
+// We are creating unique port only for the in the master cluster
+if (cluster.isMaster) {
+  getPort((info, port) => {
+    master(port);
+  });
+} else {
   worker();
+}
 
 
-function master() {
+function master(port) {
   let listening = 0;
 
   // Fork 4 workers.
   for (let i = 0; i < NUM_WORKERS; i++)
-    cluster.fork();
+    cluster.fork().send(port);
 
   // Wait until all workers are listening.
   cluster.on('listening', common.mustCall(() => {
@@ -60,7 +72,7 @@ function master() {
     doSend();
 
     function doSend() {
-      socket.send(buf, 0, buf.length, common.PORT, '127.0.0.1', afterSend);
+      socket.send(buf, 0, buf.length, port, '127.0.0.1', afterSend);
     }
 
     function afterSend() {
@@ -106,10 +118,13 @@ function worker() {
 
     // Every 10 messages, notify the master.
     if (received === PACKETS_PER_WORKER) {
-      process.send({received: received});
+      process.send({ received: received });
       socket.close();
     }
   }, PACKETS_PER_WORKER));
-
-  socket.bind(common.PORT);
+  // We are getting the PORT through the process
+  // message in the master process => cluster.fork().send(port);
+  process.on('message', common.mustCall((port, info) => {
+    socket.bind(port);
+  }));
 }

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -39,7 +39,7 @@ function getPort(cb) {
 
 if (common.isWindows) {
   common.skip('dgram clustering is currently not supported ' +
-    'on windows.');
+              'on windows.');
   return;
 }
 


### PR DESCRIPTION
Hi,

This is my first attempt at a pull request here. Attempted to fix the issue referenced below.

Note that we pass the port from the cluster master to the workers via `process.send`.

Got some (administrative) help from @benjamingr #goodnessSquad

Refs: https://github.com/nodejs/node/issues/12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
