### PR TITLE
test: fix warning in n-api reference test

### DIFF
--- a/test/addons-napi/test_reference/test_reference.c
+++ b/test/addons-napi/test_reference/test_reference.c
@@ -61,7 +61,7 @@ napi_value CheckExternal(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, argtype == napi_external, "Expected an external value.")
 
   int* data;
-  NAPI_CALL(env, napi_get_value_external(env, arg, &data));
+  NAPI_CALL(env, napi_get_value_external(env, arg, (void*)&data));
 
   NAPI_ASSERT(env, data != NULL && *data == test_value,
     "An external data value of 1 was expected.")

--- a/test/addons-napi/test_reference/test_reference.c
+++ b/test/addons-napi/test_reference/test_reference.c
@@ -60,10 +60,10 @@ napi_value CheckExternal(napi_env env, napi_callback_info info) {
 
   NAPI_ASSERT(env, argtype == napi_external, "Expected an external value.")
 
-  int* data;
-  NAPI_CALL(env, napi_get_value_external(env, arg, (void*)&data));
+  void* data;
+  NAPI_CALL(env, napi_get_value_external(env, arg, &data));
 
-  NAPI_ASSERT(env, data != NULL && *data == test_value,
+  NAPI_ASSERT(env, data != NULL && *(int*)data == test_value,
     "An external data value of 1 was expected.")
 
   return NULL;


### PR DESCRIPTION
Add cast to avoid warning during build of addon.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, n-api