### PR TITLE
test: replace port in cluster dgram reuse test

### DIFF
--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -17,24 +17,22 @@ if (cluster.isMaster) {
   return;
 }
 
-const sockets = [];
-function next() {
-  sockets.push(this);
-  if (sockets.length !== 2)
-    return;
-
-  // Work around health check issue
-  process.nextTick(() => {
-    for (let i = 0; i < sockets.length; i++)
-      sockets[i].close(close);
-  });
-}
-
 let waiting = 2;
 function close() {
   if (--waiting === 0)
     cluster.worker.disconnect();
 }
 
-for (let i = 0; i < 2; i++)
-  dgram.createSocket({ type: 'udp4', reuseAddr: true }).bind(common.PORT, next);
+const options = { type: 'udp4', reuseAddr: true };
+const socket1 = dgram.createSocket(options);
+const socket2 = dgram.createSocket(options);
+
+socket1.bind(0, () => {
+  socket2.bind(socket1.address().port, () => {
+    // Work around health check issue
+    process.nextTick(() => {
+      socket1.close(close);
+      socket2.close(close);
+    });
+  });
+});


### PR DESCRIPTION
Replaced common.PORT with zero in the following test.
test-cluster-dgram-reuse.js

Refs: nodejs#12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test