### PR TITLE
backport: 11665 to v7

### DIFF
--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -4,20 +4,30 @@ const common = require('../common');
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
-  kind: ['lstat', 'stat']
+  n: [20e4],
+  kind: ['fstat', 'lstat', 'stat']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
+  const kind = conf.kind;
+  var arg;
+  if (kind === 'fstat')
+    arg = fs.openSync(__filename, 'r');
+  else
+    arg = __filename;
 
   bench.start();
   (function r(cntr, fn) {
-    if (cntr-- <= 0)
-      return bench.end(n);
-    fn(__filename, function() {
+    if (cntr-- <= 0) {
+      bench.end(n);
+      if (kind === 'fstat')
+        fs.closeSync(arg);
+      return;
+    }
+    fn(arg, function() {
       r(cntr, fn);
     });
-  }(n, fs[conf.kind]));
+  }(n, fs[kind]));
 }

--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -4,36 +4,23 @@ const common = require('../common');
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
-  n: [1e4],
+  n: [1e6],
   kind: ['fstatSync', 'lstatSync', 'statSync']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  var fn;
-  var i;
-  switch (conf.kind) {
-    case 'statSync':
-    case 'lstatSync':
-      fn = fs[conf.kind];
-      bench.start();
-      for (i = 0; i < n; i++) {
-        fn(__filename);
-      }
-      bench.end(n);
-      break;
-    case 'fstatSync':
-      fn = fs.fstatSync;
-      const fd = fs.openSync(__filename, 'r');
-      bench.start();
-      for (i = 0; i < n; i++) {
-        fn(fd);
-      }
-      bench.end(n);
-      fs.closeSync(fd);
-      break;
-    default:
-      throw new Error('Invalid kind argument');
+  const kind = conf.kind;
+  const arg = (kind === 'fstatSync' ? fs.openSync(__filename, 'r') : __dirname);
+  const fn = fs[conf.kind];
+
+  bench.start();
+  for (var i = 0; i < n; i++) {
+    fn(arg);
   }
+  bench.end(n);
+
+  if (kind === 'fstat')
+    fs.closeSync(arg);
 }

