### PR TITLE
net: move debug statement

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -859,14 +859,15 @@ function internalConnect(
   var err;
 
   if (localAddress || localPort) {
-    debug('binding to localAddress: %s and localPort: %d (addressType: %d)',
-          localAddress, localPort, addressType);
-
     if (addressType === 4) {
       localAddress = localAddress || '0.0.0.0';
+      debug('binding to localAddress: %s and localPort: %d (addressType: 4)',
+            localAddress, localPort);
       err = self._handle.bind(localAddress, localPort);
     } else if (addressType === 6) {
       localAddress = localAddress || '::';
+      debug('binding to localAddress: %s and localPort: %d (addressType: 6)',
+            localAddress, localPort);
       err = self._handle.bind6(localAddress, localPort);
     } else {
       self._destroy(new TypeError('Invalid addressType: ' + addressType));


### PR DESCRIPTION
This will allow `localAddress` to be properly set before writing debug output.

/cc @bnoordhuis 

CI: https://ci.nodejs.org/job/node-test-pull-request/7631/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* net
