### PR TITLE
util: deprecate util.deprecate()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -590,6 +590,27 @@ Type: Runtime
 `node debug` corresponds to the legacy CLI debugger which has been replaced with
 a V8-inspector based CLI debugger available through `node inspect`.
 
+<a id="DEP00XX"></a>
+### DEP00XX: util.deprecate()
+
+Type: Runtime
+
+The `util.deprecate()` method has been deprecated. Please use a userland
+alternative, such as [depd](https://www.npmjs.com/package/depd), instead.
+
+Alternatively, the `process.emitWarning()` API can also be used:
+
+```js
+let depWarn = true;
+function deprecationWarning(msg) {
+  if (depWarn) {
+    process.emitWarning(msg, 'DeprecationWarning');
+    depWarn = false;
+  }
+}
+deprecationWarning('This function is deprecated');
+```
+
 [alloc]: buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -50,10 +50,13 @@ environment variable. For example: `NODE_DEBUG=fs,net,tls`.
 ## util.deprecate(function, string)
 <!-- YAML
 added: v0.8.0
+deprecated: REPLACEMENT
 -->
 
-The `util.deprecate()` method wraps the given `function` or class in such a way that
-it is marked as deprecated.
+> Stability: 0 - Deprecated: Use a userland alternative instead.
+
+The `util.deprecate()` method wraps the given `function` or class in such a way
+that it is marked as deprecated.
 
 ```js
 const util = require('util');

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -27,6 +27,7 @@
 // unless they address existing, critical bugs.
 
 const util = require('util');
+const { deprecate } = require('internal/util');
 const EventEmitter = require('events');
 const inherits = util.inherits;
 
@@ -320,7 +321,7 @@ Domain.prototype.bind = function(cb) {
 };
 
 
-Domain.prototype.dispose = util.deprecate(function() {
+Domain.prototype.dispose = deprecate(function() {
   if (this._disposed) return;
 
   // if we're the active domain, then get out now.

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -206,7 +206,7 @@
       configurable: true
     });
     global.process = process;
-    const util = NativeModule.require('util');
+    const util = NativeModule.require('internal/util');
 
     function makeGetter(name) {
       return util.deprecate(function() {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -43,7 +43,7 @@
 'use strict';
 
 const internalModule = require('internal/module');
-const internalUtil = require('internal/util');
+const { deprecate, decorateErrorStack } = require('internal/util');
 const util = require('util');
 const utilBinding = process.binding('util');
 const inherits = util.inherits;
@@ -282,7 +282,7 @@ function REPLServer(prompt,
   self._domain.on('error', function debugDomainError(e) {
     debug('domain error');
     const top = replMap.get(self);
-    internalUtil.decorateErrorStack(e);
+    decorateErrorStack(e);
     if (e instanceof SyntaxError && e.stack) {
       // remove repl:line-number and stack trace
       e.stack = e.stack
@@ -1234,7 +1234,7 @@ function regexpEscape(s) {
  */
 // TODO(princejwesley): Remove it prior to v8.0.0 release
 // Reference: https://github.com/nodejs/node/pull/7829
-REPLServer.prototype.convertToContext = util.deprecate(function(cmd) {
+REPLServer.prototype.convertToContext = deprecate(function(cmd) {
   const scopeVar = /^\s*var\s*([\w$]+)(.*)$/m;
   const scopeFunc = /^\s*function\s*([\w$]+)/;
   var matches;

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,10 +23,9 @@
 
 const uv = process.binding('uv');
 const Buffer = require('buffer').Buffer;
-const internalUtil = require('internal/util');
 const binding = process.binding('util');
 
-const isError = internalUtil.isError;
+const { isError, deprecate, customInspectSymbol } = require('internal/util');
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
@@ -144,7 +143,10 @@ exports.format = function(f) {
 };
 
 
-exports.deprecate = internalUtil.deprecate;
+exports.deprecate =
+  deprecate(deprecate,
+            'util.deprecate() is deprecated. Please use a userland module ' +
+            'instead', 'DEP00XX');
 
 
 var debugs = {};
@@ -243,8 +245,6 @@ inspect.styles = Object.assign(Object.create(null), {
   // "name": intentionally not styling
   'regexp': 'red'
 });
-
-const customInspectSymbol = internalUtil.customInspectSymbol;
 
 exports.inspect = inspect;
 exports.inspect.custom = customInspectSymbol;
@@ -1008,26 +1008,26 @@ function hasOwnProperty(obj, prop) {
 
 // Deprecated old stuff.
 
-exports.print = internalUtil.deprecate(function() {
+exports.print = deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(String(arguments[i]));
   }
 }, 'util.print is deprecated. Use console.log instead.', 'DEP0026');
 
 
-exports.puts = internalUtil.deprecate(function() {
+exports.puts = deprecate(function() {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stdout.write(arguments[i] + '\n');
   }
 }, 'util.puts is deprecated. Use console.log instead.', 'DEP0027');
 
 
-exports.debug = internalUtil.deprecate(function(x) {
+exports.debug = deprecate(function(x) {
   process.stderr.write(`DEBUG: ${x}\n`);
 }, 'util.debug is deprecated. Use console.error instead.', 'DEP0028');
 
 
-exports.error = internalUtil.deprecate(function(x) {
+exports.error = deprecate(function(x) {
   for (var i = 0, len = arguments.length; i < len; ++i) {
     process.stderr.write(arguments[i] + '\n');
   }


### PR DESCRIPTION
Deprecate `util.deprecate()`... there are better userland alternatives and core is using it from
`internal/util`. 

/cc @sam-github @nodejs/ctc 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

util, repl, lib, domain