### PR TITLE
benchmark: add improvement and t-test in Node

### DIFF
--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const readline = require('readline');
-
 function pad(input, minLength, fill) {
   var result = String(input);
   var padding = fill.repeat(Math.max(0, minLength - result.length));
@@ -25,7 +23,7 @@ function getTime(diff) {
 // A run is an item in the job queue: { binary, filename, iter }
 // A config is an item in the subqueue: { binary, filename, iter, configs }
 class BenchmarkProgress {
-  constructor(queue, benchmarks) {
+  constructor(queue, benchmarks, showAlways) {
     this.queue = queue;  // Scheduled runs.
     this.benchmarks = benchmarks;  // Filenames of scheduled benchmarks.
     this.completedRuns = 0;  // Number of completed runs.
@@ -41,6 +39,7 @@ class BenchmarkProgress {
     // Total number of configurations for the current file
     this.scheduledConfig = 0;
     this.interval = 0;  // result of setInterval for updating the elapsed time
+    this.showAlways = showAlways; // show even if stdout is TTY
   }
 
   startQueue(index) {
@@ -110,11 +109,11 @@ class BenchmarkProgress {
   }
 
   updateProgress(finished) {
-    if (!process.stderr.isTTY || process.stdout.isTTY) {
+    if ((!process.stderr.isTTY || process.stdout.isTTY) && !this.showAlways) {
       return;
     }
-    readline.clearLine(process.stderr);
-    readline.cursorTo(process.stderr, 0);
+    process.stderr.clearLine();
+    process.stderr.cursorTo(0);
     process.stderr.write(this.getProgress());
   }
 }

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -4,6 +4,7 @@ const fork = require('child_process').fork;
 const path = require('path');
 const CLI = require('./_cli.js');
 const BenchmarkProgress = require('./_benchmark_progress.js');
+const TTest = require('./t-test');
 
 //
 // Parse arguments
@@ -20,9 +21,10 @@ const cli = CLI(`usage: ./node compare.js [options] [--] <category> ...
   --filter   pattern            string to filter benchmark scripts
   --set      variable=value     set benchmark variable (can be repeated)
   --no-progress                 don't show benchmark progress indicator
+  --stats                       calculate the improvement and confidence
 `, {
   arrayArgs: ['set'],
-  boolArgs: ['no-progress']
+  boolArgs: ['no-progress', 'stats']
 });
 
 if (!cli.optional.new || !cli.optional.old) {
@@ -55,16 +57,103 @@ for (const filename of benchmarks) {
 }
 // queue.length = binary.length * runs * benchmarks.length
 
-// Print csv header
-console.log('"binary", "filename", "configuration", "rate", "time"');
-
 const kStartOfQueue = 0;
 
 const showProgress = !cli.optional['no-progress'];
+const showStats = cli.optional['stats'];
+
+// Print csv header
+if (!showStats)
+  console.log('"binary", "filename", "configuration", "rate", "time"');
+
 let progress;
 if (showProgress) {
-  progress = new BenchmarkProgress(queue, benchmarks);
+  progress = new BenchmarkProgress(queue, benchmarks, showStats);
   progress.startQueue(kStartOfQueue);
+}
+
+const outputs = [];
+
+function calculateStats() {
+  const stats = {};
+  var maxLength = 0;
+  var i;
+  for (i = 0; i < outputs.length; i++) {
+    var job = outputs[i];
+    if (!stats[job.conf]) {
+      stats[job.conf] = {
+        conf: job.conf,
+        filename: job.filename,
+        improvement: 0,
+        pValue: 0,
+        confidence: '   ',
+        old: {
+          count: 0,
+          total: 0,
+          mean: 0,
+          values: []
+        },
+        new: {
+          count: 0,
+          total: 0,
+          mean: 0,
+          values: []
+        }
+      };
+    }
+    if (job.conf.length + job.filename.length > maxLength)
+      maxLength = job.conf.length + job.filename.length;
+    const stat = stats[job.conf][job.binary];
+    stat.count++;
+    stat.total += job.rate;
+    stat.values.push(job.rate);
+  }
+
+  var consoleOutputs = [];
+  var maxLengthImprovement = 0;
+  for (var name in stats) {
+    const stat = stats[name];
+    stat.old.mean = stat.old.total / stat.old.count;
+    stat.new.mean = stat.new.total / stat.new.count;
+    stat.improvement = (stat.new.mean - stat.old.mean) / stat.old.mean * 100;
+    stat.improvementStr = '' + stat.improvement.toFixed(2) + ' %';
+    if (stat.improvementStr.length > maxLengthImprovement)
+      maxLengthImprovement = stat.improvementStr.length;
+    var ttest = new TTest(stat.old.values, stat.new.values);
+    stat.pValue = ttest.pValue();
+    stat.pValueStr = stat.pValue.toExponential();
+    if (stat.pValue < 0.001) {
+      stat.confidence = '***';
+    } else if (stat.pValue < 0.01) {
+      stat.confidence = ' **';
+    } else if (stat.pValue < 0.05) {
+      stat.confidence = '  *';
+    }
+    consoleOutputs.push({
+      name: ' ' + stat.filename + ' ' + stat.conf,
+      improvement: stat.improvementStr,
+      confidence: stat.confidence,
+      pValue: stat.pValueStr
+    });
+  }
+  maxLength += 7;
+  var current;
+  var s = '';
+  while (s.length < maxLength - 5)
+    s += ' ';
+  s += 'improvement confidence      p.value';
+  console.log(s);
+  for (i = consoleOutputs.length - 1; i >= 0; i--) {
+    current = consoleOutputs[i];
+    s = current.name;
+    while (s.length < maxLength)
+      s += ' ';
+    while (current.improvement.length < maxLengthImprovement)
+      current.improvement = ' ' + current.improvement;
+    s += current.improvement + '       ' + current.confidence + ' ' +
+         current.pValue;
+    console.log(s);
+  }
 }
 
 (function recursive(i) {
@@ -82,11 +171,22 @@ if (showProgress) {
         conf += ` ${key}=${JSON.stringify(data.conf[key])}`;
       }
       conf = conf.slice(1);
-      // Escape quotes (") for correct csv formatting
-      conf = conf.replace(/"/g, '""');
 
-      console.log(`"${job.binary}", "${job.filename}", "${conf}", ${
-                   data.rate}, ${data.time}`);
+      if (showStats) {
+        outputs.push({
+          binary: job.binary,
+          filename: job.filename,
+          conf: conf,
+          rate: data.rate,
+          time: data.time
+        });
+      } else {
+        // Escape quotes (") for correct csv formatting
+        conf = conf.replace(/"/g, '""');
+        console.log(`"${job.binary}", "${job.filename}", "${conf}", ${
+                     data.rate}, ${data.time}`);
+      }
+
       if (showProgress) {
         // One item in the subqueue has been completed.
         progress.completeConfig(data);

--- a/benchmark/compare.js
+++ b/benchmark/compare.js
@@ -209,6 +209,8 @@ function calculateStats() {
     // If there are more benchmarks execute the next
     if (i + 1 < queue.length) {
       recursive(i + 1);
+    } else {
+      calculateStats();
     }
   });
 })(kStartOfQueue);

--- a/benchmark/t-test.js
+++ b/benchmark/t-test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Class for doing statistic test following a Student's t-distribution,
+// with default configuration: mu = 0, alternative = two.sided
+function TTest(leftData, rightData) {
+  this.left = this.createData(leftData);
+  this.right = this.createData(rightData);
+  this.df = this.left.size + this.right.size - 2;
+  this.dfhalf = this.df / 2;
+  this.mean = this.left.mean - this.right.mean;
+  this.commonVariance = ((this.left.size - 1) * this.left.variance +
+                         (this.right.size - 1) * this.right.variance) / this.df;
+  this.se = Math.sqrt(this.commonVariance * (1 / this.left.size + 1 /
+                      this.right.size));
+}
+
+TTest.prototype.createData = function(data) {
+  // Calculate the sum
+  var sum = 0;
+  var i;
+  for (i = 0; i < data.length; i++) {
+    sum += data[i];
+  }
+  // Calculate the mean.
+  var mean = sum / data.length;
+  // Calculate the sqsum.
+  var sqsum = 0;
+  for (i = 0; i < data.length; i++) {
+    sqsum += (data[i] - mean) * (data[i] - mean);
+  }
+  // Calculate the variance
+  var variance = sqsum / (data.length - 1);
+  // Return data.
+  return {
+    sum: sum,
+    mean: mean,
+    sqsum: sqsum,
+    variance: variance,
+    data: data,
+    size: data.length
+  };
+};
+
+// Calculates a fast aproximation of the Gamma Function.
+TTest.prototype.gamma = function(x) {
+  var p = [0.99999999999980993, 676.5203681218851, -1259.1392167224028,
+           771.32342877765313, -176.61502916214059, 12.507343278686905,
+           -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7];
+
+  var g = 7;
+  if (x < 0.5) {
+    return Math.PI / (Math.sin(Math.PI * x) * this.gamma(1 - x));
+  }
+
+  x -= 1;
+  var a = p[0];
+  var t = x + g + 0.5;
+  for (var i = 1; i < p.length; i++) {
+    a += p[i] / (x + i);
+  }
+
+  return Math.sqrt(2 * Math.PI) * Math.pow(t, x + 0.5) * Math.exp(-t) * a;
+};
+
+TTest.prototype.logGamma = function(n) {
+  return Math.log(Math.abs(this.gamma(n)));
+};
+
+TTest.prototype.log1p = function(n) {
+  return Math.log(n + 1);
+};
+
+TTest.prototype.betacf = function(x, a, b) {
+  var fpmin = 1e-30;
+  var c = 1;
+  var d = 1 - (a + b) * x / (a + 1);
+  var m2, aa, del, h;
+  if (Math.abs(d) < fpmin) d = fpmin;
+  d = 1 / d;
+  h = d;
+  for (var m = 1; m <= 100; m++) {
+    m2 = 2 * m;
+    aa = m * (b - m) * x / ((a - 1 + m2) * (a + m2));
+    d = 1 + aa * d;
+    if (Math.abs(d) < fpmin) d = fpmin;
+    c = 1 + aa / c;
+    if (Math.abs(c) < fpmin) c = fpmin;
+    d = 1 / d;
+    h *= d * c;
+    aa = -(a + m) * (a + b + m) * x / ((a + m2) * (a + 1 + m2));
+    d = 1 + aa * d;
+    if (Math.abs(d) < fpmin) d = fpmin;
+    c = 1 + aa / c;
+    if (Math.abs(c) < fpmin) c = fpmin;
+    d = 1 / d;
+    del = d * c;
+    h *= del;
+    if (Math.abs(del - 1.0) < 3e-7) break;
+  }
+  return h;
+};
+
+TTest.prototype.incBeta = function(x, a, b) {
+  if ((a === 1 && b === 1) || (x === 0) || (x === 1))
+    return x;
+  if (a === 0)
+    return 1;
+  if (b === 0)
+    return 0;
+  var bt = Math.exp(this.logGamma(a + b) - this.logGamma(a) - this.logGamma(b) +
+    a * Math.log(x) + b * this.log1p(-x));
+  if (x < (a + 1) / (a + b + 2))
+    return bt * this.betacf(x, a, b) / a;
+  return 1 - bt * this.betacf(1 - x, b, a) / b;
+};
+
+TTest.prototype.cdf = function(x) {
+  var fac = Math.sqrt(x * x + this.df);
+  return this.incBeta((x + fac) / (2 * fac), this.dfhalf, this.dfhalf);
+};
+
+TTest.prototype.testValue = function() {
+  return this.mean / this.se;
+};
+
+TTest.prototype.pValue = function() {
+  return 2 * (1 - this.cdf(Math.abs(this.testValue())));
+};
+
+module.exports = TTest;

--- a/benchmark/t-test.js
+++ b/benchmark/t-test.js
@@ -65,14 +65,14 @@ TTest.prototype.gamma = function(x) {
 TTest.prototype.logGamma = function(n) {
   if (n <= 0) {
     throw new RangeError('logGamma(x): x must be positive.');
-	}
+  }
   return Math.log(Math.abs(this.gamma(n)));
 };
 
 TTest.prototype.log1p = function(n) {
   if (n <= -1) {
     throw new RangeError('log1p(x): x must be extrictly greater than -1');
-  }  
+  }
   return Math.log(n + 1);
 };
 

--- a/benchmark/t-test.js
+++ b/benchmark/t-test.js
@@ -63,10 +63,16 @@ TTest.prototype.gamma = function(x) {
 };
 
 TTest.prototype.logGamma = function(n) {
+  if (n <= 0) {
+    throw new RangeError('logGamma(x): x must be positive.');
+	}
   return Math.log(Math.abs(this.gamma(n)));
 };
 
 TTest.prototype.log1p = function(n) {
+  if (n <= -1) {
+    throw new RangeError('log1p(x): x must be extrictly greater than -1');
+  }  
   return Math.log(n + 1);
 };
 


### PR DESCRIPTION
Added the capability of calculate the improvement, the p.value and the
confidence directly from node, for those that wants to check the
performance impact of their changes without installing R.

This is not a replacement for the R scripts, still needed for the
scatters and for having a more reliable results. But is a good way of
avoid the R dependency when you only want to measure the improvement
of your changes. Important note: the p.value calculated by R and the
one calculated by the Student's test implementation in node are not
equal, but pretty similar enough in scale, so the confidence should
be the same. This is due to not knowing exactly how is implemented the
Student's test in R, and also because the approximation of the gamma
function.

The compare.js script works as always, but now you have a new parameter
--stats. When this parameter is added, the csv lines are not showed in
the console, and when all the jobs are processed the stats are
calculated and shown in the console in the same format as the R script
does.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
