### PR TITLE
stream: remove {writeableState/readableState}.length

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -441,9 +441,17 @@ See also: [`writable.cork()`][].
 <!-- YAML
 added: v9.3.0
 -->
-
 Return the value of `highWaterMark` passed when constructing this
 `Writable`.
+
+##### writable.writableLength
+<!-- YAML
+added: REPLACEME
+-->
+
+This property contains the number of bytes (or objects) in the queue
+ready to be written. The value provides introspection data regarding
+the status of the `highWaterMark`.
 
 ##### writable.write(chunk[, encoding][, callback])
 <!-- YAML
@@ -944,6 +952,15 @@ event will also be emitted.
 
 *Note*: Calling [`stream.read([size])`][stream-read] after the [`'end'`][]
 event has been emitted will return `null`. No runtime error will be raised.
+
+##### readable.readableLength
+<!-- YAML
+added: REPLACEME
+-->
+
+This property contains the number of bytes (or objects) in the queue
+ready to be read. The value provides introspection data regarding
+the status of the `highWaterMark`.
 
 ##### readable.resume()
 <!-- YAML

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -69,7 +69,7 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function() {
+  get() {
     return this._writableState.highWaterMark;
   }
 });
@@ -81,6 +81,16 @@ Object.defineProperty(Duplex.prototype, 'writableBuffer', {
   enumerable: false,
   get: function() {
     return this._writableState && this._writableState.getBuffer();
+  }
+});
+
+Object.defineProperty(Duplex.prototype, 'writableLength', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState.length;
   }
 });
 
