### PR TITLE
src: replace IsConstructCalls with lambda

### DIFF
--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -53,11 +53,6 @@ class ShutdownWrap : public ReqWrap<uv_shutdown_t>,
     Wrap(req_wrap_obj, this);
   }
 
-  NODE_DEPRECATED("Use lambda expression instead",
-  static void NewShutdownWrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.IsConstructCall());
-  })
-
   static ShutdownWrap* from_req(uv_shutdown_t* req) {
     return ContainerOf(&ShutdownWrap::req_, req);
   }
@@ -83,11 +78,6 @@ class WriteWrap: public ReqWrap<uv_write_t>,
   inline StreamBase* wrap() const { return wrap_; }
 
   size_t self_size() const override { return storage_size_; }
-
-  NODE_DEPRECATED("Use lambda expression instead",
-  static void NewWriteWrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    CHECK(args.IsConstructCall());
-  })
 
   static WriteWrap* from_req(uv_write_t* req) {
     return ContainerOf(&WriteWrap::req_, req);

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -53,9 +53,10 @@ class ShutdownWrap : public ReqWrap<uv_shutdown_t>,
     Wrap(req_wrap_obj, this);
   }
 
+  NODE_DEPRECATED("Use lambda expression instead",
   static void NewShutdownWrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
     CHECK(args.IsConstructCall());
-  }
+  })
 
   static ShutdownWrap* from_req(uv_shutdown_t* req) {
     return ContainerOf(&ShutdownWrap::req_, req);
@@ -83,9 +84,10 @@ class WriteWrap: public ReqWrap<uv_write_t>,
 
   size_t self_size() const override { return storage_size_; }
 
+  NODE_DEPRECATED("Use lambda expression instead",
   static void NewWriteWrap(const v8::FunctionCallbackInfo<v8::Value>& args) {
     CHECK(args.IsConstructCall());
-  }
+  })
 
   static WriteWrap* from_req(uv_write_t* req) {
     return ContainerOf(&WriteWrap::req_, req);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -59,15 +59,19 @@ void StreamWrap::Initialize(Local<Object> target,
                             Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
+  auto is_construct_call_callback =
+      [](const FunctionCallbackInfo<Value>& args) {
+    CHECK(args.IsConstructCall());
+  };
   Local<FunctionTemplate> sw =
-      FunctionTemplate::New(env->isolate(), ShutdownWrap::NewShutdownWrap);
+      FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   sw->InstanceTemplate()->SetInternalFieldCount(1);
   sw->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap"));
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap"),
               sw->GetFunction());
 
   Local<FunctionTemplate> ww =
-      FunctionTemplate::New(env->isolate(), WriteWrap::NewWriteWrap);
+      FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   ww->InstanceTemplate()->SetInternalFieldCount(1);
   ww->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap"));
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap"),


### PR DESCRIPTION
I've added a deprecation notice as the functions are public, but not
sure if this is correct or the format of the deprecation notice.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src