### PR TITLE
n-api: tighten null-checking and clean up last error

### DIFF
--- a/test/addons-napi/common.h
+++ b/test/addons-napi/common.h
@@ -3,12 +3,12 @@
 
 #define GET_AND_THROW_LAST_ERROR(env)                                    \
   do {                                                                   \
+    const napi_extended_error_info *error_info;                          \
+    napi_get_last_error_info((env), &error_info);                        \
     bool is_pending;                                                     \
     napi_is_exception_pending((env), &is_pending);                       \
     /* If an exception is already pending, don't rethrow it */           \
     if (!is_pending) {                                                   \
-      const napi_extended_error_info* error_info;                        \
-      napi_get_last_error_info((env), &error_info);                      \
       const char* error_message = error_info->error_message != NULL ?    \
         error_info->error_message :                                      \
         "empty error message";                                           \


### PR DESCRIPTION
We left out null-checks for many of the parameters passed to our APIs.
In particular, arguments of type `napi_value` were often accepted
without a null-check, even though they should never be null.

Additionally, many APIs simply returned `napi_ok` on success. This
leaves in place an error that may have occurred in a previous N-API
call. Others (those which perform `NAPI_PREAMBLE(env)` at the top)
OTOH explicitly clear the last error before proceeding. With this
modification all APIs explicitly clear the last error on success.

Fixes https://github.com/nodejs/abi-stable-node/issues/227

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api