### PR TITLE
v8: refactor the v8 module

### DIFF
--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  method: [
+    'getHeapStatistics',
+    'getHeapSpaceStatistics'
+  ],
+  n: [1e6],
+  flags: ['--ignition --turbo', '']
+});
+
+function main(conf) {
+  const n = +conf.n;
+  const method = conf.method;
+  var i = 0;
+  bench.start();
+  for (; i < n; i++)
+    v8[method]();
+  bench.end(n);
+}

--- a/benchmark/v8/get-stats.js
+++ b/benchmark/v8/get-stats.js
@@ -8,8 +8,7 @@ const bench = common.createBenchmark(main, {
     'getHeapStatistics',
     'getHeapSpaceStatistics'
   ],
-  n: [1e6],
-  flags: ['--ignition --turbo', '']
+  n: [1e6]
 });
 
 function main(conf) {

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -14,44 +14,50 @@
 
 'use strict';
 
-const Buffer = require('buffer').Buffer;
-
-const v8binding = process.binding('v8');
-const serdesBinding = process.binding('serdes');
-const bufferBinding = process.binding('buffer');
-
+const { Buffer } = require('buffer');
+const { Serializer, Deserializer } = process.binding('serdes');
+const { copy } = process.binding('buffer');
 const { objectToString } = require('internal/util');
 const { FastBuffer } = require('internal/buffer');
 
-// Properties for heap statistics buffer extraction.
-const heapStatisticsBuffer =
-    new Float64Array(v8binding.heapStatisticsArrayBuffer);
-const kTotalHeapSizeIndex = v8binding.kTotalHeapSizeIndex;
-const kTotalHeapSizeExecutableIndex = v8binding.kTotalHeapSizeExecutableIndex;
-const kTotalPhysicalSizeIndex = v8binding.kTotalPhysicalSizeIndex;
-const kTotalAvailableSize = v8binding.kTotalAvailableSize;
-const kUsedHeapSizeIndex = v8binding.kUsedHeapSizeIndex;
-const kHeapSizeLimitIndex = v8binding.kHeapSizeLimitIndex;
-const kDoesZapGarbageIndex = v8binding.kDoesZapGarbageIndex;
-const kMallocedMemoryIndex = v8binding.kMallocedMemoryIndex;
-const kPeakMallocedMemoryIndex = v8binding.kPeakMallocedMemoryIndex;
+const {
+  cachedDataVersionTag,
+  setFlagsFromString,
+  heapStatisticsArrayBuffer,
+  heapSpaceStatisticsArrayBuffer,
+  updateHeapStatisticsArrayBuffer,
+  updateHeapSpaceStatisticsArrayBuffer,
 
-// Properties for heap space statistics buffer extraction.
-const heapSpaceStatisticsBuffer =
-    new Float64Array(v8binding.heapSpaceStatisticsArrayBuffer);
-const kHeapSpaces = v8binding.kHeapSpaces;
+  // Properties for heap and heap space statistics buffer extraction.
+  kTotalHeapSizeIndex,
+  kTotalHeapSizeExecutableIndex,
+  kTotalPhysicalSizeIndex,
+  kTotalAvailableSize,
+  kUsedHeapSizeIndex,
+  kHeapSizeLimitIndex,
+  kDoesZapGarbageIndex,
+  kMallocedMemoryIndex,
+  kPeakMallocedMemoryIndex,
+  kHeapSpaces,
+  kHeapSpaceStatisticsPropertiesCount,
+  kSpaceSizeIndex,
+  kSpaceUsedSizeIndex,
+  kSpaceAvailableSizeIndex,
+  kPhysicalSpaceSizeIndex
+} = process.binding('v8');
+
 const kNumberOfHeapSpaces = kHeapSpaces.length;
-const kHeapSpaceStatisticsPropertiesCount =
-    v8binding.kHeapSpaceStatisticsPropertiesCount;
-const kSpaceSizeIndex = v8binding.kSpaceSizeIndex;
-const kSpaceUsedSizeIndex = v8binding.kSpaceUsedSizeIndex;
-const kSpaceAvailableSizeIndex = v8binding.kSpaceAvailableSizeIndex;
-const kPhysicalSpaceSizeIndex = v8binding.kPhysicalSpaceSizeIndex;
 
-exports.getHeapStatistics = function() {
+const heapStatisticsBuffer =
+    new Float64Array(heapStatisticsArrayBuffer);
+
+const heapSpaceStatisticsBuffer =
+    new Float64Array(heapSpaceStatisticsArrayBuffer);
+
+function getHeapStatistics() {
   const buffer = heapStatisticsBuffer;
 
-  v8binding.updateHeapStatisticsArrayBuffer();
+  updateHeapStatisticsArrayBuffer();
 
   return {
     'total_heap_size': buffer[kTotalHeapSizeIndex],
@@ -64,15 +70,12 @@ exports.getHeapStatistics = function() {
     'peak_malloced_memory': buffer[kPeakMallocedMemoryIndex],
     'does_zap_garbage': buffer[kDoesZapGarbageIndex]
   };
-};
+}
 
-exports.cachedDataVersionTag = v8binding.cachedDataVersionTag;
-exports.setFlagsFromString = v8binding.setFlagsFromString;
-
-exports.getHeapSpaceStatistics = function() {
+function getHeapSpaceStatistics() {
   const heapSpaceStatistics = new Array(kNumberOfHeapSpaces);
   const buffer = heapSpaceStatisticsBuffer;
-  v8binding.updateHeapSpaceStatisticsArrayBuffer();
+  updateHeapSpaceStatisticsArrayBuffer();
 
   for (var i = 0; i < kNumberOfHeapSpaces; i++) {
     const propertyOffset = i * kHeapSpaceStatisticsPropertiesCount;
@@ -86,17 +89,14 @@ exports.getHeapSpaceStatistics = function() {
   }
 
   return heapSpaceStatistics;
-};
+}
 
 /* V8 serialization API */
-
-const Serializer = exports.Serializer = serdesBinding.Serializer;
-const Deserializer = exports.Deserializer = serdesBinding.Deserializer;
 
 /* JS methods for the base objects */
 Serializer.prototype._getDataCloneError = Error;
 
-Deserializer.prototype.readRawBytes = function(length) {
+Deserializer.prototype.readRawBytes = function readRawBytes(length) {
   const offset = this._readRawBytes(length);
   // `this.buffer` can be a Buffer or a plain Uint8Array, so just calling
   // `.slice()` doesn't work.
@@ -155,8 +155,6 @@ class DefaultSerializer extends Serializer {
   }
 }
 
-exports.DefaultSerializer = DefaultSerializer;
-
 class DefaultDeserializer extends Deserializer {
   constructor(buffer) {
     super(buffer);
@@ -176,27 +174,37 @@ class DefaultDeserializer extends Deserializer {
                       byteLength / BYTES_PER_ELEMENT);
     } else {
       // Copy to an aligned buffer first.
-      const copy = Buffer.allocUnsafe(byteLength);
-      bufferBinding.copy(this.buffer, copy, 0,
-                         byteOffset, byteOffset + byteLength);
-      return new ctor(copy.buffer,
-                      copy.byteOffset,
+      const buffer_copy = Buffer.allocUnsafe(byteLength);
+      copy(this.buffer, buffer_copy, 0, byteOffset, byteOffset + byteLength);
+      return new ctor(buffer_copy.buffer,
+                      buffer_copy.byteOffset,
                       byteLength / BYTES_PER_ELEMENT);
     }
   }
 }
 
-exports.DefaultDeserializer = DefaultDeserializer;
-
-exports.serialize = function serialize(value) {
+function serialize(value) {
   const ser = new DefaultSerializer();
   ser.writeHeader();
   ser.writeValue(value);
   return ser.releaseBuffer();
-};
+}
 
-exports.deserialize = function deserialize(buffer) {
+function deserialize(buffer) {
   const der = new DefaultDeserializer(buffer);
   der.readHeader();
   return der.readValue();
+}
+
+module.exports = exports = {
+  cachedDataVersionTag,
+  getHeapStatistics,
+  getHeapSpaceStatistics,
+  setFlagsFromString,
+  Serializer,
+  Deserializer,
+  DefaultSerializer,
+  DefaultDeserializer,
+  deserialize,
+  serialize
 };


### PR DESCRIPTION
* Use the more efficient `module.exports = {}` pattern,
* Refactor the imports from bindings and requires
* Add a benchmark

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
v8