### PR TITLE
test: add callback to fs.close() in test-fs-chmod

### DIFF
--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -114,7 +114,7 @@ fs.open(file2, 'a', common.mustCall((err, fd) => {
       assert.strictEqual(mode_sync, fs.fstatSync(fd).mode & 0o777);
     }
 
-    fs.close(fd);
+    fs.close(fd, assert.ifError);
   }));
 }));
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, fs

To avoid `[DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.`
