### PR TITLE
cluster: remove debug arg handling

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -70,17 +70,7 @@ cluster.setupMaster = function(options) {
   assert(schedulingPolicy === SCHED_NONE || schedulingPolicy === SCHED_RR,
          `Bad cluster.schedulingPolicy: ${schedulingPolicy}`);
 
-  const hasDebugArg = process.execArgv.some((argv) => {
-    return /^(--debug|--debug-brk)(=\d+)?$/.test(argv);
-  });
-
   process.nextTick(setupSettingsNT, settings);
-
-  // Send debug signal only if not started in debug mode, this helps a lot
-  // on windows, because RegisterDebugHandler is not called when node starts
-  // with --debug.* arg.
-  if (hasDebugArg)
-    return;
 
   process.on('internalMessage', (message) => {
     if (message.cmd !== 'NODE_DEBUG_ENABLED')


### PR DESCRIPTION
--debug and --debug-brk are no longer valid flags so remove special
handling for them in the cluster module. Even if they are restored, they
will be aliases for inspect and will not use the legacy debug protocol,
so the special handling will not be needed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
cluster debugger