### PR TITLE
src: split CryptoPemCallback into two functions

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -464,7 +464,6 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
 
-  bool has_password = true;
   unsigned int len = args.Length();
   if (len < 1) {
     return env->ThrowError("Private key argument is mandatory");
@@ -474,7 +473,8 @@ void SecureContext::SetKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Only private key and pass phrase are expected");
   }
 
-  if (len == 2) {
+  bool has_password = len == 2;
+  if (has_password) {
     if (args[1]->IsUndefined() || args[1]->IsNull())
       has_password = false;
     else

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -242,7 +242,10 @@ static int PasswordCallback(char *buf, int size, int rwflag, void *u) {
 
 
 // This callback is used to avoid the default passphrase callback in OpenSSL
-// which will typically prompt for the passphrase.
+// which will typically prompt for the passphrase. The prompting is designed
+// for the OpenSSL CLI, but works poorly for Node.js because it involves
+// synchronous interaction with the controlling terminal, something we never
+// want, and use this function to avoid it.
 static int NoPasswordCallback(char *buf, int size, int rwflag, void *u) {
   return 0;
 }

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -237,6 +237,7 @@ static int PasswordCallback(char *buf, int size, int rwflag, void *u) {
   return len;
 }
 
+
 // This callback is used to avoid the default passphrase callback in OpenSSL
 // which will typically prompt for the passphrase.
 static int NoPasswordCallback(char *buf, int size, int rwflag, void *u) {


### PR DESCRIPTION
Currently the function CryptoPemCallback is used for two things:
1. As a passphrase callback.
2. To avoid the default OpenSSL passphrase routine.

The default OpenSSL passphase routine would apply if both
the callback and the passphrase are null pointers and the typical
behaviour is to prompt for the passphase which is not appropriate in
node.

This commit suggests that the PasswordCallback function only handle
passphrases, and that an additional function named NoPasswordCallback
used for the second case to avoid OpenSSL's passphase routine.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src