### PR TITLE
test: add coverage for error apis

### DIFF
--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -55,3 +55,61 @@ assert.strictEqual(test_error.checkError({}), false,
 // Test that non-error primitive is correctly classed
 assert.strictEqual(test_error.checkError('non-object'), false,
                    'Non-error primitive correctly classed by napi_is_error');
+
+try {
+  test_error.throwExistingError();
+} catch (error) {
+  assert.ok(error instanceof Error,
+            'expected error to be an instance of Error');
+  assert.strictEqual(error.message,
+                     'existing error',
+                     'expected message to be "existing error"');
+}
+
+try {
+  test_error.throwError();
+} catch (error) {
+  assert.ok(error instanceof Error,
+            'expected error to be an instance of Error');
+  assert.strictEqual(error.message,
+                     'error',
+                     'expected message to be "error"');
+}
+
+try {
+  test_error.throwRangeError();
+} catch (error) {
+  assert.ok(error instanceof RangeError,
+            'expected error to be an instance of RangeError');
+  assert.strictEqual(error.message,
+                     'range error',
+                     'expected message to be "range error"');
+}
+
+try {
+  test_error.throwTypeError();
+} catch (error) {
+  assert.ok(error instanceof TypeError,
+            'expected error to be an instance of TypeError');
+  assert.strictEqual(error.message,
+                     'type error',
+                     'expected message to be "type error"');
+}
+
+let error = test_error.createError();
+assert.ok(error instanceof Error, 'expected error to be an instance of Error');
+assert.strictEqual(error.message, 'error', 'expected message to be "error"');
+
+error = test_error.createRangeError();
+assert.ok(error instanceof RangeError,
+          'expected error to be an instance of RangeError');
+assert.strictEqual(error.message,
+                   'range error',
+                   'expected message to be "range error"');
+
+error = test_error.createTypeError();
+assert.ok(error instanceof TypeError,
+          'expected error to be an instance of TypeeError');
+assert.strictEqual(error.message,
+                   'type error',
+                   'expected message to be "type error"');

--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -58,19 +58,19 @@ assert.strictEqual(test_error.checkError('non-object'), false,
 
 assert.throws(() => {
   test_error.throwExistingError();
-}, /Error: existing error/);
+}, /^Error: existing error$/);
 
 assert.throws(() => {
   test_error.throwError();
-}, /Error: error/);
+}, /^Error: error$/);
 
 assert.throws(() => {
   test_error.throwRangeError();
-}, /RangeError: range error/);
+}, /^RangeError: range error$/);
 
 assert.throws(() => {
   test_error.throwTypeError();
-}, /TypeError: type error/);
+}, /^TypeError: type error$/);
 
 let error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');

--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -56,45 +56,21 @@ assert.strictEqual(test_error.checkError({}), false,
 assert.strictEqual(test_error.checkError('non-object'), false,
                    'Non-error primitive correctly classed by napi_is_error');
 
-try {
+assert.throws(() => {
   test_error.throwExistingError();
-} catch (error) {
-  assert.ok(error instanceof Error,
-            'expected error to be an instance of Error');
-  assert.strictEqual(error.message,
-                     'existing error',
-                     'expected message to be "existing error"');
-}
+}, /Error: existing error/);
 
-try {
+assert.throws(() => {
   test_error.throwError();
-} catch (error) {
-  assert.ok(error instanceof Error,
-            'expected error to be an instance of Error');
-  assert.strictEqual(error.message,
-                     'error',
-                     'expected message to be "error"');
-}
+}, /Error: error/);
 
-try {
+assert.throws(() => {
   test_error.throwRangeError();
-} catch (error) {
-  assert.ok(error instanceof RangeError,
-            'expected error to be an instance of RangeError');
-  assert.strictEqual(error.message,
-                     'range error',
-                     'expected message to be "range error"');
-}
+}, /RangeError: range error/);
 
-try {
+assert.throws(() => {
   test_error.throwTypeError();
-} catch (error) {
-  assert.ok(error instanceof TypeError,
-            'expected error to be an instance of TypeError');
-  assert.strictEqual(error.message,
-                     'type error',
-                     'expected message to be "type error"');
-}
+}, /TypeError: type error/);
 
 let error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
@@ -109,7 +85,7 @@ assert.strictEqual(error.message,
 
 error = test_error.createTypeError();
 assert.ok(error instanceof TypeError,
-          'expected error to be an instance of TypeeError');
+          'expected error to be an instance of TypeError');
 assert.strictEqual(error.message,
                    'type error',
                    'expected message to be "type error"');

--- a/test/addons-napi/test_error/test_error.cc
+++ b/test/addons-napi/test_error/test_error.cc
@@ -15,9 +15,64 @@ napi_value checkError(napi_env env, napi_callback_info info) {
   return result;
 }
 
+napi_value throwExistingError(napi_env env, napi_callback_info info) {
+  napi_value message;
+  napi_value error;
+  NAPI_CALL(env, napi_create_string_utf8(env, "existing error", -1, &message));
+  NAPI_CALL(env, napi_create_error(env, message, &error));
+  NAPI_CALL(env, napi_throw(env, error));
+  return nullptr;
+}
+
+napi_value throwError(napi_env env, napi_callback_info info) {
+  NAPI_CALL(env, napi_throw_error(env, "error"));
+  return nullptr;
+}
+
+napi_value throwRangeError(napi_env env, napi_callback_info info) {
+  NAPI_CALL(env, napi_throw_range_error(env, "range error"));
+  return nullptr;
+}
+
+napi_value throwTypeError(napi_env env, napi_callback_info info) {
+  NAPI_CALL(env, napi_throw_type_error(env, "type error"));
+  return nullptr;
+}
+
+napi_value createError(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_value message;
+  NAPI_CALL(env, napi_create_string_utf8(env, "error", -1, &message));
+  NAPI_CALL(env, napi_create_error(env, message, &result));
+  return result;
+}
+
+napi_value createRangeError(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_value message;
+  NAPI_CALL(env, napi_create_string_utf8(env, "range error", -1, &message));
+  NAPI_CALL(env, napi_create_range_error(env, message, &result));
+  return result;
+}
+
+napi_value createTypeError(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_value message;
+  NAPI_CALL(env, napi_create_string_utf8(env, "type error", -1, &message));
+  NAPI_CALL(env, napi_create_type_error(env, message, &result));
+  return result;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("checkError", checkError),
+    DECLARE_NAPI_PROPERTY("throwExistingError", throwExistingError),
+    DECLARE_NAPI_PROPERTY("throwError", throwError),
+    DECLARE_NAPI_PROPERTY("throwRangeError", throwRangeError),
+    DECLARE_NAPI_PROPERTY("throwTypeError", throwTypeError),
+    DECLARE_NAPI_PROPERTY("createError", createError),
+    DECLARE_NAPI_PROPERTY("createRangeError", createRangeError),
+    DECLARE_NAPI_PROPERTY("createTypeError", createTypeError),
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(


### PR DESCRIPTION
Add coverage for N-API functions related to
throwing and creating errors.  A number of these
are currently showing as not having any
coverage in the nightly code coverage reports.

#### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test, n-api