### PR TITLE
doc: improve randomfill and fix broken link

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1713,18 +1713,18 @@ This should normally never take longer than a few milliseconds. The only time
 when generating the random bytes may conceivably block for a longer period of
 time is right after boot, when the whole system is still low on entropy.
 
-### crypto.randomFillSync(buf[, offset][, size])
+### crypto.randomFillSync(buffer[, offset][, size])
 <!-- YAML
 added: REPLACEME
 -->
 
-* `buf` {Buffer|Uint8Array} Must be supplied.
+* `buffer` {Buffer|Uint8Array} Must be supplied.
 * `offset` {number} Defaults to `0`.
-* `size` {number} Defaults to `buf.length - offset`.
+* `size` {number} Defaults to `buffer.length - offset`.
 
 Synchronous version of [`crypto.randomFill()`][].
 
-Returns `buf`
+Returns `buffer`
 
 ```js
 const buf = Buffer.alloc(10);
@@ -1738,14 +1738,14 @@ crypto.randomFillSync(buf, 5, 5);
 console.log(buf.toString('hex'));
 ```
 
-### crypto.randomFill(buf[, offset][, size], callback)
+### crypto.randomFill(buffer[, offset][, size], callback)
 <!-- YAML
 added: REPLACEME
 -->
 
-* `buf` {Buffer|Uint8Array} Must be supplied.
+* `buffer` {Buffer|Uint8Array} Must be supplied.
 * `offset` {number} Defaults to `0`.
-* `size` {number} Defaults to `buf.length - offset`.
+* `size` {number} Defaults to `buffer.length - offset`.
 * `callback` {Function} `function(err, buf) {}`.
 
 This function is similar to [`crypto.randomBytes()`][] but requires the first
@@ -2213,7 +2213,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`crypto.getHashes()`]: #crypto_crypto_gethashes
 [`crypto.pbkdf2()`]: #crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
 [`crypto.randomBytes()`]: #crypto_crypto_randombytes_size_callback
-[`crypto.randomFill()`]: #crypto_crypto_randombytesbuffer_buf_size_offset_cb
+[`crypto.randomFill()`]: #crypto_crypto_randomfill_buffer_offset_size_callback
 [`decipher.final()`]: #crypto_decipher_final_output_encoding
 [`decipher.update()`]: #crypto_decipher_update_data_input_encoding_output_encoding
 [`diffieHellman.setPublicKey()`]: #crypto_diffiehellman_setpublickey_public_key_encoding


### PR DESCRIPTION
This patch replaces the word `buf` with `buffer` and fixes the broken
link to `randomfill`.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

doc crypo

---

cc @evanlucas 