### PR TITLE
Revert "net: remove unnecessary process.nextTick()"

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1005,7 +1005,10 @@ function lookupAndConnect(self, options) {
   // If host is an IP, skip performing a lookup
   var addressType = cares.isIP(host);
   if (addressType) {
-    internalConnect(self, host, port, addressType, localAddress, localPort);
+    nextTick(self[async_id_symbol], function() {
+      if (self.connecting)
+        internalConnect(self, host, port, addressType, localAddress, localPort);
+    });
     return;
   }
 

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -48,13 +48,16 @@ const server = net
     { port: server.address().port, host: server.address().address },
     common.mustCall(onconnected));
   const tcps = hooks.activitiesOfTypes('TCPWRAP');
-  const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
   assert.strictEqual(
     tcps.length, 2,
     '2 TCPWRAPs present when client is connecting');
-  assert.strictEqual(
-    tcpconnects.length, 1,
-    '1 TCPCONNECTWRAP present when client is connecting');
+  process.nextTick(() => {
+    const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
+    assert.strictEqual(
+      tcpconnects.length, 1,
+      '1 TCPCONNECTWRAP present when client is connecting');
+  });
+
   tcp2 = tcps[1];
   assert.strictEqual(tcps.length, 2,
                      '2 TCPWRAP present when client is connecting');

--- a/test/parallel/test-http-client-immediate-error.js
+++ b/test/parallel/test-http-client-immediate-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// Make sure http.request() can catch immediate errors in
+// net.createConnection().
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const req = http.get({ host: '127.0.0.1', port: 1 });
+req.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ECONNREFUSED');
+}));


### PR DESCRIPTION
This reverts commit 571882c5a45872ac67e4e29513c4c8f23af9f781.

Removing the process.nextTick() call can prevent the consumer
from being able to catch error events.

Looks like we ran into this before in https://github.com/nodejs/node/commit/af249fa8a15bad8996187e73b480b30dcd881bad

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

/cc @bnoordhuis 