### PR TITLE
test: dynamic port in dgram bind shared ports

### DIFF
--- a/test/parallel/test-dgram-bind-shared-ports.js
+++ b/test/parallel/test-dgram-bind-shared-ports.js
@@ -26,7 +26,10 @@ const cluster = require('cluster');
 const dgram = require('dgram');
 
 if (cluster.isMaster) {
-  const worker1 = cluster.fork();
+  const worker1 = cluster.fork({
+    SOCKET1: 0,
+    SOCKET2: 0
+  });
 
   if (common.isWindows) {
     const checkErrType = (er) => {
@@ -38,16 +41,21 @@ if (cluster.isMaster) {
     return;
   }
 
-  worker1.on('message', (msg) => {
-    assert.strictEqual(msg, 'success');
-    const worker2 = cluster.fork();
+  worker1.on('message', common.mustCall((msg) => {
+    assert(msg.socketPort1);
+    assert(msg.socketPort2);
 
-    worker2.on('message', (msg) => {
+    const worker2 = cluster.fork({
+      SOCKET1: msg.socketPort1,
+      SOCKET2: msg.socketPort2
+    });
+
+    worker2.on('message', common.mustCall((msg) => {
       assert.strictEqual(msg, 'socket2:EADDRINUSE');
       worker1.kill();
       worker2.kill();
-    });
-  });
+    }));
+  }));
 } else {
   const socket1 = dgram.createSocket('udp4', common.noop);
   const socket2 = dgram.createSocket('udp4', common.noop);
@@ -64,12 +72,23 @@ if (cluster.isMaster) {
 
   socket1.bind({
     address: 'localhost',
-    port: common.PORT,
+    port: 0,
     exclusive: false
-  }, () => {
-    socket2.bind({ port: common.PORT + 1, exclusive: true }, () => {
+  }, common.mustCall(() => {
+    if (process.env.SOCKET1 !== '0') {
+      assert.strictEqual(process.env.SOCKET1, '' + socket1.address().port);
+    }
+
+    socket2.bind({
+      address: 'localhost',
+      port: process.env.SOCKET2,
+      exclusive: true
+    }, common.mustCall(() => {
       // the first worker should succeed
-      process.send('success');
-    });
-  });
+      process.send({
+        socketPort1: socket1.address().port,
+        socketPort2: socket2.address().port
+      });
+    }));
+  }));
 }


### PR DESCRIPTION
Removed common.PORT from test-dgram-bind-shared-ports in order to
eliminate the possibility of port collision with other tests.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
