### PR TITLE
inspector: do not add 'inspector' property

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -254,52 +254,41 @@
   }
 
   function setupGlobalConsole() {
-    var inspectorConsole;
-    var wrapConsoleCall;
-    if (process.inspector) {
-      inspectorConsole = global.console;
-      wrapConsoleCall = process.inspector.wrapConsoleCall;
-      delete process.inspector.wrapConsoleCall;
-      if (Object.keys(process.inspector).length === 0)
-        delete process.inspector;
-    }
-    var console;
+    const originalConsole = global.console;
+    let console;
     Object.defineProperty(global, 'console', {
       configurable: true,
       enumerable: true,
       get: function() {
         if (!console) {
-          console = NativeModule.require('console');
-          installInspectorConsoleIfNeeded(console,
-                                          inspectorConsole,
-                                          wrapConsoleCall);
+          console = installInspectorConsole(originalConsole);
         }
         return console;
       }
     });
   }
 
-  function installInspectorConsoleIfNeeded(console,
-                                           inspectorConsole,
-                                           wrapConsoleCall) {
-    if (!inspectorConsole)
-      return;
+  function installInspectorConsole(globalConsole) {
+    const wrappedConsole = NativeModule.require('console');
+    const inspector = process.binding('inspector');
     const config = {};
-    for (const key of Object.keys(console)) {
-      if (!inspectorConsole.hasOwnProperty(key))
+    for (const key of Object.keys(wrappedConsole)) {
+      if (!globalConsole.hasOwnProperty(key))
         continue;
-      // If node console has the same method as inspector console,
+      // If global console has the same method as inspector console,
       // then wrap these two methods into one. Native wrapper will preserve
       // the original stack.
-      console[key] = wrapConsoleCall(inspectorConsole[key],
-                                     console[key],
-                                     config);
+      wrappedConsole[key] = inspector.consoleCall.bind(wrappedConsole,
+                                                       globalConsole[key],
+                                                       wrappedConsole[key],
+                                                       config);
     }
-    for (const key of Object.keys(inspectorConsole)) {
-      if (console.hasOwnProperty(key))
+    for (const key of Object.keys(globalConsole)) {
+      if (wrappedConsole.hasOwnProperty(key))
         continue;
-      console[key] = inspectorConsole[key];
+      wrappedConsole[key] = globalConsole[key];
     }
+    return wrappedConsole;
   }
 
   function setupProcessFatal() {

--- a/lib/module.js
+++ b/lib/module.js
@@ -472,19 +472,6 @@ function tryModuleLoad(module, filename) {
   }
 }
 
-function getInspectorCallWrapper() {
-  var inspector = process.inspector;
-  if (!inspector || !inspector.callAndPauseOnStart) {
-    return null;
-  }
-  var wrapper = inspector.callAndPauseOnStart.bind(inspector);
-  delete inspector.callAndPauseOnStart;
-  if (Object.keys(process.inspector).length === 0) {
-    delete process.inspector;
-  }
-  return wrapper;
-}
-
 Module._resolveFilename = function(request, parent, isMain) {
   if (NativeModule.nonInternalExists(request)) {
     return request;
@@ -563,7 +550,7 @@ Module.prototype._compile = function(content, filename) {
     // Set breakpoint on module start
     if (filename === resolvedArgv) {
       delete process._debugWaitConnect;
-      inspectorWrapper = getInspectorCallWrapper();
+      inspectorWrapper = process.binding('inspector').callAndPauseOnStart;
       if (!inspectorWrapper) {
         const Debug = vm.runInDebugContext('Debug');
         Debug.setBreakPoint(compiledWrapper, 0, 0);

--- a/src/env.h
+++ b/src/env.h
@@ -72,6 +72,7 @@ namespace node {
   V(arrow_message_private_symbol, "node:arrowMessage")                        \
   V(contextify_context_private_symbol, "node:contextify:context")             \
   V(contextify_global_private_symbol, "node:contextify:global")               \
+  V(inspector_delegate_private_symbol, "node:inspector:delegate")             \
   V(decorated_private_symbol, "node:decorated")                               \
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(processed_private_symbol, "node:processed")                               \

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -17,11 +17,13 @@ class Environment;
 }  // namespace node
 
 namespace v8 {
+class Context;
 template <typename V>
 class FunctionCallbackInfo;
 template<typename T>
 class Local;
 class Message;
+class Object;
 class Platform;
 class Value;
 }  // namespace v8
@@ -61,19 +63,21 @@ class Agent {
   void Disconnect();
   void Dispatch(const v8_inspector::StringView& message);
   void RunMessageLoop();
+  bool enabled() {
+    return enabled_;
+  }
+  void PauseOnNextJavascriptStatement(const std::string& reason);
+  static void InitJSBindings(v8::Local<v8::Object> target,
+                             v8::Local<v8::Value> unused,
+                             v8::Local<v8::Context> context,
+                             void* priv);
 
  private:
-  static void CallAndPauseOnStart(const v8::FunctionCallbackInfo<v8::Value>&);
-  static void InspectorConsoleCall(
-      const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void InspectorWrapConsoleCall(
-      const v8::FunctionCallbackInfo<v8::Value>& info);
-
   node::Environment* parent_env_;
   std::unique_ptr<NodeInspectorClient> inspector_;
   std::unique_ptr<InspectorIo> io_;
   v8::Platform* platform_;
-  bool inspector_console_;
+  bool enabled_;
   std::string path_;
   DebugOptions debug_options_;
 };

--- a/src/node.cc
+++ b/src/node.cc
@@ -4624,3 +4624,9 @@ int Start(int argc, char** argv) {
 
 
 }  // namespace node
+
+#if !HAVE_INSPECTOR
+static void InitEmptyBindings() {}
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(inspector, InitEmptyBindings);
+#endif  // !HAVE_INSPECTOR


### PR DESCRIPTION
'inspector' property is not an official API and should not be published
on process object, where the user may discover it.

This change was extracted from https://github.com/nodejs/node/pull/12263
that will be focused on creating JS bindings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
inspector: new object is not created and insteaad JS bindings are defined.
