### PR TITLE
test: remove AIX guard in fs-options-immutable

### DIFF
--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -58,21 +58,17 @@ if (common.canCreateSymLink()) {
   );
 }
 
-if (!common.isAix) {
-  // TODO(thefourtheye) Remove this guard once
-  // https://github.com/nodejs/node/issues/5085 is fixed
-  {
-    let watch;
-    assert.doesNotThrow(() => {
-      watch = fs.watch(__filename, options, common.noop);
-    });
-    watch.close();
-  }
+{
+  let watch;
+  assert.doesNotThrow(() => {
+    watch = fs.watch(__filename, options, common.noop);
+  });
+  watch.close();
+}
 
-  {
-    assert.doesNotThrow(() => fs.watchFile(__filename, options, common.noop));
-    fs.unwatchFile(__filename);
-  }
+{
+  assert.doesNotThrow(() => fs.watchFile(__filename, options, common.noop));
+  fs.unwatchFile(__filename);
 }
 
 {


### PR DESCRIPTION
The fs watch test was not run on AIX till now because of the known
issue, https://github.com/nodejs/node/issues/5085. Now that it is
completed, this guard can be removed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

fs aix test

---

@nodejs/platform-aix 
