### PR TITLE
test: reduce string concatenations

### DIFF
--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -39,7 +39,7 @@ process.on('exit', function() {
 
 const lines = [
   // This line shouldn't cause an assertion error.
-  'require(\'' + buildPath + '\')' +
+  `require('${buildPath}')` +
   // Log output to double check callback ran.
   '.method(function() { console.log(\'cb_ran\'); });',
 ];

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -55,9 +55,8 @@ exports.isLinux = process.platform === 'linux';
 exports.isOSX = process.platform === 'darwin';
 
 exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
-exports.bufferMaxSizeMsg = new RegExp('^RangeError: "size" argument' +
-                                      ' must not be larger than ' +
-                                      buffer.kMaxLength + '$');
+exports.bufferMaxSizeMsg = new RegExp(
+  `^RangeError: "size" argument must not be larger than ${buffer.kMaxLength}$`);
 const cpus = os.cpus();
 exports.enoughTestCpu = Array.isArray(cpus) &&
                         (cpus.length > 1 || cpus[0].speed > 999);
@@ -118,7 +117,7 @@ exports.refreshTmpDir = function() {
 
 if (process.env.TEST_THREAD_ID) {
   exports.PORT += process.env.TEST_THREAD_ID * 100;
-  exports.tmpDirName += '.' + process.env.TEST_THREAD_ID;
+  exports.tmpDirName += `.${process.env.TEST_THREAD_ID}`;
 }
 exports.tmpDir = path.join(testRoot, exports.tmpDirName);
 
@@ -217,10 +216,10 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 if (exports.isWindows) {
   exports.PIPE = '\\\\.\\pipe\\libuv-test';
   if (process.env.TEST_THREAD_ID) {
-    exports.PIPE += '.' + process.env.TEST_THREAD_ID;
+    exports.PIPE += `.${process.env.TEST_THREAD_ID}`;
   }
 } else {
-  exports.PIPE = exports.tmpDir + '/test.sock';
+  exports.PIPE = `${exports.tmpDir}/test.sock`;
 }
 
 const ifaces = os.networkInterfaces();
@@ -256,10 +255,9 @@ exports.childShouldThrowAndAbort = function() {
 exports.ddCommand = function(filename, kilobytes) {
   if (exports.isWindows) {
     const p = path.resolve(exports.fixturesDir, 'create-file.js');
-    return '"' + process.argv[0] + '" "' + p + '" "' +
-           filename + '" ' + (kilobytes * 1024);
+    return `"${process.argv[0]}" "${p}" "${filename}" ${kilobytes * 1024}`;
   } else {
-    return 'dd if=/dev/zero of="' + filename + '" bs=1024 count=' + kilobytes;
+    return `dd if=/dev/zero of="${filename}" bs=1024 count=${kilobytes}`;
   }
 };
 
@@ -495,7 +493,7 @@ exports.canCreateSymLink = function() {
     let output = '';
 
     try {
-      output = execSync(whoamiPath + ' /priv', { timout: 1000 });
+      output = execSync(`${whoamiPath} /priv`, { timout: 1000 });
     } catch (e) {
       err = true;
     } finally {
@@ -522,7 +520,7 @@ exports.skip = function(msg) {
 function ArrayStream() {
   this.run = function(data) {
     data.forEach((line) => {
-      this.emit('data', line + '\n');
+      this.emit('data', `${line}\n`);
     });
   };
 }

--- a/test/debugger/helper-debugger-repl.js
+++ b/test/debugger/helper-debugger-repl.js
@@ -34,11 +34,11 @@ let quit;
 
 function startDebugger(scriptToDebug) {
   scriptToDebug = process.env.NODE_DEBUGGER_TEST_SCRIPT ||
-                  common.fixturesDir + '/' + scriptToDebug;
+                  `${common.fixturesDir}/${scriptToDebug}`;
 
-  child = spawn(process.execPath, ['debug', '--port=' + port, scriptToDebug]);
+  child = spawn(process.execPath, ['debug', `--port=${port}`, scriptToDebug]);
 
-  console.error('./node', 'debug', '--port=' + port, scriptToDebug);
+  console.error('./node', 'debug', `--port=${port}`, scriptToDebug);
 
   child.stdout.setEncoding('utf-8');
   child.stdout.on('data', function(data) {
@@ -53,10 +53,10 @@ function startDebugger(scriptToDebug) {
   child.on('line', function(line) {
     line = line.replace(/^(debug> *)+/, '');
     console.log(line);
-    assert.ok(expected.length > 0, 'Got unexpected line: ' + line);
+    assert.ok(expected.length > 0, `Got unexpected line: ${line}`);
 
     const expectedLine = expected[0].lines.shift();
-    assert.ok(line.match(expectedLine) !== null, line + ' != ' + expectedLine);
+    assert.ok(line.match(expectedLine) !== null, `${line} != ${expectedLine}`);
 
     if (expected[0].lines.length === 0) {
       const callback = expected[0].callback;
@@ -83,7 +83,7 @@ function startDebugger(scriptToDebug) {
     console.error('dying badly buffer=%j', buffer);
     let err = 'Timeout';
     if (expected.length > 0 && expected[0].lines) {
-      err = err + '. Expected: ' + expected[0].lines.shift();
+      err = `${err}. Expected: ${expected[0].lines.shift()}`;
     }
 
     child.on('close', function() {
@@ -112,8 +112,8 @@ function startDebugger(scriptToDebug) {
 function addTest(input, output) {
   function next() {
     if (expected.length > 0) {
-      console.log('debug> ' + expected[0].input);
-      child.stdin.write(expected[0].input + '\n');
+      console.log(`debug> ${expected[0].input}`);
+      child.stdin.write(`${expected[0].input}\n`);
 
       if (!expected[0].lines) {
         const callback = expected[0].callback;

--- a/test/debugger/test-debugger-repl-utf8.js
+++ b/test/debugger/test-debugger-repl-utf8.js
@@ -21,7 +21,7 @@
 
 'use strict';
 const common = require('../common');
-const script = common.fixturesDir + '/breakpoints_utf8.js';
+const script = `${common.fixturesDir}/breakpoints_utf8.js`;
 process.env.NODE_DEBUGGER_TEST_SCRIPT = script;
 
 require('./test-debugger-repl.js');

--- a/test/gc/test-http-client-connaborted.js
+++ b/test/gc/test-http-client-connaborted.js
@@ -15,7 +15,7 @@ let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log('We should do ' + todo + ' requests');
+console.log(`We should do ${todo} requests`);
 
 const server = http.createServer(serverHandler);
 server.listen(0, getall);

--- a/test/gc/test-http-client-onerror.js
+++ b/test/gc/test-http-client-onerror.js
@@ -17,7 +17,7 @@ let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log('We should do ' + todo + ' requests');
+console.log(`We should do ${todo} requests`);
 
 const server = http.createServer(serverHandler);
 server.listen(0, runTest);

--- a/test/gc/test-http-client-timeout.js
+++ b/test/gc/test-http-client-timeout.js
@@ -19,7 +19,7 @@ let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log('We should do ' + todo + ' requests');
+console.log(`We should do ${todo} requests`);
 
 const server = http.createServer(serverHandler);
 server.listen(0, getall);

--- a/test/gc/test-http-client.js
+++ b/test/gc/test-http-client.js
@@ -15,7 +15,7 @@ let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log('We should do ' + todo + ' requests');
+console.log(`We should do ${todo} requests`);
 
 const server = http.createServer(serverHandler);
 server.listen(0, getall);

--- a/test/gc/test-net-timeout.js
+++ b/test/gc/test-net-timeout.js
@@ -26,7 +26,7 @@ let done = 0;
 let count = 0;
 let countGC = 0;
 
-console.log('We should do ' + todo + ' requests');
+console.log(`We should do ${todo} requests`);
 
 const server = net.createServer(serverHandler);
 server.listen(0, getall);

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -169,13 +169,15 @@ TestSession.prototype.processMessage_ = function(message) {
     assert.strictEqual(id, this.expectedId_);
     this.expectedId_++;
     if (this.responseCheckers_[id]) {
-      assert(message['result'], JSON.stringify(message) + ' (response to ' +
-             JSON.stringify(this.messages_[id]) + ')');
+      const messageJSON = JSON.stringify(message);
+      const idJSON = JSON.stringify(this.messages_[id]);
+      assert(message['result'], `${messageJSON} (response to ${idJSON})`);
       this.responseCheckers_[id](message['result']);
       delete this.responseCheckers_[id];
     }
-    assert(!message['error'], JSON.stringify(message) + ' (replying to ' +
-           JSON.stringify(this.messages_[id]) + ')');
+    const messageJSON = JSON.stringify(message);
+    const idJSON = JSON.stringify(this.messages_[id]);
+    assert(!message['error'], `${messageJSON} (replying to ${idJSON})`);
     delete this.messages_[id];
     if (id === this.lastId_) {
       this.lastMessageResponseCallback_ && this.lastMessageResponseCallback_();
@@ -213,12 +215,8 @@ TestSession.prototype.sendInspectorCommands = function(commands) {
     };
     this.sendAll_(commands, () => {
       timeoutId = setTimeout(() => {
-        let s = '';
-        for (const id in this.messages_) {
-          s += id + ', ';
-        }
-        assert.fail('Messages without response: ' +
-                    s.substring(0, s.length - 2));
+        assert.fail(`Messages without response: ${
+                    Object.keys(this.messages_).join(', ')}`);
       }, TIMEOUT);
     });
   });
@@ -241,7 +239,7 @@ TestSession.prototype.expectMessages = function(expects) {
   if (!(expects instanceof Array)) expects = [ expects ];
 
   const callback = this.createCallbackWithTimeout_(
-      'Matching response was not received:\n' + expects[0]);
+      `Matching response was not received:\n${expects[0]}`);
   this.messagefilter_ = (message) => {
     if (expects[0](message))
       expects.shift();
@@ -256,7 +254,7 @@ TestSession.prototype.expectMessages = function(expects) {
 TestSession.prototype.expectStderrOutput = function(regexp) {
   this.harness_.addStderrFilter(
       regexp,
-      this.createCallbackWithTimeout_('Timed out waiting for ' + regexp));
+      this.createCallbackWithTimeout_(`Timed out waiting for ${regexp}`));
   return this;
 };
 

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -19,7 +19,7 @@ function checkVersion(err, response) {
   assert.ifError(err);
   assert.ok(response);
   const expected = {
-    'Browser': 'node.js/' + process.version,
+    'Browser': `node.js/${process.version}`,
     'Protocol-Version': '1.1',
   };
   assert.strictEqual(JSON.stringify(response),
@@ -36,7 +36,7 @@ function expectMainScriptSource(result) {
   const expected = helper.mainScriptSource();
   const source = result['scriptSource'];
   assert(source && (source.includes(expected)),
-         'Script source is wrong: ' + source);
+         `Script source is wrong: ${source}`);
 }
 
 function setupExpectBreakOnLine(line, url, session, scopeIdCallback) {
@@ -187,7 +187,7 @@ function testI18NCharacters(session) {
     {
       'method': 'Debugger.evaluateOnCallFrame', 'params': {
         'callFrameId': '{"ordinal":0,"injectedScriptId":1}',
-        'expression': 'console.log("' + chars + '")',
+        'expression': `console.log("${chars}")`,
         'objectGroup': 'console',
         'includeCommandLineAPI': true,
         'silent': false,

--- a/test/internet/test-dns-cares-domains.js
+++ b/test/internet/test-dns-cares-domains.js
@@ -21,7 +21,7 @@ methods.forEach(function(method) {
   const d = domain.create();
   d.run(function() {
     dns[method]('google.com', function() {
-      assert.strictEqual(process.domain, d, method + ' retains domain');
+      assert.strictEqual(process.domain, d, `${method} retains domain`);
     });
   });
 });

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -164,7 +164,7 @@ TEST(function test_lookup_all_ipv6(done) {
 
       ips.forEach((ip) => {
         assert.ok(isIPv6(ip.address),
-                  'Invalid IPv6: ' + ip.address.toString());
+                  `Invalid IPv6: ${ip.address.toString()}`);
         assert.strictEqual(ip.family, 6);
       });
 

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -545,7 +545,7 @@ req.oncomplete = function(err, domains) {
 };
 
 process.on('exit', function() {
-  console.log(completed + ' tests completed');
+  console.log(`${completed} tests completed`);
   assert.strictEqual(running, false);
   assert.strictEqual(expected, completed);
   assert.ok(getaddrinfoCallbackCalled);

--- a/test/internet/test-tls-add-ca-cert.js
+++ b/test/internet/test-tls-add-ca-cert.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/known_issues/test-cwd-enoent-file.js
+++ b/test/known_issues/test-cwd-enoent-file.js
@@ -19,7 +19,7 @@ if (process.argv[2] === 'child') {
   // Do nothing.
 } else {
   common.refreshTmpDir();
-  const dir = fs.mkdtempSync(common.tmpDir + '/');
+  const dir = fs.mkdtempSync(`${common.tmpDir}/`);
   process.chdir(dir);
   fs.rmdirSync(dir);
   assert.throws(process.cwd,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -177,7 +177,7 @@ assert.doesNotThrow(makeBlock(a.deepEqual, a1, a2));
 
 // having an identical prototype property
 const nbRoot = {
-  toString: function() { return this.first + ' ' + this.last; }
+  toString: function() { return `${this.first} ${this.last}`; }
 };
 
 function nameBuilder(first, last) {

--- a/test/parallel/test-async-wrap-check-providers.js
+++ b/test/parallel/test-async-wrap-check-providers.js
@@ -94,8 +94,8 @@ process.on('SIGINT', () => process.exit());
 // Run from closed net server above.
 function checkTLS() {
   const options = {
-    key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
-    cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
+    key: fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`),
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`)
   };
   const server = tls.createServer(options, common.noop)
     .listen(0, function() {

--- a/test/parallel/test-buffer-badhex.js
+++ b/test/parallel/test-buffer-badhex.js
@@ -44,6 +44,6 @@ const Buffer = require('buffer').Buffer;
   const hex = buf.toString('hex');
   assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf);
 
-  const badHex = hex.slice(0, 256) + 'xx' + hex.slice(256, 510);
+  const badHex = `${hex.slice(0, 256)}xx${hex.slice(256, 510)}`;
   assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf.slice(0, 128));
 }

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -199,7 +199,7 @@ const longBufferString = Buffer.from(longString);
 let pattern = 'ABACABADABACABA';
 for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
   const includes = longBufferString.includes(pattern, i);
-  assert(includes, 'Long ABACABA...-string at index ' + i);
+  assert(includes, `Long ABACABA...-string at index ${i}`);
 }
 assert(longBufferString.includes('AJABACA'), 'Long AJABACA, First J');
 assert(longBufferString.includes('AJABACA', 511), 'Long AJABACA, Second J');

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -255,7 +255,7 @@ let pattern = 'ABACABADABACABA';
 for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
   const index = longBufferString.indexOf(pattern, i);
   assert.strictEqual((i + 15) & ~0xf, index,
-                     'Long ABACABA...-string at index ' + i);
+                     `Long ABACABA...-string at index ${i}`);
 }
 assert.strictEqual(510, longBufferString.indexOf('AJABACA'),
                    'Long AJABACA, First J');

--- a/test/parallel/test-child-process-buffering.js
+++ b/test/parallel/test-child-process-buffering.js
@@ -29,12 +29,12 @@ function pwd(callback) {
 
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(s) {
-    console.log('stdout: ' + JSON.stringify(s));
+    console.log(`stdout: ${JSON.stringify(s)}`);
     output += s;
   });
 
   child.on('exit', common.mustCall(function(c) {
-    console.log('exit: ' + c);
+    console.log(`exit: ${c}`);
     assert.strictEqual(0, c);
   }));
 

--- a/test/parallel/test-child-process-default-options.js
+++ b/test/parallel/test-child-process-default-options.js
@@ -39,7 +39,7 @@ let response = '';
 child.stdout.setEncoding('utf8');
 
 child.stdout.on('data', function(chunk) {
-  console.log('stdout: ' + chunk);
+  console.log(`stdout: ${chunk}`);
   response += chunk;
 });
 

--- a/test/parallel/test-child-process-double-pipe.js
+++ b/test/parallel/test-child-process-double-pipe.js
@@ -56,7 +56,7 @@ if (common.isWindows) {
 
 // pipe echo | grep
 echo.stdout.on('data', function(data) {
-  console.error('grep stdin write ' + data.length);
+  console.error(`grep stdin write ${data.length}`);
   if (!grep.stdin.write(data)) {
     echo.stdout.pause();
   }
@@ -86,7 +86,7 @@ sed.on('exit', function() {
 
 // pipe grep | sed
 grep.stdout.on('data', function(data) {
-  console.error('grep stdout ' + data.length);
+  console.error(`grep stdout ${data.length}`);
   if (!sed.stdin.write(data)) {
     grep.stdout.pause();
   }

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -45,7 +45,7 @@ let response = '';
 child.stdout.setEncoding('utf8');
 
 child.stdout.on('data', function(chunk) {
-  console.log('stdout: ' + chunk);
+  console.log(`stdout: ${chunk}`);
   response += chunk;
 });
 

--- a/test/parallel/test-child-process-exec-env.js
+++ b/test/parallel/test-child-process-exec-env.js
@@ -31,9 +31,9 @@ let child;
 function after(err, stdout, stderr) {
   if (err) {
     error_count++;
-    console.log('error!: ' + err.code);
-    console.log('stdout: ' + JSON.stringify(stdout));
-    console.log('stderr: ' + JSON.stringify(stderr));
+    console.log(`error!: ${err.code}`);
+    console.log(`stdout: ${JSON.stringify(stdout)}`);
+    console.log(`stderr: ${JSON.stringify(stderr)}`);
     assert.strictEqual(false, err.killed);
   } else {
     success_count++;

--- a/test/parallel/test-child-process-fork-close.js
+++ b/test/parallel/test-child-process-fork-close.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const fork = require('child_process').fork;
 
-const cp = fork(common.fixturesDir + '/child-process-message-and-exit.js');
+const cp = fork(`${common.fixturesDir}/child-process-message-and-exit.js`);
 
 let gotMessage = false;
 let gotExit = false;

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const fork = require('child_process').fork;
 const args = ['foo', 'bar'];
 
-const n = fork(common.fixturesDir + '/child-process-spawn-node.js', args);
+const n = fork(`${common.fixturesDir}/child-process-spawn-node.js`, args);
 
 assert.strictEqual(n.channel, n._channel);
 assert.deepStrictEqual(args, ['foo', 'bar']);

--- a/test/parallel/test-child-process-fork3.js
+++ b/test/parallel/test-child-process-fork3.js
@@ -23,4 +23,4 @@
 const common = require('../common');
 const child_process = require('child_process');
 
-child_process.fork(common.fixturesDir + '/empty.js'); // should not hang
+child_process.fork(`${common.fixturesDir}/empty.js`); // should not hang

--- a/test/parallel/test-child-process-internal.js
+++ b/test/parallel/test-child-process-internal.js
@@ -25,8 +25,8 @@ const assert = require('assert');
 
 //messages
 const PREFIX = 'NODE_';
-const normal = {cmd: 'foo' + PREFIX};
-const internal = {cmd: PREFIX + 'bar'};
+const normal = {cmd: `foo${PREFIX}`};
+const internal = {cmd: `${PREFIX}bar`};
 
 if (process.argv[2] === 'child') {
   //send non-internal message containing PREFIX at a non prefix position

--- a/test/parallel/test-child-process-ipc.js
+++ b/test/parallel/test-child-process-ipc.js
@@ -36,13 +36,13 @@ let gotEcho = false;
 const child = spawn(process.argv[0], [sub]);
 
 child.stderr.on('data', function(data) {
-  console.log('parent stderr: ' + data);
+  console.log(`parent stderr: ${data}`);
 });
 
 child.stdout.setEncoding('utf8');
 
 child.stdout.on('data', function(data) {
-  console.log('child said: ' + JSON.stringify(data));
+  console.log(`child said: ${JSON.stringify(data)}`);
   if (!gotHelloWorld) {
     console.error('testing for hello world');
     assert.strictEqual('hello world\r\n', data);

--- a/test/parallel/test-child-process-set-blocking.js
+++ b/test/parallel/test-child-process-set-blocking.js
@@ -26,7 +26,7 @@ const ch = require('child_process');
 
 const SIZE = 100000;
 
-const cp = ch.spawn('python', ['-c', 'print ' + SIZE + ' * "C"'], {
+const cp = ch.spawn('python', ['-c', `print ${SIZE} * "C"`], {
   stdio: 'inherit'
 });
 

--- a/test/parallel/test-child-process-spawn-error.js
+++ b/test/parallel/test-child-process-spawn-error.js
@@ -32,7 +32,7 @@ const enoentChild = spawn(enoentPath, spawnargs);
 enoentChild.on('error', common.mustCall(function(err) {
   assert.strictEqual(err.code, 'ENOENT');
   assert.strictEqual(err.errno, 'ENOENT');
-  assert.strictEqual(err.syscall, 'spawn ' + enoentPath);
+  assert.strictEqual(err.syscall, `spawn ${enoentPath}`);
   assert.strictEqual(err.path, enoentPath);
   assert.deepStrictEqual(err.spawnargs, spawnargs);
 }));

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -32,7 +32,7 @@ const invalidArgsMsg = /Incorrect value of args option/;
 const invalidOptionsMsg = /"options" argument must be an object/;
 const invalidFileMsg =
   /^TypeError: "file" argument must be a non-empty string$/;
-const empty = common.fixturesDir + '/empty.js';
+const empty = `${common.fixturesDir}/empty.js`;
 
 assert.throws(function() {
   const child = spawn(invalidcmd, 'this is not an array');

--- a/test/parallel/test-child-process-spawnsync-input.js
+++ b/test/parallel/test-child-process-spawnsync-input.js
@@ -30,8 +30,8 @@ const msgOut = 'this is stdout';
 const msgErr = 'this is stderr';
 
 // this is actually not os.EOL?
-const msgOutBuf = Buffer.from(msgOut + '\n');
-const msgErrBuf = Buffer.from(msgErr + '\n');
+const msgOutBuf = Buffer.from(`${msgOut}\n`);
+const msgErrBuf = Buffer.from(`${msgErr}\n`);
 
 const args = [
   '-e',
@@ -117,5 +117,5 @@ verifyBufOutput(spawnSync(process.execPath, args));
 ret = spawnSync(process.execPath, args, { encoding: 'utf8' });
 
 checkSpawnSyncRet(ret);
-assert.strictEqual(ret.stdout, msgOut + '\n');
-assert.strictEqual(ret.stderr, msgErr + '\n');
+assert.strictEqual(ret.stdout, `${msgOut}\n`);
+assert.strictEqual(ret.stderr, `${msgErr}\n`);

--- a/test/parallel/test-child-process-spawnsync-maxbuf.js
+++ b/test/parallel/test-child-process-spawnsync-maxbuf.js
@@ -5,7 +5,7 @@ const spawnSync = require('child_process').spawnSync;
 const msgOut = 'this is stdout';
 
 // This is actually not os.EOL?
-const msgOutBuf = Buffer.from(msgOut + '\n');
+const msgOutBuf = Buffer.from(`${msgOut}\n`);
 
 const args = [
   '-e',

--- a/test/parallel/test-child-process-stdin.js
+++ b/test/parallel/test-child-process-stdin.js
@@ -39,7 +39,7 @@ let response = '';
 
 cat.stdout.setEncoding('utf8');
 cat.stdout.on('data', function(chunk) {
-  console.log('stdout: ' + chunk);
+  console.log(`stdout: ${chunk}`);
   response += chunk;
 });
 

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -203,7 +203,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   const opt = ' --eval "console.log(process.argv.slice(1).join(\' \'))"';
   const cmd = `${nodejs}${opt} -- ${args}`;
   child.exec(cmd, common.mustCall(function(err, stdout, stderr) {
-    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stdout, `${args}\n`);
     assert.strictEqual(stderr, '');
     assert.strictEqual(err, null);
   }));
@@ -212,7 +212,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   const popt = ' --print "process.argv.slice(1).join(\' \')"';
   const pcmd = `${nodejs}${popt} -- ${args}`;
   child.exec(pcmd, common.mustCall(function(err, stdout, stderr) {
-    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stdout, `${args}\n`);
     assert.strictEqual(stderr, '');
     assert.strictEqual(err, null);
   }));
@@ -222,7 +222,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   // filename.
   const filecmd = `${nodejs} -- ${__filename} ${args}`;
   child.exec(filecmd, common.mustCall(function(err, stdout, stderr) {
-    assert.strictEqual(stdout, args + '\n');
+    assert.strictEqual(stdout, `${args}\n`);
     assert.strictEqual(stderr, '');
     assert.strictEqual(err, null);
   }));

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -31,8 +31,7 @@ function disallow(opt) {
   const options = {env: {NODE_OPTIONS: opt}};
   exec(process.execPath, options, common.mustCall(function(err) {
     const message = err.message.split(/\r?\n/)[1];
-    const expect = process.execPath + ': ' + opt +
-                   ' is not allowed in NODE_OPTIONS';
+    const expect = `${process.execPath}: ${opt} is not allowed in NODE_OPTIONS`;
 
     assert.strictEqual(err.code, 9);
     assert.strictEqual(message, expect);
@@ -41,7 +40,7 @@ function disallow(opt) {
 
 const printA = require.resolve('../fixtures/printA.js');
 
-expect('-r ' + printA, 'A\nB\n');
+expect(`-r ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');
 expect('--trace-warnings', 'B\n');
@@ -75,7 +74,7 @@ function expect(opt, want) {
     if (!RegExp(want).test(stdout)) {
       console.error('For %j, failed to find %j in: <\n%s\n>',
                     opt, expect, stdout);
-      assert(false, 'Expected ' + expect);
+      assert(false, `Expected ${expect}`);
     }
   }));
 }

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -31,7 +31,7 @@ const syntaxArgs = [
     // no output should be produced
     assert.strictEqual(c.stdout, '', 'stdout produced');
     assert.strictEqual(c.stderr, '', 'stderr produced');
-    assert.strictEqual(c.status, 0, 'code === ' + c.status);
+    assert.strictEqual(c.status, 0, `code === ${c.status}`);
   });
 });
 
@@ -59,7 +59,7 @@ const syntaxArgs = [
     const match = c.stderr.match(/^SyntaxError: Unexpected identifier$/m);
     assert(match, 'stderr incorrect');
 
-    assert.strictEqual(c.status, 1, 'code === ' + c.status);
+    assert.strictEqual(c.status, 1, `code === ${c.status}`);
   });
 });
 
@@ -82,7 +82,7 @@ const syntaxArgs = [
     const match = c.stderr.match(/^Error: Cannot find module/m);
     assert(match, 'stderr incorrect');
 
-    assert.strictEqual(c.status, 1, 'code === ' + c.status);
+    assert.strictEqual(c.status, 1, `code === ${c.status}`);
   });
 });
 
@@ -96,7 +96,7 @@ syntaxArgs.forEach(function(args) {
   assert.strictEqual(c.stdout, '', 'stdout produced');
   assert.strictEqual(c.stderr, '', 'stderr produced');
 
-  assert.strictEqual(c.status, 0, 'code === ' + c.status);
+  assert.strictEqual(c.status, 0, `code === ${c.status}`);
 });
 
 // should throw if code piped from stdin with --check has bad syntax
@@ -115,7 +115,7 @@ syntaxArgs.forEach(function(args) {
   const match = c.stderr.match(/^SyntaxError: Unexpected identifier$/m);
   assert(match, 'stderr incorrect');
 
-  assert.strictEqual(c.status, 1, 'code === ' + c.status);
+  assert.strictEqual(c.status, 1, `code === ${c.status}`);
 });
 
 // should throw if -c and -e flags are both passed
@@ -130,6 +130,6 @@ syntaxArgs.forEach(function(args) {
       )
     );
 
-    assert.strictEqual(c.status, 9, 'code === ' + c.status);
+    assert.strictEqual(c.status, 9, `code === ${c.status}`);
   });
 });

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -54,14 +54,14 @@ if (!id) {
   a.on('exit', common.mustCall((c) => {
     if (c) {
       b.send('QUIT');
-      throw new Error('A exited with ' + c);
+      throw new Error(`A exited with ${c}`);
     }
   }));
 
   b.on('exit', common.mustCall((c) => {
     if (c) {
       a.send('QUIT');
-      throw new Error('B exited with ' + c);
+      throw new Error(`B exited with ${c}`);
     }
   }));
 

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -58,7 +58,7 @@ if (cluster.isMaster) {
 
 } else {
   common.refreshTmpDir();
-  const cp = fork(common.fixturesDir + '/listen-on-socket-and-exit.js',
+  const cp = fork(`${common.fixturesDir}/listen-on-socket-and-exit.js`,
                 { stdio: 'inherit' });
 
   // message from the child indicates it's ready and listening

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -29,8 +29,8 @@ const assert = require('assert');
 const fork = require('child_process').fork;
 const net = require('net');
 
-const id = '' + process.argv[2];
-const port = '' + process.argv[3];
+const id = String(process.argv[2]);
+const port = String(process.argv[3]);
 
 if (id === 'undefined') {
   const server = net.createServer(common.mustNotCall());

--- a/test/parallel/test-cluster-message.js
+++ b/test/parallel/test-cluster-message.js
@@ -123,7 +123,7 @@ if (cluster.isWorker) {
       if (data.code === 'received message') {
         check('worker', data.echo === 'message from master');
       } else {
-        throw new Error('wrong TCP message received: ' + data);
+        throw new Error(`wrong TCP message received: ${data}`);
       }
     });
 
@@ -139,9 +139,8 @@ if (cluster.isWorker) {
 
   process.once('exit', function() {
     forEach(checks, function(check, type) {
-      assert.ok(check.receive, 'The ' + type + ' did not receive any message');
-      assert.ok(check.correct,
-                'The ' + type + ' did not get the correct message');
+      assert.ok(check.receive, `The ${type} did not receive any message`);
+      assert.ok(check.correct, `The ${type} did not get the correct message`);
     });
   });
 }

--- a/test/parallel/test-cluster-worker-exit.js
+++ b/test/parallel/test-cluster-worker-exit.js
@@ -125,9 +125,8 @@ function checkResults(expected_results, results) {
     const actual = results[k];
     const expected = expected_results[k];
 
-    assert.strictEqual(actual,
-                       expected && expected.length ? expected[0] : expected,
-                       (expected[1] || '') +
-                         ` [expected: ${expected[0]} / actual: ${actual}]`);
+    assert.strictEqual(
+      actual, expected && expected.length ? expected[0] : expected,
+      `${expected[1] || ''} [expected: ${expected[0]} / actual: ${actual}]`);
   }
 }

--- a/test/parallel/test-cluster-worker-kill.js
+++ b/test/parallel/test-cluster-worker-kill.js
@@ -111,9 +111,8 @@ function checkResults(expected_results, results) {
     const actual = results[k];
     const expected = expected_results[k];
 
-    assert.strictEqual(actual,
-                       expected && expected.length ? expected[0] : expected,
-                       (expected[1] || '') +
-                         ` [expected: ${expected[0]} / actual: ${actual}]`);
+    assert.strictEqual(
+      actual, expected && expected.length ? expected[0] : expected,
+      `${expected[1] || ''} [expected: ${expected[0]} / actual: ${actual}]`);
   }
 }

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -123,13 +123,13 @@ const expectedStrings = [
 ];
 
 for (const expected of expectedStrings) {
-  assert.strictEqual(expected + '\n', strings.shift());
-  assert.strictEqual(expected + '\n', errStrings.shift());
+  assert.strictEqual(`${expected}\n`, strings.shift());
+  assert.strictEqual(`${expected}\n`, errStrings.shift());
 }
 
 for (const expected of expectedStrings) {
-  assert.strictEqual(expected + '\n', strings.shift());
-  assert.strictEqual(expected + '\n', errStrings.shift());
+  assert.strictEqual(`${expected}\n`, strings.shift());
+  assert.strictEqual(`${expected}\n`, errStrings.shift());
 }
 
 assert.strictEqual("{ foo: 'bar', inspect: [Function: inspect] }\n",

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -334,7 +334,7 @@ for (const i in TEST_CASES) {
   const test = TEST_CASES[i];
 
   if (!ciphers.includes(test.algo)) {
-    common.skip('unsupported ' + test.algo + ' test');
+    common.skip(`unsupported ${test.algo} test`);
     continue;
   }
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -37,17 +37,16 @@ const fs = require('fs');
 const path = require('path');
 const tls = require('tls');
 const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
+const fixtDir = common.fixturesDir;
 
 crypto.DEFAULT_ENCODING = 'latin1';
 
 // Test Certificates
-const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-const certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
-const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
-const rsaPubPem = fs.readFileSync(common.fixturesDir + '/test_rsa_pubkey.pem',
-                                  'ascii');
-const rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
-                                  'ascii');
+const certPem = fs.readFileSync(`${fixtDir}/test_cert.pem`, 'ascii');
+const certPfx = fs.readFileSync(`${fixtDir}/test_cert.pfx`);
+const keyPem = fs.readFileSync(`${fixtDir}/test_key.pem`, 'ascii');
+const rsaPubPem = fs.readFileSync(`${fixtDir}/test_rsa_pubkey.pem`, 'ascii');
+const rsaKeyPem = fs.readFileSync(`${fixtDir}/test_rsa_privkey.pem`, 'ascii');
 
 // PFX tests
 assert.doesNotThrow(function() {
@@ -408,7 +407,7 @@ const h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
 assert.strictEqual(h1, h2, 'multipled updates');
 
 // Test hashing for binary files
-const fn = path.join(common.fixturesDir, 'sample.png');
+const fn = path.join(fixtDir, 'sample.png');
 const sha1Hash = crypto.createHash('sha1');
 const fileStream = fs.createReadStream(fn);
 fileStream.on('data', function(data) {
@@ -617,11 +616,9 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test RSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(
-      common.fixturesDir + '/test_rsa_privkey_2.pem');
+  const privateKey = fs.readFileSync(`${fixtDir}/test_rsa_privkey_2.pem`);
 
-  const publicKey = fs.readFileSync(
-      common.fixturesDir + '/test_rsa_pubkey_2.pem');
+  const publicKey = fs.readFileSync(`${fixtDir}/test_rsa_pubkey_2.pem`);
 
   const input = 'I AM THE WALRUS';
 
@@ -649,11 +646,9 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test DSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(
-      common.fixturesDir + '/test_dsa_privkey.pem');
+  const privateKey = fs.readFileSync(`${fixtDir}/test_dsa_privkey.pem`);
 
-  const publicKey = fs.readFileSync(
-      common.fixturesDir + '/test_dsa_pubkey.pem');
+  const publicKey = fs.readFileSync(`${fixtDir}/test_dsa_pubkey.pem`);
 
   const input = 'I AM THE WALRUS';
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -34,9 +34,9 @@ crypto.DEFAULT_ENCODING = 'buffer';
 const fs = require('fs');
 
 // Test Certificates
-const spkacValid = fs.readFileSync(common.fixturesDir + '/spkac.valid');
-const spkacFail = fs.readFileSync(common.fixturesDir + '/spkac.fail');
-const spkacPem = fs.readFileSync(common.fixturesDir + '/spkac.pem');
+const spkacValid = fs.readFileSync(`${common.fixturesDir}/spkac.valid`);
+const spkacFail = fs.readFileSync(`${common.fixturesDir}/spkac.fail`);
+const spkacPem = fs.readFileSync(`${common.fixturesDir}/spkac.pem`);
 
 const certificate = new crypto.Certificate();
 

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -31,19 +31,18 @@ function addToEnv(newVar, value) {
 }
 
 function testHelper(stream, args, expectedOutput, cmd, env) {
-  const fullArgs = args.concat(['-e', 'console.log(' + cmd + ')']);
+  const fullArgs = args.concat(['-e', `console.log(${cmd})`]);
   const child = spawnSync(process.execPath, fullArgs, {
     cwd: path.dirname(process.execPath),
     env: env
   });
 
-  console.error('Spawned child [pid:' + child.pid + '] with cmd \'' +
-      cmd + '\' expect %j with args \'' + args + '\'' +
-      ' OPENSSL_CONF=%j', expectedOutput, env.OPENSSL_CONF);
+  console.error(
+    `Spawned child [pid:${child.pid}] with cmd '${cmd}' expect %j with args '${
+    args}' OPENSSL_CONF=%j`, expectedOutput, env.OPENSSL_CONF);
 
   function childOk(child) {
-    console.error('Child #' + ++num_children_ok +
-        ' [pid:' + child.pid + '] OK.');
+    console.error(`Child #${++num_children_ok} [pid:${child.pid}] OK.`);
   }
 
   function responseHandler(buffer, expectedOutput) {

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -10,21 +10,19 @@ if (!common.hasCrypto) {
 const constants = require('crypto').constants;
 const crypto = require('crypto');
 
+const fixtDir = common.fixturesDir;
+
 // Test certificates
-const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
-const rsaPubPem = fs.readFileSync(common.fixturesDir + '/test_rsa_pubkey.pem',
-                                  'ascii');
-const rsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_rsa_privkey.pem',
-                                  'ascii');
+const certPem = fs.readFileSync(`${fixtDir}/test_cert.pem`, 'ascii');
+const keyPem = fs.readFileSync(`${fixtDir}/test_key.pem`, 'ascii');
+const rsaPubPem = fs.readFileSync(`${fixtDir}/test_rsa_pubkey.pem`, 'ascii');
+const rsaKeyPem = fs.readFileSync(`${fixtDir}/test_rsa_privkey.pem`, 'ascii');
 const rsaKeyPemEncrypted = fs.readFileSync(
-  common.fixturesDir + '/test_rsa_privkey_encrypted.pem', 'ascii');
-const dsaPubPem = fs.readFileSync(common.fixturesDir + '/test_dsa_pubkey.pem',
-                                  'ascii');
-const dsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_dsa_privkey.pem',
-                                  'ascii');
+  `${fixtDir}/test_rsa_privkey_encrypted.pem`, 'ascii');
+const dsaPubPem = fs.readFileSync(`${fixtDir}/test_dsa_pubkey.pem`, 'ascii');
+const dsaKeyPem = fs.readFileSync(`${fixtDir}/test_dsa_privkey.pem`, 'ascii');
 const dsaKeyPemEncrypted = fs.readFileSync(
-  common.fixturesDir + '/test_dsa_privkey_encrypted.pem', 'ascii');
+  `${fixtDir}/test_dsa_privkey_encrypted.pem`, 'ascii');
 
 const decryptError =
   /^Error: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt$/;
@@ -178,11 +176,9 @@ assert.throws(() => {
 // Test RSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(
-      common.fixturesDir + '/test_rsa_privkey_2.pem');
+  const privateKey = fs.readFileSync(`${fixtDir}/test_rsa_privkey_2.pem`);
 
-  const publicKey = fs.readFileSync(
-      common.fixturesDir + '/test_rsa_pubkey_2.pem');
+  const publicKey = fs.readFileSync(`${fixtDir}/test_rsa_pubkey_2.pem`);
 
   const input = 'I AM THE WALRUS';
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -12,8 +12,8 @@ if (!common.hasCrypto) {
 const crypto = require('crypto');
 
 // Test certificates
-const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
+const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
+const keyPem = fs.readFileSync(`${common.fixturesDir}/test_key.pem`, 'ascii');
 const modSize = 1024;
 
 // Test signing and verifying
@@ -265,10 +265,10 @@ const modSize = 1024;
   const msgfile = path.join(common.tmpDir, 's5.msg');
   fs.writeFileSync(msgfile, msg);
 
-  const cmd = '"' + common.opensslCli + '" dgst -sha256 -verify "' + pubfile +
-              '" -signature "' + sigfile +
-              '" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "' +
-              msgfile + '"';
+  const cmd =
+    `"${common.opensslCli}" dgst -sha256 -verify "${pubfile}" -signature "${
+    sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${
+    msgfile}"`;
 
   exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert(stdout.includes('Verified OK'));

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -33,11 +33,11 @@ crypto.DEFAULT_ENCODING = 'buffer';
 
 const fs = require('fs');
 
-const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
+const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.Server(options, (socket) => {

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -35,10 +35,10 @@ const tls = require('tls');
 crypto.DEFAULT_ENCODING = 'buffer';
 
 // Test Certificates
-const caPem = fs.readFileSync(common.fixturesDir + '/test_ca.pem', 'ascii');
-const certPem = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-const certPfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
-const keyPem = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
+const caPem = fs.readFileSync(`${common.fixturesDir}/test_ca.pem`, 'ascii');
+const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
+const certPfx = fs.readFileSync(`${common.fixturesDir}/test_cert.pfx`);
+const keyPem = fs.readFileSync(`${common.fixturesDir}/test_key.pem`, 'ascii');
 
 // 'this' safety
 // https://github.com/joyent/node/issues/6690
@@ -177,8 +177,8 @@ assert.throws(function() {
   //   $ openssl pkcs8 -topk8 -inform PEM -outform PEM -in mykey.pem \
   //     -out private_key.pem -nocrypt;
   //   Then open private_key.pem and change its header and footer.
-  const sha1_privateKey = fs.readFileSync(common.fixturesDir +
-                                        '/test_bad_rsa_privkey.pem', 'ascii');
+  const sha1_privateKey = fs.readFileSync(
+    `${common.fixturesDir}/test_bad_rsa_privkey.pem`, 'ascii');
   // this would inject errors onto OpenSSL's error stack
   crypto.createSign('sha1').sign(sha1_privateKey);
 }, /asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag/);

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -10,7 +10,7 @@ if (common.isSunOS || common.isWindows || common.isAix) {
   return;
 }
 
-const dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
 const abspathFile = require('path').join(common.fixturesDir, 'a.js');
 common.refreshTmpDir();
 fs.mkdirSync(dirname);

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -10,7 +10,7 @@ if (common.isSunOS || common.isWindows || common.isAix) {
   return;
 }
 
-const dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
 common.refreshTmpDir();
 fs.mkdirSync(dirname);
 process.chdir(dirname);

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -10,7 +10,7 @@ if (common.isSunOS || common.isWindows || common.isAix) {
   return;
 }
 
-const dirname = common.tmpDir + '/cwd-does-not-exist-' + process.pid;
+const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
 common.refreshTmpDir();
 fs.mkdirSync(dirname);
 process.chdir(dirname);

--- a/test/parallel/test-dgram-bind-shared-ports.js
+++ b/test/parallel/test-dgram-bind-shared-ports.js
@@ -54,12 +54,12 @@ if (cluster.isMaster) {
 
   socket1.on('error', (err) => {
     // no errors expected
-    process.send('socket1:' + err.code);
+    process.send(`socket1:${err.code}`);
   });
 
   socket2.on('error', (err) => {
     // an error is expected on the second worker
-    process.send('socket2:' + err.code);
+    process.send(`socket2:${err.code}`);
   });
 
   socket1.bind({

--- a/test/parallel/test-dgram-error-message-address.js
+++ b/test/parallel/test-dgram-error-message-address.js
@@ -49,7 +49,7 @@ socket_ipv6.on('error', common.mustCall(function(e) {
   const allowed = ['EADDRNOTAVAIL', 'EAFNOSUPPORT', 'EPROTONOSUPPORT'];
   assert.notStrictEqual(allowed.indexOf(e.code), -1);
   assert.strictEqual(e.port, undefined);
-  assert.strictEqual(e.message, 'bind ' + e.code + ' 111::1');
+  assert.strictEqual(e.message, `bind ${e.code} 111::1`);
   assert.strictEqual(e.address, '111::1');
   socket_ipv6.close();
 }));

--- a/test/parallel/test-domain-enter-exit.js
+++ b/test/parallel/test-domain-enter-exit.js
@@ -41,20 +41,20 @@ c.name = 'c';
 
 a.enter(); // push
 assert.deepStrictEqual(domain._stack, [a],
-                       'a not pushed: ' + names(domain._stack));
+                       `a not pushed: ${names(domain._stack)}`);
 
 b.enter(); // push
 assert.deepStrictEqual(domain._stack, [a, b],
-                       'b not pushed: ' + names(domain._stack));
+                       `b not pushed: ${names(domain._stack)}`);
 
 c.enter(); // push
 assert.deepStrictEqual(domain._stack, [a, b, c],
-                       'c not pushed: ' + names(domain._stack));
+                       `c not pushed: ${names(domain._stack)}`);
 
 b.exit(); // pop
 assert.deepStrictEqual(domain._stack, [a],
-                       'b and c not popped: ' + names(domain._stack));
+                       `b and c not popped: ${names(domain._stack)}`);
 
 b.enter(); // push
 assert.deepStrictEqual(domain._stack, [a, b],
-                       'b not pushed: ' + names(domain._stack));
+                       `b not pushed: ${names(domain._stack)}`);

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -184,16 +184,15 @@ if (process.argv[2] === 'child') {
       test.expectedMessages.forEach(function(expectedMessage) {
         if (test.messagesReceived === undefined ||
           test.messagesReceived.indexOf(expectedMessage) === -1)
-          assert.fail('test ' + test.fn.name + ' should have sent message: ' +
-                      expectedMessage + ' but didn\'t');
+          assert.fail(`test ${test.fn.name} should have sent message: ${
+                      expectedMessage} but didn't`);
       });
 
       if (test.messagesReceived) {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (test.expectedMessages.indexOf(receivedMessage) === -1) {
-            assert.fail('test ' + test.fn.name +
-                        ' should not have sent message: ' + receivedMessage +
-                        ' but did');
+            assert.fail(`test ${test.fn.name} should not have sent message: ${
+                        receivedMessage} but did`);
           }
         });
       }

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -103,14 +103,8 @@ if (process.argv[2] === 'child') {
     if (options.useTryCatch)
       useTryCatchOpt = 'useTryCatch';
 
-    cmdToExec += process.argv[0] + ' ';
-    cmdToExec += (cmdLineOption ? cmdLineOption : '') + ' ';
-    cmdToExec += process.argv[1] + ' ';
-    cmdToExec += [
-      'child',
-      throwInDomainErrHandlerOpt,
-      useTryCatchOpt
-    ].join(' ');
+    cmdToExec += `${process.argv[0]} ${cmdLineOption ? cmdLineOption : ''} ${
+      process.argv[1]} child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
 
     const child = exec(cmdToExec);
 

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -251,9 +251,7 @@ assert.strictEqual(result, 'return value');
 
 
 // check if the executed function take in count the applied parameters
-result = d.run(function(a, b) {
-  return a + ' ' + b;
-}, 'return', 'value');
+result = d.run((a, b) => `${a} ${b}`, 'return', 'value');
 assert.strictEqual(result, 'return value');
 
 

--- a/test/parallel/test-dsa-fips-invalid-key.js
+++ b/test/parallel/test-dsa-fips-invalid-key.js
@@ -12,8 +12,8 @@ const fs = require('fs');
 
 const input = 'hello';
 
-const dsapri = fs.readFileSync(common.fixturesDir +
-                             '/keys/dsa_private_1025.pem');
+const dsapri = fs.readFileSync(
+  `${common.fixturesDir}/keys/dsa_private_1025.pem`);
 const sign = crypto.createSign('DSS1');
 sign.update(input);
 

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -26,8 +26,7 @@ const exec = require('child_process').exec;
 const path = require('path');
 
 function errExec(script, callback) {
-  const cmd = '"' + process.argv[0] + '" "' +
-              path.join(common.fixturesDir, script) + '"';
+  const cmd = `"${process.argv[0]}" "${path.join(common.fixturesDir, script)}"`;
   return exec(cmd, function(err, stdout, stderr) {
     // There was some error
     assert.ok(err);

--- a/test/parallel/test-eval.js
+++ b/test/parallel/test-eval.js
@@ -29,7 +29,7 @@ const cmd = [
   `"${process.execPath}"`, '-e',
   '"console.error(process.argv)"',
   'foo', 'bar'].join(' ');
-const expected = util.format([process.execPath, 'foo', 'bar']) + '\n';
+const expected = `${util.format([process.execPath, 'foo', 'bar'])}\n`;
 exec(cmd, common.mustCall((err, stdout, stderr) => {
   assert.ifError(err);
   assert.strictEqual(stderr, expected);

--- a/test/parallel/test-exception-handler2.js
+++ b/test/parallel/test-exception-handler2.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 
 process.on('uncaughtException', function(err) {
-  console.log('Caught exception: ' + err);
+  console.log(`Caught exception: ${err}`);
 });
 
 setTimeout(common.mustCall(function() {

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -43,9 +43,9 @@ process.on('exit', function() {
     console.log('  Test callback events missing or out of order:');
     console.log('    expected: %j', cb_expected);
     console.log('    occurred: %j', cb_occurred);
-    assert.strictEqual(cb_occurred, cb_expected,
-                       'events missing or out of order: "' +
-                       cb_occurred + '" !== "' + cb_expected + '"');
+    assert.strictEqual(
+      cb_occurred, cb_expected,
+      `events missing or out of order: "${cb_occurred}" !== "${cb_expected}"`);
   } else {
     console.log('ok');
   }
@@ -101,7 +101,7 @@ file.on('error', function(err) {
 
 
 for (let i = 0; i < 11; i++) {
-  const ret = file.write(i + '');
+  const ret = file.write(String(i));
   console.error('%d %j', i, ret);
 
   // return false when i hits 10

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -44,9 +44,9 @@ process.on('exit', function() {
     console.log('  Test callback events missing or out of order:');
     console.log('    expected: %j', cb_expected);
     console.log('    occurred: %j', cb_occurred);
-    assert.strictEqual(cb_occurred, cb_expected,
-                       'events missing or out of order: "' +
-                       cb_occurred + '" !== "' + cb_expected + '"');
+    assert.strictEqual(
+      cb_occurred, cb_expected,
+      `events missing or out of order: "${cb_occurred}" !== "${cb_expected}"`);
   }
 });
 

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -83,7 +83,7 @@ if (!common.isWindows) {
 
 const fileData4 = fs.readFileSync(filename4);
 
-assert.strictEqual(Buffer.byteLength('' + num) + currentFileData.length,
+assert.strictEqual(Buffer.byteLength(String(num)) + currentFileData.length,
                    fileData4.length);
 
 // test that appendFile accepts file descriptors

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -109,7 +109,7 @@ fs.appendFile(filename4, n, { mode: m }, function(e) {
   fs.readFile(filename4, function(e, buffer) {
     assert.ifError(e);
     ncallbacks++;
-    assert.strictEqual(Buffer.byteLength('' + n) + currentFileData.length,
+    assert.strictEqual(Buffer.byteLength(String(n)) + currentFileData.length,
                        buffer.length);
   });
 });

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -16,5 +16,5 @@ common.refreshTmpDir();
 v.forEach((value) => {
   const fd = fs.openSync(filePath, 'w');
   fs.writeSync(fd, value);
-  assert.strictEqual(fs.readFileSync(filePath).toString(), value + '');
+  assert.strictEqual(fs.readFileSync(filePath).toString(), String(value));
 });

--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -225,7 +225,8 @@ try {
 }
 
 process.on('exit', function() {
-  assert.strictEqual(expected, errors.length,
-                     'Test fs sync exceptions raised, got ' + errors.length +
-               ' expected ' + expected);
+  assert.strictEqual(
+    expected, errors.length,
+    `Test fs sync exceptions raised, got ${errors.length} expected ${expected}`
+  );
 });

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -29,9 +29,9 @@ fs.exists(f, common.mustCall(function(y) {
   assert.strictEqual(y, true);
 }));
 
-fs.exists(f + '-NO', common.mustCall(function(y) {
+fs.exists(`${f}-NO`, common.mustCall(function(y) {
   assert.strictEqual(y, false);
 }));
 
 assert(fs.existsSync(f));
-assert(!fs.existsSync(f + '-NO'));
+assert(!fs.existsSync(`${f}-NO`));

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -34,7 +34,7 @@ function unlink(pathname) {
 common.refreshTmpDir();
 
 {
-  const pathname = common.tmpDir + '/test1';
+  const pathname = `${common.tmpDir}/test1`;
 
   unlink(pathname);
 
@@ -49,7 +49,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = common.tmpDir + '/test2';
+  const pathname = `${common.tmpDir}/test2`;
 
   unlink(pathname);
 
@@ -64,7 +64,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = common.tmpDir + '/test3';
+  const pathname = `${common.tmpDir}/test3`;
 
   unlink(pathname);
   fs.mkdirSync(pathname);

--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -29,6 +29,7 @@ assert.throws(function() {
               "start as string didn't throw an error for createWriteStream");
 
 saneEmitter.on('data', common.mustCall(function(data) {
-  assert.strictEqual(sanity, data.toString('utf8'), 'read ' +
-                     data.toString('utf8') + ' instead of ' + sanity);
+  assert.strictEqual(
+    sanity, data.toString('utf8'),
+    `read ${data.toString('utf8')} instead of ${sanity}`);
 }));

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -12,7 +12,7 @@ common.refreshTmpDir();
 
 // Create the necessary files
 files.forEach(function(currentFile) {
-  fs.closeSync(fs.openSync(readdirDir + '/' + currentFile, 'w'));
+  fs.closeSync(fs.openSync(`${readdirDir}/${currentFile}`, 'w'));
 });
 
 // Check the readdir Sync version

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -34,13 +34,13 @@ if (common.isFreeBSD) {
 
 function test(env, cb) {
   const filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
-  const execPath = '"' + process.execPath + '" "' + filename + '"';
+  const execPath = `"${process.execPath}" "${filename}"`;
   const options = { env: Object.assign(process.env, env) };
   exec(execPath, options, common.mustCall((err, stdout, stderr) => {
     assert(err);
     assert.strictEqual(stdout, '');
     assert.notStrictEqual(stderr, '');
-    cb('' + stderr);
+    cb(String(stderr));
   }));
 }
 

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -29,6 +29,7 @@ let async_completed = 0;
 let async_expected = 0;
 const unlink = [];
 let skipSymlinks = false;
+const tmpDir = common.tmpDir;
 
 common.refreshTmpDir();
 
@@ -62,11 +63,11 @@ if (common.isWindows) {
 
 
 function tmp(p) {
-  return path.join(common.tmpDir, p);
+  return path.join(tmpDir, p);
 }
 
-const targetsAbsDir = path.join(common.tmpDir, 'targets');
-const tmpAbsDir = common.tmpDir;
+const targetsAbsDir = path.join(tmpDir, 'targets');
+const tmpAbsDir = tmpDir;
 
 // Set up targetsAbsDir and expected subdirectories
 fs.mkdirSync(targetsAbsDir);
@@ -105,10 +106,10 @@ function test_simple_relative_symlink(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  const entry = common.tmpDir + '/symlink';
-  const expected = common.tmpDir + '/cycles/root.js';
+  const entry = `${tmpDir}/symlink`;
+  const expected = `${tmpDir}/cycles/root.js`;
   [
-    [entry, '../' + common.tmpDirName + '/cycles/root.js']
+    [entry, `../${common.tmpDirName}/cycles/root.js`]
   ].forEach(function(t) {
     try { fs.unlinkSync(t[0]); } catch (e) {}
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], t[0], 'file');
@@ -131,8 +132,8 @@ function test_simple_absolute_symlink(callback) {
 
   console.log('using type=%s', type);
 
-  const entry = tmpAbsDir + '/symlink';
-  const expected = common.fixturesDir + '/nested-index/one';
+  const entry = `${tmpAbsDir}/symlink`;
+  const expected = `${common.fixturesDir}/nested-index/one`;
   [
     [entry, expected]
   ].forEach(function(t) {
@@ -212,11 +213,11 @@ function test_cyclic_link_protection(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  const entry = path.join(common.tmpDir, '/cycles/realpath-3a');
+  const entry = path.join(tmpDir, '/cycles/realpath-3a');
   [
     [entry, '../cycles/realpath-3b'],
-    [path.join(common.tmpDir, '/cycles/realpath-3b'), '../cycles/realpath-3c'],
-    [path.join(common.tmpDir, '/cycles/realpath-3c'), '../cycles/realpath-3a']
+    [path.join(tmpDir, '/cycles/realpath-3b'), '../cycles/realpath-3c'],
+    [path.join(tmpDir, '/cycles/realpath-3c'), '../cycles/realpath-3a']
   ].forEach(function(t) {
     try { fs.unlinkSync(t[0]); } catch (e) {}
     fs.symlinkSync(t[1], t[0], 'dir');
@@ -239,10 +240,10 @@ function test_cyclic_link_overprotection(callback) {
     common.skip('symlink test (no privs)');
     return runNextTest();
   }
-  const cycles = common.tmpDir + '/cycles';
+  const cycles = `${tmpDir}/cycles`;
   const expected = fs.realpathSync(cycles);
-  const folder = cycles + '/folder';
-  const link = folder + '/cycles';
+  const folder = `${cycles}/folder`;
+  const link = `${folder}/cycles`;
   let testPath = cycles;
   testPath += '/folder/cycles'.repeat(10);
   try { fs.unlinkSync(link); } catch (ex) {}
@@ -264,12 +265,12 @@ function test_relative_input_cwd(callback) {
   // we need to calculate the relative path to the tmp dir from cwd
   const entrydir = process.cwd();
   const entry = path.relative(entrydir,
-                              path.join(common.tmpDir + '/cycles/realpath-3a'));
-  const expected = common.tmpDir + '/cycles/root.js';
+                              path.join(`${tmpDir}/cycles/realpath-3a`));
+  const expected = `${tmpDir}/cycles/root.js`;
   [
     [entry, '../cycles/realpath-3b'],
-    [common.tmpDir + '/cycles/realpath-3b', '../cycles/realpath-3c'],
-    [common.tmpDir + '/cycles/realpath-3c', 'root.js']
+    [`${tmpDir}/cycles/realpath-3b`, '../cycles/realpath-3c'],
+    [`${tmpDir}/cycles/realpath-3c`, 'root.js']
   ].forEach(function(t) {
     const fn = t[0];
     console.error('fn=%j', fn);
@@ -317,16 +318,16 @@ function test_deep_symlink_mix(callback) {
   fs.mkdirSync(tmp('node-test-realpath-d2'), 0o700);
   try {
     [
-      [entry, common.tmpDir + '/node-test-realpath-d1/foo'],
+      [entry, `${tmpDir}/node-test-realpath-d1/foo`],
       [tmp('node-test-realpath-d1'),
-       common.tmpDir + '/node-test-realpath-d2'],
+       `${tmpDir}/node-test-realpath-d2`],
       [tmp('node-test-realpath-d2/foo'), '../node-test-realpath-f2'],
-      [tmp('node-test-realpath-f2'), targetsAbsDir +
-        '/nested-index/one/realpath-c'],
-      [targetsAbsDir + '/nested-index/one/realpath-c', targetsAbsDir +
-        '/nested-index/two/realpath-c'],
-      [targetsAbsDir + '/nested-index/two/realpath-c',
-       common.tmpDir + '/cycles/root.js']
+      [tmp('node-test-realpath-f2'),
+       `${targetsAbsDir}/nested-index/one/realpath-c`],
+      [`${targetsAbsDir}/nested-index/one/realpath-c`,
+       `${targetsAbsDir}/nested-index/two/realpath-c`],
+      [`${targetsAbsDir}/nested-index/two/realpath-c`,
+       `${tmpDir}/cycles/root.js`]
     ].forEach(function(t) {
       try { fs.unlinkSync(t[0]); } catch (e) {}
       fs.symlinkSync(t[1], t[0]);
@@ -335,7 +336,7 @@ function test_deep_symlink_mix(callback) {
   } finally {
     unlink.push(tmp('node-test-realpath-d2'));
   }
-  const expected = tmpAbsDir + '/cycles/root.js';
+  const expected = `${tmpAbsDir}/cycles/root.js`;
   assertEqualPath(fs.realpathSync(entry), path.resolve(expected));
   asynctest(fs.realpath, [entry], callback, function(err, result) {
     assertEqualPath(result, path.resolve(expected));
@@ -346,8 +347,8 @@ function test_deep_symlink_mix(callback) {
 function test_non_symlinks(callback) {
   console.log('test_non_symlinks');
   const entrydir = path.dirname(tmpAbsDir);
-  const entry = tmpAbsDir.substr(entrydir.length + 1) + '/cycles/root.js';
-  const expected = tmpAbsDir + '/cycles/root.js';
+  const entry = `${tmpAbsDir.substr(entrydir.length + 1)}/cycles/root.js`;
+  const expected = `${tmpAbsDir}/cycles/root.js`;
   const origcwd = process.cwd();
   process.chdir(entrydir);
   assertEqualPath(fs.realpathSync(entry), path.resolve(expected));
@@ -362,15 +363,15 @@ const upone = path.join(process.cwd(), '..');
 function test_escape_cwd(cb) {
   console.log('test_escape_cwd');
   asynctest(fs.realpath, ['..'], cb, function(er, uponeActual) {
-    assertEqualPath(upone, uponeActual,
-                    'realpath("..") expected: ' + path.resolve(upone) +
-                    ' actual:' + uponeActual);
+    assertEqualPath(
+      upone, uponeActual,
+      `realpath("..") expected: ${path.resolve(upone)} actual:${uponeActual}`);
   });
 }
 const uponeActual = fs.realpathSync('..');
-assertEqualPath(upone, uponeActual,
-                'realpathSync("..") expected: ' + path.resolve(upone) +
-                ' actual:' + uponeActual);
+assertEqualPath(
+  upone, uponeActual,
+  `realpathSync("..") expected: ${path.resolve(upone)} actual:${uponeActual}`);
 
 
 // going up with .. multiple times
@@ -442,7 +443,7 @@ function test_abs_with_kids(cb) {
 
   console.log('using type=%s', type);
 
-  const root = tmpAbsDir + '/node-test-realpath-abs-kids';
+  const root = `${tmpAbsDir}/node-test-realpath-abs-kids`;
   function cleanup() {
     ['/a/b/c/x.txt',
      '/a/link'
@@ -464,15 +465,15 @@ function test_abs_with_kids(cb) {
      '/a/b',
      '/a/b/c'
     ].forEach(function(folder) {
-      console.log('mkdir ' + root + folder);
+      console.log(`mkdir ${root}${folder}`);
       fs.mkdirSync(root + folder, 0o700);
     });
-    fs.writeFileSync(root + '/a/b/c/x.txt', 'foo');
-    fs.symlinkSync(root + '/a/b', root + '/a/link', type);
+    fs.writeFileSync(`${root}/a/b/c/x.txt`, 'foo');
+    fs.symlinkSync(`${root}/a/b`, `${root}/a/link`, type);
   }
   setup();
-  const linkPath = root + '/a/link/c/x.txt';
-  const expectPath = root + '/a/b/c/x.txt';
+  const linkPath = `${root}/a/link/c/x.txt`;
+  const expectPath = `${root}/a/b/c/x.txt`;
   const actual = fs.realpathSync(linkPath);
   // console.log({link:linkPath,expect:expectPath,actual:actual},'sync');
   assertEqualPath(actual, path.resolve(expectPath));
@@ -506,8 +507,7 @@ function runNextTest(err) {
   assert.ifError(err);
   const test = tests.shift();
   if (!test) {
-    return console.log(numtests +
-                       ' subtests completed OK for fs.realpath');
+    return console.log(`${numtests} subtests completed OK for fs.realpath`);
   }
   testsRun++;
   test(runNextTest);

--- a/test/parallel/test-fs-sir-writes-alot.js
+++ b/test/parallel/test-fs-sir-writes-alot.js
@@ -56,7 +56,7 @@ function testBuffer(b) {
   for (let i = 0; i < b.length; i++) {
     bytesChecked++;
     if (b[i] !== 'a'.charCodeAt(0) && b[i] !== '\n'.charCodeAt(0)) {
-      throw new Error('invalid char ' + i + ',' + b[i]);
+      throw new Error(`invalid char ${i},${b[i]}`);
     }
   }
 }

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -77,25 +77,25 @@ fs.stat(__filename, common.mustCall(function(err, s) {
 
   console.dir(s);
 
-  console.log('isDirectory: ' + JSON.stringify(s.isDirectory()));
+  console.log(`isDirectory: ${JSON.stringify(s.isDirectory())}`);
   assert.strictEqual(false, s.isDirectory());
 
-  console.log('isFile: ' + JSON.stringify(s.isFile()));
+  console.log(`isFile: ${JSON.stringify(s.isFile())}`);
   assert.strictEqual(true, s.isFile());
 
-  console.log('isSocket: ' + JSON.stringify(s.isSocket()));
+  console.log(`isSocket: ${JSON.stringify(s.isSocket())}`);
   assert.strictEqual(false, s.isSocket());
 
-  console.log('isBlockDevice: ' + JSON.stringify(s.isBlockDevice()));
+  console.log(`isBlockDevice: ${JSON.stringify(s.isBlockDevice())}`);
   assert.strictEqual(false, s.isBlockDevice());
 
-  console.log('isCharacterDevice: ' + JSON.stringify(s.isCharacterDevice()));
+  console.log(`isCharacterDevice: ${JSON.stringify(s.isCharacterDevice())}`);
   assert.strictEqual(false, s.isCharacterDevice());
 
-  console.log('isFIFO: ' + JSON.stringify(s.isFIFO()));
+  console.log(`isFIFO: ${JSON.stringify(s.isFIFO())}`);
   assert.strictEqual(false, s.isFIFO());
 
-  console.log('isSymbolicLink: ' + JSON.stringify(s.isSymbolicLink()));
+  console.log(`isSymbolicLink: ${JSON.stringify(s.isSymbolicLink())}`);
   assert.strictEqual(false, s.isSymbolicLink());
 
   assert.ok(s.mtime instanceof Date);

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -29,9 +29,9 @@ test1(fs.createReadStream(__filename));
 test2(fs.createReadStream(__filename));
 test3(fs.createReadStream(__filename));
 
-test1(fs.createWriteStream(common.tmpDir + '/dummy1'));
-test2(fs.createWriteStream(common.tmpDir + '/dummy2'));
-test3(fs.createWriteStream(common.tmpDir + '/dummy3'));
+test1(fs.createWriteStream(`${common.tmpDir}/dummy1`));
+test2(fs.createWriteStream(`${common.tmpDir}/dummy2`));
+test3(fs.createWriteStream(`${common.tmpDir}/dummy3`));
 
 function test1(stream) {
   stream.destroy();

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -48,8 +48,8 @@ function verifyLink(linkPath) {
   const stats = fs.lstatSync(linkPath);
   assert.ok(stats.isSymbolicLink());
 
-  const data1 = fs.readFileSync(linkPath + '/x.txt', 'ascii');
-  const data2 = fs.readFileSync(linkTarget + '/x.txt', 'ascii');
+  const data1 = fs.readFileSync(`${linkPath}/x.txt`, 'ascii');
+  const data2 = fs.readFileSync(`${linkTarget}/x.txt`, 'ascii');
   assert.strictEqual(data1, data2);
 
   // Clean up.

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -31,8 +31,8 @@ const linkPath = path.join(common.tmpDir, 'cycles_link');
 
 common.refreshTmpDir();
 
-console.log('linkData: ' + linkData);
-console.log('linkPath: ' + linkPath);
+console.log(`linkData: ${linkData}`);
+console.log(`linkPath: ${linkPath}`);
 
 fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   assert.ifError(err);

--- a/test/parallel/test-fs-timestamp-parsing-error.js
+++ b/test/parallel/test-fs-timestamp-parsing-error.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 [Infinity, -Infinity, NaN].forEach((input) => {
   assert.throws(() => fs._toUnixTimestamp(input),
-                new RegExp('^Error: Cannot parse time: ' + input + '$'));
+                new RegExp(`^Error: Cannot parse time: ${input}$`));
 });
 
 assert.throws(() => fs._toUnixTimestamp({}),

--- a/test/parallel/test-fs-truncate-GH-6233.js
+++ b/test/parallel/test-fs-truncate-GH-6233.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const filename = common.tmpDir + '/truncate-file.txt';
+const filename = `${common.tmpDir}/truncate-file.txt`;
 
 common.refreshTmpDir();
 

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -77,7 +77,7 @@ fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
   fs.readFile(filename3, common.mustCall(function(e, buffer) {
     assert.ifError(e);
 
-    assert.strictEqual(Buffer.byteLength('' + n), buffer.length);
+    assert.strictEqual(Buffer.byteLength(String(n)), buffer.length);
   }));
 }));
 

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -26,7 +26,7 @@ const fs = require('fs');
 
 common.refreshTmpDir();
 
-const stream = fs.createWriteStream(common.tmpDir + '/out', {
+const stream = fs.createWriteStream(`${common.tmpDir}/out`, {
   highWaterMark: 10
 });
 const err = new Error('BAM');

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -9,7 +9,7 @@ common.refreshTmpDir();
 
 const fn = path.join(common.tmpDir, 'write-string-coerce.txt');
 const data = true;
-const expected = data + '';
+const expected = String(data);
 
 fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   assert.ifError(err);

--- a/test/parallel/test-http-abort-client.js
+++ b/test/parallel/test-http-abort-client.js
@@ -38,11 +38,11 @@ server.listen(0, common.mustCall(function() {
   }, common.mustCall(function(res) {
     server.close();
 
-    console.log('Got res: ' + res.statusCode);
+    console.log(`Got res: ${res.statusCode}`);
     console.dir(res.headers);
 
     res.on('data', function(chunk) {
-      console.log('Read ' + chunk.length + ' bytes');
+      console.log(`Read ${chunk.length} bytes`);
       console.log(' chunk=%j', chunk.toString());
     });
 

--- a/test/parallel/test-http-abort-queued.js
+++ b/test/parallel/test-http-abort-queued.js
@@ -80,11 +80,11 @@ server.listen(0, function() {
     assert.strictEqual(Object.keys(agent.sockets).length, 1);
     assert.strictEqual(Object.keys(agent.requests).length, 1);
 
-    console.log('Got res: ' + res1.statusCode);
+    console.log(`Got res: ${res1.statusCode}`);
     console.dir(res1.headers);
 
     res1.on('data', function(chunk) {
-      console.log('Read ' + chunk.length + ' bytes');
+      console.log(`Read ${chunk.length} bytes`);
       console.log(' chunk=%j', chunk.toString());
       complete();
     });

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -64,7 +64,7 @@ server.listen(0, function() {
 function doRequest(i) {
   http.get({
     port: server.address().port,
-    path: '/request' + i
+    path: `/request${i}`
   }, common.mustCall(function(res) {
     console.error('Client got GET response');
     let data = '';
@@ -73,7 +73,7 @@ function doRequest(i) {
       data += chunk;
     });
     res.on('end', function() {
-      assert.strictEqual(data, '/request' + i);
+      assert.strictEqual(data, `/request${i}`);
       ++clientResponses;
       if (clientResponses === 2) {
         server.close();

--- a/test/parallel/test-http-agent-error-on-idle.js
+++ b/test/parallel/test-http-agent-error-on-idle.js
@@ -29,7 +29,7 @@ server.listen(0, function() {
       process.nextTick(function() {
         const freeSockets = agent.freeSockets[socketKey];
         assert.strictEqual(freeSockets.length, 1,
-                           'expect a free socket on ' + socketKey);
+                           `expect a free socket on ${socketKey}`);
 
         //generate a random error on the free socket
         const freeSocket = freeSockets[0];

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -35,4 +35,4 @@ for (const family of [0, null, undefined, 'bogus'])
   assert.strictEqual(agent.getName({ family }), 'localhost::');
 
 for (const family of [4, 6])
-  assert.strictEqual(agent.getName({ family }), 'localhost:::' + family);
+  assert.strictEqual(agent.getName({ family }), `localhost:::${family}`);

--- a/test/parallel/test-http-agent-maxsockets.js
+++ b/test/parallel/test-http-agent-maxsockets.js
@@ -30,7 +30,7 @@ function done() {
   }
   const freepool = agent.freeSockets[Object.keys(agent.freeSockets)[0]];
   assert.strictEqual(freepool.length, 2,
-                     'expect keep 2 free sockets, but got ' + freepool.length);
+                     `expect keep 2 free sockets, but got ${freepool.length}`);
   agent.destroy();
   server.close();
 }

--- a/test/parallel/test-http-buffer-sanity.js
+++ b/test/parallel/test-http-buffer-sanity.js
@@ -58,7 +58,7 @@ const web = http.Server(function(req, res) {
   });
 
   req.connection.on('error', function(e) {
-    console.log('http server-side error: ' + e.message);
+    console.log(`http server-side error: ${e.message}`);
     process.exit(1);
   });
 });

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -82,7 +82,7 @@ cp.exec(ddcmd, function(err, stdout, stderr) {
     // End the response on exit (and log errors)
     cat.on('exit', (code) => {
       if (code !== 0) {
-        console.error('subprocess exited with code ' + code);
+        console.error(`subprocess exited with code ${code}`);
         process.exit(1);
       }
     });

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -36,7 +36,7 @@ const server = http.Server(function(req, res) {
   // event like "aborted" or something.
   req.on('aborted', function() {
     clientAborts++;
-    console.log('Got abort ' + clientAborts);
+    console.log(`Got abort ${clientAborts}`);
     if (clientAborts === N) {
       console.log('All aborts detected, you win.');
       server.close();
@@ -52,10 +52,10 @@ server.listen(0, function() {
   console.log('Server listening.');
 
   for (let i = 0; i < N; i++) {
-    console.log('Making client ' + i);
-    const options = { port: this.address().port, path: '/?id=' + i };
+    console.log(`Making client ${i}`);
+    const options = { port: this.address().port, path: `/?id=${i}` };
     const req = http.get(options, function(res) {
-      console.log('Client response code ' + res.statusCode);
+      console.log(`Client response code ${res.statusCode}`);
 
       res.resume();
       if (++responses === N) {

--- a/test/parallel/test-http-client-agent.js
+++ b/test/parallel/test-http-client-agent.js
@@ -49,7 +49,7 @@ server.listen(0, function() {
 function request(i) {
   const req = http.get({
     port: server.address().port,
-    path: '/' + i
+    path: `/${i}`
   }, function(res) {
     const socket = req.socket;
     socket.on('close', function() {

--- a/test/parallel/test-http-client-default-headers-exist.js
+++ b/test/parallel/test-http-client-default-headers-exist.js
@@ -42,21 +42,21 @@ const server = http.createServer(function(req, res) {
   res.end();
 
   assert(expectedHeaders.hasOwnProperty(req.method),
-         req.method + ' was an unexpected method');
+         `${req.method} was an unexpected method`);
 
   const requestHeaders = Object.keys(req.headers);
   requestHeaders.forEach(function(header) {
     assert.notStrictEqual(
       expectedHeaders[req.method].indexOf(header.toLowerCase()),
       -1,
-      header + ' shoud not exist for method ' + req.method
+      `${header} should not exist for method ${req.method}`
     );
   });
 
   assert.strictEqual(
     requestHeaders.length,
     expectedHeaders[req.method].length,
-    'some headers were missing for method: ' + req.method
+    `some headers were missing for method: ${req.method}`
   );
 
   if (expectedMethods.length === requestCount)

--- a/test/parallel/test-http-client-timeout-agent.js
+++ b/test/parallel/test-http-client-timeout-agent.js
@@ -51,27 +51,27 @@ server.listen(0, options.host, function() {
   let req;
 
   for (requests_sent = 0; requests_sent < 30; requests_sent += 1) {
-    options.path = '/' + requests_sent;
+    options.path = `/${requests_sent}`;
     req = http.request(options);
     req.id = requests_sent;
     req.on('response', function(res) {
       res.on('data', function(data) {
-        console.log('res#' + this.req.id + ' data:' + data);
+        console.log(`res#${this.req.id} data:${data}`);
       });
       res.on('end', function(data) {
-        console.log('res#' + this.req.id + ' end');
+        console.log(`res#${this.req.id} end`);
         requests_done += 1;
       });
     });
     req.on('close', function() {
-      console.log('req#' + this.id + ' close');
+      console.log(`req#${this.id} close`);
     });
     req.on('error', function() {
-      console.log('req#' + this.id + ' error');
+      console.log(`req#${this.id} error`);
       this.destroy();
     });
     req.setTimeout(50, function() {
-      console.log('req#' + this.id + ' timeout');
+      console.log(`req#${this.id} timeout`);
       this.abort();
       requests_done += 1;
     });

--- a/test/parallel/test-http-client-timeout-with-data.js
+++ b/test/parallel/test-http-client-timeout-with-data.js
@@ -51,7 +51,7 @@ server.listen(0, options.host, function() {
     }));
 
     res.on('data', common.mustCall(function(data) {
-      assert.strictEqual('' + data, '*');
+      assert.strictEqual(String(data), '*');
       nchunks++;
     }, 2));
 

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const http = require('http');
 
 for (let i = 0; i <= 32; i += 1) {
-  const path = 'bad' + String.fromCharCode(i) + 'path';
+  const path = `bad${String.fromCharCode(i)}path`;
   assert.throws(() => http.get({ path }, common.mustNotCall()),
                 /contains unescaped characters/);
 }

--- a/test/parallel/test-http-client-upload.js
+++ b/test/parallel/test-http-client-upload.js
@@ -31,7 +31,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
   let sent_body = '';
 
   req.on('data', function(chunk) {
-    console.log('server got: ' + JSON.stringify(chunk));
+    console.log(`server got: ${JSON.stringify(chunk)}`);
     sent_body += chunk;
   });
 

--- a/test/parallel/test-http-connect-req-res.js
+++ b/test/parallel/test-http-connect-req-res.js
@@ -39,7 +39,7 @@ server.listen(0, common.mustCall(function() {
     console.error('Client got CONNECT request');
 
     // Make sure this request got removed from the pool.
-    const name = 'localhost:' + server.address().port;
+    const name = `localhost:${server.address().port}`;
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
     assert(!http.globalAgent.requests.hasOwnProperty(name));
 

--- a/test/parallel/test-http-connect.js
+++ b/test/parallel/test-http-connect.js
@@ -53,7 +53,7 @@ server.listen(0, common.mustCall(function() {
 
   req.on('connect', common.mustCall((res, socket, firstBodyChunk) => {
     // Make sure this request got removed from the pool.
-    const name = 'localhost:' + server.address().port;
+    const name = `localhost:${server.address().port}`;
     assert(!http.globalAgent.sockets.hasOwnProperty(name));
     assert(!http.globalAgent.requests.hasOwnProperty(name));
 

--- a/test/parallel/test-http-contentLength0.js
+++ b/test/parallel/test-http-contentLength0.js
@@ -35,7 +35,7 @@ const s = http.createServer(function(req, res) {
 s.listen(0, function() {
 
   const request = http.request({ port: this.address().port }, (response) => {
-    console.log('STATUS: ' + response.statusCode);
+    console.log(`STATUS: ${response.statusCode}`);
     s.close();
     response.resume();
   });

--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -35,8 +35,8 @@ const fs = require('fs');
 const path = require('path');
 const fixtures = path.join(common.fixturesDir, 'keys');
 const options = {
-  key: fs.readFileSync(fixtures + '/agent1-key.pem'),
-  cert: fs.readFileSync(fixtures + '/agent1-cert.pem')
+  key: fs.readFileSync(`${fixtures}/agent1-key.pem`),
+  cert: fs.readFileSync(`${fixtures}/agent1-cert.pem`)
 };
 let gotHttpsResp = false;
 let gotHttpResp = false;

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -32,14 +32,14 @@ const server = http.createServer(function(req, res) {
 
 server.listen(0, function() {
   for (let i = 0; i < 4; i += 1) {
-    http.get({ port: this.address().port, path: '/busy/' + i });
+    http.get({ port: this.address().port, path: `/busy/${i}` });
   }
 });
 
 let exception_count = 0;
 
 process.on('uncaughtException', function(err) {
-  console.log('Caught an exception: ' + err);
+  console.log(`Caught an exception: ${err}`);
   if (err.name === 'AssertionError') throw err;
   if (++exception_count === 4) process.exit(0);
 });

--- a/test/parallel/test-http-expect-continue.js
+++ b/test/parallel/test-http-expect-continue.js
@@ -71,8 +71,8 @@ server.on('listening', function() {
   req.on('response', function(res) {
     assert.strictEqual(got_continue, true,
                        'Full response received before 100 Continue');
-    assert.strictEqual(200, res.statusCode, 'Final status code was ' +
-                       res.statusCode + ', not 200.');
+    assert.strictEqual(200, res.statusCode,
+                       `Final status code was ${res.statusCode}, not 200.`);
     res.setEncoding('utf8');
     res.on('data', function(chunk) { body += chunk; });
     res.on('end', function() {

--- a/test/parallel/test-http-expect-handling.js
+++ b/test/parallel/test-http-expect-handling.js
@@ -35,8 +35,8 @@ function nextTest() {
   }
 
   http.get(options, function(response) {
-    console.log('client: expected status: ' + test);
-    console.log('client: statusCode: ' + response.statusCode);
+    console.log(`client: expected status: ${test}`);
+    console.log(`client: statusCode: ${response.statusCode}`);
     assert.strictEqual(response.statusCode, test);
     assert.strictEqual(response.statusMessage, 'Expectation Failed');
 

--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -65,7 +65,7 @@ const server = net.createServer(function(socket) {
 server.listen(0, common.mustCall(function() {
   http.get({ port: this.address().port }, common.mustCall(function(res) {
     let buffer = '';
-    console.log('Got res code: ' + res.statusCode);
+    console.log(`Got res code: ${res.statusCode}`);
 
     res.setEncoding('utf8');
     res.on('data', function(chunk) {
@@ -73,7 +73,7 @@ server.listen(0, common.mustCall(function() {
     });
 
     res.on('end', common.mustCall(function() {
-      console.log('Response ended, read ' + buffer.length + ' bytes');
+      console.log(`Response ended, read ${buffer.length} bytes`);
       assert.strictEqual(body, buffer);
       server.close();
     }));

--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -43,7 +43,7 @@ function runAb(opts, callback) {
   exec(command, function(err, stdout, stderr) {
     if (err) {
       if (/ab|apr/mi.test(stderr)) {
-        common.skip('problem spawning `ab`.\n' + stderr);
+        common.skip(`problem spawning \`ab\`.\n${stderr}`);
         process.reallyExit(0);
       }
       process.exit();

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -32,9 +32,9 @@ http.globalAgent.maxSockets = 1;
 
 common.refreshTmpDir();
 
-const image = fs.readFileSync(common.fixturesDir + '/person.jpg');
+const image = fs.readFileSync(`${common.fixturesDir}/person.jpg`);
 
-console.log('image.length = ' + image.length);
+console.log(`image.length = ${image.length}`);
 
 const total = 10;
 let requests = 0;
@@ -67,12 +67,12 @@ server.listen(0, function() {
       };
 
       http.get(opts, function(res) {
-        console.error('recv ' + x);
-        const s = fs.createWriteStream(common.tmpDir + '/' + x + '.jpg');
+        console.error(`recv ${x}`);
+        const s = fs.createWriteStream(`${common.tmpDir}/${x}.jpg`);
         res.pipe(s);
 
         s.on('finish', function() {
-          console.error('done ' + x);
+          console.error(`done ${x}`);
           if (++responses === total) {
             checkFiles();
           }
@@ -93,12 +93,12 @@ function checkFiles() {
   assert(total <= files.length);
 
   for (let i = 0; i < total; i++) {
-    const fn = i + '.jpg';
-    assert.ok(files.includes(fn), "couldn't find '" + fn + "'");
-    const stat = fs.statSync(common.tmpDir + '/' + fn);
-    assert.strictEqual(image.length, stat.size,
-                       "size doesn't match on '" + fn +
-                 "'. Got " + stat.size + ' bytes');
+    const fn = `${i}.jpg`;
+    assert.ok(files.includes(fn), `couldn't find '${fn}'`);
+    const stat = fs.statSync(`${common.tmpDir}/${fn}`);
+    assert.strictEqual(
+      image.length, stat.size,
+      `size doesn't match on '${fn}'. Got ${stat.size} bytes`);
   }
 
   checkedFiles = true;

--- a/test/parallel/test-http-host-headers.js
+++ b/test/parallel/test-http-host-headers.js
@@ -29,9 +29,9 @@ function reqHandler(req, res) {
   if (req.url === '/setHostFalse5') {
     assert.strictEqual(req.headers.host, undefined);
   } else {
-    assert.strictEqual(req.headers.host, `localhost:${this.address().port}`,
-                       'Wrong host header for req[' + req.url + ']: ' +
-                 req.headers.host);
+    assert.strictEqual(
+      req.headers.host, `localhost:${this.address().port}`,
+      `Wrong host header for req[${req.url}]: ${req.headers.host}`);
   }
   res.writeHead(200, {});
   res.end('ok');
@@ -55,7 +55,7 @@ function testHttp() {
     assert.ifError(er);
     http.get({
       method: 'GET',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
@@ -63,7 +63,7 @@ function testHttp() {
 
     http.request({
       method: 'GET',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
@@ -71,7 +71,7 @@ function testHttp() {
 
     http.request({
       method: 'POST',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
@@ -79,7 +79,7 @@ function testHttp() {
 
     http.request({
       method: 'PUT',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false
@@ -87,7 +87,7 @@ function testHttp() {
 
     http.request({
       method: 'DELETE',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       port: httpServer.address().port,
       rejectUnauthorized: false

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -28,11 +28,9 @@ const checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
   '4+2',
   '3.14159265359'
 ].forEach(function(str) {
-  assert.strictEqual(checkIsHttpToken(str),
-                     true,
-                     'checkIsHttpToken(' +
-                       inspect(str) +
-                       ') unexpectedly failed');
+  assert.strictEqual(
+    checkIsHttpToken(str), true,
+    `checkIsHttpToken(${inspect(str)}) unexpectedly failed`);
 });
 // Bad header field names
 [
@@ -56,11 +54,9 @@ const checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
   '"Quote"',
   'This,That'
 ].forEach(function(str) {
-  assert.strictEqual(checkIsHttpToken(str),
-                     false,
-                     'checkIsHttpToken(' +
-                       inspect(str) +
-                       ') unexpectedly succeeded');
+  assert.strictEqual(
+    checkIsHttpToken(str), false,
+    `checkIsHttpToken(${inspect(str)}) unexpectedly succeeded`);
 });
 
 
@@ -71,11 +67,9 @@ const checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
   '0123456789ABCdef',
   '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`'
 ].forEach(function(str) {
-  assert.strictEqual(checkInvalidHeaderChar(str),
-                     false,
-                     'checkInvalidHeaderChar(' +
-                       inspect(str) +
-                       ') unexpectedly failed');
+  assert.strictEqual(
+    checkInvalidHeaderChar(str), false,
+    `checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed`);
 });
 
 // Bad header field values
@@ -89,9 +83,7 @@ const checkInvalidHeaderChar = require('_http_common')._checkInvalidHeaderChar;
   'foo\vbar',
   'Ding!\x07'
 ].forEach(function(str) {
-  assert.strictEqual(checkInvalidHeaderChar(str),
-                     true,
-                     'checkInvalidHeaderChar(' +
-                       inspect(str) +
-                       ') unexpectedly succeeded');
+  assert.strictEqual(
+    checkInvalidHeaderChar(str), true,
+    `checkInvalidHeaderChar(${inspect(str)}) unexpectedly succeeded`);
 });

--- a/test/parallel/test-http-keepalive-client.js
+++ b/test/parallel/test-http-keepalive-client.js
@@ -59,7 +59,7 @@ function makeRequest(n) {
   const req = http.request({
     port: server.address().port,
     agent: agent,
-    path: '/' + n
+    path: `/${n}`
   });
 
   req.end();
@@ -79,7 +79,7 @@ function makeRequest(n) {
       data += c;
     });
     res.on('end', function() {
-      assert.strictEqual(data, '/' + n);
+      assert.strictEqual(data, `/${n}`);
       setTimeout(function() {
         actualRequests++;
         makeRequest(n - 1);

--- a/test/parallel/test-http-keepalive-maxsockets.js
+++ b/test/parallel/test-http-keepalive-maxsockets.js
@@ -84,7 +84,7 @@ server.listen(0, function() {
   function makeReq(i, cb) {
     http.request({
       port: server.address().port,
-      path: '/' + i,
+      path: `/${i}`,
       agent: agent
     }, function(res) {
       let data = '';
@@ -93,7 +93,7 @@ server.listen(0, function() {
         data += c;
       });
       res.on('end', function() {
-        assert.strictEqual(data, '/' + i);
+        assert.strictEqual(data, `/${i}`);
         cb();
       });
     }).end();

--- a/test/parallel/test-http-keepalive-request.js
+++ b/test/parallel/test-http-keepalive-request.js
@@ -58,7 +58,7 @@ function makeRequest(n) {
 
   const req = http.request({
     port: server.address().port,
-    path: '/' + n,
+    path: `/${n}`,
     agent: agent
   });
 
@@ -79,7 +79,7 @@ function makeRequest(n) {
       data += c;
     });
     res.on('end', function() {
-      assert.strictEqual(data, '/' + n);
+      assert.strictEqual(data, `/${n}`);
       setTimeout(function() {
         actualRequests++;
         makeRequest(n - 1);

--- a/test/parallel/test-http-localaddress-bind-error.js
+++ b/test/parallel/test-http-localaddress-bind-error.js
@@ -27,11 +27,11 @@ const http = require('http');
 const invalidLocalAddress = '1.2.3.4';
 
 const server = http.createServer(function(req, res) {
-  console.log('Connect from: ' + req.connection.remoteAddress);
+  console.log(`Connect from: ${req.connection.remoteAddress}`);
 
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('You are from: ' + req.connection.remoteAddress);
+    res.end(`You are from: ${req.connection.remoteAddress}`);
   });
   req.resume();
 });
@@ -46,7 +46,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   }, function(res) {
     assert.fail('unexpectedly got response from server');
   }).on('error', common.mustCall(function(e) {
-    console.log('client got error: ' + e.message);
+    console.log(`client got error: ${e.message}`);
     server.close();
   })).end();
 }));

--- a/test/parallel/test-http-localaddress.js
+++ b/test/parallel/test-http-localaddress.js
@@ -30,12 +30,12 @@ if (!common.hasMultiLocalhost()) {
 }
 
 const server = http.createServer(function(req, res) {
-  console.log('Connect from: ' + req.connection.remoteAddress);
+  console.log(`Connect from: ${req.connection.remoteAddress}`);
   assert.strictEqual('127.0.0.2', req.connection.remoteAddress);
 
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('You are from: ' + req.connection.remoteAddress);
+    res.end(`You are from: ${req.connection.remoteAddress}`);
   });
   req.resume();
 });

--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -33,7 +33,7 @@ let nrequests_completed = 0;
 const nrequests_expected = 1;
 
 const server = http.createServer(function(req, res) {
-  console.log('req: ' + JSON.stringify(url.parse(req.url)));
+  console.log(`req: ${JSON.stringify(url.parse(req.url))}`);
 
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('Hello World');

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -30,7 +30,7 @@ let responses = 0;
 const headers = {};
 const N = 2000;
 for (let i = 0; i < N; ++i) {
-  headers['key' + i] = i;
+  headers[`key${i}`] = i;
 }
 
 const maxAndExpected = [ // for server

--- a/test/parallel/test-http-outgoing-finish.js
+++ b/test/parallel/test-http-outgoing-finish.js
@@ -60,7 +60,7 @@ function write(out) {
     finishEvent = true;
     console.error('%s finish event', name);
     process.nextTick(function() {
-      assert(endCb, name + ' got finish event before endcb!');
+      assert(endCb, `${name} got finish event before endcb!`);
       console.log('ok - %s finishEvent', name);
     });
   });
@@ -69,7 +69,7 @@ function write(out) {
     endCb = true;
     console.error('%s endCb', name);
     process.nextTick(function() {
-      assert(finishEvent, name + ' got endCb event before finishEvent!');
+      assert(finishEvent, `${name} got endCb event before finishEvent!`);
       console.log('ok - %s endCb', name);
     });
   });

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -82,7 +82,7 @@ function mustCall(f, times) {
 
 function expectBody(expected) {
   return mustCall(function(buf, start, len) {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, expected);
   });
 }
@@ -92,9 +92,7 @@ function expectBody(expected) {
 // Simple request test.
 //
 {
-  const request = Buffer.from(
-      'GET /hello HTTP/1.1' + CRLF +
-      CRLF);
+  const request = Buffer.from(`GET /hello HTTP/1.1${CRLF}${CRLF}`);
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -148,7 +146,7 @@ function expectBody(expected) {
   };
 
   const onBody = (buf, start, len) => {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, 'pong');
   };
 
@@ -164,8 +162,7 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'HTTP/1.0 200 Connection established' + CRLF +
-      CRLF);
+    `HTTP/1.0 200 Connection established${CRLF}${CRLF}`);
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -219,7 +216,7 @@ function expectBody(expected) {
   };
 
   const onBody = (buf, start, len) => {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, 'ping');
     seen_body = true;
   };
@@ -264,8 +261,7 @@ function expectBody(expected) {
 //
 {
   // 256 X-Filler headers
-  let lots_of_headers = 'X-Filler: 42' + CRLF;
-  lots_of_headers = lots_of_headers.repeat(256);
+  const lots_of_headers = `X-Filler: 42${CRLF}`.repeat(256);
 
   const request = Buffer.from(
       'GET /foo/bar/baz?quux=42#1337 HTTP/1.0' + CRLF +
@@ -316,7 +312,7 @@ function expectBody(expected) {
   };
 
   const onBody = (buf, start, len) => {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, 'foo=42&bar=1337');
   };
 
@@ -357,7 +353,7 @@ function expectBody(expected) {
   const body_parts = ['123', '123456', '1234567890'];
 
   const onBody = (buf, start, len) => {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, body_parts[body_part++]);
   };
 
@@ -396,7 +392,7 @@ function expectBody(expected) {
           ['123', '123456', '123456789', '123456789ABC', '123456789ABCDEF'];
 
   const onBody = (buf, start, len) => {
-    const body = '' + buf.slice(start, start + len);
+    const body = String(buf.slice(start, start + len));
     assert.strictEqual(body, body_parts[body_part++]);
   };
 
@@ -452,7 +448,7 @@ function expectBody(expected) {
     let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
     const onBody = (buf, start, len) => {
-      const chunk = '' + buf.slice(start, start + len);
+      const chunk = String(buf.slice(start, start + len));
       assert.strictEqual(expected_body.indexOf(chunk), 0);
       expected_body = expected_body.slice(chunk.length);
     };
@@ -468,11 +464,9 @@ function expectBody(expected) {
 
   for (let i = 1; i < request.length - 1; ++i) {
     const a = request.slice(0, i);
-    console.error('request.slice(0, ' + i + ') = ',
-                  JSON.stringify(a.toString()));
+    console.error(`request.slice(0, ${i}) = ${JSON.stringify(a.toString())}`);
     const b = request.slice(i);
-    console.error('request.slice(' + i + ') = ',
-                  JSON.stringify(b.toString()));
+    console.error(`request.slice(${i}) = ${JSON.stringify(b.toString())}`);
     test(a, b);
   }
 }
@@ -514,7 +508,7 @@ function expectBody(expected) {
   let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
 
   const onBody = (buf, start, len) => {
-    const chunk = '' + buf.slice(start, start + len);
+    const chunk = String(buf.slice(start, start + len));
     assert.strictEqual(expected_body.indexOf(chunk), 0);
     expected_body = expected_body.slice(chunk.length);
   };
@@ -590,9 +584,7 @@ function expectBody(expected) {
 // Test parser 'this' safety
 // https://github.com/joyent/node/issues/6690
 assert.throws(function() {
-  const request = Buffer.from(
-      'GET /hello HTTP/1.1' + CRLF +
-      CRLF);
+  const request = Buffer.from(`GET /hello HTTP/1.1${CRLF}${CRLF}`);
 
   const parser = newParser(REQUEST);
   const notparser = { execute: parser.execute };

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -49,7 +49,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
         }
       }, function(res) {
         res.on('end', function() {
-          console.error('res' + i + ' end');
+          console.error(`res${i} end`);
           if (i === 2) {
             server.close();
           }
@@ -57,7 +57,7 @@ const server = http.createServer(common.mustCall(function(req, res) {
         res.resume();
       });
       req.on('socket', function(s) {
-        console.error('req' + i + ' start');
+        console.error(`req${i} start`);
       });
       req.end('12345');
     }(i + 1));

--- a/test/parallel/test-http-proxy.js
+++ b/test/parallel/test-http-proxy.js
@@ -42,13 +42,13 @@ const backend = http.createServer(function(req, res) {
 });
 
 const proxy = http.createServer(function(req, res) {
-  console.error('proxy req headers: ' + JSON.stringify(req.headers));
+  console.error(`proxy req headers: ${JSON.stringify(req.headers)}`);
   http.get({
     port: backend.address().port,
     path: url.parse(req.url).pathname
   }, function(proxy_res) {
 
-    console.error('proxy res headers: ' + JSON.stringify(proxy_res.headers));
+    console.error(`proxy res headers: ${JSON.stringify(proxy_res.headers)}`);
 
     assert.strictEqual('world', proxy_res.headers['hello']);
     assert.strictEqual('text/plain', proxy_res.headers['content-type']);

--- a/test/parallel/test-http-request-methods.js
+++ b/test/parallel/test-http-request-methods.js
@@ -44,7 +44,7 @@ const http = require('http');
     c.setEncoding('utf8');
 
     c.on('connect', function() {
-      c.write(method + ' / HTTP/1.0\r\n\r\n');
+      c.write(`${method} / HTTP/1.0\r\n\r\n`);
     });
 
     c.on('data', function(chunk) {

--- a/test/parallel/test-http-response-no-headers.js
+++ b/test/parallel/test-http-response-no-headers.js
@@ -33,8 +33,7 @@ const expected = {
 
 function test(httpVersion, callback) {
   const server = net.createServer(function(conn) {
-    const reply = 'HTTP/' + httpVersion + ' 200 OK\r\n\r\n' +
-                  expected[httpVersion];
+    const reply = `HTTP/${httpVersion} 200 OK\r\n\r\n${expected[httpVersion]}`;
 
     conn.end(reply);
   });

--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -66,8 +66,8 @@ function runTest(testCaseIndex) {
     port: server.address().port,
     path: testCase.path
   }, function(response) {
-    console.log('client: expected status message: ' + testCase.statusMessage);
-    console.log('client: actual status message: ' + response.statusMessage);
+    console.log(`client: expected status message: ${testCase.statusMessage}`);
+    console.log(`client: actual status message: ${response.statusMessage}`);
     assert.strictEqual(testCase.statusMessage, response.statusMessage);
 
     response.on('end', function() {

--- a/test/parallel/test-http-server-multiheaders2.js
+++ b/test/parallel/test-http-server-multiheaders2.js
@@ -71,14 +71,13 @@ const multipleForbidden = [
 
 const srv = http.createServer(function(req, res) {
   multipleForbidden.forEach(function(header) {
-    assert.strictEqual(req.headers[header.toLowerCase()],
-                       'foo', 'header parsed incorrectly: ' + header);
+    assert.strictEqual(req.headers[header.toLowerCase()], 'foo',
+                       `header parsed incorrectly: ${header}`);
   });
   multipleAllowed.forEach(function(header) {
     const sep = (header.toLowerCase() === 'cookie' ? '; ' : ', ');
-    assert.strictEqual(req.headers[header.toLowerCase()],
-                       'foo' + sep + 'bar',
-                       'header parsed incorrectly: ' + header);
+    assert.strictEqual(req.headers[header.toLowerCase()], `foo${sep}bar`,
+                       `header parsed incorrectly: ${header}`);
   });
 
   res.writeHead(200, {'Content-Type': 'text/plain'});

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -51,10 +51,10 @@ const server = net.createServer(function(socket) {
 }).listen(0, function() {
   function makeRequest() {
     const req = http.get({port: server.address().port}, function(res) {
-      assert.strictEqual(req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
-                         SERVER_RESPONSES[responses] + ' should ' +
-                   (SHOULD_KEEP_ALIVE[responses] ? '' : 'not ') +
-                   'Keep-Alive');
+      assert.strictEqual(
+        req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
+        `${SERVER_RESPONSES[responses]} should ${
+        SHOULD_KEEP_ALIVE[responses] ? '' : 'not '}Keep-Alive`);
       ++responses;
       if (responses < SHOULD_KEEP_ALIVE.length) {
         makeRequest();

--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -34,7 +34,7 @@ let testIdx = 0;
 const s = http.createServer(function(req, res) {
   const t = tests[testIdx];
   res.writeHead(t, {'Content-Type': 'text/plain'});
-  console.log('--\nserver: statusCode after writeHead: ' + res.statusCode);
+  console.log(`--\nserver: statusCode after writeHead: ${res.statusCode}`);
   assert.strictEqual(res.statusCode, t);
   res.end('hello world\n');
 });
@@ -49,8 +49,8 @@ function nextTest() {
   const test = tests[testIdx];
 
   http.get({ port: s.address().port }, function(response) {
-    console.log('client: expected status: ' + test);
-    console.log('client: statusCode: ' + response.statusCode);
+    console.log(`client: expected status: ${test}`);
+    console.log(`client: statusCode: ${response.statusCode}`);
     assert.strictEqual(response.statusCode, test);
     response.on('end', function() {
       testsComplete++;

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -56,7 +56,7 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       'upgrade': 'websocket'
     }
   };
-  const name = options.host + ':' + options.port;
+  const name = `${options.host}:${options.port}`;
 
   const req = http.request(options);
   req.end();

--- a/test/parallel/test-http-url.parse-basic.js
+++ b/test/parallel/test-http-url.parse-basic.js
@@ -35,7 +35,7 @@ function check(request) {
   assert.strictEqual(request.url, '/');
   // the host header should use the url.parse.hostname
   assert.strictEqual(request.headers.host,
-                     testURL.hostname + ':' + testURL.port);
+                     `${testURL.hostname}:${testURL.port}`);
 }
 
 const server = http.createServer(function(request, response) {

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -34,8 +34,8 @@ const fs = require('fs');
 
 // https options
 const httpsOptions = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 function check(request) {

--- a/test/parallel/test-http-url.parse-post.js
+++ b/test/parallel/test-http-url.parse-post.js
@@ -34,7 +34,7 @@ function check(request) {
   assert.strictEqual(request.url, '/asdf?qwer=zxcv');
   //the host header should use the url.parse.hostname
   assert.strictEqual(request.headers.host,
-                     testURL.hostname + ':' + testURL.port);
+                     `${testURL.hostname}:${testURL.port}`);
 }
 
 const server = http.createServer(function(request, response) {

--- a/test/parallel/test-http-write-empty-string.js
+++ b/test/parallel/test-http-write-empty-string.js
@@ -26,7 +26,7 @@ const assert = require('assert');
 const http = require('http');
 
 const server = http.createServer(function(request, response) {
-  console.log('responding to ' + request.url);
+  console.log(`responding to ${request.url}`);
 
   response.writeHead(200, {'Content-Type': 'text/plain'});
   response.write('1\n');

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -54,7 +54,7 @@ const server = http.Server(common.mustCall(function(req, res) {
 
   req.on('end', function() {
     res.writeHead(200, {'Content-Type': 'text/plain'});
-    res.write('The path was ' + url.parse(req.url).pathname);
+    res.write(`The path was ${url.parse(req.url).pathname}`);
     res.end();
   });
   req.resume();

--- a/test/parallel/test-https-agent-create-connection.js
+++ b/test/parallel/test-https-agent-create-connection.js
@@ -14,8 +14,8 @@ const agent = new https.Agent();
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
 };
 
 const expectedHeader = /^HTTP\/1\.1 200 OK/;

--- a/test/parallel/test-https-agent-disable-session-reuse.js
+++ b/test/parallel/test-https-agent-disable-session-reuse.js
@@ -14,8 +14,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const clientSessions = [];

--- a/test/parallel/test-https-agent-secure-protocol.js
+++ b/test/parallel/test-https-agent-secure-protocol.js
@@ -11,9 +11,9 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  ca: fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
 };
 
 const server = https.Server(options, function(req, res) {

--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -10,9 +10,9 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-  ca:  fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  ca:  fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
 };
 
 

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -13,8 +13,8 @@ const fs = require('fs');
 const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
   secureOptions: SSL_OP_NO_TICKET
 };
 

--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -13,11 +13,11 @@ const crypto = require('crypto');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
-const ca = fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem');
+const ca = fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`);
 
 const clientSessions = {};
 let serverRequests = 0;

--- a/test/parallel/test-https-agent-sni.js
+++ b/test/parallel/test-https-agent-sni.js
@@ -11,8 +11,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const TOTAL = 4;
@@ -31,7 +31,7 @@ server.listen(0, function() {
   function expectResponse(id) {
     return common.mustCall(function(res) {
       res.resume();
-      assert.strictEqual(res.headers['x-sni'], 'sni.' + id);
+      assert.strictEqual(res.headers['x-sni'], `sni.${id}`);
     });
   }
 
@@ -45,7 +45,7 @@ server.listen(0, function() {
       path: '/',
       port: this.address().port,
       host: '127.0.0.1',
-      servername: 'sni.' + j,
+      servername: `sni.${j}`,
       rejectUnauthorized: false
     }, expectResponse(j));
   }

--- a/test/parallel/test-https-agent-sockets-leak.js
+++ b/test/parallel/test-https-agent-sockets-leak.js
@@ -11,9 +11,9 @@ const https = require('https');
 const assert = require('assert');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  ca: fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
 };
 
 const server = https.Server(options, common.mustCall((req, res) => {

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -32,8 +32,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 

--- a/test/parallel/test-https-byteswritten.js
+++ b/test/parallel/test-https-byteswritten.js
@@ -31,8 +31,8 @@ if (!common.hasCrypto) {
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const body = 'hello world\n';

--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -37,8 +37,8 @@ const url = require('url');
 const URL = url.URL;
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = https.createServer(options, common.mustCall(function(req, res) {

--- a/test/parallel/test-https-client-resume.js
+++ b/test/parallel/test-https-client-resume.js
@@ -36,8 +36,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 // create server

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -9,8 +9,8 @@ if (!common.hasCrypto) {
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const connections = {};
@@ -23,7 +23,7 @@ const server = https.createServer(options, function(req, res) {
 });
 
 server.on('connection', function(connection) {
-  const key = connection.remoteAddress + ':' + connection.remotePort;
+  const key = `${connection.remoteAddress}:${connection.remotePort}`;
   connection.on('close', function() {
     delete connections[key];
   });

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -64,7 +64,7 @@ server.listen(0, function() {
         return process.nextTick(send);
       }
       sent += bufSize;
-      console.error('sent: ' + sent);
+      console.error(`sent: ${sent}`);
       resumed = true;
       res.resume();
       console.error('resumed');
@@ -81,7 +81,7 @@ server.listen(0, function() {
       }
       received += data.length;
       if (received >= sent) {
-        console.error('received: ' + received);
+        console.error(`received: ${received}`);
         req.end();
         server.close();
       }

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -41,8 +41,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -40,8 +40,8 @@ if (!common.hasCrypto) {
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/agent.key'),
-  cert: fs.readFileSync(common.fixturesDir + '/agent.crt'),
+  key: fs.readFileSync(`${common.fixturesDir}/agent.key`),
+  cert: fs.readFileSync(`${common.fixturesDir}/agent.crt`),
   requestCert: true,
   rejectUnauthorized: false
 };

--- a/test/parallel/test-https-host-headers.js
+++ b/test/parallel/test-https-host-headers.js
@@ -10,19 +10,19 @@ const https = require('https');
 
 const fs = require('fs');
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 const httpsServer = https.createServer(options, reqHandler);
 
 function reqHandler(req, res) {
-  console.log('Got request: ' + req.headers.host + ' ' + req.url);
+  console.log(`Got request: ${req.headers.host} ${req.url}`);
   if (req.url === '/setHostFalse5') {
     assert.strictEqual(req.headers.host, undefined);
   } else {
-    assert.strictEqual(req.headers.host, `localhost:${this.address().port}`,
-                       'Wrong host header for req[' + req.url + ']: ' +
-                 req.headers.host);
+    assert.strictEqual(
+      req.headers.host, `localhost:${this.address().port}`,
+      `Wrong host header for req[${req.url}]: ${req.headers.host}`);
   }
   res.writeHead(200, {});
   //process.nextTick(function() { res.end('ok'); });
@@ -41,7 +41,7 @@ function testHttps() {
 
   function cb(res) {
     counter--;
-    console.log('back from https request. counter = ' + counter);
+    console.log(`back from https request. counter = ${counter}`);
     if (counter === 0) {
       httpsServer.close();
       console.log('ok');
@@ -54,7 +54,7 @@ function testHttps() {
     assert.ifError(er);
     https.get({
       method: 'GET',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       //agent: false,
       port: this.address().port,
@@ -63,7 +63,7 @@ function testHttps() {
 
     https.request({
       method: 'GET',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       //agent: false,
       port: this.address().port,
@@ -72,7 +72,7 @@ function testHttps() {
 
     https.request({
       method: 'POST',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       //agent: false,
       port: this.address().port,
@@ -81,7 +81,7 @@ function testHttps() {
 
     https.request({
       method: 'PUT',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       //agent: false,
       port: this.address().port,
@@ -90,7 +90,7 @@ function testHttps() {
 
     https.request({
       method: 'DELETE',
-      path: '/' + (counter++),
+      path: `/${counter++}`,
       host: 'localhost',
       //agent: false,
       port: this.address().port,
@@ -99,7 +99,7 @@ function testHttps() {
 
     https.get({
       method: 'GET',
-      path: '/setHostFalse' + (counter++),
+      path: `/setHostFalse${counter++}`,
       host: 'localhost',
       setHost: false,
       port: this.address().port,

--- a/test/parallel/test-https-localaddress-bind-error.js
+++ b/test/parallel/test-https-localaddress-bind-error.js
@@ -31,18 +31,18 @@ if (!common.hasCrypto) {
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const invalidLocalAddress = '1.2.3.4';
 
 const server = https.createServer(options, function(req, res) {
-  console.log('Connect from: ' + req.connection.remoteAddress);
+  console.log(`Connect from: ${req.connection.remoteAddress}`);
 
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('You are from: ' + req.connection.remoteAddress);
+    res.end(`You are from: ${req.connection.remoteAddress}`);
   });
   req.resume();
 });
@@ -57,7 +57,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   }, function(res) {
     assert.fail('unexpectedly got response from server');
   }).on('error', common.mustCall(function(e) {
-    console.log('client got error: ' + e.message);
+    console.log(`client got error: ${e.message}`);
     server.close();
   })).end();
 }));

--- a/test/parallel/test-https-localaddress.js
+++ b/test/parallel/test-https-localaddress.js
@@ -36,17 +36,17 @@ if (!common.hasMultiLocalhost()) {
 }
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = https.createServer(options, function(req, res) {
-  console.log('Connect from: ' + req.connection.remoteAddress);
+  console.log(`Connect from: ${req.connection.remoteAddress}`);
   assert.strictEqual('127.0.0.2', req.connection.remoteAddress);
 
   req.on('end', function() {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
-    res.end('You are from: ' + req.connection.remoteAddress);
+    res.end(`You are from: ${req.connection.remoteAddress}`);
   });
   req.resume();
 });

--- a/test/parallel/test-https-pfx.js
+++ b/test/parallel/test-https-pfx.js
@@ -30,7 +30,7 @@ if (!common.hasCrypto) {
 }
 const https = require('https');
 
-const pfx = fs.readFileSync(common.fixturesDir + '/test_cert.pfx');
+const pfx = fs.readFileSync(`${common.fixturesDir}/test_cert.pfx`);
 
 const options = {
   host: '127.0.0.1',

--- a/test/parallel/test-https-req-split.js
+++ b/test/parallel/test-https-req-split.js
@@ -34,8 +34,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 // Force splitting incoming data
@@ -44,7 +44,7 @@ tls.SLAB_BUFFER_SIZE = 1;
 const server = https.createServer(options);
 server.on('upgrade', common.mustCall(function(req, socket, upgrade) {
   socket.on('data', function(data) {
-    throw new Error('Unexpected data: ' + data);
+    throw new Error(`Unexpected data: ${data}`);
   });
   socket.end('HTTP/1.1 200 Ok\r\n\r\n');
 }));

--- a/test/parallel/test-https-resume-after-renew.js
+++ b/test/parallel/test-https-resume-after-renew.js
@@ -10,9 +10,9 @@ const https = require('https');
 const crypto = require('crypto');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-  ca: fs.readFileSync(common.fixturesDir + '/keys/ca1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  ca: fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
 };
 
 const server = https.createServer(options, function(req, res) {

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -32,8 +32,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const tests = 2;

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -33,8 +33,8 @@ const fs = require('fs');
 const http = require('http');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const body = 'hello world\n';

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -149,7 +149,7 @@ function makeReq(path, port, error, host, ca) {
       port === server2.address().port ? server2 :
       port === server3.address().port ? server3 :
       null;
-  if (!server) throw new Error('invalid port: ' + port);
+  if (!server) throw new Error(`invalid port: ${port}`);
   server.expectCount++;
 
   req.on('response', common.mustCall((res) => {

--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -34,8 +34,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = https.createServer(options, common.mustNotCall());

--- a/test/parallel/test-https-timeout-server.js
+++ b/test/parallel/test-https-timeout-server.js
@@ -33,8 +33,8 @@ const net = require('net');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
   handshakeTimeout: 50
 };
 

--- a/test/parallel/test-https-timeout.js
+++ b/test/parallel/test-https-timeout.js
@@ -31,8 +31,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 // a server that never replies

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -32,8 +32,8 @@ const https = require('https');
 
 const fs = require('fs');
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
 
 // number of bytes discovered empirically to trigger the bug
 const data = Buffer.alloc(1024 * 32 + 1);

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -49,16 +49,14 @@ assert.strictEqual('ç'.toUpperCase(), 'Ç');
 
 if (!common.hasIntl) {
   const erMsg =
-      '"Intl" object is NOT present but v8_enable_i18n_support is ' +
-      enablei18n;
+    `"Intl" object is NOT present but v8_enable_i18n_support is ${enablei18n}`;
   assert.strictEqual(enablei18n, 0, erMsg);
   common.skip('Intl tests because Intl object not present.');
 
 } else {
   const erMsg =
-    '"Intl" object is present but v8_enable_i18n_support is ' +
-    enablei18n +
-    '. Is this test out of date?';
+    `"Intl" object is present but v8_enable_i18n_support is ${
+    enablei18n}. Is this test out of date?`;
   assert.strictEqual(enablei18n, 1, erMsg);
 
   // Construct a new date at the beginning of Unix time
@@ -77,7 +75,7 @@ if (!common.hasIntl) {
     common.skip('detailed Intl tests because English is not ' +
                 'listed as supported.');
     // Smoke test. Does it format anything, or fail?
-    console.log('Date(0) formatted to: ' + dtf.format(date0));
+    console.log(`Date(0) formatted to: ${dtf.format(date0)}`);
     return;
   }
 

--- a/test/parallel/test-module-globalpaths-nodepath.js
+++ b/test/parallel/test-module-globalpaths-nodepath.js
@@ -30,11 +30,11 @@ const partC = '';
 if (common.isWindows) {
   partA = 'C:\\Users\\Rocko Artischocko\\AppData\\Roaming\\npm';
   partB = 'C:\\Program Files (x86)\\nodejs\\';
-  process.env['NODE_PATH'] = partA + ';' + partB + ';' + partC;
+  process.env['NODE_PATH'] = `${partA};${partB};${partC}`;
 } else {
   partA = '/usr/test/lib/node_modules';
   partB = '/usr/test/lib/node';
-  process.env['NODE_PATH'] = partA + ':' + partB + ':' + partC;
+  process.env['NODE_PATH'] = `${partA}:${partB}:${partC}`;
 }
 
 mod._initPaths();

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -51,7 +51,7 @@ if (process.argv[2] === 'child') {
         child_process.execFileSync(testExecPath, [ __filename, 'child' ],
                                    { encoding: 'utf8', env: env });
       },
-      new RegExp('Cannot find module \'' + pkgName + '\''));
+      new RegExp(`Cannot find module '${pkgName}'`));
 
   // Test module in $HOME/.node_modules.
   const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');
@@ -75,8 +75,8 @@ if (process.argv[2] === 'child') {
   fs.mkdirSync(prefixLibPath);
   const prefixLibNodePath = path.join(prefixLibPath, 'node');
   fs.mkdirSync(prefixLibNodePath);
-  const pkgPath = path.join(prefixLibNodePath, pkgName + '.js');
-  fs.writeFileSync(pkgPath, 'exports.string = \'' + expectedString + '\';');
+  const pkgPath = path.join(prefixLibNodePath, `${pkgName}.js`);
+  fs.writeFileSync(pkgPath, `exports.string = '${expectedString}';`);
 
   env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
   runTest(expectedString, env);

--- a/test/parallel/test-module-nodemodulepaths.js
+++ b/test/parallel/test-module-nodemodulepaths.js
@@ -121,6 +121,7 @@ node-gyp/node_modules/glob/node_modules',
 const platformCases = common.isWindows ? cases.WIN : cases.POSIX;
 platformCases.forEach((c) => {
   const paths = _module._nodeModulePaths(c.file);
-  assert.deepStrictEqual(c.expect, paths, 'case ' + c.file +
-    ' failed, actual paths is ' + JSON.stringify(paths));
+  assert.deepStrictEqual(
+    c.expect, paths,
+    `case ${c.file} failed, actual paths is ${JSON.stringify(paths)}`);
 });

--- a/test/parallel/test-module-require-depth.js
+++ b/test/parallel/test-module-require-depth.js
@@ -6,8 +6,8 @@ const internalModule = require('internal/module');
 
 // Module one loads two too so the expected depth for two is, well, two.
 assert.strictEqual(internalModule.requireDepth, 0);
-const one = require(common.fixturesDir + '/module-require-depth/one');
-const two = require(common.fixturesDir + '/module-require-depth/two');
+const one = require(`${common.fixturesDir}/module-require-depth/one`);
+const two = require(`${common.fixturesDir}/module-require-depth/two`);
 assert.deepStrictEqual(one, { requireDepth: 1 });
 assert.deepStrictEqual(two, { requireDepth: 2 });
 assert.strictEqual(internalModule.requireDepth, 0);

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -9,5 +9,5 @@ c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ENOENT');
-  assert.strictEqual(e.message, 'connect ENOENT ' + fp);
+  assert.strictEqual(e.message, `connect ENOENT ${fp}`);
 }));

--- a/test/parallel/test-net-bytes-stats.js
+++ b/test/parallel/test-net-bytes-stats.js
@@ -36,7 +36,7 @@ const tcp = net.Server(function(s) {
 
   s.on('end', function() {
     bytesRead += s.bytesRead;
-    console.log('tcp socket disconnect #' + count);
+    console.log(`tcp socket disconnect #${count}`);
   });
 });
 
@@ -61,8 +61,8 @@ tcp.listen(0, function doTest() {
 
   socket.on('close', function() {
     console.error('CLIENT close event #%d', count);
-    console.log('Bytes read: ' + bytesRead);
-    console.log('Bytes written: ' + bytesWritten);
+    console.log(`Bytes read: ${bytesRead}`);
+    console.log(`Bytes written: ${bytesWritten}`);
     if (count < 2) {
       console.error('RECONNECTING');
       socket.connect(tcp.address().port);

--- a/test/parallel/test-net-connect-buffer.js
+++ b/test/parallel/test-net-connect-buffer.js
@@ -45,7 +45,7 @@ const tcp = net.Server(function(s) {
   });
 
   s.on('error', function(e) {
-    console.log('tcp server-side error: ' + e.message);
+    console.log(`tcp server-side error: ${e.message}`);
     process.exit(1);
   });
 });
@@ -60,7 +60,7 @@ tcp.listen(0, function() {
     connectHappened = true;
   });
 
-  console.log('connecting = ' + socket.connecting);
+  console.log(`connecting = ${socket.connecting}`);
 
   assert.strictEqual('opening', socket.readyState);
 

--- a/test/parallel/test-net-connect-options-allowhalfopen.js
+++ b/test/parallel/test-net-connect-options-allowhalfopen.js
@@ -105,7 +105,7 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
           console.error(`No. ${index} client received FIN`);
           assert(!client.readable);
           assert(client.writable);
-          assert(client.write(index + ''));
+          assert(client.write(String(index)));
           client.end();
           clientSentFIN++;
           console.error(`No. ${index} client sent FIN, ` +

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -69,13 +69,13 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
   })
   .on('error', function(err) {
     console.error(err);
-    assert.fail(null, null, '[Pipe server]' + err);
+    assert.fail(null, null, `[Pipe server]${err}`);
   })
   .listen({path: serverPath}, common.mustCall(function serverOnListen() {
     const getSocketOpt = (index) => {
       const handle = new Pipe();
       const err = handle.bind(`${prefix}-client-${socketCounter++}`);
-      assert(err >= 0, '' + err);
+      assert(err >= 0, String(err));
       assert.notStrictEqual(handle.fd, -1);
       handleMap.set(index, handle);
       console.error(`[Pipe]Bound handle with Pipe ${handle.fd}`);
@@ -90,11 +90,11 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
       assert(handleMap.has(index));
       const oldHandle = handleMap.get(index);
       assert.strictEqual(oldHandle.fd, this._handle.fd);
-      client.write(oldHandle.fd + '');
+      client.write(String(oldHandle.fd));
       console.error(`[Pipe]Sending data through fd ${oldHandle.fd}`);
       client.on('error', function(err) {
         console.error(err);
-        assert.fail(null, null, '[Pipe Client]' + err);
+        assert.fail(null, null, `[Pipe Client]${err}`);
       });
     });
 

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -88,8 +88,8 @@ const net = require('net');
 
     // Total connections = 3 * 4(canConnect) * 6(doConnect) = 72
     canConnect(port);
-    canConnect(port + '');
-    canConnect('0x' + port.toString(16));
+    canConnect(String(port));
+    canConnect(`0x${port.toString(16)}`);
   }));
 
   // Try connecting to random ports, but do so once the server is closed
@@ -191,7 +191,7 @@ function canConnect(port) {
 function asyncFailToConnect(port) {
   const onError = () => common.mustCall(function(err) {
     const regexp = /^Error: connect (E\w+)(.+)$/;
-    assert(regexp.test(err + ''), err + '');
+    assert(regexp.test(String(err)), String(err));
   });
 
   const dont = () => common.mustNotCall();

--- a/test/parallel/test-net-internal.js
+++ b/test/parallel/test-net-internal.js
@@ -8,7 +8,7 @@ const isLegalPort = require('internal/net').isLegalPort;
 
 for (let n = 0; n <= 0xFFFF; n++) {
   assert(isLegalPort(n));
-  assert(isLegalPort('' + n));
+  assert(isLegalPort(String(n)));
   assert(`0x${n.toString(16)}`);
   assert(`0o${n.toString(8)}`);
   assert(`0b${n.toString(2)}`);

--- a/test/parallel/test-net-listen-shared-ports.js
+++ b/test/parallel/test-net-listen-shared-ports.js
@@ -44,12 +44,12 @@ if (cluster.isMaster) {
 
   server1.on('error', function(err) {
     // no errors expected
-    process.send('server1:' + err.code);
+    process.send(`server1:${err.code}`);
   });
 
   server2.on('error', function(err) {
     // an error is expected on the second worker
-    process.send('server2:' + err.code);
+    process.send(`server2:${err.code}`);
   });
 
   server1.listen({

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -41,7 +41,7 @@ if (common.isWindows) {
   // on CI for a POSIX socket. Even though this isn't actually a socket file,
   // the error will be different from the one we are expecting if we exceed the
   // limit.
-  emptyTxt = common.tmpDir + '0.txt';
+  emptyTxt = `${common.tmpDir}0.txt`;
 
   function cleanup() {
     try {

--- a/test/parallel/test-net-reconnect-error.js
+++ b/test/parallel/test-net-reconnect-error.js
@@ -33,7 +33,7 @@ const c = net.createConnection(common.PORT);
 c.on('connect', common.mustNotCall('client should not have connected'));
 
 c.on('error', function(e) {
-  console.error('CLIENT error: ' + e.code);
+  console.error(`CLIENT error: ${e.code}`);
   client_error_count++;
   assert.strictEqual('ECONNREFUSED', e.code);
 });

--- a/test/parallel/test-net-reconnect.js
+++ b/test/parallel/test-net-reconnect.js
@@ -43,7 +43,7 @@ const server = net.createServer(function(socket) {
   });
 
   socket.on('close', function(had_error) {
-    console.log('SERVER had_error: ' + JSON.stringify(had_error));
+    console.log(`SERVER had_error: ${JSON.stringify(had_error)}`);
     assert.strictEqual(false, had_error);
   });
 });
@@ -60,7 +60,7 @@ server.listen(0, function() {
 
   client.on('data', function(chunk) {
     client_recv_count += 1;
-    console.log('client_recv_count ' + client_recv_count);
+    console.log(`client_recv_count ${client_recv_count}`);
     assert.strictEqual('hello\r\n', chunk);
     console.error('CLIENT: calling end', client._writableState);
     client.end();

--- a/test/parallel/test-net-server-bind.js
+++ b/test/parallel/test-net-server-bind.js
@@ -75,9 +75,9 @@ process.on('exit', function() {
   let expectedConnectionKey1;
 
   if (address1.family === 'IPv6')
-    expectedConnectionKey1 = '6::::' + address1.port;
+    expectedConnectionKey1 = `6::::${address1.port}`;
   else
-    expectedConnectionKey1 = '4:0.0.0.0:' + address1.port;
+    expectedConnectionKey1 = `4:0.0.0.0:${address1.port}`;
 
   assert.strictEqual(connectionKey1, expectedConnectionKey1);
   assert.strictEqual(common.PORT + 1, address2.port);

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -30,7 +30,7 @@ let counter = 0;
 
 // Avoid conflict with listen-path
 function randomPipePath() {
-  return common.PIPE + '-listen-handle-' + (counter++);
+  return `${common.PIPE}-listen-handle-${counter++}`;
 }
 
 function randomHandle(type) {
@@ -146,7 +146,7 @@ if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
   net.createServer()
     .listen({fd: fd}, common.mustNotCall())
     .on('error', common.mustCall(function(err) {
-      assert.strictEqual(err + '', 'Error: listen EINVAL');
+      assert.strictEqual(String(err), 'Error: listen EINVAL');
       this.close();
     }));
 }

--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -15,7 +15,7 @@ let counter = 0;
 
 // Avoid conflict with listen-handle
 function randomPipePath() {
-  return common.PIPE + '-listen-path-' + (counter++);
+  return `${common.PIPE}-listen-path-${counter++}`;
 }
 
 // Test listen(path)

--- a/test/parallel/test-net-server-max-connections-close-makes-more-available.js
+++ b/test/parallel/test-net-server-max-connections-close-makes-more-available.js
@@ -18,12 +18,12 @@ const received = [];
 const sent = [];
 
 function createConnection(index) {
-  console.error('creating connection ' + index);
+  console.error(`creating connection ${index}`);
 
   return new Promise(function(resolve, reject) {
     const connection = net.createConnection(server.address().port, function() {
-      const msg = '' + index;
-      console.error('sending message: ' + msg);
+      const msg = String(index);
+      console.error(`sending message: ${msg}`);
       this.write(msg);
       sent.push(msg);
     });
@@ -34,12 +34,12 @@ function createConnection(index) {
     });
 
     connection.on('data', function(e) {
-      console.error('connection ' + index + ' received response');
+      console.error(`connection ${index} received response`);
       resolve();
     });
 
     connection.on('end', function() {
-      console.error('ending ' + index);
+      console.error(`ending ${index}`);
       resolve();
     });
 
@@ -48,7 +48,7 @@ function createConnection(index) {
 }
 
 function closeConnection(index) {
-  console.error('closing connection ' + index);
+  console.error(`closing connection ${index}`);
   return new Promise(function(resolve, reject) {
     connections[index].on('end', function() {
       resolve();
@@ -59,8 +59,8 @@ function closeConnection(index) {
 
 const server = net.createServer(function(socket) {
   socket.on('data', function(data) {
-    console.error('received message: ' + data);
-    received.push('' + data);
+    console.error(`received message: ${data}`);
+    received.push(String(data));
     socket.write('acknowledged');
   });
 });

--- a/test/parallel/test-next-tick-ordering.js
+++ b/test/parallel/test-next-tick-ordering.js
@@ -29,7 +29,7 @@ const done = [];
 
 function get_printer(timeout) {
   return function() {
-    console.log('Running from setTimeout ' + timeout);
+    console.log(`Running from setTimeout ${timeout}`);
     done.push(timeout);
   };
 }

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -33,7 +33,7 @@ const args = [
 
 const pkgContent = JSON.stringify({
   dependencies: {
-    'package-name': common.fixturesDir + '/packages/main'
+    'package-name': `${common.fixturesDir}/packages/main`
   }
 });
 
@@ -56,7 +56,7 @@ function handleExit(code, signalCode) {
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
   assert.doesNotThrow(function() {
-    fs.accessSync(installDir + '/node_modules/package-name');
+    fs.accessSync(`${installDir}/node_modules/package-name`);
   });
 }
 

--- a/test/parallel/test-openssl-ca-options.js
+++ b/test/parallel/test-openssl-ca-options.js
@@ -15,9 +15,9 @@ const result = childProcess.spawnSync(process.execPath, [
                                       '-p', 'process.version'],
                                       {encoding: 'utf8'});
 
-assert.strictEqual(result.stderr,
-                   process.execPath + ': either --use-openssl-ca or ' +
-                   '--use-bundled-ca can be used, not both' + os.EOL);
+assert.strictEqual(result.stderr, `${process.execPath
+  }: either --use-openssl-ca or --use-bundled-ca can be used, not both${os.EOL}`
+);
 assert.strictEqual(result.status, 9);
 
 const useBundledCA = childProcess.spawnSync(process.execPath, [

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -43,7 +43,7 @@ if (common.isWindows) {
   process.env.TEMP = '';
   assert.strictEqual(os.tmpdir(), '/tmp');
   process.env.TMP = '';
-  const expected = (process.env.SystemRoot || process.env.windir) + '\\temp';
+  const expected = `${process.env.SystemRoot || process.env.windir}\\temp`;
   assert.strictEqual(os.tmpdir(), expected);
   process.env.TEMP = '\\temp\\';
   assert.strictEqual(os.tmpdir(), '\\temp');

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -28,9 +28,9 @@ if (common.isWindows) {
   const file = path.join(common.fixturesDir, 'a.js');
   const resolvedFile = path.resolve(file);
 
-  assert.strictEqual('\\\\?\\' + resolvedFile, path._makeLong(file));
-  assert.strictEqual('\\\\?\\' + resolvedFile, path._makeLong('\\\\?\\' +
-                     file));
+  assert.strictEqual(`\\\\?\\${resolvedFile}`, path._makeLong(file));
+  assert.strictEqual(`\\\\?\\${resolvedFile}`,
+                     path._makeLong(`\\\\?\\${file}`));
   assert.strictEqual('\\\\?\\UNC\\someserver\\someshare\\somefile',
                      path._makeLong('\\\\someserver\\someshare\\somefile'));
   assert.strictEqual('\\\\?\\UNC\\someserver\\someshare\\somefile', path

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -157,12 +157,8 @@ trailingTests.forEach(function(test) {
   test[1].forEach(function(test) {
     const actual = parse(test[0]);
     const expected = test[1];
-    const fn = `path.${os}.parse(`;
-    const message = fn +
-                    JSON.stringify(test[0]) +
-                    ')' +
-                    '\n  expect=' + JSON.stringify(expected) +
-                    '\n  actual=' + JSON.stringify(actual);
+    const message = `path.${os}.parse(${JSON.stringify(test[0])})\n  expect=${
+      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
     const actualKeys = Object.keys(actual);
     const expectedKeys = Object.keys(expected);
     let failed = (actualKeys.length !== expectedKeys.length);
@@ -176,7 +172,7 @@ trailingTests.forEach(function(test) {
       }
     }
     if (failed)
-      failures.push('\n' + message);
+      failures.push(`\n${message}`);
   });
 });
 assert.strictEqual(failures.length, 0, failures.join(''));

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -195,12 +195,10 @@ assert.strictEqual(path.win32.dirname('foo'), '.');
     }
     const actual = extname(input);
     const expected = test[1];
-    const fn = `path.${os}.extname(`;
-    const message = fn + JSON.stringify(input) + ')' +
-                    '\n  expect=' + JSON.stringify(expected) +
-                    '\n  actual=' + JSON.stringify(actual);
+    const message = `path.${os}.extname(${JSON.stringify(input)})\n  expect=${
+      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
     if (actual !== expected)
-      failures.push('\n' + message);
+      failures.push(`\n${message}`);
   });
 });
 assert.strictEqual(failures.length, 0, failures.join(''));
@@ -352,10 +350,9 @@ joinTests.forEach((test) => {
       } else {
         os = 'posix';
       }
-      const fn = `path.${os}.join(`;
-      const message = fn + test[0].map(JSON.stringify).join(',') + ')' +
-                      '\n  expect=' + JSON.stringify(expected) +
-                      '\n  actual=' + JSON.stringify(actual);
+      const message =
+        `path.${os}.join(${test[0].map(JSON.stringify).join(',')})\n  expect=${
+          JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
       if (actual !== expected && actualAlt !== expected)
         failures.push(`\n${message}`);
     });
@@ -459,12 +456,11 @@ resolveTests.forEach((test) => {
       actualAlt = actual.replace(/\//g, '\\');
 
     const expected = test[1];
-    const fn = `path.${os}.resolve(`;
-    const message = fn + test[0].map(JSON.stringify).join(',') + ')' +
-                    '\n  expect=' + JSON.stringify(expected) +
-                    '\n  actual=' + JSON.stringify(actual);
+    const message =
+      `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})\n  expect=${
+      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
     if (actual !== expected && actualAlt !== expected)
-      failures.push('\n' + message);
+      failures.push(`\n${message}`);
   });
 });
 assert.strictEqual(failures.length, 0, failures.join(''));
@@ -560,12 +556,9 @@ relativeTests.forEach((test) => {
     const actual = relative(test[0], test[1]);
     const expected = test[2];
     const os = relative === path.win32.relative ? 'win32' : 'posix';
-    const fn = `path.${os}.relative(`;
-    const message = fn +
-                    test.slice(0, 2).map(JSON.stringify).join(',') +
-                    ')' +
-                    '\n  expect=' + JSON.stringify(expected) +
-                    '\n  actual=' + JSON.stringify(actual);
+    const message = `path.${os}.relative(${
+      test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
+      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
     if (actual !== expected)
       failures.push(`\n${message}`);
   });

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -16,7 +16,7 @@ const nodeBinary = process.argv[0];
 const preloadOption = (preloads) => {
   let option = '';
   preloads.forEach(function(preload, index) {
-    option += '-r ' + preload + ' ';
+    option += `-r ${preload} `;
   });
   return option;
 };
@@ -30,7 +30,7 @@ const fixtureD = fixture('define-global.js');
 const fixtureThrows = fixture('throws_error4.js');
 
 // test preloading a single module works
-childProcess.exec(nodeBinary + ' ' + preloadOption([fixtureA]) + ' ' + fixtureB,
+childProcess.exec(`${nodeBinary} ${preloadOption([fixtureA])} ${fixtureB}`,
                   function(err, stdout, stderr) {
                     assert.ifError(err);
                     assert.strictEqual(stdout, 'A\nB\n');
@@ -38,7 +38,7 @@ childProcess.exec(nodeBinary + ' ' + preloadOption([fixtureA]) + ' ' + fixtureB,
 
 // test preloading multiple modules works
 childProcess.exec(
-  nodeBinary + ' ' + preloadOption([fixtureA, fixtureB]) + ' ' + fixtureC,
+  `${nodeBinary} ${preloadOption([fixtureA, fixtureB])} ${fixtureC}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\nC\n');
@@ -47,7 +47,7 @@ childProcess.exec(
 
 // test that preloading a throwing module aborts
 childProcess.exec(
-  nodeBinary + ' ' + preloadOption([fixtureA, fixtureThrows]) + ' ' + fixtureB,
+  `${nodeBinary} ${preloadOption([fixtureA, fixtureThrows])} ${fixtureB}`,
   function(err, stdout, stderr) {
     if (err) {
       assert.strictEqual(stdout, 'A\n');
@@ -59,7 +59,7 @@ childProcess.exec(
 
 // test that preload can be used with --eval
 childProcess.exec(
-  nodeBinary + ' ' + preloadOption([fixtureA]) + '-e "console.log(\'hello\');"',
+  `${nodeBinary} ${preloadOption([fixtureA])}-e "console.log('hello');"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nhello\n');
@@ -105,8 +105,8 @@ replProc.on('close', function(code) {
 // test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
 childProcess.exec(
-  nodeBinary + ' ' + preloadOption([fixtureA]) +
-    '-e "console.log(\'hello\');" ' + preloadOption([fixtureA, fixtureB]),
+  `${nodeBinary} ${preloadOption([fixtureA])}-e "console.log('hello');" ${
+  preloadOption([fixtureA, fixtureB])}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\nhello\n');
@@ -115,7 +115,7 @@ childProcess.exec(
 
 // test that preload works with -i
 const interactive = childProcess.exec(
-  nodeBinary + ' ' + preloadOption([fixtureD]) + '-i',
+  `${nodeBinary} ${preloadOption([fixtureD])}-i`,
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, "> 'test'\n> ");
@@ -126,8 +126,8 @@ interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
 childProcess.exec(
-  `${nodeBinary} --require ${fixture('cluster-preload.js')} ` +
-    fixture('cluster-preload-test.js'),
+  `${nodeBinary} --require ${fixture('cluster-preload.js')} ${
+  fixture('cluster-preload-test.js')}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -96,9 +96,9 @@ function test(arg, exit) {
   const f = __filename;
   const option = { stdio: [ 0, 1, 'ignore' ] };
   spawn(node, [f, arg], option).on('exit', function(code) {
-    assert.strictEqual(code, exit, 'wrong exit for ' +
-                 arg + '\nexpected:' + exit +
-                 ' but got:' + code);
+    assert.strictEqual(
+      code, exit,
+      `wrong exit for ${arg}\nexpected:${exit} but got:${code}`);
     console.log('ok - %s exited with %d', arg, exit);
   });
 }

--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -30,7 +30,7 @@ switch (process.argv[2]) {
   case undefined:
     return parent();
   default:
-    throw new Error('wtf? ' + process.argv[2]);
+    throw new Error(`wtf? ${process.argv[2]}`);
 }
 
 function parent() {
@@ -46,7 +46,7 @@ function parent() {
   child.stderr.setEncoding('utf8');
 
   child.stderr.on('end', function() {
-    assert.strictEqual(output, 'I can still debug!' + os.EOL);
+    assert.strictEqual(output, `I can still debug!${os.EOL}`);
     console.log('ok - got expected message');
   });
 

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 
 common.refreshTmpDir();
 
-const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnmod = require.resolve(`${common.fixturesDir}/warnings.js`);
 const warnpath = path.join(common.tmpDir, 'warnings.txt');
 
 fork(warnmod, {env: {NODE_REDIRECT_WARNINGS: warnpath}})

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -13,7 +13,7 @@ const assert = require('assert');
 
 common.refreshTmpDir();
 
-const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnmod = require.resolve(`${common.fixturesDir}/warnings.js`);
 const warnpath = path.join(common.tmpDir, 'warnings.txt');
 
 fork(warnmod, {execArgv: [`--redirect-warnings=${warnpath}`]})

--- a/test/parallel/test-promises-unhandled-rejections.js
+++ b/test/parallel/test-promises-unhandled-rejections.js
@@ -12,11 +12,11 @@ const asyncTest = (function() {
 
   function fail(error) {
     const stack = currentTest ?
-      error.stack + '\nFrom previous event:\n' + currentTest.stack :
+      `${error.stack}\nFrom previous event:\n${currentTest.stack}` :
       error.stack;
 
     if (currentTest)
-      process.stderr.write('\'' + currentTest.description + '\' failed\n\n');
+      process.stderr.write(`'${currentTest.description}' failed\n\n`);
 
     process.stderr.write(stack);
     process.exit(2);

--- a/test/parallel/test-querystring-maxKeys-non-finite.js
+++ b/test/parallel/test-querystring-maxKeys-non-finite.js
@@ -23,7 +23,7 @@ function createManyParams(count) {
 
   for (let i = 1; i < count; i++) {
     const n = i.toString(36);
-    str += '&' + n + '=' + n;
+    str += `&${n}=${n}`;
   }
 
   return str;

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -155,7 +155,7 @@ function isWarned(emitter) {
     assert.strictEqual(line, expectedLines[callCount]);
     callCount++;
   });
-  fi.emit('data', expectedLines.join('\n') + '\n');
+  fi.emit('data', `${expectedLines.join('\n')}\n`);
   assert.strictEqual(callCount, expectedLines.length);
   rli.close();
 
@@ -216,7 +216,7 @@ function isWarned(emitter) {
     callCount++;
   });
   expectedLines.forEach(function(line) {
-    fi.emit('data', line + '\r');
+    fi.emit('data', `${line}\r`);
     fi.emit('data', '\n');
   });
   assert.strictEqual(callCount, expectedLines.length);
@@ -339,7 +339,7 @@ function isWarned(emitter) {
     assert.strictEqual(line, expectedLines[callCount]);
     callCount++;
   });
-  fi.emit('data', expectedLines.join('\n') + '\n');
+  fi.emit('data', `${expectedLines.join('\n')}\n`);
   assert.strictEqual(callCount, expectedLines.length);
   fi.emit('keypress', '.', { name: 'up' }); // 'bat'
   assert.strictEqual(rli.line, expectedLines[--callCount]);
@@ -369,7 +369,7 @@ function isWarned(emitter) {
     assert.strictEqual(line, expectedLines[callCount]);
     callCount++;
   });
-  fi.emit('data', expectedLines.join('\n') + '\n');
+  fi.emit('data', `${expectedLines.join('\n')}\n`);
   assert.strictEqual(callCount, expectedLines.length);
   fi.emit('keypress', '.', { name: 'up' }); // 'bat'
   assert.strictEqual(rli.line, expectedLines[--callCount]);

--- a/test/parallel/test-regress-GH-1531.js
+++ b/test/parallel/test-regress-GH-1531.js
@@ -10,8 +10,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = https.createServer(options, function(req, res) {

--- a/test/parallel/test-regress-GH-3739.js
+++ b/test/parallel/test-regress-GH-3739.js
@@ -12,7 +12,7 @@ common.refreshTmpDir();
 
 // Make a long path.
 for (let i = 0; i < 50; i++) {
-  dir = dir + '/1234567890';
+  dir = `${dir}/1234567890`;
   try {
     fs.mkdirSync(dir, '0777');
   } catch (e) {

--- a/test/parallel/test-regress-GH-9819.js
+++ b/test/parallel/test-regress-GH-9819.js
@@ -17,7 +17,7 @@ const scripts = [
 
 scripts.forEach((script) => {
   const node = process.execPath;
-  const code = setup + ';' + script;
+  const code = `${setup};${script}`;
   execFile(node, [ '-e', code ], common.mustCall((err, stdout, stderr) => {
     assert(stderr.includes('Error: xyz'), 'digest crashes');
   }));

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -40,8 +40,8 @@ function test1() {
     if (data.length) {
 
       // inspect output matches repl output
-      assert.strictEqual(data, util.inspect(require('fs'), null, 2, false) +
-                         '\n');
+      assert.strictEqual(data,
+                         `${util.inspect(require('fs'), null, 2, false)}\n`);
       // globally added lib matches required lib
       assert.strictEqual(global.fs, require('fs'));
       test2();

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -23,7 +23,7 @@ r.defineCommand('say1', {
   help: 'help for say1',
   action: function(thing) {
     output = '';
-    this.write('hello ' + thing);
+    this.write(`hello ${thing}`);
     this.displayPrompt();
   }
 });

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -50,10 +50,10 @@ function run(test) {
     // The REPL registers 'module' and 'require' globals
     common.allowGlobals(repl.context.module, repl.context.require);
 
-    assert.strictEqual(expected.terminal, repl.terminal, 'Expected ' +
-                       inspect(expected) + ' with ' + inspect(env));
-    assert.strictEqual(expected.useColors, repl.useColors, 'Expected ' +
-                       inspect(expected) + ' with ' + inspect(env));
+    assert.strictEqual(expected.terminal, repl.terminal,
+                       `Expected ${inspect(expected)} with ${inspect(env)}`);
+    assert.strictEqual(expected.useColors, repl.useColors,
+                       `Expected ${inspect(expected)} with ${inspect(env)}`);
     repl.close();
   });
 }

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -19,46 +19,34 @@ tests.forEach(function(test) {
 function testSloppyMode() {
   const cli = initRepl(repl.REPL_MODE_SLOPPY);
 
-  cli.input.emit('data', `
-    x = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'x = 3\n');
   assert.strictEqual(cli.output.accumulator.join(''), '> 3\n> ');
   cli.output.accumulator.length = 0;
 
-  cli.input.emit('data', `
-    let y = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'let y = 3\n');
   assert.strictEqual(cli.output.accumulator.join(''), 'undefined\n> ');
 }
 
 function testStrictMode() {
   const cli = initRepl(repl.REPL_MODE_STRICT);
 
-  cli.input.emit('data', `
-    x = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'x = 3\n');
   assert.ok(/ReferenceError: x is not defined/.test(
       cli.output.accumulator.join('')));
   cli.output.accumulator.length = 0;
 
-  cli.input.emit('data', `
-    let y = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'let y = 3\n');
   assert.strictEqual(cli.output.accumulator.join(''), 'undefined\n> ');
 }
 
 function testAutoMode() {
   const cli = initRepl(repl.REPL_MODE_MAGIC);
 
-  cli.input.emit('data', `
-    x = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'x = 3\n');
   assert.strictEqual(cli.output.accumulator.join(''), '> 3\n> ');
   cli.output.accumulator.length = 0;
 
-  cli.input.emit('data', `
-    let y = 3
-  `.trim() + '\n');
+  cli.input.emit('data', 'let y = 3\n');
   assert.strictEqual(cli.output.accumulator.join(''), 'undefined\n> ');
 }
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -35,7 +35,7 @@ class ActionStream extends stream.Stream {
       if (typeof action === 'object') {
         this.emit('keypress', '', action);
       } else {
-        this.emit('data', action + '\n');
+        this.emit('data', `${action}\n`);
       }
       setImmediate(doAction);
     };
@@ -117,19 +117,19 @@ const tests = [
   {
     env: { NODE_REPL_HISTORY: historyPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, `${prompt}'you look fabulous today'`, prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, `${prompt}'you look fabulous today'`, prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_FILE: '' },
     test: [UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, `${prompt}'you look fabulous today'`, prompt]
   },
   {
     env: {},
@@ -139,27 +139,27 @@ const tests = [
   {
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR, '\'42\'', ENTER],
-    expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt, '\'',
+    expected: [prompt, convertMsg, prompt, `${prompt}'=^.^='`, prompt, '\'',
                '4', '2', '\'', '\'42\'\n', prompt, prompt],
     clean: false
   },
   { // Requires the above testcase
     env: {},
     test: [UP, UP, ENTER],
-    expected: [prompt, prompt + '\'42\'', prompt + '\'=^.^=\'', '\'=^.^=\'\n',
+    expected: [prompt, `${prompt}'42'`, `${prompt}'=^.^='`, '\'=^.^=\'\n',
                prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPath,
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP, UP, CLEAR],
-    expected: [prompt, prompt + '\'you look fabulous today\'', prompt]
+    expected: [prompt, `${prompt}'you look fabulous today'`, prompt]
   },
   {
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath,
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP, UP, UP, CLEAR],
-    expected: [prompt, convertMsg, prompt, prompt + '\'=^.^=\'', prompt]
+    expected: [prompt, convertMsg, prompt, `${prompt}'=^.^='`, prompt]
   },
   {
     env: { NODE_REPL_HISTORY: historyPathFail,

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -45,11 +45,11 @@ const saveFileName = join(common.tmpDir, 'test.save.js');
 putIn.run(testFile);
 
 // save it to a file
-putIn.run(['.save ' + saveFileName]);
+putIn.run([`.save ${saveFileName}`]);
 
 // the file should have what I wrote
-assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'), testFile.join('\n') +
-                   '\n');
+assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
+                   `${testFile.join('\n')}\n`);
 
 {
   // save .editor mode code
@@ -81,7 +81,7 @@ testMe.complete('inner.o', function(error, data) {
 putIn.run(['.clear']);
 
 // Load the file back in
-putIn.run(['.load ' + saveFileName]);
+putIn.run([`.load ${saveFileName}`]);
 
 // make sure that the REPL data is "correct"
 testMe.complete('inner.o', function(error, data) {
@@ -96,20 +96,19 @@ let loadFile = join(common.tmpDir, 'file.does.not.exist');
 // should not break
 putIn.write = function(data) {
   // make sure I get a failed to load message and not some crazy error
-  assert.strictEqual(data, 'Failed to load:' + loadFile + '\n');
+  assert.strictEqual(data, `Failed to load:${loadFile}\n`);
   // eat me to avoid work
   putIn.write = common.noop;
 };
-putIn.run(['.load ' + loadFile]);
+putIn.run([`.load ${loadFile}`]);
 
 // throw error on loading directory
 loadFile = common.tmpDir;
 putIn.write = function(data) {
-  assert.strictEqual(data, 'Failed to load:' + loadFile +
-                     ' is not a valid file\n');
+  assert.strictEqual(data, `Failed to load:${loadFile} is not a valid file\n`);
   putIn.write = common.noop;
 };
-putIn.run(['.load ' + loadFile]);
+putIn.run([`.load ${loadFile}`]);
 
 // clear the REPL
 putIn.run(['.clear']);
@@ -121,10 +120,10 @@ const invalidFileName = join(common.tmpDir, '\0\0\0\0\0');
 // should not break
 putIn.write = function(data) {
   // make sure I get a failed to save message and not some other error
-  assert.strictEqual(data, 'Failed to save:' + invalidFileName + '\n');
+  assert.strictEqual(data, `Failed to save:${invalidFileName}\n`);
   // reset to no-op
   putIn.write = common.noop;
 };
 
 // save it to a file
-putIn.run(['.save ' + invalidFileName]);
+putIn.run([`.save ${invalidFileName}`]);

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -207,7 +207,7 @@ putIn.run(['.clear']);
 testMe.complete('require(\'', common.mustCall(function(error, data) {
   assert.strictEqual(error, null);
   repl._builtinLibs.forEach(function(lib) {
-    assert.notStrictEqual(data[0].indexOf(lib), -1, lib + ' not found');
+    assert.notStrictEqual(data[0].indexOf(lib), -1, `${lib} not found`);
   });
 }));
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -46,19 +46,19 @@ console.error('repl test');
 
 // function for REPL to run
 global.invoke_me = function(arg) {
-  return 'invoked ' + arg;
+  return `invoked ${arg}`;
 };
 
 function send_expect(list) {
   if (list.length > 0) {
     const cur = list.shift();
 
-    console.error('sending ' + JSON.stringify(cur.send));
+    console.error(`sending ${JSON.stringify(cur.send)}`);
 
     cur.client.expect = cur.expect;
     cur.client.list = list;
     if (cur.send.length > 0) {
-      cur.client.write(cur.send + '\n');
+      cur.client.write(`${cur.send}\n`);
     }
   }
 }
@@ -83,10 +83,11 @@ function error_test() {
 
   client_unix.on('data', function(data) {
     read_buffer += data.toString('ascii', 0, data.length);
-    console.error('Unix data: ' + JSON.stringify(read_buffer) + ', expecting ' +
-                 (client_unix.expect.exec ?
-                  client_unix.expect :
-                  JSON.stringify(client_unix.expect)));
+    console.error(
+      `Unix data: ${JSON.stringify(read_buffer)}, expecting ${
+      client_unix.expect.exec ?
+      client_unix.expect :
+      JSON.stringify(client_unix.expect)}`);
 
     if (read_buffer.includes(prompt_unix)) {
       // if it's an exact match, then don't do the regexp
@@ -217,7 +218,7 @@ function error_test() {
     { client: client_unix, send: 'function blah() { return 1; }',
       expect: prompt_unix },
     { client: client_unix, send: 'blah()',
-      expect: '1\n' + prompt_unix },
+      expect: `1\n${prompt_unix}` },
     // Functions should not evaluate twice (#2773)
     { client: client_unix, send: 'var I = [1,2,3,function() {}]; I.pop()',
       expect: '[Function]' },
@@ -241,7 +242,7 @@ function error_test() {
     { client: client_unix, send: '2)',
       expect: prompt_multiline },
     { client: client_unix, send: ')',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     // npm prompt error message
     { client: client_unix, send: 'npm install foobar',
       expect: expect_npm },
@@ -256,18 +257,18 @@ function error_test() {
     // this makes sure that we don't print `undefined` when we actually print
     // the error message
     { client: client_unix, send: '.invalid_repl_command',
-      expect: 'Invalid REPL keyword\n' + prompt_unix },
+      expect: `Invalid REPL keyword\n${prompt_unix}` },
     // this makes sure that we don't crash when we use an inherited property as
     // a REPL command
     { client: client_unix, send: '.toString',
-      expect: 'Invalid REPL keyword\n' + prompt_unix },
+      expect: `Invalid REPL keyword\n${prompt_unix}` },
     // fail when we are not inside a String and a line continuation is used
     { client: client_unix, send: '[] \\',
       expect: /\bSyntaxError: Invalid or unexpected token/ },
     // do not fail when a String is created with line continuation
     { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'thefourtheye\'\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n${
+              prompt_unix}` },
     // Don't fail when a partial String is created and line continuation is used
     // with whitespace characters at the end of the string. We are to ignore it.
     // This test is to make sure that we properly remove the whitespace
@@ -276,12 +277,12 @@ function error_test() {
       expect: prompt_unix },
     // multiline strings preserve whitespace characters in them
     { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
+      expect: `${prompt_multiline}${
+              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
     // more than one multiline strings also should preserve whitespace chars
     { client: client_unix, send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
-      expect: prompt_multiline + prompt_multiline +
-              '\'the    fourth\\t\\t  eye  \'\n' + prompt_unix },
+      expect: `${prompt_multiline}${
+              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
     // using REPL commands within a string literal should still work
     { client: client_unix, send: '\'\\\n.break',
       expect: prompt_unix },
@@ -293,8 +294,8 @@ function error_test() {
       expect: prompt_unix + prompt_unix + prompt_unix },
     // empty lines in the string literals should not affect the string
     { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
-      expect: prompt_multiline + prompt_multiline +
-              '\'thefourtheye\'\n' + prompt_unix },
+      expect: `${prompt_multiline}${
+              prompt_multiline}'thefourtheye'\n${prompt_unix}` },
     // Regression test for https://github.com/nodejs/node/issues/597
     { client: client_unix,
       send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
@@ -307,39 +308,39 @@ function error_test() {
                '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
     // regression tests for https://github.com/nodejs/node/issues/2749
     { client: client_unix, send: 'function x() {\nreturn \'\\n\';\n }',
-      expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
+              prompt_unix}` },
     { client: client_unix, send: 'function x() {\nreturn \'\\\\\';\n }',
-      expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
+              prompt_unix}` },
     // regression tests for https://github.com/nodejs/node/issues/3421
     { client: client_unix, send: 'function x() {\n//\'\n }',
-      expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
+              prompt_unix}` },
     { client: client_unix, send: 'function x() {\n//"\n }',
-      expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
+              prompt_unix}` },
     { client: client_unix, send: 'function x() {//\'\n }',
-      expect: prompt_multiline + 'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {//"\n }',
-      expect: prompt_multiline + 'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {\nvar i = "\'";\n }',
-      expect: prompt_multiline + prompt_multiline +
-              'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
+              prompt_unix}` },
     { client: client_unix, send: 'function x(/*optional*/) {}',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x(/* // 5 */) {}',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: '// /* 5 */',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: '"//"',
-      expect: '\'//\'\n' + prompt_unix },
+      expect: `'//'\n${prompt_unix}` },
     { client: client_unix, send: '"data /*with*/ comment"',
-      expect: '\'data /*with*/ comment\'\n' + prompt_unix },
+      expect: `'data /*with*/ comment'\n${prompt_unix}` },
     { client: client_unix, send: 'function x(/*fn\'s optional params*/) {}',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: '/* \'\n"\n\'"\'\n*/',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     // REPL should get a normal require() function, not one that allows
     // access to internal modules without the --expose_internals flag.
     { client: client_unix, send: 'require("internal/repl")',
@@ -347,31 +348,31 @@ function error_test() {
     // REPL should handle quotes within regexp literal in multiline mode
     { client: client_unix,
       send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
-      expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}` +
+            `undefined\n${prompt_unix}` },
     { client: client_unix,
       send: "function x(s) {\nreturn s.replace(/'/,'');\n}",
-      expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}` +
+            `undefined\n${prompt_unix}` },
     { client: client_unix,
       send: 'function x(s) {\nreturn s.replace(/"/,"");\n}',
-      expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}` +
+            `undefined\n${prompt_unix}` },
     { client: client_unix,
       send: 'function x(s) {\nreturn s.replace(/.*/,"");\n}',
-      expect: prompt_multiline + prompt_multiline +
-            'undefined\n' + prompt_unix },
+      expect: `${prompt_multiline}${prompt_multiline}` +
+            `undefined\n${prompt_unix}` },
     { client: client_unix, send: '{ var x = 4; }',
-      expect: 'undefined\n' + prompt_unix },
+      expect: `undefined\n${prompt_unix}` },
     // Illegal token is not recoverable outside string literal, RegExp literal,
     // or block comment. https://github.com/nodejs/node/issues/3611
     { client: client_unix, send: 'a = 3.5e',
       expect: /\bSyntaxError: Invalid or unexpected token/ },
     // Mitigate https://github.com/nodejs/node/issues/548
     { client: client_unix, send: 'function name(){ return "node"; };name()',
-      expect: "'node'\n" + prompt_unix },
+      expect: `'node'\n${prompt_unix}` },
     { client: client_unix, send: 'function name(){ return "nodejs"; };name()',
-      expect: "'nodejs'\n" + prompt_unix },
+      expect: `'nodejs'\n${prompt_unix}` },
     // Avoid emitting repl:line-number for SyntaxError
     { client: client_unix, send: 'a = 3.5e',
       expect: /^(?!repl)/ },
@@ -400,17 +401,17 @@ function error_test() {
 
     {
       client: client_unix, send: '(function() {\nreturn /foo/ / /bar/;\n}())',
-      expect: prompt_multiline + prompt_multiline + 'NaN\n' + prompt_unix
+      expect: `${prompt_multiline}${prompt_multiline}NaN\n${prompt_unix}`
     },
 
     {
       client: client_unix, send: '(function() {\nif (false) {} /bar"/;\n}())',
-      expect: prompt_multiline + prompt_multiline + 'undefined\n' + prompt_unix
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n${prompt_unix}`
     },
 
     // Newline within template string maintains whitespace.
     { client: client_unix, send: '`foo \n`',
-      expect: prompt_multiline + '\'foo \\n\'\n' + prompt_unix },
+      expect: `${prompt_multiline}'foo \\n'\n${prompt_unix}` },
     // Whitespace is not evaluated.
     { client: client_unix, send: ' \t  \n',
       expect: prompt_unix }
@@ -445,15 +446,15 @@ function tcp_test() {
         { client: client_tcp, send: 'a += 1',
           expect: (`12346\n${prompt_tcp}`) },
         { client: client_tcp,
-          send: 'require(' + JSON.stringify(moduleFilename) + ').number',
+          send: `require(${JSON.stringify(moduleFilename)}).number`,
           expect: (`42\n${prompt_tcp}`) }
       ]);
     });
 
     client_tcp.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
-      console.error('TCP data: ' + JSON.stringify(read_buffer) +
-                   ', expecting ' + JSON.stringify(client_tcp.expect));
+      console.error(`TCP data: ${JSON.stringify(read_buffer)}, expecting ${
+                    JSON.stringify(client_tcp.expect)}`);
       if (read_buffer.includes(prompt_tcp)) {
         assert.strictEqual(client_tcp.expect, read_buffer);
         console.error('match');
@@ -522,8 +523,8 @@ function unix_test() {
 
     client_unix.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
-      console.error('Unix data: ' + JSON.stringify(read_buffer) +
-                   ', expecting ' + JSON.stringify(client_unix.expect));
+      console.error(`Unix data: ${JSON.stringify(read_buffer)}, expecting ${
+                    JSON.stringify(client_unix.expect)}`);
       if (read_buffer.includes(prompt_unix)) {
         assert.strictEqual(client_unix.expect, read_buffer);
         console.error('match');

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -3,13 +3,13 @@ const common = require('../common');
 const assert = require('assert');
 const m = require('module');
 
-const a = require(common.fixturesDir + '/module-require/relative/dot.js');
-const b = require(common.fixturesDir + '/module-require/relative/dot-slash.js');
+const a = require(`${common.fixturesDir}/module-require/relative/dot.js`);
+const b = require(`${common.fixturesDir}/module-require/relative/dot-slash.js`);
 
 assert.strictEqual(a.value, 42);
 assert.strictEqual(a, b, 'require(".") should resolve like require("./")');
 
-process.env.NODE_PATH = common.fixturesDir + '/module-require/relative';
+process.env.NODE_PATH = `${common.fixturesDir}/module-require/relative`;
 m._initPaths();
 
 const c = require('.');

--- a/test/parallel/test-require-exceptions.js
+++ b/test/parallel/test-require-exceptions.js
@@ -25,12 +25,12 @@ const assert = require('assert');
 
 // A module with an error in it should throw
 assert.throws(function() {
-  require(common.fixturesDir + '/throws_error');
+  require(`${common.fixturesDir}/throws_error`);
 }, /^Error: blah$/);
 
 // Requiring the same module again should throw as well
 assert.throws(function() {
-  require(common.fixturesDir + '/throws_error');
+  require(`${common.fixturesDir}/throws_error`);
 }, /^Error: blah$/);
 
 // Requiring a module that does not exist should throw an

--- a/test/parallel/test-signal-handler.js
+++ b/test/parallel/test-signal-handler.js
@@ -28,7 +28,7 @@ if (common.isWindows) {
   return;
 }
 
-console.log('process.pid: ' + process.pid);
+console.log(`process.pid: ${process.pid}`);
 
 process.on('SIGUSR1', common.mustCall());
 
@@ -41,7 +41,7 @@ process.on('SIGUSR1', common.mustCall(function() {
 
 let i = 0;
 setInterval(function() {
-  console.log('running process...' + ++i);
+  console.log(`running process...${++i}`);
 
   if (i === 5) {
     process.kill(process.pid, 'SIGUSR1');

--- a/test/parallel/test-signal-unregister.js
+++ b/test/parallel/test-signal-unregister.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-const child = spawn(process.argv[0], [common.fixturesDir + '/should_exit.js']);
+const child = spawn(process.argv[0], [`${common.fixturesDir}/should_exit.js`]);
 child.stdout.once('data', function() {
   child.kill('SIGINT');
 });

--- a/test/parallel/test-socket-write-after-fin-error.js
+++ b/test/parallel/test-socket-write-after-fin-error.js
@@ -17,7 +17,7 @@ let gotServerError = false;
 const server = net.createServer(function(sock) {
   sock.setEncoding('utf8');
   sock.on('error', function(er) {
-    console.error(er.code + ': ' + er.message);
+    console.error(`${er.code}: ${er.message}`);
     gotServerError = er;
   });
 

--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -14,9 +14,9 @@ if (!process.argv[2]) {
   const spawn = require('child_process').spawn;
   const path = require('path');
 
-  const pipeNamePrefix = path.basename(__filename) + '.' + process.pid;
-  const stdinPipeName = '\\\\.\\pipe\\' + pipeNamePrefix + '.stdin';
-  const stdoutPipeName = '\\\\.\\pipe\\' + pipeNamePrefix + '.stdout';
+  const pipeNamePrefix = `${path.basename(__filename)}.${process.pid}`;
+  const stdinPipeName = `\\\\.\\pipe\\${pipeNamePrefix}.stdin`;
+  const stdoutPipeName = `\\\\.\\pipe\\${pipeNamePrefix}.stdout`;
 
   const stdinPipeServer = net.createServer(function(c) {
     c.on('end', common.mustCall(function() {

--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -8,8 +8,7 @@ const fs = require('fs');
 const stdoutScript = join(common.fixturesDir, 'echo-close-check.js');
 const tmpFile = join(common.tmpDir, 'stdin.txt');
 
-const cmd = '"' + process.argv[0] + '" "' + stdoutScript + '" < "' +
-            tmpFile + '"';
+const cmd = `"${process.argv[0]}" "${stdoutScript}" < "${tmpFile}"`;
 
 const string = 'abc\nümlaut.\nsomething else\n' +
                '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，' +
@@ -26,7 +25,7 @@ const string = 'abc\nümlaut.\nsomething else\n' +
 
 common.refreshTmpDir();
 
-console.log(cmd + '\n\n');
+console.log(`${cmd}\n\n`);
 
 fs.writeFileSync(tmpFile, string);
 
@@ -34,6 +33,6 @@ childProcess.exec(cmd, common.mustCall(function(err, stdout, stderr) {
   fs.unlinkSync(tmpFile);
 
   assert.ifError(err);
-  assert.strictEqual(stdout, 'hello world\r\n' + string);
+  assert.strictEqual(stdout, `hello world\r\n${string}`);
   assert.strictEqual('', stderr);
 }));

--- a/test/parallel/test-stdin-script-child.js
+++ b/test/parallel/test-stdin-script-child.js
@@ -8,7 +8,7 @@ const child = spawn(process.execPath, [], {
     NODE_DEBUG: process.argv[2]
   })
 });
-const wanted = child.pid + '\n';
+const wanted = `${child.pid}\n`;
 let found = '';
 
 child.stdout.setEncoding('utf8');
@@ -18,7 +18,7 @@ child.stdout.on('data', function(c) {
 
 child.stderr.setEncoding('utf8');
 child.stderr.on('data', function(c) {
-  console.error('> ' + c.trim().split(/\n/).join('\n> '));
+  console.error(`> ${c.trim().split(/\n/).join('\n> ')}`);
 });
 
 child.on('close', common.mustCall(function(c) {

--- a/test/parallel/test-stdout-stderr-reading.js
+++ b/test/parallel/test-stdout-stderr-reading.js
@@ -31,7 +31,7 @@ function parent() {
   });
   c1.stderr.setEncoding('utf8');
   c1.stderr.on('data', function(chunk) {
-    console.error('c1err: ' + chunk.split('\n').join('\nc1err: '));
+    console.error(`c1err: ${chunk.split('\n').join('\nc1err: ')}`);
   });
   c1.on('close', common.mustCall(function(code, signal) {
     assert(!code);
@@ -48,7 +48,7 @@ function parent() {
   });
   c1.stderr.setEncoding('utf8');
   c1.stderr.on('data', function(chunk) {
-    console.error('c1err: ' + chunk.split('\n').join('\nc1err: '));
+    console.error(`c1err: ${chunk.split('\n').join('\nc1err: ')}`);
   });
   c2.on('close', common.mustCall(function(code, signal) {
     assert(!code);

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -13,13 +13,8 @@ const tmpFile = path.join(common.tmpDir, 'stdout.txt');
 common.refreshTmpDir();
 
 function test(size, useBuffer, cb) {
-  const cmd = '"' + process.argv[0] + '"' +
-              ' ' +
-              '"' + (useBuffer ? scriptBuffer : scriptString) + '"' +
-              ' ' +
-              size +
-              ' > ' +
-              '"' + tmpFile + '"';
+  const cmd = `"${process.argv[0]}" "${
+              useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
 
   try {
     fs.unlinkSync(tmpFile);

--- a/test/parallel/test-stream-base-no-abort.js
+++ b/test/parallel/test-stream-base-no-abort.js
@@ -42,8 +42,8 @@ async_wrap.enable();
 
 const checkTLS = common.mustCall(function checkTLS() {
   const options = {
-    key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
-    cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
+    key: fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`),
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`)
   };
   const server = tls.createServer(options, common.noop)
     .listen(0, function() {

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -56,7 +56,7 @@ const results = [];
 ms.on('readable', function() {
   let chunk;
   while (null !== (chunk = ms.read()))
-    results.push(chunk + '');
+    results.push(String(chunk));
 });
 
 const expect = [ 'first chunksecond to last chunk', 'last chunk' ];

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -58,11 +58,11 @@ function flow(stream, size, callback) {
     callback(chunk);
 
   depth -= 1;
-  console.log('flow(' + depth + '): exit');
+  console.log(`flow(${depth}): exit`);
 }
 
 flow(stream, 5000, function() {
-  console.log('complete (' + depth + ')');
+  console.log(`complete (${depth})`);
 });
 
 process.on('exit', function(code) {

--- a/test/parallel/test-stream2-base64-single-char-read-end.js
+++ b/test/parallel/test-stream2-base64-single-char-read-end.js
@@ -46,7 +46,7 @@ dst._write = function(chunk, enc, cb) {
 };
 
 src.on('end', function() {
-  assert.strictEqual(Buffer.concat(accum) + '', 'MQ==');
+  assert.strictEqual(String(Buffer.concat(accum)), 'MQ==');
   clearTimeout(timeout);
 });
 

--- a/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
+++ b/test/parallel/test-stream2-readable-empty-buffer-no-eof.js
@@ -75,7 +75,7 @@ function test1() {
   function flow() {
     let chunk;
     while (null !== (chunk = r.read()))
-      results.push(chunk + '');
+      results.push(String(chunk));
   }
   r.on('readable', flow);
   r.on('end', function() {
@@ -103,7 +103,7 @@ function test2() {
   function flow() {
     let chunk;
     while (null !== (chunk = r.read()))
-      results.push(chunk + '');
+      results.push(String(chunk));
   }
   r.on('readable', flow);
   r.on('end', function() {

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -344,7 +344,7 @@ test('passthrough event emission', function(t) {
   t.equal(emits, 1);
 
   t.equal(pt.read(5).toString(), 'foogb');
-  t.equal(pt.read(5) + '', 'null');
+  t.equal(String(pt.read(5)), 'null');
 
   console.error('need emit 1');
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -228,7 +228,7 @@ test('write callbacks', function(t) {
       callbacks._called[i] = chunk;
     }];
   }).reduce(function(set, x) {
-    set['callback-' + x[0]] = x[1];
+    set[`callback-${x[0]}`] = x[1];
     return set;
   }, {});
   callbacks._called = [];
@@ -246,7 +246,7 @@ test('write callbacks', function(t) {
   });
 
   chunks.forEach(function(chunk, i) {
-    tw.write(chunk, callbacks['callback-' + i]);
+    tw.write(chunk, callbacks[`callback-${i}`]);
   });
   tw.end();
 });

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -167,7 +167,7 @@ function test(encoding, input, expected, singleSequence) {
 function unicodeEscape(str) {
   let r = '';
   for (let i = 0; i < str.length; i++) {
-    r += '\\u' + str.charCodeAt(i).toString(16);
+    r += `\\u${str.charCodeAt(i).toString(16)}`;
   }
   return r;
 }

--- a/test/parallel/test-tcp-wrap-listen.js
+++ b/test/parallel/test-tcp-wrap-listen.js
@@ -40,7 +40,7 @@ server.onconnection = (err, client) => {
       assert.strictEqual(returnCode, 0);
       client.pendingWrites.push(req);
 
-      console.log('client.writeQueueSize: ' + client.writeQueueSize);
+      console.log(`client.writeQueueSize: ${client.writeQueueSize}`);
       // 11 bytes should flush
       assert.strictEqual(0, client.writeQueueSize);
 
@@ -57,7 +57,7 @@ server.onconnection = (err, client) => {
         assert.strictEqual(client, client_);
         assert.strictEqual(req, req_);
 
-        console.log('client.writeQueueSize: ' + client.writeQueueSize);
+        console.log(`client.writeQueueSize: ${client.writeQueueSize}`);
         assert.strictEqual(0, client.writeQueueSize);
 
         maybeCloseClient();

--- a/test/parallel/test-timers-ordering.js
+++ b/test/parallel/test-timers-ordering.js
@@ -32,15 +32,14 @@ let last_ts = 0;
 function f(i) {
   if (i <= N) {
     // check order
-    assert.strictEqual(i, last_i + 1, 'order is broken: ' + i + ' != ' +
-                 last_i + ' + 1');
+    assert.strictEqual(i, last_i + 1, `order is broken: ${i} != ${last_i} + 1`);
     last_i = i;
 
     // check that this iteration is fired at least 1ms later than the previous
     const now = Timer.now();
     console.log(i, now);
     assert(now >= last_ts + 1,
-           'current ts ' + now + ' < prev ts ' + last_ts + ' + 1');
+           `current ts ${now} < prev ts ${last_ts} + 1`);
     last_ts = now;
 
     // schedule next iteration

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -34,8 +34,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/0-dns/0-dns-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/0-dns/0-dns-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/0-dns/0-dns-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/0-dns/0-dns-cert.pem`)
 }, function(c) {
   c.once('data', function() {
     c.destroy();

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -16,7 +16,7 @@ const net = require('net');
 const fs = require('fs');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -40,7 +40,7 @@ const spawn = require('child_process').spawn;
 let success = false;
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-ca-concat.js
+++ b/test/parallel/test-tls-ca-concat.js
@@ -12,7 +12,7 @@ const {
 connect({
   client: {
     checkServerIdentity: (servername, cert) => { },
-    ca: keys.agent1.cert + '\n' + keys.agent6.ca,
+    ca: `${keys.agent1.cert}\n${keys.agent6.ca}`,
   },
   server: {
     cert: keys.agent6.cert,

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -36,8 +36,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 const big = Buffer.alloc(2 * 1024 * 1024, 'Y');

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -9,8 +9,8 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 
 const fs = require('fs');
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
 
 let ntests = 0;
 let nsuccess = 0;
@@ -18,7 +18,7 @@ let nsuccess = 0;
 function loadDHParam(n) {
   let path = common.fixturesDir;
   if (n !== 'error') path += '/keys';
-  return fs.readFileSync(path + '/dh' + n + '.pem');
+  return fs.readFileSync(`${path}/dh${n}.pem`);
 }
 
 const cipherlist = {

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -9,8 +9,8 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 
 const fs = require('fs');
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
 
 let nsuccess = 0;
 let nerror = 0;
@@ -18,7 +18,7 @@ let nerror = 0;
 function loadDHParam(n) {
   let path = common.fixturesDir;
   if (n !== 'error') path += '/keys';
-  return fs.readFileSync(path + '/dh' + n + '.pem');
+  return fs.readFileSync(`${path}/dh${n}.pem`);
 }
 
 function test(size, err, next) {

--- a/test/parallel/test-tls-client-resume.js
+++ b/test/parallel/test-tls-client-resume.js
@@ -36,8 +36,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 // create server

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -65,7 +65,7 @@ const testCases =
   ];
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 
@@ -105,7 +105,7 @@ function testServers(index, servers, clientOptions, cb) {
       const authorized = client.authorized ||
                          hosterr.test(client.authorizationError);
 
-      console.error('expected: ' + ok + ' authed: ' + authorized);
+      console.error(`expected: ${ok} authed: ${authorized}`);
 
       assert.strictEqual(ok, authorized);
       server.close();

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -12,8 +12,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
 }).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, common.mustNotCall());

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -31,8 +31,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
   // Send close-notify without shutting down TCP socket
   if (c._handle.shutdownSSL() !== 1)

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const path = require('path');
 
 function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', n + '.pem');
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -31,8 +31,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 common.refreshTmpDir();

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -33,8 +33,8 @@ const fs = require('fs');
 let serverConnected = 0;
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.Server(options, common.mustCall(function(socket) {

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -12,9 +12,9 @@ const stream = require('stream');
 const net = require('net');
 
 const cert_dir = common.fixturesDir;
-const options = { key: fs.readFileSync(cert_dir + '/test_key.pem'),
-                  cert: fs.readFileSync(cert_dir + '/test_cert.pem'),
-                  ca: [ fs.readFileSync(cert_dir + '/test_ca.pem') ],
+const options = { key: fs.readFileSync(`${cert_dir}/test_key.pem`),
+                  cert: fs.readFileSync(`${cert_dir}/test_cert.pem`),
+                  ca: [ fs.readFileSync(`${cert_dir}/test_ca.pem`) ],
                   ciphers: 'AES256-GCM-SHA384' };
 const content = 'hello world';
 const recv_bufs = [];

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -12,8 +12,8 @@ const net = require('net');
 const bonkers = Buffer.alloc(1024, 42);
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = net.createServer(common.mustCall(function(c) {

--- a/test/parallel/test-tls-delayed-attach.js
+++ b/test/parallel/test-tls-delayed-attach.js
@@ -36,8 +36,8 @@ const sent = 'hello world';
 let received = '';
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = net.createServer(function(c) {

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -38,8 +38,8 @@ const tls = require('tls');
 
 const spawn = require('child_process').spawn;
 const fs = require('fs');
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
 let nsuccess = 0;
 let ntests = 0;
 const ciphers = 'DHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
@@ -51,7 +51,7 @@ common.expectWarning('SecurityWarning',
 function loadDHParam(n) {
   let path = common.fixturesDir;
   if (n !== 'error') path += '/keys';
-  return fs.readFileSync(path + '/dh' + n + '.pem');
+  return fs.readFileSync(`${path}/dh${n}.pem`);
 }
 
 function test(keylen, expectedCipher, cb) {
@@ -88,7 +88,7 @@ function test(keylen, expectedCipher, cb) {
     client.stdout.on('end', function() {
       // DHE key length can be checked -brief option in s_client but it
       // is only supported in openssl 1.0.2 so we cannot check it.
-      const reg = new RegExp('Cipher    : ' + expectedCipher);
+      const reg = new RegExp(`Cipher    : ${expectedCipher}`);
       if (reg.test(out)) {
         nsuccess++;
         server.close();

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -39,8 +39,8 @@ const exec = require('child_process').exec;
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
   ciphers: 'ECDHE-RSA-RC4-SHA',
   ecdhCurve: false
 };
@@ -48,8 +48,8 @@ const options = {
 const server = tls.createServer(options, common.mustNotCall());
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
-  let cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ` -connect 127.0.0.1:${this.address().port}`;
+  let cmd = `"${common.opensslCli}" s_client -cipher ${
+            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -39,8 +39,8 @@ const exec = require('child_process').exec;
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
   ciphers: '-ALL:ECDHE-RSA-AES128-SHA256',
   ecdhCurve: 'prime256v1'
 };
@@ -52,8 +52,8 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 }));
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
-  let cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ` -connect 127.0.0.1:${this.address().port}`;
+  let cmd = `"${common.opensslCli}" s_client -cipher ${
+            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-env-bad-extra-ca.js
+++ b/test/parallel/test-tls-env-bad-extra-ca.js
@@ -19,7 +19,7 @@ if (process.env.CHILD) {
 
 const env = {
   CHILD: 'yes',
-  NODE_EXTRA_CA_CERTS: common.fixturesDir + '/no-such-file-exists',
+  NODE_EXTRA_CA_CERTS: `${common.fixturesDir}/no-such-file-exists`,
 };
 
 const opts = {

--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -25,8 +25,8 @@ if (process.env.CHILD) {
 }
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
 };
 
 const server = tls.createServer(options, function(s) {
@@ -36,7 +36,7 @@ const server = tls.createServer(options, function(s) {
   const env = {
     CHILD: 'yes',
     PORT: this.address().port,
-    NODE_EXTRA_CA_CERTS: common.fixturesDir + '/keys/ca1-cert.pem',
+    NODE_EXTRA_CA_CERTS: `${common.fixturesDir}/keys/ca1-cert.pem`,
   };
 
   fork(__filename, {env: env}).on('exit', common.mustCall(function(status) {

--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -32,9 +32,9 @@ const tls = require('tls');
 const fs = require('fs');
 
 const dir = common.fixturesDir;
-const options = { key: fs.readFileSync(dir + '/test_key.pem'),
-                  cert: fs.readFileSync(dir + '/test_cert.pem'),
-                  ca: [ fs.readFileSync(dir + '/test_ca.pem') ] };
+const options = { key: fs.readFileSync(`${dir}/test_key.pem`),
+                  cert: fs.readFileSync(`${dir}/test_cert.pem`),
+                  ca: [ fs.readFileSync(`${dir}/test_ca.pem`) ] };
 
 const server = tls.createServer(options, onconnection);
 let gotChunk = false;

--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -31,8 +31,8 @@ const tls = require('tls');
 
 const fs = require('fs');
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
 
 tls.createServer({ key: key, cert: cert }, common.mustCall(function(conn) {
   conn.end();

--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -33,8 +33,8 @@ const fs = require('fs');
 const cipher_list = ['AES128-SHA256', 'AES256-SHA256'];
 const cipher_version_pattern = /TLS|SSL/;
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
   ciphers: cipher_list.join(':'),
   honorCipherOrder: true
 };

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -17,8 +17,8 @@ const clientConfigs = [
 ];
 
 const serverConfig = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 const server = tls.createServer(serverConfig, common.mustCall(function() {

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -12,8 +12,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
   rejectUnauthorized: true
 }, function(c) {
 }).listen(0, common.mustCall(function() {

--- a/test/parallel/test-tls-hello-parser-failure.js
+++ b/test/parallel/test-tls-hello-parser-failure.js
@@ -35,8 +35,8 @@ const net = require('net');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/test_key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`)
 };
 
 const bonkers = Buffer.alloc(1024 * 1024, 42);

--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -23,8 +23,8 @@ process.on('exit', function() {
 function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
   const soptions = {
     secureProtocol: SSL_Method,
-    key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-    cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+    key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
     ciphers: 'AES256-SHA256:AES128-GCM-SHA256:AES128-SHA256:' +
              'ECDHE-RSA-AES128-GCM-SHA256',
     honorCipherOrder: !!honorCipherOrder

--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -33,9 +33,9 @@ const tls = require('tls');
 const fs = require('fs');
 
 const dir = common.fixturesDir;
-const options = { key: fs.readFileSync(dir + '/test_key.pem'),
-                  cert: fs.readFileSync(dir + '/test_cert.pem'),
-                  ca: [ fs.readFileSync(dir + '/test_ca.pem') ] };
+const options = { key: fs.readFileSync(`${dir}/test_key.pem`),
+                  cert: fs.readFileSync(`${dir}/test_cert.pem`),
+                  ca: [ fs.readFileSync(`${dir}/test_ca.pem`) ] };
 
 const writes = [
   'some server data',

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -35,8 +35,8 @@ const fs = require('fs');
 let received = '';
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
   c._write('hello ', null, function() {
     c._write('world!', null, function() {

--- a/test/parallel/test-tls-js-stream.js
+++ b/test/parallel/test-tls-js-stream.js
@@ -18,8 +18,8 @@ const connected = {
 };
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
   console.log('new client');
   connected.server++;

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -32,8 +32,8 @@ const fs = require('fs');
 const net = require('net');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 const server = tls.createServer(options, common.mustNotCall());

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -33,8 +33,8 @@ const errorMessageRegex =
   /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/;
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 assert.throws(function() {

--- a/test/parallel/test-tls-max-send-fragment.js
+++ b/test/parallel/test-tls-max-send-fragment.js
@@ -36,8 +36,8 @@ let received = 0;
 const maxChunk = 768;
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
   // Lower and upper limits
   assert(!c.setMaxSendFragment(511));

--- a/test/parallel/test-tls-multi-key.js
+++ b/test/parallel/test-tls-multi-key.js
@@ -32,12 +32,12 @@ const fs = require('fs');
 
 const options = {
   key: [
-    fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
-    fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
+    fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`),
+    fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
   ],
   cert: [
-    fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
-    fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
+    fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+    fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`)
   ]
 };
 

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -32,8 +32,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/ec-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/ec-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`)
 };
 
 const server = tls.createServer(options, function(conn) {

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -16,14 +16,14 @@ if (common.opensslCli === false) {
   return;
 }
 
-const cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem');
-const key = fs.readFileSync(common.fixturesDir + '/test_key.pem');
+const cert = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`);
+const key = fs.readFileSync(`${common.fixturesDir}/test_key.pem`);
 const server = tls.createServer({ cert: cert, key: key }, common.mustNotCall());
 const errors = [];
 let stderr = '';
 
 server.listen(0, '127.0.0.1', function() {
-  const address = this.address().address + ':' + this.address().port;
+  const address = `${this.address().address}:${this.address().port}`;
   const args = ['s_client',
                 '-ssl3',
                 '-connect', address];

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -38,7 +38,7 @@ const tls = require('tls');
 
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -14,8 +14,8 @@ const net = require('net');
 let out = '';
 
 const server = tls.createServer({
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 }, function(c) {
   c.end('hello');
 }).listen(0, function() {

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -35,8 +35,8 @@ const http = require('http');
 
 let gotRequest = false;
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
 
 const options = {
   key: key,

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -69,7 +69,7 @@ server.listen(0, function() {
         return process.nextTick(send);
       }
       sent += bufSize;
-      console.error('sent: ' + sent);
+      console.error(`sent: ${sent}`);
       resumed = true;
       client.resume();
       console.error('resumed', client);
@@ -82,7 +82,7 @@ server.listen(0, function() {
     console.error('received', received);
     console.error('sent', sent);
     if (received >= sent) {
-      console.error('received: ' + received);
+      console.error(`received: ${received}`);
       client.end();
       server.close();
     }

--- a/test/parallel/test-tls-regr-gh-5108.js
+++ b/test/parallel/test-tls-regr-gh-5108.js
@@ -11,8 +11,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -32,8 +32,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.Server(options, common.mustCall(function(socket) {

--- a/test/parallel/test-tls-retain-handle-no-abort.js
+++ b/test/parallel/test-tls-retain-handle-no-abort.js
@@ -14,8 +14,8 @@ const util = require('util');
 const sent = 'hello world';
 const serverOptions = {
   isServer: true,
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 let ssl = null;

--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -11,8 +11,8 @@ const fs = require('fs');
 const tls = require('tls');
 
 const sslcontext = tls.createSecureContext({
-  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
-  key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+  cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
+  key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
 });
 
 let catchedServername;
@@ -23,7 +23,7 @@ const pair = tls.createSecurePair(sslcontext, true, false, false, {
 });
 
 // captured traffic from browser's request to https://www.google.com
-const sslHello = fs.readFileSync(common.fixturesDir + '/google_ssl_hello.bin');
+const sslHello = fs.readFileSync(`${common.fixturesDir}/google_ssl_hello.bin`);
 
 pair.encrypted.write(sslHello);
 

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -44,11 +44,11 @@ const key = fs.readFileSync(join(common.fixturesDir, 'agent.key')).toString();
 const cert = fs.readFileSync(join(common.fixturesDir, 'agent.crt')).toString();
 
 function log(a) {
-  console.error('***server*** ' + a);
+  console.error(`***server*** ${a}`);
 }
 
 const server = net.createServer(common.mustCall(function(socket) {
-  log('connection fd=' + socket.fd);
+  log(`connection fd=${socket.fd}`);
   const sslcontext = tls.createSecureContext({key: key, cert: cert});
   sslcontext.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
@@ -70,7 +70,7 @@ const server = net.createServer(common.mustCall(function(socket) {
   });
 
   pair.cleartext.on('data', function(data) {
-    log('read bytes ' + data.length);
+    log(`read bytes ${data.length}`);
     pair.cleartext.write(data);
   });
 

--- a/test/parallel/test-tls-server-connection-server.js
+++ b/test/parallel/test-tls-server-connection-server.js
@@ -11,8 +11,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.createServer(options, function(s) {

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -134,7 +134,7 @@ const spawn = require('child_process').spawn;
 
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 
@@ -154,13 +154,13 @@ function runClient(prefix, port, options, cb) {
   // - Certificate, but not signed by CA.
   // - Certificate signed by CA.
 
-  const args = ['s_client', '-connect', '127.0.0.1:' + port];
+  const args = ['s_client', '-connect', `127.0.0.1:${port}`];
 
   // for the performance issue in s_client on Windows
   if (common.isWindows)
     args.push('-no_rand_screen');
 
-  console.log(prefix + '  connecting with', options.name);
+  console.log(`${prefix}  connecting with`, options.name);
 
   switch (options.name) {
     case 'agent1':
@@ -201,7 +201,7 @@ function runClient(prefix, port, options, cb) {
       break;
 
     default:
-      throw new Error(prefix + 'Unknown agent name');
+      throw new Error(`${prefix}Unknown agent name`);
   }
 
   // To test use: openssl s_client -connect localhost:8000
@@ -218,7 +218,7 @@ function runClient(prefix, port, options, cb) {
     out += d;
 
     if (!goodbye && /_unauthed/g.test(out)) {
-      console.error(prefix + '  * unauthed');
+      console.error(`${prefix}  * unauthed`);
       goodbye = true;
       client.kill();
       authed = false;
@@ -226,7 +226,7 @@ function runClient(prefix, port, options, cb) {
     }
 
     if (!goodbye && /_authed/g.test(out)) {
-      console.error(prefix + '  * authed');
+      console.error(`${prefix}  * authed`);
       goodbye = true;
       client.kill();
       authed = true;
@@ -237,17 +237,21 @@ function runClient(prefix, port, options, cb) {
   //client.stdout.pipe(process.stdout);
 
   client.on('exit', function(code) {
-    //assert.strictEqual(0, code, prefix + options.name +
-    //      ": s_client exited with error code " + code);
+    //assert.strictEqual(
+    //  0, code,
+    //  `${prefix}${options.name}: s_client exited with error code ${code}`);
     if (options.shouldReject) {
-      assert.strictEqual(true, rejected, prefix + options.name +
-          ' NOT rejected, but should have been');
+      assert.strictEqual(
+        true, rejected,
+        `${prefix}${options.name} NOT rejected, but should have been`);
     } else {
-      assert.strictEqual(false, rejected, prefix + options.name +
-          ' rejected, but should NOT have been');
-      assert.strictEqual(options.shouldAuth, authed, prefix +
-          options.name + ' authed is ' + authed +
-          ' but should have been ' + options.shouldAuth);
+      assert.strictEqual(
+        false, rejected,
+        `${prefix}${options.name} rejected, but should NOT have been`);
+      assert.strictEqual(
+        options.shouldAuth, authed,
+        `${prefix}${options.name} authed is ${authed} but should have been ${
+        options.shouldAuth}`);
     }
 
     cb();
@@ -258,11 +262,11 @@ function runClient(prefix, port, options, cb) {
 // Run the tests
 let successfulTests = 0;
 function runTest(port, testIndex) {
-  const prefix = testIndex + ' ';
+  const prefix = `${testIndex} `;
   const tcase = testCases[testIndex];
   if (!tcase) return;
 
-  console.error(prefix + "Running '%s'", tcase.title);
+  console.error(`${prefix}Running '%s'`, tcase.title);
 
   const cas = tcase.CAs.map(loadPEM);
 
@@ -297,7 +301,7 @@ function runTest(port, testIndex) {
     if (tcase.renegotiate && !renegotiated) {
       renegotiated = true;
       setTimeout(function() {
-        console.error(prefix + '- connected, renegotiating');
+        console.error(`${prefix}- connected, renegotiating`);
         c.write('\n_renegotiating\n');
         return c.renegotiate({
           requestCert: true,
@@ -312,11 +316,11 @@ function runTest(port, testIndex) {
     }
 
     if (c.authorized) {
-      console.error(prefix + '- authed connection: ' +
-                    c.getPeerCertificate().subject.CN);
+      console.error(`${prefix}- authed connection: ${
+                    c.getPeerCertificate().subject.CN}`);
       c.write('\n_authed\n');
     } else {
-      console.error(prefix + '- unauthed connection: %s', c.authorizationError);
+      console.error(`${prefix}- unauthed connection: %s`, c.authorizationError);
       c.write('\n_unauthed\n');
     }
   });
@@ -324,7 +328,7 @@ function runTest(port, testIndex) {
   function runNextClient(clientIndex) {
     const options = tcase.clients[clientIndex];
     if (options) {
-      runClient(prefix + clientIndex + ' ', port, options, function() {
+      runClient(`${prefix}${clientIndex} `, port, options, function() {
         runNextClient(clientIndex + 1);
       });
     } else {
@@ -337,14 +341,14 @@ function runTest(port, testIndex) {
   server.listen(port, function() {
     port = server.address().port;
     if (tcase.debug) {
-      console.error(prefix + 'TLS server running on port ' + port);
+      console.error(`${prefix}TLS server running on port ${port}`);
     } else {
       if (tcase.renegotiate) {
         runNextClient(0);
       } else {
         let clientsCompleted = 0;
         for (let i = 0; i < tcase.clients.length; i++) {
-          runClient(prefix + i + ' ', port, tcase.clients[i], function() {
+          runClient(`${prefix}${i} `, port, tcase.clients[i], function() {
             clientsCompleted++;
             if (clientsCompleted === tcase.clients.length) {
               server.close();

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -38,8 +38,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
   ciphers: 'DES-CBC3-SHA'
 };
 
@@ -55,8 +55,8 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 }));
 
 server.listen(0, '127.0.0.1', function() {
-  let cmd = '"' + common.opensslCli + '" s_client -cipher ' + options.ciphers +
-            ` -connect 127.0.0.1:${this.address().port}`;
+  let cmd = `"${common.opensslCli}" s_client -cipher ${
+            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -33,8 +33,8 @@ const fs = require('fs');
 
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 // Contains a UTF8 only character

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -37,7 +37,7 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -37,7 +37,7 @@ if (!common.hasCrypto) {
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', n + '.pem');
+  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -10,8 +10,8 @@ const tls = require('tls');
 const fs = require('fs');
 const net = require('net');
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
 
 let tlsSocket;
 // tls server

--- a/test/parallel/test-tls-socket-destroy.js
+++ b/test/parallel/test-tls-socket-destroy.js
@@ -11,8 +11,8 @@ const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
 const secureContext = tls.createSecureContext({ key, cert });
 
 const server = net.createServer(common.mustCall((conn) => {

--- a/test/parallel/test-tls-startcom-wosign-whitelist.js
+++ b/test/parallel/test-tls-startcom-wosign-whitelist.js
@@ -13,7 +13,7 @@ const path = require('path');
 let finished = 0;
 
 function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', n + '.pem');
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -15,8 +15,8 @@ const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
 
-const key = fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem');
-const cert = fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem');
+const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
+const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
 
 const server = net.createServer(common.mustCall((s) => {
   const tlsSocket = new tls.TLSSocket(s, {

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -45,8 +45,8 @@ function createServer() {
   let previousKey = null;
 
   const server = tls.createServer({
-    key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-    cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+    key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
     ticketKeys: keys
   }, function(c) {
     serverLog.push(id);

--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -32,8 +32,8 @@ const tls = require('tls');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.createServer(options, common.mustCall(function(cleartext) {

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -32,8 +32,8 @@ const net = require('net');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem'),
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
   handshakeTimeout: 50
 };
 

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -35,5 +35,5 @@ function test(ca, next) {
 }
 
 const array = [ca1, ca2];
-const string = ca1 + '\n' + ca2;
+const string = `${ca1}\n${ca2}`;
 test(array, () => test(string, common.noop));

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -12,8 +12,8 @@ const net = require('net');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const server = tls.createServer(options, common.mustCall((c) => {

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -251,10 +251,8 @@ for (const u in formatTests) {
   const actual = url.format(u);
   const actualObj = url.format(formatTests[u]);
   assert.strictEqual(actual, expect,
-                     'wonky format(' + u + ') == ' + expect +
-                     '\nactual:' + actual);
+                     `wonky format(${u}) == ${expect}\nactual:${actual}`);
   assert.strictEqual(actualObj, expect,
-                     'wonky format(' + JSON.stringify(formatTests[u]) +
-                     ') == ' + expect +
-                     '\nactual: ' + actualObj);
+                     `wonky format(${JSON.stringify(formatTests[u])}) == ${
+                     expect}\nactual: ${actualObj}`);
 }

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -919,5 +919,5 @@ for (const u in parseTests) {
   actual = url.format(parseTests[u]);
 
   assert.strictEqual(actual, expected,
-                     'format(' + u + ') == ' + u + '\nactual:' + actual);
+                     `format(${u}) == ${u}\nactual:${actual}`);
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -514,8 +514,7 @@ assert.doesNotThrow(() => {
 
     const withoutColor = util.inspect(input, false, 0, false);
     const withColor = util.inspect(input, false, 0, true);
-    const expect = '\u001b[' + color[0] + 'm' + withoutColor +
-                   '\u001b[' + color[1] + 'm';
+    const expect = `\u001b[${color[0]}m${withoutColor}\u001b[${color[1]}m`;
     assert.strictEqual(
       withColor,
       expect,

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -32,7 +32,7 @@ function produce(source, count) {
     console.log(data);
   `, source]);
 
-  assert.strictEqual(out.status, 0, out.stderr + '');
+  assert.strictEqual(out.status, 0, String(out.stderr));
 
   return Buffer.from(out.stdout.toString(), 'base64');
 }

--- a/test/parallel/test-vm-create-context-accessors.js
+++ b/test/parallel/test-vm-create-context-accessors.js
@@ -38,7 +38,7 @@ Object.defineProperty(ctx, 'setter', {
     val = _val;
   },
   get: function() {
-    return 'ok=' + val;
+    return `ok=${val}`;
   }
 });
 

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -77,7 +77,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 // Can set listeners and breakpoints on a single line file
 {
   const Debug = vm.runInDebugContext('Debug');
-  const fn = require(common.fixturesDir + '/exports-function-with-param');
+  const fn = require(`${common.fixturesDir}/exports-function-with-param`);
   let called = false;
 
   Debug.setListener(function(event, state, data) {
@@ -94,7 +94,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 
 // See https://github.com/nodejs/node/issues/1190, fatal errors should not
 // crash the process.
-const script = common.fixturesDir + '/vm-run-in-debug-context.js';
+const script = `${common.fixturesDir}/vm-run-in-debug-context.js`;
 let proc = spawn(process.execPath, [script]);
 const data = [];
 proc.stdout.on('data', common.mustNotCall());

--- a/test/parallel/test-vm-syntax-error-stderr.js
+++ b/test/parallel/test-vm-syntax-error-stderr.js
@@ -13,7 +13,7 @@ const p = child_process.spawn(process.execPath, [
 ]);
 
 p.stdout.on('data', function(data) {
-  assert.fail('Unexpected stdout data: ' + data);
+  assert.fail(`Unexpected stdout data: ${data}`);
 });
 
 let output = '';

--- a/test/parallel/test-zlib-convenience-methods.js
+++ b/test/parallel/test-zlib-convenience-methods.js
@@ -66,8 +66,8 @@ for (const [type, expect] of [
     }));
 
     {
-      const compressed = zlib[method[0] + 'Sync'](expect, opts);
-      const decompressed = zlib[method[1] + 'Sync'](compressed, opts);
+      const compressed = zlib[`${method[0]}Sync`](expect, opts);
+      const decompressed = zlib[`${method[1]}Sync`](compressed, opts);
       assert.strictEqual(decompressed.toString(), expectStr,
                          `Should get original string after ${method[0]}Sync/` +
                          `${method[1]}Sync ${type} with options.`);
@@ -75,8 +75,8 @@ for (const [type, expect] of [
 
 
     {
-      const compressed = zlib[method[0] + 'Sync'](expect);
-      const decompressed = zlib[method[1] + 'Sync'](compressed);
+      const compressed = zlib[`${method[0]}Sync`](expect);
+      const decompressed = zlib[`${method[1]}Sync`](compressed);
       assert.strictEqual(decompressed.toString(), expectStr,
                          `Should get original string after ${method[0]}Sync/` +
                          `${method[1]}Sync ${type} without options.`);

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -88,7 +88,7 @@ assert.doesNotThrow(
 
 // Throws if opt.strategy is the wrong type.
 assert.throws(
-  () => { new zlib.Deflate({strategy: '' + zlib.constants.Z_RLE }); },
+  () => { new zlib.Deflate({ strategy: String(zlib.constants.Z_RLE) }); },
   /^TypeError: Invalid strategy: 3$/
 );
 

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -46,6 +46,6 @@ out.on('close', function() {
   const actual = fs.readFileSync(outputFile);
   assert.strictEqual(actual.length, expect.length, 'length should match');
   for (let i = 0, l = actual.length; i < l; i++) {
-    assert.strictEqual(actual[i], expect[i], 'byte[' + i + ']');
+    assert.strictEqual(actual[i], expect[i], `byte[${i}]`);
   }
 });

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -47,14 +47,14 @@ const unzips = [ zlib.Unzip(),
                  zlib.InflateRaw() ];
 const hadError = [];
 unzips.forEach(function(uz, i) {
-  console.error('Error for ' + uz.constructor.name);
+  console.error(`Error for ${uz.constructor.name}`);
   uz.on('error', function(er) {
     console.error('Error event', er);
     hadError[i] = true;
   });
 
   uz.on('end', function(er) {
-    throw new Error('end event should not be emitted ' + uz.constructor.name);
+    throw new Error(`end event should not be emitted ${uz.constructor.name}`);
   });
 
   // this will trigger error event

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -184,10 +184,8 @@ Object.keys(tests).forEach(function(file) {
 
                 // verify that the same exact buffer comes out the other end.
                 buf.on('data', function(c) {
-                  const msg = file + ' ' +
-                              chunkSize + ' ' +
-                              JSON.stringify(opts) + ' ' +
-                              Def.name + ' -> ' + Inf.name;
+                  const msg = `${file} ${chunkSize} ${
+                              JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;
                   let ok = true;
                   const testNum = ++done;
                   let i;
@@ -199,17 +197,17 @@ Object.keys(tests).forEach(function(file) {
                     }
                   }
                   if (ok) {
-                    console.log('ok ' + (testNum) + ' ' + msg);
+                    console.log(`ok ${testNum} ${msg}`);
                   } else {
-                    console.log('not ok ' + (testNum) + ' ' + msg);
+                    console.log(`not ok ${testNum} msg`);
                     console.log('  ...');
-                    console.log('  testfile: ' + file);
-                    console.log('  type: ' + Def.name + ' -> ' + Inf.name);
-                    console.log('  position: ' + i);
-                    console.log('  options: ' + JSON.stringify(opts));
-                    console.log('  expect: ' + test[i]);
-                    console.log('  actual: ' + c[i]);
-                    console.log('  chunkSize: ' + chunkSize);
+                    console.log(`  testfile: ${file}`);
+                    console.log(`  type: ${Def.name} -> ${Inf.name}`);
+                    console.log(`  position: ${i}`);
+                    console.log(`  options: ${JSON.stringify(opts)}`);
+                    console.log(`  expect: ${test[i]}`);
+                    console.log(`  actual: ${c[i]}`);
+                    console.log(`  chunkSize: ${chunkSize}`);
                     console.log('  ---');
                   }
                 });
@@ -227,7 +225,7 @@ Object.keys(tests).forEach(function(file) {
 });
 
 process.on('exit', function(code) {
-  console.log('1..' + done);
-  assert.strictEqual(done, total, (total - done) + ' tests left unfinished');
+  console.log(`1..${done}`);
+  assert.strictEqual(done, total, `${total - done} tests left unfinished`);
   assert.strictEqual(failures, 0, 'some test failures');
 });

--- a/test/pseudo-tty/no_dropped_stdio.js
+++ b/test/pseudo-tty/no_dropped_stdio.js
@@ -6,10 +6,10 @@ const common = require('../common');
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
 // (48 + {2}) * 20 = 1000
-let out = ('o'.repeat(48) + '\n').repeat(20);
+let out = `${'o'.repeat(48)}\n`.repeat(20);
 // Add the remaining 24 bytes and terminate with an 'O'.
 // This results in 1025 bytes, just enough to overflow the 1kb OS X TTY buffer.
-out += 'o'.repeat(24) + 'O';
+out += `${'o'.repeat(24)}O`;
 
 // In AIX, the child exits even before the python parent
 // can setup the readloop. Provide a reasonable delay.

--- a/test/pseudo-tty/no_interleaved_stdio.js
+++ b/test/pseudo-tty/no_interleaved_stdio.js
@@ -6,10 +6,10 @@ const common = require('../common');
 // 1000 bytes wrapped at 50 columns
 // \n turns into a double-byte character
 // (48 + {2}) * 20 = 1000
-let out = ('o'.repeat(48) + '\n').repeat(20);
+let out = `${'o'.repeat(48)}\n`.repeat(20);
 // Add the remaining 24 bytes and terminate with an 'O'.
 // This results in 1025 bytes, just enough to overflow the 1kb OS X TTY buffer.
-out += 'o'.repeat(24) + 'O';
+out += `${'o'.repeat(24)}O`;
 
 const err = '__This is some stderr__';
 

--- a/test/pummel/test-abort-fatal-error.js
+++ b/test/pummel/test-abort-fatal-error.js
@@ -30,7 +30,7 @@ if (common.isWindows) {
 
 const exec = require('child_process').exec;
 
-let cmdline = 'ulimit -c 0; ' + process.execPath;
+let cmdline = `ulimit -c 0; ${process.execPath}`;
 cmdline += ' --max-old-space-size=4 --max-semi-space-size=1';
 cmdline += ' -e "a = []; for (i = 0; i < 1e9; i++) { a.push({}) }"';
 

--- a/test/pummel/test-child-process-spawn-loop.js
+++ b/test/pummel/test-child-process-spawn-loop.js
@@ -30,7 +30,7 @@ const N = 40;
 let finished = false;
 
 function doSpawn(i) {
-  const child = spawn('python', ['-c', 'print ' + SIZE + ' * "C"']);
+  const child = spawn('python', ['-c', `print ${SIZE} * "C"`]);
   let count = 0;
 
   child.stdout.setEncoding('ascii');
@@ -39,7 +39,7 @@ function doSpawn(i) {
   });
 
   child.stderr.on('data', (chunk) => {
-    console.log('stderr: ' + chunk);
+    console.log(`stderr: ${chunk}`);
   });
 
   child.on('close', () => {

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -40,7 +40,7 @@ const stalloogle = (str) => {
 };
 
 const bagnoogle = (arg0, arg1) => {
-  stalloogle(arg0 + ' is ' + arg1 + ' except that it is read-only');
+  stalloogle(`${arg0} is ${arg1} except that it is read-only`);
 };
 
 let done = false;
@@ -59,13 +59,13 @@ const spawn = require('child_process').spawn;
  * when we call getloadavg() -- with the implicit assumption that our
  * deepest function is the only caller of os.loadavg().
  */
-const dtrace = spawn('dtrace', [ '-qwn', 'syscall::getloadavg:entry/pid == ' +
-  process.pid + '/{ustack(100, 8192); exit(0); }' ]);
+const dtrace = spawn('dtrace', [ '-qwn', `syscall::getloadavg:entry/pid == ${
+                                process.pid}/{ustack(100, 8192); exit(0); }` ]);
 
 let output = '';
 
 dtrace.stderr.on('data', function(data) {
-  console.log('dtrace: ' + data);
+  console.log(`dtrace: ${data}`);
 });
 
 dtrace.stdout.on('data', function(data) {
@@ -74,7 +74,7 @@ dtrace.stdout.on('data', function(data) {
 
 dtrace.on('exit', function(code) {
   if (code !== 0) {
-    console.error('dtrace exited with code ' + code);
+    console.error(`dtrace exited with code ${code}`);
     process.exit(code);
   }
 
@@ -92,12 +92,12 @@ dtrace.on('exit', function(code) {
     const frame = line.substr(line.indexOf(sentinel) + sentinel.length);
     const top = frames.shift();
 
-    assert.strictEqual(frame.indexOf(top), 0, 'unexpected frame where ' +
-      top + ' was expected');
+    assert.strictEqual(frame.indexOf(top), 0,
+                       `unexpected frame where ${top} was expected`);
   }
 
   assert.strictEqual(frames.length, 0,
-                     'did not find expected frame ' + frames[0]);
+                     `did not find expected frame ${frames[0]}`);
   process.exit(0);
 });
 

--- a/test/pummel/test-exec.js
+++ b/test/pummel/test-exec.js
@@ -40,13 +40,13 @@ let error_count = 0;
 
 
 exec(
-  '"' + process.execPath + '" -p -e process.versions',
+  `"${process.execPath}" -p -e process.versions`,
   function(err, stdout, stderr) {
     if (err) {
       error_count++;
-      console.log('error!: ' + err.code);
-      console.log('stdout: ' + JSON.stringify(stdout));
-      console.log('stderr: ' + JSON.stringify(stderr));
+      console.log(`error!: ${err.code}`);
+      console.log(`stdout: ${JSON.stringify(stdout)}`);
+      console.log(`stderr: ${JSON.stringify(stderr)}`);
       assert.strictEqual(false, err.killed);
     } else {
       success_count++;
@@ -64,9 +64,9 @@ exec('thisisnotavalidcommand', function(err, stdout, stderr) {
     assert.notStrictEqual(err.code, 0);
     assert.strictEqual(false, err.killed);
     assert.strictEqual(null, err.signal);
-    console.log('error code: ' + err.code);
-    console.log('stdout: ' + JSON.stringify(stdout));
-    console.log('stderr: ' + JSON.stringify(stderr));
+    console.log(`error code: ${err.code}`);
+    console.log(`stdout: ${JSON.stringify(stdout)}`);
+    console.log(`stderr: ${JSON.stringify(stderr)}`);
   } else {
     success_count++;
     console.dir(stdout);

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -141,7 +141,7 @@ assert.doesNotThrow(
       function a() {
         ++watchSeenFour;
         assert.strictEqual(1, watchSeenFour);
-        fs.unwatchFile('.' + path.sep + filenameFour, a);
+        fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
       }
       fs.watchFile(filenameFour, a);
     }

--- a/test/pummel/test-http-client-reconnect-bug.js
+++ b/test/pummel/test-http-client-reconnect-bug.js
@@ -37,7 +37,7 @@ server.on('listening', common.mustCall(function() {
   const request = client.request('GET', '/', {'host': 'localhost'});
   request.end();
   request.on('response', function(response) {
-    console.log('STATUS: ' + response.statusCode);
+    console.log(`STATUS: ${response.statusCode}`);
   });
 }));
 

--- a/test/pummel/test-https-ci-reneg-attack.js
+++ b/test/pummel/test-https-ci-reneg-attack.js
@@ -53,8 +53,8 @@ const LIMITS = [0, 1, 2, 3, 5, 10, 16];
 
 function test(next) {
   const options = {
-    cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
-    key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+    cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
+    key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
   };
 
   let seenError = false;
@@ -62,7 +62,7 @@ function test(next) {
   const server = https.createServer(options, function(req, res) {
     const conn = req.connection;
     conn.on('error', function(err) {
-      console.error('Caught exception: ' + err);
+      console.error(`Caught exception: ${err}`);
       assert(/TLS session renegotiation attack/.test(err));
       conn.destroy();
       seenError = true;
@@ -71,7 +71,7 @@ function test(next) {
   });
 
   server.listen(common.PORT, function() {
-    const args = ('s_client -connect 127.0.0.1:' + common.PORT).split(' ');
+    const args = (`s_client -connect 127.0.0.1:${common.PORT}`).split(' ');
     const child = spawn(common.opensslCli, args);
 
     //child.stdout.pipe(process.stdout);
@@ -86,9 +86,9 @@ function test(next) {
 
     child.stderr.on('data', function(data) {
       if (seenError) return;
-      handshakes += (('' + data).match(/verify return:1/g) || []).length;
+      handshakes += ((String(data)).match(/verify return:1/g) || []).length;
       if (handshakes === 2) spam();
-      renegs += (('' + data).match(/RENEGOTIATING/g) || []).length;
+      renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
     });
 
     child.on('exit', function() {

--- a/test/pummel/test-https-large-response.js
+++ b/test/pummel/test-https-large-response.js
@@ -32,8 +32,8 @@ if (!common.hasCrypto) {
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 process.stdout.write('build body...');

--- a/test/pummel/test-net-pause.js
+++ b/test/pummel/test-net-pause.js
@@ -52,21 +52,21 @@ server.on('listening', function() {
 
   setTimeout(function() {
     chars_recved = recv.length;
-    console.log('pause at: ' + chars_recved);
+    console.log(`pause at: ${chars_recved}`);
     assert.strictEqual(true, chars_recved > 1);
     client.pause();
     setTimeout(function() {
-      console.log('resume at: ' + chars_recved);
+      console.log(`resume at: ${chars_recved}`);
       assert.strictEqual(chars_recved, recv.length);
       client.resume();
 
       setTimeout(function() {
         chars_recved = recv.length;
-        console.log('pause at: ' + chars_recved);
+        console.log(`pause at: ${chars_recved}`);
         client.pause();
 
         setTimeout(function() {
-          console.log('resume at: ' + chars_recved);
+          console.log(`resume at: ${chars_recved}`);
           assert.strictEqual(chars_recved, recv.length);
           client.resume();
 

--- a/test/pummel/test-net-pingpong.js
+++ b/test/pummel/test-net-pingpong.js
@@ -40,7 +40,7 @@ function pingPongTest(port, host, on_complete) {
     } else if (host == null || host === 'localhost') {
       assert(address === '127.0.0.1' || address === '::ffff:127.0.0.1');
     } else {
-      console.log('host = ' + host + ', remoteAddress = ' + address);
+      console.log(`host = ${host}, remoteAddress = ${address}`);
       assert.strictEqual(address, '::1');
     }
 
@@ -49,7 +49,7 @@ function pingPongTest(port, host, on_complete) {
     socket.timeout = 0;
 
     socket.on('data', function(data) {
-      console.log('server got: ' + JSON.stringify(data));
+      console.log(`server got: ${JSON.stringify(data)}`);
       assert.strictEqual('open', socket.readyState);
       assert.strictEqual(true, count <= N);
       if (/PING/.exec(data)) {
@@ -80,7 +80,7 @@ function pingPongTest(port, host, on_complete) {
     });
 
     client.on('data', function(data) {
-      console.log('client got: ' + data);
+      console.log(`client got: ${data}`);
 
       assert.strictEqual('PONG', data);
       count += 1;

--- a/test/pummel/test-net-throttle.js
+++ b/test/pummel/test-net-throttle.js
@@ -32,13 +32,13 @@ let npauses = 0;
 console.log('build big string');
 const body = 'C'.repeat(N);
 
-console.log('start server on port ' + common.PORT);
+console.log(`start server on port ${common.PORT}`);
 
 const server = net.createServer(function(connection) {
   connection.write(body.slice(0, part_N));
   connection.write(body.slice(part_N, 2 * part_N));
   assert.strictEqual(false, connection.write(body.slice(2 * part_N, N)));
-  console.log('bufferSize: ' + connection.bufferSize, 'expecting', N);
+  console.log(`bufferSize: ${connection.bufferSize}`, 'expecting', N);
   assert.ok(0 <= connection.bufferSize &&
             connection._writableState.length <= N);
   connection.end();
@@ -50,7 +50,7 @@ server.listen(common.PORT, function() {
   client.setEncoding('ascii');
   client.on('data', function(d) {
     chars_recved += d.length;
-    console.log('got ' + chars_recved);
+    console.log(`got ${chars_recved}`);
     if (!paused) {
       client.pause();
       npauses += 1;

--- a/test/pummel/test-net-timeout.js
+++ b/test/pummel/test-net-timeout.js
@@ -55,7 +55,7 @@ const echo_server = net.createServer(function(socket) {
 });
 
 echo_server.listen(common.PORT, function() {
-  console.log('server listening at ' + common.PORT);
+  console.log(`server listening at ${common.PORT}`);
 
   const client = net.createConnection(common.PORT);
   client.setEncoding('UTF8');
@@ -74,7 +74,7 @@ echo_server.listen(common.PORT, function() {
       }, 500);
 
       if (exchanges === 5) {
-        console.log('wait for timeout - should come in ' + timeout + ' ms');
+        console.log(`wait for timeout - should come in ${timeout} ms`);
         starttime = new Date();
         console.dir(starttime);
       }
@@ -101,7 +101,7 @@ process.on('exit', function() {
   assert.ok(timeouttime != null);
 
   const diff = timeouttime - starttime;
-  console.log('diff = ' + diff);
+  console.log(`diff = ${diff}`);
 
   assert.ok(timeout < diff);
 

--- a/test/pummel/test-net-timeout2.js
+++ b/test/pummel/test-net-timeout2.js
@@ -42,7 +42,7 @@ const server = net.createServer(function(socket) {
     }
 
     if (socket.writable) {
-      socket.write(Date.now() + '\n');
+      socket.write(`${Date.now()}\n`);
     }
   }, 1000);
 });

--- a/test/pummel/test-net-write-callbacks.js
+++ b/test/pummel/test-net-write-callbacks.js
@@ -44,11 +44,11 @@ function makeCallback(c) {
   let called = false;
   return function() {
     if (called)
-      throw new Error('called callback #' + c + ' more than once');
+      throw new Error(`called callback #${c} more than once`);
     called = true;
     if (c < lastCalled)
-      throw new Error('callbacks out of order. last=' + lastCalled +
-                      ' current=' + c);
+      throw new Error(
+        `callbacks out of order. last=${lastCalled} current=${c}`);
     lastCalled = c;
     cbcount++;
   };

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -28,7 +28,7 @@ const assert = require('assert');
 const fs = require('fs');
 const testFileName = require('path').join(common.tmpDir, 'GH-814_test.txt');
 const testFD = fs.openSync(testFileName, 'w');
-console.error(testFileName + '\n');
+console.error(`${testFileName}\n`);
 
 
 const tailProc = require('child_process').spawn('tail', ['-f', testFileName]);

--- a/test/pummel/test-regress-GH-892.js
+++ b/test/pummel/test-regress-GH-892.js
@@ -81,8 +81,8 @@ function makeRequest() {
 
 
 const serverOptions = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 let uploadCount = 0;

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -38,7 +38,7 @@ setTimeout(common.mustCall(function() {
 
   const diff = endtime - starttime;
   assert.ok(diff > 0);
-  console.error('diff: ' + diff);
+  console.error(`diff: ${diff}`);
 
   assert.strictEqual(true, 1000 - WINDOW < diff && diff < 1000 + WINDOW);
 }), 1000);
@@ -53,7 +53,7 @@ setInterval(function() {
 
   const diff = endtime - starttime;
   assert.ok(diff > 0);
-  console.error('diff: ' + diff);
+  console.error(`diff: ${diff}`);
 
   const t = interval_count * 1000;
 

--- a/test/pummel/test-tls-ci-reneg-attack.js
+++ b/test/pummel/test-tls-ci-reneg-attack.js
@@ -52,15 +52,15 @@ const LIMITS = [0, 1, 2, 3, 5, 10, 16];
 
 function test(next) {
   const options = {
-    cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
-    key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+    cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
+    key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
   };
 
   let seenError = false;
 
   const server = tls.createServer(options, function(conn) {
     conn.on('error', function(err) {
-      console.error('Caught exception: ' + err);
+      console.error(`Caught exception: ${err}`);
       assert(/TLS session renegotiation attack/.test(err));
       conn.destroy();
       seenError = true;
@@ -69,7 +69,7 @@ function test(next) {
   });
 
   server.listen(common.PORT, function() {
-    const args = ('s_client -connect 127.0.0.1:' + common.PORT).split(' ');
+    const args = (`s_client -connect 127.0.0.1:${common.PORT}`).split(' ');
     const child = spawn(common.opensslCli, args);
 
     //child.stdout.pipe(process.stdout);
@@ -84,9 +84,9 @@ function test(next) {
 
     child.stderr.on('data', function(data) {
       if (seenError) return;
-      handshakes += (('' + data).match(/verify return:1/g) || []).length;
+      handshakes += ((String(data)).match(/verify return:1/g) || []).length;
       if (handshakes === 2) spam();
-      renegs += (('' + data).match(/RENEGOTIATING/g) || []).length;
+      renegs += ((String(data)).match(/RENEGOTIATING/g) || []).length;
     });
 
     child.on('exit', function() {

--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -40,8 +40,8 @@ assert.strictEqual(
 );
 
 tls.createServer({
-  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
-  key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+  cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
+  key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
 }).listen(common.PORT);
 
 {

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -166,15 +166,15 @@ function test(keyfn, certfn, check, next) {
     });
 
     pair.encrypted.on('error', function(err) {
-      console.log('encrypted error: ' + err);
+      console.log(`encrypted error: ${err}`);
     });
 
     s.on('error', function(err) {
-      console.log('socket error: ' + err);
+      console.log(`socket error: ${err}`);
     });
 
     pair.on('error', function(err) {
-      console.log('secure error: ' + err);
+      console.log(`secure error: ${err}`);
     });
   }
 

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -36,8 +36,8 @@ const util = require('util');
 const request = Buffer.from('ABCD'.repeat(1024 * 256 - 1)); // 1mb
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 function Mediator() {

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -81,7 +81,7 @@ function doTest() {
   function Client(cb) {
     const flags = [
       's_client',
-      '-connect', 'localhost:' + common.PORT,
+      '-connect', `localhost:${common.PORT}`,
       '-sess_in', sessionFileName,
       '-sess_out', sessionFileName
     ];

--- a/test/pummel/test-tls-throttle.js
+++ b/test/pummel/test-tls-throttle.js
@@ -38,8 +38,8 @@ const body = 'hello world\n'.repeat(1024 * 1024);
 process.stdout.write('done\n');
 
 const options = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent2-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent2-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
 };
 
 const server = tls.Server(options, common.mustCall(function(socket) {

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -66,7 +66,7 @@ assert.throws(function() {
 }, /Command failed: iamabadcommand/);
 
 const msg = 'foobar';
-const msgBuf = Buffer.from(msg + '\n');
+const msgBuf = Buffer.from(`${msg}\n`);
 
 // console.log ends every line with just '\n', even on Windows.
 
@@ -79,7 +79,7 @@ assert.deepStrictEqual(ret, msgBuf, 'execSync result buffer should match');
 
 ret = execSync(cmd, { encoding: 'utf8' });
 
-assert.strictEqual(ret, msg + '\n', 'execSync encoding result should match');
+assert.strictEqual(ret, `${msg}\n`, 'execSync encoding result should match');
 
 const args = [
   '-e',
@@ -91,7 +91,7 @@ assert.deepStrictEqual(ret, msgBuf);
 
 ret = execFileSync(process.execPath, args, { encoding: 'utf8' });
 
-assert.strictEqual(ret, msg + '\n',
+assert.strictEqual(ret, `${msg}\n`,
                    'execFileSync encoding result should match');
 
 // Verify that the cwd option works - GH #7824

--- a/test/sequential/test-deprecation-flags.js
+++ b/test/sequential/test-deprecation-flags.js
@@ -23,17 +23,17 @@
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const depmod = require.resolve(common.fixturesDir + '/deprecated.js');
+const depmod = require.resolve(`${common.fixturesDir}/deprecated.js`);
 const node = process.execPath;
 
 const depUserlandFunction =
-  require.resolve(common.fixturesDir + '/deprecated-userland-function.js');
+  require.resolve(`${common.fixturesDir}/deprecated-userland-function.js`);
 
 const depUserlandClass =
-  require.resolve(common.fixturesDir + '/deprecated-userland-class.js');
+  require.resolve(`${common.fixturesDir}/deprecated-userland-class.js`);
 
 const depUserlandSubClass =
-  require.resolve(common.fixturesDir + '/deprecated-userland-subclass.js');
+  require.resolve(`${common.fixturesDir}/deprecated-userland-subclass.js`);
 
 const normal = [depmod];
 const noDep = ['--no-deprecation', depmod];

--- a/test/sequential/test-dgram-pingpong.js
+++ b/test/sequential/test-dgram-pingpong.js
@@ -15,7 +15,7 @@ function pingPongTest(port, host) {
   });
 
   server.on('listening', function() {
-    console.log('server listening on ' + port);
+    console.log(`server listening on ${port}`);
 
     const client = dgram.createSocket('udp4');
 
@@ -30,7 +30,7 @@ function pingPongTest(port, host) {
       throw e;
     });
 
-    console.log('Client sending to ' + port);
+    console.log(`Client sending to ${port}`);
 
     function clientSend() {
       client.send('PING', 0, 4, port, 'localhost');

--- a/test/sequential/test-domain-abort-on-uncaught.js
+++ b/test/sequential/test-domain-abort-on-uncaught.js
@@ -245,9 +245,10 @@ if (process.argv[2] === 'child') {
     const child = child_process.exec(testCmd);
 
     child.on('exit', function onExit(code, signal) {
-      assert.strictEqual(code, 0, 'Test at index ' + testIndex +
-        ' should have exited with exit code 0 but instead exited with code ' +
-        code + ' and signal ' + signal);
+      assert.strictEqual(
+        code, 0, `Test at index ${testIndex
+        } should have exited with exit code 0 but instead exited with code ${
+        code} and signal ${signal}`);
     });
   });
 }

--- a/test/sequential/test-https-set-timeout-server.js
+++ b/test/sequential/test-https-set-timeout-server.js
@@ -35,8 +35,8 @@ const fs = require('fs');
 const tests = [];
 
 const serverOptions = {
-  key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),
-  cert: fs.readFileSync(common.fixturesDir + '/keys/agent1-cert.pem')
+  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
 function test(fn) {

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -189,25 +189,25 @@ try {
   require.extensions['.reg'] = require.extensions['.js'];
   require.extensions['.reg2'] = require.extensions['.js'];
 
-  assert.strictEqual(require(loadOrder + 'file1').file1, 'file1', msg);
-  assert.strictEqual(require(loadOrder + 'file2').file2, 'file2.js', msg);
+  assert.strictEqual(require(`${loadOrder}file1`).file1, 'file1', msg);
+  assert.strictEqual(require(`${loadOrder}file2`).file2, 'file2.js', msg);
   try {
-    require(loadOrder + 'file3');
+    require(`${loadOrder}file3`);
   } catch (e) {
     // Not a real .node module, but we know we require'd the right thing.
     assert.ok(e.message.replace(/\\/g, '/').match(/file3\.node/));
   }
-  assert.strictEqual(require(loadOrder + 'file4').file4, 'file4.reg', msg);
-  assert.strictEqual(require(loadOrder + 'file5').file5, 'file5.reg2', msg);
-  assert.strictEqual(require(loadOrder + 'file6').file6, 'file6/index.js', msg);
+  assert.strictEqual(require(`${loadOrder}file4`).file4, 'file4.reg', msg);
+  assert.strictEqual(require(`${loadOrder}file5`).file5, 'file5.reg2', msg);
+  assert.strictEqual(require(`${loadOrder}file6`).file6, 'file6/index.js', msg);
   try {
-    require(loadOrder + 'file7');
+    require(`${loadOrder}file7`);
   } catch (e) {
     assert.ok(e.message.replace(/\\/g, '/').match(/file7\/index\.node/));
   }
-  assert.strictEqual(require(loadOrder + 'file8').file8, 'file8/index.reg',
+  assert.strictEqual(require(`${loadOrder}file8`).file8, 'file8/index.reg',
                      msg);
-  assert.strictEqual(require(loadOrder + 'file9').file9, 'file9/index.reg2',
+  assert.strictEqual(require(`${loadOrder}file9`).file9, 'file9/index.reg2',
                      msg);
 }
 

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -92,7 +92,7 @@ function parent() {
     inp.on('data', function(c) {
       c = c.trim();
       if (!c) return;
-      out.write(w + c.split('\n').join('\n' + w) + '\n');
+      out.write(`${w}${c.split('\n').join(`\n${w}`)}\n`);
     });
   }
 }

--- a/test/sequential/test-process-warnings.js
+++ b/test/sequential/test-process-warnings.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnmod = require.resolve(`${common.fixturesDir}/warnings.js`);
 const node = process.execPath;
 
 const normal = [warnmod];

--- a/test/sequential/test-regress-GH-1697.js
+++ b/test/sequential/test-regress-GH-1697.js
@@ -29,7 +29,7 @@ if (process.argv[2] === 'server') {
 
   const server = net.createServer(function(conn) {
     conn.on('data', function(data) {
-      console.log('server received ' + data.length + ' bytes');
+      console.log(`server received ${data.length} bytes`);
     });
 
     conn.on('close', function() {

--- a/test/sequential/test-regress-GH-4015.js
+++ b/test/sequential/test-regress-GH-4015.js
@@ -24,8 +24,8 @@ const common = require('../common');
 const assert = require('assert');
 const exec = require('child_process').exec;
 
-const cmd = '"' + process.execPath + '" ' +
-            '"' + common.fixturesDir + '/test-regress-GH-4015.js"';
+const cmd =
+  `"${process.execPath}" "${common.fixturesDir}/test-regress-GH-4015.js"`;
 
 exec(cmd, function(err, stdout, stderr) {
   assert(/RangeError: Maximum call stack size exceeded/.test(stderr));

--- a/test/sequential/test-regress-GH-784.js
+++ b/test/sequential/test-regress-GH-784.js
@@ -69,7 +69,7 @@ const responses = [];
 
 function afterPing(result) {
   responses.push(result);
-  console.error('afterPing. responses.length = ' + responses.length);
+  console.error(`afterPing. responses.length = ${responses.length}`);
   switch (responses.length) {
     case 2:
       assert.ok(/ECONNREFUSED/.test(responses[0]));
@@ -130,7 +130,7 @@ function ping() {
   let hadError = false;
 
   req.on('error', function(error) {
-    console.log('Error making ping req: ' + error);
+    console.log(`Error making ping req: ${error}`);
     hadError = true;
     assert.ok(!gotEnd);
     afterPing(error.message);

--- a/test/sequential/test-regress-GH-877.js
+++ b/test/sequential/test-regress-GH-877.js
@@ -54,9 +54,10 @@ server.listen(common.PORT, '127.0.0.1', function() {
 
     assert.strictEqual(req.agent, agent);
 
-    console.log('Socket: ' + agent.sockets[addrString].length + '/' +
-                agent.maxSockets + ' queued: ' + (agent.requests[addrString] ?
-                agent.requests[addrString].length : 0));
+    console.log(
+      `Socket: ${agent.sockets[addrString].length}/${
+      agent.maxSockets} queued: ${
+      agent.requests[addrString] ? agent.requests[addrString].length : 0}`);
 
     const agentRequests = agent.requests[addrString] ?
         agent.requests[addrString].length : 0;

--- a/test/sequential/test-repl-timeout-throw.js
+++ b/test/sequential/test-repl-timeout-throw.js
@@ -31,7 +31,7 @@ child.stdout.once('data', function() {
   setTimeout(fsTest, 50);
   function fsTest() {
     const f = JSON.stringify(__filename);
-    child.stdin.write('fs.readFile(' + f + ', thrower);\n');
+    child.stdin.write(`fs.readFile(${f}, thrower);\n`);
     setTimeout(eeTest, 50);
   }
 

--- a/test/sequential/test-require-cache-without-stat.js
+++ b/test/sequential/test-require-cache-without-stat.js
@@ -46,7 +46,7 @@ fs.stat = function() {
 };
 
 // Load the module 'a' and 'http' once. It should become cached.
-require(common.fixturesDir + '/a');
+require(`${common.fixturesDir}/a`);
 require('../fixtures/a.js');
 require('./../fixtures/a.js');
 require('http');
@@ -57,7 +57,7 @@ const counterBefore = counter;
 // Now load the module a bunch of times with equivalent paths.
 // stat should not be called.
 for (let i = 0; i < 100; i++) {
-  require(common.fixturesDir + '/a');
+  require(`${common.fixturesDir}/a`);
   require('../fixtures/a.js');
   require('./../fixtures/a.js');
 }

--- a/test/sequential/test-stream2-stderr-sync.js
+++ b/test/sequential/test-stream2-stderr-sync.js
@@ -29,7 +29,7 @@ function parent() {
   const assert = require('assert');
   let i = 0;
   children.forEach(function(_, c) {
-    const child = spawn(process.execPath, [__filename, '' + c]);
+    const child = spawn(process.execPath, [__filename, String(c)]);
     let err = '';
 
     child.stderr.on('data', function(c) {
@@ -37,10 +37,10 @@ function parent() {
     });
 
     child.on('close', function() {
-      assert.strictEqual(err, 'child ' + c + '\nfoo\nbar\nbaz\n');
+      assert.strictEqual(err, `child ${c}\nfoo\nbar\nbaz\n`);
       console.log('ok %d child #%d', ++i, c);
       if (i === children.length)
-        console.log('1..' + i);
+        console.log(`1..${i}`);
     });
   });
 }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test

Refs: https://github.com/nodejs/node/pull/12455

This is not an exhaustive deliverance from all string concatenations: if a result looked too ugly and messy, I've abstained to change, so some concatenations still remain. I am not sure if we should to add `prefer-template: error` to test `.eslintrc.yaml`, so I've also abstained from proposing, but let me know if this is discussable.

Concerning reviews: https://github.com/nodejs/node/pull/12735#issuecomment-298996435

- [ ] 01. test: reduce string concatenations (the base commit, with `test/common.js` only)
- [ ] 02. fixup: addons – known_issues, pseudo-tty
- [ ] 03. fixup: pummel
- [ ] 04. fixup: sequential
- [ ] 05. fixup: parallel/assert* – child-process*
- [ ] 06. fixup: parallel/cli* – cwd*
- [ ] 07. fixup: parallel/dgram* – file*
- [ ] 08. fixup: parallel/fs*
- [ ] 09. fixup: parallel/http* – http-full-response
- [ ] 10. fixup: parallel/http-get-pipeline-problem – http-write-empty-string!
- [ ] 11. fixup: parallel/https* – https-drain
- [ ] 12. fixup: parallel/https-eof-for-eom – https-truncate
- [ ] 13. fixup: parallel/intl* – net*
- [ ] 14. fixup: parallel/next-tick* – regress*
- [ ] 15. fixup: parallel/repl* – spawn*
- [ ] 16. fixup: parallel/stdin* – timers*
- [ ] 17. fixup: parallel/tls* – tls-connect*
- [ ] 18. fixup: parallel/tls-delayed* – tls-invoke-queued
- [ ] 19. fixup: parallel/tls-js-stream – tls-securepair*
- [ ] 20. fixup: parallel/tls-server* – tls-wrap-timeout
- [ ] 21. fixup: parallel/url* – zlib*
