### PR TITLE
build: warn about `--without-ssl` disabling debugger

### DIFF
--- a/configure
+++ b/configure
@@ -465,8 +465,14 @@ parser.add_option('--no-browser-globals',
 
 parser.add_option('--without-inspector',
     action='store_true',
-    dest='without_inspector',
-    help='disable experimental V8 inspector support')
+    dest='without_debugger',
+    help='disable V8 inspector support, the only node debugger API')
+
+# more explicit alias to --without-inspector
+parser.add_option('--without-debugger',
+    action='store_true',
+    dest='without_debugger',
+    help='disable V8 inspector support, the only node debugger API')
 
 parser.add_option('--shared',
     action='store_true',
@@ -495,6 +501,8 @@ parser.add_option('-C',
     help=optparse.SUPPRESS_HELP)
 
 (options, args) = parser.parse_args()
+
+
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
 options.prefix = os.path.expanduser(options.prefix or '')
@@ -1296,11 +1304,15 @@ def configure_intl(o):
         pprint.pformat(icu_config, indent=2) + '\n')
   return  # end of configure_intl
 
-def configure_inspector(o):
-  disable_inspector = (options.without_inspector or
-                       options.with_intl in (None, 'none') or
-                       options.without_ssl)
-  o['variables']['v8_enable_inspector'] = 0 if disable_inspector else 1
+def configure_debugger(o):
+  implicit_disable = (options.with_intl in (None, 'none') or
+                      options.without_ssl)
+  if implicit_disable and not options.without_debugger:
+    raise Exception('Setting --without_ssl or --without-intl will disable the '
+                    '`inspector` protocol. Ever since the removal of the '
+                    '`debug` protocol this is the only available debugger '
+                    'API, so it will leave the binary with no debug interfacehence --without-debugger must be set explicitly.')
+  o['variables']['v8_enable_inspector'] = 0 if options.without_debugger else 1
 
 output = {
   'variables': {},
@@ -1332,7 +1344,7 @@ configure_v8(output)
 configure_openssl(output)
 configure_intl(output)
 configure_static(output)
-configure_inspector(output)
+configure_debugger(output)
 
 # variables should be a root level element,
 # move everything else to target_defaults

--- a/configure
+++ b/configure
@@ -465,14 +465,8 @@ parser.add_option('--no-browser-globals',
 
 parser.add_option('--without-inspector',
     action='store_true',
-    dest='without_debugger',
-    help='disable V8 inspector support, the only node debugger API')
-
-# more explicit alias to --without-inspector
-parser.add_option('--without-debugger',
-    action='store_true',
-    dest='without_debugger',
-    help='disable V8 inspector support, the only node debugger API')
+    dest='without_inspector',
+    help='disable experimental V8 inspector support')
 
 parser.add_option('--shared',
     action='store_true',
@@ -501,8 +495,6 @@ parser.add_option('-C',
     help=optparse.SUPPRESS_HELP)
 
 (options, args) = parser.parse_args()
-
-
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
 options.prefix = os.path.expanduser(options.prefix or '')
@@ -1307,12 +1299,15 @@ def configure_intl(o):
 def configure_debugger(o):
   implicit_disable = (options.with_intl in (None, 'none') or
                       options.without_ssl)
-  if implicit_disable and not options.without_debugger:
-    raise Exception('Setting --without_ssl or --without-intl will disable the '
-                    '`inspector` protocol. Ever since the removal of the '
-                    '`debug` protocol this is the only available debugger '
-                    'API, so it will leave the binary with no debug interfacehence --without-debugger must be set explicitly.')
-  o['variables']['v8_enable_inspector'] = 0 if options.without_debugger else 1
+  if implicit_disable and not options.without_inspector:
+    options.without_inspector = True
+    print('********************* Warning *************************')
+    print('Setting --without_ssl or --without-intl will disable the')
+    print('`inspector` protocol. Ever since the removal of the `debug`')
+    print('protocol this is the only available debugger API, so it will leave')
+    print('the binary with no debug interface.')
+  print('*********************************************************')
+  o['variables']['v8_enable_inspector'] = 0 if options.without_inspector else 1
 
 output = {
   'variables': {},


### PR DESCRIPTION
* To fix #12758, added an assertion that if
  `--without-ssl` or `--without-intl` are set, --without-debugger must
  also be explicitly set.

* Added `--without-debugger` is an alias to `--without-inspector`, since
  we removed the old TCP `debug` protocol the V8 `inspect` protocol is the
  only debugger available. Hence disabling `inspector` means disabling
  any kind on JS debugger.

Depends on: https://github.com/nodejs/node/pull/12197
Fixes: https://github.com/nodejs/node/issues/12758
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
build, tools, inspector, debugger
