### PR TITLE
doc: remove test-npm from general build doc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -123,15 +123,6 @@ To run the tests:
 $ make test
 ```
 
-To run the npm test suite:
-
-*note: to run the suite on node v4 or earlier you must first*
-*run `make install`*
-
-```console
-$ make test-npm
-```
-
 To build the documentation:
 
 This will build Node.js first (if necessary) and then use it to build the docs:


### PR DESCRIPTION
`make test-npm` is not particularly robust (currently fails on Linux and
Windows, reportedly) and results in a fair number of requests for help
from people new to the project. It is used when upgrading npm in core,
which only a small number of mostly-predefined people do. Remove it from
the general build doc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc