### PR TITLE
Migrate zlib errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -750,6 +750,29 @@ an attempt is made to launch a Node.js process with an unknown `stdout` or
 in user code, although it is not impossible. Occurrences of this error are most
 likely an indication of a bug within Node.js itself.
 
+<a id="ERR_OUT_OF_RANGE"></a>
+### ERR_OUT_OF_RANGE
+
+The `'ERR_OUT_OF_RANGE'` code is used to show the value set to a variable is not
+between in range of acceptable values.
+
+<a id="ERR_LESS_THAN_MIN"></a>
+### ERR_LESS_THAN_MIN
+
+The `'ERR_LESS_THAN_MIN'` code is used to show the value set to a variable is less
+than the minimum acceptable value.
+
+<a id="ERR_ZLIB_BINDING_CLOSED"></a>
+### ERR_ZLIB_BINDING_CLOSED
+
+The `'ERR_ZLIB_BINDING_CLOSED'` code is used when the binding object is not accessible
+anymore. e.g.: cause something it happened like connection was closed unexpectedly.
+
+<a id="ERR_INVALID_RANGE"></a>
+### ERR_INVALID_RANGE
+
+The `'ERR_INVALID_RANGE'` error code is used generically to identify that
+a range value is out.
 
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`child.kill()`]: child_process.html#child_process_child_kill_signal

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -612,6 +612,12 @@ process. See [`child.send()`] and [`process.send()`] for more information.
 The `'ERR_INVALID_OPT_VALUE'` error code is used generically to identify when
 an invalid or unexpected value has been passed in an options object.
 
+<a id="ERR_INVALID_RANGE"></a>
+### ERR_INVALID_RANGE
+
+The `'ERR_INVALID_RANGE'` error code is used generically to identify that
+a range value is out.
+
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
 
@@ -693,6 +699,12 @@ an IPC communication channel with a synchronous forked Node.js process.
 See the documentation for the [`child_process`](child_process.html)
 module for more information.
 
+<a id="ERR_LESS_THAN_MIN"></a>
+### ERR_LESS_THAN_MIN
+
+The `'ERR_LESS_THAN_MIN'` code is used to show the value set to a variable is less
+than the minimum acceptable value.
+
 <a id="ERR_MISSING_ARGS"></a>
 ### ERR_MISSING_ARGS
 
@@ -702,6 +714,12 @@ in the [WHATWG URL API][] for strict compliance with the specification (which
 in some cases may accept `func(undefined)` but not `func()`). In most native
 Node.js APIs, `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
+
+<a id="ERR_OUT_OF_RANGE"></a>
+### ERR_OUT_OF_RANGE
+
+The `'ERR_OUT_OF_RANGE'` code is used to show the value set to a variable is not
+between in range of acceptable values.
 
 <a id="ERR_STDERR_CLOSE"></a>
 ### ERR_STDERR_CLOSE
@@ -750,29 +768,11 @@ an attempt is made to launch a Node.js process with an unknown `stdout` or
 in user code, although it is not impossible. Occurrences of this error are most
 likely an indication of a bug within Node.js itself.
 
-<a id="ERR_OUT_OF_RANGE"></a>
-### ERR_OUT_OF_RANGE
-
-The `'ERR_OUT_OF_RANGE'` code is used to show the value set to a variable is not
-between in range of acceptable values.
-
-<a id="ERR_LESS_THAN_MIN"></a>
-### ERR_LESS_THAN_MIN
-
-The `'ERR_LESS_THAN_MIN'` code is used to show the value set to a variable is less
-than the minimum acceptable value.
-
 <a id="ERR_ZLIB_BINDING_CLOSED"></a>
 ### ERR_ZLIB_BINDING_CLOSED
 
 The `'ERR_ZLIB_BINDING_CLOSED'` code is used when the binding object is not accessible
 anymore. e.g.: cause something it happened like connection was closed unexpectedly.
-
-<a id="ERR_INVALID_RANGE"></a>
-### ERR_INVALID_RANGE
-
-The `'ERR_INVALID_RANGE'` error code is used generically to identify that
-a range value is out.
 
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`child.kill()`]: child_process.html#child_process_child_kill_signal

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -570,6 +570,12 @@ The `'ERR_ARG_NOT_ITERABLE'` error code is used generically to identify that an
 iterable argument (i.e. a value that works with `for...of` loops) is required,
 but not provided to a Node.js API.
 
+<a id="ERR_EXCEEDS_MAX_BUFFER_LENGTH"></a>
+### ERR_EXCEEDS_MAX_BUFFER_LENGTH
+
+The `'ERR_EXCEEDS_MAX_BUFFER_LENGTH'` error code is used to show the buffer
+exceeds the maximum length supported.
+
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 
@@ -611,12 +617,6 @@ process. See [`child.send()`] and [`process.send()`] for more information.
 
 The `'ERR_INVALID_OPT_VALUE'` error code is used generically to identify when
 an invalid or unexpected value has been passed in an options object.
-
-<a id="ERR_INVALID_RANGE"></a>
-### ERR_INVALID_RANGE
-
-The `'ERR_INVALID_RANGE'` error code is used generically to identify that
-a range value is out.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -87,6 +87,8 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
+E('ERR_EXCEEDS_MAX_BUFFER_LENGTH',
+  (value) => `Exceeds the max buffer length of 0x${value.toString(16)} bytes`);
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');
@@ -96,7 +98,6 @@ E('ERR_INVALID_OPT_VALUE',
   (name, value) => {
     return `The value "${String(value)}" is invalid for option "${name}"`;
   });
-E('ERR_INVALID_RANGE', (msg) => msg);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   (value) => {
     return 'Asynchronous forks do not support Buffer, Uint8Array or string' +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -118,9 +118,48 @@ E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 // Add new errors from here...
-E('ERR_OUT_OF_RANGE', (n, a, b) => {
-  return `${n} is out of range [${a} to ${b}]`;
-});
+E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
+E('ERR_OUT_OF_RANGE', invalidRange);
+E('ERR_LESS_THAN_MIN', invalidMinRange);
+
+
+function invalidMinRange(name, min) {
+
+  assert(name, 'name is required');
+
+  if (typeof min !== 'number') {
+
+    if (!min)
+      assert(min, 'min is required');
+  }
+
+  var msg = `"${name}" is out of range. `;
+  msg += `It should be equal or greater than ${min}.`;
+
+  return msg;
+}
+
+function invalidRange(name, min, max) {
+
+  assert(name, 'name is required');
+
+  if (typeof min !== 'number') {
+
+    if (!min)
+      assert(min, 'min is required');
+  }
+
+  if (typeof max !== 'number') {
+
+    if (!max)
+      assert(max, 'max is required');
+  }
+
+  var msg = `"${name}" is out of range. `;
+  msg += `It should be between ${min} and ${max}.`;
+
+  return msg;
+}
 
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();
@@ -146,7 +185,7 @@ function missingArgs(...args) {
       break;
     default:
       msg += args.slice(0, len - 1).join(', ');
-      msg += `, and ${args[len - 1]} arguments`;
+      msg += ` and ${args[len - 1]} arguments`;
       break;
   }
   return `${msg} must be specified`;
@@ -160,7 +199,7 @@ function oneOf(expected, thing) {
     assert(len > 0, 'At least one expected value needs to be specified');
     expected = expected.map((i) => String(i));
     if (len > 2) {
-      return `one of ${thing} ${expected.slice(0, len - 1).join(', ')}, or ` +
+      return `one of ${thing} ${expected.slice(0, len - 1).join(', ')} or ` +
              expected[len - 1];
     } else if (len === 2) {
       return `one of ${thing} ${expected[0]} or ${expected[1]}`;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -96,6 +96,7 @@ E('ERR_INVALID_OPT_VALUE',
   (name, value) => {
     return `The value "${String(value)}" is invalid for option "${name}"`;
   });
+E('ERR_INVALID_RANGE', (msg) => msg);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   (value) => {
     return 'Asynchronous forks do not support Buffer, Uint8Array or string' +
@@ -110,57 +111,18 @@ E('ERR_IPC_CHANNEL_CLOSED', 'channel closed');
 E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected');
 E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe');
 E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
+E('ERR_LESS_THAN_MIN', invalidMinRange);
 E('ERR_MISSING_ARGS', missingArgs);
+E('ERR_OUT_OF_RANGE', invalidRange);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
 E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
-// Add new errors from here...
+E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
 E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
-E('ERR_INVALID_RANGE', (msg) => msg);
-E('ERR_OUT_OF_RANGE', invalidRange);
-E('ERR_LESS_THAN_MIN', invalidMinRange);
-
-
-function invalidMinRange(name, min) {
-
-  assert(name, 'name is required');
-
-  if (typeof min !== 'number') {
-
-    if (!min)
-      assert(min, 'min is required');
-  }
-
-  var msg = `"${name}" is out of range. `;
-  msg += `It should be equal or greater than ${min}.`;
-
-  return msg;
-}
-
-function invalidRange(name, min, max) {
-
-  assert(name, 'name is required');
-
-  if (typeof min !== 'number') {
-
-    if (!min)
-      assert(min, 'min is required');
-  }
-
-  if (typeof max !== 'number') {
-
-    if (!max)
-      assert(max, 'max is required');
-  }
-
-  var msg = `"${name}" is out of range. `;
-  msg += `It should be between ${min} and ${max}.`;
-
-  return msg;
-}
+// Add new errors from here...
 
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();
@@ -169,6 +131,22 @@ function invalidArgType(name, expected, actual) {
   if (arguments.length >= 3) {
     msg += `. Received type ${actual !== null ? typeof actual : 'null'}`;
   }
+  return msg;
+}
+
+function invalidMinRange(name, min) {
+  assert(name, 'name is required');
+  assert(typeof min === 'number', 'min must be a number');
+  var msg = `"${name}" must be a number equal or greater than ${min}.`;
+  return msg;
+}
+
+function invalidRange(name, min, max) {
+  assert(name, 'name is required');
+  assert(typeof min === 'number', 'min must be a number');
+  assert(typeof max === 'number', 'max must be a number');
+  var msg = `"${name}" is out of range. `;
+  msg += `It should be between ${min} and ${max}.`;
   return msg;
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -119,6 +119,7 @@ E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 // Add new errors from here...
 E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
+E('ERR_INVALID_RANGE', (msg) => msg);
 E('ERR_OUT_OF_RANGE', invalidRange);
 E('ERR_LESS_THAN_MIN', invalidMinRange);
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -118,6 +118,9 @@ E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 // Add new errors from here...
+E('ERR_OUT_OF_RANGE', (n, a, b) => {
+  return `${n} is out of range [${a} to ${b}]`;
+});
 
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -28,10 +28,6 @@ const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
 const assert = require('assert').ok;
 const kMaxLength = require('buffer').kMaxLength;
-const kRangeErrorBufferMessage = 'Cannot create final Buffer. It would be ' +
-                                 `larger than 0x${kMaxLength.toString(16)} ` +
-                                 'bytes';
-
 const constants = process.binding('constants').zlib;
 const createClassWrapper = internalUtil.createClassWrapper;
 
@@ -120,8 +116,8 @@ function zlibBuffer(engine, buffer, callback) {
     var err = null;
 
     if (nread >= kMaxLength) {
-      err = new errors.RangeError('ERR_INVALID_RANGE',
-                                  kRangeErrorBufferMessage);
+      err = new errors.RangeError('ERR_EXCEEDS_MAX_BUFFER_LENGTH',
+                                  kMaxLength);
     } else {
       buf = Buffer.concat(buffers, nread);
     }
@@ -425,8 +421,8 @@ class Zlib extends Transform {
 
       if (nread >= kMaxLength) {
         _close(this);
-        throw new errors.RangeError('ERR_INVALID_RANGE',
-                                    kRangeErrorBufferMessage);
+        throw new errors.RangeError('ERR_EXCEEDS_MAX_BUFFER_LENGTH',
+                                    kMaxLength);
       }
 
       var buf = Buffer.concat(buffers, nread);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -28,8 +28,9 @@ const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
 const assert = require('assert').ok;
 const kMaxLength = require('buffer').kMaxLength;
-const kRangeErrorMessage = 'Cannot create final Buffer. It would be larger ' +
-                           `than 0x${kMaxLength.toString(16)} bytes`;
+const kRangeErrorBufferMessage = 'Cannot create final Buffer. It would be ' +
+                                 `larger than 0x${kMaxLength.toString(16)} ` +
+                                 'bytes';
 
 const constants = process.binding('constants').zlib;
 const createClassWrapper = internalUtil.createClassWrapper;
@@ -73,7 +74,7 @@ function isInvalidFlushFlag(flag) {
 function isInvalidStrategy(strategy) {
 
   return strategy < constants.Z_DEFAULT_STRATEGY ||
-    strategy > constants.Z_FIXED;
+         strategy > constants.Z_FIXED;
 
   // Covers: constants.Z_FILTERED, (1)
   //         constants.Z_HUFFMAN_ONLY (2),
@@ -119,7 +120,8 @@ function zlibBuffer(engine, buffer, callback) {
     var err = null;
 
     if (nread >= kMaxLength) {
-      err = new errors.RangeError('ERR_INVALID_RANGE', kRangeErrorMessage);
+      err = new errors.RangeError('ERR_INVALID_RANGE',
+                                  kRangeErrorBufferMessage);
     } else {
       buf = Buffer.concat(buffers, nread);
     }
@@ -135,7 +137,7 @@ function zlibBufferSync(engine, buffer) {
     buffer = Buffer.from(buffer);
   else if (!ArrayBuffer.isView(buffer))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
-      ['string', 'Buffer', 'TypedArray', 'DataView']);
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
 
   var flushFlag = engine._finishFlushFlag;
 
@@ -180,12 +182,12 @@ class Zlib extends Transform {
 
       if (!isNumber(opts.flush)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flush',
-          'number');
+                                   'number');
       }
 
       if (isInvalidFlushFlag(opts.flush)) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'flush',
-          constants.Z_NO_FLUSH, constants.Z_BLOCK);
+                                    constants.Z_NO_FLUSH, constants.Z_BLOCK);
       }
     }
 
@@ -193,12 +195,12 @@ class Zlib extends Transform {
 
       if (!isNumber(opts.finishFlush)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'finishFlush',
-          'number');
+                                   'number');
       }
 
       if (isInvalidFlushFlag(opts.finishFlush)) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'finishFlush',
-          constants.Z_NO_FLUSH, constants.Z_BLOCK);
+                                    constants.Z_NO_FLUSH, constants.Z_BLOCK);
       }
     }
 
@@ -209,31 +211,34 @@ class Zlib extends Transform {
     if (opts.chunkSize) {
       if (opts.chunkSize < constants.Z_MIN_CHUNK) {
         throw new errors.RangeError('ERR_LESS_THAN_MIN', 'chunkSize',
-          constants.Z_MIN_CHUNK);
+                                    constants.Z_MIN_CHUNK);
       }
     }
 
     if (opts.windowBits) {
       if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
-        opts.windowBits > constants.Z_MAX_WINDOWBITS) {
+          opts.windowBits > constants.Z_MAX_WINDOWBITS) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'windowBits',
-          constants.Z_MIN_WINDOWBITS, constants.Z_MAX_WINDOWBITS);
+                                    constants.Z_MIN_WINDOWBITS,
+                                    constants.Z_MAX_WINDOWBITS);
       }
     }
 
     if (opts.level) {
       if (opts.level < constants.Z_MIN_LEVEL ||
-        opts.level > constants.Z_MAX_LEVEL) {
+          opts.level > constants.Z_MAX_LEVEL) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'level',
-          constants.Z_MIN_LEVEL, constants.Z_MAX_LEVEL);
+                                    constants.Z_MIN_LEVEL,
+                                    constants.Z_MAX_LEVEL);
       }
     }
 
     if (opts.memLevel) {
       if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
-        opts.memLevel > constants.Z_MAX_MEMLEVEL) {
+          opts.memLevel > constants.Z_MAX_MEMLEVEL) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'memLevel',
-          constants.Z_MIN_MEMLEVEL, constants.Z_MAX_MEMLEVEL);
+                                    constants.Z_MIN_MEMLEVEL,
+                                    constants.Z_MAX_MEMLEVEL);
       }
     }
 
@@ -241,19 +246,20 @@ class Zlib extends Transform {
 
       if (!isNumber(opts.strategy)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'strategy',
-          'number');
+                                   'number');
       }
 
       if (isInvalidStrategy(opts.strategy)) {
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'strategy',
-          constants.Z_DEFAULT_STRATEGY, constants.Z_FIXED);
+                                    constants.Z_DEFAULT_STRATEGY,
+                                    constants.Z_FIXED);
       }
     }
 
     if (opts.dictionary) {
       if (!ArrayBuffer.isView(opts.dictionary)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dictionary',
-          ['Buffer', 'TypedArray', 'DataView']);
+                                   ['Buffer', 'TypedArray', 'DataView']);
       }
     }
 
@@ -289,17 +295,18 @@ class Zlib extends Transform {
     if (level < constants.Z_MIN_LEVEL ||
         level > constants.Z_MAX_LEVEL) {
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'level',
-          constants.Z_MIN_LEVEL, constants.Z_MAX_LEVEL);
+                                  constants.Z_MIN_LEVEL, constants.Z_MAX_LEVEL);
     }
 
     if (!isNumber(strategy)) {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'strategy',
-        'number');
+                                 'number');
     }
 
     if (isInvalidStrategy(strategy)) {
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'strategy',
-        constants.Z_DEFAULT_STRATEGY, constants.Z_FIXED);
+                                  constants.Z_DEFAULT_STRATEGY,
+                                  constants.Z_FIXED);
     }
 
     if (this._level !== level || this._strategy !== strategy) {
@@ -359,7 +366,7 @@ class Zlib extends Transform {
 
     if (chunk !== null && !ArrayBuffer.isView(chunk))
       return cb(new errors.TypeError('ERR_INVALID_ARG_TYPE', 'chunk',
-        'Buffer'));
+                                     'Buffer'));
 
     if (!this._handle)
       return cb(new errors.Error('ERR_ZLIB_BINDING_CLOSED'));
@@ -418,7 +425,8 @@ class Zlib extends Transform {
 
       if (nread >= kMaxLength) {
         _close(this);
-        throw new errors.RangeError('ERR_INVALID_RANGE', kRangeErrorMessage);
+        throw new errors.RangeError('ERR_INVALID_RANGE',
+                                    kRangeErrorBufferMessage);
       }
 
       var buf = Buffer.concat(buffers, nread);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -119,7 +119,7 @@ function zlibBuffer(engine, buffer, callback) {
     var err = null;
 
     if (nread >= kMaxLength) {
-      err = new RangeError(kRangeErrorMessage);
+      err = new errors.RangeError('ERR_INVALID_RANGE', kRangeErrorMessage);
     } else {
       buf = Buffer.concat(buffers, nread);
     }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -418,7 +418,7 @@ class Zlib extends Transform {
 
       if (nread >= kMaxLength) {
         _close(this);
-        throw new RangeError(kRangeErrorMessage);
+        throw new errors.RangeError('ERR_INVALID_RANGE', kRangeErrorMessage);
       }
 
       var buf = Buffer.concat(buffers, nread);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -53,8 +53,8 @@ for (var ck = 0; ck < ckeys.length; ck++) {
   codes[codes[ckey]] = ckey;
 }
 
-function isNotNumber(value) {
-  return typeof value !== 'number';
+function isNumber(value) {
+  return typeof value === 'number';
 }
 
 function isInvalidFlushFlag(flag) {
@@ -71,9 +71,9 @@ function isInvalidFlushFlag(flag) {
 }
 
 function isInvalidStrategy(strategy) {
-  return typeof strategy !== 'number' ||
-         strategy < constants.Z_DEFAULT_STRATEGY ||
-         strategy > constants.Z_FIXED;
+
+  return strategy < constants.Z_DEFAULT_STRATEGY ||
+    strategy > constants.Z_FIXED;
 
   // Covers: constants.Z_FILTERED, (1)
   //         constants.Z_HUFFMAN_ONLY (2),
@@ -134,8 +134,8 @@ function zlibBufferSync(engine, buffer) {
   if (typeof buffer === 'string')
     buffer = Buffer.from(buffer);
   else if (!ArrayBuffer.isView(buffer))
-    throw new TypeError('"buffer" argument must be a string, Buffer, ' +
-                        'TypedArray, or DataView');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+      ['string', 'Buffer', 'TypedArray', 'DataView']);
 
   var flushFlag = engine._finishFlushFlag;
 
@@ -176,24 +176,30 @@ class Zlib extends Transform {
     this._opts = opts;
     this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
 
-    if (opts.flush && isNotNumber(opts.flush)) {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flush',
-        'number');
+    if (opts.flush) {
+
+      if (!isNumber(opts.flush)) {
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flush',
+          'number');
+      }
+
+      if (isInvalidFlushFlag(opts.flush)) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'flush',
+          constants.Z_NO_FLUSH, constants.Z_BLOCK);
+      }
     }
 
-    if (isInvalidFlushFlag(opts.flush)) {
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'flush',
-        constants.Z_NO_FLUSH, constants.Z_BLOCK);
-    }
+    if (opts.finishFlush) {
 
-    if (opts.finishFlush && isNotNumber(opts.finishFlush)) {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'finishFlush',
-        'number');
-    }
+      if (!isNumber(opts.finishFlush)) {
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'finishFlush',
+          'number');
+      }
 
-    if (isInvalidFlushFlag(opts.finishFlush)) {
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'finishFlush',
-        constants.Z_NO_FLUSH, constants.Z_BLOCK);
+      if (isInvalidFlushFlag(opts.finishFlush)) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'finishFlush',
+          constants.Z_NO_FLUSH, constants.Z_BLOCK);
+      }
     }
 
     this._flushFlag = opts.flush || constants.Z_NO_FLUSH;
@@ -202,38 +208,52 @@ class Zlib extends Transform {
 
     if (opts.chunkSize) {
       if (opts.chunkSize < constants.Z_MIN_CHUNK) {
-        throw new RangeError('Invalid chunk size: ' + opts.chunkSize);
+        throw new errors.RangeError('ERR_LESS_THAN_MIN', 'chunkSize',
+          constants.Z_MIN_CHUNK);
       }
     }
 
     if (opts.windowBits) {
       if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
-          opts.windowBits > constants.Z_MAX_WINDOWBITS) {
-        throw new RangeError('Invalid windowBits: ' + opts.windowBits);
+        opts.windowBits > constants.Z_MAX_WINDOWBITS) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'windowBits',
+          constants.Z_MIN_WINDOWBITS, constants.Z_MAX_WINDOWBITS);
       }
     }
 
     if (opts.level) {
       if (opts.level < constants.Z_MIN_LEVEL ||
-          opts.level > constants.Z_MAX_LEVEL) {
-        throw new RangeError('Invalid compression level: ' + opts.level);
+        opts.level > constants.Z_MAX_LEVEL) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'level',
+          constants.Z_MIN_LEVEL, constants.Z_MAX_LEVEL);
       }
     }
 
     if (opts.memLevel) {
       if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
-          opts.memLevel > constants.Z_MAX_MEMLEVEL) {
-        throw new RangeError('Invalid memLevel: ' + opts.memLevel);
+        opts.memLevel > constants.Z_MAX_MEMLEVEL) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'memLevel',
+          constants.Z_MIN_MEMLEVEL, constants.Z_MAX_MEMLEVEL);
       }
     }
 
-    if (opts.strategy && isInvalidStrategy(opts.strategy))
-      throw new TypeError('Invalid strategy: ' + opts.strategy);
+    if (opts.strategy) {
+
+      if (!isNumber(opts.strategy)) {
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'strategy',
+          'number');
+      }
+
+      if (isInvalidStrategy(opts.strategy)) {
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'strategy',
+          constants.Z_DEFAULT_STRATEGY, constants.Z_FIXED);
+      }
+    }
 
     if (opts.dictionary) {
       if (!ArrayBuffer.isView(opts.dictionary)) {
-        throw new TypeError(
-          'Invalid dictionary: it should be a Buffer, TypedArray, or DataView');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dictionary',
+          ['Buffer', 'TypedArray', 'DataView']);
       }
     }
 
@@ -268,10 +288,19 @@ class Zlib extends Transform {
   params(level, strategy, callback) {
     if (level < constants.Z_MIN_LEVEL ||
         level > constants.Z_MAX_LEVEL) {
-      throw new RangeError('Invalid compression level: ' + level);
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'level',
+          constants.Z_MIN_LEVEL, constants.Z_MAX_LEVEL);
     }
-    if (isInvalidStrategy(strategy))
-      throw new TypeError('Invalid strategy: ' + strategy);
+
+    if (!isNumber(strategy)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'strategy',
+        'number');
+    }
+
+    if (isInvalidStrategy(strategy)) {
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'strategy',
+        constants.Z_DEFAULT_STRATEGY, constants.Z_FIXED);
+    }
 
     if (this._level !== level || this._strategy !== strategy) {
       this.flush(constants.Z_SYNC_FLUSH,
@@ -329,10 +358,11 @@ class Zlib extends Transform {
     var last = ending && (!chunk || ws.length === chunk.byteLength);
 
     if (chunk !== null && !ArrayBuffer.isView(chunk))
-      return cb(new TypeError('invalid input'));
+      return cb(new errors.TypeError('ERR_INVALID_ARG_TYPE', 'chunk',
+        'Buffer'));
 
     if (!this._handle)
-      return cb(new Error('zlib binding closed'));
+      return cb(new errors.Error('ERR_ZLIB_BINDING_CLOSED'));
 
     // If it's the last chunk, or a final flush, we use the Z_FINISH flush flag
     // (or whatever flag was provided using opts.finishFlush).

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -23,6 +23,7 @@
 
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
+const errors = require('internal/errors');
 const Transform = require('_stream_transform');
 const binding = process.binding('zlib');
 const assert = require('assert').ok;
@@ -52,9 +53,13 @@ for (var ck = 0; ck < ckeys.length; ck++) {
   codes[codes[ckey]] = ckey;
 }
 
+function isNotNumber(value) {
+  return typeof value !== 'number';
+}
+
 function isInvalidFlushFlag(flag) {
-  return typeof flag !== 'number' ||
-         flag < constants.Z_NO_FLUSH ||
+
+  return flag < constants.Z_NO_FLUSH ||
          flag > constants.Z_BLOCK;
 
   // Covers: constants.Z_NO_FLUSH (0),
@@ -171,11 +176,24 @@ class Zlib extends Transform {
     this._opts = opts;
     this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
 
-    if (opts.flush && isInvalidFlushFlag(opts.flush)) {
-      throw new RangeError('Invalid flush flag: ' + opts.flush);
+    if (opts.flush && isNotNumber(opts.flush)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flush',
+        'number');
     }
-    if (opts.finishFlush && isInvalidFlushFlag(opts.finishFlush)) {
-      throw new RangeError('Invalid flush flag: ' + opts.finishFlush);
+
+    if (isInvalidFlushFlag(opts.flush)) {
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'flush',
+        constants.Z_NO_FLUSH, constants.Z_BLOCK);
+    }
+
+    if (opts.finishFlush && isNotNumber(opts.finishFlush)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'finishFlush',
+        'number');
+    }
+
+    if (isInvalidFlushFlag(opts.finishFlush)) {
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'finishFlush',
+        constants.Z_NO_FLUSH, constants.Z_BLOCK);
     }
 
     this._flushFlag = opts.flush || constants.Z_NO_FLUSH;

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -228,24 +228,33 @@ assert.throws(
 assert.strictEqual(errors.message('ERR_ZLIB_BINDING_CLOSED'),
                    'zlib binding closed');
 
-assert.throws(() => errors.message('ERR_OUT_OF_RANGE', [null]),
-              /name is required/);
+assert.throws(
+  () => errors.message('ERR_OUT_OF_RANGE', [null]),
+  /name is required/
+);
 
-assert.throws(() => errors.message('ERR_OUT_OF_RANGE', ['a', null]),
-              /min is required/);
+assert.throws(
+  () => errors.message('ERR_OUT_OF_RANGE', ['a', null]),
+  /min must be a number/
+);
 
-assert.throws(() => errors.message('ERR_OUT_OF_RANGE', ['a', 1, null]),
-              /max is required/);
+assert.throws(
+  () => errors.message('ERR_OUT_OF_RANGE', ['a', 1, null]),
+  /max must be a number/
+);
 
 assert.strictEqual(errors.message('ERR_OUT_OF_RANGE', ['a', 1, 5]),
                    '"a" is out of range. It should be between 1 and 5.');
 
-assert.throws(() => errors.message('ERR_LESS_THAN_MIN', [null]),
-              /name is required/);
+assert.throws(
+  () => errors.message('ERR_LESS_THAN_MIN', [null]),
+  /name is required/
+);
 
-assert.throws(() => errors.message('ERR_LESS_THAN_MIN', ['a', null]),
-              /min is required/);
+assert.throws(
+  () => errors.message('ERR_LESS_THAN_MIN', ['a', null]),
+  /min must be a number/
+);
 
 assert.strictEqual(errors.message('ERR_LESS_THAN_MIN', ['a', 10]),
-                   '"a" is out of range. It should be equal or ' +
-                   'greater than 10.');
+                   '"a" must be a number equal or greater than 10.');

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -182,7 +182,7 @@ assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', ['b', 'c']]),
                    'The "a" argument must be one of type b or c');
 assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE',
                                   ['a', ['b', 'c', 'd']]),
-                   'The "a" argument must be one of type b, c, or d');
+                   'The "a" argument must be one of type b, c or d');
 assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', 'b', 'c']),
                    'The "a" argument must be of type b. Received type string');
 assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE',
@@ -201,7 +201,7 @@ assert.strictEqual(errors.message('ERR_INVALID_URL_SCHEME', [['file']]),
 assert.strictEqual(errors.message('ERR_INVALID_URL_SCHEME', [['http', 'ftp']]),
                    'The URL must be one of scheme http or ftp');
 assert.strictEqual(errors.message('ERR_INVALID_URL_SCHEME', [['a', 'b', 'c']]),
-                   'The URL must be one of scheme a, b, or c');
+                   'The URL must be one of scheme a, b or c');
 assert.throws(
   () => errors.message('ERR_INVALID_URL_SCHEME', [[]]),
   common.expectsError({
@@ -215,7 +215,7 @@ assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['name']),
 assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['name', 'value']),
                    'The "name" and "value" arguments must be specified');
 assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['a', 'b', 'c']),
-                   'The "a", "b", and "c" arguments must be specified');
+                   'The "a", "b" and "c" arguments must be specified');
 assert.throws(
   () => errors.message('ERR_MISSING_ARGS'),
   common.expectsError({

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -221,4 +221,31 @@ assert.throws(
   common.expectsError({
     code: 'ERR_ASSERTION',
     message: /^At least one arg needs to be specified$/
-  }));
+  })
+);
+
+// Tests ERR RANGE
+assert.strictEqual(errors.message('ERR_ZLIB_BINDING_CLOSED'),
+                   'zlib binding closed');
+
+assert.throws(() => errors.message('ERR_OUT_OF_RANGE', [null]),
+              /name is required/);
+
+assert.throws(() => errors.message('ERR_OUT_OF_RANGE', ['a', null]),
+              /min is required/);
+
+assert.throws(() => errors.message('ERR_OUT_OF_RANGE', ['a', 1, null]),
+              /max is required/);
+
+assert.strictEqual(errors.message('ERR_OUT_OF_RANGE', ['a', 1, 5]),
+                   '"a" is out of range. It should be between 1 and 5.');
+
+assert.throws(() => errors.message('ERR_LESS_THAN_MIN', [null]),
+              /name is required/);
+
+assert.throws(() => errors.message('ERR_LESS_THAN_MIN', ['a', null]),
+              /min is required/);
+
+assert.strictEqual(errors.message('ERR_LESS_THAN_MIN', ['a', 10]),
+                   '"a" is out of range. It should be equal or ' +
+                   'greater than 10.');

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -225,6 +225,10 @@ assert.throws(
 );
 
 // Tests ERR RANGE
+assert.strictEqual(errors.message('ERR_EXCEEDS_MAX_BUFFER_LENGTH',
+                   [84947843812734]),
+                   'Exceeds the max buffer length of 0x4d42760e0d7e bytes');
+
 assert.strictEqual(errors.message('ERR_ZLIB_BINDING_CLOSED'),
                    'zlib binding closed');
 

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 const zlib = require('zlib');
 const assert = require('assert');
@@ -14,8 +14,13 @@ assert.ok(new zlib.DeflateRaw() instanceof zlib.DeflateRaw);
 
 // Throws if `opts.chunkSize` is invalid
 assert.throws(
-  () => { new zlib.Deflate({chunkSize: -Infinity}); },
-  /^RangeError: Invalid chunk size: -Infinity$/
+  () => { new zlib.Deflate({ chunkSize: -Infinity }); },
+  common.expectsError({
+    code: 'ERR_LESS_THAN_MIN',
+    type: RangeError,
+    message: '"chunkSize" is out of range. It should be equal or greater ' +
+    `than ${zlib.constants.Z_MIN_CHUNK}.`
+  })
 );
 
 // Confirm that maximum chunk size cannot be exceeded because it is `Infinity`.
@@ -23,89 +28,186 @@ assert.strictEqual(zlib.constants.Z_MAX_CHUNK, Infinity);
 
 // Throws if `opts.windowBits` is invalid
 assert.throws(
-  () => { new zlib.Deflate({windowBits: -Infinity}); },
-  /^RangeError: Invalid windowBits: -Infinity$/
+  () => { new zlib.Deflate({ windowBits: -Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"windowBits" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_WINDOWBITS} and ${zlib.constants.Z_MAX_WINDOWBITS}.`
+  })
 );
 
 assert.throws(
-  () => { new zlib.Deflate({windowBits: Infinity}); },
-  /^RangeError: Invalid windowBits: Infinity$/
+  () => { new zlib.Deflate({ windowBits: Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"windowBits" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_WINDOWBITS} and ${zlib.constants.Z_MAX_WINDOWBITS}.`
+  })
 );
 
 // Throws if `opts.level` is invalid
 assert.throws(
-  () => { new zlib.Deflate({level: -Infinity}); },
-  /^RangeError: Invalid compression level: -Infinity$/
+  () => { new zlib.Deflate({ level: -Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"level" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_LEVEL} and ${zlib.constants.Z_MAX_LEVEL}.`
+  })
 );
 
 assert.throws(
-  () => { new zlib.Deflate({level: Infinity}); },
-  /^RangeError: Invalid compression level: Infinity$/
+  () => { new zlib.Deflate({ level: Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"level" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_LEVEL} and ${zlib.constants.Z_MAX_LEVEL}.`
+  })
 );
 
 // Throws a RangeError if `level` invalid in  `Deflate.prototype.params()`
 assert.throws(
   () => { new zlib.Deflate().params(-Infinity); },
-  /^RangeError: Invalid compression level: -Infinity$/
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"level" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_LEVEL} and ${zlib.constants.Z_MAX_LEVEL}.`
+  })
 );
 
 assert.throws(
   () => { new zlib.Deflate().params(Infinity); },
-  /^RangeError: Invalid compression level: Infinity$/
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"level" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_LEVEL} and ${zlib.constants.Z_MAX_LEVEL}.`
+  })
 );
 
 // Throws if `opts.memLevel` is invalid
 assert.throws(
-  () => { new zlib.Deflate({memLevel: -Infinity}); },
-  /^RangeError: Invalid memLevel: -Infinity$/
+  () => { new zlib.Deflate({ memLevel: -Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"memLevel" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_MEMLEVEL} and ${zlib.constants.Z_MAX_MEMLEVEL}.`
+  })
 );
 
 assert.throws(
-  () => { new zlib.Deflate({memLevel: Infinity}); },
-  /^RangeError: Invalid memLevel: Infinity$/
+  () => { new zlib.Deflate({ memLevel: Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"memLevel" is out of range. It should be between ' +
+    `${zlib.constants.Z_MIN_MEMLEVEL} and ${zlib.constants.Z_MAX_MEMLEVEL}.`
+  })
 );
 
 // Does not throw if opts.strategy is valid
 assert.doesNotThrow(
-  () => { new zlib.Deflate({strategy: zlib.constants.Z_FILTERED}); }
+  () => { new zlib.Deflate({ strategy: zlib.constants.Z_FILTERED }); }
 );
 
 assert.doesNotThrow(
-  () => { new zlib.Deflate({strategy: zlib.constants.Z_HUFFMAN_ONLY}); }
+  () => { new zlib.Deflate({ strategy: zlib.constants.Z_HUFFMAN_ONLY }); }
 );
 
 assert.doesNotThrow(
-  () => { new zlib.Deflate({strategy: zlib.constants.Z_RLE}); }
+  () => { new zlib.Deflate({ strategy: zlib.constants.Z_RLE }); }
 );
 
 assert.doesNotThrow(
-  () => { new zlib.Deflate({strategy: zlib.constants.Z_FIXED}); }
+  () => { new zlib.Deflate({ strategy: zlib.constants.Z_FIXED }); }
 );
 
 assert.doesNotThrow(
-  () => { new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY}); }
+  () => { new zlib.Deflate({ strategy: zlib.constants.Z_DEFAULT_STRATEGY }); }
 );
 
 // Throws if opt.strategy is the wrong type.
 assert.throws(
   () => { new zlib.Deflate({ strategy: String(zlib.constants.Z_RLE) }); },
-  /^TypeError: Invalid strategy: 3$/
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "strategy" argument must be of type number'
+  })
 );
 
 // Throws if opts.strategy is invalid
 assert.throws(
-  () => { new zlib.Deflate({strategy: 'this is a bogus strategy'}); },
-  /^TypeError: Invalid strategy: this is a bogus strategy$/
+  () => { new zlib.Deflate({ strategy: 'this is a bogus strategy' }); },
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "strategy" argument must be of type number'
+  })
+);
+
+assert.throws(
+  () => { new zlib.Deflate({ strategy: -Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"strategy" is out of range. It should be between ' +
+    `${zlib.constants.Z_DEFAULT_STRATEGY} and ${zlib.constants.Z_FIXED}.`
+  })
+);
+
+assert.throws(
+  () => { new zlib.Deflate({ strategy: Infinity }); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"strategy" is out of range. It should be between ' +
+    `${zlib.constants.Z_DEFAULT_STRATEGY} and ${zlib.constants.Z_FIXED}.`
+  })
 );
 
 // Throws TypeError if `strategy` is invalid in `Deflate.prototype.params()`
 assert.throws(
   () => { new zlib.Deflate().params(0, 'I am an invalid strategy'); },
-  /^TypeError: Invalid strategy: I am an invalid strategy$/
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "strategy" argument must be of type number'
+  })
+);
+
+assert.throws(
+  () => { new zlib.Deflate().params(0, -Infinity); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"strategy" is out of range. It should be between ' +
+    `${zlib.constants.Z_DEFAULT_STRATEGY} and ${zlib.constants.Z_FIXED}.`
+  })
+);
+
+assert.throws(
+  () => { new zlib.Deflate().params(0, Infinity); },
+  common.expectsError({
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: '"strategy" is out of range. It should be between ' +
+    `${zlib.constants.Z_DEFAULT_STRATEGY} and ${zlib.constants.Z_FIXED}.`
+  })
 );
 
 // Throws if opts.dictionary is not a Buffer
 assert.throws(
-  () => { new zlib.Deflate({dictionary: 'not a buffer'}); },
-  /^TypeError: Invalid dictionary: it should be a Buffer, TypedArray, or DataView$/
+  () => { new zlib.Deflate({ dictionary: 'not a buffer' }); },
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "dictionary" argument must be one of type Buffer, ' +
+    'TypedArray or DataView'
+  })
 );

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -18,8 +18,8 @@ assert.throws(
   common.expectsError({
     code: 'ERR_LESS_THAN_MIN',
     type: RangeError,
-    message: '"chunkSize" is out of range. It should be equal or greater ' +
-    `than ${zlib.constants.Z_MIN_CHUNK}.`
+    message: '"chunkSize" must be a number equal or ' +
+    `greater than ${zlib.constants.Z_MIN_CHUNK}.`
   })
 );
 

--- a/test/parallel/test-zlib-flush-flags.js
+++ b/test/parallel/test-zlib-flush-flags.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
@@ -9,11 +10,18 @@ assert.doesNotThrow(() => {
 
 assert.throws(() => {
   zlib.createGzip({ flush: 'foobar' });
-}, /^RangeError: Invalid flush flag: foobar$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "flush" argument must be of type number' }));
 
 assert.throws(() => {
   zlib.createGzip({ flush: 10000 });
-}, /^RangeError: Invalid flush flag: 10000$/);
+}, common.expectsError({
+  code: 'ERR_OUT_OF_RANGE',
+  type: RangeError,
+  message: `flush is out of range` +
+    ` [${zlib.constants.Z_NO_FLUSH} to ${zlib.constants.Z_BLOCK}]` }));
 
 assert.doesNotThrow(() => {
   zlib.createGzip({ finishFlush: zlib.constants.Z_SYNC_FLUSH });
@@ -21,8 +29,15 @@ assert.doesNotThrow(() => {
 
 assert.throws(() => {
   zlib.createGzip({ finishFlush: 'foobar' });
-}, /^RangeError: Invalid flush flag: foobar$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "finishFlush" argument must be of type number' }));
 
 assert.throws(() => {
   zlib.createGzip({ finishFlush: 10000 });
-}, /^RangeError: Invalid flush flag: 10000$/);
+}, common.expectsError({
+  code: 'ERR_OUT_OF_RANGE',
+  type: RangeError,
+  message: `finishFlush is out of range` +
+    ` [${zlib.constants.Z_NO_FLUSH} to ${zlib.constants.Z_BLOCK}]` }));

--- a/test/parallel/test-zlib-flush-flags.js
+++ b/test/parallel/test-zlib-flush-flags.js
@@ -20,8 +20,8 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_OUT_OF_RANGE',
   type: RangeError,
-  message: `flush is out of range` +
-    ` [${zlib.constants.Z_NO_FLUSH} to ${zlib.constants.Z_BLOCK}]` }));
+  message: '"flush" is out of range. It should be between ' +
+    `${zlib.constants.Z_NO_FLUSH} and ${zlib.constants.Z_BLOCK}.` }));
 
 assert.doesNotThrow(() => {
   zlib.createGzip({ finishFlush: zlib.constants.Z_SYNC_FLUSH });
@@ -39,5 +39,5 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_OUT_OF_RANGE',
   type: RangeError,
-  message: `finishFlush is out of range` +
-    ` [${zlib.constants.Z_NO_FLUSH} to ${zlib.constants.Z_BLOCK}]` }));
+  message: '"finishFlush" is out of range. It should be between ' +
+    `${zlib.constants.Z_NO_FLUSH} and ${zlib.constants.Z_BLOCK}.` }));

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -21,4 +21,4 @@ assert.throws(() => { zlib.deflateSync(false); }, expected);
 assert.throws(() => { zlib.deflateSync(0); }, expected);
 assert.throws(() => { zlib.deflateSync(1); }, expected);
 assert.throws(() => { zlib.deflateSync([1, 2, 3]); }, expected);
-assert.throws(() => { zlib.deflateSync({foo: 'bar'}); }, expected);
+assert.throws(() => { zlib.deflateSync({ foo: 'bar' }); }, expected);

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -3,11 +3,16 @@
 // Check the error condition testing for passing something other than a string
 // or buffer.
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-const expected = /^TypeError: "buffer" argument must be a string, Buffer, TypedArray, or DataView$/;
+const expected = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "buffer" argument must be one of type string, Buffer, ' +
+  'TypedArray or DataView'
+});
 
 assert.throws(() => { zlib.deflateSync(undefined); }, expected);
 assert.throws(() => { zlib.deflateSync(null); }, expected);

--- a/test/parallel/test-zlib-write-after-close.js
+++ b/test/parallel/test-zlib-write-after-close.js
@@ -27,5 +27,9 @@ const zlib = require('zlib');
 zlib.gzip('hello', common.mustCall(function(err, out) {
   const unzip = zlib.createGunzip();
   unzip.close(common.mustCall());
-  assert.throws(() => unzip.write(out), /^Error: zlib binding closed$/);
+  assert.throws(() => unzip.write(out), common.expectsError({
+    code: 'ERR_ZLIB_BINDING_CLOSED',
+    type: Error,
+    message: 'zlib binding closed'
+  }));
 }));


### PR DESCRIPTION
Migrate [zlib.js](https://github.com/nodejs/node/blob/master/lib/zlib.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js).

Ref: #11273 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib, errors