### PR TITLE
v6.x: async_wrap: close the destroy_ids_idle_handle_

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -271,6 +271,16 @@ inline void Environment::CleanupHandles() {
     delete hc;
   }
 
+  // Closing the destroy_ids_idle_handle_ within the handle cleanup queue
+  // prevents the async wrap destroy hook from being called.
+  uv_handle_t* handle =
+    reinterpret_cast<uv_handle_t*>(&destroy_ids_idle_handle_);
+  handle->data = this;
+  handle_cleanup_waiting_ = 1;
+  uv_close(handle, [](uv_handle_t* handle) {
+    static_cast<Environment*>(handle->data)->FinishHandleCleanup(handle);
+  });
+
   while (handle_cleanup_waiting_ != 0)
     uv_run(event_loop(), UV_RUN_ONCE);
 }


### PR DESCRIPTION
The destroy_ids_idle_handle_ needs to be closed on
environment destruction. Not closing the handle leaves
a dangling pointer in the used uv loop. This leads to
undefined behavior when the uv loop is used after the
environment has been destroyed.

PR-URL: https://github.com/nodejs/node/pull/10385