### PR TITLE
querystring: improve querystring unescapeBuffer perf

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -64,69 +64,42 @@ const unhexTable = [
 // a safe fast alternative to decodeURIComponent
 function unescapeBuffer(s, decodeSpaces) {
   var out = Buffer.allocUnsafe(s.length);
-  var state = 0;
-  var n, m, hexchar, c;
-
-  for (var inIndex = 0, outIndex = 0; ; inIndex++) {
-    if (inIndex < s.length) {
-      c = s.charCodeAt(inIndex);
-    } else {
-      if (state > 0) {
-        out[outIndex++] = 37/*%*/;
-        if (state === 2)
-          out[outIndex++] = hexchar;
+  var index = 0;
+  var outIndex = 0;
+  var c, c1, n, m;
+  var maxLength = s.length - 2;
+  // Flag to know if some hex chars have been decoded
+  var hasHex = false;
+  while (index < s.length) {
+    c = s.charCodeAt(index);
+    if (c === 43 /*'+'*/ && decodeSpaces) {
+      out[outIndex++] = 32; // ' '
+      index++;
+      continue;
+    }
+    if (c === 37 /*'%'*/ && index < maxLength) {
+      c = s.charCodeAt(++index);
+      n = unhexTable[c];
+      if (n < 0) {
+        out[outIndex++] = 37; // '%'
+      } else {
+        c1 = s.charCodeAt(++index);
+        m = unhexTable[c1];
+        if (m < 0) {
+          out[outIndex++] = 37; // '%'
+          out[outIndex++] = c;
+          c = c1;
+        } else {
+          hasHex = true;
+          c = n * 16 + m;
+        }
       }
-      break;
     }
-    switch (state) {
-      case 0: // Any character
-        switch (c) {
-          case 37: // '%'
-            n = 0;
-            m = 0;
-            state = 1;
-            break;
-          case 43: // '+'
-            if (decodeSpaces)
-              c = 32; // ' '
-            // falls through
-          default:
-            out[outIndex++] = c;
-            break;
-        }
-        break;
-
-      case 1: // First hex digit
-        hexchar = c;
-        n = unhexTable[c];
-        if (!(n >= 0)) {
-          out[outIndex++] = 37/*%*/;
-          out[outIndex++] = c;
-          state = 0;
-          break;
-        }
-        state = 2;
-        break;
-
-      case 2: // Second hex digit
-        state = 0;
-        m = unhexTable[c];
-        if (!(m >= 0)) {
-          out[outIndex++] = 37/*%*/;
-          out[outIndex++] = hexchar;
-          out[outIndex++] = c;
-          break;
-        }
-        out[outIndex++] = 16 * n + m;
-        break;
-    }
+    out[outIndex++] = c;
+    index++;
   }
-
-  // TODO support returning arbitrary buffers.
-
-  return out.slice(0, outIndex);
+  return hasHex ? out.slice(0, outIndex) : out;
 }
-
 
 function qsUnescape(s, decodeSpaces) {
   try {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -80,12 +80,12 @@ function unescapeBuffer(s, decodeSpaces) {
     if (c === 37 /*'%'*/ && index < maxLength) {
       c = s.charCodeAt(++index);
       n = unhexTable[c];
-      if (n < 0) {
+      if !(n >= 0) {
         out[outIndex++] = 37; // '%'
       } else {
         c1 = s.charCodeAt(++index);
         m = unhexTable[c1];
-        if (m < 0) {
+        if !(m >= 0) {
           out[outIndex++] = 37; // '%'
           out[outIndex++] = c;
           c = c1;
@@ -100,6 +100,7 @@ function unescapeBuffer(s, decodeSpaces) {
   }
   return hasHex ? out.slice(0, outIndex) : out;
 }
+
 
 function qsUnescape(s, decodeSpaces) {
   try {

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -66,36 +66,39 @@ function unescapeBuffer(s, decodeSpaces) {
   var out = Buffer.allocUnsafe(s.length);
   var index = 0;
   var outIndex = 0;
-  var c, c1, n, m;
+  var currentChar;
+  var nextChar;
+  var hexHigh;
+  var hexLow;
   var maxLength = s.length - 2;
   // Flag to know if some hex chars have been decoded
   var hasHex = false;
   while (index < s.length) {
-    c = s.charCodeAt(index);
-    if (c === 43 /*'+'*/ && decodeSpaces) {
+    currentChar = s.charCodeAt(index);
+    if (currentChar === 43 /*'+'*/ && decodeSpaces) {
       out[outIndex++] = 32; // ' '
       index++;
       continue;
     }
-    if (c === 37 /*'%'*/ && index < maxLength) {
-      c = s.charCodeAt(++index);
-      n = unhexTable[c];
-      if (!(n >= 0)) {
+    if (currentChar === 37 /*'%'*/ && index < maxLength) {
+      currentChar = s.charCodeAt(++index);
+      hexHigh = unhexTable[currentChar];
+      if (!(hexHigh >= 0)) {
         out[outIndex++] = 37; // '%'
       } else {
-        c1 = s.charCodeAt(++index);
-        m = unhexTable[c1];
-        if (!(m >= 0)) {
+        nextChar = s.charCodeAt(++index);
+        hexLow = unhexTable[nextChar];
+        if (!(hexLow >= 0)) {
           out[outIndex++] = 37; // '%'
-          out[outIndex++] = c;
-          c = c1;
+          out[outIndex++] = currentChar;
+          currentChar = nextChar;
         } else {
           hasHex = true;
-          c = n * 16 + m;
+          currentChar = hexHigh * 16 + hexLow;
         }
       }
     }
-    out[outIndex++] = c;
+    out[outIndex++] = currentChar;
     index++;
   }
   return hasHex ? out.slice(0, outIndex) : out;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -80,12 +80,12 @@ function unescapeBuffer(s, decodeSpaces) {
     if (c === 37 /*'%'*/ && index < maxLength) {
       c = s.charCodeAt(++index);
       n = unhexTable[c];
-      if !(n >= 0) {
+      if (!(n >= 0)) {
         out[outIndex++] = 37; // '%'
       } else {
         c1 = s.charCodeAt(++index);
         m = unhexTable[c1];
-        if !(m >= 0) {
+        if (!(m >= 0)) {
           out[outIndex++] = 37; // '%'
           out[outIndex++] = c;
           c = c1;


### PR DESCRIPTION
Refactored the unescapeBuffer function in order to simplify it,
and also to improve the performance.

The benchmark:

```improvement confidence      p.value
querystring/querystring-unescapebuffer.js n=1000000 input="%20%21%2..."
   18.10 %        *** 6.671620e-29
querystring/querystring-unescapebuffer.js n=1000000 input="there%20..."
   2.75 %          * 1.775320e-02
querystring/querystring-unescapebuffer.js n=1000000 input="there%2Q..."
   34.12 %        *** 8.074612e-25
querystring/querystring-unescapebuffer.js n=1000000 input="there is..."
   27.92 %        *** 4.923348e-29
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
