### PR TITLE
stream: fix highWaterMark integer overflow

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -72,7 +72,7 @@ function ReadableState(options, stream) {
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.
-  this.highWaterMark = ~~this.highWaterMark;
+  this.highWaterMark = Math.trunc(this.highWaterMark);
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -72,7 +72,7 @@ function ReadableState(options, stream) {
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.
-  this.highWaterMark = Math.trunc(this.highWaterMark);
+  this.highWaterMark = Math.floor(this.highWaterMark);
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -55,7 +55,7 @@ function WritableState(options, stream) {
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.
-  this.highWaterMark = Math.trunc(this.highWaterMark);
+  this.highWaterMark = Math.floor(this.highWaterMark);
 
   // drain event flag.
   this.needDrain = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -55,7 +55,7 @@ function WritableState(options, stream) {
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.
-  this.highWaterMark = ~~this.highWaterMark;
+  this.highWaterMark = Math.trunc(this.highWaterMark);
 
   // drain event flag.
   this.needDrain = false;

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -1,6 +1,9 @@
 'use strict';
-
 require('../common');
+
+// This test ensures that the stream implementation correctly handles values
+// for highWaterMark which exceed the range of signed 32 bit integers.
+
 const assert = require('assert');
 const stream = require('stream');
 

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+const readable = stream.Readable({ highWaterMark: 2147483648 });
+assert.strictEqual(readable._readableState.highWaterMark, 2147483648);
+
+const writable = stream.Writable({ highWaterMark: 2147483648 });
+assert.strictEqual(writable._writableState.highWaterMark, 2147483648);

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -4,8 +4,12 @@ require('../common');
 const assert = require('assert');
 const stream = require('stream');
 
-const readable = stream.Readable({ highWaterMark: 2147483648 });
-assert.strictEqual(readable._readableState.highWaterMark, 2147483648);
+// This number exceeds the range of 32 bit integer arithmetic but should still
+// be handled correctly.
+const ovfl = Number.MAX_SAFE_INTEGER;
 
-const writable = stream.Writable({ highWaterMark: 2147483648 });
-assert.strictEqual(writable._writableState.highWaterMark, 2147483648);
+const readable = stream.Readable({ highWaterMark: ovfl });
+assert.strictEqual(readable._readableState.highWaterMark, ovfl);
+
+const writable = stream.Writable({ highWaterMark: ovfl });
+assert.strictEqual(writable._writableState.highWaterMark, ovfl);


### PR DESCRIPTION
Fixes integer overflows when supplying values exceeding `2 ^ 31 - 1` for `highWaterMark`.

Fixes: https://github.com/nodejs/node/issues/12553

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream