### PR TITLE
test: dynamic port in parallel cluster tests

### DIFF
--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -60,7 +60,7 @@ if (cluster.isWorker) {
     maybeReply();
   });
 
-  server.listen(common.PORT, '127.0.0.1');
+  server.listen(0, '127.0.0.1');
 } else if (cluster.isMaster) {
 
   const checks = {
@@ -109,9 +109,9 @@ if (cluster.isWorker) {
   });
 
   // When a TCP server is listening in the worker connect to it
-  worker.on('listening', function() {
+  worker.on('listening', function(address) {
 
-    client = net.connect(common.PORT, function() {
+    client = net.connect(address.port, function() {
       // Send message to worker.
       worker.send('message from master');
     });

--- a/test/parallel/test-cluster-server-restart-none.js
+++ b/test/parallel/test-cluster-server-restart-none.js
@@ -23,10 +23,10 @@ if (cluster.isMaster) {
 } else {
   const net = require('net');
   const server = net.createServer();
-  server.listen(common.PORT, common.mustCall(() => {
+  server.listen(0, common.mustCall(() => {
     if (cluster.worker.id === 2) {
       server.close(() => {
-        server.listen(common.PORT, common.mustCall(() => {
+        server.listen(0, common.mustCall(() => {
           server.close(() => {
             process.disconnect();
           });

--- a/test/parallel/test-cluster-server-restart-rr.js
+++ b/test/parallel/test-cluster-server-restart-rr.js
@@ -23,10 +23,10 @@ if (cluster.isMaster) {
 } else {
   const net = require('net');
   const server = net.createServer();
-  server.listen(common.PORT, common.mustCall(() => {
+  server.listen(0, common.mustCall(() => {
     if (cluster.worker.id === 2) {
       server.close(() => {
-        server.listen(common.PORT, common.mustCall(() => {
+        server.listen(0, common.mustCall(() => {
           server.close(() => {
             process.disconnect();
           });

--- a/test/parallel/test-cluster-shared-handle-bind-error.js
+++ b/test/parallel/test-cluster-shared-handle-bind-error.js
@@ -31,16 +31,17 @@ if (cluster.isMaster) {
   // Hog the TCP port so that when the worker tries to bind, it'll fail.
   const server = net.createServer(common.mustNotCall());
 
-  server.listen(common.PORT, common.mustCall(() => {
-    const worker = cluster.fork();
+  server.listen(0, common.mustCall(() => {
+    const worker = cluster.fork({PORT: server.address().port});
     worker.on('exit', common.mustCall((exitCode) => {
       assert.strictEqual(exitCode, 0);
       server.close();
     }));
   }));
 } else {
+  assert(process.env.PORT);
   const s = net.createServer(common.mustNotCall());
-  s.listen(common.PORT, common.mustNotCall('listen should have failed'));
+  s.listen(process.env.PORT, common.mustNotCall('listen should have failed'));
   s.on('error', common.mustCall((err) => {
     assert.strictEqual(err.code, 'EADDRINUSE');
     process.disconnect();


### PR DESCRIPTION
Removed common.PORT from:
- test-cluster-message
- test-cluster-server-restart-none
- test-cluster-server-restart-rr
- test-cluster-shared-handle-bind-error 

In order to eliminate the possibility that a dynamic port used in another test will collide with `common.PORT`.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
