### PR TITLE
test: chdir before running test-cli-node-options

### DIFF
--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -8,6 +8,9 @@ if (process.config.variables.node_without_node_options)
 const assert = require('assert');
 const exec = require('child_process').execFile;
 
+common.refreshTmpDir();
+process.chdir(common.tmpDir);
+
 disallow('--version');
 disallow('-v');
 disallow('--help');


### PR DESCRIPTION
When test-cli-node-options is run it uses the --trace-events-enabled
option which generates a file named node_trace.1.log. This commit
changes the working directory to the test tmp directory to avoid this
file being created in the project root.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test