### PR TITLE
os: refactor structure of the os module

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -21,31 +21,50 @@
 
 'use strict';
 
-const binding = process.binding('os');
-const getCPUs = binding.getCPUs;
-const getLoadAvg = binding.getLoadAvg;
 const pushValToArrayMax = process.binding('util').pushValToArrayMax;
 const constants = process.binding('constants').os;
-const internalUtil = require('internal/util');
+const deprecate = require('internal/util').deprecate;
 const isWindows = process.platform === 'win32';
 
-exports.hostname = binding.getHostname;
-exports.uptime = binding.getUptime;
-exports.freemem = binding.getFreeMem;
-exports.totalmem = binding.getTotalMem;
-exports.type = binding.getOSType;
-exports.release = binding.getOSRelease;
-exports.networkInterfaces = binding.getInterfaceAddresses;
-exports.homedir = binding.getHomeDirectory;
-exports.userInfo = binding.getUserInfo;
+const {
+  getCPUs,
+  getFreeMem,
+  getHomeDirectory,
+  getHostname,
+  getInterfaceAddresses,
+  getLoadAvg,
+  getOSRelease,
+  getOSType,
+  getTotalMem,
+  getUserInfo,
+  getUptime,
+  isBigEndian
+} = process.binding('os');
+
+getFreeMem[Symbol.toPrimitive] = () => getFreeMem();
+getHostname[Symbol.toPrimitive] = () => getHostname();
+getHomeDirectory[Symbol.toPrimitive] = () => getHomeDirectory();
+getOSRelease[Symbol.toPrimitive] = () => getOSRelease();
+getOSType[Symbol.toPrimitive] = () => getOSType();
+getTotalMem[Symbol.toPrimitive] = () => getTotalMem();
+getUptime[Symbol.toPrimitive] = () => getUptime();
+
+const kEndianness = isBigEndian ? 'BE' : 'LE';
+
+const tmpDirDeprecationMsg =
+  'os.tmpDir() is deprecated. Use os.tmpdir() instead.';
+
+const getNetworkInterfacesDepMsg =
+  'os.getNetworkInterfaces is deprecated. Use os.networkInterfaces instead.';
 
 const avgValues = new Float64Array(3);
-exports.loadavg = function loadavg() {
+const cpuValues = new Float64Array(6 * pushValToArrayMax);
+
+function loadavg() {
   getLoadAvg(avgValues);
   return [avgValues[0], avgValues[1], avgValues[2]];
-};
+}
 
