### PR TITLE
src: remove erroneous dot

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -73,7 +73,7 @@
 #endif
 
 #include <errno.h>
-#include <fcntl.h>. // _O_RDWR
+#include <fcntl.h>  // _O_RDWR
 #include <limits.h>  // PATH_MAX
 #include <locale.h>
 #include <signal.h>


### PR DESCRIPTION
This got accidentally added when landing original commit