### PR TITLE
zlib: expose amount of data read for compression/decompression

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -79,10 +79,7 @@ function isInvalidStrategy(strategy) {
 
 function responseData(engine, buffer) {
   if (engine._opts.info) {
-    return {
-      buffer: buffer,
-      engine: engine
-    };
+    return { buffer, engine };
   }
   return buffer;
 }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -77,6 +77,16 @@ function isInvalidStrategy(strategy) {
   //         constants.Z_DEFAULT_STRATEGY (0)
 }
 
+function responseData(engine, buffer) {
+  if (engine._opts.info) {
+    return {
+      buffer: buffer,
+      engine: engine
+    };
+  }
+  return buffer;
+}
+
 function zlibBuffer(engine, buffer, callback) {
   // Streams do not support non-Buffer ArrayBufferViews yet. Convert it to a
   // Buffer without copying.
@@ -121,7 +131,7 @@ function zlibBuffer(engine, buffer, callback) {
 
     buffers = [];
     engine.close();
-    callback(err, buf);
+    callback(err, responseData(engine, buf));
   }
 }
 
@@ -134,7 +144,7 @@ function zlibBufferSync(engine, buffer) {
 
   var flushFlag = engine._finishFlushFlag;
 
-  return engine._processChunk(buffer, flushFlag);
+  return responseData(engine, engine._processChunk(buffer, flushFlag));
 }
 
 function zlibOnError(message, errno) {
@@ -167,6 +177,8 @@ class Zlib extends Transform {
   constructor(opts, mode) {
     opts = opts || {};
     super(opts);
+
+    this.bytesRead = 0;
 
     this._opts = opts;
     this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
@@ -407,6 +419,8 @@ class Zlib extends Transform {
 
       var have = availOutBefore - availOutAfter;
       assert(have >= 0, 'have should not go down');
+
+      self.bytesRead += availInBefore - availInAfter;
 
       if (have > 0) {
         var out = self._buffer.slice(self._offset, self._offset + have);

--- a/test/parallel/test-zlib-bytes-read.js
+++ b/test/parallel/test-zlib-bytes-read.js
@@ -1,0 +1,92 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+const expectStr = 'abcdefghijklmnopqrstuvwxyz'.repeat(2);
+const expectBuf = Buffer.from(expectStr);
+
+function createWriter(target, buffer) {
+  const writer = { size: 0 };
+  const write = () => {
+    target.write(Buffer.from([buffer[writer.size++]]));
+    if (writer.size < buffer.length) {
+      setTimeout(write, 25);
+    } else {
+      target.end();
+    }
+  };
+  write();
+  return writer;
+}
+
+for (const method of [
+  ['createGzip', 'createGunzip', false],
+  ['createGzip', 'createUnzip', false],
+  ['createDeflate', 'createInflate', true],
+  ['createDeflateRaw', 'createInflateRaw', true]
+]) {
+  let compWriter;
+  let compData = new Buffer(0);
+
+  const comp = zlib[method[0]]();
+  comp.on('data', function(d) {
+    compData = Buffer.concat([compData, d]);
+    assert.strictEqual(this.bytesRead, compWriter.size,
+                       `Should get write size on ${method[0]} data.`);
+  });
+  comp.on('end', common.mustCall(function() {
+    assert.strictEqual(this.bytesRead, compWriter.size,
+                       `Should get write size on ${method[0]} end.`);
+    assert.strictEqual(this.bytesRead, expectStr.length,
+                       `Should get data size on ${method[0]} end.`);
+
+    {
+      let decompWriter;
+      let decompData = new Buffer(0);
+
+      const decomp = zlib[method[1]]();
+      decomp.on('data', function(d) {
+        decompData = Buffer.concat([decompData, d]);
+        assert.strictEqual(this.bytesRead, decompWriter.size,
+                           `Should get write size on ${method[0]}/` +
+                           `${method[1]} data.`);
+      });
+      decomp.on('end', common.mustCall(function() {
+        assert.strictEqual(this.bytesRead, compData.length,
+                           `Should get compressed size on ${method[0]}/` +
+                           `${method[1]} end.`);
+        assert.strictEqual(decompData.toString(), expectStr,
+                           `Should get original string on ${method[0]}/` +
+                           `${method[1]} end.`);
+      }));
+      decompWriter = createWriter(decomp, compData);
+    }
+
+    // Some methods should allow extra data after the compressed data
+    if (method[2]) {
+      const compDataExtra = Buffer.concat([compData, new Buffer('extra')]);
+
+      let decompWriter;
+      let decompData = new Buffer(0);
+
+      const decomp = zlib[method[1]]();
+      decomp.on('data', function(d) {
+        decompData = Buffer.concat([decompData, d]);
+        assert.strictEqual(this.bytesRead, decompWriter.size,
+                           `Should get write size on ${method[0]}/` +
+                           `${method[1]} data.`);
+      });
+      decomp.on('end', common.mustCall(function() {
+        assert.strictEqual(this.bytesRead, compData.length,
+                           `Should get compressed size on ${method[0]}/` +
+                           `${method[1]} end.`);
+        assert.strictEqual(decompData.toString(), expectStr,
+                           `Should get original string on ${method[0]}/` +
+                           `${method[1]} end.`);
+      }));
+      decompWriter = createWriter(decomp, compDataExtra);
+    }
+  }));
+  compWriter = createWriter(comp, expectBuf);
+}


### PR DESCRIPTION
Added bytesRead property to Zlib engines and an option to expose the engine to
convenience method callbacks (so that the bytesRead value can be used in the convenience methods, per related issue).

Fixes: https://github.com/nodejs/node/issues/8874

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- zlib

--------

I can try to add documentation later, once I know the API does not need any changes.
