### PR TITLE
test: remove obsolete lint config comments

### DIFF
--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -194,7 +194,7 @@ function error_test() {
     {
       client: client_unix,
       send: '(function(a, a, b) { "use strict"; return a + b + c; })()',
-      expect: /\bSyntaxError: Duplicate parameter name not allowed in this context/ // eslint-disable-line max-len
+      expect: /\bSyntaxError: Duplicate parameter name not allowed in this context/
     },
     {
       client: client_unix,
@@ -204,7 +204,7 @@ function error_test() {
     {
       client: client_unix,
       send: '(function() { "use strict"; var x; delete x; })()',
-      expect: /\bSyntaxError: Delete of an unqualified identifier in strict mode/ // eslint-disable-line max-len
+      expect: /\bSyntaxError: Delete of an unqualified identifier in strict mode/
     },
     { client: client_unix,
       send: '(function() { "use strict"; eval = 17; })()',
@@ -212,7 +212,7 @@ function error_test() {
     {
       client: client_unix,
       send: '(function() { "use strict"; if (true) function f() { } })()',
-      expect: /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block\./ // eslint-disable-line max-len
+      expect: /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block\./
     },
     // Named functions can be used:
     { client: client_unix, send: 'function blah() { return 1; }',


### PR DESCRIPTION
The `max-len` ESLint rule is configured to be forgiving for lines that
contain a regular expression literal. Remove disabling comments that are
no longer required in test-repl.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test