### PR TITLE
deps: backport 75f2d65f00 from upstream V8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 98
+#define V8_PATCH_LEVEL 99
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/ast/scopes.cc
+++ b/deps/v8/src/ast/scopes.cc
@@ -1083,12 +1083,15 @@ Variable* Scope::LookupRecursive(VariableProxy* proxy,
     if (var != NULL && proxy->is_assigned()) var->set_maybe_assigned();
     *binding_kind = DYNAMIC_LOOKUP;
     return NULL;
-  } else if (calls_sloppy_eval() && !is_script_scope() &&
-             name_can_be_shadowed) {
+  } else if (calls_sloppy_eval() && is_declaration_scope() &&
+             !is_script_scope() && name_can_be_shadowed) {
     // A variable binding may have been found in an outer scope, but the current
     // scope makes a sloppy 'eval' call, so the found variable may not be
     // the correct one (the 'eval' may introduce a binding with the same name).
     // In that case, change the lookup result to reflect this situation.
+    // Only scopes that can host var bindings (declaration scopes) need be
+    // considered here (this excludes block and catch scopes), and variable
+    // lookups at script scope are always dynamic.
     if (*binding_kind == BOUND) {
       *binding_kind = BOUND_EVAL_SHADOWED;
     } else if (*binding_kind == UNBOUND) {

--- a/deps/v8/test/mjsunit/regress/regress-crbug-608279.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-608279.js
@@ -1,0 +1,18 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Flags: --always-opt --no-lazy
+
+function __f_38() {
+  try {
+    throw 0;
+  } catch (e) {
+    eval();
+    var __v_38 = { a: 'hest' };
+    __v_38.m = function () { return __v_38.a; };
+  }
+  return __v_38;
+}
+var __v_40 = __f_38();
+__v_40.m();


### PR DESCRIPTION
Original commit message:

    Don't treat catch scopes as possibly-shadowing for sloppy eval

    Scope analysis is over-conservative when treating variable
    resolutions as possibly-shadowed by a sloppy eval. In the attached
    bug, this comes into play since catch scopes have different behavior
    with respect to the "calls eval" in eager vs lazy compilation (in
    the latter, they are never marked as "calls eval" because
    CatchContexts don't have an associated ScopeInfo).

    This patch changes the scope-type check to also eliminate a few
    other cases where shadowing isn't possible, such as non-declaration
    block scopes.

    BUG=chromium:608279
    LOG=n

    Committed:
    https://crrev.com/75f2d65f003ebb22815489e9970913ba37234f1b
    Cr-Commit-Position: refs/heads/master@{#36046}

Fixes: #12308

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
deps
