### PR TITLE
assert: restore TypeError if no arguments

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -47,7 +47,7 @@ const assert = module.exports = ok;
 
 // TODO(jasnell): Consider moving AssertionError into internal/errors.js
 class AssertionError extends Error {
-  constructor(options = {}) {
+  constructor(options) {
     if (typeof options !== 'object' || options === null) {
       // Lazy because the errors module itself uses assertions, leading to
       // a circular dependency. This can be eliminated by moving this class

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -701,12 +701,16 @@ assert.throws(() => {
   code: 'ERR_ASSERTION',
   message: new RegExp(`^'${'A'.repeat(127)} === ''$`)}));
 
-[1, true, false, '', null, Infinity, Symbol('test')].forEach((input) => {
-  assert.throws(
-    () => new assert.AssertionError(input),
-    common.expectsError({
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: /^The "options" argument must be of type object$/
-    }));
-});
+{
+  // bad args to AssertionError constructor should throw TypeError
+  const args = [1, true, false, '', null, Infinity, Symbol('test'), undefined];
+  args.forEach((input) => {
+    assert.throws(
+      () => new assert.AssertionError(input),
+      common.expectsError({
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: /^The "options" argument must be of type object$/
+      }));
+  });
+}


### PR DESCRIPTION
In Node 7.x, calling `throw new assert.AssertionError()` resulted in a
TypeError.

In current master, the same call does not result in an error but, due to
the default option, it results in uninformative output ("undefined
undefined undefined").

This change removes the default argument, restoring a TypeError if there
is no argument. This also will restore our test coverage to 100%. (The
default argument is not tested in our current test suite.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert