### PR TITLE
test: Added relative path to accommodate limit

### DIFF
--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -33,8 +33,8 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
 
 // Test Pipe fd is wrapped correctly
 {
-  // Using relative path on osx if the path is greaterthan 108 chars
-  // an AssertionError: -48 is thrown
+  // Use relative path to avoid hitting 108-char length limit
+  // for socket paths in libuv.
   const prefix = path.relative('.', `${common.PIPE}-net-connect-options-fd`);
   const serverPath = `${prefix}-server`;
   let counter = 0;

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -33,8 +33,9 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
 
 // Test Pipe fd is wrapped correctly
 {
-  const prefix = path.relative(`${common.PIPE}-net-connect-options-fd`,
-                               `${__dirname}-net-connect-options-fd`);
+  // Using relative path on osx if the path is greaterthan 108 chars
+  // an AssertionError: -48 is thrown
+  const prefix = path.relative('.', `${common.PIPE}-net-connect-options-fd`);
   const serverPath = `${prefix}-server`;
   let counter = 0;
   let socketCounter = 0;

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const net = require('net');
+const path = require('path');
 const Pipe = process.binding('pipe_wrap').Pipe;
 
 if (common.isWindows) {
@@ -32,7 +33,8 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
 
 // Test Pipe fd is wrapped correctly
 {
-  const prefix = `${common.PIPE}-net-connect-options-fd`;
+  const prefix = path.relative(`${common.PIPE}-net-connect-options-fd`,
+                               `${__dirname}-net-connect-options-fd`);
   const serverPath = `${prefix}-server`;
   let counter = 0;
   let socketCounter = 0;


### PR DESCRIPTION
Found that libuv had a path character limit of 108. Used path.relative() to set prefix with relative path.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
