### PR TITLE
tools: enable no-useless-return eslint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -50,6 +50,7 @@ rules:
   no-unused-labels: 2
   no-useless-call: 2
   no-useless-escape: 2
+  no-useless-return: 2
   no-void: 2
   no-with: 2
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -64,6 +64,7 @@ Errors that occur within _Asynchronous APIs_ may be reported in multiple ways:
   argument is not `null` and is an instance of `Error`, then an error occurred
   that should be handled.
 
+<!-- eslint-disable no-useless-return -->
   ```js
   const fs = require('fs');
   fs.readFile('a file that does not exist', (err, data) => {

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1566,6 +1566,7 @@ unexpected and inconsistent behavior depending on whether the stream is
 operating in flowing or paused mode. Using the `'error'` event ensures
 consistent and predictable handling of errors.
 
+<!-- eslint-disable no-useless-return -->
 ```js
 const Readable = require('stream').Readable;
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -307,7 +307,6 @@ function enqueue(self, toEnqueue) {
     self.once('listening', onListenSuccess);
   }
   self._queue.push(toEnqueue);
-  return;
 }
 
 

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -30,9 +30,9 @@ if (common.isWindows) {
     if (err || !o.includes('SeCreateSymbolicLinkPrivilege')) {
       common.skip('insufficient privileges');
       return;
-    } else {
-      test();
     }
+
+    test();
   });
 } else {
   test();

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -243,7 +243,6 @@ function processList(section) {
         current.options.push(n);
         current = n;
       }
-      return;
     } else if (type === 'list_item_end') {
       if (!current) {
         throw new Error('invalid list - end without current item\n' +
@@ -516,9 +515,6 @@ function finishSection(section, parent) {
             parent[k] = parent[k].concat(section[k]);
           } else if (!parent[k]) {
             parent[k] = section[k];
-          } else {
-            // parent already has, and it's not an array.
-            return;
           }
       }
     });


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
tools