### PR TITLE
contextify: ignore property if getter throws

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -144,8 +144,6 @@ class ContextifyContext {
         context->Global()->GetPrototype()->ToObject(env()->isolate());
     Local<Object> sandbox_obj = sandbox();
 
-    Local<Function> clone_property_method;
-
     Local<Array> names = global->GetOwnPropertyNames();
     int length = names->Length();
     for (int i = 0; i < length; i++) {
@@ -157,9 +155,16 @@ class ContextifyContext {
         return;
 
       if (!has.FromJust()) {
+        TryCatch try_catch(env()->isolate());
+        MaybeLocal<Value> maybe_desc_vm_context =
+            global->GetOwnPropertyDescriptor(context, key);
+
+        if (maybe_desc_vm_context.IsEmpty()) {
+          continue;
+        }
+
         Local<Object> desc_vm_context =
-            global->GetOwnPropertyDescriptor(context, key)
-            .ToLocalChecked().As<Object>();
+            maybe_desc_vm_context.ToLocalChecked().As<Object>();
 
         bool is_accessor =
             desc_vm_context->Has(context, env()->get_string()).FromJust() ||

--- a/test/parallel/test-vm-getter-throw.js
+++ b/test/parallel/test-vm-getter-throw.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const vm = require('vm');
+
+const x = {};
+
+const code = `
+  var foo = 1;
+  Object.defineProperty(this, "bar", {
+    enumerable: true,
+    get: function () { throw 42 }
+  });
+  var baz = 2;
+`;
+vm.runInNewContext(code, x);
+
+// bar is skipped, see known_issues/test-vm-attributes-property-not-on-sandbox.js
+assert.deepEqual(x, { foo: 1, baz: 2 });


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
vm
