### PR TITLE
(v7.x backport) src: guard bundled_ca/openssl_ca with HAVE_OPENSSL

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3632,6 +3632,7 @@ static void ParseArgs(int* argc,
   const char** new_exec_argv = new const char*[nargs];
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
+  const char** local_preload_modules = new const char*[nargs];
   bool use_bundled_ca = false;
   bool use_openssl_ca = false;
 
@@ -3747,7 +3748,9 @@ static void ParseArgs(int* argc,
       default_cipher_list = arg + 18;
     } else if (strncmp(arg, "--use-openssl-ca", 16) == 0) {
       ssl_openssl_cert_store = true;
+      use_openssl_ca = true;
     } else if (strncmp(arg, "--use-bundled-ca", 16) == 0) {
+      use_bundled_ca = true;
       ssl_openssl_cert_store = false;
 #if NODE_FIPS_MODE
     } else if (strcmp(arg, "--enable-fips") == 0) {
@@ -3781,6 +3784,16 @@ static void ParseArgs(int* argc,
     new_exec_argc += args_consumed;
     index += args_consumed;
   }
+
+#if HAVE_OPENSSL
+  if (use_openssl_ca && use_bundled_ca) {
+    fprintf(stderr,
+            "%s: either --use-openssl-ca or --use-bundled-ca can be used, "
+            "not both\n",
+            argv[0]);
+    exit(9);
+  }
+#endif
 
   // Copy remaining arguments.
   const unsigned int args_left = nargs - index;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3633,8 +3633,10 @@ static void ParseArgs(int* argc,
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
   const char** local_preload_modules = new const char*[nargs];
+#if HAVE_OPENSSL
   bool use_bundled_ca = false;
   bool use_openssl_ca = false;
+#endif  // HAVE_OPENSSL
 
   for (unsigned int i = 0; i < nargs; ++i) {
     new_exec_argv[i] = nullptr;

--- a/test/parallel/test-openssl-ca-options.js
+++ b/test/parallel/test-openssl-ca-options.js
@@ -1,0 +1,31 @@
+'use strict';
+// This test checks the usage of --use-bundled-ca and --use-openssl-ca arguments
+// to verify that both are not used at the same time.
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const assert = require('assert');
+const os = require('os');
+const childProcess = require('child_process');
+const result = childProcess.spawnSync(process.execPath, [
+                                      '--use-bundled-ca',
+                                      '--use-openssl-ca',
+                                      '-p', 'process.version'],
+                                      {encoding: 'utf8'});
+
+assert.strictEqual(result.stderr,
+                   process.execPath + ': either --use-openssl-ca or ' +
+                   '--use-bundled-ca can be used, not both' + os.EOL);
+assert.strictEqual(result.status, 9);
+
+const useBundledCA = childProcess.spawnSync(process.execPath, [
+                                            '--use-bundled-ca',
+                                            '-p', 'process.version']);
+assert.strictEqual(useBundledCA.status, 0);
+
+const useOpenSSLCA = childProcess.spawnSync(process.execPath, [
+                                            '--use-openssl-ca',
+                                            '-p', 'process.version']);
+assert.strictEqual(useOpenSSLCA.status, 0);


### PR DESCRIPTION
Currently, the following warning will be reported when configuring
without-ssl:

../src/node.cc:3653:8: warning: unused variable 'use_bundled_ca'
[-Wunused-variable]
  bool use_bundled_ca = false;
       ^
../src/node.cc:3654:8: warning: unused variable 'use_openssl_ca'
[-Wunused-variable]
  bool use_openssl_ca = false;
       ^

I missed this when working on
commit 8a7db9d4b5798679045d7a4f6f62243ba4be5b8c ("src: add
--use-bundled-ca --use-openssl-ca check").

Refs: https://github.com/nodejs/node/pull/12087
PR-URL: https://github.com/nodejs/node/pull/12302
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
