### PR TITLE
src: remove GTEST_DONT_DEFINE_ASSERT_EQ in util.h

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -124,14 +124,6 @@ template <typename T> using remove_reference = std::remove_reference<T>;
     }                                                                         \
   } while (0)
 
-// FIXME(bnoordhuis) cctests don't link in node::Abort() and node::Assert().
-#ifdef GTEST_DONT_DEFINE_ASSERT_EQ
-#undef ABORT
-#undef CHECK
-#define ABORT ABORT_NO_BACKTRACE
-#define CHECK assert
-#endif
-
 #ifdef NDEBUG
 #define ASSERT(expr)
 #else


### PR DESCRIPTION
As indicated by the FIXME comment, this macro guard is no longer needed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src