### PR TITLE
lib: remove useless default caught

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -308,7 +308,7 @@
       var caught;
 
       if (process.domain && process.domain._errorHandler)
-        caught = process.domain._errorHandler(er) || caught;
+        caught = process.domain._errorHandler(er);
 
       if (!caught)
         caught = process.emit('uncaughtException', er);


### PR DESCRIPTION
The variable caught's value is undefined, so the '|| caught' is
useless.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internel/bootstrap_node