### PR TITLE
doc: Update doc of publicEncrypt method

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1637,7 +1637,7 @@ treated as the key with no passphrase and will use `RSA_PKCS1_PADDING`.
 <!-- YAML
 added: v1.1.0
 -->
-- `private_key` {Object | string}
+- `public_key` {Object | string}
   - `key` {string} A PEM encoded private key.
   - `passphrase` {string} An optional passphrase for the private key.
   - `padding` {crypto.constants} An optional padding value defined in
@@ -1657,7 +1657,7 @@ be passed instead of a public key.
 <!-- YAML
 added: v0.11.14
 -->
-- `private_key` {Object | string}
+- `public_key` {Object | string}
   - `key` {string} A PEM encoded private key.
   - `passphrase` {string} An optional passphrase for the private key.
   - `padding` {crypto.constants} An optional padding value defined in
@@ -1665,7 +1665,8 @@ added: v0.11.14
     `RSA_PKCS1_PADDING`, or `crypto.constants.RSA_PKCS1_OAEP_PADDING`.
 - `buffer` {Buffer | TypedArray | DataView}
 
-Encrypts `buffer` with `public_key`.
+Encrypts the content of `buffer` with `public_key` and returns a new
+[`Buffer`][] with encrypted content.
 
 `public_key` can be an object or a string. If `public_key` is a string, it is
 treated as the key with no passphrase and will use `RSA_PKCS1_OAEP_PADDING`.


### PR DESCRIPTION
As per https://github.com/nodejs/node/issues/12946
the crypto doc for `publicEncrypt` doesn't tell
you whether the encryption happens in place or not.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc