### PR TITLE
test: skipIfInspectorDisabled cluster-inspect-brk

### DIFF
--- a/test/sequential/test-cluster-inspect-brk.js
+++ b/test/sequential/test-cluster-inspect-brk.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+common.skipIfInspectorDisabled();
 
 // A test to ensure that cluster properly interoperates with the
 // --inspect-brk option.


### PR DESCRIPTION
When configured --without-ssl the inspect-brk option will not be
available and the process will exit with a exit value of 9 "Invalid
Argument/Bad option".

This commit adds a skipIfInspectorDisabled check since --without-ssl
implies that no inspector support is build as well.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src