### PR TITLE
test: add hasCrypto check to test-cli-node-options

### DIFF
--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -50,9 +50,11 @@ expect('--track-heap-objects', 'B\n');
 expect('--throw-deprecation', 'B\n');
 expect('--zero-fill-buffers', 'B\n');
 expect('--v8-pool-size=10', 'B\n');
-expect('--use-openssl-ca', 'B\n');
-expect('--use-bundled-ca', 'B\n');
-expect('--openssl-config=_ossl_cfg', 'B\n');
+if (common.hasCrypto) {
+  expect('--use-openssl-ca', 'B\n');
+  expect('--use-bundled-ca', 'B\n');
+  expect('--openssl-config=_ossl_cfg', 'B\n');
+}
 expect('--icu-data-dir=_d', 'B\n');
 
     // V8 options


### PR DESCRIPTION
Currently when configure --without-ssl the test will throw the following
error:
```console
bad option: --use-openssl-ca
```
This commit checks if crypto was enabled and skips the crypto related
tests if that is the case.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test