### PR TITLE
test: make a test path-independent

### DIFF
--- a/test/parallel/test-spawn-cmd-named-pipe.js
+++ b/test/parallel/test-spawn-cmd-named-pipe.js
@@ -37,15 +37,10 @@ if (!process.argv[2]) {
   });
   stdoutPipeServer.listen(stdoutPipeName);
 
-  const comspec = process.env['comspec'];
-  if (!comspec || comspec.length === 0) {
-    assert.fail('Failed to get COMSPEC');
-  }
+  const args =
+    [`"${__filename}"`, 'child', '<', stdinPipeName, '>', stdoutPipeName];
 
-  const args = ['/c', process.execPath, __filename, 'child',
-                '<', stdinPipeName, '>', stdoutPipeName];
-
-  const child = spawn(comspec, args);
+  const child = spawn(`"${process.execPath}"`, args, { shell: true });
 
   child.on('exit', common.mustCall(function(exitCode) {
     stdinPipeServer.close();


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, child_process

This is the first step to fix the #12773.

I've decided to start from the most whimsical one (section 4 in the #12773): `parallel/test-spawn-cmd-named-pipe.js` fails if spaces exist both in node.exe and the test paths. If there are no spaces or there are spaces only in one of the paths (either), the test passes.

If I get it right, the cause is the very complicated rules for `cmd.exe` command line syntax concerning spaces and quotes: see "Quote Characters in a command" [here](https://ss64.com/nt/syntax-cmd.html) and "Examples:" [here](https://ss64.com/nt/cmd.html).

The fixed test passes with all 4 paths variants (spaceless + spaceless, spacy + spaceless, spaceless + spacy, and spacy + spacy).

Please, test in more environments and propose better fixes if you have some)

cc @nodejs/testing, @nodejs/platform-windows, @bnoordhuis, @cjihrig
