### PR TITLE
events: remove code duplication

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -100,55 +100,53 @@ EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
 // arguments and can be deoptimized because of that. These functions always have
 // the same number of arguments and thus do not get deoptimized, so the code
 // inside them can execute faster.
-function emitNone(handler, isFn, self) {
-  if (isFn)
-    handler.call(self);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self);
-  }
+function emitNone(handler, self) {
+  handler.call(self);
 }
-function emitOne(handler, isFn, self, arg1) {
-  if (isFn)
-    handler.call(self, arg1);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1);
-  }
+function emitOne(handler, self, args) {
+  handler.call(self, args[0]);
 }
-function emitTwo(handler, isFn, self, arg1, arg2) {
-  if (isFn)
-    handler.call(self, arg1, arg2);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1, arg2);
-  }
+function emitTwo(handler, self, args) {
+  handler.call(self, args[0], args[1]);
 }
-function emitThree(handler, isFn, self, arg1, arg2, arg3) {
-  if (isFn)
-    handler.call(self, arg1, arg2, arg3);
-  else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      listeners[i].call(self, arg1, arg2, arg3);
-  }
+function emitThree(handler, self, args) {
+  handler.call(self, args[0], args[1], args[2]);
 }
 
-function emitMany(handler, isFn, self, args) {
+function emitMany(handler, self, args) {
+  handler.apply(self, args);
+}
+
+function _emit(handler, isFn, self, args) {
+  var runHandler;
+  var len = args.length;
+
+  switch (len) {
+    // fast cases
+    case 0:
+      runHandler = emitNone;
+      break;
+    case 1:
+      runHandler = emitOne;
+      break;
+    case 2:
+      runHandler = emitTwo;
+      break;
+    case 3:
+      runHandler = emitThree;
+      break;
+    // slower
+    default:
+      runHandler = emitMany;
+  }
+
   if (isFn)
-    handler.apply(self, args);
+    runHandler(handler, self, args);
   else {
-    var len = handler.length;
+    len = handler.length;
     var listeners = arrayClone(handler, len);
     for (var i = 0; i < len; ++i)
-      listeners[i].apply(self, args);
+      runHandler(listeners[i], self, args);
   }
 }
 
@@ -201,27 +199,10 @@ EventEmitter.prototype.emit = function emit(type) {
 
   var isFn = typeof handler === 'function';
   len = arguments.length;
-  switch (len) {
-    // fast cases
-    case 1:
-      emitNone(handler, isFn, this);
-      break;
-    case 2:
-      emitOne(handler, isFn, this, arguments[1]);
-      break;
-    case 3:
-      emitTwo(handler, isFn, this, arguments[1], arguments[2]);
-      break;
-    case 4:
-      emitThree(handler, isFn, this, arguments[1], arguments[2], arguments[3]);
-      break;
-    // slower
-    default:
-      args = new Array(len - 1);
-      for (i = 1; i < len; i++)
-        args[i - 1] = arguments[i];
-      emitMany(handler, isFn, this, args);
-  }
+  args = new Array(len - 1);
+  for (i = 1; i < len; i++)
+    args[i - 1] = arguments[i];
+  _emit(handler, isFn, this, args);
 
   if (needDomainExit)
     domain.exit();

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -10,9 +10,9 @@ SyntaxError: Strict mode code may not include a with statement
     at evalScript (bootstrap_node.js:*:*)
     at Socket.<anonymous> (bootstrap_node.js:*:*)
     at emitNone (events.js:*:*)
+    at _emit (events.js:*:*)
     at Socket.emit (events.js:*:*)
     at endReadableNT (_stream_readable.js:*:*)
-    at _combinedTickCallback (internal/process/next_tick.js:*:*)
 42
 42
 [stdin]:1
@@ -28,8 +28,8 @@ Error: hello
     at evalScript (bootstrap_node.js:*:*)
     at Socket.<anonymous> (bootstrap_node.js:*:*)
     at emitNone (events.js:*:*)
+    at _emit (events.js:*:*)
     at Socket.emit (events.js:*:*)
-    at endReadableNT (_stream_readable.js:*:*)
 [stdin]:1
 throw new Error("hello")
 ^
@@ -43,8 +43,8 @@ Error: hello
     at evalScript (bootstrap_node.js:*:*)
     at Socket.<anonymous> (bootstrap_node.js:*:*)
     at emitNone (events.js:*:*)
+    at _emit (events.js:*:*)
     at Socket.emit (events.js:*:*)
-    at endReadableNT (_stream_readable.js:*:*)
 100
 [stdin]:1
 var x = 100; y = x;
@@ -59,8 +59,8 @@ ReferenceError: y is not defined
     at evalScript (bootstrap_node.js:*:*)
     at Socket.<anonymous> (bootstrap_node.js:*:*)
     at emitNone (events.js:*:*)
+    at _emit (events.js:*:*)
     at Socket.emit (events.js:*:*)
-    at endReadableNT (_stream_readable.js:*:*)
 
 [stdin]:1
 var ______________________________________________; throw 10


### PR DESCRIPTION
Code duplications are removed from emit* functions.

EventEmitter.prototype.emit becomes shorter.

The logic of selecting an emit* function is in a separate function now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
events
