### PR TITLE
test: make tests cwd-independent

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -105,7 +105,7 @@ testData.forEach((item) => {
         {
           input: preprocessed,
           filename: 'foo',
-          template: 'doc/template.html',
+          template: path.resolve(__dirname, '../../doc/template.html'),
           nodeVersion: process.version,
           analytics: item.analyticsId,
         },

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -94,6 +94,8 @@ child.exec(`${nodejs} --print "os.platform()"`,
            }));
 
 // Module path resolve bug regression test.
+const cwd = process.cwd();
+process.chdir(path.resolve(__dirname, '../../'));
 child.exec(`${nodejs} --eval "require('./test/parallel/test-cli-eval.js')"`,
            common.mustCall((err, stdout, stderr) => {
              assert.strictEqual(err.code, 42);
@@ -101,6 +103,7 @@ child.exec(`${nodejs} --eval "require('./test/parallel/test-cli-eval.js')"`,
                stdout, 'Loaded as a module, exiting with status code 42.\n');
              assert.strictEqual(stderr, '');
            }));
+process.chdir(cwd);
 
 // Missing argument should not crash.
 child.exec(`${nodejs} -e`, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+process.chdir('..');
 assert.notStrictEqual(process.cwd(), __dirname);
 process.chdir(__dirname);
 assert.strictEqual(process.cwd(), __dirname);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test

Editing and checking various tests, I've sometimes stumbled on cases when tests failed depending on cwd. So I've run all the tests with [this simple script](https://gist.github.com/vsemozhetbyt/a6e2f3917a414f8dfe6e66e5dd18095a) to find out cwd-dependent tests. The script runs all tests from repo root (default test runner `tools/test.py` behavior) as well as from these ones: `root/..`, `root/test`, `root/test/<test subdirectory>`. If a test fails in all cases or in no cases, it is loosely considered cwd-independent.

So I've found out these 3 cwd-dependent tests:

1. `parallel/test-process-chdir.js` can only be run outside of its directory (it makes too optimistic assumption that `process.cwd()` always  `!== __dirname` after test start).
2. `doctool/test-doctool-html.js` can only be run from the repo root.
3. `parallel/test-cli-eval.js` can only be run from the repo root. It tests some murky old regression bug in the critical fragment, so I've tried to be extra careful there.

After this PR, these tests can be launched from any cwd.
