### PR TITLE
src: turn buffer type-CHECK into exception

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -189,8 +189,13 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
 int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsObject());
-  CHECK(Buffer::HasInstance(args[1]));
+
   Environment* env = Environment::GetCurrent(args);
+
+  if (!args[1]->IsUint8Array()) {
+    env->ThrowTypeError("Second argument must be a buffer");
+    return 0;
+  }
 
   Local<Object> req_wrap_obj = args[0].As<Object>();
   const char* data = Buffer::Data(args[1]);

--- a/test/parallel/test-stream-base-typechecking.js
+++ b/test/parallel/test-stream-base-typechecking.js
@@ -1,0 +1,7 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(() => {
+  process.stdout.write('broken', 'buffer');
+}, /^TypeError: Second argument must be a buffer$/);

--- a/test/parallel/test-stream-base-typechecking.js
+++ b/test/parallel/test-stream-base-typechecking.js
@@ -1,7 +1,14 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+const net = require('net');
 
-assert.throws(() => {
-  process.stdout.write('broken', 'buffer');
-}, /^TypeError: Second argument must be a buffer$/);
+const server = net.createServer().listen(0, common.mustCall(() => {
+  const client = net.connect(server.address().port, common.mustCall(() => {
+    assert.throws(() => {
+      client.write('broken', 'buffer');
+    }, /^TypeError: Second argument must be a buffer$/);
+    client.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
Turn a `CHECK()` that could be brought to fail using public APIs
into throwing an error.

Fixes: https://github.com/nodejs/node/issues/12152

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

stream_base