### PR TITLE
src: add fcntl.h include to node.cc

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -80,6 +80,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <fcntl.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
PR https://github.com/nodejs/node/pull/11863 added `_O_RDWR` to `node.cc` which is defined in fcntl.h. This adds this include directly to `node.cc` to prevent build fails like in https://github.com/nodejs/node/pull/12498

/cc @MylesBorins 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src
