### PR TITLE
backport v4.x: test: fix flaky test-tls-wrap-timeout

### DIFF
--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -1,42 +1,54 @@
 'use strict';
-var common = require('../common');
-var assert = require('assert');
+const common = require('../common');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-var tls = require('tls');
+const assert = require('assert');
+const tls = require('tls');
 
-var net = require('net');
-var fs = require('fs');
+const net = require('net');
+const fs = require('fs');
 
-var options = {
+const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
   cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
 };
 
-var server = tls.createServer(options, function(c) {
-  setTimeout(function() {
-    c.write('hello');
-    setTimeout(function() {
-      c.destroy();
-      server.close();
-    }, 150);
-  }, 150);
-});
+const server = tls.createServer(options, common.mustCall((c) => {
+  setImmediate(() => {
+    c.write('hello', () => {
+      setImmediate(() => {
+        c.destroy();
+        server.close();
+      });
+    });
+  });
+}));
 
-server.listen(0, function() {
-  var socket = net.connect(this.address().port, function() {
-    var s = socket.setTimeout(common.platformTimeout(240), function() {
+var socket;
+var lastIdleStart;
+
+server.listen(0, () => {
+  socket = net.connect(server.address().port, function() {
+    const s = socket.setTimeout(Number.MAX_VALUE, function() {
       throw new Error('timeout');
     });
     assert.ok(s instanceof net.Socket);
 
-    var tsocket = tls.connect({
+    assert.notStrictEqual(socket._idleTimeout, -1);
+    lastIdleStart = socket._idleStart;
+
+    const tsocket = tls.connect({
       socket: socket,
       rejectUnauthorized: false
     });
     tsocket.resume();
   });
+});
+
+process.on('exit', () => {
+  assert.strictEqual(socket._idleTimeout, -1);
+  assert(lastIdleStart < socket._idleStart);
 });


### PR DESCRIPTION
Competing timers were causing a race condition and thus the test was
flaky. Instead, we check an object property on process exit.

Fixes: https://github.com/nodejs/node/issues/7650
PR-URL: https://github.com/nodejs/node/pull/7857
Reviewed-By: Santiago Gimeno <santiago.gimeno@gmail.com>
Reviewed-By: Fedor Indutny <fedor.indutny@gmail.com>
Reviewed-By: jasnell - James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
