### PR TITLE
test: remove eslint comments

### DIFF
--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -52,8 +52,7 @@ assert.strictEqual(false, util.isRegExp(Object.create(RegExp.prototype)));
 // isDate
 assert.strictEqual(true, util.isDate(new Date()));
 assert.strictEqual(true, util.isDate(new Date(0)));
-// eslint-disable-next-line new-parens
-assert.strictEqual(true, util.isDate(new (context('Date'))));
+assert.strictEqual(true, util.isDate(new (context('Date'))()));
 assert.strictEqual(false, util.isDate(Date()));
 assert.strictEqual(false, util.isDate({}));
 assert.strictEqual(false, util.isDate([]));
@@ -64,11 +63,9 @@ assert.strictEqual(false, util.isDate(Object.create(Date.prototype)));
 assert.strictEqual(true, util.isError(new Error()));
 assert.strictEqual(true, util.isError(new TypeError()));
 assert.strictEqual(true, util.isError(new SyntaxError()));
-/* eslint-disable new-parens */
-assert.strictEqual(true, util.isError(new (context('Error'))));
-assert.strictEqual(true, util.isError(new (context('TypeError'))));
-assert.strictEqual(true, util.isError(new (context('SyntaxError'))));
-/* eslint-enable */
+assert.strictEqual(true, util.isError(new (context('Error'))()));
+assert.strictEqual(true, util.isError(new (context('TypeError'))()));
+assert.strictEqual(true, util.isError(new (context('SyntaxError'))()));
 assert.strictEqual(false, util.isError({}));
 assert.strictEqual(false, util.isError({ name: 'Error', message: '' }));
 assert.strictEqual(false, util.isError([]));

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -4,13 +4,11 @@ const common = require('../common');
 const URL = require('url').URL;
 const { test, assert_equals } = common.WPT;
 
-/* eslint-disable */
 /* WPT Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 test(() => {
-  const a = new URL("https://example.com/")
-  assert_equals(JSON.stringify(a), "\"https://example.com/\"")
-})
-/* eslint-enable */
+  const a = new URL('https://example.com/');
+  assert_equals(JSON.stringify(a), '"https://example.com/"');
+});


### PR DESCRIPTION
This PR refactors two tests to remove the need for ESLint comments.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test