### PR TITLE
refactor http.get expectedCount with common.mustCall

### DIFF
--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -91,8 +91,6 @@ server2.listen(0, listening());
 server3.listen(0, listening());
 
 const responseErrors = {};
-let expectResponseCount = 0;
-let responseCount = 0;
 let pending = 0;
 
 
@@ -147,12 +145,10 @@ function makeReq(path, port, error, host, ca) {
     options.headers = { host: host };
   }
   const req = https.get(options);
-  expectResponseCount++;
   const server = port === server1.address().port ? server1 :
       port === server2.address().port ? server2 :
       port === server3.address().port ? server3 :
       null;
-
   if (!server) throw new Error('invalid port: ' + port);
   server.expectCount++;
 

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -156,8 +156,7 @@ function makeReq(path, port, error, host, ca) {
   if (!server) throw new Error('invalid port: ' + port);
   server.expectCount++;
 
-  req.on('response', (res) => {
-    responseCount++;
+  req.on('response', common.mustCall((res) => {
     assert.strictEqual(res.connection.authorizationError, error);
     responseErrors[path] = res.connection.authorizationError;
     pending--;
@@ -167,7 +166,7 @@ function makeReq(path, port, error, host, ca) {
       server3.close();
     }
     res.resume();
-  });
+  }));
 }
 
 function allListening() {
@@ -220,5 +219,4 @@ process.on('exit', () => {
   assert.strictEqual(server1.requests.length, server1.expectCount);
   assert.strictEqual(server2.requests.length, server2.expectCount);
   assert.strictEqual(server3.requests.length, server3.expectCount);
-  assert.strictEqual(responseCount, expectResponseCount);
 });


### PR DESCRIPTION
refactor http.get expectedCount with common.mustCall

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
