### PR TITLE
test: fix flaky test-https-client-get-url

### DIFF
--- a/test/parallel/test-https-client-get-url.js
+++ b/test/parallel/test-https-client-get-url.js
@@ -41,18 +41,21 @@ const options = {
   cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
-const server = https.createServer(options, common.mustCall(function(req, res) {
+const server = https.createServer(options, common.mustCall((req, res) => {
   assert.strictEqual('GET', req.method);
   assert.strictEqual('/foo?bar', req.url);
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('hello\n');
   res.end();
-  server.close();
 }, 3));
 
-server.listen(0, function() {
-  const u = `https://127.0.0.1:${this.address().port}/foo?bar`;
-  https.get(u);
-  https.get(url.parse(u));
-  https.get(new URL(u));
-});
+server.listen(0, common.mustCall(() => {
+  const u = `https://${common.localhostIPv4}:${server.address().port}/foo?bar`;
+  https.get(u, common.mustCall(() => {
+    https.get(url.parse(u), common.mustCall(() => {
+      https.get(new URL(u), common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}));


### PR DESCRIPTION
Fixes test-https-client-get-url by waiting on HTTPS GET 
requests to finish before closing the server.

Fixes: https://github.com/nodejs/node/issues/12873

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
