### PR TITLE
build: avoid /docs/api and /docs/doc/api upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -748,9 +748,9 @@ ifeq ($(XZ), 0)
 endif
 
 doc-upload: doc
-	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)"
+	ssh $(STAGINGSERVER) "mkdir -p nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs/"
 	chmod -R ug=rw-x+X,o=r+X out/doc/
-	scp -pr out/doc/ $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs/
+	scp -pr out/doc/* $(STAGINGSERVER):nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs/
 	ssh $(STAGINGSERVER) "touch nodejs/$(DISTTYPEDIR)/$(FULLVERSION)/docs.done"
 
 $(TARBALL)-headers: release-only


### PR DESCRIPTION
Fixes problem of having /docs/api and /docs/doc/api directories in our distributions, caused by a double (or more) build on CI server prior to promotion as reported and discussed in https://github.com/nodejs/node/issues/12833.

`scp -pr out/doc/ server:.../docs/` first sees a missing `/docs/` directory so puts the out/doc/ contents into /docs/, second pass it sees an existing directory so makes a new /docs/doc/ directory for the upload.

This fix ensures the directory exists initially and then does an `scp` of the _contents_ of the out/doc/ directory rather than the directory itself.

Needs to be backported to all active release lines once confirmed working.