### PR TITLE
lib: add guard to originalConsole

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -261,7 +261,9 @@
       enumerable: true,
       get: function() {
         if (!console) {
-          console = installInspectorConsole(originalConsole);
+          console = originalConsole === undefined ?
+              NativeModule.require('console') :
+              installInspectorConsole(originalConsole);
         }
         return console;
       }


### PR DESCRIPTION
Currently when building --without-ssl or --without-inspector there will
be an error when trying to set up the console in bootstrap_node.js:
```console
Can't determine the arch of: 'out/Release/node'
bootstrap_node.js:276
      if (!globalConsole.hasOwnProperty(key))
                        ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
    at installInspectorConsole (bootstrap_node.js:276:25)
    at get (bootstrap_node.js:264:21)
    at evalScript (bootstrap_node.js:395:30)
    at startup (bootstrap_node.js:125:9)
    at bootstrap_node.js:537:3
```
I think this issue was introduced in commit
3f48ab30420981f888ff2c69fc1ea5abb37f3f2e ("inspector: do not add
'inspector' property").

This commit attempts to fix this.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
lib
##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
