### PR TITLE
test: replace port in dgram cb length test

### DIFF
--- a/test/parallel/test-dgram-send-callback-buffer-length.js
+++ b/test/parallel/test-dgram-send-callback-buffer-length.js
@@ -38,4 +38,7 @@ const messageSent = common.mustCall(function messageSent(err, bytes) {
   client.close();
 });
 
-client.send(buf, offset, len, common.PORT, '127.0.0.1', messageSent);
+client.bind(0, () => client.send(buf, offset, len,
+                                 client.address().port,
+                                 '127.0.0.1',
+                                 messageSent));


### PR DESCRIPTION
Replaced common.PORT in the following test.
test-dgram-send-callback-buffer-length.js

Ref: nodejs#12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram