### PR TITLE
test: dynamic port in test cluster ipc throw

### DIFF
--- a/test/parallel/test-cluster-ipc-throw.js
+++ b/test/parallel/test-cluster-ipc-throw.js
@@ -2,20 +2,23 @@
 const common = require('../common');
 const http = require('http');
 const cluster = require('cluster');
+const assert = require('assert');
 
 cluster.schedulingPolicy = cluster.SCHED_RR;
 
 const server = http.createServer();
 
 if (cluster.isMaster) {
-  server.listen(common.PORT);
-  const worker = cluster.fork();
-  worker.on('exit', common.mustCall(() => {
-    server.close();
+  server.listen({port: 0}, common.mustCall(() => {
+    const worker = cluster.fork({PORT: server.address().port});
+    worker.on('exit', common.mustCall(() => {
+      server.close();
+    }));
   }));
 } else {
+  assert(process.env.PORT);
   process.on('uncaughtException', common.mustCall((e) => {}));
-  server.listen(common.PORT);
+  server.listen(process.env.PORT);
   server.on('error', common.mustCall((e) => {
     cluster.worker.disconnect();
     throw e;


### PR DESCRIPTION
Removed common.PORT from test-cluster-ipc-throw to eliminate the
possibility that a dynamic port used in another test will collide
with common.PORT.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
