### PR TITLE
doc: note that EoL platforms are not supported

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,6 +33,10 @@ Support is divided into three tiers:
 
 ### Supported platforms
 
+The community does not build or test against end of life distributions (EoL).
+Thus we do not recommend that you use Node on end of life or unsupported platforms
+in production.
+
 |  System      | Support type | Version                          | Architectures        | Notes            |
 |--------------|--------------|----------------------------------|----------------------|------------------|
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x86, x64, arm, arm64 |                  |


### PR DESCRIPTION
Add a note to clarify that any platform that is EoL will not be
supported by Node.js.

Fixes: https://github.com/nodejs/build/issues/688

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, build