### PR TITLE
test: apply no-useless-concat ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -49,6 +49,7 @@ rules:
   no-throw-literal: 2
   no-unused-labels: 2
   no-useless-call: 2
+  no-useless-concat: 2
   no-useless-escape: 2
   no-useless-return: 2
   no-void: 2

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -93,11 +93,10 @@ function createTestCmdLine(options) {
   testCmd += process.argv[0];
 
   if (options && options.withAbortOnUncaughtException) {
-    testCmd += ' ' + '--abort-on-uncaught-exception';
+    testCmd += ' --abort-on-uncaught-exception';
   }
 
-  testCmd += ' ' + process.argv[1];
-  testCmd += ' ' + 'child';
+  testCmd += ` ${process.argv[1]} child`;
 
   return testCmd;
 }

--- a/test/parallel/test-http-server-unconsume-consume.js
+++ b/test/parallel/test-http-server-unconsume-consume.js
@@ -4,8 +4,8 @@ const http = require('http');
 
 const testServer = http.createServer(common.mustNotCall());
 testServer.on('connect', common.mustCall((req, socket, head) => {
-  socket.write('HTTP/1.1 200 Connection Established' + '\r\n' +
-      'Proxy-agent: Node-Proxy' + '\r\n' +
+  socket.write('HTTP/1.1 200 Connection Established\r\n' +
+      'Proxy-agent: Node-Proxy\r\n' +
       '\r\n');
   // This shouldn't raise an assertion in StreamBase::Consume.
   testServer.emit('connection', socket);

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -30,7 +30,7 @@ let outstanding_reqs = 0;
 const server = http.createServer(function(req, res) {
   res.writeHead(200, [['content-type', 'text/plain']]);
   res.addTrailers({'x-foo': 'bar'});
-  res.end('stuff' + '\n');
+  res.end('stuff\n');
 });
 server.listen(0);
 

--- a/test/parallel/test-net-write-connect-write.js
+++ b/test/parallel/test-net-write-connect-write.js
@@ -33,7 +33,7 @@ const server = net.createServer(function(socket) {
   conn.setEncoding('utf8');
   conn.write('before');
   conn.on('connect', function() {
-    conn.write('after');
+    conn.write(' after');
   });
   conn.on('data', function(buf) {
     received += buf;
@@ -41,6 +41,6 @@ const server = net.createServer(function(socket) {
   });
   conn.on('end', common.mustCall(function() {
     server.close();
-    assert.strictEqual(received, 'before' + 'after');
+    assert.strictEqual(received, 'before after');
   }));
 }));

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -128,7 +128,7 @@ interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
 childProcess.exec(
-  nodeBinary + ' ' + '--require ' + fixture('cluster-preload.js') + ' ' +
+  `${nodeBinary} --require ${fixture('cluster-preload.js')} ` +
     fixture('cluster-preload-test.js'),
   function(err, stdout, stderr) {
     assert.ifError(err);
@@ -139,8 +139,8 @@ childProcess.exec(
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
 childProcess.exec(
-  nodeBinary + ' ' + '--expose_natives_as=v8natives ' + '--require ' +
-    fixture('cluster-preload.js') + ' ' + 'cluster-preload-test.js',
+  `${nodeBinary} --expose_natives_as=v8natives --require ` +
+     `${fixture('cluster-preload.js')} cluster-preload-test.js`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -442,12 +442,12 @@ function tcp_test() {
         { client: client_tcp, send: '',
           expect: prompt_tcp },
         { client: client_tcp, send: 'invoke_me(333)',
-          expect: ('\'' + 'invoked 333' + '\'\n' + prompt_tcp) },
+          expect: (`'invoked 333'\n${prompt_tcp}`) },
         { client: client_tcp, send: 'a += 1',
-          expect: ('12346' + '\n' + prompt_tcp) },
+          expect: (`12346\n${prompt_tcp}`) },
         { client: client_tcp,
           send: 'require(' + JSON.stringify(moduleFilename) + ').number',
-          expect: ('42' + '\n' + prompt_tcp) }
+          expect: (`42\n${prompt_tcp}`) }
       ]);
     });
 
@@ -511,13 +511,13 @@ function unix_test() {
         { client: client_unix, send: '',
           expect: prompt_unix },
         { client: client_unix, send: 'message',
-          expect: ('\'' + message + '\'\n' + prompt_unix) },
+          expect: (`'${message}'\n${prompt_unix}`) },
         { client: client_unix, send: 'invoke_me(987)',
-          expect: ('\'' + 'invoked 987' + '\'\n' + prompt_unix) },
+          expect: (`'invoked 987'\n${prompt_unix}`) },
         { client: client_unix, send: 'a = 12345',
-          expect: ('12345' + '\n' + prompt_unix) },
+          expect: (`12345\n${prompt_unix}`) },
         { client: client_unix, send: '{a:1}',
-          expect: ('{ a: 1 }' + '\n' + prompt_unix) }
+          expect: (`{ a: 1 }\n${prompt_unix}`) }
       ]);
     });
 

--- a/test/sequential/test-domain-abort-on-uncaught.js
+++ b/test/sequential/test-domain-abort-on-uncaught.js
@@ -239,11 +239,8 @@ if (process.argv[2] === 'child') {
       testCmd += 'ulimit -c 0 && ';
     }
 
-    testCmd += process.argv[0];
-    testCmd += ' ' + '--abort-on-uncaught-exception';
-    testCmd += ' ' + process.argv[1];
-    testCmd += ' ' + 'child';
-    testCmd += ' ' + testIndex;
+    testCmd += `${process.argv[0]} --abort-on-uncaught-exception ` +
+               `${process.argv[1]} child ${testIndex}`;
 
     const child = child_process.exec(testCmd);
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test

It seems to me that [no-useless-concat](http://eslint.org/docs/rules/no-useless-concat) is a simple reasonable rule, so I've tried:
```
eslint --rulesdir tools/eslint-rules/ --rule "no-useless-concat: error" benchmark lib test tools
```
which have found only some fragments in tests. Occasionally, I've added some template literals for simplicity, but that was not the main aim. Please, take a look, if this is a reasonable change.