### PR TITLE
url: ignore IDN errors when domainname have two hyphens

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -472,8 +472,8 @@ int32_t ToUnicode(MaybeStackBuffer<char>* buf,
   // 9.0.0 (rev. 17), but were found to be incompatible with many actual domain
   // names in the wild. As such, in the current UTS #46 draft (rev. 18) these
   // checks are made optional depending on the CheckHyphens flag, which will be
-  // disabled in WHATWG URL's "domain to ASCII" algorithm as soon as the UTS #46
-  // draft becomes standard.
+  // disabled in WHATWG URL's "domain to unicode" algorithm as soon as the UTS
+  // #46 draft becomes standard.
   // Refs:
   // - https://github.com/whatwg/url/issues/53
   // - http://www.unicode.org/review/pri317/

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -468,6 +468,21 @@ int32_t ToUnicode(MaybeStackBuffer<char>* buf,
   // #46. Therefore, explicitly filters out that error here.
   info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
 
+  // These error conditions are mandated unconditionally by UTS #46 version
+  // 9.0.0 (rev. 17), but were found to be incompatible with many actual domain
+  // names in the wild. As such, in the current UTS #46 draft (rev. 18) these
+  // checks are made optional depending on the CheckHyphens flag, which will be
+  // disabled in WHATWG URL's "domain to ASCII" algorithm as soon as the UTS #46
+  // draft becomes standard.
+  // Refs:
+  // - https://github.com/whatwg/url/issues/53
+  // - http://www.unicode.org/review/pri317/
+  // - http://www.unicode.org/reports/tr46/tr46-18.html
+  // - https://www.icann.org/news/announcement-2000-01-07-en
+  info.errors &= ~UIDNA_ERROR_HYPHEN_3_4;
+  info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
+  info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
+
   if (U_FAILURE(status) || (!lenient && info.errors != 0)) {
     len = -1;
     buf->SetLength(0);
@@ -516,7 +531,21 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
   info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
   info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
+
+  // These error conditions are mandated unconditionally by UTS #46 version
+  // 9.0.0 (rev. 17), but were found to be incompatible with many actual domain
+  // names in the wild. As such, in the current UTS #46 draft (rev. 18) these
+  // checks are made optional depending on the CheckHyphens flag, which will be
+  // disabled in WHATWG URL's "domain to ASCII" algorithm as soon as the UTS #46
+  // draft becomes standard.
+  // Refs:
+  // - https://github.com/whatwg/url/issues/53
+  // - http://www.unicode.org/review/pri317/
+  // - http://www.unicode.org/reports/tr46/tr46-18.html
+  // - https://www.icann.org/news/announcement-2000-01-07-en
   info.errors &= ~UIDNA_ERROR_HYPHEN_3_4;
+  info.errors &= ~UIDNA_ERROR_LEADING_HYPHEN;
+  info.errors &= ~UIDNA_ERROR_TRAILING_HYPHEN;
 
   if (U_FAILURE(status) || (!lenient && info.errors != 0)) {
     len = -1;

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -516,6 +516,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
   info.errors &= ~UIDNA_ERROR_EMPTY_LABEL;
   info.errors &= ~UIDNA_ERROR_LABEL_TOO_LONG;
   info.errors &= ~UIDNA_ERROR_DOMAIN_NAME_TOO_LONG;
+  info.errors &= ~UIDNA_ERROR_HYPHEN_3_4;
 
   if (U_FAILURE(status) || (!lenient && info.errors != 0)) {
     len = -1;

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -43,8 +43,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
                 bool lenient = false);
 int32_t ToUnicode(MaybeStackBuffer<char>* buf,
                   const char* input,
-                  size_t length,
-                  bool lenient = false);
+                  size_t length);
 
 }  // namespace i18n
 }  // namespace node

--- a/test/fixtures/url-idna.js
+++ b/test/fixtures/url-idna.js
@@ -204,6 +204,14 @@ module.exports = {
     {
       ascii: 'sn-a5mlrn7s-.gevideo.com',
       unicode: 'sn-a5mlrn7s-.gevideo.com'
+    },
+    {
+      ascii: '-sn-a5mlrn7s-.gevideo.com',
+      unicode: '-sn-a5mlrn7s-.gevideo.com'
+    },
+    {
+      ascii: '-sn--a5mlrn7s-.gevideo.com',
+      unicode: '-sn--a5mlrn7s-.gevideo.com'
     }
   ],
   invalid: [

--- a/test/fixtures/url-idna.js
+++ b/test/fixtures/url-idna.js
@@ -219,15 +219,6 @@ module.exports = {
     {
       url: '\ufffd.com',
       mode: 'ascii'
-    },
-    {
-      url: '\ufffd.com',
-      mode: 'unicode'
-    },
-    // invalid Punycode
-    {
-      url: 'xn---abc.com',
-      mode: 'unicode'
     }
   ]
 }

--- a/test/fixtures/url-idna.js
+++ b/test/fixtures/url-idna.js
@@ -191,6 +191,19 @@ module.exports = {
     {
       ascii: `${`${'a'.repeat(64)}.`.repeat(4)}com`,
       unicode: `${`${'a'.repeat(64)}.`.repeat(4)}com`
+    },
+    // URLs with hyphen
+    {
+      ascii: 'r4---sn-a5mlrn7s.gevideo.com',
+      unicode: 'r4---sn-a5mlrn7s.gevideo.com'
+    },
+    {
+      ascii: '-sn-a5mlrn7s.gevideo.com',
+      unicode: '-sn-a5mlrn7s.gevideo.com'
+    },
+    {
+      ascii: 'sn-a5mlrn7s-.gevideo.com',
+      unicode: 'sn-a5mlrn7s-.gevideo.com'
     }
   ],
   invalid: [

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -487,6 +487,16 @@ const parseTests = {
     path: '/bar'
   },
 
+  'https://r4---sn-a5mlrn7s.gevideo.com/bar': {
+    href: 'https://r4---sn-a5mlrn7s.gevideo.com/bar',
+    host: 'r4---sn-a5mlrn7s.gevideo.com',
+    hostname: 'r4---sn-a5mlrn7s.gevideo.com',
+    protocol: 'https:',
+    slashes: true,
+    pathname: '/bar',
+    path: '/bar'
+  },
+
   // IDNA tests
   'http://www.日本語.com/': {
     href: 'http://www.xn--wgv71a119e.com/',

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -487,16 +487,6 @@ const parseTests = {
     path: '/bar'
   },
 
-  'https://r4---sn-a5mlrn7s.gevideo.com/bar': {
-    href: 'https://r4---sn-a5mlrn7s.gevideo.com/bar',
-    host: 'r4---sn-a5mlrn7s.gevideo.com',
-    hostname: 'r4---sn-a5mlrn7s.gevideo.com',
-    protocol: 'https:',
-    slashes: true,
-    pathname: '/bar',
-    path: '/bar'
-  },
-
   // IDNA tests
   'http://www.日本語.com/': {
     href: 'http://www.xn--wgv71a119e.com/',


### PR DESCRIPTION
There are valid domain names with hyphens at 3 and 4th position, new
node WHATWG URL parser was failing for it assume its an invalid IDN.

Fixes: https://github.com/nodejs/node/issues/12965

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
