### PR TITLE
tools: relax lint rule for regexps

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -106,7 +106,10 @@ rules:
   key-spacing: [2, {mode: minimum}]
   keyword-spacing: 2
   linebreak-style: [2, unix]
-  max-len: [2, {code: 80, ignoreUrls: true, tabWidth: 2}]
+  max-len: [2, {code: 80,
+                ignoreRegExpLiterals: true,
+                ignoreUrls: true,
+                tabWidth: 2}]
   new-parens: 2
   no-mixed-spaces-and-tabs: 2
   no-multiple-empty-lines: [2, {max: 2, maxEOF: 0, maxBOF: 0}]

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -35,8 +35,8 @@ const outHeadersKey = require('internal/http').outHeadersKey;
 const CRLF = common.CRLF;
 const debug = common.debug;
 
-var RE_FIELDS = new RegExp('^(?:Connection|Transfer-Encoding|Content-Length|' +
-                           'Date|Expect|Trailer|Upgrade)$', 'i');
+var RE_FIELDS =
+  /^(?:Connection|Transfer-Encoding|Content-Length|Date|Expect|Trailer|Upgrade)$/i;
 var RE_CONN_VALUES = /(?:^|\W)close|upgrade(?:$|\W)/ig;
 var RE_TE_CHUNKED = common.chunkExpression;
 

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -927,8 +927,8 @@ Buffer.poolSize = ps;
 assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);
 
-const regErrorMsg = new RegExp('First argument must be a string, Buffer, ' +
-                               'ArrayBuffer, Array, or array-like object\\.');
+const regErrorMsg =
+  /First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object\./;
 
 assert.throws(() => Buffer.from(), regErrorMsg);
 assert.throws(() => Buffer.from(null), regErrorMsg);

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -23,9 +23,8 @@ assert.strictEqual(secret2.toString('base64'), secret1);
 assert.strictEqual(dh1.verifyError, 0);
 assert.strictEqual(dh2.verifyError, 0);
 
