### PR TITLE
(v7.x backport) crypto: add randomFill and randomFillSync

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1584,6 +1584,66 @@ This should normally never take longer than a few milliseconds. The only time
 when generating the random bytes may conceivably block for a longer period of
 time is right after boot, when the whole system is still low on entropy.
 
+### crypto.randomFillSync(buf[, offset][, size])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buf` {Buffer|Uint8Array} Must be supplied.
+* `offset` {number} Defaults to `0`.
+* `size` {number} Defaults to `buf.length - offset`.
+
+Synchronous version of [`crypto.randomFill()`][].
+
+Returns `buf`
+
+```js
+const buf = Buffer.alloc(10);
+console.log(crypto.randomFillSync(buf).toString('hex'));
+
+crypto.randomFillSync(buf, 5);
+console.log(buf.toString('hex'));
+
+// The above is equivalent to the following:
+crypto.randomFillSync(buf, 5, 5);
+console.log(buf.toString('hex'));
+```
+
+### crypto.randomFill(buf[, offset][, size], callback)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `buf` {Buffer|Uint8Array} Must be supplied.
+* `offset` {number} Defaults to `0`.
+* `size` {number} Defaults to `buf.length - offset`.
+* `callback` {Function} `function(err, buf) {}`.
+
+This function is similar to [`crypto.randomBytes()`][] but requires the first
+argument to be a [`Buffer`][] that will be filled. It also
+requires that a callback is passed in.
+
+If the `callback` function is not provided, an error will be thrown.
+
+```js
+const buf = Buffer.alloc(10);
+crypto.randomFill(buf, (err, buf) => {
+  if (err) throw err;
+  console.log(buf.toString('hex'));
+});
+
+crypto.randomFill(buf, 5, (err, buf) => {
+  if (err) throw err;
+  console.log(buf.toString('hex'));
+});
+
+// The above is equivalent to the following:
+crypto.randomFill(buf, 5, 5, (err, buf) => {
+  if (err) throw err;
+  console.log(buf.toString('hex'));
+});
+```
+
 ### crypto.setEngine(engine[, flags])
 <!-- YAML
 added: v0.11.11
@@ -2003,6 +2063,8 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`crypto.getCurves()`]: #crypto_crypto_getcurves
 [`crypto.getHashes()`]: #crypto_crypto_gethashes
 [`crypto.pbkdf2()`]: #crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+[`crypto.randomBytes()`]: #crypto_crypto_randombytes_size_callback
+[`crypto.randomFill()`]: #crypto_crypto_randombytesbuffer_buf_size_offset_cb
 [`decipher.final()`]: #crypto_decipher_final_output_encoding
 [`decipher.update()`]: #crypto_decipher_update_data_input_encoding_output_encoding
 [`diffieHellman.setPublicKey()`]: #crypto_diffiehellman_setpublickey_public_key_encoding

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -19,8 +19,10 @@ const setFipsCrypto = binding.setFipsCrypto;
 const timingSafeEqual = binding.timingSafeEqual;
 
 const Buffer = require('buffer').Buffer;
+const kBufferMaxLength = require('buffer').kMaxLength;
 const stream = require('stream');
 const util = require('util');
+const { isUint8Array } = process.binding('util');
 const LazyTransform = require('internal/streams/lazy_transform');
 
 const DH_GENERATOR = 2;
@@ -633,6 +635,74 @@ exports.setEngine = function setEngine(id, flags) {
 
   return binding.setEngine(id, flags);
 };
