### PR TITLE
doc: add docu for server.address() for pipe case

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -99,10 +99,13 @@ added: v0.1.90
 -->
 
 Returns the bound address, the address family name, and port of the server
-as reported by the operating system.
+as reported by the operating system if listening on an IP socket.
 Useful to find which port was assigned when getting an OS-assigned address.
 Returns an object with `port`, `family`, and `address` properties:
-`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
+`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`.
+
+For servers listening on a pipe or unix domain sockets the name is returned
+as string.
 
 Example:
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -102,10 +102,10 @@ Returns the bound address, the address family name, and port of the server
 as reported by the operating system if listening on an IP socket.
 Useful to find which port was assigned when getting an OS-assigned address.
 Returns an object with `port`, `family`, and `address` properties:
-`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`.
+`{ port: 12346, family: 'IPv4', address: '127.0.0.1' }`
 
-For servers listening on a pipe or unix domain sockets the name is returned
-as string.
+For a server listening on a pipe or UNIX domain socket, the name is returned
+as a string.
 
 Example:
 


### PR DESCRIPTION
Add documentation for net.server.address() for the case it is listening
on a pipe or unix domain socket instead an IP socket.

Fixes: https://github.com/nodejs/node/issues/12895

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc