### PR TITLE
src: deprecate vm.runInDebugContext

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -598,7 +598,7 @@ a V8-inspector based CLI debugger available through `node inspect`.
 <a id="DEP0069"></a>
 ### DEP0069: vm.runInDebugContext(string)
 
-Type: Documentation-only
+Type: Runtime
 
 The DebugContext will be removed in V8 soon and will not be available in Node
 10+.

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -313,6 +313,11 @@ console.log(util.inspect(sandbox));
 ## vm.runInDebugContext(code)
 <!-- YAML
 added: v0.11.14
+deprecated: v8.0.0
+changes:
+    - version: REPLACEME
+      pr-url: https://github.com/nodejs/node/pull/12815
+      description: Calling this function now emits a deprecation warning.
 -->
 
 > Stability: 0 - Deprecated. An alternative is in development.

--- a/lib/util.js
+++ b/lib/util.js
@@ -385,7 +385,11 @@ function stylizeNoColor(str, styleType) {
 function ensureDebugIsInitialized() {
   if (Debug === undefined) {
     const runInDebugContext = require('vm').runInDebugContext;
+    // a workaround till this entire method is removed
+    const originalValue = process.noDeprecation;
+    process.noDeprecation = true;
     Debug = runInDebugContext('Debug');
+    process.noDeprecation = originalValue;
   }
 }
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -27,7 +27,7 @@ const {
 
   makeContext,
   isContext,
-  runInDebugContext
+  runInDebugContext: runInDebugContext_
 } = process.binding('contextify');
 
 // The binding provides a few useful primitives:
@@ -103,6 +103,19 @@ function sigintHandlersWrap(fn, thisArg, argsArray) {
       process.addListener('SIGINT', listener);
     }
   }
+}
+
+let runInDebugContextWarned = false;
+function runInDebugContext(code) {
+  if (runInDebugContextWarned === false) {
+    runInDebugContextWarned = true;
+    process.emitWarning(
+      'DebugContext has been deprecated and will be removed in a ' +
+      'future version.',
+      'DeprecationWarning',
+      'DEP0069');
+  }
+  return runInDebugContext_(code);
 }
 
 function runInContext(code, contextifiedSandbox, options) {

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -27,6 +27,11 @@ const vm = require('vm');
 const { spawn } = require('child_process');
 const fixtures = require('../common/fixtures');
 
+const msg = 'DebugContext has been deprecated and will be removed in ' +
+            'a future version.';
+common.expectWarning('DeprecationWarning', msg);
+vm.runInDebugContext();
+
 assert.throws(function() {
   vm.runInDebugContext('*');
 }, /SyntaxError/);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Runtime deprecation of `vm.runInDebugContext`. To land in v9.x.
