### PR TITLE
fix wrong hash results on Windows with some CPUs that support Intel SHA Extension

### DIFF
--- a/deps/openssl/asm/x64-win32-masm/aes/aesni-sha256-x86_64.asm
+++ b/deps/openssl/asm/x64-win32-masm/aes/aesni-sha256-x86_64.asm
@@ -4150,7 +4150,7 @@ $L$prologue_shaext::
 	lea	rcx,QWORD PTR[112+rcx]
 
 	pshufd	xmm0,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	pshufd	xmm2,xmm2,01bh
 	movdqa	xmm7,xmm3
 DB	102,15,58,15,202,8
@@ -4475,9 +4475,9 @@ $L$aesenclast4::
 	lea	rdi,QWORD PTR[64+rdi]
 	jnz	$L$oop_shaext
 
-	pshufd	xmm2,xmm2,1h
+	pshufd	xmm2,xmm2,0b1h
 	pshufd	xmm3,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	punpckhqdq	xmm1,xmm2
 DB	102,15,58,15,211,8
 

--- a/deps/openssl/asm/x64-win32-masm/ec/ecp_nistz256-x86_64.asm
+++ b/deps/openssl/asm/x64-win32-masm/ec/ecp_nistz256-x86_64.asm
@@ -2051,7 +2051,7 @@ $L$SEH_begin_ecp_nistz256_point_add::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rsi]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rsi]
 	movdqu	xmm2,XMMWORD PTR[32+rsi]
 	por	xmm5,xmm3
@@ -2081,7 +2081,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montq
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm1,1h
+	pshufd	xmm4,xmm1,0b1h
 	por	xmm4,xmm1
 	pshufd	xmm5,xmm5,0
 	pshufd	xmm3,xmm4,01eh
@@ -2466,7 +2466,7 @@ $L$SEH_begin_ecp_nistz256_point_add_affine::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rbx]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rbx]
 	movdqu	xmm2,XMMWORD PTR[32+rbx]
 	por	xmm5,xmm3
@@ -2488,7 +2488,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montq
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm3,1h
+	pshufd	xmm4,xmm3,0b1h
 	mov	rax,QWORD PTR[rbx]
 
 	mov	r9,r12
@@ -3117,7 +3117,7 @@ $L$point_addx::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rsi]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rsi]
 	movdqu	xmm2,XMMWORD PTR[32+rsi]
 	por	xmm5,xmm3
@@ -3147,7 +3147,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montx
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm1,1h
+	pshufd	xmm4,xmm1,0b1h
 	por	xmm4,xmm1
 	pshufd	xmm5,xmm5,0
 	pshufd	xmm3,xmm4,01eh
@@ -3528,7 +3528,7 @@ $L$point_add_affinex::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rbx]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rbx]
 	movdqu	xmm2,XMMWORD PTR[32+rbx]
 	por	xmm5,xmm3
@@ -3550,7 +3550,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montx
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm3,1h
+	pshufd	xmm4,xmm3,0b1h
 	mov	rdx,QWORD PTR[rbx]
 
 	mov	r9,r12

--- a/deps/openssl/asm/x64-win32-masm/sha/sha256-x86_64.asm
+++ b/deps/openssl/asm/x64-win32-masm/sha/sha256-x86_64.asm
@@ -1796,7 +1796,7 @@ $L$prologue_shaext::
 	movdqa	xmm7,XMMWORD PTR[((512-128))+rcx]
 
 	pshufd	xmm0,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	pshufd	xmm2,xmm2,01bh
 	movdqa	xmm8,xmm7
 DB	102,15,58,15,202,8
@@ -1983,9 +1983,9 @@ DB	15,56,203,202
 	paddd	xmm1,xmm9
 	jnz	$L$oop_shaext
 
-	pshufd	xmm2,xmm2,1h
+	pshufd	xmm2,xmm2,0b1h
 	pshufd	xmm7,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	punpckhqdq	xmm1,xmm2
 DB	102,15,58,15,215,8
 

