### PR TITLE
tls: do not wrap net.Socket with StreamWrap

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -31,7 +31,6 @@ const util = require('util');
 const common = require('_tls_common');
 const StreamWrap = require('_stream_wrap').StreamWrap;
 const Buffer = require('buffer').Buffer;
-const Duplex = require('stream').Duplex;
 const debug = util.debuglog('tls');
 const Timer = process.binding('timer_wrap').Timer;
 const tls_wrap = process.binding('tls_wrap');
@@ -275,12 +274,10 @@ function TLSSocket(socket, options) {
 
   // Wrap plain JS Stream into StreamWrap
   var wrap;
-  if (!(socket instanceof net.Socket) && socket instanceof Duplex)
-    wrap = new StreamWrap(socket);
-  else if ((socket instanceof net.Socket) && !socket._handle)
-    wrap = new StreamWrap(socket);
-  else
+  if ((socket instanceof net.Socket && socket._handle) || !socket)
     wrap = socket;
+  else
+    wrap = new StreamWrap(socket);
 
   // Just a documented property to make secure sockets
   // distinguishable from regular ones.

--- a/test/parallel/test-tls-wrap-event-emmiter.js
+++ b/test/parallel/test-tls-wrap-event-emmiter.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/*
+ * Issue: https://github.com/nodejs/node/issues/3655
+ * Test checks if we get exception instead of runtime error
+ */
+
+require('../common');
+const assert = require('assert');
+
+const TlsSocket = require('tls').TLSSocket;
+const EventEmitter = require('events').EventEmitter;
+assert.throws(
+  () => { new TlsSocket(new EventEmitter()); },
+  /^TypeError: this\.stream\.pause is not a function/
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Hi :)
In this PR I just wanted to avoid "c-like" error from this issue - https://github.com/nodejs/node/issues/3655. You can see below how error looks like now. At least there is stacktrace exist. 

Please update me if I did something horribly wrong here or maybe if this is not a fix at all so I will close this PR. 

```
_stream_wrap.js:42
  this.stream.pause();
              ^

TypeError: this.stream.pause is not a function
    at new StreamWrap (_stream_wrap.js:42:15)
    at new TLSSocket (_tls_wrap.js:280:12)
    at Object.<anonymous> (/path/to/test-file.js:4:1)
    at Module._compile (module.js:582:30)
    at Object.Module._extensions..js (module.js:593:10)
    at Module.load (module.js:516:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:618:10)
    at startup (bootstrap_node.js:144:16)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
