### PR TITLE
net: check and throw on error for getsockname

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1469,8 +1469,10 @@ Object.defineProperty(Server.prototype, 'listening', {
 Server.prototype.address = function() {
   if (this._handle && this._handle.getsockname) {
     var out = {};
-    this._handle.getsockname(out);
-    // TODO(bnoordhuis) Check err and throw?
+    var err = this._handle.getsockname(out);
+    if (err) {
+      throw errnoException(err, 'address');
+    }
     return out;
   } else if (this._pipeName) {
     return this._pipeName;

--- a/test/parallel/test-socket-address.js
+++ b/test/parallel/test-socket-address.js
@@ -12,6 +12,6 @@ server.listen(0, common.mustCall(function() {
     return -1;
   };
   assert.throws(() => this.address(),
-                /^Error: address EPERM$/);
+                /^Error: address (\w+)$/);
   server.close();
 }));

--- a/test/parallel/test-socket-address.js
+++ b/test/parallel/test-socket-address.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+// This tests checks that if server._handle.getsockname
+// returns an error number, an error is thrown.
+
+const server = net.createServer({});
+server.listen(0, common.mustCall(function() {
+  server._handle.getsockname = function(out) {
+    return -1;
+  };
+  assert.throws(() => this.address(),
+                /^Error: address EPERM$/);
+  server.close();
+}));

--- a/test/parallel/test-socket-address.js
+++ b/test/parallel/test-socket-address.js
@@ -12,6 +12,6 @@ server.listen(0, common.mustCall(function() {
     return -1;
   };
   assert.throws(() => this.address(),
-                /^Error: address (\w+)$/);
+                /^Error: address ([\w|\s-\d])+$/);
   server.close();
 }));


### PR DESCRIPTION
This commit attempts fix a TODO in net.js:
TODO(bnoordhuis) Check err and throw?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib