### PR TITLE
benchmark: chunky http client should exit with 0

### DIFF
--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var assert = require('assert');
 var path = require('path');
 var http = require('http');
 var fs = require('fs');
@@ -37,6 +38,7 @@ server.listen(PIPE);
 
 var child = fork(pep, process.argv.slice(2));
 child.on('message', common.sendResult);
-child.on('close', function() {
+child.on('close', function(code) {
   server.close();
+  assert.strictEqual(code, 0);
 });


### PR DESCRIPTION
Previously when there is an error in the chunky client of the
http benchmark, the server would not check the exit code and
thus produce invalid results.

Fixes: https://github.com/nodejs/node/issues/12903

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, benchmark