### PR TITLE
test: minimize time for child_process benchmark

### DIFF
--- a/test/sequential/test-benchmark-child-process.js
+++ b/test/sequential/test-benchmark-child-process.js
@@ -11,6 +11,8 @@ const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 const child = fork(runjs, ['--set', 'dur=0.1',
                            '--set', 'n=1',
                            '--set', 'len=1',
+                           '--set', 'params=1',
+                           '--set', 'methodName=exec',
                            'child_process'],
                    {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
 child.on('exit', (code, signal) => {

--- a/test/sequential/test-benchmark-child-process.js
+++ b/test/sequential/test-benchmark-child-process.js
@@ -12,7 +12,7 @@ const child = fork(runjs, ['--set', 'dur=0.1',
                            '--set', 'n=1',
                            '--set', 'len=1',
                            '--set', 'params=1',
-                           '--set', 'methodName=exec',
+                           '--set', 'methodName=execSync',
                            'child_process'],
                    {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
 child.on('exit', (code, signal) => {

--- a/test/sequential/test-benchmark-child-process.js
+++ b/test/sequential/test-benchmark-child-process.js
@@ -8,7 +8,7 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
-const child = fork(runjs, ['--set', 'dur=0.1',
+const child = fork(runjs, ['--set', 'dur=0',
                            '--set', 'n=1',
                            '--set', 'len=1',
                            '--set', 'params=1',


### PR DESCRIPTION
test-benchmark-child-process sometimes times out on Windows in CI.
Minimize the number of configurations that run so it will (hopefully)
not time out anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process benchmark