### PR TITLE
test: verify listener leak is only emitted once

### DIFF
--- a/test/parallel/test-event-emitter-max-listeners-warning.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning.js
@@ -19,4 +19,5 @@ process.on('warning', common.mustCall((warning) => {
 }));
 
 e.on('event-type', common.noop);
-e.on('event-type', common.noop);
+e.on('event-type', common.noop);  // Trigger warning.
+e.on('event-type', common.noop);  // Verify that warning is emitted only once.


### PR DESCRIPTION
When a possible listener leak is detected, a warning is emitted. This commit updates an existing test to verify that the warning is only emitted once.

In conjunction with #12501, should bring coverage of `lib/events.js` up to 100%.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test