### PR TITLE
crypto: throw proper errors if out enc is UTF-16

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3798,6 +3798,10 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
+  if (encoding == UCS2) {
+    return env->ThrowError("hmac.digest() does not support UTF-16");
+  }
+
   unsigned char* md_value = nullptr;
   unsigned int md_len = 0;
 
@@ -3919,6 +3923,10 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() >= 1) {
     CHECK(args[0]->IsString());
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
+  }
+
+  if (encoding == UCS2) {
+    return env->ThrowError("hash.digest() does not support UTF-16");
   }
 
   unsigned char md_value[EVP_MAX_MD_SIZE];

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -108,10 +108,12 @@ const h3 = crypto.createHash('sha256');
 h3.digest();
 assert.throws(function() {
   h3.digest();
-},
-              /Digest already called/);
+}, /Digest already called/);
 
 assert.throws(function() {
   h3.update('foo');
-},
-              /Digest already called/);
+}, /Digest already called/);
+
+assert.throws(function() {
+  crypto.createHash('sha256').digest('ucs2');
+}, /^Error: hash\.digest\(\) does not support UTF-16$/);

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -377,3 +377,7 @@ for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
     `Test HMAC-SHA1 : Test case ${i + 1} rfc 2202`
   );
 }
+
+assert.throws(function() {
+  crypto.createHmac('sha256', 'w00t').digest('ucs2');
+}, /^Error: hmac\.digest\(\) does not support UTF-16$/);


### PR DESCRIPTION
Throw `Error`s instead of hard crashing when the `.digest()` output
encoding is UTF-16.

Fixes: https://github.com/nodejs/node/issues/9817

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

crypto