### PR TITLE
doc: unify trailing commas in code examples

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -64,18 +64,18 @@ const assert = require('assert');
 
 const obj1 = {
   a : {
-    b : 1
-  }
+    b : 1,
+  },
 };
 const obj2 = {
   a : {
-    b : 2
-  }
+    b : 2,
+  },
 };
 const obj3 = {
   a : {
-    b : 1
-  }
+    b : 1,
+  },
 };
 const obj4 = Object.create(obj1);
 
@@ -323,18 +323,18 @@ const assert = require('assert');
 
 const obj1 = {
   a : {
-    b : 1
-  }
+    b : 1,
+  },
 };
 const obj2 = {
   a : {
-    b : 2
-  }
+    b : 2,
+  },
 };
 const obj3 = {
   a : {
-    b : 1
-  }
+    b : 1,
+  },
 };
 const obj4 = Object.create(obj1);
 

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -201,7 +201,7 @@ the process is spawned. The default options are:
   maxBuffer: 200*1024,
   killSignal: 'SIGTERM',
   cwd: null,
-  env: null
+  env: null,
 }
 ```
 
@@ -364,7 +364,7 @@ A third argument may be used to specify additional options, with these defaults:
 ```js
 {
   cwd: undefined,
-  env: process.env
+  env: process.env,
 }
 ```
 
@@ -487,7 +487,7 @@ const spawn = require('child_process').spawn;
 
 const child = spawn(process.argv[0], ['child_program.js'], {
   detached: true,
-  stdio: 'ignore'
+  stdio: 'ignore',
 });
 
 child.unref();
@@ -503,7 +503,7 @@ const err = fs.openSync('./out.log', 'a');
 
 const child = spawn('prg', [], {
   detached: true,
-  stdio: [ 'ignore', out, err ]
+  stdio: [ 'ignore', out, err ],
 });
 
 child.unref();
@@ -934,9 +934,9 @@ const spawn = require('child_process').spawn;
 const child = spawn('sh', ['-c',
   `node -e "setInterval(() => {
       console.log(process.pid, 'is alive')
-    }, 500);"`
+    }, 500);"`,
   ], {
-    stdio: ['inherit', 'inherit', 'inherit']
+    stdio: ['inherit', 'inherit', 'inherit'],
   });
 
 setTimeout(() => {
@@ -1192,8 +1192,8 @@ const child = child_process.spawn('ls', {
   stdio: [
     0, // Use parent's stdin for child
     'pipe', // Pipe child's stdout to parent
-    fs.openSync('err.out', 'w') // Direct child's stderr to a file
-  ]
+    fs.openSync('err.out', 'w'), // Direct child's stderr to a file
+  ],
 });
 
 assert.strictEqual(child.stdio[0], null);

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -789,12 +789,12 @@ const cluster = require('cluster');
 cluster.setupMaster({
   exec: 'worker.js',
   args: ['--use', 'https'],
-  silent: true
+  silent: true,
 });
 cluster.fork(); // https worker
 cluster.setupMaster({
   exec: 'worker.js',
-  args: ['--use', 'http']
+  args: ['--use', 'http'],
 });
 cluster.fork(); // http worker
 ```

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -197,7 +197,7 @@ An example socket listening on an exclusive port is shown below.
 socket.bind({
   address: 'localhost',
   port: 8000,
-  exclusive: true
+  exclusive: true,
 });
 ```
 

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -300,7 +300,7 @@ For example:
   regexp: '',
   replacement: '_sip._udp.example.com',
   order: 30,
-  preference: 100
+  preference: 100,
 }
 ```
 
@@ -360,7 +360,7 @@ be an object with the following properties:
   refresh: 10000,
   retry: 2400,
   expire: 604800,
-  minttl: 3600
+  minttl: 3600,
 }
 ```
 
@@ -387,7 +387,7 @@ be an array of objects with the following properties:
   priority: 10,
   weight: 5,
   port: 21223,
-  name: 'service.example.com'
+  name: 'service.example.com',
 }
 ```
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -635,7 +635,7 @@ default value of 64 kb for the same parameter.
   encoding: null,
   fd: null,
   mode: 0o666,
-  autoClose: true
+  autoClose: true,
 }
 ```
 
@@ -701,7 +701,7 @@ Returns a new [`WriteStream`][] object. (See [Writable Stream][]).
   defaultEncoding: 'utf8',
   fd: null,
   mode: 0o666,
-  autoClose: true
+  autoClose: true,
 }
 ```
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -97,7 +97,7 @@ http.get({
   hostname: 'localhost',
   port: 80,
   path: '/',
-  agent: false  // create a new agent just for this one request
+  agent: false,  // create a new agent just for this one request
 }, (res) => {
   // Do stuff with response
 });
@@ -334,7 +334,7 @@ proxy.listen(1337, '127.0.0.1', () => {
     port: 1337,
     hostname: '127.0.0.1',
     method: 'CONNECT',
-    path: 'www.google.com:80'
+    path: 'www.google.com:80',
   };
 
   const req = http.request(options);
@@ -427,8 +427,8 @@ srv.listen(1337, '127.0.0.1', () => {
     hostname: '127.0.0.1',
     headers: {
       'Connection': 'Upgrade',
-      'Upgrade': 'websocket'
-    }
+      'Upgrade': 'websocket',
+    },
   };
 
   const req = http.request(options);
@@ -1667,7 +1667,7 @@ Example:
 
 ```js
 const postData = querystring.stringify({
-  'msg': 'Hello World!'
+  'msg': 'Hello World!',
 });
 
 const options = {
@@ -1677,8 +1677,8 @@ const options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Content-Length': Buffer.byteLength(postData)
-  }
+    'Content-Length': Buffer.byteLength(postData),
+  },
 };
 
 const req = http.request(options, (res) => {

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -54,7 +54,7 @@ const fs = require('fs');
 
 const options = {
   key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
-  cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
+  cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem'),
 };
 
 https.createServer(options, (req, res) => {
@@ -71,7 +71,7 @@ const fs = require('fs');
 
 const options = {
   pfx: fs.readFileSync('test/fixtures/test_cert.pfx'),
-  passphrase: 'sample'
+  passphrase: 'sample',
 };
 
 https.createServer(options, (req, res) => {
@@ -172,7 +172,7 @@ const options = {
   hostname: 'encrypted.google.com',
   port: 443,
   path: '/',
-  method: 'GET'
+  method: 'GET',
 };
 
 const req = https.request(options, (res) => {
@@ -198,7 +198,7 @@ const options = {
   path: '/',
   method: 'GET',
   key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
-  cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
+  cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem'),
 };
 options.agent = new https.Agent(options);
 
@@ -219,7 +219,7 @@ const options = {
   method: 'GET',
   key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
   cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem'),
-  agent: false
+  agent: false,
 };
 
 const req = https.request(options, (res) => {

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -54,7 +54,7 @@ The `square` module is defined in `square.js`:
 // assigning to exports will not modify module, must use module.exports
 module.exports = (width) => {
   return {
-    area: () => width ** 2
+    area: () => width ** 2,
   };
 };
 ```

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -256,7 +256,7 @@ shown below.
 server.listen({
   host: 'localhost',
   port: 80,
-  exclusive: true
+  exclusive: true,
 });
 ```
 

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -81,8 +81,8 @@ For example:
       nice: 0,
       sys: 30340,
       idle: 1070356870,
-      irq: 0
-    }
+      irq: 0,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -92,8 +92,8 @@ For example:
       nice: 0,
       sys: 26980,
       idle: 1071569080,
-      irq: 0
-    }
+      irq: 0,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -103,8 +103,8 @@ For example:
       nice: 0,
       sys: 21750,
       idle: 1070919370,
-      irq: 0
-    }
+      irq: 0,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -114,8 +114,8 @@ For example:
       nice: 0,
       sys: 19430,
       idle: 1070905480,
-      irq: 20
-    }
+      irq: 20,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -125,8 +125,8 @@ For example:
       nice: 20,
       sys: 40900,
       idle: 1070842510,
-      irq: 0
-    }
+      irq: 0,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -136,8 +136,8 @@ For example:
       nice: 0,
       sys: 34360,
       idle: 1070888000,
-      irq: 10
-    }
+      irq: 10,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -147,8 +147,8 @@ For example:
       nice: 0,
       sys: 55410,
       idle: 1071129970,
-      irq: 880
-    }
+      irq: 880,
+    },
   },
   {
     model: 'Intel(R) Core(TM) i7 CPU         860  @ 2.80GHz',
@@ -158,9 +158,9 @@ For example:
       nice: 1480,
       sys: 34920,
       idle: 1072572010,
-      irq: 30
-    }
-  }
+      irq: 30,
+    },
+  },
 ]
 ```
 
@@ -261,15 +261,15 @@ The properties available on the assigned network address object include:
       netmask: '255.0.0.0',
       family: 'IPv4',
       mac: '00:00:00:00:00:00',
-      internal: true
+      internal: true,
     },
     {
       address: '::1',
       netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
       family: 'IPv6',
       mac: '00:00:00:00:00:00',
-      internal: true
-    }
+      internal: true,
+    },
   ],
   eth0: [
     {
@@ -277,16 +277,16 @@ The properties available on the assigned network address object include:
       netmask: '255.255.255.0',
       family: 'IPv4',
       mac: '01:02:03:0a:0b:0c',
-      internal: false
+      internal: false,
     },
     {
       address: 'fe80::a00:27ff:fe4e:66a1',
       netmask: 'ffff:ffff:ffff:ffff::',
       family: 'IPv6',
       mac: '01:02:03:0a:0b:0c',
-      internal: false
-    }
-  ]
+      internal: false,
+    },
+  ],
 }
 ```
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -211,7 +211,7 @@ For example, on POSIX:
 path.format({
   root: '/ignored',
   dir: '/home/user/dir',
-  base: 'file.txt'
+  base: 'file.txt',
 });
 // Returns: '/home/user/dir/file.txt'
 
