### PR TITLE
test: dynamic port in dgram tests

### DIFF
--- a/test/parallel/test-dgram-close-in-listening.js
+++ b/test/parallel/test-dgram-close-in-listening.js
@@ -13,6 +13,14 @@ socket.on('listening', function() {
   socket.close();
 });
 
-// adds a listener to 'listening' to send the data when
-// the socket is available
-socket.send(buf, 0, buf.length, common.PORT, 'localhost');
+// get a random port for send
+const portGetter = dgram.createSocket('udp4')
+  .bind(0, 'localhost', common.mustCall(() => {
+    // adds a listener to 'listening' to send the data when
+    // the socket is available
+    socket.send(buf, 0, buf.length,
+                portGetter.address().port,
+                portGetter.address().address);
+
+    portGetter.close();
+  }));

--- a/test/parallel/test-dgram-close-is-not-callback.js
+++ b/test/parallel/test-dgram-close-is-not-callback.js
@@ -6,9 +6,16 @@ const buf = Buffer.alloc(1024, 42);
 
 const socket = dgram.createSocket('udp4');
 
-socket.send(buf, 0, buf.length, common.PORT, 'localhost');
+// get a random port for send
+const portGetter = dgram.createSocket('udp4')
+  .bind(0, 'localhost', common.mustCall(() => {
+    socket.send(buf, 0, buf.length,
+                portGetter.address().port,
+                portGetter.address().address);
 
-// if close callback is not function, ignore the argument.
-socket.close('bad argument');
+    // if close callback is not function, ignore the argument.
+    socket.close('bad argument');
+    portGetter.close();
 
-socket.on('close', common.mustCall());
+    socket.on('close', common.mustCall());
+  }));

--- a/test/parallel/test-dgram-exclusive-implicit-bind.js
+++ b/test/parallel/test-dgram-exclusive-implicit-bind.js
@@ -70,15 +70,15 @@ if (cluster.isMaster) {
   });
 
   target.on('listening', function() {
-    cluster.fork();
-    cluster.fork();
+    cluster.fork({PORT: target.address().port});
+    cluster.fork({PORT: target.address().port});
     if (!common.isWindows) {
-      cluster.fork({BOUND: 'y'});
-      cluster.fork({BOUND: 'y'});
+      cluster.fork({BOUND: 'y', PORT: target.address().port});
+      cluster.fork({BOUND: 'y', PORT: target.address().port});
     }
   });
 
-  target.bind({port: common.PORT, exclusive: true});
+  target.bind({port: 0, exclusive: true});
 
   return;
 }
@@ -98,7 +98,8 @@ if (process.env.BOUND === 'y') {
   source.unref();
 }
 
+assert(process.env.PORT);
 const buf = Buffer.from(process.pid.toString());
 const interval = setInterval(() => {
-  source.send(buf, common.PORT, '127.0.0.1');
+  source.send(buf, process.env.PORT, '127.0.0.1');
 }, 1).unref();

--- a/test/parallel/test-dgram-oob-buffer.js
+++ b/test/parallel/test-dgram-oob-buffer.js
@@ -29,12 +29,17 @@ const dgram = require('dgram');
 
 const socket = dgram.createSocket('udp4');
 const buf = Buffer.from([1, 2, 3, 4]);
+const portGetter = dgram.createSocket('udp4')
+  .bind(0, 'localhost', common.mustCall(() => {
+    const address = portGetter.address();
+    portGetter.close(common.mustCall(() => {
+      socket.send(buf, 0, 0, address.port, address.address, common.noop);
+      socket.send(buf, 0, 4, address.port, address.address, common.noop);
+      socket.send(buf, 1, 3, address.port, address.address, common.noop);
+      socket.send(buf, 3, 1, address.port, address.address, common.noop);
+      // Since length of zero means nothing, don't error despite OOB.
+      socket.send(buf, 4, 0, address.port, address.address, common.noop);
 
-socket.send(buf, 0, 0, common.PORT, '127.0.0.1', common.noop); // useful? no
-socket.send(buf, 0, 4, common.PORT, '127.0.0.1', common.noop);
-socket.send(buf, 1, 3, common.PORT, '127.0.0.1', common.noop);
-socket.send(buf, 3, 1, common.PORT, '127.0.0.1', common.noop);
-// Since length of zero means nothing, don't error despite OOB.
-socket.send(buf, 4, 0, common.PORT, '127.0.0.1', common.noop);
-
-socket.close();
+      socket.close();
+    }));
+  }));


### PR DESCRIPTION
Removed common.PORT from:
- test-dgram-close-in-listening
- test-dgram-close-is-not-callback
- test-dgram-close
- test-dgram-exclusive-implicit-bind
- test-dgram-oob-buffer

This is required in order to eliminate the possibility of port collision in parallel tests.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
