### PR TITLE
test: add a simple abort check in windows

### DIFF
--- a/test/parallel/test-windows-abort-exitcode.js
+++ b/test/parallel/test-windows-abort-exitcode.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+// This test makes sure that an aborted node process
+// exits with code 3 on Windows.
+// Spawn a child, force an abort, and then check the
+// exit code in the parent.
+
+const spawn = require('child_process').spawn;
+if (!common.isWindows) {
+  common.skip('test is windows specific');
+  return;
+}
+if (process.argv[2] === 'child') {
+  process.abort();
+} else {
+  const child = spawn(process.execPath, [__filename, 'child']);
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 3);
+    assert.strictEqual(signal, null);
+  }));
+}


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

Working with @gireeshpunathil, I came up with this PR following @refack's suggestion 
in #12856 . Though associated with that, this test is logically independent of that PR, 
and does not need to co-exist with that one, and hence a separate one.

Make a simple assertion that Windows aborts with exit code 3.
