### PR TITLE
test: update test for url.parse() to match the exact error through re…

### DIFF
--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -12,10 +12,13 @@ const url = require('url');
   0.0,
   0,
   [],
-  {}
+  {},
+  () => {},
+  Symbol('foo')
 ].forEach((val) => {
   assert.throws(() => { url.parse(val); },
-                /^TypeError: Parameter "url" must be a string, not (undefined|boolean|number|object)$/);
+                /^TypeError: Parameter "url" must be a string, not (undefined|boolean|number|object|function|symbol)$/);
 });
 
-assert.throws(() => { url.parse('http://%E0%A4%A@fail'); }, /^URIError: URI malformed$/);
+assert.throws(() => { url.parse('http://%E0%A4%A@fail'); },
+              /^URIError: URI malformed$/);

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -13,8 +13,8 @@ const url = require('url');
   0,
   [],
   {}
-].forEach(function(val) {
-  assert.throws(function() { url.parse(val); }, TypeError);
+].forEach((val) => {
+  assert.throws(() => { url.parse(val); }, /^TypeError: Parameter "url" must be a string, not undefined|boolean|number|object$/);
 });
 
-assert.throws(function() { url.parse('http://%E0%A4%A@fail'); }, /^URIError: URI malformed$/);
+assert.throws(() => { url.parse('http://%E0%A4%A@fail'); }, /^URIError: URI malformed$/);

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -14,7 +14,8 @@ const url = require('url');
   [],
   {}
 ].forEach((val) => {
-  assert.throws(() => { url.parse(val); }, /^TypeError: Parameter "url" must be a string, not undefined|boolean|number|object$/);
+  assert.throws(() => { url.parse(val); },
+                /^TypeError: Parameter "url" must be a string, not (undefined|boolean|number|object)$/);
 });
 
 assert.throws(() => { url.parse('http://%E0%A4%A@fail'); }, /^URIError: URI malformed$/);


### PR DESCRIPTION
When called with invalid values, url.parse() throws a TypeError with a specific message. Update test to check that the message matches the error thrown.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test