### PR TITLE
test: move WPT to its own testing module

### DIFF
--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -5,7 +5,7 @@ var http = require('http');
 var fs = require('fs');
 var fork = require('child_process').fork;
 var common = require('../common.js');
-var test = require('../../test/common.js');
+var test = require('../../test/common');
 var pep = `${path.dirname(process.argv[1])}/_chunky_http_client.js`;
 var PIPE = test.PIPE;
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,17 +1,12 @@
 # Node.js Core Tests
 
-This folder contains code and data used to test the Node.js implementation.
+This directory contains code and data used to test the Node.js implementation.
 
 For a detailed guide on how to write tests in this
 directory, see [the guide on writing tests](../doc/guides/writing-tests.md).
 
 On how to run tests in this direcotry, see
 [the contributing guide](../CONTRIBUTING.md#step-5-test).
-
-## Table of Contents
-
-* [Test directories](#test-directories)
-* [Common module API](#common-module-api)
 
 ## Test Directories
 
@@ -46,6 +41,14 @@ On how to run tests in this direcotry, see
       <td>Yes</td>
       <td>
         C++ test that is run as part of the build process.
+      </td>
+    </tr>
+    <tr>
+      <td>common</td>
+      <td></td>
+      <td>
+        Common modules shared among many tests.
+        <a href="./common/README.md">[Documentation]</a>
       </td>
     </tr>
     <tr>
@@ -158,277 +161,3 @@ On how to run tests in this direcotry, see
     </tr>
   </tbody>
 </table>
-
-## Common module API
-
-The common.js module is used by tests for consistency across repeated
-tasks. It has a number of helpful functions and properties to help with
-writing tests.
-
-### allowGlobals(...whitelist)
-* `whitelist` [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) Array of Globals
-* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-
-Takes `whitelist` and concats that with predefined `knownGlobals`.
-
-### arrayStream
-A stream to push an array into a REPL
-
-### busyLoop(time)
-* `time` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
-
-Blocks for `time` amount of time.
-
-### canCreateSymLink
-API to indicate whether the current running process can create
-symlinks. On Windows, this returns false if the process running
-doesn't have privileges to create symlinks (specifically
-[SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)).
-On non-Windows platforms, this currently returns true.
-
-### crashOnUnhandledRejection()
-
-Installs a `process.on('unhandledRejection')` handler that crashes the process
-after a tick. This is useful for tests that use Promises and need to make sure
-no unexpected rejections occur, because currently they result in silent
-failures.
-
-### ddCommand(filename, kilobytes)
-* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-Platform normalizes the `dd` command
-
-### enoughTestMem
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Check if there is more than 1gb of total memory.
-
-### expectsError(settings)
-* `settings` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-  with the following optional properties:
-  * `code` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-    expected error must have this value for its `code` property
-  * `type` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-    expected error must be an instance of `type`
-  * `message` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-    or [&lt;RegExp>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
-    if a string is provided for `message`, expected error must have it for its
-    `message` property; if a regular expression is provided for `message`, the
-    regular expression must match the `message` property of the expected error
-
-* return function suitable for use as a validation function passed as the second
-  argument to `assert.throws()`
-
-The expected error should be [subclassed by the `internal/errors` module](https://github.com/nodejs/node/blob/master/doc/guides/using-internal-errors.md#api).
-
-### expectWarning(name, expected)
-* `name` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-* `expected` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) | [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-
-Tests whether `name` and `expected` are part of a raised warning.
-
-## getArrayBufferViews(buf)
-* `buf` [&lt;Buffer>](https://nodejs.org/api/buffer.html#buffer_class_buffer)
-* return [&lt;ArrayBufferView&#91;&#93;>](https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView)
-
-Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
-
-### hasCrypto
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks for 'openssl'.
-
-### hasFipsCrypto
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks `hasCrypto` and `crypto` with fips.
-
-### hasIPv6
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks whether `IPv6` is supported on this platform.
-
-### hasMultiLocalhost
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks if there are multiple localhosts available.
-
-### fileExists(pathname)
-* pathname [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks if `pathname` exists
-
-### fixturesDir
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Path to the 'fixtures' directory.
-
-### globalCheck
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Turn this off if the test should not check for global leaks.
-
-### inFreeBSDJail
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks whether free BSD Jail is true or false.
-
-### isAix
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Advanced Interactive eXecutive (AIX).
-
-### isAlive(pid)
-* `pid` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Attempts to 'kill' `pid`
-
-### isFreeBSD
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Free BSD.
-
-### isLinux
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Linux.
-
-### isLinuxPPCBE
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Linux on PowerPC.
-
-### isOSX
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for macOS.
-
-### isSunOS
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for SunOS.
-
-### isWindows
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Windows.
-
-### isWOW64
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Platform check for Windows 32-bit on Windows 64-bit.
-
-### leakedGlobals
-* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-
-Checks whether any globals are not on the `knownGlobals` list.
-
-### localhostIPv4
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Gets IP of localhost
-
-### localIPv6Hosts
-* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-
-Array of IPV6 hosts.
-
-### mustCall([fn][, expected])
-* fn [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-* expected [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
-* return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-
-Returns a function that calls `fn`. If the returned function has not been called
-exactly `expected` number of times when the test is complete, then the test will
-fail.
-
-If `fn` is not provided, `common.noop` will be used.
-
-### nodeProcessAborted(exitCode, signal)
-* `exitCode` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
-* `signal` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Returns `true` if the exit code `exitCode` and/or signal name `signal` represent the exit code and/or signal name of a node process that aborted, `false` otherwise.
-
-### noop
-
-A non-op `Function` that can be used for a variety of scenarios.
-
-For instance,
-
-<!-- eslint-disable strict, no-undef -->
-```js
-const common = require('../common');
-
-someAsyncAPI('foo', common.mustCall(common.noop));
-```
-
-### opensslCli
-* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-
-Checks whether 'opensslCli' is supported.
-
-### platformTimeout(ms)
-* `ms` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
-* return [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
-
-Platform normalizes timeout.
-
-### PIPE
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Path to the test sock.
-
-### PORT
-* return [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = `12346`
-
-Port tests are running on.
-
-### refreshTmpDir
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Deletes the 'tmp' dir and recreates it
-
-### rootDir
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Path to the 'root' directory. either `/` or `c:\\` (windows)
-
-### skip(msg)
-* `msg` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Logs '1..0 # Skipped: ' + `msg`
-
-### spawnPwd(options)
-* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-Platform normalizes the `pwd` command.
-
-### spawnSyncPwd(options)
-* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-Synchronous version of `spawnPwd`.
-
-### tmpDir
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-The realpath of the 'tmp' directory.
-
-### tmpDirName
-* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
-
-Name of the temp directory used by tests.
-
-### WPT
-
-A port of parts of
-[W3C testharness.js](https://github.com/w3c/testharness.js) for testing the
-Node.js
-[WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api)
-implementation with tests from
-[W3C Web Platform Tests](https://github.com/w3c/web-platform-tests).

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1,0 +1,281 @@
+# Node.js Core Test Common Modules
+
+This directory contains modules used to test the Node.js implementation.
+
+## Table of Contents
+
+* [Common module API](#common-module-api)
+* [WPT module](#wpt-module)
+
+## Common Module API
+
+The `common` module is used by tests for consistency across repeated
+tasks.
+
+### allowGlobals(...whitelist)
+* `whitelist` [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) Array of Globals
+* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+
+Takes `whitelist` and concats that with predefined `knownGlobals`.
+
+### arrayStream
+A stream to push an array into a REPL
+
+### busyLoop(time)
+* `time` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
+
+Blocks for `time` amount of time.
+
+### canCreateSymLink
+API to indicate whether the current running process can create
+symlinks. On Windows, this returns false if the process running
+doesn't have privileges to create symlinks (specifically
+[SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)).
+On non-Windows platforms, this currently returns true.
+
+### crashOnUnhandledRejection()
+
+Installs a `process.on('unhandledRejection')` handler that crashes the process
+after a tick. This is useful for tests that use Promises and need to make sure
+no unexpected rejections occur, because currently they result in silent
+failures.
+
+### ddCommand(filename, kilobytes)
+* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
+Platform normalizes the `dd` command
+
+### enoughTestMem
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Check if there is more than 1gb of total memory.
+
+### expectsError(settings)
+* `settings` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+  with the following optional properties:
+  * `code` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+    expected error must have this value for its `code` property
+  * `type` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    expected error must be an instance of `type`
+  * `message` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+    or [&lt;RegExp>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+    if a string is provided for `message`, expected error must have it for its
+    `message` property; if a regular expression is provided for `message`, the
+    regular expression must match the `message` property of the expected error
+
+* return function suitable for use as a validation function passed as the second
+  argument to `assert.throws()`
+
+The expected error should be [subclassed by the `internal/errors` module](https://github.com/nodejs/node/blob/master/doc/guides/using-internal-errors.md#api).
+
+### expectWarning(name, expected)
+* `name` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+* `expected` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) | [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+
+Tests whether `name` and `expected` are part of a raised warning.
+
+### fileExists(pathname)
+* pathname [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks if `pathname` exists
+
+### fixturesDir
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Path to the 'fixtures' directory.
+
+### getArrayBufferViews(buf)
+* `buf` [&lt;Buffer>](https://nodejs.org/api/buffer.html#buffer_class_buffer)
+* return [&lt;ArrayBufferView&#91;&#93;>](https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView)
+
+Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
+
+### globalCheck
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Turn this off if the test should not check for global leaks.
+
+### hasCrypto
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks for 'openssl'.
+
+### hasFipsCrypto
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks `hasCrypto` and `crypto` with fips.
+
+### hasIPv6
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks whether `IPv6` is supported on this platform.
+
+### hasMultiLocalhost
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks if there are multiple localhosts available.
+
+### inFreeBSDJail
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks whether free BSD Jail is true or false.
+
+### isAix
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Advanced Interactive eXecutive (AIX).
+
+### isAlive(pid)
+* `pid` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Attempts to 'kill' `pid`
+
+### isFreeBSD
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Free BSD.
+
+### isLinux
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Linux.
+
+### isLinuxPPCBE
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Linux on PowerPC.
+
+### isOSX
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for macOS.
+
+### isSunOS
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for SunOS.
+
+### isWindows
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Windows.
+
+### isWOW64
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Platform check for Windows 32-bit on Windows 64-bit.
+
+### leakedGlobals
+* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+
+Checks whether any globals are not on the `knownGlobals` list.
+
+### localhostIPv4
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Gets IP of localhost
+
+### localIPv6Hosts
+* return [&lt;Array>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+
+Array of IPV6 hosts.
+
+### mustCall([fn][, expected])
+* fn [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+* expected [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
+* return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+
+Returns a function that calls `fn`. If the returned function has not been called
+exactly `expected` number of times when the test is complete, then the test will
+fail.
+
+If `fn` is not provided, `common.noop` will be used.
+
+### nodeProcessAborted(exitCode, signal)
+* `exitCode` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
+* `signal` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Returns `true` if the exit code `exitCode` and/or signal name `signal` represent the exit code and/or signal name of a node process that aborted, `false` otherwise.
+
+### noop
+
+A non-op `Function` that can be used for a variety of scenarios.
+
+For instance,
+
+<!-- eslint-disable strict, no-undef -->
+```js
+const common = require('../common');
+
+someAsyncAPI('foo', common.mustCall(common.noop));
+```
+
+### opensslCli
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks whether 'opensslCli' is supported.
+
+### platformTimeout(ms)
+* `ms` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
+* return [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)
+
+Platform normalizes timeout.
+
+### PIPE
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Path to the test sock.
+
+### PORT
+* return [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = `12346`
+
+Port tests are running on.
+
+### refreshTmpDir
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Deletes the 'tmp' dir and recreates it
+
+### rootDir
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Path to the 'root' directory. either `/` or `c:\\` (windows)
+
+### skip(msg)
+* `msg` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Logs '1..0 # Skipped: ' + `msg`
+
+### spawnPwd(options)
+* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
+Platform normalizes the `pwd` command.
+
+### spawnSyncPwd(options)
+* `options` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+* return [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
+Synchronous version of `spawnPwd`.
+
+### tmpDir
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+The realpath of the 'tmp' directory.
+
+### tmpDirName
+* return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
+
+Name of the temp directory used by tests.
+
+## WPT Module
+
+The wpt.js module is a port of parts of
+[W3C testharness.js](https://github.com/w3c/testharness.js) for testing the
+Node.js
+[WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api)
+implementation with tests from
+[W3C Web Platform Tests](https://github.com/w3c/web-platform-tests).

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -33,12 +33,12 @@ const Timer = process.binding('timer_wrap').Timer;
 const execSync = require('child_process').execSync;
 
 const testRoot = process.env.NODE_TEST_DIR ?
-                   fs.realpathSync(process.env.NODE_TEST_DIR) : __dirname;
+  fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
 
 const noop = () => {};
 
 exports.noop = noop;
-exports.fixturesDir = path.join(__dirname, 'fixtures');
+exports.fixturesDir = path.join(__dirname, '..', 'fixtures');
 exports.tmpDirName = 'tmp';
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
@@ -630,32 +630,6 @@ Object.defineProperty(exports, 'hasIntl', {
     return process.binding('config').hasIntl;
   }
 });
-
-// https://github.com/w3c/testharness.js/blob/master/testharness.js
-exports.WPT = {
-  test: (fn, desc) => {
-    try {
-      fn();
-    } catch (err) {
-      console.error(`In ${desc}:`);
-      throw err;
-    }
-  },
-  assert_equals: assert.strictEqual,
-  assert_true: (value, message) => assert.strictEqual(value, true, message),
-  assert_false: (value, message) => assert.strictEqual(value, false, message),
-  assert_throws: (code, func, desc) => {
-    assert.throws(func, (err) => {
-      return typeof err === 'object' &&
-             'name' in err &&
-             err.name.startsWith(code.name);
-    }, desc);
-  },
-  assert_array_equals: assert.deepStrictEqual,
-  assert_unreached(desc) {
-    assert.fail(`Reached unreachable code: ${desc}`);
-  }
-};
 
 // Useful for testing expected internal/error objects
 exports.expectsError = function expectsError({code, type, message}) {

--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -1,0 +1,30 @@
+/* eslint-disable required-modules */
+'use strict';
+
+const assert = require('assert');
+
+// https://github.com/w3c/testharness.js/blob/master/testharness.js
+module.exports = {
+  test: (fn, desc) => {
+    try {
+      fn();
+    } catch (err) {
+      console.error(`In ${desc}:`);
+      throw err;
+    }
+  },
+  assert_equals: assert.strictEqual,
+  assert_true: (value, message) => assert.strictEqual(value, true, message),
+  assert_false: (value, message) => assert.strictEqual(value, false, message),
+  assert_throws: (code, func, desc) => {
+    assert.throws(func, function(err) {
+      return typeof err === 'object' &&
+             'name' in err &&
+             err.name.startsWith(code.name);
+    }, desc);
+  },
+  assert_array_equals: assert.deepStrictEqual,
+  assert_unreached(desc) {
+    assert.fail(`Reached unreachable code: ${desc}`);
+  }
+};

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -2,7 +2,8 @@
 const common = require('../common');
 const path = require('path');
 const { URL, URLSearchParams } = require('url');
-const { test, assert_equals, assert_true, assert_throws } = common.WPT;
+const { test, assert_equals, assert_true, assert_throws } =
+  require('../common/wpt');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 const URL = require('url').URL;
-const { test, assert_equals, assert_throws } = common.WPT;
+const { test, assert_equals, assert_throws } = require('../common/wpt');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const path = require('path');
 const URL = require('url').URL;
-const { test, assert_equals } = common.WPT;
+const { test, assert_equals } = require('../common/wpt');
 
 if (!common.hasIntl) {
   // A handful of the tests fail when ICU is not included.

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_equals, assert_true } = common.WPT;
+const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -6,7 +6,7 @@ const URLSearchParams = require('url').URLSearchParams;
 const {
   test, assert_equals, assert_true,
   assert_false, assert_throws, assert_array_equals
-} = common.WPT;
+} = require('../common/wpt');
 
 /* eslint-disable */
 var params;  // Strict mode fix for WPT.

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -3,7 +3,8 @@
 const common = require('../common');
 const assert = require('assert');
 const { URL, URLSearchParams } = require('url');
-const { test, assert_equals, assert_true, assert_false } = common.WPT;
+const { test, assert_equals, assert_true, assert_false } =
+  require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -3,7 +3,8 @@
 const common = require('../common');
 const assert = require('assert');
 const { URL, URLSearchParams } = require('url');
-const { test, assert_array_equals, assert_unreached } = common.WPT;
+const { test, assert_array_equals, assert_unreached } =
+  require('../common/wpt');
 
 /* eslint-disable */
 var i;  // Strict mode fix for WPT.

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_equals, assert_true } = common.WPT;
+const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -3,7 +3,8 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_equals, assert_true, assert_array_equals } = common.WPT;
+const { test, assert_equals, assert_true, assert_array_equals } =
+  require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_false, assert_true } = common.WPT;
+const { test, assert_false, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_equals, assert_true } = common.WPT;
+const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const { URL, URLSearchParams } = require('url');
-const { test, assert_array_equals } = common.WPT;
+const { test, assert_array_equals } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
-const { test, assert_equals } = common.WPT;
+const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const URL = require('url').URL;
-const { test, assert_equals } = common.WPT;
+const { test, assert_equals } = require('../common/wpt');
 const additionalTestCases = require(
     path.join(common.fixturesDir, 'url-setter-tests-additional.js'));
 

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const URL = require('url').URL;
-const { test, assert_equals } = common.WPT;
+const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
 /* WPT Refs:

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -243,7 +243,7 @@ try {
   }, {});
 
   assert.deepStrictEqual(children, {
-    'common.js': {},
+    'common/index.js': {},
     'fixtures/not-main-module.js': {},
     'fixtures/a.js': {
       'fixtures/b/c.js': {


### PR DESCRIPTION
This is first in a hoped-for series of moves away from a monolithic
common.js that is loaded for every test and towards a more modular
approach. (In the end, common.js will hopefully contain checks for
variables leaking into the global space and perhaps some of the more
ubiquitous functions like common.mustCall().)

Move the WPT testing code to its own module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test url