@@ -101,6 +111,10 @@ function onEndNT(self) {
 }
 
 Object.defineProperty(Duplex.prototype, 'destroyed', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
   get() {
     if (this._readableState === undefined ||
         this._writableState === undefined) {

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -159,6 +159,10 @@ function Readable(options) {
 }
 
 Object.defineProperty(Readable.prototype, 'destroyed', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
   get() {
     if (this._readableState === undefined) {
       return false;
@@ -952,6 +956,16 @@ Object.defineProperty(Readable.prototype, 'readableFlowing', {
 
 // exposed for testing purposes only.
 Readable._fromList = fromList;
+
+Object.defineProperty(Readable.prototype, 'readableLength', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._readableState.length;
+  }
+});
 
 // Pluck off n bytes from an array of buffers.
 // Length is the combined lengths of all the buffers in the list.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -583,6 +583,15 @@ Writable.prototype.end = function(chunk, encoding, cb) {
     endWritable(this, state, cb);
 };
 
+Object.defineProperty(Writable.prototype, 'writableLength', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get() {
+    return this._writableState.length;
+  }
+});
 
 function needFinish(state) {
   return (state.ending &&
@@ -657,6 +666,10 @@ function onCorkedFinish(corkReq, state, err) {
 }
 
 Object.defineProperty(Writable.prototype, 'destroyed', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
   get() {
     if (this._writableState === undefined) {
       return false;

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -531,7 +531,7 @@ function CleartextStream(pair, options) {
       self._reading = false;
     },
     readStart: function() {
-      if (self._reading && self._readableState.length > 0) return;
+      if (self._reading && self.readableLength > 0) return;
       self._reading = true;
       self.read(0);
       if (self._opposite.readable) self._opposite.read(0);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -267,7 +267,7 @@ function initRead(tls, wrapped) {
     return;
 
   // Socket already has some buffered data - emulate receiving it
-  if (wrapped && wrapped._readableState && wrapped._readableState.length) {
+  if (wrapped && wrapped.readableLength) {
     var buf;
     while ((buf = wrapped.read()) !== null)
       tls._handle.receive(buf);

--- a/lib/net.js
+++ b/lib/net.js
@@ -473,7 +473,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 Object.defineProperty(Socket.prototype, 'bufferSize', {
   get: function() {
     if (this._handle) {
-      return this._handle.writeQueueSize + this._writableState.length;
+      return this._handle.writeQueueSize + this.writableLength;
     }
   }
 });
@@ -519,7 +519,7 @@ function maybeDestroy(socket) {
       !socket.writable &&
       !socket.destroyed &&
       !socket.connecting &&
-      !socket._writableState.length) {
+      !socket.writableLength) {
     socket.destroy();
   }
 }
@@ -627,7 +627,7 @@ function onread(nread, buffer) {
   // `end` -> `close`
   self.push(null);
 
-  if (self._readableState.length === 0) {
+  if (self.readableLength === 0) {
     self.readable = false;
     maybeDestroy(self);
   }

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -57,7 +57,7 @@ function httpsTest() {
 
 const test = common.mustCall(function(res) {
   res.on('end', common.mustCall(function() {
-    assert.strictEqual(res._readableState.length, 0);
+    assert.strictEqual(res.readableLength, 0);
     assert.strictEqual(bytes, data.length);
   }));
 

--- a/test/parallel/test-stream-readable-flow-recursion.js
+++ b/test/parallel/test-stream-readable-flow-recursion.js
@@ -70,7 +70,7 @@ process.on('exit', function(code) {
   // we pushed up the high water mark
   assert.strictEqual(stream.readableHighWaterMark, 8192);
   // length is 0 right now, because we pulled it all out.
-  assert.strictEqual(stream._readableState.length, 0);
+  assert.strictEqual(stream.readableLength, 0);
   assert(!code);
   assert.strictEqual(depth, 0);
   console.log('ok');

--- a/test/parallel/test-stream2-push.js
+++ b/test/parallel/test-stream2-push.js
@@ -48,7 +48,7 @@ stream.on('end', function() {
 
 source.on('data', function(chunk) {
   const ret = stream.push(chunk);
-  console.error('data', stream._readableState.length);
+  console.error('data', stream.readableLength);
   if (!ret)
     readStop();
 });

--- a/test/parallel/test-stream2-read-sync-stack.js
+++ b/test/parallel/test-stream2-read-sync-stack.js
@@ -36,8 +36,8 @@ r._read = function(n) {
 };
 
 r.on('readable', function onReadable() {
-  if (!(r._readableState.length % 256))
-    console.error('readable', r._readableState.length);
+  if (!(r.readableLength % 256))
+    console.error('readable', r.readableLength);
   r.read(N * 2);
 });
 

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -43,7 +43,7 @@ const Transform = require('_stream_transform');
   }
   tx.end();
 
-  assert.strictEqual(tx._readableState.length, 10);
+  assert.strictEqual(tx.readableLength, 10);
   assert.strictEqual(transformed, 10);
   assert.strictEqual(tx._transformState.writechunk.length, 5);
   assert.deepStrictEqual(tx.writableBuffer.map(function(c) {

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -68,6 +68,6 @@ console.error(src._readableState);
 process.on('exit', function() {
   src.readableBuffer.length = 0;
   console.error(src._readableState);
-  assert(src._readableState.length >= src.readableHighWaterMark);
+  assert(src.readableLength >= src.readableHighWaterMark);
   console.log('ok');
 });

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -110,7 +110,7 @@ for (let i = 0; i < chunks.length; i++) {
     } while (ret !== false && i < chunks.length);
 
     if (i < chunks.length) {
-      assert(tw._writableState.length >= 50);
+      assert(tw.writableLength >= 50);
       tw.once('drain', W);
     } else {
       tw.end();

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -54,7 +54,7 @@ server.listen(common.PORT, function() {
     setTimeout(function() {
       // Read buffer should be somewhere near high watermark
       // (i.e. should not leak)
-      assert(res._readableState.length < 100 * 1024);
+      assert(res.readableLength < 100 * 1024);
       process.exit(0);
     }, 2000);
   });

--- a/test/pummel/test-net-throttle.js
+++ b/test/pummel/test-net-throttle.js
@@ -40,7 +40,7 @@ const server = net.createServer(function(connection) {
   assert.strictEqual(false, connection.write(body.slice(2 * part_N, N)));
   console.log(`bufferSize: ${connection.bufferSize}`, 'expecting', N);
   assert.ok(0 <= connection.bufferSize &&
-            connection._writableState.length <= N);
+            connection.writableLength <= N);
   connection.end();
 });
 


### PR DESCRIPTION
As part of the readableState/writableState mega issue #445, this
removes all of the references to .length on those properties and
replaces them with a readLength and writeLength getter.

cc @nodejs/streams 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
streams, tls, net
