### PR TITLE
lib: AssertionError moved to internal/error

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -40,39 +40,6 @@ function lazyErrors() {
 
 const assert = module.exports = ok;
 
-// The AssertionError is defined in assert.
-// new assert.AssertionError({ message: message,
-//                             actual: actual,
-//                             expected: expected });
-
-// TODO(jasnell): Consider moving AssertionError into internal/errors.js
-class AssertionError extends Error {
-  constructor(options) {
-    if (typeof options !== 'object' || options === null) {
-      // Lazy because the errors module itself uses assertions, leading to
-      // a circular dependency. This can be eliminated by moving this class
-      // into internal/errors.js
-      const errors = lazyErrors();
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
-    }
-    const message = options.message ||
-                    `${util.inspect(options.actual).slice(0, 128)} ` +
-                    `${options.operator} ` +
-                    util.inspect(options.expected).slice(0, 128);
-    super(message);
-    this.generatedMessage = !options.message;
-    this.name = 'AssertionError [ERR_ASSERTION]';
-    this.code = 'ERR_ASSERTION';
-    this.actual = options.actual;
-    this.expected = options.expected;
-    this.operator = options.operator;
-    var stackStartFunction = options.stackStartFunction || fail;
-    Error.captureStackTrace(this, stackStartFunction);
-  }
-}
-
-assert.AssertionError = AssertionError;
-
 // At present only the three keys mentioned above are used and
 // understood by the spec. Implementations or sub modules can pass
 // other keys to the AssertionError's constructor - they will be
@@ -89,7 +56,8 @@ function fail(actual, expected, message, operator, stackStartFunction) {
     message = actual;
   if (arguments.length === 2)
     operator = '!=';
-  throw new AssertionError({
+  const errors = lazyErrors();
+  throw new errors.AssertionError({
     message: message,
     actual: actual,
     expected: expected,
@@ -100,6 +68,13 @@ function fail(actual, expected, message, operator, stackStartFunction) {
 
 // EXTENSION! allows for well behaved errors defined elsewhere.
 assert.fail = fail;
+
+// The AssertionError is defined in internal/error.
+// new assert.AssertionError({ message: message,
+//                             actual: actual,
+//                             expected: expected });
+assert.AssertionError = lazyErrors().AssertionError;
+
 
 // Pure assertion tests whether a value is truthy, as determined
 // by !!guard.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -41,6 +41,30 @@ function makeNodeError(Base) {
   };
 }
 
+class AssertionError extends Error {
+  constructor(options) {
+    if (typeof options !== 'object' || options === null) {
+      throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+    }
+    const util = lazyUtil();
+    const assert = lazyAssert();
+    const message = options.message ||
+                    `${util.inspect(options.actual).slice(0, 128)} ` +
+                    `${options.operator} ` +
+                    util.inspect(options.expected).slice(0, 128);
+
+    super(message);
+    this.generatedMessage = !options.message;
+    this.name = 'AssertionError [ERR_ASSERTION]';
+    this.code = 'ERR_ASSERTION';
+    this.actual = options.actual;
+    this.expected = options.expected;
+    this.operator = options.operator;
+    const stackStartFunction = options.stackStartFunction || assert.fail;
+    Error.captureStackTrace(this, stackStartFunction);
+  }
+}
+
 function message(key, args) {
   const assert = lazyAssert();
   assert.strictEqual(typeof key, 'string');
@@ -69,6 +93,7 @@ module.exports = exports = {
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),
   RangeError: makeNodeError(RangeError),
+  AssertionError,
   E // This is exported only to facilitate testing.
 };
 

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -1,6 +1,6 @@
 Exiting with code=1
 assert.js:*
-  throw new AssertionError({
+  throw new errors.AssertionError({
   ^
 
 AssertionError [ERR_ASSERTION]: 1 === 2


### PR DESCRIPTION
AssertionError class is moved to internal/error
in reference to the TODO in assert.js. This was
suggested to get rid of the cyclic dependency
between assert.js and internal/error.js


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
assert
