### PR TITLE
doc: adding "rules of thumb"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ This document will guide you through the contribution process.
 ### Rules of thumb
 
 1. #### Provide motivation for the change
-   Why will this change make the code better; does it fix a bug, is it a new
-   feature, etc. This should be in the commit messages as well as in the PR
-   description.
+   Try to explain why this change will make the code better. For example, does
+   it fix a bug, or is it a new feature, etc. This should expressed in the 
+   commit messages as well as in the PR description.
 2. #### Don't make _unnecessary_ code changes
-   Things that are changed because of personal preference or style, like:
-   renaming of variables or functions, adding or removing white spaces,
-   reordering lines or whole code blocks. These sort of changes should have
-   a good reason since they cause unnecessary
+   _Unnecessary_ code changes are changes made because of personal preference
+   or style. For example, renaming of variables or functions, adding or removing
+   white spaces, and reordering lines or whole code blocks. These sort of 
+   changes should have a good reason since otherwise they cause unnecessary
    ["code churn"](https://blog.gitprime.com/why-code-churn-matters).
    As part of the project's strategy we maintain multiple release lines, code
    churn might hinder back-porting changes to other lines. Also when you
@@ -154,6 +154,7 @@ changed and why. Follow these guidelines when writing one:
     Refs: http://eslint.org/docs/rules/space-in-parens.html
     Refs: https://github.com/nodejs/node/pull/3615
     ```
+    - It's it's not a fix, you should document the motivation for the change
 
 A good commit log can look something like this:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ This document will guide you through the contribution process.
    use Google's cpplint (with some ajustments) so following their [style-guide](https://github.com/google/styleguide)
    should keep you in line.  
    For JS we use this [ruleset](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
-   for ESLint plus some of [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules)  
-   For markdown we have a [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md)
+   for ESLint plus some of [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules).  
+   For markdown we have a [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md).
 
 ### Step 1: Fork
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,12 @@ This document will guide you through the contribution process.
    Things that are changed because of personal preference or style, like:
    renaming of variables or functions, adding or removing white spaces,
    reordering lines or whole code blocks. These sort of changes should have
-   a good reason since they cause unnecessary ["code churn"](https://blog.gitprime.com/why-code-churn-matters).
+   a good reason since they cause unnecessary
+   ["code churn"](https://blog.gitprime.com/why-code-churn-matters).
    As part of the project's strategy we maintain multiple release lines, code
    churn might hinder back-porting changes to other lines. Also when you
-   change a line, your name will come up in `git blame` and might hide the
-   previous writer of the code.
+   change a line, your name will come up in `git blame` and shadow the name of
+   the previous author of that line.
 3. #### Keep your change-set self contained but at a reasonable size
    Use your good judgment when making a big change. If you can't think of a
    good reason but need to make a very big PR, try to break it into smaller
@@ -52,11 +53,14 @@ This document will guide you through the contribution process.
    You can also mark some of them as `blocked` pending the others.   
 4. #### Be aware of our style rules
    As part of acceptance of a PR the changes must pass our linters. For C++ we
-   use Google's cpplint (with some ajustments) so following their [style-guide](https://github.com/google/styleguide)
-   should keep you in line.  
-   For JS we use this [ruleset](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
-   for ESLint plus some of [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules).  
-   For markdown we have a [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md).
+   use Google's `cpplint` (with some adjustments) so following their
+   [style-guide](https://github.com/google/styleguide) should keep you in line.  
+   For JS we use this
+   [rule-set](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
+   for ESLint plus some of
+   [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules).  
+   For markdown we have a
+   [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md).
 
 ### Step 1: Fork
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,34 @@ works.
 
 This document will guide you through the contribution process.
 
+### Rules of thumb
+
+1. #### Provide motivation for the change
+   Why will this change make the code better; does it fix a bug, is it a new
+   feature, etc. This should be in the commit messages as well as in the PR
+   description.
+2. #### Don't make _unnecessary_ code changes
+   Things that are changed because of personal preference or style, like:
+   renaming of variables or functions, adding or removing white spaces,
+   reordering lines or whole code blocks. These sort of changes should have
+   a good reason since they cause unnecessary ["code churn"](https://blog.gitprime.com/why-code-churn-matters).
+   As part of the project's strategy we maintain multiple release lines, code
+   churn might hinder back-porting changes to other lines. Also when you
+   change a line, your name will come up in `git blame` and might hide the
+   previous writer of the code.
+3. #### Keep your change-set self contained but at a reasonable size
+   Use your good judgment when making a big change. If you can't think of a
+   good reason but need to make a very big PR, try to break it into smaller
+   pieces (still as self-contained as possible), and cross-reference them.
+   You can also mark some of them as `blocked` pending the others.   
+4. #### Be aware of our style rules
+   As part of acceptance of a PR the changes must pass our linters. For C++ we
+   use Google's cpplint (with some ajustments) so following their [style-guide](https://github.com/google/styleguide)
+   should keep you in line.  
+   For JS we use this [ruleset](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
+   for ESLint plus some of [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules)  
+   For markdown we have a [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md)
+
 ### Step 1: Fork
 
 Fork the project [on GitHub](https://github.com/nodejs/node) and check out your

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,14 +52,15 @@ This document will guide you through the contribution process.
    pieces (still as self-contained as possible), and cross-reference them.
    You can also mark some of them as `blocked` pending the others.   
 4. #### Be aware of our style rules
-   As part of acceptance of a PR the changes must pass our linters. For C++ we
-   use Google's `cpplint` (with some adjustments) so following their
-   [style-guide](https://github.com/google/styleguide) should keep you in line.  
-   For JS we use this
+   As part of accepting a PR the changes __must__ pass our linters.
+   * For C++ we use Google's `cpplint` (with some adjustments) so following their
+   [style-guide](https://github.com/google/styleguide) should make your code
+   compliant with our linter.  
+   * For JS we use this
    [rule-set](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
    for ESLint plus some of
    [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules).  
-   For markdown we have a
+   * For markdown we have a
    [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md).
 
 ### Step 1: Fork

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,36 +32,45 @@ This document will guide you through the contribution process.
 
 ### Rules of thumb
 
-1. #### Provide motivation for the change
-   Try to explain why this change will make the code better. For example, does
-   it fix a bug, or is it a new feature, etc. This should expressed in the 
-   commit messages as well as in the PR description.
-2. #### Don't make _unnecessary_ code changes
-   _Unnecessary_ code changes are changes made because of personal preference
-   or style. For example, renaming of variables or functions, adding or removing
-   white spaces, and reordering lines or whole code blocks. These sort of 
-   changes should have a good reason since otherwise they cause unnecessary
-   ["code churn"](https://blog.gitprime.com/why-code-churn-matters).
-   As part of the project's strategy we maintain multiple release lines, code
-   churn might hinder back-porting changes to other lines. Also when you
-   change a line, your name will come up in `git blame` and shadow the name of
-   the previous author of that line.
-3. #### Keep your change-set self contained but at a reasonable size
-   Use your good judgment when making a big change. If you can't think of a
-   good reason but need to make a very big PR, try to break it into smaller
-   pieces (still as self-contained as possible), and cross-reference them.
-   You can also mark some of them as `blocked` pending the others.   
-4. #### Be aware of our style rules
-   As part of accepting a PR the changes __must__ pass our linters.
-   * For C++ we use Google's `cpplint` (with some adjustments) so following their
-   [style-guide](https://github.com/google/styleguide) should make your code
-   compliant with our linter.  
-   * For JS we use this
-   [rule-set](https://github.com/nodejs/node/blob/master/.eslintrc.yaml)
-   for ESLint plus some of
-   [our own custom rules](https://github.com/nodejs/node/tree/master/tools/eslint-rules).  
-   * For markdown we have a
-   [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md).
+<details>
+<summary><strong>Provide motivation for the change</strong></summary>
+Try to explain why this change will make the code better. For example, does
+it fix a bug, or is it a new feature, etc. This should expressed in the 
+commit messages as well as in the PR description.
+</details>
+<details>
+<summary><strong>Don't make <em>unnecessary</em> code changes</strong></summary>
+<em>Unnecessary</em> code changes are changes made because of personal preference
+or style. For example, renaming of variables or functions, adding or removing
+white spaces, and reordering lines or whole code blocks. These sort of 
+changes should have a good reason since otherwise they cause unnecessary
+<a href="https://blog.gitprime.com/why-code-churn-matters">"code churn"</a>.
+As part of the project's strategy we maintain multiple release lines, code
+churn might hinder back-porting changes to other lines. Also when you
+change a line, your name will come up in `git blame` and shadow the name of
+the previous author of that line.
+</details>
+<details>
+<summary><strong>Keep your change-set self contained but at a reasonable size</strong></summary>
+Use your good judgment when making a big change. If you can't think of a
+good reason but need to make a very big PR, try to break it into smaller
+pieces (still as self-contained as possible), and cross-reference them.
+You can also mark some of them as `blocked` pending the others.   
+</details>
+<details>
+<summary><strong>Be aware of our style rules</strong></summary>
+As part of accepting a PR the changes <strong>must</strong> pass our linters.
+<ul>
+<li>For C++ we use Google's `cpplint` (with some adjustments) so following their
+<a href="https://github.com/google/styleguide">style-guide</a> should make your code
+compliant with our linter.</li>
+<li>For JS we use this
+<a hreaf="https://github.com/nodejs/node/blob/master/.eslintrc.yaml">rule-set</a>
+for ESLint plus some of
+<a href="https://github.com/nodejs/node/tree/master/tools/eslint-rules">our own custom rules</a>.</li>
+<li>For markdown we have a <a href="https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md">style guide</a></li>
+</ul>
+</details>
 
 ### Step 1: Fork
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,14 @@ This document will guide you through the contribution process.
 <details>
 <summary><strong>Provide motivation for the change</strong></summary>
 Try to explain why this change will make the code better. For example, does
-it fix a bug, or is it a new feature, etc. This should expressed in the 
+it fix a bug, or is it a new feature, etc. This should be expressed in the
 commit messages as well as in the PR description.
 </details>
 <details>
 <summary><strong>Don't make <em>unnecessary</em> code changes</strong></summary>
 <em>Unnecessary</em> code changes are changes made because of personal preference
 or style. For example, renaming of variables or functions, adding or removing
-white spaces, and reordering lines or whole code blocks. These sort of 
+white spaces, and reordering lines or whole code blocks. These sort of
 changes should have a good reason since otherwise they cause unnecessary
 <a href="https://blog.gitprime.com/why-code-churn-matters">"code churn"</a>.
 As part of the project's strategy we maintain multiple release lines, code
@@ -52,10 +52,10 @@ the previous author of that line.
 </details>
 <details>
 <summary><strong>Keep the change-set self contained but at a reasonable size</strong></summary>
-Use good judgment when making a big change. If a reason doesn't come to mid
-but a very big chage needs to be made, try to break it into smaller
-pieces (still as self-contained as possible), and cross-reference them, and 
-marking some of them as `blocked` pending the others.   
+Use good judgment when making a big change. If a reason doesn't come to mind
+but a very big change needs to be made, try to break it into smaller
+pieces (still as self-contained as possible), and cross-reference them,
+explicitly stating that they are dependent on each other.
 </details>
 <details>
 <summary><strong>Be aware of our style rules</strong></summary>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,11 +51,11 @@ change a line, your name will come up in `git blame` and shadow the name of
 the previous author of that line.
 </details>
 <details>
-<summary><strong>Keep your change-set self contained but at a reasonable size</strong></summary>
-Use your good judgment when making a big change. If you can't think of a
-good reason but need to make a very big PR, try to break it into smaller
-pieces (still as self-contained as possible), and cross-reference them.
-You can also mark some of them as `blocked` pending the others.   
+<summary><strong>Keep the change-set self contained but at a reasonable size</strong></summary>
+Use good judgment when making a big change. If a reason doesn't come to mid
+but a very big chage needs to be made, try to break it into smaller
+pieces (still as self-contained as possible), and cross-reference them, and 
+marking some of them as `blocked` pending the others.   
 </details>
 <details>
 <summary><strong>Be aware of our style rules</strong></summary>
@@ -164,7 +164,7 @@ changed and why. Follow these guidelines when writing one:
     Refs: http://eslint.org/docs/rules/space-in-parens.html
     Refs: https://github.com/nodejs/node/pull/3615
     ```
-    - It's it's not a fix, you should document the motivation for the change
+    - If its not a bug fix, document the motivation for the change.
 
 A good commit log can look something like this:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ changed and why. Follow these guidelines when writing one:
     Refs: http://eslint.org/docs/rules/space-in-parens.html
     Refs: https://github.com/nodejs/node/pull/3615
     ```
-    - If its not a bug fix, document the motivation for the change.
+    - If it is not a bug fix, document the motivation for the change.
 
 A good commit log can look something like this:
 


### PR DESCRIPTION
# Discussion moved to #12791


Fixes: #12636
#### [edit]
As I understand the term "rules of thumb", they are guidelines one should have in mind and try to adhere to, but are not necessarily hard requirements. Our requirements should be stated in the other parts of the document.
#### [/edit]
My suggestion for a few "rules of thumb" for code contributions.
These are obviously my personal opinion, so this PR welcomes edit and suggestions. I do think that we should put some loose guidelines in writing.

The following made me think of this, and are not critique!
Ref: https://github.com/nodejs/node/pull/12603 - motivation
Ref: https://github.com/nodejs/node/pull/12735 - size

### Open questions:
1. A significant amount of the first-time contributors don't look at this document at all. So is this the best place to put this?
2. Are some of these not just rules of thumb but rather requirements that are better moved to appropriate places of the document.

---

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
doc
