### PR TITLE
src: make SIGPROF message a real warning

### DIFF
--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -92,7 +92,8 @@ class SignalWrap : public HandleWrap {
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);
       if (env->inspector_agent()->IsStarted()) {
-        fprintf(stderr, "process.on(SIGPROF) is reserved while debugging\n");
+        ProcessEmitWarning(env,
+                           "process.on(SIGPROF) is reserved while debugging");
         return;
       }
     }

--- a/test/parallel/test-warn-sigprof.js
+++ b/test/parallel/test-warn-sigprof.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+
+// The inspector attempts to start when Node starts. Once started, the inspector
+// warns on the use of a SIGPROF listener.
+
+common.skipIfInspectorDisabled();
+
+if (common.isWindows) {
+  common.skip('test does not apply to Windows');
+  return;
+}
+
+common.expectWarning('Warning',
+                     'process.on(SIGPROF) is reserved while debugging');
+
+process.on('SIGPROF', () => {});


### PR DESCRIPTION
This commit replaces a `fprintf()` with a call to `ProcessEmitWarning()`.

R= @Fishrock123 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
src