### PR TITLE
repl: fix /dev/null history file regression

### DIFF
--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -172,23 +172,16 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
       return ready(err);
     }
     fs.ftruncate(hnd, 0, (err) => {
-      return onftruncate(err, hnd);
-    });
-  }
+      repl._historyHandle = hnd;
+      repl.on('line', online);
 
-  function onftruncate(err, hnd) {
-    if (err) {
-      return ready(err);
-    }
-    repl._historyHandle = hnd;
-    repl.on('line', online);
-
-    // reading the file data out erases it
-    repl.once('flushHistory', function() {
-      repl.resume();
-      ready(null, repl);
+      // reading the file data out erases it
+      repl.once('flushHistory', function() {
+        repl.resume();
+        ready(null, repl);
+      });
+      flushHistory();
     });
-    flushHistory();
   }
 
   // ------ history listeners ------

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -78,6 +78,8 @@ const emptyHistoryPath = path.join(fixtures, '.empty-repl-history-file');
 const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
 const emptyHiddenHistoryPath = path.join(fixtures,
                                          '.empty-hidden-repl-history-file');
+const devNullHistoryPath = path.join(common.tmpDir,
+                                     '.dev-null-repl-history-file');
 
 const tests = [
   {
@@ -175,6 +177,15 @@ const tests = [
       }
     },
     env: { NODE_REPL_HISTORY: emptyHiddenHistoryPath },
+    test: [UP],
+    expected: [prompt]
+  },
+  {
+    before: function before() {
+      if (!common.isWindows)
+        fs.symlinkSync('/dev/null', devNullHistoryPath);
+    },
+    env: { NODE_REPL_HISTORY: devNullHistoryPath },
     test: [UP],
     expected: [prompt]
   },


### PR DESCRIPTION
This fixes a regression from 83887f35fa where `ftruncate()` fails on a file symlinked to /dev/null.

/cc @bzoz @jasnell 

CI: https://ci.nodejs.org/job/node-test-pull-request/7761/

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

* repl
