### PR TITLE
test: dynamic port in test cluster eaddrinuse

### DIFF
--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -30,11 +30,12 @@ const fork = require('child_process').fork;
 const net = require('net');
 
 const id = '' + process.argv[2];
+const port = '' + process.argv[3];
 
 if (id === 'undefined') {
   const server = net.createServer(common.mustNotCall());
-  server.listen(common.PORT, function() {
-    const worker = fork(__filename, ['worker']);
+  server.listen(0, function() {
+    const worker = fork(__filename, ['worker', server.address().port]);
     worker.on('message', function(msg) {
       if (msg !== 'stop-listening') return;
       server.close(function() {
@@ -44,14 +45,14 @@ if (id === 'undefined') {
   });
 } else if (id === 'worker') {
   let server = net.createServer(common.mustNotCall());
-  server.listen(common.PORT, common.mustNotCall());
+  server.listen(port, common.mustNotCall());
   server.on('error', common.mustCall(function(e) {
     assert(e.code, 'EADDRINUSE');
     process.send('stop-listening');
     process.once('message', function(msg) {
       if (msg !== 'stopped-listening') return;
       server = net.createServer(common.mustNotCall());
-      server.listen(common.PORT, common.mustCall(function() {
+      server.listen(port, common.mustCall(function() {
         server.close();
       }));
     });


### PR DESCRIPTION
Removed common.PORT from test-cluster-eaddrinuse to eliminate the
possibility that a dynamic port used in another test will collide
with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
