### PR TITLE
(v7.x backport) net: remove an unused internal module `assertPort`

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -1,7 +1,5 @@
 'use strict';
 
-module.exports = { isLegalPort, assertPort };
-
 // Check that the port number is not NaN when coerced to a number,
 // is an integer and that it falls within the legal range of port numbers.
 function isLegalPort(port) {
@@ -11,8 +9,6 @@ function isLegalPort(port) {
   return +port === (+port >>> 0) && port <= 0xFFFF;
 }
 
-
-function assertPort(port) {
-  if (typeof port !== 'undefined' && !isLegalPort(port))
-    throw new RangeError('"port" argument must be >= 0 and < 65536');
-}
+module.exports = {
+  isLegalPort
+};


### PR DESCRIPTION
Backport of #11812 to 7.x:

> **net: remove an unused internal module `assertPort`**
>
> A module `assertPort` in `lib/internal/net.js` is not used anymore.

##### Checklist
- [x] `make -j4 test`
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
net