### PR TITLE
inspector: enable --inspect-brk in v6

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3616,6 +3616,15 @@ static bool ParseDebugOpt(const char* arg) {
     use_debug_agent = true;
     use_inspector = true;
     port = arg + sizeof("--inspect=") - 1;
+  } else if (!strcmp(arg, "--inspect-brk")) {
+    use_debug_agent = true;
+    use_inspector = true;
+    debug_wait_connect = true;
+  } else if (!strncmp(arg, "--inspect-brk=", sizeof("--inspect-brk=") - 1)) {
+    use_debug_agent = true;
+    use_inspector = true;
+    debug_wait_connect = true;
+    port = arg + sizeof("--inspect-brk=") - 1;
 #else
   } else if (!strncmp(arg, "--inspect", sizeof("--inspect") - 1)) {
     fprintf(stderr,


### PR DESCRIPTION
`--inspect-brk` doesn't exist in v6, leaving no consistent
way to start node with inspector activated and breaking on first line.
Add `--inspect-brk[=port]` as an undocumented option to v6.x

Fixes: https://github.com/nodejs/node/issues/12364

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
inspector, debugger