+
+const kMaxUint32 = Math.pow(2, 32) - 1;
+
+function randomFillSync(buf, offset = 0, size) {
+  if (!isUint8Array(buf)) {
+    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+  }
+
+  assertOffset(offset, buf.length);
+
+  if (size === undefined) size = buf.length - offset;
+
+  assertSize(size, offset, buf.length);
+
+  return binding.randomFill(buf, offset, size);
+}
+exports.randomFillSync = randomFillSync;
+
+function randomFill(buf, offset, size, cb) {
+  if (!isUint8Array(buf)) {
+    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+  }
+
+  if (typeof offset === 'function') {
+    cb = offset;
+    offset = 0;
+    size = buf.length;
+  } else if (typeof size === 'function') {
+    cb = size;
+    size = buf.length - offset;
+  } else if (typeof cb !== 'function') {
+    throw new TypeError('"cb" argument must be a function');
+  }
+
+  assertOffset(offset, buf.length);
+  assertSize(size, offset, buf.length);
+
+  return binding.randomFill(buf, offset, size, cb);
+}
+exports.randomFill = randomFill;
+
+function assertOffset(offset, length) {
+  if (typeof offset !== 'number' || offset !== offset) {
+    throw new TypeError('offset must be a number');
+  }
+
+  if (offset > kMaxUint32 || offset < 0) {
+    throw new TypeError('offset must be a uint32');
+  }
+
+  if (offset > kBufferMaxLength || offset > length) {
+    throw new RangeError('offset out of range');
+  }
+}
+
+function assertSize(size, offset, length) {
+  if (typeof size !== 'number' || size !== size) {
+    throw new TypeError('size must be a number');
+  }
+
+  if (size > kMaxUint32 || size < 0) {
+    throw new TypeError('size must be a uint32');
+  }
+
+  if (size + offset > length || size > kBufferMaxLength) {
+    throw new RangeError('buffer too small');
+  }
+}
 
 exports.randomBytes = exports.pseudoRandomBytes = randomBytes;
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -29,6 +29,210 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
   });
 });
 
+const noop = () => {};
+
+{
+  const buf = Buffer.alloc(10);
+  const before = buf.toString('hex');
+  const after = crypto.randomFillSync(buf).toString('hex');
+  assert.notStrictEqual(before, after);
+}
+
+{
+  const buf = new Uint8Array(new Array(10).fill(0));
+  const before = Buffer.from(buf).toString('hex');
+  crypto.randomFillSync(buf);
+  const after = Buffer.from(buf).toString('hex');
+  assert.notStrictEqual(before, after);
+}
+
+{
+  const buf = Buffer.alloc(10);
+  const before = buf.toString('hex');
+  crypto.randomFill(buf, common.mustCall((err, buf) => {
+    assert.ifError(err);
+    const after = buf.toString('hex');
+    assert.notStrictEqual(before, after);
+  }));
+}
+
+{
+  const buf = new Uint8Array(new Array(10).fill(0));
+  const before = Buffer.from(buf).toString('hex');
+  crypto.randomFill(buf, common.mustCall((err, buf) => {
+    assert.ifError(err);
+    const after = Buffer.from(buf).toString('hex');
+    assert.notStrictEqual(before, after);
+  }));
+}
+
+{
+  const buf = Buffer.alloc(10);
+  const before = buf.toString('hex');
+  crypto.randomFillSync(buf, 5, 5);
+  const after = buf.toString('hex');
+  assert.notStrictEqual(before, after);
+  assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
+}
+
+{
+  const buf = new Uint8Array(new Array(10).fill(0));
+  const before = Buffer.from(buf).toString('hex');
+  crypto.randomFillSync(buf, 5, 5);
+  const after = Buffer.from(buf).toString('hex');
+  assert.notStrictEqual(before, after);
+  assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
+}
+
+{
+  const buf = Buffer.alloc(10);
+  const before = buf.toString('hex');
+  crypto.randomFillSync(buf, 5);
+  const after = buf.toString('hex');
+  assert.notStrictEqual(before, after);
+  assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
+}
+
+{
+  const buf = Buffer.alloc(10);
+  const before = buf.toString('hex');
+  crypto.randomFill(buf, 5, 5, common.mustCall((err, buf) => {
+    assert.ifError(err);
+    const after = buf.toString('hex');
+    assert.notStrictEqual(before, after);
+    assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
+  }));
+}
+
+{
+  const buf = new Uint8Array(new Array(10).fill(0));
+  const before = Buffer.from(buf).toString('hex');
+  crypto.randomFill(buf, 5, 5, common.mustCall((err, buf) => {
+    assert.ifError(err);
+    const after = Buffer.from(buf).toString('hex');
+    assert.notStrictEqual(before, after);
+    assert.deepStrictEqual(before.slice(0, 5), after.slice(0, 5));
+  }));
+}
+
+{
+  const bufs = [
+    Buffer.alloc(10),
+    new Uint8Array(new Array(10).fill(0))
+  ];
+
+  for (const buf of bufs) {
+    const len = Buffer.byteLength(buf);
+    assert.strictEqual(len, 10, `Expected byteLength of 10, got ${len}`);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 'test');
+    }, /offset must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, NaN);
+    }, /offset must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 'test', noop);
+    }, /offset must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, NaN, noop);
+    }, /offset must be a number/);
+
+    const max = require('buffer').kMaxLength + 1;
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 11);
+    }, /offset out of range/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, max);
+    }, /offset out of range/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 11, noop);
+    }, /offset out of range/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, max, noop);
+    }, /offset out of range/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 0, 'test');
+    }, /size must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 0, NaN);
+    }, /size must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 0, 'test', noop);
+    }, /size must be a number/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 0, NaN, noop);
+    }, /size must be a number/);
+
+    {
+      const size = (-1 >>> 0) + 1;
+
+      assert.throws(() => {
+        crypto.randomFillSync(buf, 0, -10);
+      }, /size must be a uint32/);
+
+      assert.throws(() => {
+        crypto.randomFillSync(buf, 0, size);
+      }, /size must be a uint32/);
+
+      assert.throws(() => {
+        crypto.randomFill(buf, 0, -10, noop);
+      }, /size must be a uint32/);
+
+      assert.throws(() => {
+        crypto.randomFill(buf, 0, size, noop);
+      }, /size must be a uint32/);
+    }
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, -10);
+    }, /offset must be a uint32/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, -10, noop);
+    }, /offset must be a uint32/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 1, 10);
+    }, /buffer too small/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 1, 10, noop);
+    }, /buffer too small/);
+
+    assert.throws(() => {
+      crypto.randomFillSync(buf, 0, 12);
+    }, /buffer too small/);
+
+    assert.throws(() => {
+      crypto.randomFill(buf, 0, 12, noop);
+    }, /buffer too small/);
+
+    {
+      // Offset is too big
+      const offset = (-1 >>> 0) + 1;
+      assert.throws(() => {
+        crypto.randomFillSync(buf, offset, 10);
+      }, /offset must be a uint32/);
+
+      assert.throws(() => {
+        crypto.randomFill(buf, offset, 10, noop);
+      }, /offset must be a uint32/);
+    }
+  }
+}
+
 // #5126, "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData()
 // length exceeds max acceptable value"
 assert.throws(function() {

--- a/test/parallel/test-domain-crypto.js
+++ b/test/parallel/test-domain-crypto.js
@@ -17,6 +17,8 @@ global.domain = require('domain');
 // should not throw a 'TypeError: undefined is not a function' exception
 crypto.randomBytes(8);
 crypto.randomBytes(8, function() {});
+const buf = Buffer.alloc(8);
+crypto.randomFillSync(buf);
 crypto.pseudoRandomBytes(8);
 crypto.pseudoRandomBytes(8, function() {});
 crypto.pbkdf2('password', 'salt', 8, 8, function() {});


### PR DESCRIPTION
crypto.randomFill and crypto.randomFillSync are similar to
crypto.randomBytes, but allow passing in a buffer as the first
argument. This allows us to reuse buffers to prevent having to
create a new one on every call.

PR-URL: https://github.com/nodejs/node/pull/10209
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Anna Henningsen <anna@addaleax.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
