### PR TITLE
n-api: Sync with back-compat changes

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -12,10 +12,11 @@
 #include <node_object_wrap.h>
 #include <string.h>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <vector>
+#include "uv.h"
 #include "node_api.h"
-#include "env-inl.h"
 
 static
 napi_status napi_set_last_error(napi_env env, napi_status error_code,
@@ -45,9 +46,9 @@ struct napi_env__ {
     }                                                                   \
   } while (0)
 
-#define CHECK_ENV(env)                                               \
-  if ((env) == nullptr) {                                            \
-    node::FatalError(__func__, "environment(env) must not be null"); \
+#define CHECK_ENV(env)        \
+  if ((env) == nullptr) {     \
+    return napi_invalid_arg;  \
   }
 
 #define CHECK_ARG(env, arg) \
@@ -578,8 +579,7 @@ class SetterCallbackWrapper
 
   /*virtual*/
   void SetReturnValue(napi_value value) override {
-    node::FatalError("napi_set_return_value",
-      "Cannot return a value from a setter callback.");
+    // Ignore any value returned from a setter callback.
   }
 
  private:
@@ -744,7 +744,8 @@ napi_status napi_get_last_error_info(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  static_assert(node::arraysize(error_messages) == napi_status_last,
+  static_assert(
+      (sizeof (error_messages) / sizeof (*error_messages)) == napi_status_last,
       "Count of error messages must match count of error values");
   assert(env->last_error.error_code < napi_status_last);
 
@@ -1694,7 +1695,7 @@ napi_status napi_get_value_int32(napi_env env,
 
   v8::Isolate* isolate = env->isolate;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  *result = val->Int32Value(context).ToChecked();
+  *result = val->Int32Value(context).FromJust();
 
   return napi_clear_last_error(env);
 }
@@ -1713,7 +1714,7 @@ napi_status napi_get_value_uint32(napi_env env,
 
   v8::Isolate* isolate = env->isolate;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  *result = val->Uint32Value(context).ToChecked();
+  *result = val->Uint32Value(context).FromJust();
 
   return napi_clear_last_error(env);
 }
@@ -1738,7 +1739,7 @@ napi_status napi_get_value_int64(napi_env env,
   } else {
     v8::Isolate* isolate = env->isolate;
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    *result = val->IntegerValue(context).ToChecked();
+    *result = val->IntegerValue(context).FromJust();
   }
 
   return napi_clear_last_error(env);
@@ -2819,9 +2820,11 @@ napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
-  // Consider: Encapsulate the uv_loop_t into an opaque pointer parameter
-  uv_loop_t* event_loop =
-    node::Environment::GetCurrent(env->isolate)->event_loop();
+  // Consider: Encapsulate the uv_loop_t into an opaque pointer parameter.
+  // Currently the environment event loop is the same as the UV default loop.
+  // Someday (if node ever supports multiple isolates), it may be better to get
+  // the loop from node::Environment::GetCurrent(env->isolate)->event_loop();
+  uv_loop_t* event_loop = uv_default_loop();
 
   uvimpl::Work* w = reinterpret_cast<uvimpl::Work*>(work);
 


### PR DESCRIPTION
Background: To enable N-API support for node versions back to v4, the N-API code can also be built as an external addon. To make maintenance easier, a single codebase needs to support both built-in and external scenarios, along with Node versions >= 4 (and corresponding V8 versions).

This change includes several minor fixes to avoid using node internal APIs and support older V8 versions:
  - Expand `node::arraysize()`
  - In the `CHECK_ENV()` macro, return an error code instead of `calling node::FatalError()`. This is more consistent with how other invalid arguments to N-API functions are handled.
  - In `v8impl::SetterCallbackWrapper::SetReturnValue()`, do nothing instead of calling `node::FatalError()`. This is more consistent with JavaScript setter callbacks, where any returned value is silently ignored.
  - When queueing async work items, get the uv default loop instead of getting the loop from `node::Environment::GetCurrent()`. Currently that returns the same loop anyway. If/when node supports multiple environments, it should have a public API for getting the environment & event loop, and we can update this implementation then.
  - Use `v8::Maybe::FromJust()` instead of the newer alias `ToChecked()`

These changes were copied directly from https://github.com/nodejs/node-api/commit/c7d4df47b786add74a54e203f068723f8f25c8cc where they were reviewed as part of
https://github.com/nodejs/node-api/pull/25

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api