### PR TITLE
test: replace port in https address family test

### DIFF
--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -19,10 +19,10 @@ function runTest() {
   https.createServer({ ciphers }, common.mustCall(function(req, res) {
     this.close();
     res.end();
-  })).listen(common.PORT, '::1', common.mustCall(function() {
+  })).listen(0, '::1', common.mustCall(function() {
     const options = {
       host: 'localhost',
-      port: common.PORT,
+      port: this.address().port,
       family: 6,
       ciphers: ciphers,
       rejectUnauthorized: false,


### PR DESCRIPTION
Replaced common.PORT with zero in the following test.
test-https-connect-address-family.js

Refs: #12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test https