### PR TITLE
doc: add suggestion to use --3way

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -376,7 +376,7 @@ If the merge fails even though recent CI runs were successful, then a 3-way merg
 be required.  In this case try:
 
 ```text
-$ curl -L https://github.com/nodejs/node/pull/xxx.patch | git am --3way --whitespace=fix
+$ curl -L https://github.com/nodejs/node/pull/xxx.patch | git am -3 --whitespace=fix
 ```
 If the 3-way merge succeeds you can proceed, but make sure to check the changes
 against the original PR carefully and build/test on at least one platform

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -372,6 +372,16 @@ Apply external patches
 $ curl -L https://github.com/nodejs/node/pull/xxx.patch | git am --whitespace=fix
 ```
 
+If the merge fails even though recent CI runs were successful, then a 3-way merge may
+be required.  In this case try:
+
+```text
+$ curl -L https://github.com/nodejs/node/pull/xxx.patch | git am --3way --whitespace=fix
+```
+If the 3-way merge succeeds you can proceed, but make sure to check the changes
+against the original PR carefully and build/test on at least one platform
+before landing.
+
 Check and re-review the changes
 
 ```text

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -376,11 +376,13 @@ If the merge fails even though recent CI runs were successful, then a 3-way merg
 be required.  In this case try:
 
 ```text
+$ git am --abort
 $ curl -L https://github.com/nodejs/node/pull/xxx.patch | git am -3 --whitespace=fix
 ```
 If the 3-way merge succeeds you can proceed, but make sure to check the changes
 against the original PR carefully and build/test on at least one platform
-before landing.
+before landing. If the 3-way merge fails, then it is most likely that a conflicting
+PR has landed since the CI run and you will have to ask the author to rebase.
 
 Check and re-review the changes
 

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -103,16 +103,6 @@ to update from nodejs/node:
 * `git merge --ff-only upstream/master` (or `REMOTENAME/BRANCH`)
 
 
-## If `git am` fails
-
-* if `git am` fails – use `git am --abort`
-  * this usually means the PR needs updated
-  * prefer to make the originating user update the code, since they have it fresh in mind
-* first, reattempt with `git am -3` (3-way merge)`
-* if `-3` still fails, and you need to get it merged:
-  * `git fetch upstream pull/N/head:pr-N && git checkout pr-N && git rebase master`
-
-
 ## best practices
 
 * commit often, out to your github fork (origin), open a PR


### PR DESCRIPTION
The CI seems to do a 3way merge so it is possible
that even though the CI passed, the existing git am command
may fail.  Add text to suggest how to handle this
by adding the --3way option.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
doc