-const argumentsError = new RegExp('^TypeError: First argument should be ' +
-                                  'number, string, Buffer, TypedArray, or ' +
-                                  'DataView$');
+const argumentsError =
+  /^TypeError: First argument should be number, string, Buffer, TypedArray, or DataView$/;
 
 assert.throws(() => {
   crypto.createDiffieHellman([0x1, 0x2]);
@@ -61,8 +60,7 @@ const secret3 = dh3.computeSecret(key2, 'hex', 'base64');
 assert.strictEqual(secret1, secret3);
 
 const wrongBlockLength =
-    new RegExp('^Error: error:0606506D:digital envelope' +
-    ' routines:EVP_DecryptFinal_ex:wrong final block length$');
+  /^Error: error:0606506D:digital envelope routines:EVP_DecryptFinal_ex:wrong final block length$/;
 
 // Run this one twice to make sure that the dh3 clears its error properly
 {

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -26,8 +26,8 @@ const dsaKeyPem = fs.readFileSync(common.fixturesDir + '/test_dsa_privkey.pem',
 const dsaKeyPemEncrypted = fs.readFileSync(
   common.fixturesDir + '/test_dsa_privkey_encrypted.pem', 'ascii');
 
-const decryptError = new RegExp('^Error: error:06065064:digital envelope ' +
-                                'routines:EVP_DecryptFinal_ex:bad decrypt$');
+const decryptError =
+  /^Error: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt$/;
 
 // Test RSA encryption/decryption
 {

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -30,8 +30,8 @@ client.send(buf, port, undefined, onMessage);
 // valid address: not provided
 client.send(buf, port, onMessage);
 
-const expectedError = new RegExp('^TypeError: Invalid arguments: address ' +
-  'must be a nonempty string or falsy$');
+const expectedError =
+  /^TypeError: Invalid arguments: address must be a nonempty string or falsy$/;
 
 // invalid address: object
 assert.throws(() => {

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const numberError = new RegExp('^TypeError: "options" must be a string ' +
-                               'or an object, got number instead\\.$');
+const numberError =
+  /^TypeError: "options" must be a string or an object, got number instead\.$/;
 
-const booleanError = new RegExp('^TypeError: "options" must be a string ' +
-                                'or an object, got boolean instead\\.$');
+const booleanError =
+  /^TypeError: "options" must be a string or an object, got boolean instead\.$/;
 
 const example = path.join(common.tmpDir, 'dummy');
 

--- a/test/parallel/test-tls-env-bad-extra-ca.js
+++ b/test/parallel/test-tls-env-bad-extra-ca.js
@@ -33,10 +33,9 @@ fork(__filename, opts)
     assert.strictEqual(status, 0, 'client did not succeed in connecting');
   }))
   .on('close', common.mustCall(function() {
-    assert(stderr.match(new RegExp(
-      'Warning: Ignoring extra certs from.*no-such-file-exists' +
-      '.* load failed:.*No such file or directory'
-    )), stderr);
+    assert(stderr.match(
+      /Warning: Ignoring extra certs from.*no-such-file-exists.* load failed:.*No such file or directory/
+    ), stderr);
   }))
   .stderr.setEncoding('utf8').on('data', function(str) {
     stderr += str;

--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -29,8 +29,8 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const tls = require('tls');
 const fs = require('fs');
-const errorMessageRegex = new RegExp('^Error: error:0B080074:x509 ' +
-  'certificate routines:X509_check_private_key:key values mismatch$');
+const errorMessageRegex =
+  /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/;
 
 const options = {
   key: fs.readFileSync(common.fixturesDir + '/keys/agent1-key.pem'),

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -4,8 +4,7 @@ require('../common');
 const assert = require('assert');
 const inherits = require('util').inherits;
 const errCheck =
-  new RegExp('^TypeError: The super constructor to "inherits" must not be ' +
-                      'null or undefined$');
+  /^TypeError: The super constructor to "inherits" must not be null or undefined$/;
 
 
 // super constructor

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -44,8 +44,7 @@ assert.strictEqual(url.searchParams, oldParams);  // [SameObject]
 // non-writable property should throw.
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.origin = 'http://foo.bar.com:22',
-              new RegExp('TypeError: Cannot set property origin of' +
-                         ' \\[object URL\\] which has only a getter'));
+              /TypeError: Cannot set property origin of \[object URL\] which has only a getter$/);
 assert.strictEqual(url.origin, 'http://foo.bar.com:21');
 assert.strictEqual(url.toString(),
                    'http://user:pass@foo.bar.com:21/aaa/zzz?l=25#test');
@@ -120,8 +119,7 @@ assert.strictEqual(url.hash, '#abcd');
 // non-writable property should throw.
 // Note: this error message is subject to change in V8 updates
 assert.throws(() => url.searchParams = '?k=88',
-              new RegExp('TypeError: Cannot set property searchParams of' +
-                         ' \\[object URL\\] which has only a getter'));
+              /^TypeError: Cannot set property searchParams of \[object URL\] which has only a getter$/);
 assert.strictEqual(url.searchParams, oldParams);
 assert.strictEqual(url.toString(),
                    'https://user2:pass2@foo.bar.org:23/aaa/bbb?k=99#abcd');

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -107,6 +107,5 @@ assert.throws(
 // Throws if opts.dictionary is not a Buffer
 assert.throws(
   () => { new zlib.Deflate({dictionary: 'not a buffer'}); },
-  new RegExp('^TypeError: Invalid dictionary: it should be a Buffer, ' +
-             'TypedArray, or DataView$')
+  /^TypeError: Invalid dictionary: it should be a Buffer, TypedArray, or DataView$/
 );

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -7,8 +7,7 @@ require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-const expected = new RegExp('^TypeError: "buffer" argument must be a string, ' +
-                            'Buffer, TypedArray, or DataView$');
+const expected = /^TypeError: "buffer" argument must be a string, Buffer, TypedArray, or DataView$/;
 
 assert.throws(() => { zlib.deflateSync(undefined); }, expected);
 assert.throws(() => { zlib.deflateSync(null); }, expected);


### PR DESCRIPTION
Relax the rule for maximum line length in JS files if the line contains
a regular expression literal. This will avoid the need to convert a
regular expression literal into a RegExp constructor call broken across
multiple lines in order to satisfy the maximum line length rule. That
practice hampers readability.

In lib and test (but mostly test), replace RegExp constructors with regular expression literals where
possible.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools lib test