### PR TITLE
docs: explain why path.posix.normalize does not replace windows slashes

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -330,6 +330,15 @@ For example on POSIX:
 path.normalize('/foo/bar//baz/asdf/quux/..');
 // Returns: '/foo/bar/baz/asdf'
 ```
+*Note*: The `path.posix.normalize()` method will not attempt to convert \ 
+(Windows) to / (POSIX), as \ is not recognized by POSIX as a valid directory 
+separator.  
+
+For example:
+```js
+path.posix.normalize("\\some\\thing\\like\\this")
+//Returns '\some\thing\like\this'
+```
 
 On Windows:
 
@@ -415,16 +424,6 @@ added: v0.11.15
 
 The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
-
-### path.posix.normalize(path)
-The `path.posix.normalize()` method will not attempt to convert / (Windows) to 
-\ (POSIX), as / is not recognized by POSIX as a valid directory separator.  
-
-For example:
-```js
-path.posix.normalize("/some/thing/like/this")
-//Returns '/some/thing/like/this'
-```
 
 ## path.relative(from, to)
 <!-- YAML

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -417,8 +417,8 @@ The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
 
 ### path.posix.normalize(path)
-The `path.posix.normalize()` method will not attempt to convert / (Windows) to \ (POSIX), as / is not recognized by 
-POSIX as a valid directory separator.  
+The `path.posix.normalize()` method will not attempt to convert / (Windows) to 
+\ (POSIX), as / is not recognized by POSIX as a valid directory separator.  
 
 For example:
 ```js

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -416,6 +416,16 @@ added: v0.11.15
 The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
 
+### path.posix.normalize(path)
+The `path.posix.normalize()` method will not attempt to convert / (Windows) to \ (POSIX), as / is not recognized by 
+POSIX as a valid directory separator.  
+
+For example:
+```js
+path.posix.normalize("/some/thing/like/this")
+//Returns '/some/thing/like/this'
+```
+
 ## path.relative(from, to)
 <!-- YAML
 added: v0.5.0

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -319,8 +319,8 @@ The `path.normalize()` method normalizes the given `path`, resolving `'..'` and
 
 When multiple, sequential path segment separation characters are found (e.g.
 `/` on POSIX and either `\` or `/` on Windows), they are replaced by a single 
-instance of the platform specific path segment separator. Trailing separators 
-are preserved.
+instance of the platform specific path segment separator (`/` on POSIX and 
+`\` on Windows). Trailing separators are preserved.
 
 If the `path` is a zero-length string, `'.'` is returned, representing the
 current working directory.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -330,14 +330,14 @@ For example on POSIX:
 path.normalize('/foo/bar//baz/asdf/quux/..');
 // Returns: '/foo/bar/baz/asdf'
 ```
-*Note*: The `path.posix.normalize()` method will not attempt to convert \ 
-(Windows) to / (POSIX), as \ is not recognized by POSIX as a valid directory 
-separator.  
+*Note*: The `path.posix.normalize()` method will not attempt to convert `\ ` 
+(Windows) to `/` (POSIX), as `\ ` is not recognized by POSIX as a valid 
+directory separator.  
 
 For example:
 ```js
-path.posix.normalize("\\some\\thing\\like\\this")
-//Returns '\some\thing\like\this'
+path.posix.normalize("\\..\\some\\thing\\like\\this")
+//Returns '\..\some\thing\like\this'
 ```
 
 On Windows:

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -318,8 +318,9 @@ The `path.normalize()` method normalizes the given `path`, resolving `'..'` and
 `'.'` segments.
 
 When multiple, sequential path segment separation characters are found (e.g.
-`/` on POSIX and `\` on Windows), they are replaced by a single instance of the
-platform specific path segment separator. Trailing separators are preserved.
+`/` on POSIX and either `\` or `/` on Windows), they are replaced by a single 
+instance of the platform specific path segment separator. Trailing separators 
+are preserved.
 
 If the `path` is a zero-length string, `'.'` is returned, representing the
 current working directory.
@@ -330,21 +331,20 @@ For example on POSIX:
 path.normalize('/foo/bar//baz/asdf/quux/..');
 // Returns: '/foo/bar/baz/asdf'
 ```
-*Note*: The `path.posix.normalize()` method will not attempt to convert `\ ` 
-(Windows) to `/` (POSIX), as `\ ` is not recognized by POSIX as a valid 
-directory separator.  
-
-For example:
-```js
-path.posix.normalize("\\..\\some\\thing\\like\\this")
-//Returns '\..\some\thing\like\this'
-```
 
 On Windows:
 
 ```js
 path.normalize('C:\\temp\\\\foo\\bar\\..\\');
 // Returns: 'C:\\temp\\foo\\'
+```
+
+Since Windows recognizes multiple path separators, both separators will be
+replaced by instances of the Windows preferred separator (`\`):
+
+```js
+path.win32.normalize("C:////temp\\\\/\\/\\\/foo/bar")
+// Returns: 'C:\\temp\\foo\\bar'
 ```
 
 A [`TypeError`][] is thrown if `path` is not a string.


### PR DESCRIPTION
Add section to path docs that explains that path.posix.normalize
does not replace Windows slashes with POSIX slashes because POSIX
does not recognize \ as a valid path separator.

Fixes: https://github.com/nodejs/node/issues/12298

Added a note about directory separator conversion under path.posix.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
doc