### PR TITLE
benchmark: terminate child process on Windows

### DIFF
--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -10,7 +10,8 @@ const bench = common.createBenchmark(main, {
   dur: [5]
 });
 
-const exec = require('child_process').exec;
+const child_process = require('child_process');
+const exec = child_process.exec;
 function main(conf) {
   bench.start();
 
@@ -29,7 +30,12 @@ function main(conf) {
   });
 
   setTimeout(function() {
-    child.kill();
     bench.end(bytes);
+    if (process.platform === 'win32') {
+      // Sometimes there's a yes.exe process left hanging around on Windows...
+      child_process.execSync(`taskkill /f /t /pid ${child.pid}`);
+    } else {
+      child.kill();
+    }
   }, dur * 1000);
 }


### PR DESCRIPTION
test-benchmark-child-process failures reveal that
child-process-exec-stdout benchmark sometimes leaves around a stray
yes.exe process. Add code to terminate the process.

Refs: https://github.com/nodejs/node/issues/12560

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark child_process