### PR TITLE
test, build: add test-ci wrappers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,9 +169,16 @@ C++ linting.
 
 If you are updating tests and just want to run a single test to check it:
 
-```text
-$ python tools/test.py -v --mode=release parallel/test-stream2-transform
+```console
+$ ./tools/test-ci.sh parallel/test-stream2-transform
 ```
+
+Windows:
+
+```console
+> tools\test-ci parallel\test-stream2-transform
+```
+
 
 You can usually run tests directly with node:
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ NODE_EXE = node$(EXEEXT)
 NODE ?= ./$(NODE_EXE)
 NODE_G_EXE = node_g$(EXEEXT)
 NPM ?= ./deps/npm/bin/npm-cli.js
+TEST_CI = ./tools/test-ci.sh
 
 # Flags for packaging.
 BUILD_DOWNLOAD_FLAGS ?= --download=all
@@ -195,18 +196,18 @@ test: all
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
 	$(MAKE) cctest
-	$(PYTHON) tools/test.py --mode=release -J \
+	$(TEST_CI) \
 		doctool inspector known_issues message pseudo-tty parallel sequential $(CI_NATIVE_SUITES)
 	$(MAKE) lint
 
 test-parallel: all
-	$(PYTHON) tools/test.py --mode=release parallel -J
+	$(TEST_CI) parallel
 
 test-valgrind: all
 	$(PYTHON) tools/test.py --mode=release --valgrind sequential parallel message
 
 test-check-deopts: all
-	$(PYTHON) tools/test.py --mode=release --check-deopts parallel sequential -J
+	$(TEST_CI) --check-deopts parallel sequential
 
 # Implicitly depends on $(NODE_EXE).  We don't depend on it explicitly because
 # it always triggers a rebuild due to it being a .PHONY rule.  See the comment

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LOGLEVEL ?= silent
 OSTYPE := $(shell uname -s | tr '[A-Z]' '[a-z]')
 COVTESTS ?= test
 GTEST_FILTER ?= "*"
+export PYTHON
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)

--- a/tools/test-ci.cmd
+++ b/tools/test-ci.cmd
@@ -1,0 +1,3 @@
+pushd %~dp0\..
+python tools\test.py -J --mode=release %*
+popd

--- a/tools/test-ci.cmd
+++ b/tools/test-ci.cmd
@@ -1,3 +1,5 @@
 pushd %~dp0\..
 python tools\test.py -J --mode=release %*
+set TEST_CI_EXIT=%ERRORLEVEL%
 popd
+exit /b %TEST_CI_EXIT%

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd `dirname $0`/.. > /dev/null
-if [ -z "${PYTHON+x}" ]; then export PYTHON=`which python`; fi
+if [ -z "${PYTHON}" ]; then export PYTHON=`which python`; fi
 "${PYTHON}" tools/test.py -J --mode=release $*
 exit $?

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -2,3 +2,4 @@
 cd `dirname $0`/.. > /dev/null
 if [ -z ${PYTHON+x} ]; then export PYTHON=`which python`; fi
 ${PYTHON} tools/test.py -J --mode=release $*
+exit $?

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd `dirname $0`/.. > /dev/null
+`which python` tools/test.py -J --mode=release $*

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd `dirname $0`/.. > /dev/null
-if [ -z ${PYTHON+x} ]; then export PYTHON=`which python`; fi
-${PYTHON} tools/test.py -J --mode=release $*
+if [ -z "${PYTHON+x}" ]; then export PYTHON=`which python`; fi
+"${PYTHON}" tools/test.py -J --mode=release $*
 exit $?

--- a/tools/test-ci.sh
+++ b/tools/test-ci.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 cd `dirname $0`/.. > /dev/null
-`which python` tools/test.py -J --mode=release $*
+if [ -z ${PYTHON+x} ]; then export PYTHON=`which python`; fi
+${PYTHON} tools/test.py -J --mode=release $*

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -403,7 +403,7 @@ if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
 :node-check-deopts
-set "test_deopts_cmd=tools\test-ci.cmd --check-deopts parallel sequential"
+set "test_deopts_cmd=%~dp0tools\test-ci.cmd --check-deopts parallel sequential"
 echo running '%test_deopts_cmd%'
 call %test_deopts_cmd%
 if defined test_node_inspect goto node-test-inspect
@@ -420,7 +420,7 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-set "test_cmd=tools\test-ci.cmd %test_args%"
+set "test_cmd=%~dp0tools\test-ci.cmd %test_args%"
 echo running '%test_cmd%'
 call %test_cmd%
 goto cpplint

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -403,7 +403,9 @@ if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
 :node-check-deopts
-python tools\test.py --mode=release --check-deopts parallel sequential -J
+set "test_deopts_cmd=tools\test-ci.cmd --check-deopts parallel sequential"
+echo running '%test_deopts_cmd%'
+call %test_deopts_cmd%
 if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
@@ -418,8 +420,9 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-echo running 'python tools\test.py %test_args%'
-python tools\test.py %test_args%
+set "test_cmd=tools\test-ci.cmd %test_args%"
+echo running '%test_cmd%'
+call %test_cmd%
 goto cpplint
 
 :cpplint


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/12830#discussion_r115124401
Fixes: #12771

Added scripts that use the same args as the CI for use with single files or suites

Need help reviewing the change in `Makefile` whether it's safe as it bypasses the PYTHON var in `config.mk`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
