### PR TITLE
test: replace assertion error functions w regex err msg

### DIFF
--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -3,5 +3,7 @@ require('../common');
 const assert = require('assert');
 const v8 = require('v8');
 
-assert.throws(function() { v8.setFlagsFromString(1); }, TypeError);
-assert.throws(function() { v8.setFlagsFromString(); }, TypeError);
+assert.throws(function() { v8.setFlagsFromString(1); },
+              /^TypeError: v8 flag must be a string$/);
+assert.throws(function() { v8.setFlagsFromString(); },
+              /^TypeError: v8 flag is required$/);

--- a/test/parallel/test-v8-flags.js
+++ b/test/parallel/test-v8-flags.js
@@ -12,5 +12,7 @@ assert(eval('%_IsSmi(42)'));
 assert(vm.runInThisContext('%_IsSmi(43)'));
 
 v8.setFlagsFromString('--noallow_natives_syntax');
-assert.throws(function() { eval('%_IsSmi(44)'); }, SyntaxError);
-assert.throws(function() { vm.runInThisContext('%_IsSmi(45)'); }, SyntaxError);
+assert.throws(function() { eval('%_IsSmi(44)'); },
+              /^SyntaxError: Unexpected token %$/);
+assert.throws(function() { vm.runInThisContext('%_IsSmi(45)'); },
+              /^SyntaxError: Unexpected token %$/);


### PR DESCRIPTION
[updated by @refack]
Error message changes are `semver-major`, so it should be a good practice to tighten up the tests to check for it.
[end update]

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
