### PR TITLE
src: fix linting error

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -73,7 +73,7 @@
 #endif
 
 #include <errno.h>
-#include <fcntl.h>. // _O_RDWR
+#include <fcntl.h>.  // _O_RDWR
 #include <limits.h>  // PATH_MAX
 #include <locale.h>
 #include <signal.h>


### PR DESCRIPTION
43c1b625a6 introduced a minor c linting issue

This should land quickly so linting master is green again.
/cc @MylesBorins 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src