### PR TITLE
test: add skipIfInspectorDisabled to debugger-pid

### DIFF
--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -1,9 +1,9 @@
 'use strict';
 const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-common.skipIfInspectorDisabled();
 
 let buffer = '';
 

--- a/test/parallel/test-debugger-pid.js
+++ b/test/parallel/test-debugger-pid.js
@@ -3,6 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
+common.skipIfInspectorDisabled();
+
 let buffer = '';
 
 // connect to debug agent


### PR DESCRIPTION
Currently this test will fail if node was configured --without-ssl.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test