### PR TITLE
test: fix wording for presence of headers

### DIFF
--- a/test/parallel/test-http-date-header.js
+++ b/test/parallel/test-http-date-header.js
@@ -28,7 +28,7 @@ const testResBody = 'other stuff!\n';
 
 const server = http.createServer(function(req, res) {
   assert.ok(!('date' in req.headers),
-            'Request headers contained a Date.');
+            'Request headers did not contain a date.');
   res.writeHead(200, {
     'Content-Type': 'text/plain'
   });
@@ -45,7 +45,7 @@ server.addListener('listening', function() {
   };
   const req = http.request(options, function(res) {
     assert.ok('date' in res.headers,
-              'Response headers didn\'t contain a Date.');
+              'Response headers contain a Date.');
     res.addListener('end', function() {
       server.close();
       process.exit();


### PR DESCRIPTION
in the first assertion we test that the header is *not* present
and in the second assertion that it is, and not vice versa.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test