### PR TITLE
Revert "test: remove eslint comments"

### DIFF
--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -4,11 +4,13 @@ const common = require('../common');
 const URL = require('url').URL;
 const { test, assert_equals } = common.WPT;
 
+/* eslint-disable */
 /* WPT Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 test(() => {
-  const a = new URL('https://example.com/');
-  assert_equals(JSON.stringify(a), '"https://example.com/"');
-});
+  const a = new URL("https://example.com/")
+  assert_equals(JSON.stringify(a), "\"https://example.com/\"")
+})
+/* eslint-enable */


### PR DESCRIPTION
This reverts commit 8d1f15bf992a70eab3107986a4fc71afc16a9c99 to preserve the original WPT code.

Refs: https://github.com/nodejs/node/pull/12669/files/b2c7a51dd7542add59f08a8e9361ac4715c7f5ab#r114009488

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, url-whatwg