### PR TITLE
stream: improve multiple callback error message

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -88,8 +88,10 @@ function afterTransform(stream, er, data) {
 
   var cb = ts.writecb;
 
-  if (!cb)
-    return stream.emit('error', new Error('no writecb in Transform class'));
+  if (!cb) {
+    return stream.emit('error',
+                       new Error('write callback called multiple times'));
+  }
 
   ts.writechunk = null;
   ts.writecb = null;

--- a/test/parallel/test-stream-transform-callback-twice.js
+++ b/test/parallel/test-stream-transform-callback-twice.js
@@ -1,0 +1,14 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Transform } = require('stream');
+const stream = new Transform({
+  transform(chunk, enc, cb) { cb(); cb(); }
+});
+
+stream.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.toString(),
+                     'Error: write callback called multiple times');
+}));
+
+stream.write('foo');


### PR DESCRIPTION
When a transform stream's callback is called more than once, an error is emitted with a somewhat confusing message. This commit hopes to improve the quality of the error message.

Fixes: https://github.com/nodejs/node/issues/12513

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
stream