-const cpuValues = new Float64Array(6 * pushValToArrayMax);
 function addCPUInfo() {
   for (var i = 0, c = 0; i < arguments.length; ++i, c += 6) {
     this[this.length] = {
@@ -61,25 +80,22 @@ function addCPUInfo() {
     };
   }
 }
-exports.cpus = function cpus() {
+
+function cpus() {
   return getCPUs(addCPUInfo, cpuValues, []);
-};
+}
 
-Object.defineProperty(exports, 'constants', {
-  configurable: false,
-  enumerable: true,
-  value: constants
-});
-
-exports.arch = function() {
+function arch() {
   return process.arch;
-};
+}
+arch[Symbol.toPrimitive] = () => process.arch;
 
-exports.platform = function() {
+function platform() {
   return process.platform;
-};
+}
+platform[Symbol.toPrimitive] = () => process.platform;
 
-exports.tmpdir = function() {
+function tmpdir() {
   var path;
   if (isWindows) {
     path = process.env.TEMP ||
@@ -97,22 +113,41 @@ exports.tmpdir = function() {
   }
 
   return path;
+}
+tmpdir[Symbol.toPrimitive] = () => tmpdir();
+
+function endianness() {
+  return kEndianness;
+}
+endianness[Symbol.toPrimitive] = () => kEndianness;
+
+module.exports = exports = {
+  arch,
+  cpus,
+  EOL: isWindows ? '\r\n' : '\n',
+  endianness,
+  freemem: getFreeMem,
+  homedir: getHomeDirectory,
+  hostname: getHostname,
+  loadavg,
+  networkInterfaces: getInterfaceAddresses,
+  platform,
+  release: getOSRelease,
+  tmpdir,
+  totalmem: getTotalMem,
+  type: getOSType,
+  userInfo: getUserInfo,
+  uptime: getUptime,
+
+  // Deprecated APIs
+  getNetworkInterfaces: deprecate(getInterfaceAddresses,
+                                  getNetworkInterfacesDepMsg,
+                                  'DEP0023'),
+  tmpDir: deprecate(tmpdir, tmpDirDeprecationMsg, 'DEP0022')
 };
 
-const tmpDirDeprecationMsg =
-  'os.tmpDir() is deprecated. Use os.tmpdir() instead.';
-exports.tmpDir = internalUtil.deprecate(exports.tmpdir,
-                                        tmpDirDeprecationMsg,
-                                        'DEP0022');
-
-exports.getNetworkInterfaces = internalUtil.deprecate(function() {
-  return exports.networkInterfaces();
-}, 'os.getNetworkInterfaces is deprecated. ' +
-   'Use os.networkInterfaces instead.', 'DEP0023');
-
-exports.EOL = isWindows ? '\r\n' : '\n';
-
-if (binding.isBigEndian)
-  exports.endianness = function() { return 'BE'; };
-else
-  exports.endianness = function() { return 'LE'; };
+Object.defineProperty(module.exports, 'constants', {
+  configurable: false,
+  enumerable: true,
+  value: constants
+});

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -191,3 +191,12 @@ is.string(pwd.username);
 assert.ok(pwd.homedir.includes(path.sep));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
+
+// Test that the Symbol.toPrimitive functions work correctly
+[
+  [`${os.hostname}`, os.hostname()],
+  [`${os.homedir}`, os.homedir()],
+  [`${os.release}`, os.release()],
+  [`${os.type}`, os.type()],
+  [`${os.endianness}`, os.endianness()]
+].forEach((set) => assert.strictEqual(set[0], set[1]));

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -70,32 +70,26 @@ if (common.isWindows) {
 }
 
 const endianness = os.endianness();
-console.log('endianness = %s', endianness);
 is.string(endianness);
 assert.ok(/[BL]E/.test(endianness));
 
 const hostname = os.hostname();
-console.log('hostname = %s', hostname);
 is.string(hostname);
 assert.ok(hostname.length > 0);
 
 const uptime = os.uptime();
-console.log('uptime = %d', uptime);
 is.number(uptime);
 assert.ok(uptime > 0);
 
 const cpus = os.cpus();
-console.log('cpus = ', cpus);
 is.array(cpus);
 assert.ok(cpus.length > 0);
 
 const type = os.type();
-console.log('type = ', type);
 is.string(type);
 assert.ok(type.length > 0);
 
 const release = os.release();
-console.log('release = ', release);
 is.string(release);
 assert.ok(release.length > 0);
 //TODO: Check format on more than just AIX
@@ -103,12 +97,10 @@ if (common.isAix)
   assert.ok(/^\d+\.\d+$/.test(release));
 
 const platform = os.platform();
-console.log('platform = ', platform);
 is.string(platform);
 assert.ok(platform.length > 0);
 
 const arch = os.arch();
-console.log('arch = ', arch);
 is.string(arch);
 assert.ok(arch.length > 0);
 
@@ -121,7 +113,6 @@ if (!common.isSunOS) {
 
 
 const interfaces = os.networkInterfaces();
-console.error(interfaces);
 switch (platform) {
   case 'linux':
     {
@@ -151,7 +142,6 @@ assert.ok(EOL.length > 0);
 
 const home = os.homedir();
 
-console.log('homedir = ' + home);
 is.string(home);
 assert.ok(home.includes(path.sep));
 


### PR DESCRIPTION
Refactoring the structure of the os module to use the more efficient `module.exports = {}` pattern.

Also adds simple `Symbol.toPrimitive` support for each of the os methods that return simple primitives.

Lastly, removes extraneous console output from the test-os.js

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
os