### PR TITLE
test: fix flaky test-net-connect-local-error

### DIFF
--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -3,25 +3,28 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server = net.createServer();
-server.listen(0);
-const port = server.address().port;
 const client = net.connect({
-  port: port + 1,
-  localPort: port,
+  port: common.PORT + 1,
+  localPort: common.PORT,
   localAddress: common.localhostIPv4
 });
 
 client.on('error', common.mustCall(function onError(err) {
+  assert.strictEqual(err.syscall, 'connect');
+  assert.strictEqual(err.code, 'ECONNREFUSED');
   assert.strictEqual(
     err.localPort,
-    port,
-    `${err.localPort} !== ${port} in ${err}`
+    common.PORT,
+    `${err.localPort} !== ${common.PORT} in ${err}`
   );
   assert.strictEqual(
     err.localAddress,
     common.localhostIPv4,
     `${err.localAddress} !== ${common.localhostIPv4} in ${err}`
   );
+  assert.strictEqual(
+    err.message,
+    `connect ECONNREFUSED ${err.address}:${err.port} ` +
+    `- Local (${err.localAddress}:${err.localPort})`
+  );
 }));
-server.close();


### PR DESCRIPTION
Fixed test-net-connect-local-error by moving the test from parallel to sequential.
Reverted to commit https://github.com/nodejs/node/blob/eeae3bd07145a770209e4899a9d40f67109d3d01/test/parallel/test-net-connect-local-error.js. Added a few more assertions.

Fixes: https://github.com/nodejs/node/issues/12950

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
