### PR TITLE
build: only require docs 'Added' fixes for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -662,8 +662,7 @@ PACKAGEMAKER ?= /Developer/Applications/Utilities/PackageMaker.app/Contents/MacO
 PKGDIR=out/dist-osx
 
 release-only:
-	@if [ "$(DISTTYPE)" != "nightly" ] && [ "$(DISTTYPE)" != "next-nightly" ] && \
-		`grep -q REPLACEME doc/api/*.md`; then \
+	@if [ "$(DISTTYPE)" == "release" ] && `grep -q REPLACEME doc/api/*.md`; then \
 		echo 'Please update REPLACEME in Added: tags in doc/api/*.md (See doc/releases.md)' ; \
 		exit 1 ; \
 	fi


### PR DESCRIPTION
Discovered while trying to do a `test` build for #12957. There are `Added:` tags without versions in the docs on `master` so it's borking on build. Test builds use the `DISTTYPE` of `"custom"` which isn't allowed through here, like `"nightly"` is. So I've inverted the logic since `"release"` would be the only `DISTTYPE` (also the default if you don't set one) that's allowed through.

/cc @nodejs/build 