### PR TITLE
test: remove common.PORT from test-tls-connect

### DIFF
--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -37,7 +37,7 @@ const path = require('path');
   const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
   const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-  const options = {cert: cert, key: key, port: common.PORT};
+  const options = {cert: cert, key: key, port: 0};
   const conn = tls.connect(options, common.mustNotCall());
 
   conn.on('error', common.mustCall());
@@ -51,7 +51,7 @@ const path = require('path');
   const conn = tls.connect({
     cert: cert,
     key: key,
-    port: common.PORT,
+    port: 0,
     ciphers: 'rick-128-roll'
   }, common.mustNotCall());
 


### PR DESCRIPTION
Replace common.PORT with 0 to prevent the occurence of
any EADDRINUSE errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls https