### PR TITLE
test: improve n-api array func coverage

### DIFF
--- a/test/addons-napi/test_array/test.js
+++ b/test/addons-napi/test_array/test.js
@@ -19,8 +19,12 @@ const array = [
   ]
 ];
 
-assert.strictEqual(test_array.TestGetElement(array, array.length + 1),
-                   'Index out of bound!');
+assert.throws(
+  () => {
+    test_array.TestGetElement(array, array.length + 1);
+  },
+  /Index out of bounds!/
+);
 
 assert.throws(
   () => {

--- a/test/addons-napi/test_array/test.js
+++ b/test/addons-napi/test_array/test.js
@@ -19,19 +19,26 @@ const array = [
   ]
 ];
 
-assert.strictEqual(test_array.Test(array, array.length + 1),
+assert.strictEqual(test_array.TestGetElement(array, array.length + 1),
                    'Index out of bound!');
 
 assert.throws(
   () => {
-    test_array.Test(array, -2);
+    test_array.TestGetElement(array, -2);
   },
   /Invalid index\. Expects a positive integer\./
 );
 
 array.forEach(function(element, index) {
-  assert.strictEqual(test_array.Test(array, index), element);
+  assert.strictEqual(test_array.TestGetElement(array, index), element);
 });
 
 
 assert.deepStrictEqual(test_array.New(array), array);
+
+assert(test_array.TestHasElement(array, 0));
+assert.strictEqual(false, test_array.TestHasElement(array, array.length + 1));
+
+assert(test_array.NewWithLength(0) instanceof Array);
+assert(test_array.NewWithLength(1) instanceof Array);
+assert(test_array.NewWithLength(2 ^ 32 - 1) instanceof Array);

--- a/test/addons-napi/test_array/test.js
+++ b/test/addons-napi/test_array/test.js
@@ -23,14 +23,14 @@ assert.throws(
   () => {
     test_array.TestGetElement(array, array.length + 1);
   },
-  /Index out of bounds!/
+  /^Error: assertion \(\(\(uint32_t\)index < length\)\) failed: Index out of bounds!$/
 );
 
 assert.throws(
   () => {
     test_array.TestGetElement(array, -2);
   },
-  /Invalid index\. Expects a positive integer\./
+  /^Error: assertion \(index >= 0\) failed: Invalid index\. Expects a positive integer\.$/
 );
 
 array.forEach(function(element, index) {
@@ -41,8 +41,9 @@ array.forEach(function(element, index) {
 assert.deepStrictEqual(test_array.New(array), array);
 
 assert(test_array.TestHasElement(array, 0));
-assert.strictEqual(false, test_array.TestHasElement(array, array.length + 1));
+assert.strictEqual(test_array.TestHasElement(array, array.length + 1), false);
 
 assert(test_array.NewWithLength(0) instanceof Array);
 assert(test_array.NewWithLength(1) instanceof Array);
-assert(test_array.NewWithLength(2 ^ 32 - 1) instanceof Array);
+// check max allowed length for an array 2^32 -1
+assert(test_array.NewWithLength(4294967295) instanceof Array);

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include "../common.h"
 
-napi_value Test(napi_env env, napi_callback_info info) {
+napi_value TestGetElement(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value args[2];
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
@@ -52,6 +52,45 @@ napi_value Test(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+napi_value TestHasElement(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 2, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_object,
+    "Wrong type of arguments. Expects an array as first argument.");
+
+  napi_valuetype valuetype1;
+  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+
+  NAPI_ASSERT(env, valuetype1 == napi_number,
+    "Wrong type of arguments. Expects an integer as second argument.");
+
+  napi_value array = args[0];
+  int32_t index;
+  NAPI_CALL(env, napi_get_value_int32(env, args[1], &index));
+
+  bool isarray;
+  NAPI_CALL(env, napi_is_array(env, array, &isarray));
+
+  if (!isarray) {
+    return NULL;
+  }
+
+  bool has_element;
+  NAPI_CALL(env, napi_has_element(env, array, index, &has_element));
+
+  napi_value ret;
+  NAPI_CALL(env, napi_get_boolean(env, has_element, &ret));
+
+  return ret;
+}
+
 napi_value New(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1];
@@ -80,10 +119,34 @@ napi_value New(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+napi_value NewWithLength(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc >= 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_number,
+    "Wrong type of arguments. Expects an integer the first argument.");
+
+  int32_t array_length;
+  NAPI_CALL(env, napi_get_value_int32(env, args[0], &array_length));
+
+  napi_value ret;
+  NAPI_CALL(env, napi_create_array_with_length(env, array_length, &ret));
+
+  return ret;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {
-    DECLARE_NAPI_PROPERTY("Test", Test),
+    DECLARE_NAPI_PROPERTY("TestGetElement", TestGetElement),
+    DECLARE_NAPI_PROPERTY("TestHasElement", TestHasElement),
     DECLARE_NAPI_PROPERTY("New", New),
+    DECLARE_NAPI_PROPERTY("NewWithLength", NewWithLength),
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -37,14 +37,7 @@ napi_value TestGetElement(napi_env env, napi_callback_info info) {
   uint32_t length;
   NAPI_CALL(env, napi_get_array_length(env, array, &length));
 
-  if ((uint32_t)index >= length) {
-    napi_value str;
-    const char* str_val = "Index out of bound!";
-    size_t str_len = strlen(str_val);
-    NAPI_CALL(env, napi_create_string_utf8(env, str_val, str_len, &str));
-
-    return str;
-  }
+  NAPI_ASSERT(env, ((uint32_t)index < length), "Index out of bounds!");
 
   napi_value ret;
   NAPI_CALL(env, napi_get_element(env, array, index, &ret));


### PR DESCRIPTION
- add coverage for napi_has_element
- add coverage for napi_create_array_with_length

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test, n-api
