### PR TITLE
buffer: fix Buffer.isEncoding() return value for empty string

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -375,6 +375,7 @@ Buffer.compare = function compare(a, b) {
 
 Buffer.isEncoding = function(encoding) {
   return typeof encoding === 'string' &&
+         encoding.length > 0 &&
          typeof internalUtil.normalizeEncoding(encoding) === 'string';
 };
 Buffer[internalUtil.kIsEncodingSymbol] = Buffer.isEncoding;

--- a/test/parallel/test-buffer-isencoding.js
+++ b/test/parallel/test-buffer-isencoding.js
@@ -17,10 +17,13 @@ const assert = require('assert');
     assert.strictEqual(Buffer.isEncoding(enc), true);
   });
 
-[ 'utf9',
+[ '',
+  'utf9',
   'utf-7',
   'Unicode-FTW',
   'new gnu gun',
+  undefined,
+  null,
   false,
   NaN,
   {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
For now the return value of `Buffer.isEncoding('')` is `true` which seems not the preferred behavior:

```js
> Buffer.isEncoding('')
true
```

This PR is to fix this.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->