### PR TITLE
benchmark: check for time precision in common.js

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -196,6 +196,9 @@ Benchmark.prototype.end = function(operations) {
   if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED && operations <= 0) {
     throw new Error('called end() with operation count <= 0');
   }
+  if (elapsed[0] === 0 && elapsed[1] === 0) {
+    throw new Error('insufficient time precision for short benchmark');
+  }
 
   const time = elapsed[0] + elapsed[1] / 1e9;
   const rate = operations / time;


### PR DESCRIPTION
Some benchmark tests are failing intermittently, possibly due to
hrtime() imprecision on particular hosts. This change will confirm or
refute that as the root cause the next time the test fails on CI. Either
way, it's a valid check.

Refs: https://github.com/nodejs/node/issues/12497
Refs: https://github.com/nodejs/node/issues/12433

/cc @addaleax @joyeecheung 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark test