### PR TITLE
test: cleanup test-fs-watch.js 

### DIFF
--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -57,10 +57,10 @@ assert.doesNotThrow(
     function() {
       const watcher = fs.watch(filepathOne);
       watcher.on('change', function(event, filename) {
-        assert.strictEqual('change', event);
+        assert.strictEqual(event, 'change');
 
         if (expectFilePath) {
-          assert.strictEqual('watch.txt', filename);
+          assert.strictEqual(filename, 'watch.txt');
         }
         watcher.close();
         ++watchSeenOne;
@@ -80,10 +80,10 @@ fs.writeFileSync(filepathTwoAbs, 'howdy');
 assert.doesNotThrow(
     function() {
       const watcher = fs.watch(filepathTwo, function(event, filename) {
-        assert.strictEqual('change', event);
+        assert.strictEqual(event, 'change');
 
         if (expectFilePath) {
-          assert.strictEqual('hasOwnProperty', filename);
+          assert.strictEqual(filename, 'hasOwnProperty');
         }
         watcher.close();
         ++watchSeenTwo;
@@ -103,11 +103,11 @@ assert.doesNotThrow(
     function() {
       const watcher = fs.watch(testsubdir, function(event, filename) {
         const renameEv = common.isSunOS || common.isAix ? 'change' : 'rename';
-        assert.strictEqual(renameEv, event);
+        assert.strictEqual(event, renameEv);
         if (expectFilePath) {
-          assert.strictEqual('newfile.txt', filename);
+          assert.strictEqual(filename, 'newfile.txt');
         } else {
-          assert.strictEqual(null, filename);
+          assert.strictEqual(filename, null);
         }
         watcher.close();
         ++watchSeenThree;
@@ -134,7 +134,7 @@ assert.throws(function() {
   oldhandle = w._handle;
   w._handle = { close: w._handle.close };
   w.close();
-}, TypeError);
+}, /^TypeError: Illegal invocation$/);
 oldhandle.close(); // clean up
 
 assert.throws(function() {
@@ -142,5 +142,5 @@ assert.throws(function() {
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();
-}, TypeError);
+}, /^TypeError: Illegal invocation$/);
 oldhandle.stop(); // clean up


### PR DESCRIPTION
Reversed "actual" and "expected" arguments for assert.strictEqual().

Replaced constructor with regular expression for assert.throws().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