@@ -221,7 +221,7 @@ path.format({
 path.format({
   root: '/',
   base: 'file.txt',
-  ext: 'ignored'
+  ext: 'ignored',
 });
 // Returns: '/file.txt'
 
@@ -229,7 +229,7 @@ path.format({
 path.format({
   root: '/',
   name: 'file',
-  ext: '.txt'
+  ext: '.txt',
 });
 // Returns: '/file.txt'
 ```
@@ -239,7 +239,7 @@ On Windows:
 ```js
 path.format({
   dir: 'C:\\path\\dir',
-  base: 'file.txt'
+  base: 'file.txt',
 });
 // Returns: 'C:\\path\\dir\\file.txt'
 ```

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -530,16 +530,14 @@ running the `./configure` script.
 An example of the possible output looks like:
 
 ```js
-{
-  target_defaults:
+{ target_defaults:
    { cflags: [],
      default_configuration: 'Release',
      defines: [],
      include_dirs: [],
      libraries: [] },
   variables:
-   {
-     host_arch: 'x64',
+   { host_arch: 'x64',
      node_install_npm: 'true',
      node_prefix: '',
      node_shared_cares: 'false',
@@ -551,9 +549,7 @@ An example of the possible output looks like:
      node_shared_openssl: 'false',
      strict_aliasing: 'true',
      target_arch: 'x64',
-     v8_use_snapshot: 'true'
-   }
-}
+     v8_use_snapshot: 'true' } }
 ```
 
 *Note*: The `process.config` property is **not** read-only and there are
@@ -757,7 +753,7 @@ An example of this object looks like:
   SHLVL: '1',
   HOME: '/Users/maciej',
   LOGNAME: 'maciej',
-  _: '/usr/local/bin/node'
+  _: '/usr/local/bin/node',
 }
 ```
 
@@ -1175,12 +1171,10 @@ console.log(process.memoryUsage());
 Will generate:
 
 ```js
-{
-  rss: 4935680,
+{ rss: 4935680,
   heapTotal: 1826816,
   heapUsed: 650472,
-  external: 49879
-}
+  external: 49879 }
 ```
 
 `heapTotal` and `heapUsed` refer to V8's memory usage.
@@ -1346,13 +1340,11 @@ tarball.
 For example:
 
 ```js
-{
-  name: 'node',
+{ name: 'node',
   lts: 'Argon',
   sourceUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5.tar.gz',
   headersUrl: 'https://nodejs.org/download/release/v4.4.5/node-v4.4.5-headers.tar.gz',
-  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib'
-}
+  libUrl: 'https://nodejs.org/download/release/v4.4.5/win-x64/node.lib' }
 ```
 
 In custom builds from non-release versions of the source tree, only the
@@ -1711,8 +1703,7 @@ console.log(process.versions);
 Will generate output similar to:
 
 ```js
-{
-  http_parser: '2.3.0',
+{ http_parser: '2.3.0',
   node: '1.1.1',
   v8: '4.1.0.14',
   uv: '1.3.0',

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -62,7 +62,7 @@ For example, the query string `'foo=bar&abc=xyz&abc=123'` is parsed into:
 ```js
 {
   foo: 'bar',
-  abc: ['xyz', '123']
+  abc: ['xyz', '123'],
 }
 ```
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -16,7 +16,7 @@ const readline = require('readline');
 
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 
 rl.question('What do you think of Node.js? ', (answer) => {
@@ -383,7 +383,7 @@ For example:
 const readline = require('readline');
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 ```
 
@@ -486,7 +486,7 @@ const readline = require('readline');
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
-  prompt: 'OHAI> '
+  prompt: 'OHAI> ',
 });
 
 rl.prompt();
@@ -518,7 +518,7 @@ const readline = require('readline');
 const fs = require('fs');
 
 const rl = readline.createInterface({
-  input: fs.createReadStream('sample.txt')
+  input: fs.createReadStream('sample.txt'),
 });
 
 rl.on('line', (line) => {

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -121,7 +121,7 @@ const r = repl.start('> ');
 Object.defineProperty(r.context, 'm', {
   configurable: false,
   enumerable: true,
-  value: msg
+  value: msg,
 });
 ```
 
@@ -333,7 +333,7 @@ replServer.defineCommand('sayhello', {
     this.bufferedCommand = '';
     console.log(`Hello, ${name}!`);
     this.displayPrompt();
-  }
+  },
 });
 replServer.defineCommand('saybye', () => {
   console.log('Goodbye!');
@@ -517,7 +517,7 @@ let connections = 0;
 repl.start({
   prompt: 'Node.js via stdin> ',
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 });
 
 net.createServer((socket) => {
@@ -525,7 +525,7 @@ net.createServer((socket) => {
   repl.start({
     prompt: 'Node.js via Unix socket> ',
     input: socket,
-    output: socket
+    output: socket,
   }).on('exit', () => {
     socket.end();
   });
@@ -536,7 +536,7 @@ net.createServer((socket) => {
   repl.start({
     prompt: 'Node.js via TCP socket> ',
     input: socket,
-    output: socket
+    output: socket,
   }).on('exit', () => {
     socket.end();
   });

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1221,7 +1221,7 @@ const Writable = require('stream').Writable;
 const myWritable = new Writable({
   write(chunk, encoding, callback) {
     // ...
-  }
+  },
 });
 ```
 
@@ -1289,7 +1289,7 @@ const myWritable = new Writable({
   },
   writev(chunks, callback) {
     // ...
-  }
+  },
 });
 ```
 
@@ -1379,7 +1379,7 @@ const myWritable = new Writable({
     } else {
       callback();
     }
-  }
+  },
 });
 ```
 
@@ -1464,7 +1464,7 @@ const Readable = require('stream').Readable;
 const myReadable = new Readable({
   read(size) {
     // ...
-  }
+  },
 });
 ```
 
@@ -1576,7 +1576,7 @@ const myReadable = new Readable({
       return;
     }
     // do some work
-  }
+  },
 });
 ```
 
@@ -1679,7 +1679,7 @@ const myDuplex = new Duplex({
   },
   write(chunk, encoding, callback) {
     // ...
-  }
+  },
 });
 ```
 
@@ -1750,7 +1750,7 @@ const myTransform = new Transform({
 
     // Push the data onto the readable queue.
     callback(null, '0'.repeat(data.length % 2) + data);
-  }
+  },
 });
 
 myTransform.setEncoding('ascii');
@@ -1831,7 +1831,7 @@ const Transform = require('stream').Transform;
 const myTransform = new Transform({
   transform(chunk, encoding, callback) {
     // ...
-  }
+  },
 });
 ```
 

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -830,7 +830,7 @@ const options = {
   cert: fs.readFileSync('client-cert.pem'),
 
   // Necessary only if the server uses the self-signed certificate
-  ca: [ fs.readFileSync('server-cert.pem') ]
+  ca: [ fs.readFileSync('server-cert.pem') ],
 };
 
 const socket = tls.connect(8000, options, () => {
@@ -855,7 +855,7 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  pfx: fs.readFileSync('client.pfx')
+  pfx: fs.readFileSync('client.pfx'),
 };
 
 const socket = tls.connect(8000, options, () => {
@@ -1079,7 +1079,7 @@ const options = {
   requestCert: true,
 
   // This is necessary only if the client uses the self-signed certificate.
-  ca: [ fs.readFileSync('client-cert.pem') ]
+  ca: [ fs.readFileSync('client-cert.pem') ],
 };
 
 const server = tls.createServer(options, (socket) => {

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -688,7 +688,7 @@ with [`JSON.stringify()`][].
 ```js
 const myURLs = [
   new URL('https://www.example.com'),
-  new URL('https://test.example.org')
+  new URL('https://test.example.org'),
 ];
 console.log(JSON.stringify(myURLs));
   // Prints ["https://www.example.com/","https://test.example.org/"]
@@ -781,7 +781,7 @@ which simply joins all array elements with commas.
 const { URLSearchParams } = require('url');
 const params = new URLSearchParams({
   user: 'abc',
-  query: ['first', 'second']
+  query: ['first', 'second'],
 });
 console.log(params.getAll('query'));
   // Prints ['first,second']
@@ -810,7 +810,7 @@ let params;
 params = new URLSearchParams([
   ['user', 'abc'],
   ['query', 'first'],
-  ['query', 'second']
+  ['query', 'second'],
 ]);
 console.log(params.toString());
   // Prints 'user=abc&query=first&query=second'
@@ -835,7 +835,7 @@ console.log(params.toString());
 
 // Each key-value pair must have exactly two elements
 new URLSearchParams([
-  ['user', 'abc', 'error']
+  ['user', 'abc', 'error'],
 ]);
   // Throws TypeError: Each query pair must be a name/value tuple
 ```

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -323,7 +323,7 @@ class Box {
     }
 
     const newOptions = Object.assign({}, options, {
-      depth: options.depth === null ? null : options.depth - 1
+      depth: options.depth === null ? null : options.depth - 1,
     });
 
     // Five space padding because that's the size of "Box< ".

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -117,8 +117,7 @@ swapped out by the operating system.
 For example:
 
 ```js
-{
-  total_heap_size: 7326976,
+{ total_heap_size: 7326976,
   total_heap_size_executable: 4194304,
   total_physical_size: 7326976,
   total_available_size: 1152656,
@@ -126,8 +125,7 @@ For example:
   heap_size_limit: 1535115264,
   malloced_memory: 16384,
   peak_malloced_memory: 1127496,
-  does_zap_garbage: 0
-}
+  does_zap_garbage: 0 }
 ```
 
 ## v8.setFlagsFromString(string)

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -110,7 +110,7 @@ const vm = require('vm');
 
 const sandbox = {
   animal: 'cat',
-  count: 2
+  count: 2,
 };
 
 const script = new vm.Script('count += 1; name = "kitty";');
@@ -363,7 +363,7 @@ const vm = require('vm');
 
 const sandbox = {
   animal: 'cat',
-  count: 2
+  count: 2,
 };
 
 vm.runInNewContext('count += 1; name = "kitty"', sandbox);


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
doc

There were some trailing commas in code examples, so I've tried to unify this (in some places I've updated output examples according to actual output that is incompatible with trailing commas, just to be consistent).

This change may secure a bit possible future editing and may reduce diff noise in such cases (see [ESLint rule](http://eslint.org/docs/rules/comma-dangle)).

Feel free to close if this is an overestimated cosmetic change.