### PR TITLE
build: reduce one level of spawning in node_gyp

### DIFF
--- a/configure
+++ b/configure
@@ -40,6 +40,7 @@ import nodedownload
 # imports in tools/
 sys.path.insert(0, os.path.join(root_dir, 'tools'))
 import getmoduleversion
+from gyp_node import run_gyp
 
 # parse our options
 parser = optparse.OptionParser()
@@ -1380,7 +1381,7 @@ config = '\n'.join(map('='.join, config.iteritems())) + '\n'
 
 write('config.mk', do_not_edit + config)
 
-gyp_args = [sys.executable, 'tools/gyp_node.py', '--no-parallel']
+gyp_args = ['--no-parallel']
 
 if options.use_xcode:
   gyp_args += ['-f', 'xcode']
@@ -1399,4 +1400,4 @@ gyp_args += args
 if warn.warned:
   warn('warnings were emitted in the configure phase')
 
-sys.exit(subprocess.call(gyp_args))
+run_gyp(gyp_args)

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -16,16 +16,11 @@ def run_gyp(args):
   # GYP bug.
   # On msvs it will crash if it gets an absolute path.
   # On Mac/make it will crash if it doesn't get an absolute path.
-  if sys.platform == 'win32':
-    args.append(os.path.join(node_root, 'node.gyp'))
-    common_fn  = os.path.join(node_root, 'common.gypi')
-    options_fn = os.path.join(node_root, 'config.gypi')
-    options_fips_fn = os.path.join(node_root, 'config_fips.gypi')
-  else:
-    args.append(os.path.join(os.path.abspath(node_root), 'node.gyp'))
-    common_fn  = os.path.join(os.path.abspath(node_root), 'common.gypi')
-    options_fn = os.path.join(os.path.abspath(node_root), 'config.gypi')
-    options_fips_fn = os.path.join(os.path.abspath(node_root), 'config_fips.gypi')
+  a_path = node_root if sys.platform == 'win32' else os.path.abspath(node_root)
+  args.append(os.path.join(a_path, 'node.gyp'))
+  common_fn = os.path.join(a_path, 'common.gypi')
+  options_fn = os.path.join(a_path, 'config.gypi')
+  options_fips_fn = os.path.join(a_path, 'config_fips.gypi')
 
   if os.path.exists(common_fn):
     args.extend(['-I', common_fn])

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -13,14 +13,6 @@ import gyp
 output_dir = os.path.join(os.path.abspath(node_root), 'out')
 
 def run_gyp(args):
-  rc = gyp.main(args)
-  if rc != 0:
-    print 'Error running GYP'
-    sys.exit(rc)
-
-if __name__ == '__main__':
-  args = sys.argv[1:]
-
   # GYP bug.
   # On msvs it will crash if it gets an absolute path.
   # On Mac/make it will crash if it doesn't get an absolute path.
@@ -63,5 +55,11 @@ if __name__ == '__main__':
   args.append('-Dlinux_use_bundled_gold=0')
   args.append('-Dlinux_use_gold_flags=0')
 
-  gyp_args = list(args)
-  run_gyp(gyp_args)
+  rc = gyp.main(args)
+  if rc != 0:
+    print 'Error running GYP'
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+  run_gyp(sys.argv[1:])


### PR DESCRIPTION
`configure` will now call `node_gyp` as a module instead of forking
makes it easier to debug

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
build
