### PR TITLE
test: test documented napi_get_value_int32 behaviour

### DIFF
--- a/test/addons-napi/test_number/test.js
+++ b/test/addons-napi/test_number/test.js
@@ -37,3 +37,11 @@ assert.strictEqual(num7, test_number.Test(num7));
 
 const num8 = Number.NEGATIVE_INFINITY;
 assert.strictEqual(num8, test_number.Test(num8));
+
+
+// validate documented behaviour when value is retrieved
+// as 32 bit integer with napi_get_value_int32
+assert.strictEqual(1, test_number.TestInt32Truncation(4294967297));
+assert.strictEqual(0, test_number.TestInt32Truncation(4294967296));
+assert.strictEqual(-1, test_number.TestInt32Truncation(4294967295));
+assert.strictEqual(3, test_number.TestInt32Truncation(4294967296 * 5 + 3));

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -23,9 +23,32 @@ napi_value Test(napi_env env, napi_callback_info info) {
   return output;
 }
 
+napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_number,
+    "Wrong type of arguments. Expects a number as first argument.");
+
+  int32_t input;
+  NAPI_CALL(env, napi_get_value_int32(env, args[0], &input));
+
+  napi_value output;
+  NAPI_CALL(env, napi_create_number(env, input, &output));
+
+  return output;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
+    DECLARE_NAPI_PROPERTY("TestInt32Truncation", TestInt32Truncation),
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(


### PR DESCRIPTION
We chose to document this in the docs as there are
different possible behaviours.  Adding this test to validate
that all vm implementations do it the same way.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, n-api