### PR TITLE
test: detect all types of aborts in windows

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -550,10 +550,13 @@ exports.nodeProcessAborted = function nodeProcessAborted(exitCode, signal) {
   // or SIGABRT (depending on the compiler).
   const expectedSignals = ['SIGILL', 'SIGTRAP', 'SIGABRT'];
 
-  // On Windows, v8's base::OS::Abort triggers an access violation,
+  // On Windows, 'aborts' are of 2 types, depending on the context:
+  // (i) Forced access violation, if --abort-on-uncaught-exception is on
   // which corresponds to exit code 3221225477 (0xC0000005)
+  // (ii) raise(SIGABRT) or abort(), which lands up in CRT library calls
+  // which corresponds to exit code 3.
   if (exports.isWindows)
-    expectedExitCodes = [3221225477];
+    expectedExitCodes = [3221225477, 3];
 
   // When using --abort-on-uncaught-exception, V8 will use
   // base::OS::Abort to terminate the process.


### PR DESCRIPTION
On Windows, 'aborts' are of 2 types, depending on the context:
(i) Forced access violation, if --abort-on-uncaught-exception is on
which corresponds to exit code 3221225477 (0xC0000005)
(ii) raise(SIGABRT) or abort(), which lands up in CRT library calls
which corresponds to exit code 3

For background, please refer to #12823

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test