### PR TITLE
WIP: src,inspector: add --inspect-silent option

### DIFF
--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -61,7 +61,8 @@ DebugOptions::DebugOptions() : debugger_enabled_(false),
                                inspector_enabled_(false),
 #endif  // HAVE_INSPECTOR
                                wait_connect_(false), http_enabled_(false),
-                               host_name_("127.0.0.1"), port_(-1) { }
+                               host_name_("127.0.0.1"), port_(-1),
+                               out_(stderr) { }
 
 void DebugOptions::EnableDebugAgent(DebugAgentType tool) {
   switch (tool) {
@@ -101,6 +102,10 @@ bool DebugOptions::ParseOption(const std::string& option) {
     debugger_enabled_ = true;
     enable_inspector = true;
     wait_connect_ = true;
+  } else if (option_name == "--inspect-silent") {
+    debugger_enabled_ = true;
+    enable_inspector = true;
+    out_ = NULL;
   } else if ((option_name != "--debug-port" &&
               option_name != "--inspect-port") ||
               !has_argument) {

--- a/src/node_debug_options.h
+++ b/src/node_debug_options.h
@@ -34,6 +34,7 @@ class DebugOptions {
   std::string host_name() const { return host_name_; }
   int port() const;
   void set_port(int port) { port_ = port; }
+  FILE* out() const { return out_; }
 
  private:
   bool debugger_enabled_;
@@ -44,6 +45,9 @@ class DebugOptions {
   bool http_enabled_;
   std::string host_name_;
   int port_;
+#if HAVE_INSPECTOR
+  FILE* out_;
+#endif  // HAVE_INSPECTOR
 };
 
 }  // namespace node


### PR DESCRIPTION
Allow the inspector to be used without printing anything to the console. This is useful when working with tools that know how to use the inspector.

If this is OK, I'll add the tests and docs.

Fixes: https://github.com/nodejs/node/issues/12665

R= @eugeneo 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
