### PR TITLE
src: call linux getauxval(AT_SECURE) in SafeGetenv

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -230,6 +230,8 @@ bool config_expose_internals = false;
 
 bool v8_initialized = false;
 
+bool linux_at_secure = false;
+
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
 static bool debugger_running;
@@ -959,13 +961,15 @@ Local<Value> UVException(Isolate* isolate,
 // Look up environment variable unless running as setuid root.
 bool SafeGetenv(const char* key, std::string* text) {
 #ifndef _WIN32
-  // TODO(bnoordhuis) Should perhaps also check whether getauxval(AT_SECURE)
-  // is non-zero on Linux.
   if (getuid() != geteuid() || getgid() != getegid()) {
     text->clear();
     return false;
   }
 #endif
+  if (linux_at_secure) {
+    text->clear();
+    return false;
+  }
   if (const char* value = getenv(key)) {
     *text = value;
     return true;

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -78,7 +78,7 @@ int wmain(int argc, wchar_t *wargv[]) {
 #else
 #define Elf_auxv_t Elf32_auxv_t
 #endif  // __LP64__
-extern char **environ;
+extern char** environ;
 #endif  // __linux__
 
 namespace node {

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -73,7 +73,6 @@ int wmain(int argc, wchar_t *wargv[]) {
 // UNIX
 #ifdef __linux__
 #include <elf.h>
-#include <inttypes.h>
 #ifdef __LP64__
 #define Elf_auxv_t Elf64_auxv_t
 #else

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -71,7 +71,33 @@ int wmain(int argc, wchar_t *wargv[]) {
 }
 #else
 // UNIX
+#ifdef __linux__
+#include <elf.h>
+#include <inttypes.h>
+#ifdef __LP64__
+#define Elf_auxv_t Elf64_auxv_t
+#else
+#define Elf_auxv_t Elf32_auxv_t
+#endif  // __LP64__
+extern char **environ;
+#endif  // __linux__
+
+namespace node {
+  extern bool linux_at_secure;
+}  // namespace node
+
 int main(int argc, char *argv[]) {
+#if defined(__linux__)
+  char** envp = environ;
+  while (*envp++ != nullptr) {}
+  Elf_auxv_t* auxv = reinterpret_cast<Elf_auxv_t*>(envp);
+  for (; auxv->a_type != AT_NULL; auxv++) {
+    if (auxv->a_type == AT_SECURE) {
+      node::linux_at_secure = auxv->a_un.a_val;
+      break;
+    }
+  }
+#endif
   // Disable stdio buffering, it interacts poorly with printf()
   // calls elsewhere in the program (e.g., any logging from V8.)
   setvbuf(stdout, nullptr, _IONBF, 0);


### PR DESCRIPTION
This commit attempts to fix the following TODO:
```
// TODO(bnoordhuis) Should perhaps also check whether getauxval(AT_SECURE) is non-zero on Linux.
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src