### PR TITLE
test: add callback to fs.close() in test-fs-stat

### DIFF
--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -49,7 +49,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   fs.fstat(fd, common.mustCall(function(err, stats) {
     assert.ifError(err);
     assert.ok(stats.mtime instanceof Date);
-    fs.close(fd);
+    fs.close(fd, assert.ifError);
     assert.strictEqual(this, global);
   }));
 
@@ -68,7 +68,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
     console.dir(stats);
     assert.ok(stats.mtime instanceof Date);
   }
-  fs.close(fd);
+  fs.close(fd, assert.ifError);
 }));
 
 console.log(`stating:  ${__filename}`);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, fs

To avoid `[DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.`