### PR TITLE
test: set benchmark-child-process flaky on windows

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -7,6 +7,7 @@ prefix sequential
 [true] # This section applies to all platforms
 
 [$system==win32]
+test-benchmark-child-process  : PASS,FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
sequential/test-benchmark-child-process is still failing sometimes flaky
on Windows in CI. Mark it as flaky in sequential.status until it gets
sorted.

Refs: https://github.com/nodejs/node/issues/12560

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process benchmark