### PR TITLE
test: dynamic port in parallel regress tests

### DIFF
--- a/test/parallel/test-regress-GH-5051.js
+++ b/test/parallel/test-regress-GH-5051.js
@@ -12,20 +12,22 @@ agent.maxSockets = 0;
 
 // localAddress is used when naming requests / sockets
 // while using the Legacy API
-agent.addRequest(req, 'localhost', common.PORT, '127.0.0.1');
+// port 8080 is hardcoded since this does not create a network connection
+agent.addRequest(req, 'localhost', 8080, '127.0.0.1');
 assert.strictEqual(Object.keys(agent.requests).length, 1);
 assert.strictEqual(
   Object.keys(agent.requests)[0],
-  'localhost:' + common.PORT + ':127.0.0.1');
+  'localhost:8080:127.0.0.1');
 
 // path is *not* used when naming requests / sockets
+// port 8080 is hardcoded since this does not create a network connection
 agent.addRequest(req, {
   host: 'localhost',
-  port: common.PORT,
+  port: 8080,
   localAddress: '127.0.0.1',
   path: '/foo'
 });
 assert.strictEqual(Object.keys(agent.requests).length, 1);
 assert.strictEqual(
   Object.keys(agent.requests)[0],
-  'localhost:' + common.PORT + ':127.0.0.1');
+  'localhost:8080:127.0.0.1');

--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -6,9 +6,9 @@ const net = require('net');
 const invalidPort = -1 >>> 0;
 const errorMessage = /"port" argument must be >= 0 and < 65536/;
 
-net.Server().listen(common.PORT, function() {
+net.Server().listen(0, function() {
   const address = this.address();
-  const key = `${address.family.slice(-1)}:${address.address}:${common.PORT}`;
+  const key = `${address.family.slice(-1)}:${address.address}:0`;
 
   assert.strictEqual(this._connectionKey, key);
   this.close();


### PR DESCRIPTION
Removed common.PORT from test-regress-GH-5051 and
test-regress-GH-5727 in order to eliminate the possibility
of port collision.

Refs: https://github.com/nodejs/node/issues/12376

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test
