### PR TITLE
test, fs: fix chmod mask testing on windows

### DIFF
--- a/test/known_issues/test-fs-fchmod-12835.js
+++ b/test/known_issues/test-fs-fchmod-12835.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+
+// Windows only: Test fchmod on files with `attrib -a -h -i -r -s`
+// setting RO then can't set RW back
+
+const {strictEqual, ok} = require('assert');
+const {execSync} = require('child_process');
+const fs = require('fs');
+
+ok(common.isWindows, 'reset of test only for windows');
+
+process.on('exit', function() {
+  console.log('Trying to cleanup');
+  try {
+    execSync(`del /q /f ${tmpFile}`);
+  } catch (e) {
+    console.log(e);
+  }
+});
+
+const RO = 0o100444; // 33060 0b1000000100100100
+const RW = 0o100666; // 33206 0b1000000110110110
+
+const tmpFile = `${common.tmpDir}\\${Date.now()}gigi.js`;
+
+const fd = fs.openSync(tmpFile, 'a');
+execSync(`attrib -a -h -i -r -s ${tmpFile}`);
+fs.fchmodSync(fd, RO);
+const actual2 = fs.fstatSync(fd).mode;
+console.log(`${tmpFile} mode: ${actual2}`);
+strictEqual(actual2, RO);
+
+fs.fchmodSync(fd, RW); // This does not work.
+const actual3 = fs.fstatSync(fd).mode;
+console.log(`${tmpFile} mode: ${actual3}`);
+strictEqual(actual3, RW); // BANG!

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -7,10 +7,14 @@ prefix parallel
 [true] # This section applies to all platforms
 
 [$system==win32]
+# https://github.com/nodejs/node/issues/12803
+test-fs-chmod                 : PASS,FLAKY
 
 [$system==linux]
 
 [$system==macos]
+# https://github.com/nodejs/node/issues/12803
+test-fs-chmod                 : PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
 


### PR DESCRIPTION
Currently this uncovers a regression in `fs.fchmodSync(fd, mode_sync);`
No solution yet...

Fixes:https://github.com/nodejs/node/issues/12803
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
fs,libuv,test