--- a/benchmark/fs/readFileSync.js
+++ b/benchmark/fs/readFileSync.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var common = require('../common.js');
+var fs = require('fs');
+
+var bench = common.createBenchmark(main, {
+  n: [60e4]
+});
+
+function main(conf) {
+  var n = +conf.n;
+
+  bench.start();
+  for (var i = 0; i < n; ++i)
+    fs.readFileSync(__filename);
+  bench.end(n);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -22,6 +22,7 @@ const assertEncoding = internalFS.assertEncoding;
 const stringToFlags = internalFS.stringToFlags;
 const SyncWriteStream = internalFS.SyncWriteStream;
 const getPathFromURL = internalURL.getPathFromURL;
+const { StorageObject } = require('internal/querystring');
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -1574,10 +1575,23 @@ fs.unwatchFile = function(filename, listener) {
 };
 
 
-// Regex to find the device root, including trailing slash. E.g. 'c:\\'.
-const splitRootRe = isWindows ?
-  /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
-  /^[/]*/;
+var splitRoot;
+if (isWindows) {
+  // Regex to find the device root on Windows (e.g. 'c:\\'), including trailing
+  // slash.
+  const splitRootRe = /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/;
+  splitRoot = function splitRoot(str) {
+    return splitRootRe.exec(str)[0];
+  };
+} else {
+  splitRoot = function splitRoot(str) {
+    for (var i = 0; i < str.length; ++i) {
+      if (str.charCodeAt(i) !== 47/*'/'*/)
+        return str.slice(0, i);
+    }
+    return str;
+  };
+}
 
 function encodeRealpathResult(result, options) {
   if (!options || !options.encoding || options.encoding === 'utf8')
@@ -1605,11 +1619,17 @@ if (isWindows) {
   nextPart = function nextPart(p, i) { return p.indexOf('/', i); };
 }
 
+const emptyObj = new StorageObject();
 fs.realpathSync = function realpathSync(p, options) {
-  options = getOptions(options, {});
-  handleError((p = getPathFromURL(p)));
-  if (typeof p !== 'string')
-    p += '';
+  if (!options)
+    options = emptyObj;
+  else
+    options = getOptions(options, emptyObj);
+  if (typeof p !== 'string') {
+    handleError((p = getPathFromURL(p)));
+    if (typeof p !== 'string')
+      p += '';
+  }
   nullCheck(p);
 
   p = pathModule.resolve(p);
@@ -1621,8 +1641,8 @@ fs.realpathSync = function realpathSync(p, options) {
     return maybeCachedResult;
   }
 
-  const seenLinks = {};
-  const knownHard = {};
+  const seenLinks = new StorageObject();
+  const knownHard = new StorageObject();
   const original = p;
 
   // current character position in p
@@ -1635,10 +1655,8 @@ fs.realpathSync = function realpathSync(p, options) {
   var previous;
 
   // Skip over roots
-  var m = splitRootRe.exec(p);
-  pos = m[0].length;
-  current = m[0];
-  base = m[0];
+  current = base = splitRoot(p);
+  pos = current.length;
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
@@ -1677,7 +1695,8 @@ fs.realpathSync = function realpathSync(p, options) {
       // Use stats array directly to avoid creating an fs.Stats instance just
       // for our internal use.
 
-      binding.lstat(pathModule._makeLong(base));
+      var baseLong = pathModule._makeLong(base);
+      binding.lstat(baseLong);
 
       if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
         knownHard[base] = true;
@@ -1693,13 +1712,13 @@ fs.realpathSync = function realpathSync(p, options) {
         var dev = statValues[0/*dev*/].toString(32);
         var ino = statValues[7/*ino*/].toString(32);
         id = `${dev}:${ino}`;
-        if (seenLinks.hasOwnProperty(id)) {
+        if (seenLinks[id]) {
           linkTarget = seenLinks[id];
         }
       }
       if (linkTarget === null) {
-        binding.stat(pathModule._makeLong(base));
-        linkTarget = binding.readlink(pathModule._makeLong(base));
+        binding.stat(baseLong);
+        linkTarget = binding.readlink(baseLong);
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 
@@ -1711,10 +1730,8 @@ fs.realpathSync = function realpathSync(p, options) {
     p = pathModule.resolve(resolvedLink, p.slice(pos));
 
     // Skip over roots
-    m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
+    current = base = splitRoot(p);
+    pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {
@@ -1730,18 +1747,23 @@ fs.realpathSync = function realpathSync(p, options) {
 
 fs.realpath = function realpath(p, options, callback) {
   callback = maybeCallback(typeof options === 'function' ? options : callback);
-  options = getOptions(options, {});
-  if (handleError((p = getPathFromURL(p)), callback))
-    return;
-  if (typeof p !== 'string')
-    p += '';
+  if (!options)
+    options = emptyObj;
+  else
+    options = getOptions(options, emptyObj);
+  if (typeof p !== 'string') {
+    if (handleError((p = getPathFromURL(p)), callback))
+      return;
+    if (typeof p !== 'string')
+      p += '';
+  }
   if (!nullCheck(p, callback))
     return;
 
   p = pathModule.resolve(p);
 
-  const seenLinks = {};
-  const knownHard = {};
+  const seenLinks = new StorageObject();
+  const knownHard = new StorageObject();
 
   // current character position in p
   var pos;
@@ -1752,11 +1774,8 @@ fs.realpath = function realpath(p, options, callback) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  var m = splitRootRe.exec(p);
-  pos = m[0].length;
-  current = m[0];
-  base = m[0];
-  previous = '';
+  current = base = splitRoot(p);
+  pos = current.length;
 
   // On windows, check that the root exists. On unix there is no need.
   if (isWindows && !knownHard[base]) {
@@ -1819,7 +1838,7 @@ fs.realpath = function realpath(p, options, callback) {
       var dev = statValues[0/*ino*/].toString(32);
       var ino = statValues[7/*ino*/].toString(32);
       id = `${dev}:${ino}`;
-      if (seenLinks.hasOwnProperty(id)) {
+      if (seenLinks[id]) {
         return gotTarget(null, seenLinks[id], base);
       }
     }
@@ -1843,11 +1862,8 @@ fs.realpath = function realpath(p, options, callback) {
   function gotResolvedLink(resolvedLink) {
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
+    current = base = splitRoot(p);
+    pos = current.length;
 
     // On windows, check that the root exists. On unix there is no need.
     if (isWindows && !knownHard[base]) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const constants = process.binding('constants').fs;
+const { S_IFMT, S_IFREG, S_IFLNK } = constants;
 const util = require('util');
 const pathModule = require('path');
 const { isUint8Array } = process.binding('util');
@@ -115,6 +116,24 @@ function makeCallback(cb) {
   };
 }
 
+// Special case of `makeCallback()` that is specific to async `*stat()` calls as
+// an optimization, since the data passed back to the callback needs to be
+// transformed anyway.
+function makeStatsCallback(cb) {
+  if (cb === undefined) {
+    return rethrow();
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('"callback" argument must be a function');
+  }
+
+  return function(err) {
+    if (err) return cb(err);
+    cb(err, statsFromValues());
+  };
+}
+
 function nullCheck(path, callback) {
   if (('' + path).indexOf('\u0000') !== -1) {
     var er = new Error('Path must be a string without null bytes');
@@ -131,7 +150,7 @@ function isFd(path) {
   return (path >>> 0) === path;
 }
 
-// Static method to set the stats properties on a Stats object.
+// Constructor for file stats.
 function Stats(
     dev,
     mode,
@@ -164,40 +183,48 @@ function Stats(
 }
 fs.Stats = Stats;
 
-// Create a C++ binding to the function which creates a Stats object.
-binding.FSInitialize(fs.Stats);
-
-fs.Stats.prototype._checkModeProperty = function(property) {
-  return ((this.mode & constants.S_IFMT) === property);
+Stats.prototype._checkModeProperty = function(property) {
+  return ((this.mode & S_IFMT) === property);
 };
 
-fs.Stats.prototype.isDirectory = function() {
+Stats.prototype.isDirectory = function() {
   return this._checkModeProperty(constants.S_IFDIR);
 };
 
-fs.Stats.prototype.isFile = function() {
-  return this._checkModeProperty(constants.S_IFREG);
+Stats.prototype.isFile = function() {
+  return this._checkModeProperty(S_IFREG);
 };
 
-fs.Stats.prototype.isBlockDevice = function() {
+Stats.prototype.isBlockDevice = function() {
   return this._checkModeProperty(constants.S_IFBLK);
 };
 
-fs.Stats.prototype.isCharacterDevice = function() {
+Stats.prototype.isCharacterDevice = function() {
   return this._checkModeProperty(constants.S_IFCHR);
 };
 
-fs.Stats.prototype.isSymbolicLink = function() {
-  return this._checkModeProperty(constants.S_IFLNK);
+Stats.prototype.isSymbolicLink = function() {
+  return this._checkModeProperty(S_IFLNK);
 };
 
-fs.Stats.prototype.isFIFO = function() {
+Stats.prototype.isFIFO = function() {
   return this._checkModeProperty(constants.S_IFIFO);
 };
 
-fs.Stats.prototype.isSocket = function() {
+Stats.prototype.isSocket = function() {
   return this._checkModeProperty(constants.S_IFSOCK);
 };
+
+const statValues = binding.getStatValues();
+
+function statsFromValues() {
+  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
+                   statValues[4], statValues[5],
+                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
+                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
+                   statValues[10], statValues[11], statValues[12],
+                   statValues[13]);
+}
 
 // Don't allow mode to accidentally be overwritten.
 Object.defineProperties(fs, {
@@ -256,7 +283,7 @@ fs.exists = function(path, callback) {
   var req = new FSReqWrap();
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
-  function cb(err, stats) {
+  function cb(err) {
     if (callback) callback(err ? false : true);
   }
 };
@@ -265,7 +292,7 @@ fs.existsSync = function(path) {
   try {
     handleError((path = getPathFromURL(path)));
     nullCheck(path);
-    binding.stat(pathModule._makeLong(path), statValues);
+    binding.stat(pathModule._makeLong(path));
     return true;
   } catch (e) {
     return false;
@@ -368,13 +395,19 @@ function readFileAfterOpen(err, fd) {
   binding.fstat(fd, req);
 }
 
-function readFileAfterStat(err, st) {
+function readFileAfterStat(err) {
   var context = this.context;
 
   if (err)
     return context.close(err);
 
-  var size = context.size = st.isFile() ? st.size : 0;
+  // Use stats array directly to avoid creating an fs.Stats instance just for
+  // our internal use.
+  var size;
+  if ((statValues[1/*mode*/] & S_IFMT) === S_IFREG)
+    size = context.size = statValues[8/*size*/];
+  else
+    size = context.size = 0;
 
   if (size === 0) {
     context.buffers = [];
@@ -451,14 +484,13 @@ function tryToString(buf, encoding, callback) {
 
 function tryStatSync(fd, isUserFd) {
   var threw = true;
-  var st;
   try {
-    st = fs.fstatSync(fd);
+    binding.fstat(fd);
     threw = false;
   } finally {
     if (threw && !isUserFd) fs.closeSync(fd);
   }
-  return st;
+  return !threw;
 }
 
 function tryCreateBuffer(size, fd, isUserFd) {
@@ -490,8 +522,13 @@ fs.readFileSync = function(path, options) {
   var isUserFd = isFd(path); // file descriptor ownership
   var fd = isUserFd ? path : fs.openSync(path, options.flag || 'r', 0o666);
 
-  var st = tryStatSync(fd, isUserFd);
-  var size = st.isFile() ? st.size : 0;
+  // Use stats array directly to avoid creating an fs.Stats instance just for
+  // our internal use.
+  var size;
+  if (tryStatSync(fd, isUserFd) && (statValues[1/*mode*/] & S_IFMT) === S_IFREG)
+    size = statValues[8/*size*/];
+  else
+    size = 0;
   var pos = 0;
   var buffer; // single buffer with file data
   var buffers; // list for when size is unknown
@@ -916,12 +953,12 @@ fs.readdirSync = function(path, options) {
 
 fs.fstat = function(fd, callback) {
   var req = new FSReqWrap();
-  req.oncomplete = makeCallback(callback);
+  req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
 };
 
 fs.lstat = function(path, callback) {
-  callback = makeCallback(callback);
+  callback = makeStatsCallback(callback);
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
@@ -931,7 +968,7 @@ fs.lstat = function(path, callback) {
 };
 
 fs.stat = function(path, callback) {
-  callback = makeCallback(callback);
+  callback = makeStatsCallback(callback);
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
@@ -940,32 +977,22 @@ fs.stat = function(path, callback) {
   binding.stat(pathModule._makeLong(path), req);
 };
 
-const statValues = new Float64Array(14);
-function statsFromValues() {
-  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
-                   statValues[4], statValues[5],
-                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
-                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
-                   statValues[10], statValues[11], statValues[12],
-                   statValues[13]);
-}
-
 fs.fstatSync = function(fd) {
-  binding.fstat(fd, statValues);
+  binding.fstat(fd);
   return statsFromValues();
 };
 
 fs.lstatSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  binding.lstat(pathModule._makeLong(path), statValues);
+  binding.lstat(pathModule._makeLong(path));
   return statsFromValues();
 };
 
 fs.statSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  binding.stat(pathModule._makeLong(path), statValues);
+  binding.stat(pathModule._makeLong(path));
   return statsFromValues();
 };
 
@@ -1440,6 +1467,15 @@ function emitStop(self) {
   self.emit('stop');
 }
 
+function statsFromPrevValues() {
+  return new Stats(statValues[14], statValues[15], statValues[16],
+                   statValues[17], statValues[18], statValues[19],
+                   statValues[20] < 0 ? undefined : statValues[20],
+                   statValues[21], statValues[22],
+                   statValues[23] < 0 ? undefined : statValues[23],
+                   statValues[24], statValues[25], statValues[26],
+                   statValues[27]);
+}
 function StatWatcher() {
   EventEmitter.call(this);
 
@@ -1450,13 +1486,13 @@ function StatWatcher() {
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(current, previous, newStatus) {
+  this._handle.onchange = function(newStatus) {
     if (oldStatus === -1 &&
         newStatus === -1 &&
-        current.nlink === previous.nlink) return;
+        statValues[2/*new nlink*/] === statValues[16/*old nlink*/]) return;
 
     oldStatus = newStatus;
-    self.emit('change', current, previous);
+    self.emit('change', statsFromValues(), statsFromPrevValues());
   };
 
   this._handle.onstop = function() {
@@ -1538,12 +1574,6 @@ fs.unwatchFile = function(filename, listener) {
 };
 
 
-// Regexp that finds the next portion of a (partial) path
-// result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
-const nextPartRe = isWindows ?
-  /(.*?)(?:[/\\]+|$)/g :
-  /(.*?)(?:[/]+|$)/g;
-
 // Regex to find the device root, including trailing slash. E.g. 'c:\\'.
 const splitRootRe = isWindows ?
   /^(?:[a-zA-Z]:|[\\/]{2}[^\\/]+[\\/][^\\/]+)?[\\/]*/ :
@@ -1560,23 +1590,40 @@ function encodeRealpathResult(result, options) {
   }
 }
 
+// Finds the next portion of a (partial) path, up to the next path delimiter
+var nextPart;
+if (isWindows) {
+  nextPart = function nextPart(p, i) {
+    for (; i < p.length; ++i) {
+      const ch = p.charCodeAt(i);
+      if (ch === 92/*'\'*/ || ch === 47/*'/'*/)
+        return i;
+    }
+    return -1;
+  };
+} else {
+  nextPart = function nextPart(p, i) { return p.indexOf('/', i); };
+}
+
 fs.realpathSync = function realpathSync(p, options) {
   options = getOptions(options, {});
   handleError((p = getPathFromURL(p)));
+  if (typeof p !== 'string')
+    p += '';
   nullCheck(p);
 
-  p = p.toString('utf8');
   p = pathModule.resolve(p);
 
-  const seenLinks = {};
-  const knownHard = {};
   const cache = options[internalFS.realpathCacheKey];
-  const original = p;
 
   const maybeCachedResult = cache && cache.get(p);
   if (maybeCachedResult) {
     return maybeCachedResult;
   }
+
+  const seenLinks = {};
+  const knownHard = {};
+  const original = p;
 
   // current character position in p
   var pos;
@@ -1587,21 +1634,16 @@ fs.realpathSync = function realpathSync(p, options) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  start();
+  // Skip over roots
+  var m = splitRootRe.exec(p);
+  pos = m[0].length;
+  current = m[0];
+  base = m[0];
 
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstatSync(base);
-      knownHard[base] = true;
-    }
+  // On windows, check that the root exists. On unix there is no need.
+  if (isWindows && !knownHard[base]) {
+    binding.lstat(pathModule._makeLong(base));
+    knownHard[base] = true;
   }
 
   // walk down the path, swapping out linked pathparts for their real
@@ -1609,12 +1651,18 @@ fs.realpathSync = function realpathSync(p, options) {
   // NB: p.length changes.
   while (pos < p.length) {
     // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
+    var result = nextPart(p, pos);
     previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
+    if (result === -1) {
+      var last = p.slice(pos);
+      current += last;
+      base = previous + last;
+      pos = p.length;
+    } else {
+      current += p.slice(pos, result + 1);
+      base = previous + p.slice(pos, result);
+      pos = result + 1;
+    }
 
     // continue if not a symlink
     if (knownHard[base] || (cache && cache.get(base) === base)) {
@@ -1622,12 +1670,16 @@ fs.realpathSync = function realpathSync(p, options) {
     }
 
     var resolvedLink;
-    const maybeCachedResolved = cache && cache.get(base);
+    var maybeCachedResolved = cache && cache.get(base);
     if (maybeCachedResolved) {
       resolvedLink = maybeCachedResolved;
     } else {
-      var stat = fs.lstatSync(base);
-      if (!stat.isSymbolicLink()) {
+      // Use stats array directly to avoid creating an fs.Stats instance just
+      // for our internal use.
+
+      binding.lstat(pathModule._makeLong(base));
+
+      if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
         knownHard[base] = true;
         if (cache) cache.set(base, base);
         continue;
@@ -1635,17 +1687,19 @@ fs.realpathSync = function realpathSync(p, options) {
 
       // read the link if it wasn't read before
       // dev/ino always return 0 on windows, so skip the check.
-      let linkTarget = null;
-      let id;
+      var linkTarget = null;
+      var id;
       if (!isWindows) {
-        id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+        var dev = statValues[0/*dev*/].toString(32);
+        var ino = statValues[7/*ino*/].toString(32);
+        id = `${dev}:${ino}`;
         if (seenLinks.hasOwnProperty(id)) {
           linkTarget = seenLinks[id];
         }
       }
       if (linkTarget === null) {
-        fs.statSync(base);
-        linkTarget = fs.readlinkSync(base);
+        binding.stat(pathModule._makeLong(base));
+        linkTarget = binding.readlink(pathModule._makeLong(base));
       }
       resolvedLink = pathModule.resolve(previous, linkTarget);
 
@@ -1655,7 +1709,18 @@ fs.realpathSync = function realpathSync(p, options) {
 
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
+
+    // Skip over roots
+    m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      binding.lstat(pathModule._makeLong(base));
+      knownHard[base] = true;
+    }
   }
 
   if (cache) cache.set(original, p);
@@ -1668,10 +1733,11 @@ fs.realpath = function realpath(p, options, callback) {
   options = getOptions(options, {});
   if (handleError((p = getPathFromURL(p)), callback))
     return;
+  if (typeof p !== 'string')
+    p += '';
   if (!nullCheck(p, callback))
     return;
 
-  p = p.toString('utf8');
   p = pathModule.resolve(p);
 
   const seenLinks = {};
@@ -1686,26 +1752,21 @@ fs.realpath = function realpath(p, options, callback) {
   // the partial path scanned in the previous round, with slash
   var previous;
 
-  start();
+  var m = splitRootRe.exec(p);
+  pos = m[0].length;
+  current = m[0];
+  base = m[0];
+  previous = '';
 
-  function start() {
-    // Skip over roots
-    var m = splitRootRe.exec(p);
-    pos = m[0].length;
-    current = m[0];
-    base = m[0];
-    previous = '';
-
-    // On windows, check that the root exists. On unix there is no need.
-    if (isWindows && !knownHard[base]) {
-      fs.lstat(base, function(err) {
-        if (err) return callback(err);
-        knownHard[base] = true;
-        LOOP();
-      });
-    } else {
-      process.nextTick(LOOP);
-    }
+  // On windows, check that the root exists. On unix there is no need.
+  if (isWindows && !knownHard[base]) {
+    fs.lstat(base, function(err) {
+      if (err) return callback(err);
+      knownHard[base] = true;
+      LOOP();
+    });
+  } else {
+    process.nextTick(LOOP);
   }
 
   // walk down the path, swapping out linked pathparts for their real
@@ -1717,12 +1778,18 @@ fs.realpath = function realpath(p, options, callback) {
     }
 
     // find the next part
-    nextPartRe.lastIndex = pos;
-    var result = nextPartRe.exec(p);
+    var result = nextPart(p, pos);
     previous = current;
-    current += result[0];
-    base = previous + result[1];
-    pos = nextPartRe.lastIndex;
+    if (result === -1) {
+      var last = p.slice(pos);
+      current += last;
+      base = previous + last;
+      pos = p.length;
+    } else {
+      current += p.slice(pos, result + 1);
+      base = previous + p.slice(pos, result);
+      pos = result + 1;
+    }
 
     // continue if not a symlink
     if (knownHard[base]) {
@@ -1732,11 +1799,14 @@ fs.realpath = function realpath(p, options, callback) {
     return fs.lstat(base, gotStat);
   }
 
-  function gotStat(err, stat) {
+  function gotStat(err) {
     if (err) return callback(err);
 
+    // Use stats array directly to avoid creating an fs.Stats instance just for
+    // our internal use.
+
     // if not a symlink, skip to the next path part
-    if (!stat.isSymbolicLink()) {
+    if ((statValues[1/*mode*/] & S_IFMT) !== S_IFLNK) {
       knownHard[base] = true;
       return process.nextTick(LOOP);
     }
@@ -1746,7 +1816,9 @@ fs.realpath = function realpath(p, options, callback) {
     // dev/ino always return 0 on windows, so skip the check.
     let id;
     if (!isWindows) {
-      id = `${stat.dev.toString(32)}:${stat.ino.toString(32)}`;
+      var dev = statValues[0/*ino*/].toString(32);
+      var ino = statValues[7/*ino*/].toString(32);
+      id = `${dev}:${ino}`;
       if (seenLinks.hasOwnProperty(id)) {
         return gotTarget(null, seenLinks[id], base);
       }
@@ -1771,7 +1843,22 @@ fs.realpath = function realpath(p, options, callback) {
   function gotResolvedLink(resolvedLink) {
     // resolve the link, then start over
     p = pathModule.resolve(resolvedLink, p.slice(pos));
-    start();
+    var m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+    previous = '';
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      fs.lstat(base, function(err) {
+        if (err) return callback(err);
+        knownHard[base] = true;
+        LOOP();
+      });
+    } else {
+      process.nextTick(LOOP);
+    }
   }
 };
 
@@ -1950,28 +2037,25 @@ ReadStream.prototype.destroy = function() {
 
 
 ReadStream.prototype.close = function(cb) {
-  var self = this;
   if (cb)
     this.once('close', cb);
   if (this.closed || typeof this.fd !== 'number') {
     if (typeof this.fd !== 'number') {
-      this.once('open', close);
+      this.once('open', this.close.bind(this, null));
       return;
     }
     return process.nextTick(() => this.emit('close'));
   }
   this.closed = true;
-  close();
 
-  function close(fd) {
-    fs.close(fd || self.fd, function(er) {
-      if (er)
-        self.emit('error', er);
-      else
-        self.emit('close');
-    });
-    self.fd = null;
-  }
+  fs.close(this.fd, (er) => {
+    if (er)
+      this.emit('error', er);
+    else
+      this.emit('close');
+  });
+
+  this.fd = null;
 };
 
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -178,6 +178,7 @@ inline Environment::Environment(IsolateData* isolate_data,
 #endif
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
+      fs_stats_field_array_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());
@@ -357,6 +358,15 @@ inline char* Environment::http_parser_buffer() const {
 inline void Environment::set_http_parser_buffer(char* buffer) {
   CHECK_EQ(http_parser_buffer_, nullptr);  // Should be set only once.
   http_parser_buffer_ = buffer;
+}
+
+inline double* Environment::fs_stats_field_array() const {
+  return fs_stats_field_array_;
+}
+
+inline void Environment::set_fs_stats_field_array(double* fields) {
+  CHECK_EQ(fs_stats_field_array_, nullptr);  // Should be set only once.
+  fs_stats_field_array_ = fields;
 }
 
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {

--- a/src/env.h
+++ b/src/env.h
@@ -232,7 +232,6 @@ namespace node {
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(domains_stack_array, v8::Array)                                           \
-  V(fs_stats_constructor_function, v8::Function)                              \
   V(generic_internal_field_template, v8::ObjectTemplate)                      \
   V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
@@ -472,6 +471,9 @@ class Environment {
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
 
+  inline double* fs_stats_field_array() const;
+  inline void set_fs_stats_field_array(double* fields);
+
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
   inline void ThrowRangeError(const char* errmsg);
@@ -579,6 +581,8 @@ class Environment {
   double* heap_space_statistics_buffer_ = nullptr;
 
   char* http_parser_buffer_;
+
+  double* fs_stats_field_array_;
 
 #define V(PropertyName, TypeName)                                             \
   v8::Persistent<TypeName> PropertyName ## _;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -29,7 +29,6 @@ namespace node {
 using v8::Array;
 using v8::ArrayBuffer;
 using v8::Context;
-using v8::EscapableHandleScope;
 using v8::Float64Array;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -190,6 +189,14 @@ static void After(uv_fs_t *req) {
         argc = 1;
         break;
 
+      case UV_FS_STAT:
+      case UV_FS_LSTAT:
+      case UV_FS_FSTAT:
+        argc = 1;
+        FillStatsArray(env->fs_stats_field_array(),
+                       static_cast<const uv_stat_t*>(req->ptr));
+        break;
+
       case UV_FS_UTIME:
       case UV_FS_FUTIME:
         argc = 0;
@@ -201,13 +208,6 @@ static void After(uv_fs_t *req) {
 
       case UV_FS_WRITE:
         argv[1] = Integer::New(env->isolate(), req->result);
-        break;
-
-      case UV_FS_STAT:
-      case UV_FS_LSTAT:
-      case UV_FS_FSTAT:
-        argv[1] = BuildStatsObject(env,
-                                   static_cast<const uv_stat_t*>(req->ptr));
         break;
 
       case UV_FS_MKDTEMP:
@@ -420,116 +420,6 @@ static void Close(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
-  EscapableHandleScope handle_scope(env->isolate());
-
-  // If you hit this assertion, you forgot to enter the v8::Context first.
-  CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
-
-  // The code below is very nasty-looking but it prevents a segmentation fault
-  // when people run JS code like the snippet below. It's apparently more
-  // common than you would expect, several people have reported this crash...
-  //
-  //   function crash() {
-  //     fs.statSync('.');
-  //     crash();
-  //   }
-  //
-  // We need to check the return value of Number::New() and Date::New()
-  // and make sure that we bail out when V8 returns an empty handle.
-
-  // Unsigned integers. It does not actually seem to be specified whether
-  // uid and gid are unsigned or not, but in practice they are unsigned,
-  // and Node’s (F)Chown functions do check their arguments for unsignedness.
-#define X(name)                                                               \
-  Local<Value> name = Integer::NewFromUnsigned(env->isolate(), s->st_##name); \
-  if (name.IsEmpty())                                                         \
-    return Local<Object>();                                                   \
-
-  X(uid)
-  X(gid)
-# if defined(__POSIX__)
-  X(blksize)
-# else
-  Local<Value> blksize = Undefined(env->isolate());
-# endif
-#undef X
-
-  // Integers.
-#define X(name)                                                               \
-  Local<Value> name = Integer::New(env->isolate(), s->st_##name);             \
-  if (name.IsEmpty())                                                         \
-    return Local<Object>();                                                   \
-
-  X(dev)
-  X(mode)
-  X(nlink)
-  X(rdev)
-#undef X
-
-  // Numbers.
-#define X(name)                                                               \
-  Local<Value> name = Number::New(env->isolate(),                             \
-                                  static_cast<double>(s->st_##name));         \
-  if (name.IsEmpty())                                                         \
-    return Local<Object>();                                                   \
-
-  X(ino)
-  X(size)
-# if defined(__POSIX__)
-  X(blocks)
-# else
-  Local<Value> blocks = Undefined(env->isolate());
-# endif
-#undef X
-
-  // Dates.
-#define X(name)                                                               \
-  Local<Value> name##_msec =                                                  \
-    Number::New(env->isolate(),                                               \
-        (static_cast<double>(s->st_##name.tv_sec) * 1000) +                   \
-        (static_cast<double>(s->st_##name.tv_nsec / 1000000)));               \
-                                                                              \
-  if (name##_msec.IsEmpty())                                                  \
-    return Local<Object>();                                                   \
-
-  X(atim)
-  X(mtim)
-  X(ctim)
-  X(birthtim)
-#undef X
-
-  // Pass stats as the first argument, this is the object we are modifying.
-  Local<Value> argv[] = {
-    dev,
-    mode,
-    nlink,
-    uid,
-    gid,
-    rdev,
-    blksize,
-    ino,
-    size,
-    blocks,
-    atim_msec,
-    mtim_msec,
-    ctim_msec,
-    birthtim_msec
-  };
-
-  // Call out to JavaScript to create the stats object.
-  Local<Value> stats =
-      env->fs_stats_constructor_function()->NewInstance(
-          env->context(),
-          arraysize(argv),
-          argv).FromMaybe(Local<Value>());
-
-  if (stats.IsEmpty())
-    return handle_scope.Escape(Local<Object>());
-
-  return handle_scope.Escape(stats);
-}
-
 void FillStatsArray(double* fields, const uv_stat_t* s) {
   fields[0] = s->st_dev;
   fields[1] = s->st_mode;
@@ -645,15 +535,12 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   ASSERT_PATH(path)
 
-  if (args[1]->IsFloat64Array()) {
-    Local<Float64Array> array = args[1].As<Float64Array>();
-    CHECK_EQ(array->Length(), 14);
-    Local<ArrayBuffer> ab = array->Buffer();
-    double* fields = static_cast<double*>(ab->GetContents().Data());
-    SYNC_CALL(stat, *path, *path)
-    FillStatsArray(fields, static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
-  } else if (args[1]->IsObject()) {
+  if (args[1]->IsObject()) {
     ASYNC_CALL(stat, args[1], UTF8, *path)
+  } else {
+    SYNC_CALL(stat, *path, *path)
+    FillStatsArray(env->fs_stats_field_array(),
+                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
   }
 }
 
@@ -666,15 +553,12 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
   BufferValue path(env->isolate(), args[0]);
   ASSERT_PATH(path)
 
-  if (args[1]->IsFloat64Array()) {
-    Local<Float64Array> array = args[1].As<Float64Array>();
-    CHECK_EQ(array->Length(), 14);
-    Local<ArrayBuffer> ab = array->Buffer();
-    double* fields = static_cast<double*>(ab->GetContents().Data());
-    SYNC_CALL(lstat, *path, *path)
-    FillStatsArray(fields, static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
-  } else if (args[1]->IsObject()) {
+  if (args[1]->IsObject()) {
     ASYNC_CALL(lstat, args[1], UTF8, *path)
+  } else {
+    SYNC_CALL(lstat, *path, *path)
+    FillStatsArray(env->fs_stats_field_array(),
+                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
   }
 }
 
@@ -688,15 +572,12 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
 
   int fd = args[0]->Int32Value();
 
-  if (args[1]->IsFloat64Array()) {
-    Local<Float64Array> array = args[1].As<Float64Array>();
-    CHECK_EQ(array->Length(), 14);
-    Local<ArrayBuffer> ab = array->Buffer();
-    double* fields = static_cast<double*>(ab->GetContents().Data());
-    SYNC_CALL(fstat, 0, fd)
-    FillStatsArray(fields, static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
-  } else if (args[1]->IsObject()) {
+  if (args[1]->IsObject()) {
     ASYNC_CALL(fstat, args[1], UTF8, fd)
+  } else {
+    SYNC_CALL(fstat, nullptr, fd)
+    FillStatsArray(env->fs_stats_field_array(),
+                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
   }
 }
 
@@ -1475,12 +1356,20 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void FSInitialize(const FunctionCallbackInfo<Value>& args) {
-  Local<Function> stats_constructor = args[0].As<Function>();
-  CHECK(stats_constructor->IsFunction());
-
+void GetStatValues(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  env->set_fs_stats_constructor_function(stats_constructor);
+  double* fields = env->fs_stats_field_array();
+  if (fields == nullptr) {
+    // stat fields contains twice the number of entries because `fs.StatWatcher`
+    // needs room to store data for *two* `fs.Stats` instances.
+    fields = new double[2 * 14];
+    env->set_fs_stats_field_array(fields);
+  }
+  Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(),
+                                           fields,
+                                           sizeof(double) * 2 * 14);
+  Local<Float64Array> fields_array = Float64Array::New(ab, 0, 2 * 14);
+  args.GetReturnValue().Set(fields_array);
 }
 
 void InitFs(Local<Object> target,
@@ -1488,10 +1377,6 @@ void InitFs(Local<Object> target,
             Local<Context> context,
             void* priv) {
   Environment* env = Environment::GetCurrent(context);
-
-  // Function which creates a new Stats object.
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "FSInitialize"),
-              env->NewFunctionTemplate(FSInitialize)->GetFunction());
 
   env->SetMethod(target, "access", Access);
   env->SetMethod(target, "close", Close);
@@ -1530,6 +1415,8 @@ void InitFs(Local<Object> target,
   env->SetMethod(target, "futimes", FUTimes);
 
   env->SetMethod(target, "mkdtemp", Mkdtemp);
+
+  env->SetMethod(target, "getStatValues", GetStatValues);
 
   StatWatcher::Initialize(env, target);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -136,7 +136,7 @@ NO_RETURN void FatalError(const char* location, const char* message);
 
 void ProcessEmitWarning(Environment* env, const char* fmt, ...);
 
-v8::Local<v8::Value> BuildStatsObject(Environment* env, const uv_stat_t* s);
+void FillStatsArray(double* fields, const uv_stat_t* s);
 
 void SetupProcessObject(Environment* env,
                         int argc,

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -65,12 +65,11 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
   Environment* env = wrap->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-  Local<Value> argv[] = {
-    BuildStatsObject(env, curr),
-    BuildStatsObject(env, prev),
-    Integer::New(env->isolate(), status)
-  };
-  wrap->MakeCallback(env->onchange_string(), arraysize(argv), argv);
+
+  FillStatsArray(env->fs_stats_field_array(), curr);
+  FillStatsArray(env->fs_stats_field_array() + 14, prev);
+  Local<Value> arg = Integer::New(env->isolate(), status);
+  wrap->MakeCallback(env->onchange_string(), 1, &arg);
 }
 
 

--- a/test/parallel/test-fs-sync-fd-leak.js
+++ b/test/parallel/test-fs-sync-fd-leak.js
@@ -18,7 +18,7 @@ fs.writeSync = function() {
   throw new Error('BAM');
 };
 
-fs.fstatSync = function() {
+process.binding('fs').fstat = function() {
   throw new Error('BAM');
 };
 


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/11665 + a few non-semver-major changes (specifically only to `fs.realpathSync()` and `fs.realpath()`) from https://github.com/nodejs/node/pull/10789.

https://github.com/nodejs/node/pull/11665 was initially labeled as semver-major by me as I typically like to err on the side of caution because of the nature of some of the changes. However, some have expressed interest in downgrading it to a semver-minor to allow (a more straightforward backport of) a necessary fix for a discrepancy that exists currently in v7.x because of the way `fs.Stats` values are generated for `fs.stat()` vs `fs.statSync()` for example.

Landing this should fix the issue described in https://github.com/nodejs/node/issues/12419.

/cc @nodejs/ctc

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* fs
