### PR TITLE
test: complete coverage of buffer

### DIFF
--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -106,3 +106,12 @@ assert.strictEqual(Buffer.byteLength('Il était tué', 'utf8'), 14);
 // Test that ArrayBuffer from a different context is detected correctly
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');
 assert.strictEqual(Buffer.byteLength(arrayBuf), 0);
+
+// Verify that invalid encodings are treated as utf8
+for (let i = 1; i < 10; i++) {
+  const encoding = String(i).repeat(i);
+
+  assert.ok(!Buffer.isEncoding(encoding));
+  assert.strictEqual(Buffer.byteLength('foo', encoding),
+                     Buffer.byteLength('foo', 'utf8'));
+}

--- a/test/parallel/test-buffer-tostring.js
+++ b/test/parallel/test-buffer-tostring.js
@@ -4,8 +4,8 @@ require('../common');
 const assert = require('assert');
 
 // utf8, ucs2, ascii, latin1, utf16le
-const encodings = ['utf8', 'ucs2', 'ucs-2', 'ascii', 'latin1', 'binary',
-                   'utf16le', 'utf-16le'];
+const encodings = ['utf8', 'utf-8', 'ucs2', 'ucs-2', 'ascii', 'latin1',
+                   'binary', 'utf16le', 'utf-16le'];
 
 encodings
   .reduce((es, e) => es.concat(e, e.toUpperCase()), [])
@@ -23,3 +23,12 @@ encodings
   assert.strictEqual(Buffer.from('666f6f', encoding).toString(encoding),
                      '666f6f');
 });
+
+// Invalid encodings
+for (let i = 1; i < 10; i++) {
+  const encoding = String(i).repeat(i);
+  const error = new RegExp(`^TypeError: Unknown encoding: ${encoding}$`);
+
+  assert.ok(!Buffer.isEncoding(encoding));
+  assert.throws(() => Buffer.from('foo').toString(encoding), error);
+}

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -53,3 +53,12 @@ encodings
   assert.strictEqual(buf.write('666f6f', 0, len, encoding), len);
   assert.deepStrictEqual(buf, resultMap.get(encoding.toLowerCase()));
 });
+
+// Invalid encodings
+for (let i = 1; i < 10; i++) {
+  const encoding = String(i).repeat(i);
+  const error = new RegExp(`^TypeError: Unknown encoding: ${encoding}$`);
+
+  assert.ok(!Buffer.isEncoding(encoding));
+  assert.throws(() => Buffer.alloc(9).write('foo', encoding), error);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Complete coverage of `lib/buffer.js`. According to https://coverage.nodejs.org/coverage-ff001c12b032c33d/root/buffer.js.html , this PR adds the coverage for some missing `break` cases and one `utf-8` case which are not get covered in https://github.com/nodejs/node/pull/12714 .

PS: When i was writing the test cases for those invalid encodings cases, i found that the way each `Buffer` API treats the invalid value of the `encoding` parameter seems quite inconsistent, for instance:
- `Buffer.from` treats all JavaScript falsy values and all other non-string values as `utf8`
  - `Buffer.from('foo', false)` equals `Buffer.from('foo', 'utf8')`
  - `Buffer.from('foo', 123)` equals `Buffer.from('foo', 'utf8')`
- `buf.toString` only treats `undefined` as `utf8`, and throws an error when comes to all other invalid values  
  - `Buffer.from('foo').toString(undefined)` equals `Buffer.from('foo').toString('utf8')`
  - `Buffer.from('foo').toString('u')` and `Buffer.from('foo').toString(0)` will throw
- `buf.write` just treats all JavaScript falsy value as `utf8`, and throws an error when comes to all other invalid values   
  - `Buffer.alloc(9).write('foo', 0)` equals `Buffer.alloc(9).write('foo', 'utf8')`
- ...

So shall we find a consistent way to deal with this *invalid encoding parameter situation* to avoid some potential  confusions?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test