--- a/deps/openssl/asm_obsolete/x64-win32-masm/ec/ecp_nistz256-x86_64.asm
+++ b/deps/openssl/asm_obsolete/x64-win32-masm/ec/ecp_nistz256-x86_64.asm
@@ -1537,7 +1537,7 @@ $L$SEH_begin_ecp_nistz256_point_add::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rsi]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rsi]
 	movdqu	xmm2,XMMWORD PTR[32+rsi]
 	por	xmm5,xmm3
@@ -1567,7 +1567,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montq
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm1,1h
+	pshufd	xmm4,xmm1,0b1h
 	por	xmm4,xmm1
 	pshufd	xmm5,xmm5,0
 	pshufd	xmm3,xmm4,01eh
@@ -1948,7 +1948,7 @@ $L$SEH_begin_ecp_nistz256_point_add_affine::
 	por	xmm5,xmm4
 
 	movdqu	xmm0,XMMWORD PTR[rbx]
-	pshufd	xmm3,xmm5,1h
+	pshufd	xmm3,xmm5,0b1h
 	movdqu	xmm1,XMMWORD PTR[16+rbx]
 	movdqu	xmm2,XMMWORD PTR[32+rbx]
 	por	xmm5,xmm3
@@ -1970,7 +1970,7 @@ DB	102,72,15,110,199
 	call	__ecp_nistz256_sqr_montq
 
 	pcmpeqd	xmm5,xmm4
-	pshufd	xmm4,xmm3,1h
+	pshufd	xmm4,xmm3,0b1h
 	mov	rax,QWORD PTR[rbx]
 
 	mov	r9,r12

--- a/deps/openssl/asm_obsolete/x64-win32-masm/sha/sha256-x86_64.asm
+++ b/deps/openssl/asm_obsolete/x64-win32-masm/sha/sha256-x86_64.asm
@@ -1788,7 +1788,7 @@ $L$prologue_shaext::
 	movdqa	xmm7,XMMWORD PTR[((512-128))+rcx]
 
 	pshufd	xmm0,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	pshufd	xmm2,xmm2,01bh
 	movdqa	xmm8,xmm7
 DB	102,15,58,15,202,8
@@ -1975,9 +1975,9 @@ DB	15,56,203,202
 	paddd	xmm1,xmm9
 	jnz	$L$oop_shaext
 
-	pshufd	xmm2,xmm2,1h
+	pshufd	xmm2,xmm2,0b1h
 	pshufd	xmm7,xmm1,01bh
-	pshufd	xmm1,xmm1,1h
+	pshufd	xmm1,xmm1,0b1h
 	punpckhqdq	xmm1,xmm2
 DB	102,15,58,15,215,8
 

--- a/deps/openssl/openssl/crypto/perlasm/x86_64-xlate.pl
+++ b/deps/openssl/openssl/crypto/perlasm/x86_64-xlate.pl
@@ -206,8 +206,9 @@ my %globals;
 	    }
 	    sprintf "\$%s",$self->{value};
 	} else {
-	    $self->{value} =~ s/0x([0-9a-f]+)/0$1h/ig if ($masm);
-	    sprintf "%s",$self->{value};
+	    my $value = $self->{value};
+	    $value =~ s/0x([0-9a-f]+)/0$1h/ig if ($masm);
+	    sprintf "%s",$value;
 	}
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
openssl 

This PR fixes wrong hash results on Windows with some CPUs that support  Intel SHA Extension and resolves the issue of TLS connection errors.

The same issue was reported to the upstream in https://github.com/openssl/openssl/issues/3241 and fixed in https://github.com/openssl/openssl/pull/3385. 

This PR has the cherry-pick of the fix and asm files are updated. 

This fix has already confirmed by the issue reporter in https://github.com/nodejs/node/issues/12691#issuecomment-299793715 because the issue can be reproduced on only limited CPU.

Fixes: #12691 

CC: @nodejs/crypto 