### PR TITLE
doc: clarify arch support for power platforms

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -40,8 +40,8 @@ Support is divided into three tiers:
 | Windows      | Tier 1       | >= Windows 7 or >= Windows2008R2 | x86, x64             |                  |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
-| GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le, >=power8    |                  |
-| AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be, >=power7    |                  |
+| GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
+| AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be >=power7     |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |
 | macOS        | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -40,8 +40,8 @@ Support is divided into three tiers:
 | Windows      | Tier 1       | >= Windows 7 or >= Windows2008R2 | x86, x64             |                  |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
-| GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le              |                  |
-| AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be              |                  |
+| GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le, >=power8    |                  |
+| AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be, >=power7    |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |
 | macOS        | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |


### PR DESCRIPTION
Add specifics as to the level of hardware supported for
power platforms.  Power 8 is the first processor level to
support ppc little endian.  Set the minimum level
for AIX to Power7 for Node version 8 and later.
This will allow the potential to leverage new instructions
and optimizations going forward.  We have spoken to the
AIX team and they agree this makes sense. Earlier processor
levels will continue to be supported for version 4.x and 6.x
on AIX.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
doc