### PR TITLE
test: remove flaky designation for test on AIX

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -17,9 +17,4 @@ test-benchmark-child-process  : PASS,FLAKY
 
 [$system==freebsd]
 
-# fs-watch currently needs special configuration on AIX and we
-# want to improve under https://github.com/nodejs/node/issues/5085.
-# Tests are disabled so CI can be green and we can spot other
-# regressions until this work is complete
 [$system==aix]
-test-fs-watch               : FAIL,PASS

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -27,7 +27,8 @@ const fs = require('fs');
 
 const expectFilePath = common.isWindows ||
                        common.isLinux ||
-                       common.isOSX;
+                       common.isOSX ||
+                       common.isAix;
 
 let watchSeenOne = 0;
 let watchSeenTwo = 0;
@@ -101,7 +102,7 @@ const filepathThree = path.join(testsubdir, filenameThree);
 assert.doesNotThrow(
     function() {
       const watcher = fs.watch(testsubdir, function(event, filename) {
-        const renameEv = common.isSunOS ? 'change' : 'rename';
+        const renameEv = common.isSunOS || common.isAix ? 'change' : 'rename';
         assert.strictEqual(renameEv, event);
         if (expectFilePath) {
           assert.strictEqual('newfile.txt', filename);


### PR DESCRIPTION
https://github.com/nodejs/node/issues/5085 has been completed so
presumably test-fs-watch is not flaky on AIX anymore. Remove flaky
designation from sequential.status.

/cc @nodejs/platform-aix 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs