### PR TITLE
tools: require function declarations

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -97,6 +97,7 @@ rules:
   eol-last: 2
   func-call-spacing: 2
   func-name-matching: 2
+  func-style: [2, declaration, {allowArrowFunctions: true}]
   indent: [2, 2, {ArrayExpression: first,
                   CallExpression: {arguments: first},
                   MemberExpression: 1,

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -592,7 +592,7 @@ Returns `true` if the given `object` is a `Function`. Otherwise, returns
 const util = require('util');
 
 function Foo() {}
-const Bar = function() {};
+const Bar = () => {};
 
 util.isFunction({});
 // Returns: false

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -448,9 +448,9 @@ CryptoStream.prototype.destroySoon = function(err) {
     // was written on this side was read from the other side.
     var self = this;
     var waiting = 1;
-    var finish = function() {
+    function finish() {
       if (--waiting === 0) self.destroy();
-    };
+    }
     this._opposite.once('end', finish);
     if (!this._finished) {
       this.once('finish', finish);

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -645,11 +645,11 @@ function pbkdf2(password, salt, iterations, keylen, digest, callback) {
   // at this point, we need to handle encodings.
   var encoding = exports.DEFAULT_ENCODING;
   if (callback) {
-    var next = function(er, ret) {
+    function next(er, ret) {
       if (ret)
         ret = ret.toString(encoding);
       callback(er, ret);
-    };
+    }
     binding.PBKDF2(password, salt, iterations, keylen, digest, next);
   } else {
     var ret = binding.PBKDF2(password, salt, iterations, keylen, digest);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -143,9 +143,9 @@ function cachedResult(fn) {
 //   B() instanceof A // true
 //   B() instanceof B // true
 function createClassWrapper(type) {
-  const fn = function(...args) {
+  function fn(...args) {
     return Reflect.construct(type, args, new.target || type);
-  };
+  }
   // Mask the wrapper function name and length values
   Object.defineProperties(fn, {
     name: {value: type.name},

--- a/test/addons-napi/test_async/test.js
+++ b/test/addons-napi/test_async/test.js
@@ -6,8 +6,7 @@ const test_async = require(`./build/${common.buildType}/test_async`);
 test_async.Test(5, common.mustCall(function(err, val) {
   assert.strictEqual(err, null);
   assert.strictEqual(val, 10);
-  process.nextTick(common.mustCall(function() {}));
+  process.nextTick(common.mustCall());
 }));
 
-const cancelSuceeded = function() {};
-test_async.TestCancel(common.mustCall(cancelSuceeded));
+test_async.TestCancel(common.mustCall());

--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -4,12 +4,12 @@ const common = require('../../common');
 const test_exception = require(`./build/${common.buildType}/test_exception`);
 const assert = require('assert');
 const theError = new Error('Some error');
-const throwTheError = function() {
+function throwTheError() {
   throw theError;
-};
+}
 let caughtError;
 
-const throwNoError = function() {};
+const throwNoError = common.noop;
 
 // Test that the native side successfully captures the exception
 let returnedError = test_exception.returnException(throwTheError);

--- a/test/addons-napi/test_instanceof/test.js
+++ b/test/addons-napi/test_instanceof/test.js
@@ -57,14 +57,14 @@ if (typeof Symbol !== 'undefined' && 'hasInstance' in Symbol &&
       (theObject instanceof theConstructor));
   }
 
-  const MyClass = function MyClass() {};
+  function MyClass() {}
   Object.defineProperty(MyClass, Symbol.hasInstance, {
     value: function(candidate) {
       return 'mark' in candidate;
     }
   });
 
-  const MySubClass = function MySubClass() {};
+  function MySubClass() {}
   MySubClass.prototype = new MyClass();
 
   let x = new MySubClass();

--- a/test/addons/make-callback/test.js
+++ b/test/addons/make-callback/test.js
@@ -57,9 +57,9 @@ const forward = vm.runInNewContext(`
     })
 `);
 // Runs in outer context.
-const endpoint = function($Object) {
+function endpoint($Object) {
   if (Object === $Object)
     throw new Error('bad');
   return Object;
-};
+}
 assert.strictEqual(Object, makeCallback(process, forward, endpoint));

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -122,7 +122,7 @@ function timeout(message, multiplicator) {
                     TIMEOUT * (multiplicator || 1));
 }
 
-const TestSession = function(socket, harness) {
+function TestSession(socket, harness) {
   this.mainScriptPath = harness.mainScriptPath;
   this.mainScriptId = null;
 
@@ -147,7 +147,7 @@ const TestSession = function(socket, harness) {
         buffer = buffer.slice(consumed);
     } while (consumed);
   }).on('close', () => assert(this.expectClose_, 'Socket closed prematurely'));
-};
+}
 
 TestSession.prototype.scriptUrlForId = function(id) {
   return this.scripts_[id];
@@ -304,7 +304,7 @@ TestSession.prototype.testHttpResponse = function(path, check) {
 };
 
 
-const Harness = function(port, childProcess) {
+function Harness(port, childProcess) {
   this.port = port;
   this.mainScriptPath = mainScript;
   this.stderrFilters_ = [];
@@ -329,7 +329,7 @@ const Harness = function(port, childProcess) {
     this.returnCode_ = code;
     this.running_ = false;
   });
-};
+}
 
 Harness.prototype.addStderrFilter = function(regexp, callback) {
   this.stderrFilters_.push((message) => {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -449,7 +449,7 @@ a.throws(makeBlock(thrower, TypeError), function(err) {
 
     AnotherErrorType = class extends Error {};
 
-    const functionThatThrows = function() {
+    const functionThatThrows = () => {
       throw new AnotherErrorType('foo');
     };
 
@@ -493,6 +493,7 @@ a.throws(makeBlock(a.deepEqual, args, []));
 
 // more checking that arguments objects are handled correctly
 {
+  // eslint-disable-next-line func-style
   const returnArguments = function() { return arguments; };
 
   const someArgs = returnArguments('a');

--- a/test/parallel/test-child-process-fork-dgram.js
+++ b/test/parallel/test-child-process-fork-dgram.js
@@ -78,7 +78,7 @@ if (process.argv[2] === 'child') {
     });
   });
 
-  const sendMessages = function() {
+  function sendMessages() {
     const serverPort = parentServer.address().port;
 
     const timer = setInterval(function() {
@@ -102,7 +102,7 @@ if (process.argv[2] === 'child') {
         );
       }
     }, 1);
-  };
+  }
 
   parentServer.bind(0, '127.0.0.1');
 

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -87,7 +87,7 @@ if (process.argv[2] === 'child') {
   }));
 
   // send net.Server to child and test by connecting
-  const testServer = function(callback) {
+  function testServer(callback) {
 
     // destroy server execute callback when done
     const progress = new ProgressTracker(2, function() {
@@ -116,7 +116,7 @@ if (process.argv[2] === 'child') {
     server.listen(0);
 
     // handle client messages
-    const messageHandlers = function(msg) {
+    function messageHandlers(msg) {
 
       if (msg.what === 'listening') {
         // make connections
@@ -138,13 +138,13 @@ if (process.argv[2] === 'child') {
         child.removeListener('message', messageHandlers);
         callback();
       }
-    };
+    }
 
     child.on('message', messageHandlers);
-  };
+  }
 
   // send net.Socket to child
-  const testSocket = function(callback) {
+  function testSocket(callback) {
 
     // create a new server and connect to it,
     // but the socket will be handled by the child
@@ -179,7 +179,7 @@ if (process.argv[2] === 'child') {
         server.close();
       });
     });
-  };
+  }
 
   // create server and send it to child
   let serverSuccess = false;

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -144,7 +144,7 @@ if (process.argv[2] === 'child') {
 
   server.listen(0, '127.0.0.1');
 
-  const closeServer = function() {
+  function closeServer() {
     server.close();
 
     setTimeout(function() {
@@ -153,7 +153,7 @@ if (process.argv[2] === 'child') {
       child2.send('close');
       child3.disconnect();
     }, 200);
-  };
+  }
 
   process.on('exit', function() {
     assert.strictEqual(disconnected, count);

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -89,7 +89,7 @@ assert.throws(function() {
 // Argument types for combinatorics
 const a = [];
 const o = {};
-const c = function c() {};
+function c() {}
 const s = 'string';
 const u = undefined;
 const n = null;

--- a/test/parallel/test-cluster-disconnect.js
+++ b/test/parallel/test-cluster-disconnect.js
@@ -38,7 +38,7 @@ if (cluster.isWorker) {
   const servers = 2;
 
   // test a single TCP server
-  const testConnection = function(port, cb) {
+  const testConnection = (port, cb) => {
     const socket = net.connect(port, '127.0.0.1', () => {
       // buffer result
       let result = '';
@@ -52,7 +52,7 @@ if (cluster.isWorker) {
   };
 
   // test both servers created in the cluster
-  const testCluster = function(cb) {
+  const testCluster = (cb) => {
     let done = 0;
 
     for (let i = 0; i < servers; i++) {
@@ -67,7 +67,7 @@ if (cluster.isWorker) {
   };
 
   // start two workers and execute callback when both is listening
-  const startCluster = function(cb) {
+  const startCluster = (cb) => {
     const workers = 8;
     let online = 0;
 
@@ -81,7 +81,7 @@ if (cluster.isWorker) {
     }
   };
 
-  const test = function(again) {
+  const test = (again) => {
     //1. start cluster
     startCluster(common.mustCall(() => {
       //2. test cluster

--- a/test/parallel/test-cluster-master-error.js
+++ b/test/parallel/test-cluster-master-error.js
@@ -101,7 +101,7 @@ if (cluster.isWorker) {
     // Check that the cluster died accidentally (non-zero exit code)
     masterExited = !!code;
 
-    const pollWorkers = function() {
+    const pollWorkers = () => {
       // When master is dead all workers should be dead too
       let alive = false;
       workers.forEach((pid) => alive = common.isAlive(pid));

--- a/test/parallel/test-cluster-master-kill.js
+++ b/test/parallel/test-cluster-master-kill.js
@@ -68,7 +68,7 @@ if (cluster.isWorker) {
     assert.strictEqual(code, 0);
 
     // check worker process status
-    const pollWorker = function() {
+    const pollWorker = () => {
       alive = common.isAlive(pid);
       if (alive) {
         setTimeout(pollWorker, 50);

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -80,7 +80,7 @@ if (cluster.isWorker) {
 
 
   let client;
-  const check = function(type, result) {
+  const check = (type, result) => {
     checks[type].receive = true;
     checks[type].correct = result;
     console.error('check', checks);

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -103,7 +103,7 @@ if (cluster.isWorker) {
     }
   }));
 
-  const finish_test = function() {
+  const finish_test = () => {
     try {
       checkResults(expected_results, results);
     } catch (exc) {

--- a/test/parallel/test-console-not-call-toString.js
+++ b/test/parallel/test-console-not-call-toString.js
@@ -23,7 +23,7 @@
 require('../common');
 const assert = require('assert');
 
-const func = function() {};
+function func() {}
 let toStringCalled = false;
 func.toString = function() {
   toStringCalled = true;

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -68,8 +68,8 @@ const EventEmitter = require('events');
 }
 
 {
-  const listen1 = function listen1() {};
-  const listen2 = function listen2() {};
+  const listen1 = () => {};
+  const listen2 = () => {};
   const ee = new EventEmitter();
 
   ee.once('newListener', function() {

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -33,9 +33,9 @@ e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 e.emit('hello', 'a', 'b');
 
-const remove = function() {
+function remove() {
   assert.fail('once->foo should not be emitted');
-};
+}
 
 e.once('foo', remove);
 e.removeListener('foo', remove);

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -7,10 +7,10 @@ const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
 const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
 const readWriteFile = path.join(common.tmpDir, 'read_write_file');
 
-const createFileWithPerms = function(file, mode) {
+function createFileWithPerms(file, mode) {
   fs.writeFileSync(file, '');
   fs.chmodSync(file, mode);
-};
+}
 
 common.refreshTmpDir();
 createFileWithPerms(readOnlyFile, 0o444);

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -11,11 +11,11 @@ const srcPath = path.join(common.tmpDir, 'hardlink-target.txt');
 const dstPath = path.join(common.tmpDir, 'link1.js');
 fs.writeFileSync(srcPath, 'hello world');
 
-const callback = function(err) {
+function callback(err) {
   assert.ifError(err);
   const dstContent = fs.readFileSync(dstPath, 'utf8');
   assert.strictEqual('hello world', dstContent);
-};
+}
 
 fs.link(srcPath, dstPath, common.mustCall(callback));
 

--- a/test/parallel/test-fs-read-stream-fd-leak.js
+++ b/test/parallel/test-fs-read-stream-fd-leak.js
@@ -29,7 +29,7 @@ function testLeak(endFn, callback) {
   let i = 0;
   let check = 0;
 
-  const checkFunction = function() {
+  function checkFunction() {
     if (openCount !== 0 && check < totalCheck) {
       check++;
       setTimeout(checkFunction, 100);
@@ -44,7 +44,7 @@ function testLeak(endFn, callback) {
 
     openCount = 0;
     callback && setTimeout(callback, 100);
-  };
+  }
 
   setInterval(function() {
     const s = fs.createReadStream(emptyTxt);

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -96,9 +96,9 @@ function expectBody(expected) {
       'GET /hello HTTP/1.1' + CRLF +
       CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 1);
     assert.strictEqual(method, methods.indexOf('GET'));
@@ -137,9 +137,9 @@ function expectBody(expected) {
       CRLF +
       'pong');
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, undefined);
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 1);
@@ -147,7 +147,7 @@ function expectBody(expected) {
     assert.strictEqual(statusMessage, 'OK');
   };
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const body = '' + buf.slice(start, start + len);
     assert.strictEqual(body, 'pong');
   };
@@ -167,9 +167,9 @@ function expectBody(expected) {
       'HTTP/1.0 200 Connection established' + CRLF +
       CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 0);
     assert.strictEqual(method, undefined);
@@ -201,15 +201,15 @@ function expectBody(expected) {
 
   let seen_body = false;
 
-  const onHeaders = function(headers, url) {
+  const onHeaders = (headers, url) => {
     assert.ok(seen_body); // trailers should come after the body
     assert.deepStrictEqual(headers,
                            ['Vary', '*', 'Content-Type', 'text/plain']);
   };
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url || parser.url, '/it');
     assert.strictEqual(versionMajor, 1);
@@ -218,7 +218,7 @@ function expectBody(expected) {
     parser[kOnHeaders] = mustCall(onHeaders);
   };
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const body = '' + buf.slice(start, start + len);
     assert.strictEqual(body, 'ping');
     seen_body = true;
@@ -242,9 +242,9 @@ function expectBody(expected) {
       'X-Filler2:  42' + CRLF +
       CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('GET'));
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 0);
@@ -272,9 +272,9 @@ function expectBody(expected) {
       lots_of_headers +
       CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('GET'));
     assert.strictEqual(url || parser.url, '/foo/bar/baz?quux=42#1337');
     assert.strictEqual(versionMajor, 1);
@@ -306,16 +306,16 @@ function expectBody(expected) {
       CRLF +
       'foo=42&bar=1337');
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url || parser.url, '/it');
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 1);
   };
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const body = '' + buf.slice(start, start + len);
     assert.strictEqual(body, 'foo=42&bar=1337');
   };
@@ -344,9 +344,9 @@ function expectBody(expected) {
       '1234567890' + CRLF +
       '0' + CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url || parser.url, '/it');
     assert.strictEqual(versionMajor, 1);
@@ -356,7 +356,7 @@ function expectBody(expected) {
   let body_part = 0;
   const body_parts = ['123', '123456', '1234567890'];
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const body = '' + buf.slice(start, start + len);
     assert.strictEqual(body, body_parts[body_part++]);
   };
@@ -382,9 +382,9 @@ function expectBody(expected) {
       '6' + CRLF +
       '123456' + CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url || parser.url, '/it');
     assert.strictEqual(versionMajor, 1);
@@ -395,7 +395,7 @@ function expectBody(expected) {
   const body_parts =
           ['123', '123456', '123456789', '123456789ABC', '123456789ABCDEF'];
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const body = '' + buf.slice(start, start + len);
     assert.strictEqual(body, body_parts[body_part++]);
   };
@@ -440,9 +440,9 @@ function expectBody(expected) {
       '0' + CRLF);
 
   function test(a, b) {
-    const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                       method, url, statusCode, statusMessage,
-                                       upgrade, shouldKeepAlive) {
+    const onHeadersComplete = (versionMajor, versionMinor, headers,
+                               method, url, statusCode, statusMessage,
+                               upgrade, shouldKeepAlive) => {
       assert.strictEqual(method, methods.indexOf('POST'));
       assert.strictEqual(url || parser.url, '/helpme');
       assert.strictEqual(versionMajor, 1);
@@ -451,7 +451,7 @@ function expectBody(expected) {
 
     let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
-    const onBody = function(buf, start, len) {
+    const onBody = (buf, start, len) => {
       const chunk = '' + buf.slice(start, start + len);
       assert.strictEqual(expected_body.indexOf(chunk), 0);
       expected_body = expected_body.slice(chunk.length);
@@ -499,9 +499,9 @@ function expectBody(expected) {
       '123456789ABCDEF' + CRLF +
       '0' + CRLF);
 
-  const onHeadersComplete = function(versionMajor, versionMinor, headers,
-                                     method, url, statusCode, statusMessage,
-                                     upgrade, shouldKeepAlive) {
+  const onHeadersComplete = (versionMajor, versionMinor, headers,
+                             method, url, statusCode, statusMessage,
+                             upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url || parser.url, '/it');
     assert.strictEqual(versionMajor, 1);
@@ -513,7 +513,7 @@ function expectBody(expected) {
 
   let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
-  const onBody = function(buf, start, len) {
+  const onBody = (buf, start, len) => {
     const chunk = '' + buf.slice(start, start + len);
     assert.strictEqual(expected_body.indexOf(chunk), 0);
     expected_body = expected_body.slice(chunk.length);
@@ -551,9 +551,9 @@ function expectBody(expected) {
       CRLF +
       'pong');
 
-  const onHeadersComplete1 = function(versionMajor, versionMinor, headers,
-                                      method, url, statusCode, statusMessage,
-                                      upgrade, shouldKeepAlive) {
+  const onHeadersComplete1 = (versionMajor, versionMinor, headers,
+                              method, url, statusCode, statusMessage,
+                              upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('PUT'));
     assert.strictEqual(url, '/this');
     assert.strictEqual(versionMajor, 1);
@@ -563,9 +563,9 @@ function expectBody(expected) {
         ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
   };
 
-  const onHeadersComplete2 = function(versionMajor, versionMinor, headers,
-                                      method, url, statusCode, statusMessage,
-                                      upgrade, shouldKeepAlive) {
+  const onHeadersComplete2 = (versionMajor, versionMinor, headers,
+                              method, url, statusCode, statusMessage,
+                              upgrade, shouldKeepAlive) => {
     assert.strictEqual(method, methods.indexOf('POST'));
     assert.strictEqual(url, '/that');
     assert.strictEqual(versionMajor, 1);

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -59,7 +59,7 @@ const server = net.createServer(function(connection) {
   });
 });
 
-const runTest = function(testCaseIndex) {
+function runTest(testCaseIndex) {
   const testCase = testCases[testCaseIndex];
 
   http.get({
@@ -82,7 +82,7 @@ const runTest = function(testCaseIndex) {
 
     response.resume();
   });
-};
+}
 
 server.listen(0, function() { runTest(0); });
 

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -39,7 +39,7 @@ const options = {
 const tests = 2;
 let successful = 0;
 
-const testSucceeded = function() {
+const testSucceeded = () => {
   successful = successful + 1;
   if (successful === tests) {
     server.close();

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -17,7 +17,7 @@ const connections = [];
 const received = [];
 const sent = [];
 
-const createConnection = function(index) {
+function createConnection(index) {
   console.error('creating connection ' + index);
 
   return new Promise(function(resolve, reject) {
@@ -45,9 +45,9 @@ const createConnection = function(index) {
 
     connections[index] = connection;
   });
-};
+}
 
-const closeConnection = function(index) {
+function closeConnection(index) {
   console.error('closing connection ' + index);
   return new Promise(function(resolve, reject) {
     connections[index].on('end', function() {
@@ -55,7 +55,7 @@ const closeConnection = function(index) {
     });
     connections[index].end();
   });
-};
+}
 
 const server = net.createServer(function(socket) {
   socket.on('data', function(data) {

--- a/test/parallel/test-net-server-pause-on-connect.js
+++ b/test/parallel/test-net-server-pause-on-connect.js
@@ -28,7 +28,7 @@ let stopped = true;
 let server1Sock;
 
 
-const server1ConnHandler = function(socket) {
+const server1ConnHandler = (socket) => {
   socket.on('data', function(data) {
     if (stopped) {
       assert.fail('data event should not have happened yet');
@@ -44,7 +44,7 @@ const server1ConnHandler = function(socket) {
 
 const server1 = net.createServer({pauseOnConnect: true}, server1ConnHandler);
 
-const server2ConnHandler = function(socket) {
+const server2ConnHandler = (socket) => {
   socket.on('data', function(data) {
     assert.strictEqual(data.toString(), msg, 'invalid data received');
     socket.end();

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -125,7 +125,7 @@ console.error(interfaces);
 switch (platform) {
   case 'linux':
     {
-      const filter = function(e) { return e.address === '127.0.0.1'; };
+      const filter = (e) => e.address === '127.0.0.1';
       const actual = interfaces.lo.filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                           mac: '00:00:00:00:00:00', family: 'IPv4',
@@ -135,7 +135,7 @@ switch (platform) {
     }
   case 'win32':
     {
-      const filter = function(e) { return e.address === '127.0.0.1'; };
+      const filter = (e) => e.address === '127.0.0.1';
       const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
       const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
                           mac: '00:00:00:00:00:00', family: 'IPv4',

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -13,7 +13,7 @@ if (common.isSunOS) {
 
 const nodeBinary = process.argv[0];
 
-const preloadOption = function(preloads) {
+const preloadOption = (preloads) => {
   let option = '';
   preloads.forEach(function(preload, index) {
     option += '-r ' + preload + ' ';
@@ -21,9 +21,7 @@ const preloadOption = function(preloads) {
   return option;
 };
 
-const fixture = function(name) {
-  return path.join(common.fixturesDir, name);
-};
+const fixture = (name) => path.join(common.fixturesDir, name);
 
 const fixtureA = fixture('printA.js');
 const fixtureB = fixture('printB.js');

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -107,7 +107,7 @@ const qsColonTestCases = [
 ];
 
 // [wonkyObj, qs, canonicalObj]
-const extendedFunction = function() {};
+function extendedFunction() {}
 extendedFunction.prototype = {a: 'b'};
 const qsWeirdObjects = [
   // eslint-disable-next-line no-unescaped-regexp-dot

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -288,9 +288,7 @@ function isWarned(emitter) {
 
   // \t does not become part of the input when there is a completer function
   fi = new FakeInput();
-  const completer = function(line) {
-    return [[], line];
-  };
+  const completer = (line) => [[], line];
   rli = new readline.Interface({
     input: fi,
     output: fi,

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -26,9 +26,9 @@ const util = require('util');
 const stream = require('stream');
 
 
-const Read = function() {
+function Read() {
   stream.Readable.call(this);
-};
+}
 util.inherits(Read, stream.Readable);
 
 Read.prototype._read = function(size) {
@@ -37,9 +37,9 @@ Read.prototype._read = function(size) {
 };
 
 
-const Write = function() {
+function Write() {
   stream.Writable.call(this);
-};
+}
 util.inherits(Write, stream.Writable);
 
 Write.prototype._write = function(buffer, encoding, cb) {

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -29,7 +29,7 @@ const N = 30;
 let last_i = 0;
 let last_ts = 0;
 
-const f = function(i) {
+function f(i) {
   if (i <= N) {
     // check order
     assert.strictEqual(i, last_i + 1, 'order is broken: ' + i + ' != ' +
@@ -46,5 +46,5 @@ const f = function(i) {
     // schedule next iteration
     setTimeout(f, 1, i + 1);
   }
-};
+}
 f(1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -296,7 +296,7 @@ assert.strictEqual(
 
 // Function with properties
 {
-  const value = function() {};
+  const value = () => {};
   value.aprop = 42;
   assert.strictEqual(util.inspect(value), '{ [Function: value] aprop: 42 }');
 }

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -34,18 +34,18 @@ if (!common.isSunOS) {
  */
 const frames = [ 'stalloogle', 'bagnoogle', 'doogle' ];
 
-const stalloogle = function(str) {
+const stalloogle = (str) => {
   global.expected = str;
   os.loadavg();
 };
 
-const bagnoogle = function(arg0, arg1) {
+const bagnoogle = (arg0, arg1) => {
   stalloogle(arg0 + ' is ' + arg1 + ' except that it is read-only');
 };
 
 let done = false;
 
-const doogle = function() {
+const doogle = () => {
   if (!done)
     setTimeout(doogle, 10);
 

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -78,7 +78,7 @@ function doTest() {
 
   // Expects a callback -- cb(connectionType : enum ['New'|'Reused'])
 
-  const Client = function(cb) {
+  function Client(cb) {
     const flags = [
       's_client',
       '-connect', 'localhost:' + common.PORT,
@@ -95,7 +95,7 @@ function doTest() {
     });
     client.on('exit', function(code) {
       let connectionType;
-      const grepConnectionType = function(line) {
+      const grepConnectionType = (line) => {
         const matches = line.match(/(New|Reused), /);
         if (matches) {
           connectionType = matches[1];
@@ -108,7 +108,7 @@ function doTest() {
       }
       cb(connectionType);
     });
-  };
+  }
 
   const server = tls.createServer(options, function(cleartext) {
     cleartext.on('error', function(er) {


### PR DESCRIPTION
Welp, not sure how this will be received, but since it is the predominant style in our code base and since we are occasionally offering [nits to new contributors to use the style](https://github.com/nodejs/node/pull/12702/files#r113777357) to avoid potential confusion over the Temporal Dead Zone....

In lib, doc, and test (but mostly test): Replace function expressions with function declarations in preparation for a lint rule requiring function declarations.

Then: Except for arrow functions, require function declarations instead of function expressions via linting. This is the predominant style in our code base (77 instances of expressions to 2344 instances of declarations).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test lib doc