### PR TITLE
Lazy stat dates

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -263,7 +263,7 @@ Stats.prototype.toJSON = function toJSON() {
     mtime: this.mtime,
     birthtime: this.birthtime
   };
-}
+};
 
 
 Stats.prototype._checkModeProperty = function(property) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -196,12 +196,75 @@ function Stats(
   this.ino = ino;
   this.size = size;
   this.blocks = blocks;
-  this.atime = new Date(atim_msec + 0.5);
-  this.mtime = new Date(mtim_msec + 0.5);
-  this.ctime = new Date(ctim_msec + 0.5);
-  this.birthtime = new Date(birthtim_msec + 0.5);
+  this._atim_msec = atim_msec;
+  this._mtim_msec = mtim_msec;
+  this._ctim_msec = ctim_msec;
+  this._birthtim_msec = birthtim_msec;
 }
 fs.Stats = Stats;
+
+Object.defineProperties(Stats.prototype, {
+  atime: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this._atime !== undefined ?
+          this._atime :
+          (this._atime = new Date(this._atim_msec + 0.5));
+    },
+    set(value) { return this._atime = value; }
+  },
+  mtime: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this._mtime !== undefined ?
+          this._mtime :
+          (this._mtime = new Date(this._mtim_msec + 0.5));
+    },
+    set(value) { return this._mtime = value; }
+  },
+  ctime: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this._ctime !== undefined ?
+        this._ctime :
+        (this._ctime = new Date(this._ctim_msec + 0.5));
+    },
+    set(value) { return this._ctime = value; }
+  },
+  birthtime: {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this._birthtime !== undefined ?
+        this._birthtime :
+        (this._birthtime = new Date(this._birthtim_msec + 0.5));
+    },
+    set(value) { return this._birthtime = value; }
+  },
+});
+
+Stats.prototype.toJSON = function toJSON() {
+  return {
+    dev: this.dev,
+    mode: this.mode,
+    nlink: this.nlink,
+    uid: this.uid,
+    gid: this.gid,
+    rdev: this.rdev,
+    blksize: this.blksize,
+    ino: this.ino,
+    size: this.size,
+    blocks: this.blocks,
+    atime: this.atime,
+    ctime: this.ctime,
+    mtime: this.mtime,
+    birthtime: this.birthtime
+  };
+}
+
 
 Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & S_IFMT) === property);

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -98,5 +98,21 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   console.log(`isSymbolicLink: ${JSON.stringify(s.isSymbolicLink())}`);
   assert.strictEqual(false, s.isSymbolicLink());
 
+  assert.ok(s.atime instanceof Date);
   assert.ok(s.mtime instanceof Date);
+  assert.ok(s.ctime instanceof Date);
+  assert.ok(s.birthtime instanceof Date);
+}));
+
+fs.stat(__filename, common.mustCall(function(err, s) {
+  const json = JSON.parse(JSON.stringify(s));
+  const keys = [
+    'dev', 'mode', 'nlink', 'uid',
+    'gid', 'rdev', 'blksize', 'ino',
+    'size', 'blocks', 'atime', 'mtime',
+    'ctime', 'birthtime'
+  ];
+  keys.forEach(function(k) {
+    assert.ok(json[k] !== undefined && json[k] !== null);
+  });
 }));

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -113,6 +113,9 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     'ctime', 'birthtime'
   ];
   keys.forEach(function(k) {
-    assert.ok(json[k] !== undefined && json[k] !== null, k + ' should not be null or undefined');
+    assert.ok(
+      json[k] !== undefined && json[k] !== null,
+      k + ' should not be null or undefined'
+    );
   });
 }));

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -109,9 +109,12 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   const keys = [
     'dev', 'mode', 'nlink', 'uid',
     'gid', 'rdev', 'ino',
-    'size', 'blocks', 'atime', 'mtime',
+    'size', 'atime', 'mtime',
     'ctime', 'birthtime'
   ];
+  if (!common.isWindows) {
+    keys.push('blocks', 'blksize');
+  }
   keys.forEach(function(k) {
     assert.ok(
       json[k] !== undefined && json[k] !== null,

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -108,11 +108,11 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   const json = JSON.parse(JSON.stringify(s));
   const keys = [
     'dev', 'mode', 'nlink', 'uid',
-    'gid', 'rdev', 'blksize', 'ino',
+    'gid', 'rdev', 'ino',
     'size', 'blocks', 'atime', 'mtime',
     'ctime', 'birthtime'
   ];
   keys.forEach(function(k) {
-    assert.ok(json[k] !== undefined && json[k] !== null);
+    assert.ok(json[k] !== undefined && json[k] !== null, k + ' should not be null or undefined');
   });
 }));


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/12607

In order to improve performance when using fs *stat-functions, we can delay creation of the 4 date-objects until they are used.

This is a `semver-major` change:
 - `Object.keys(statResult)`, `Object.getOwnPropertyNames/Descriptors(statResult)` will no longer return `atime`, `mtime`, `ctime`, `birthtime`, and WILL return `_atime`, `_mtime`, `_ctime`, `_birthtime`, `_atim_msec`, `_mtim_msec`, `_ctim_msec`, `_birthtim_msec`
 - `for(x in statResult){}` will iterate over `_atime`, `_mtime`, `_ctime`, `_birthtime`, `_atim_msec`, `_mtim_msec`, `_ctim_msec`, `_birthtim_msec`

##### Benchmark
```
Accessing zero time fields:
                                                 improvement confidence      p.value
 fs/bench-statSync.js kind="fstatSync" n=1000000    222.82 %        *** 5.526432e-46
 fs/bench-statSync.js kind="lstatSync" n=1000000     57.40 %        *** 1.980913e-30
 fs/bench-statSync.js kind="statSync" n=1000000      57.91 %        *** 4.996535e-43

Accessing one time field:
                                                 improvement confidence      p.value
 fs/bench-statSync.js kind="fstatSync" n=1000000    112.30 %        *** 1.836060e-48
 fs/bench-statSync.js kind="lstatSync" n=1000000     33.09 %        *** 4.143412e-29
 fs/bench-statSync.js kind="statSync" n=1000000      34.87 %        *** 6.003936e-33

Accessing two time fields:
                                                 improvement confidence      p.value
 fs/bench-statSync.js kind="fstatSync" n=1000000     54.61 %        *** 4.500304e-40
 fs/bench-statSync.js kind="lstatSync" n=1000000     22.35 %        *** 6.087184e-21
 fs/bench-statSync.js kind="statSync" n=1000000      21.28 %        *** 1.345810e-21

Accessing three time fields:
                                                 improvement confidence      p.value
 fs/bench-statSync.js kind="fstatSync" n=1000000     31.65 %        *** 7.849068e-35
 fs/bench-statSync.js kind="lstatSync" n=1000000     10.82 %        *** 2.023683e-18
 fs/bench-statSync.js kind="statSync" n=1000000      12.19 %        *** 6.572484e-27

Accessing four time fields:
                                                 improvement confidence      p.value
 fs/bench-statSync.js kind="fstatSync" n=1000000      4.47 %        *** 1.026716e-16
 fs/bench-statSync.js kind="lstatSync" n=1000000      1.16 %            1.381009e-01
 fs/bench-statSync.js kind="statSync" n=1000000       1.91 %         ** 6.071880e-03
```

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
lib