### PR TITLE
v8: update v8 patch version number (v7.x)

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 372
-#define V8_PATCH_LEVEL 43
+#define V8_PATCH_LEVEL 48
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/builtins/builtins-object.cc
+++ b/deps/v8/src/builtins/builtins-object.cc
@@ -300,10 +300,10 @@ void Builtins::Generate_ObjectProtoToString(CodeStubAssembler* assembler) {
   Node* context = assembler->Parameter(3);
 
   assembler->GotoIf(
-      assembler->Word32Equal(receiver, assembler->UndefinedConstant()),
+      assembler->WordEqual(receiver, assembler->UndefinedConstant()),
       &return_undefined);
 
-  assembler->GotoIf(assembler->Word32Equal(receiver, assembler->NullConstant()),
+  assembler->GotoIf(assembler->WordEqual(receiver, assembler->NullConstant()),
                     &return_null);
 
   assembler->GotoIf(assembler->WordIsSmi(receiver), &return_number);

--- a/deps/v8/src/objects-body-descriptors.h
+++ b/deps/v8/src/objects-body-descriptors.h
@@ -99,7 +99,7 @@ class FixedBodyDescriptor final : public BodyDescriptorBase {
 
   template <typename StaticVisitor>
   static inline void IterateBody(HeapObject* obj, int object_size) {
-    IterateBody(obj);
+    IterateBody<StaticVisitor>(obj);
   }
 };
 

--- a/deps/v8/src/objects-inl.h
+++ b/deps/v8/src/objects-inl.h
@@ -39,6 +39,27 @@
 namespace v8 {
 namespace internal {
 
+template <typename Derived, typename Shape, typename Key>
+uint32_t HashTable<Derived, Shape, Key>::Hash(Key key) {
+  if (Shape::UsesSeed) {
+    return Shape::SeededHash(key, GetHeap()->HashSeed());
+  } else {
+    return Shape::Hash(key);
+  }
+}
+
+
+template <typename Derived, typename Shape, typename Key>
+uint32_t HashTable<Derived, Shape, Key>::HashForObject(Key key,
+                                                       Object* object) {
+  if (Shape::UsesSeed) {
+    return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
+  } else {
+    return Shape::HashForObject(key, object);
+  }
+}
+
+
 PropertyDetails::PropertyDetails(Smi* smi) {
   value_ = smi->value();
 }

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -3352,22 +3352,10 @@ class HashTable : public HashTableBase {
  public:
   typedef Shape ShapeT;
 
-  // Wrapper methods
-  inline uint32_t Hash(Key key) {
-    if (Shape::UsesSeed) {
-      return Shape::SeededHash(key, GetHeap()->HashSeed());
-    } else {
-      return Shape::Hash(key);
-    }
-  }
-
-  inline uint32_t HashForObject(Key key, Object* object) {
-    if (Shape::UsesSeed) {
-      return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
-    } else {
-      return Shape::HashForObject(key, object);
-    }
-  }
+  // Wrapper methods.  Defined in src/objects-inl.h
+  // to break a cycle with src/heap/heap.h.
+  inline uint32_t Hash(Key key);
+  inline uint32_t HashForObject(Key key, Object* object);
 
   // Returns a new HashTable object.
   MUST_USE_RESULT static Handle<Derived> New(

--- a/deps/v8/test/mjsunit/regress/regress-crbug-664506.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-664506.js
@@ -1,0 +1,11 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-gc --predictable --random-seed=-1109634722
+
+gc();
+gc();
+assertEquals("[object Object]", Object.prototype.toString.call({}));
+gc();
+assertEquals("[object Array]", Object.prototype.toString.call([]));


### PR DESCRIPTION
We (including yours truly) have been less than stellar with bumping
the patch level for every change to deps/v8.  This commit rectifies
that and covers the following commits:

2bbee49 v8: fix build errors with g++ 7
f882f47 deps: cherry-pick 79aee39 from upstream v8
9f73df5 deps: cherry-pick 22858cb from V8 upstream
a735c16 deps: backport ec1ffe3 from upstream V8
6130d54 deps: backport 8dde6ac from upstream V8