### PR TITLE
test: fixup test-http-hostname-typechecking

### DIFF
--- a/test/parallel/test-http-hostname-typechecking.js
+++ b/test/parallel/test-http-hostname-typechecking.js
@@ -21,7 +21,7 @@ vals.forEach((v) => {
 // These values are OK and should not throw synchronously
 ['', undefined, null].forEach((v) => {
   assert.doesNotThrow(() => {
-    http.request({hostname: v}).on('error', common.noop);
-    http.request({host: v}).on('error', common.noop);
+    http.request({hostname: v}).on('error', common.noop).end();
+    http.request({host: v}).on('error', common.noop).end();
   });
 });


### PR DESCRIPTION
This test would currently create HTTP requests to localhost:80
and would time out on machines that actually had an server listening
there.

To address that, `end()` the requests that are generated.

/cc @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

test