### PR TITLE
test: add common.mustCall() to NAPI exception test

### DIFF
--- a/test/addons-napi/test_exception/test.js
+++ b/test/addons-napi/test_exception/test.js
@@ -9,8 +9,6 @@ function throwTheError() {
 }
 let caughtError;
 
-const throwNoError = common.noop;
-
 // Test that the native side successfully captures the exception
 let returnedError = test_exception.returnException(throwTheError);
 assert.strictEqual(theError, returnedError,
@@ -34,13 +32,13 @@ assert.strictEqual(test_exception.wasPending(), true,
                    ' when it was allowed through');
 
 // Test that the native side does not capture a non-existing exception
-returnedError = test_exception.returnException(throwNoError);
+returnedError = test_exception.returnException(common.mustCall());
 assert.strictEqual(undefined, returnedError,
                    'Returned error is undefined when no exception is thrown');
 
 // Test that no exception appears that was not thrown by us
 try {
-  test_exception.allowException(throwNoError);
+  test_exception.allowException(common.mustCall());
 } catch (anError) {
   caughtError = anError;
 }


### PR DESCRIPTION
Use `common.mustCall()` to confirm that function is invoked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test