### PR TITLE
test: fix too optimistic guess in setproctitle

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -14,7 +14,7 @@ const path = require('path');
 // The title shouldn't be too long; libuv's uv_set_process_title() out of
 // security considerations no longer overwrites envp, only argv, so the
 // maximum title length is possibly quite short.
-let title = 'test';
+let title = String(process.pid);
 
 assert.notStrictEqual(process.title, title);
 process.title = title;


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, process

`test/parallel/test-setproctitle.js` assumes that `process.title` can't be `test` before the test changes it. However, if this test is launched as a child several times, `process.title` is saved in the parent on Windows and is shared with childs.

I've found this issue running tests with some script with different options. A reduced example (edit the path to reproduce):
```js
const { execSync } = require('child_process');
const cmd = 'node j:/temp/_git/node-fork/test/parallel/test-setproctitle.js';

console.log('run 1');
try { execSync(cmd); } catch (err) { console.log('run 1 error'); }
console.log('run 2');
try { execSync(cmd); } catch (err) { console.log('run 2 error'); }
```
Before this PR:
```console
run 1
run 2

assert.js:86
  throw new assert.AssertionError({
  ^
AssertionError: 'test' !== 'test'
    at Object.<anonymous> (j:\temp\_git\node-fork\test\parallel\test-setproctitle.js:19:8)
    at Module._compile (module.js:582:30)
    at Object.Module._extensions..js (module.js:593:10)
    at Module.load (module.js:516:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:618:10)
    at startup (bootstrap_node.js:144:16)
    at bootstrap_node.js:548:3
run 2 error
```
After this PR:
```console
run 1
run 2
```
It seems this better be fixed to prevent such issues with various test approaches to test base.