### PR TITLE
src: expose V8's IsNativeError() in util bindings

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -25,6 +25,7 @@ using v8::Value;
   V(isExternal, IsExternal)                                                   \
   V(isMap, IsMap)                                                             \
   V(isMapIterator, IsMapIterator)                                             \
+  V(isNativeError, IsNativeError)                                             \
   V(isPromise, IsPromise)                                                     \
   V(isRegExp, IsRegExp)                                                       \
   V(isSet, IsSet)                                                             \

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -23,6 +23,7 @@
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
+const binding = process.binding('util');
 const context = require('vm').runInNewContext;
 
 // isArray
@@ -153,3 +154,20 @@ util.print('test');
 util.puts('test');
 util.debug('test');
 util.error('test');
+
+{
+  // binding.isNativeError()
+  assert.strictEqual(binding.isNativeError(new Error()), true);
+  assert.strictEqual(binding.isNativeError(new TypeError()), true);
+  assert.strictEqual(binding.isNativeError(new SyntaxError()), true);
+  assert.strictEqual(binding.isNativeError(new (context('Error'))()), true);
+  assert.strictEqual(binding.isNativeError(new (context('TypeError'))()), true);
+  assert.strictEqual(binding.isNativeError(new (context('SyntaxError'))()),
+                     true);
+  assert.strictEqual(binding.isNativeError({}), false);
+  assert.strictEqual(binding.isNativeError({ name: 'Error', message: '' }),
+                     false);
+  assert.strictEqual(binding.isNativeError([]), false);
+  assert.strictEqual(binding.isNativeError(Object.create(Error.prototype)),
+                     false);
+}


### PR DESCRIPTION
Exposes `IsNativeError()` through `process.binding('util')`. The tests are copied from `util.isError()`. The results are the same with the exception of the last one (object inheriting from `Error`).

R= @addaleax because of https://github.com/nodejs/node/pull/12400#discussion_r111581603

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src