### PR TITLE
url: handle windows drive letter in the file state

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1169,6 +1169,7 @@ void URL::Parse(const char* input,
 
   while (p <= end) {
     const char ch = p < end ? p[0] : kEOL;
+    const size_t remaining = end == p ? 0 : (end - p - 1);
 
     if (IsASCIITabOrNewline(ch)) {
       if (state == kAuthority) {
@@ -1653,9 +1654,10 @@ void URL::Parse(const char* input,
               state = kFragment;
               break;
             default:
-              if ((!IsWindowsDriveLetter(ch, p[1]) ||
-                   end - p == 1 ||
-                   (p[2] != '/' &&
+              if ((remaining == 0 ||
+                   !IsWindowsDriveLetter(ch, p[1]) ||
+                   (remaining >= 2 &&
+                    p[2] != '/' &&
                     p[2] != '\\' &&
                     p[2] != '?' &&
                     p[2] != '#'))) {

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* WPT Refs:
-   https://github.com/w3c/web-platform-tests/blob/3afae94/url/urltestdata.json
+   https://github.com/w3c/web-platform-tests/blob/28541bb/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 module.exports =
@@ -5428,6 +5428,105 @@ module.exports =
     "port": "",
     "pathname": "/",
     "search": "?chai",
+    "hash": ""
+  },
+  "# Windows drive letter handling with the 'file:' base URL",
+  {
+    "input": "C|",
+    "base": "file://host/dir/file",
+    "href": "file:///C:",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/C:",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|#",
+    "base": "file://host/dir/file",
+    "href": "file:///C:#",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/C:",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|?",
+    "base": "file://host/dir/file",
+    "href": "file:///C:?",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/C:",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|/",
+    "base": "file://host/dir/file",
+    "href": "file:///C:/",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/C:/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|\\",
+    "base": "file://host/dir/file",
+    "href": "file:///C:/",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "/C:/",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C",
+    "base": "file://host/dir/file",
+    "href": "file://host/dir/C",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "host",
+    "hostname": "host",
+    "port": "",
+    "pathname": "/dir/C",
+    "search": "",
+    "hash": ""
+  },
+  {
+    "input": "C|a",
+    "base": "file://host/dir/file",
+    "href": "file://host/dir/C|a",
+    "protocol": "file:",
+    "username": "",
+    "password": "",
+    "host": "host",
+    "hostname": "host",
+    "port": "",
+    "pathname": "/dir/C|a",
+    "search": "",
     "hash": ""
   },
   "# Windows drive letter quirk with not empty host",


### PR DESCRIPTION
In the `whatwg-url`, `C|` should not satisfy the condition to not copy the base's path. This patch also synchronises WPT url test data to verify the update in upstream.

Refs: https://github.com/whatwg/url/pull/305
Refs: https://github.com/w3c/web-platform-tests/pull/5754

##### Checklist
- [x] `make -j4 test`
- [x] tests are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
url