### PR TITLE
events: remove unreachable code

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -374,22 +374,13 @@ EventEmitter.prototype.removeListener =
         if (position < 0)
           return this;
 
-        if (list.length === 1) {
-          if (--this._eventsCount === 0) {
-            this._events = Object.create(null);
-            return this;
-          } else {
-            delete events[type];
-          }
-        } else if (position === 0) {
+        if (position === 0)
           list.shift();
-          if (list.length === 1)
-            events[type] = list[0];
-        } else {
+        else
           spliceOne(list, position);
-          if (list.length === 1)
-            events[type] = list[0];
-        }
+
+        if (list.length === 1)
+          events[type] = list[0];
 
         if (events.removeListener)
           this.emit('removeListener', type, originalListener || listener);


### PR DESCRIPTION
Commit 8d386ed7e1301c869bbc266ce73650b280c9ae26 stopped the Event Emitter implementation from storing arrays containing a single listener. This change left a section of code in `removeListener()` as unreachable. This commit removes the unreachable code.

The effects of 8d386ed7e1301c869bbc266ce73650b280c9ae26 on code coverage can be seen by comparing [before](https://coverage.nodejs.org/coverage-a5f91ab230c574d5/root/events.js.html) and [after](https://coverage.nodejs.org/coverage-505936309dbfb530/root/events.js.html).

Refs: https://github.com/nodejs/node/pull/12043

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
events