### PR TITLE
http: fix first body chunk fast case for UTF-16

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -229,8 +229,7 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback) {
   // this at a lower level and in a more general way.
   if (!this._headerSent) {
     if (typeof data === 'string' &&
-        encoding !== 'hex' &&
-        encoding !== 'base64') {
+        (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
       data = this._header + data;
     } else {
       this.output.unshift(this._header);

--- a/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
+++ b/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+
+// Regression test for https://github.com/nodejs/node/issues/11788.
+
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+for (const enc of ['utf8', 'utf16le', 'latin1', 'UTF-8']) {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('content-type', `text/plain; charset=${enc}`);
+    res.write('helloworld', enc);
+    res.end();
+  })).listen(0);
+
+  server.on('listening', common.mustCall(() => {
+    const buffers = [];
+    const socket = net.connect(server.address().port);
+    socket.write('GET / HTTP/1.0\r\n\r\n');
+    socket.on('data', (data) => buffers.push(data));
+    socket.on('end', common.mustCall(() => {
+      const received = Buffer.concat(buffers);
+      const headerEnd = received.indexOf('\r\n\r\n', 'utf8');
+      assert.notStrictEqual(headerEnd, -1);
+
+      const header = received.toString('utf8', 0, headerEnd).split(/\r\n/g);
+      const body = received.toString(enc, headerEnd + 4);
+
+      assert.strictEqual(header[0], 'HTTP/1.1 200 OK');
+      assert.strictEqual(header[1], `content-type: text/plain; charset=${enc}`);
+      assert.strictEqual(body, 'helloworld');
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
`http.OutgoingMessage` tried to send the first chunk together
with the headers by concatenating them together as a string, but the
list of encodings for which that works was incorrect.

Change it from a blacklist to a whitelist.

Fixes: https://github.com/nodejs/node/issues/11788

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

http

CI: https://ci.nodejs.org/job/node-test-commit/9509/

@nodejs/http 