### PR TITLE
test: check that pending warning is emitted once

### DIFF
--- a/test/parallel/test-buffer-pending-deprecation.js
+++ b/test/parallel/test-buffer-pending-deprecation.js
@@ -12,4 +12,10 @@ const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
 
 common.expectWarning('DeprecationWarning', bufferWarning);
 
+// This is used to make sure that a warning is only emitted once even though
+// `new Buffer()` is called twice.
+process.on('warning', common.mustCall());
+
+new Buffer(10);
+
 new Buffer(10);


### PR DESCRIPTION
Code for the new --pending-deprecation flag contains logic to make sure
the deprecation warning is emitted only once. However, this was not
being tested. Add test coverage for this situation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test buffer