### PR TITLE
Revert "net: don't normalize twice in Socket#connect()"

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -95,7 +95,7 @@ function connect() {
     socket.setTimeout(options.timeout);
   }
 
-  return realConnect.call(socket, options, cb);
+  return Socket.prototype.connect.call(socket, options, cb);
 }
 
 
@@ -919,14 +919,10 @@ Socket.prototype.connect = function() {
   for (var i = 0; i < arguments.length; i++)
     args[i] = arguments[i];
   // TODO(joyeecheung): use destructuring when V8 is fast enough
-  var normalized = normalizeArgs(args);
-  var options = normalized[0];
-  var cb = normalized[1];
-  return realConnect.call(this, options, cb);
-};
+  const normalized = normalizeArgs(args);
+  const options = normalized[0];
+  const cb = normalized[1];
 
-
-function realConnect(options, cb) {
   if (this.write !== Socket.prototype.write)
     this.write = Socket.prototype.write;
 
@@ -967,7 +963,7 @@ function realConnect(options, cb) {
     lookupAndConnect(this, options);
   }
   return this;
-}
+};
 
 
 function lookupAndConnect(self, options) {

--- a/test/parallel/test-net-connect-call-socket-connect.js
+++ b/test/parallel/test-net-connect-call-socket-connect.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// This test checks that calling `net.connect` internally calls
+// `Socket.prototype.connect`.
+//
+// This is important for people who monkey-patch `Socket.prototype.connect`
+// since it's not possible to monkey-patch `net.connect` directly (as the core
+// `connect` function is called internally in Node instead of calling the
+// `exports.connect` function).
+//
+// Monkey-patching of `Socket.prototype.connect` is done by - among others -
+// most APM vendors, the async-listener module and the
+// continuation-local-storage module.
+//
+// See https://github.com/nodejs/node/pull/12852 for details.
+
+const common = require('../common');
+const net = require('net');
+const Socket = net.Socket;
+
+// monkey patch Socket.prototype.connect to check that it's called
+const orig = Socket.prototype.connect;
+Socket.prototype.connect = common.mustCall(function() {
+  return orig.apply(this, arguments);
+});
+
+const server = net.createServer();
+
+server.listen(common.mustCall(function() {
+  const port = server.address().port;
+  const client = net.connect({port}, common.mustCall(function() {
+    client.end();
+  }));
+  client.on('end', common.mustCall(function() {
+    server.close();
+  }));
+}));


### PR DESCRIPTION
This reverts commit bb06add4d78535f10d1dc8f0c8c3210fecb96c8a. This commit was causing failures in the async-listener module, which monkey patches `Socket.prototype.connect()`.

cc: @watson @jasnell 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
net