### PR TITLE
stream: Backport of #11876, fixes missing 'unpipe' event

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -494,7 +494,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
               dest !== process.stdout &&
               dest !== process.stderr;
 
-  var endFn = doEnd ? onend : cleanup;
+  var endFn = doEnd ? onend : unpipe;
   if (state.endEmitted)
     process.nextTick(endFn);
   else
@@ -530,7 +530,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     dest.removeListener('error', onerror);
     dest.removeListener('unpipe', onunpipe);
     src.removeListener('end', onend);
-    src.removeListener('end', cleanup);
+    src.removeListener('end', unpipe);
     src.removeListener('data', ondata);
 
     cleanedUp = true;

--- a/test/parallel/test-stream-unpipe-event.js
+++ b/test/parallel/test-stream-unpipe-event.js
@@ -1,0 +1,87 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const {Writable, Readable} = require('stream');
+class NullWriteable extends Writable {
+  _write(chunk, encoding, callback) {
+    return callback();
+  }
+}
+class QuickEndReadable extends Readable {
+  _read() {
+    this.push(null);
+  }
+}
+class NeverEndReadable extends Readable {
+  _read() {}
+}
+
+function noop() {}
+
+{
+  const dest = new NullWriteable();
+  const src = new QuickEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustCall(noop));
+  src.pipe(dest);
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 0);
+  });
+}
+
+{
+  const dest = new NullWriteable();
+  const src = new NeverEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustNotCall('unpipe should not have been emitted'));
+  src.pipe(dest);
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 1);
+  });
+}
+
+{
+  const dest = new NullWriteable();
+  const src = new NeverEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustCall(noop));
+  src.pipe(dest);
+  src.unpipe(dest);
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 0);
+  });
+}
+
+{
+  const dest = new NullWriteable();
+  const src = new QuickEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustCall(noop));
+  src.pipe(dest, {end: false});
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 0);
+  });
+}
+
+{
+  const dest = new NullWriteable();
+  const src = new NeverEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustNotCall('unpipe should not have been emitted'));
+  src.pipe(dest, {end: false});
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 1);
+  });
+}
+
+{
+  const dest = new NullWriteable();
+  const src = new NeverEndReadable();
+  dest.on('pipe', common.mustCall(noop));
+  dest.on('unpipe', common.mustCall(noop));
+  src.pipe(dest, {end: false});
+  src.unpipe(dest);
+  setImmediate(() => {
+    assert.strictEqual(src._readableState.pipesCount, 0);
+  });
+}


### PR DESCRIPTION
This is a backport of https://github.com/nodejs/node/pull/11876, specifically commit https://github.com/mcollina/node/commit/9dcf18a5c0449700598d26dd8b0d252c1eb6ce5d.

Ideally this commit can should be easily ported to v6 as well after it has been in the wild for a while.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

stream