### PR TITLE
assert: improve deepEqual perf for large input

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -285,15 +285,24 @@ function _deepEqual(actual, expected, strict, memos) {
   // Note: this accounts for both named and indexed properties on Arrays.
 
   // Use memos to handle cycles.
-  memos = memos || { actual: [], expected: [] };
-  const actualIndex = memos.actual.indexOf(actual);
-  if (actualIndex !== -1) {
-    if (actualIndex === memos.expected.indexOf(expected)) {
+  if (!memos) {
+    memos = {
+      actual: { map: new Map(), position: 0 },
+      expected: { map: new Map(), position: 0 }
+    };
+  }
+
+  const actualPosition = memos.actual.map.get(actual);
+  if (actualPosition !== undefined) {
+    if (actualPosition === memos.expected.map.get(expected)) {
       return true;
     }
+  } else {
+    memos.actual.map.set(actual, memos.actual.position++);
   }
-  memos.actual.push(actual);
-  memos.expected.push(expected);
+  if (!memos.expected.map.has(expected)) {
+    memos.expected.map.set(expected, memos.expected.position++);
+  }
 
   return objEquiv(actual, expected, strict, memos);
 }


### PR DESCRIPTION
Use a Map instead of an array for checking previously found
cyclic references.

This reduces complexity for an array-of-objects case from
O(n²) to O(n·log n).

Case from the issue, new output:

```
2, 3
3, 0
5, 0
8, 4
12, 2
18, 1
27, 4
41, 3
62, 1
93, 3
140, 4
210, 10
315, 5
473, 11
710, 16
1065, 25
1598, 40
2397, 75
3596, 119
5394, 150
8091, 216
12137, 296
18206, 419
27309, 681
40964, 944
61446, 1439
92169, 2424
```

Fixes: https://github.com/nodejs/node/issues/12842

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
