### PR TITLE
test,doc: document `crashOnUnhandledRejection()`

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -186,6 +186,13 @@ doesn't have privileges to create symlinks (specifically
 [SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)).
 On non-Windows platforms, this currently returns true.
 
+### crashOnUnhandledRejection()
+
+Installs a `process.on('unhandledRejection')` handler that crashes the process
+after a tick. This is useful for tests that use Promises and need to make sure
+no unexpected rejections occur, because currently they result in silent
+failures.
+
 ### ddCommand(filename, kilobytes)
 * return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 


### PR DESCRIPTION
Add documentation for `common.crashOnUnhandledRejection()`.

Ref: https://github.com/nodejs/node/pull/12489/files/a9c2078a60bc3012dc6156df19772697a56a2517#r113737423

@nodejs/testing