### PR TITLE
inspector: restore --debug-brk alias

### DIFF
--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -94,8 +94,6 @@ bool DebugOptions::ParseOption(const std::string& option) {
     argument = option.substr(pos + 1);
   }
 
-  // Note that --debug-port and --debug-brk are undocumented, but to be
-  // supported until 7.x is no longer supported, not even in LTS (see #12364).
   if (option_name == "--inspect") {
     debugger_enabled_ = true;
     enable_inspector = true;

--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -94,18 +94,18 @@ bool DebugOptions::ParseOption(const std::string& option) {
     argument = option.substr(pos + 1);
   }
 
+  // Note that --debug-port and --debug-brk are undocumented, but to be
+  // supported until 7.x is no longer supported, not even in LTS (see #12364).
   if (option_name == "--inspect") {
     debugger_enabled_ = true;
     enable_inspector = true;
-  } else if (option_name == "--inspect-brk") {
+  } else if (option_name == "--inspect-brk" || option_name == "--debug-brk") {
     debugger_enabled_ = true;
     enable_inspector = true;
     wait_connect_ = true;
-  } else if ((option_name != "--debug-port" &&
-              option_name != "--inspect-port") ||
-              !has_argument) {
-    // only other valid possibility is --inspect-port,
-    // which requires an argument
+  } else if (option_name == "--inspect-port" || option_name == "--debug-port") {
+    if (!has_argument) return false;
+  } else {
     return false;
   }
 

--- a/src/node_debug_options.h
+++ b/src/node_debug_options.h
@@ -40,7 +40,7 @@ class DebugOptions {
 #if HAVE_INSPECTOR
   bool inspector_enabled_;
 #endif  // HAVE_INSPECTOR
-  bool wait_connect_;
+  bool wait_connect_;  // --inspect-brk
   bool http_enabled_;
   std::string host_name_;
   int port_;


### PR DESCRIPTION
--inspect-brk didn't exist prior to 7.6.0, and --debug-brk doesn't exist
after https://github.com/nodejs/node/pull/12197, leaving no consistent
way to start node with inspector activated and breaking on first line.
Add debug-brk back in as an undocumented option until 7.x is no longer
supported.

Fixes: https://github.com/nodejs/node/issues/12364

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
inspector, debugger
