### PR TITLE
timer: refactor to use module.exports = {} and ES6 classes

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -121,15 +121,15 @@ const unrefedLists = Object.create(null);
 
 // Schedule or re-schedule a timer.
 // The item must have been enroll()'d first.
-const active = exports.active = function(item) {
+function active(item) {
   insert(item, false);
-};
+}
 
 // Internal APIs that need timeouts should use `_unrefActive()` instead of
 // `active()` so that they do not unnecessarily keep the process open.
-exports._unrefActive = function(item) {
+function _unrefActive(item) {
   insert(item, true);
-};
+}
 
 
 // The underlying logic for scheduling or re-scheduling a timer.
@@ -321,7 +321,7 @@ function reuse(item) {
 
 
 // Remove a timer. Cancels the timeout and resets the relevant timer properties.
-const unenroll = exports.unenroll = function(item) {
+function unenroll(item) {
   var handle = reuse(item);
   if (handle) {
     debug('unenroll: list empty');
@@ -329,13 +329,13 @@ const unenroll = exports.unenroll = function(item) {
   }
   // if active is called later, then we want to make sure not to insert again
   item._idleTimeout = -1;
-};
+}
 
 
 // Make a regular object able to act as a timer by setting some properties.
 // This function does not start the timer, see `active()`.
 // Using existing objects as timers slightly reduces object overhead.
-exports.enroll = function(item, msecs) {
+function enroll(item, msecs) {
   if (typeof msecs !== 'number') {
     throw new TypeError('"msecs" argument must be a number');
   }
@@ -356,7 +356,7 @@ exports.enroll = function(item, msecs) {
 
   item._idleTimeout = msecs;
   L.init(item);
-};
+}
 
 
 /*
@@ -364,7 +364,7 @@ exports.enroll = function(item, msecs) {
  */
 
 
-exports.setTimeout = function(callback, after, arg1, arg2, arg3) {
+function setTimeout(callback, after, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -383,7 +383,7 @@ exports.setTimeout = function(callback, after, arg1, arg2, arg3) {
   }
 
   return createSingleTimeout(callback, after, args);
-};
+}
 
 function createSingleTimeout(callback, after, args) {
   after *= 1; // coalesce to number or NaN
@@ -439,7 +439,7 @@ function rearm(timer) {
 }
 
 
-const clearTimeout = exports.clearTimeout = function(timer) {
+function clearTimeout(timer) {
   if (timer && (timer[kOnTimeout] || timer._onTimeout)) {
     timer[kOnTimeout] = timer._onTimeout = null;
     if (timer instanceof Timeout) {
@@ -448,10 +448,10 @@ const clearTimeout = exports.clearTimeout = function(timer) {
       unenroll(timer);
     }
   }
-};
+}
 
 
-exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
+function setInterval(callback, repeat, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -470,7 +470,7 @@ exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   }
 
   return createRepeatTimeout(callback, repeat, args);
-};
+}
 
 function createRepeatTimeout(callback, repeat, args) {
   repeat *= 1; // coalesce to number or NaN
@@ -487,12 +487,12 @@ function createRepeatTimeout(callback, repeat, args) {
   return timer;
 }
 
-exports.clearInterval = function(timer) {
+function clearInterval(timer) {
   if (timer && timer._repeat) {
     timer._repeat = null;
     clearTimeout(timer);
   }
-};
+}
 
 
 function Timeout(after, callback, args) {
@@ -715,7 +715,7 @@ function Immediate() {
   this.domain = process.domain;
 }
 
-exports.setImmediate = function(callback, arg1, arg2, arg3) {
+function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
     throw new TypeError('"callback" argument must be a function');
   }
@@ -740,7 +740,7 @@ exports.setImmediate = function(callback, arg1, arg2, arg3) {
       break;
   }
   return createImmediate(args, callback);
-};
+}
 
 function createImmediate(args, callback) {
   // declaring it `const immediate` causes v6.0.0 to deoptimize this function
@@ -760,7 +760,7 @@ function createImmediate(args, callback) {
 }
 
 
-exports.clearImmediate = function(immediate) {
+function clearImmediate(immediate) {
   if (!immediate) return;
 
   immediate._onImmediate = null;
@@ -770,4 +770,17 @@ exports.clearImmediate = function(immediate) {
   if (!immediateQueue.head) {
     process._needImmediateCallback = false;
   }
+}
+
+module.exports = {
+  _unrefActive,
+  active,
+  clearImmediate,
+  clearInterval,
+  clearTimeout,
+  enroll,
+  setImmediate,
+  setInterval,
+  setTimeout,
+  unenroll
 };

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -171,13 +171,15 @@ function createTimersList(msecs, unrefed) {
   return list;
 }
 
-function TimersList(msecs, unrefed) {
-  this._idleNext = null; // Create the list with the linkedlist properties to
-  this._idlePrev = null; // prevent any unnecessary hidden class changes.
-  this._timer = new TimerWrap();
-  this._unrefed = unrefed;
-  this.msecs = msecs;
-  this.nextTick = false;
+class TimersList {
+  constructor(msecs, unrefed) {
+    this._idleNext = null; // Create the list with the linkedlist properties to
+    this._idlePrev = null; // prevent any unnecessary hidden class changes.
+    this._timer = new TimerWrap();
+    this._unrefed = unrefed;
+    this.msecs = msecs;
+    this.nextTick = false;
+  }
 }
 
 function listOnTimeout() {
@@ -494,18 +496,63 @@ function clearInterval(timer) {
   }
 }
 
+class Timeout {
+  constructor(after, callback, args) {
+    this._called = false;
+    this._idleTimeout = after;
+    this._idlePrev = this;
+    this._idleNext = this;
+    this._idleStart = null;
+    this._onTimeout = callback;
+    this._timerArgs = args;
+    this._repeat = null;
+  }
 
-function Timeout(after, callback, args) {
-  this._called = false;
-  this._idleTimeout = after;
-  this._idlePrev = this;
-  this._idleNext = this;
-  this._idleStart = null;
-  this._onTimeout = callback;
-  this._timerArgs = args;
-  this._repeat = null;
+  unref() {
+    if (this._handle) {
+      this._handle.unref();
+    } else if (typeof this._onTimeout === 'function') {
+      var now = TimerWrap.now();
+      if (!this._idleStart) this._idleStart = now;
+      var delay = this._idleStart + this._idleTimeout - now;
+      if (delay < 0) delay = 0;
+
+      // Prevent running cb again when unref() is called during the same cb
+      if (this._called && !this._repeat) {
+        unenroll(this);
+        return;
+      }
+
+      var handle = reuse(this);
+
+      this._handle = handle || new TimerWrap();
+      this._handle.owner = this;
+      this._handle[kOnTimeout] = unrefdHandle;
+      this._handle.start(delay);
+      this._handle.domain = this.domain;
+      this._handle.unref();
+    }
+    return this;
+  }
+
+  ref() {
+    if (this._handle)
+      this._handle.ref();
+    return this;
+  }
+
+  close() {
+    this._onTimeout = null;
+    if (this._handle) {
+      this._idleTimeout = -1;
+      this._handle[kOnTimeout] = null;
+      this._handle.close();
+    } else {
+      unenroll(this);
+    }
+    return this;
+  }
 }
-
 
 function unrefdHandle() {
   // Don't attempt to call the callback if it is not a function.
@@ -521,93 +568,48 @@ function unrefdHandle() {
   }
 }
 
+// A linked list for storing `setImmediate()` requests
+class ImmediateList {
+  constructor() {
+    this.head = null;
+    this.tail = null;
+  }
 
-Timeout.prototype.unref = function() {
-  if (this._handle) {
-    this._handle.unref();
-  } else if (typeof this._onTimeout === 'function') {
-    var now = TimerWrap.now();
-    if (!this._idleStart) this._idleStart = now;
-    var delay = this._idleStart + this._idleTimeout - now;
-    if (delay < 0) delay = 0;
+  // Appends an item to the end of the linked list, adjusting the current tail's
+  // previous and next pointers where applicable
+  append(item) {
+    if (this.tail) {
+      this.tail._idleNext = item;
+      item._idlePrev = this.tail;
+    } else {
+      this.head = item;
+    }
+    this.tail = item;
+  }
 
-    // Prevent running cb again when unref() is called during the same cb
-    if (this._called && !this._repeat) {
-      unenroll(this);
-      return;
+  // Removes an item from the linked list, adjusting the pointers of adjacent
+  // items and the linked list's head or tail pointers as necessary
+  remove(item) {
+    if (item._idleNext) {
+      item._idleNext._idlePrev = item._idlePrev;
     }
 
-    var handle = reuse(this);
+    if (item._idlePrev) {
+      item._idlePrev._idleNext = item._idleNext;
+    }
 
-    this._handle = handle || new TimerWrap();
-    this._handle.owner = this;
-    this._handle[kOnTimeout] = unrefdHandle;
-    this._handle.start(delay);
-    this._handle.domain = this.domain;
-    this._handle.unref();
+    if (item === this.head)
+      this.head = item._idleNext;
+    if (item === this.tail)
+      this.tail = item._idlePrev;
+
+    item._idleNext = null;
+    item._idlePrev = null;
   }
-  return this;
-};
-
-Timeout.prototype.ref = function() {
-  if (this._handle)
-    this._handle.ref();
-  return this;
-};
-
-Timeout.prototype.close = function() {
-  this._onTimeout = null;
-  if (this._handle) {
-    this._idleTimeout = -1;
-    this._handle[kOnTimeout] = null;
-    this._handle.close();
-  } else {
-    unenroll(this);
-  }
-  return this;
-};
-
-
-// A linked list for storing `setImmediate()` requests
-function ImmediateList() {
-  this.head = null;
-  this.tail = null;
 }
 
-// Appends an item to the end of the linked list, adjusting the current tail's
-// previous and next pointers where applicable
-ImmediateList.prototype.append = function(item) {
-  if (this.tail) {
-    this.tail._idleNext = item;
-    item._idlePrev = this.tail;
-  } else {
-    this.head = item;
-  }
-  this.tail = item;
-};
-
-// Removes an item from the linked list, adjusting the pointers of adjacent
-// items and the linked list's head or tail pointers as necessary
-ImmediateList.prototype.remove = function(item) {
-  if (item._idleNext) {
-    item._idleNext._idlePrev = item._idlePrev;
-  }
-
-  if (item._idlePrev) {
-    item._idlePrev._idleNext = item._idleNext;
-  }
-
-  if (item === this.head)
-    this.head = item._idleNext;
-  if (item === this.tail)
-    this.tail = item._idlePrev;
-
-  item._idleNext = null;
-  item._idlePrev = null;
-};
-
 // Create a single linked list instance only once at startup
-var immediateQueue = new ImmediateList();
+const immediateQueue = new ImmediateList();
 
 
 function processImmediate() {
@@ -703,16 +705,17 @@ function runCallback(timer) {
   }
 }
 
-
-function Immediate() {
-  // assigning the callback here can cause optimize/deoptimize thrashing
-  // so have caller annotate the object (node v6.0.0, v8 5.0.71.35)
-  this._idleNext = null;
-  this._idlePrev = null;
-  this._callback = null;
-  this._argv = null;
-  this._onImmediate = null;
-  this.domain = process.domain;
+class Immediate {
+  constructor() {
+    // assigning the callback here can cause optimize/deoptimize thrashing
+    // so have caller annotate the object (node v6.0.0, v8 5.0.71.35)
+    this._idleNext = null;
+    this._idlePrev = null;
+    this._callback = null;
+    this._argv = null;
+    this._onImmediate = null;
+    this.domain = process.domain;
+  }
 }
 
 function setImmediate(callback, arg1, arg2, arg3) {


### PR DESCRIPTION
Refactor to use the more efficient `module.exports = {}` pattern and change up the internal objects to use ES6 classes. Benchmarking shows a minor perf improvement under turbo / ignition (not compelling enough by itself, but it's there).

/cc @Fishrock123 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
timers