### PR TITLE
assert: wrap original err on `ifError` fail

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -286,26 +286,41 @@ assert.fail('a', 'b');
 // AssertionError: 'a' != 'b'
 ```
 
-## assert.ifError(value)
+## assert.ifError(value, message)
 <!-- YAML
 added: v0.1.97
 -->
 * `value` {any}
+* `message` {any}
 
-Throws `value` if `value` is truthy. This is useful when testing the `error`
-argument in callbacks.
-
+Throws an `AssertionError` if `value` is truthy. This is useful when testing the
+`error` argument in callbacks. If the `message` parameter is undefined, a
+default error message is assigned, and `value` is be appended to it.
 ```js
 const assert = require('assert');
 
 assert.ifError(0);
 // OK
+
 assert.ifError(1);
-// Throws 1
+// outputs:
+// AssertionError [ERR_ASSERTION]: ifError failed. Original error:
+// 1
+//    at Function.ifError (assert.js:552:3)
+// ...
+
 assert.ifError('error');
-// Throws 'error'
-assert.ifError(new Error());
-// Throws Error
+// outputs:
+// AssertionError [ERR_ASSERTION]: ifError failed. Original error:
+// error
+//    at Function.ifError (assert.js:552:3)
+// ...
+
+a.ifError(new Error('hello'));
+// outputs:
+// AssertionError [ERR_ASSERTION]: ifError failed. Original error:
+// Error: hello
+//    at ...
 ```
 
 ## assert.notDeepEqual(actual, expected[, message])

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -546,4 +546,8 @@ function doesNotThrow(block, /*optional*/error, /*optional*/message) {
   _throws(false, block, error, message);
 }
 
-assert.ifError = function ifError(err) { if (err) throw err; };
+assert.ifError = function ifError(err, message) {
+  if (!err) return;
+  message = message || `ifError failed. Original error:\n${err}`;
+  fail(err, null, message, ifError);
+};

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -453,8 +453,37 @@ assert.throws(makeBlock(thrower, TypeError));
                      'a.doesNotThrow is not catching type matching errors');
 }
 
-assert.throws(function() { assert.ifError(new Error('test error')); },
-              /^Error: test error$/);
+
+// Assert that the exception is wraped with an AssertionError
+assert.throws(
+  function() { assert.ifError(new Error('test error')); },
+  common.expectsError({
+                code: 'ERR_ASSERTION',
+                type: a.AssertionError,
+                message: /^ifError failed\. Original error:$/m
+  })
+);
+// Assert that the original exception is inside
+assert.throws(
+  function() { assert.ifError(new Error('test_error_slug')); },
+  common.expectsError({
+                code: 'ERR_ASSERTION',
+                type: a.AssertionError,
+                message: /^Error: test_error_slug$/m
+  })
+);
+
+// Assert that the failing frame is in the stack
+assert.throws(
+  function goose() {
+    assert.ifError(new Error('test error'));
+  },
+  common.expectsError({
+                code: 'ERR_ASSERTION',
+                type: a.AssertionError,
+                message: /^\s+at goose(.+)test-assert\.js:\d+:\d+\)$/m
+  })
+);
 assert.doesNotThrow(function() { assert.ifError(null); });
 assert.doesNotThrow(function() { assert.ifError(); });
 


### PR DESCRIPTION
For `assert.ifError` fails, wrap the original err in a new AssertionError

Inspiration: https://github.com/nodejs/node/issues/12803#issuecomment-299041508
/cc @nodejs/testing
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
test, assert
