### PR TITLE
test: favor deepStrictEqual over deepEqual

### DIFF
--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -73,17 +73,14 @@ const s = http.createServer(common.mustCall((req, res) => {
       assert.strictEqual(res.getHeader('x-test-header2'), 'testing');
 
       const headersCopy = res.getHeaders();
-      assert.strictEqual(Object.getPrototypeOf(headersCopy), null);
-      // eslint-disable-next-line no-restricted-properties
-      assert.deepEqual(headersCopy, {
+      const expected = {
         'x-test-header': 'testing',
         'x-test-header2': 'testing',
         'set-cookie': cookies,
         'x-test-array-header': arrayValues
-      });
-      // eslint-disable-next-line no-restricted-properties
-      assert.deepEqual(headersCopy['set-cookie'], cookies);
-      assert.strictEqual(headersCopy['x-test-array-header'], arrayValues);
+      };
+      Object.setPrototypeOf(expected, null);
+      assert.deepStrictEqual(headersCopy, expected);
 
       assert.deepStrictEqual(res.getHeaderNames(),
                              ['x-test-header', 'x-test-header2',


### PR DESCRIPTION
test-http-mutable-headers uses assert.deepEqual() in three places but
appears to only needs it in two of them. Replace one with
assert.deepStrictEqual() and remove linting exception.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http