### PR TITLE
src: add --napi-modules to whitelist

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3736,6 +3736,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--force-fips",
     "--openssl-config",
     "--icu-data-dir",
+    "--napi-modules",
 
     // V8 options
     "--max_old_space_size",


### PR DESCRIPTION
Add --napi-modules to whitelist for NODE_OPTIONS
as its needed so that we can run the tests that
come along with native modules.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
core