### PR TITLE
doc: refactor WHATWG URL docs

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -131,6 +131,50 @@ The `slashes` property is a `boolean` with a value of `true` if two ASCII
 forward-slash characters (`/`) are required following the colon in the
 `protocol`.
 
+## url.domainToASCII(domain)
+
+> Stability: 1 - Experimental
+
+* `domain` {string}
+* Returns: {string}
+
+Returns the [Punycode][] ASCII serialization of the `domain`. If `domain` is an
+invalid domain, the empty string is returned.
+
+It performs the inverse operation to [`url.domainToUnicode()`][].
+
+```js
+const url = require('url');
+console.log(url.domainToASCII('español.com'));
+  // Prints xn--espaol-zwa.com
+console.log(url.domainToASCII('中文.com'));
+  // Prints xn--fiq228c.com
+console.log(url.domainToASCII('xn--iñvalid.com'));
+  // Prints an empty string
+```
+
+## url.domainToUnicode(domain)
+
+> Stability: 1 - Experimental
+
+* `domain` {string}
+* Returns: {string}
+
+Returns the Unicode serialization of the `domain`. If `domain` is an invalid
+domain, the empty string is returned.
+
+It performs the inverse operation to [`url.domainToASCII()`][].
+
+```js
+const url = require('url');
+console.log(url.domainToUnicode('xn--espaol-zwa.com'));
+  // Prints español.com
+console.log(url.domainToUnicode('xn--fiq228c.com'));
+  // Prints 中文.com
+console.log(url.domainToUnicode('xn--iñvalid.com'));
+  // Prints an empty string
+```
+
 ## url.format(urlObject)
 <!-- YAML
 added: v0.1.25
@@ -997,52 +1041,6 @@ for (const [name, value] of params) {
   // xyz baz
 ```
 
-### require('url').domainToASCII(domain)
-
-* `domain` {string}
-* Returns: {string}
-
-Returns the [Punycode][] ASCII serialization of the `domain`. If `domain` is an
-invalid domain, the empty string is returned.
-
-It performs the inverse operation to [`require('url').domainToUnicode()`][].
-
-```js
-const url = require('url');
-console.log(url.domainToASCII('español.com'));
-  // Prints xn--espaol-zwa.com
-console.log(url.domainToASCII('中文.com'));
-  // Prints xn--fiq228c.com
-console.log(url.domainToASCII('xn--iñvalid.com'));
-  // Prints an empty string
-```
-
-*Note*: The `require('url').domainToASCII()` method is introduced as part of
-the new `URL` implementation but is not part of the WHATWG URL standard.
-
-### require('url').domainToUnicode(domain)
-
-* `domain` {string}
-* Returns: {string}
-
-Returns the Unicode serialization of the `domain`. If `domain` is an invalid
-domain, the empty string is returned.
-
-It performs the inverse operation to [`require('url').domainToASCII()`][].
-
-```js
-const url = require('url');
-console.log(url.domainToUnicode('xn--espaol-zwa.com'));
-  // Prints español.com
-console.log(url.domainToUnicode('xn--fiq228c.com'));
-  // Prints 中文.com
-console.log(url.domainToUnicode('xn--iñvalid.com'));
-  // Prints an empty string
-```
-
-*Note*: The `require('url').domainToUnicode()` API is introduced as part of the
-the new `URL` implementation but is not part of the WHATWG URL standard.
-
 <a id="whatwg-percent-encoding"></a>
 ### Percent-Encoding in the WHATWG URL Standard
 
@@ -1092,6 +1090,8 @@ console.log(myURL.origin);
 [`TypeError`]: errors.html#errors_class_typeerror
 [WHATWG URL Standard]: https://url.spec.whatwg.org/
 [examples of parsed URLs]: https://url.spec.whatwg.org/#example-url-parsing
+[`url.domainToASCII()`]: #url_url_domaintoascii_domain
+[`url.domainToUnicode()`]: #url_url_domaintounicode_domain
 [`url.parse()`]: #url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [`url.format()`]: #url_url_format_urlobject
 [`require('url').format()`]: #url_url_format_url_options
@@ -1107,8 +1107,6 @@ console.log(myURL.origin);
 [`URLSearchParams`]: #url_class_urlsearchparams
 [`urlSearchParams.entries()`]: #url_urlsearchparams_entries
 [`urlSearchParams@@iterator()`]: #url_urlsearchparams_iterator
-[`require('url').domainToASCII()`]: #url_require_url_domaintoascii_domain
-[`require('url').domainToUnicode()`]: #url_require_url_domaintounicode_domain
 [stable sorting algorithm]: https://en.wikipedia.org/wiki/Sorting_algorithm#Stability
 [`JSON.stringify()`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [`url.toJSON()`]: #url_url_tojson

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -132,6 +132,9 @@ forward-slash characters (`/`) are required following the colon in the
 `protocol`.
 
 ## url.domainToASCII(domain)
+<!-- YAML
+added: v7.4.0
+-->
 
 > Stability: 1 - Experimental
 
@@ -154,6 +157,9 @@ console.log(url.domainToASCII('xn--iñvalid.com'));
 ```
 
 ## url.domainToUnicode(domain)
+<!-- YAML
+added: v7.4.0
+-->
 
 > Stability: 1 - Experimental
 
@@ -243,6 +249,9 @@ The formatting process operates as follows:
 * `result` is returned.
 
 ## url.format(URL[, options])
+<!-- YAML
+added: v7.6.0
+-->
 
 > Stability: 1 - Experimental
 
@@ -254,7 +263,7 @@ The formatting process operates as follows:
     fragment, `false` otherwise. Defaults to `true`.
   * `search` {boolean} `true` if the serialized URL string should include the
     search query, `false` otherwise. Defaults to `true`.
-  * `unicode` (Boolean) `true` if Unicode characters appearing in the host
+  * `unicode` {boolean} `true` if Unicode characters appearing in the host
     component of the URL string should be encoded directly as opposed to being
     Punycode encoded. Defaults to `false`.
 
@@ -352,6 +361,9 @@ For example, the ASCII space character (`' '`) is encoded as `%20`. The ASCII
 forward slash (`/`) character is encoded as `%3C`.
 
 ## The WHATWG URL API
+<!-- YAML
+added: v7.0.0
+-->
 
 > Stability: 1 - Experimental
 
@@ -739,6 +751,9 @@ console.log(JSON.stringify(myURLs));
 ```
 
 ### Class: URLSearchParams
+<!-- YAML
+added: v7.5.0
+-->
 
 The `URLSearchParams` API provides read and write access to the query of a
 `URL`. The `URLSearchParams` class can also be used standalone with one of the
@@ -811,6 +826,9 @@ console.log(params.toString());
 ```
 
 #### Constructor: new URLSearchParams(obj)
+<!-- YAML
+added: v7.10.0
+-->
 
 * `obj` {Object} An object representing a collection of key-value pairs
 
@@ -834,6 +852,9 @@ console.log(params.toString());
 ```
 
 #### Constructor: new URLSearchParams(iterable)
+<!-- YAML
+added: v7.10.0
+-->
 
 * `iterable` {Iterable} An iterable object whose elements are key-value pairs
 
@@ -993,6 +1014,9 @@ console.log(params.toString());
 ```
 
 #### urlSearchParams.sort()
+<!-- YAML
+added: v7.7.0
+-->
 
 Sort all existing name-value pairs in-place by their names. Sorting is done
 with a [stable sorting algorithm][], so relative order between name-value pairs


### PR DESCRIPTION
- Document `url.domainTo*()` methods separately from the WHATWG URL API
- Add missing `added` metadata

This should prepare us for [marking WHATWG URL API as stable](https://github.com/TimothyGu/node/commit/213b9ce8ccb506dfd36c392fc3da0fa82987efb8), as discussed during the [2017-04-26 CTC meeting](https://github.com/joshgav/CTC/blob/3df768ecf9bd52044283bafd7f5acb87c57dbfb3/meetings/2017-04-26.md#q-whats-new-in-node-8).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc