### PR TITLE
stream: make `.setEncoding(null)` reset to default

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -915,9 +915,14 @@ getReadableStreamSomehow()
 ##### readable.setEncoding(encoding)
 <!-- YAML
 added: v0.9.4
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/12766
+    description: If `encoding` is `null` or `'buffer'`, this will reset the stream
+                 to the default of returning `Buffer` objects.
 -->
 
-* `encoding` {string} The encoding to use.
+* `encoding` {string|null} The encoding to use.
 * Returns: `this`
 
 The `readable.setEncoding()` method sets the default character encoding for
@@ -934,9 +939,8 @@ The Readable stream will properly handle multi-byte characters delivered through
 the stream that would otherwise become improperly decoded if simply pulled from
 the stream as `Buffer` objects.
 
-Encoding can be disabled by calling `readable.setEncoding(null)`. This approach
-is useful when working with binary data or with large multi-byte strings spread
-out over multiple chunks.
+Decoding can be disabled by calling `readable.setEncoding(null)` or
+`readable.setEncoding('buffer')`.
 
 ```js
 const readable = getReadableStreamSomehow();

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -231,8 +231,16 @@ function needMoreData(state) {
           state.length === 0);
 }
 
-// backwards compatibility.
 Readable.prototype.setEncoding = function(enc) {
+  if (enc === null || enc === 'buffer') {
+    if (this._readableState.decoder) {
+      this.push(this._readableState.decoder.end());
+    }
+    this._readableState.decoder = null;
+    this._readableState.encoding = null;
+    return;
+  }
+
   if (!StringDecoder)
     StringDecoder = require('string_decoder').StringDecoder;
   this._readableState.decoder = new StringDecoder(enc);

--- a/test/parallel/test-stream-set-encoding-null.js
+++ b/test/parallel/test-stream-set-encoding-null.js
@@ -1,0 +1,32 @@
+'use strict';
+require('../common');
+const { PassThrough } = require('stream');
+const assert = require('assert');
+
+{
+  const stream = new PassThrough();
+  stream.setEncoding('utf8');
+  stream.write('foobar');
+  assert.strictEqual(stream.read(), 'foobar');
+  stream.setEncoding(null);
+  stream.write('foobar');
+  assert.deepStrictEqual(stream.read(), Buffer.from('foobar'));
+}
+
+{
+  const stream = new PassThrough();
+  stream.setEncoding('utf8');
+  stream.write('foobar');
+  assert.strictEqual(stream.read(), 'foobar');
+  stream.setEncoding('buffer');
+  stream.write('foobar');
+  assert.deepStrictEqual(stream.read(), Buffer.from('foobar'));
+}
+
+{
+  const stream = new PassThrough();
+  stream.setEncoding('utf8');
+  stream.write(Buffer.from([0xc3]));
+  stream.setEncoding('buffer');
+  assert.strictEqual(stream.read(), '\ufffd');
+}


### PR DESCRIPTION
Make `.setEncoding()` reset streams to their default state of
not decoding data.

Fixes: https://github.com/nodejs/node/issues/6038

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

streams

I am totally fine with not doing this (even though I think this makes sense), this just seemed like the easiest way to get some closure on #6038.

Labelled semver-major because we know we have to be careful with streams, even though this seems to have been (incorrectly) documented as working before.