### PR TITLE
test: use duplex streams in duplex stream test

### DIFF
--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -22,7 +22,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const Duplex = require('stream').Transform;
+const Duplex = require('stream').Duplex;
 
 const stream = new Duplex({ objectMode: true });
 


### PR DESCRIPTION
`test-stream-duplex.js` uses transform streams instead of the duplex stream base class. This leads to some code not being covered in the `Duplex` constructor.

This may lead to the equivalent code in the `Transform` constructor losing coverage. If that's the case, I'd prefer to fix that in a follow up PR.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test