### PR TITLE
test: use common.js to check platform

### DIFF
--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -27,7 +27,7 @@ const path = require('path');
 
 // `fs.readFile('/')` does not fail on FreeBSD, because you can open and read
 // the directory there.
-if (process.platform === 'freebsd') {
+if (common.isFreeBSD) {
   common.skip('platform not supported.');
   return;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Hi, 
since `common.js` has helper variables we can use them to check platforms instead of usage `process.platform === ...`. 
Actually `common.js` is used everywhere in tests for this, but except one place and this PR should replace this place with `common.js` :)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test