### PR TITLE
src: rename CryptoPemCallback -> PasswordCallback

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -228,6 +228,8 @@ static void crypto_lock_cb(int mode, int n, const char* file, int line) {
 }
 
 
+// This callback is used by OpenSSL when it needs to query for the passphrase
+// which may be used for encrypted PEM structures.
 static int PasswordCallback(char *buf, int size, int rwflag, void *u) {
   if (u) {
     size_t buflen = static_cast<size_t>(size);


### PR DESCRIPTION
While reading through node_crypto.cc I think the code could perhaps
be be a made a little clearer if CryptPemCallback was renamed.

I admit that I'm very new to the code base and openssl but having a
name like PasswordCallback or something similar would have helped me
so I'm suggesting this change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src