### PR TITLE
inspector: document bad usage for --inspect-port

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -112,6 +112,18 @@ added: v7.6.0
 -->
 
 Activate inspector on host:port and break at start of user script.
+Default host:port is 127.0.0.1:9229.
+
+
+### `--inspect-port=[host:]port`
+<!-- YAML
+added: v7.6.0
+-->
+
+Set the host:port to be used when the inspector is activated.
+Useful when activating the inspector by sending the `SIGUSR1` signal.
+
+Default host is 127.0.0.1.
 
 
 ### `--no-deprecation`

--- a/doc/node.1
+++ b/doc/node.1
@@ -104,6 +104,10 @@ instances for debugging and profiling. It uses the Chrome Debugging Protocol.
 Activate inspector on host:port and break at start of user script.
 
 .TP
+.BR \-\-inspect-port \fI=[host:]port\fR
+Set the host:port to be used when the inspector is activated.
+
+.TP
 .BR \-\-no\-deprecation
 Silence deprecation warnings.
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3604,6 +3604,8 @@ static void PrintHelp() {
          "  --inspect-brk[=[host:]port]\n"
          "                             activate inspector on host:port\n"
          "                             and break at start of user script\n"
+         "  --inspect-port=[host:]port\n"
+         "                             set host:port for inspector\n"
 #endif
          "  --no-deprecation           silence deprecation warnings\n"
          "  --trace-deprecation        show stack traces on deprecations\n"
@@ -3790,7 +3792,7 @@ static void ParseArgs(int* argc,
 
     CheckIfAllowedInEnv(argv[0], is_env, arg);
 
-    if (debug_options.ParseOption(arg)) {
+    if (debug_options.ParseOption(argv[0], arg)) {
       // Done, consumed by DebugOptions::ParseOption().
     } else if (strcmp(arg, "--version") == 0 || strcmp(arg, "-v") == 0) {
       printf("%s\n", NODE_VERSION);

--- a/src/node_debug_options.h
+++ b/src/node_debug_options.h
@@ -9,7 +9,7 @@ namespace node {
 class DebugOptions {
  public:
   DebugOptions();
-  bool ParseOption(const std::string& option);
+  bool ParseOption(const char* argv0, const std::string& option);
   bool inspector_enabled() const {
 #if HAVE_INSPECTOR
     return inspector_enabled_;

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+
+// Tests that node exits consistently on bad option syntax.
+
+const assert = require('assert');
+const spawn = require('child_process').spawnSync;
+
+requiresArgument('--inspect-port');
+requiresArgument('--inspect-port=');
+requiresArgument('--debug-port');
+requiresArgument('--debug-port=');
+requiresArgument('--eval');
+
+function requiresArgument(option) {
+  const r = spawn(process.execPath, [option], {encoding: 'utf8'});
+
+  assert.strictEqual(r.status, 9);
+
+  const msg = r.stderr.split(/\r?\n/)[0];
+  assert.strictEqual(msg, process.execPath + ': ' + option +
+                     ' requires an argument');
+}


### PR DESCRIPTION
Document --inspect-port, and fix the reporting for when it is misused.

The option requires an argument, but when the argument was omitted, the
error message incorrectly reported --inspect-port as being bad, as if
was not supported at all:

    % node --inspect-port
    node: bad option: --inspect-port
    % node --none-such
    node: bad option: --none-such

It is now correctly reported as requiring an argument:

    % ./node --inspect-port
    ./node: --inspect-port requires an argument

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
inspector
