### PR TITLE
src: support domains with empty labels in i18n 

### DIFF
--- a/test/fixtures/url-idna.js
+++ b/test/fixtures/url-idna.js
@@ -182,23 +182,18 @@ module.exports = {
       ascii: 'xn--vitnam-jk8b.icom.museum',
       unicode: 'việtnam.icom.museum'
     },
+    // long label
+    {
+      ascii: `${'a'.repeat(64)}.com`,
+      unicode: `${'a'.repeat(64)}.com`,
+    },
     // long URL
     {
-      ascii: `${`${'a'.repeat(63)}.`.repeat(3)}com`,
-      unicode: `${`${'a'.repeat(63)}.`.repeat(3)}com`
+      ascii: `${`${'a'.repeat(64)}.`.repeat(4)}com`,
+      unicode: `${`${'a'.repeat(64)}.`.repeat(4)}com`
     }
   ],
   invalid: [
-    // long label
-    {
-      url: `${'a'.repeat(64)}.com`,
-      mode: 'ascii'
-    },
-    // long URL
-    {
-      url: `${`${'a'.repeat(63)}.`.repeat(4)}com`,
-      mode: 'ascii'
-    },
     // invalid character
     {
       url: '\ufffd.com',

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* WPT Refs:
-   https://github.com/w3c/web-platform-tests/blob/3eff1bd/url/urltestdata.json
+   https://github.com/w3c/web-platform-tests/blob/3afae94/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 module.exports =
@@ -3784,6 +3784,52 @@ module.exports =
     "password": "",
     "host": "192.168.0.1",
     "hostname": "192.168.0.1",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  "Domains with empty labels",
+  {
+    "input": "http://./",
+    "base": "about:blank",
+    "href": "http://./",
+    "origin": "http://.",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": ".",
+    "hostname": ".",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "http://../",
+    "base": "about:blank",
+    "href": "http://../",
+    "origin": "http://..",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "..",
+    "hostname": "..",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "http://0..0x300/",
+    "base": "about:blank",
+    "href": "http://0..0x300/",
+    "origin": "http://0..0x300",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "0..0x300",
+    "hostname": "0..0x300",
     "port": "",
     "pathname": "/",
     "search": "",


### PR DESCRIPTION
##### Summary
The `domainToUnicode` and the `domainToASCII` could be used in the middle of parsing the origin, and it means the input values could be a non-final domain name label. Then the converter should ignore the `UIDNA_ERROR_EMPTY_LABEL` error. Since long domain name labels and long domain names are invalid already, it might not need to ignore `UIDNA_ERROR_LABEL_TOO_LONG` and `UIDNA_ERROR_DOMAIN_NAME_TOO_LONG`. 

Refs:
+ http://icu-project.org/apiref/icu4c/uidna_8h.html#ab04a0655cd1e3bcac5e8f48c18df1a57
+ https://github.com/nodejs/node/blob/6c213978b7c790b7b716df75deab45c3681e5a20/test/fixtures/url-idna.js#L192-L201
+ https://github.com/nodejs/Intl/issues/44

##### Updates
+ src: support domains with empty labels in i18n 
+ test: synchronise WPT url test data

##### Checklist
- [x] `make -j4 test`
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src, test