### PR TITLE
benchmark, libs, test: reduce iterative literal computations

### DIFF
--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -19,7 +19,7 @@ function main(conf) {
   var headers = [];
   // Chose 7 because 9 showed "Connection error" / "Connection closed"
   // An odd number could result in a better length dispersion.
-  for (var i = 7; i <= 7 * 7 * 7; i *= 7)
+  for (var i = 7; i <= 343; i *= 7) // <= 7 * 7 * 7
     headers.push('o'.repeat(i));
 
   function WriteHTTPHeaders(channel, has_keep_alive, extra_header_count) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -270,7 +270,7 @@ function Server(requestListener) {
 
   this.on('connection', connectionListener);
 
-  this.timeout = 2 * 60 * 1000;
+  this.timeout = 120000; // 2 * 60 * 1000
 
   this._pendingResponseData = 0;
   this.maxHeadersCount = null;

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -68,7 +68,7 @@ function ReadableState(options, stream) {
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+  var defaultHwm = this.objectMode ? 16 : 16384; // 16 * 1024
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -51,7 +51,7 @@ function WritableState(options, stream) {
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+  var defaultHwm = this.objectMode ? 16 : 16384; // 16 * 1024
   this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
 
   // cast to ints.

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -174,7 +174,7 @@ CryptoStream.prototype._write = function _write(data, encoding, cb) {
   //
   // TODO(indutny): Remove magic number, use watermark based limits
   if (!this._resumingSession &&
-      this._opposite._internallyPendingBytes() < 128 * 1024) {
+      this._opposite._internallyPendingBytes() < 131072) { // 128 * 1024
     // Write current buffer now
     var written;
     if (this === this.pair.cleartext) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -811,7 +811,7 @@ function Server(options, listener) {
   });
   this._sharedCreds = sharedCreds;
 
-  var timeout = options.handshakeTimeout || (120 * 1000);
+  var timeout = options.handshakeTimeout || 120000; // 120 * 1000
 
   if (typeof timeout !== 'number') {
     throw new TypeError('handshakeTimeout must be a number');

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -145,7 +145,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
   var options = {
     encoding: 'utf8',
     timeout: 0,
-    maxBuffer: 200 * 1024,
+    maxBuffer: 204800, // 200 * 1024
     killSignal: 'SIGTERM',
     cwd: null,
     env: null,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1861,7 +1861,7 @@ function ReadStream(path, options) {
   // a little bit bigger buffer and water marks by default
   options = copyObject(getOptions(options, {}));
   if (options.highWaterMark === undefined)
-    options.highWaterMark = 64 * 1024;
+    options.highWaterMark = 65536; // 64 * 1024
 
   Readable.call(this, options);
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -58,7 +58,7 @@ function Server(opts, requestListener) {
       conn.destroy(err);
   });
 
-  this.timeout = 2 * 60 * 1000;
+  this.timeout = 120000; // 2 * 60 * 1000
 }
 inherits(Server, tls.Server);
 exports.Server = Server;

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -672,7 +672,7 @@ function setupChannel(target, channel) {
     }
 
     /* If the master is > 2 read() calls behind, please stop sending. */
-    return channel.writeQueueSize < (65536 * 2);
+    return channel.writeQueueSize < 131072; // 65536 * 2
   };
 
   // connected will be set to false immediately when a disconnect() is

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -33,8 +33,8 @@ crypto.DEFAULT_ENCODING = 'buffer';
 
 function aes256(decipherFinal) {
   const iv = Buffer.from('00000000000000000000000000000000', 'hex');
-  const key = Buffer.from('0123456789abcdef0123456789abcdef' +
-                         '0123456789abcdef0123456789abcdef', 'hex');
+  const key = Buffer.from(
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
 
   function encrypt(val, pad) {
     const c = crypto.createCipheriv('aes256', key, iv);

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -108,7 +108,7 @@ const decryptError =
 }
 
 function test_rsa(padding) {
-  const size = (padding === 'RSA_NO_PADDING') ? 1024 / 8 : 32;
+  const size = (padding === 'RSA_NO_PADDING') ? 128 : 32; // 1024 / 8 : 32
   const input = Buffer.allocUnsafe(size);
   for (let i = 0; i < input.length; i++)
     input[i] = (i * 7 + 11) & 0xff;

--- a/test/parallel/test-http-many-ended-pipelines.js
+++ b/test/parallel/test-http-many-ended-pipelines.js
@@ -52,9 +52,7 @@ server.listen(0, function() {
   const client = net.connect({ port: this.address().port,
                                allowHalfOpen: true });
   for (let i = 0; i < numRequests; i++) {
-    client.write('GET / HTTP/1.1\r\n' +
-                 'Host: some.host.name\r\n' +
-                 '\r\n\r\n');
+    client.write('GET / HTTP/1.1\r\nHost: some.host.name\r\n\r\n\r\n');
   }
   client.end();
   client.pipe(process.stdout);

--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -15,7 +15,7 @@ const awaitDrainStates = [
 // never get subsequent chunks because 'drain' is only emitted once.
 const writable = new stream.Writable({
   write: common.mustCall(function(chunk, encoding, cb) {
-    if (chunk.length === 32 * 1024) { // first chunk
+    if (chunk.length === 32768) { // 32 * 1024, first chunk
       const beforePush = readable._readableState.awaitDrain;
       readable.push(new Buffer(34 * 1024)); // above hwm
       // We should check if awaitDrain counter is increased.

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -42,7 +42,7 @@ const interval = setInterval(function() {
   const rss = process.memoryUsage().rss;
   maxMem = Math.max(rss, maxMem);
 
-  if (Date.now() - start > 5 * 1000) {
+  if (Date.now() - start > 5000) { // 5 * 1000
     // wait 10 seconds.
     clearInterval(interval);
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
benchmark, lib, test

This is a simple change inspired by the [prepack](https://github.com/facebook/prepack). I am not sure about its value, just tried to clear my conscience, so feel free to reject without much doubt)

I've checked the code base with this ESLint rule:
```js
'no-restricted-syntax': ['error',
  'BinaryExpression[left.type="Literal"][right.type="Literal"]',
]
```
to find out something like [no-useless-concat](http://eslint.org/docs/rules/no-useless-concat) but with a wider covering: all binary expressions with string / number literals on both sides. They can be computed at the compile time but often are split for better readability / comprehensibility / linter conformity.

There are hundreds of these cases in the code, but I've not changed those ones which are executed once or in the edge cases: error / deprecation / debug messages, top level assignments and so on. Also, I've left out those ones that can not be easily fixed without heavy linter workarounds.

I've changed only those fragments which are executed or can be executed several times (loops, functions in libs, functions that are called more than once in tests etc.). All these times I've saved the expanded expressions in the comments to preserve readability / comprehensibility.

I understand that this change hardly causes any significant performance improvement, but maybe a microscopic one can be added here without many overhead expenses.