### PR TITLE
tls: accept `lookup` option for `tls.connect()`

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1295,4 +1295,4 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [modifying the default cipher suite]: #tls_modifying_the_default_tls_cipher_suite
 [specific attacks affecting larger AES key sizes]: https://www.schneier.com/blog/archives/2009/07/another_new_aes.html
 [tls.Server]: #tls_class_tls_server
-[`dns.lookup`]: dns.html#dns_dns_lookup_hostname_options_callback
+[`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -809,6 +809,7 @@ changes:
     `tls.createSecureContext()`. *Note*: In effect, all
     [`tls.createSecureContext()`][] options can be provided, but they will be
     _completely ignored_ unless the `secureContext` option is missing.
+  * `lookup`: {Function} Custom lookup function. Defaults to [`dns.lookup()`][].
   * ...: Optional [`tls.createSecureContext()`][] options can be provided, see
     the `secureContext` option for more information.
 * `callback` {Function}

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -753,6 +753,9 @@ decrease overall server throughput.
 added: v0.11.3
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/12839
+    description: The `lookup` option is supported now.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/11984
     description: The `ALPNProtocols` and `NPNProtocols` options can
                  be `Uint8Array`s now.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1295,3 +1295,4 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [modifying the default cipher suite]: #tls_modifying_the_default_tls_cipher_suite
 [specific attacks affecting larger AES key sizes]: https://www.schneier.com/blog/archives/2009/07/another_new_aes.html
 [tls.Server]: #tls_class_tls_server
+[`dns.lookup`]: dns.html#dns_dns_lookup_hostname_options_callback

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1066,7 +1066,8 @@ exports.connect = function(...args /* [port,] [host,] [options,] [cb] */) {
         port: options.port,
         host: options.host,
         family: options.family,
-        localAddress: options.localAddress
+        localAddress: options.localAddress,
+        lookup: options.lookup
       };
     }
     socket.connect(connect_opt, function() {

--- a/test/parallel/test-tls-lookup.js
+++ b/test/parallel/test-tls-lookup.js
@@ -5,9 +5,7 @@ const tls = require('tls');
 
 const expectedError = /^TypeError: "lookup" option should be a function$/;
 
-['foobar', 1, {}, []].forEach((input) => connectThrows(input));
-
-function connectThrows(input) {
+['foobar', 1, {}, []].forEach(function connectThrows(input) {
   const opts = {
     host: 'localhost',
     port: common.PORT,
@@ -17,9 +15,9 @@ function connectThrows(input) {
   assert.throws(function() {
     tls.connect(opts);
   }, expectedError);
-}
+});
 
-connectDoesNotThrow(common.mustCall(common.noop));
+connectDoesNotThrow(common.mustCall(() => {}));
 
 function connectDoesNotThrow(input) {
   const opts = {

--- a/test/parallel/test-tls-lookup.js
+++ b/test/parallel/test-tls-lookup.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const tls = require('tls');
+
+const expectedError = /^TypeError: "lookup" option should be a function$/;
+
+['foobar', 1, {}, []].forEach((input) => connectThrows(input));
+
+function connectThrows(input) {
+  const opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input
+  };
+
+  assert.throws(function() {
+    tls.connect(opts);
+  }, expectedError);
+}
+
+connectDoesNotThrow(common.mustCall(common.noop));
+
+function connectDoesNotThrow(input) {
+  const opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input
+  };
+
+  assert.doesNotThrow(function() {
+    tls.connect(opts);
+  });
+}


### PR DESCRIPTION
`net.connect()` and consequently `http.Agent` support custom DNS
`lookup` option. However, as we move to `https.Agent` - this option no
longer works because it is not proxied by `tls.connect`.

Fix this inconsistency by passing it down to `net.connect`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tls