### PR TITLE
src: add HAVE_OPENSSL guard to crypto providers

### DIFF
--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -34,33 +34,43 @@ namespace node {
 
 #define NODE_ASYNC_ID_OFFSET 0xA1C
 
-#define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
+#define NODE_ASYNC_NONE_CRYPTO_PROVIDER_TYPES(V)                              \
   V(NONE)                                                                     \
-  V(CONNECTION)                                                               \
   V(FSEVENTWRAP)                                                              \
   V(FSREQWRAP)                                                                \
   V(GETADDRINFOREQWRAP)                                                       \
   V(GETNAMEINFOREQWRAP)                                                       \
   V(HTTPPARSER)                                                               \
   V(JSSTREAM)                                                                 \
-  V(PBKDF2REQUEST)                                                            \
   V(PIPECONNECTWRAP)                                                          \
   V(PIPEWRAP)                                                                 \
   V(PROCESSWRAP)                                                              \
   V(QUERYWRAP)                                                                \
-  V(RANDOMBYTESREQUEST)                                                       \
   V(SHUTDOWNWRAP)                                                             \
   V(SIGNALWRAP)                                                               \
   V(STATWATCHER)                                                              \
   V(TCPCONNECTWRAP)                                                           \
   V(TCPWRAP)                                                                  \
   V(TIMERWRAP)                                                                \
-  V(TLSWRAP)                                                                  \
   V(TTYWRAP)                                                                  \
   V(UDPSENDWRAP)                                                              \
   V(UDPWRAP)                                                                  \
   V(WRITEWRAP)                                                                \
   V(ZLIB)
+
+#if HAVE_OPENSSL
+#define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)                                   \
+  V(CONNECTION)                                                               \
+  V(PBKDF2REQUEST)                                                            \
+  V(RANDOMBYTESREQUEST)                                                       \
+  V(TLSWRAP)
+#else
+#define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
+#endif  // HAVE_OPENSSL
+
+#define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
+  NODE_ASYNC_NONE_CRYPTO_PROVIDER_TYPES(V)                                    \
+  NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 
 class Environment;
 

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -34,7 +34,7 @@ namespace node {
 
 #define NODE_ASYNC_ID_OFFSET 0xA1C
 
-#define NODE_ASYNC_NONE_CRYPTO_PROVIDER_TYPES(V)                              \
+#define NODE_ASYNC_NO_CRYPTO_PROVIDER_TYPES(V)                                \
   V(NONE)                                                                     \
   V(FSEVENTWRAP)                                                              \
   V(FSREQWRAP)                                                                \
@@ -69,7 +69,7 @@ namespace node {
 #endif  // HAVE_OPENSSL
 
 #define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
-  NODE_ASYNC_NONE_CRYPTO_PROVIDER_TYPES(V)                                    \
+  NODE_ASYNC_NO_CRYPTO_PROVIDER_TYPES(V)                                      \
   NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 
 class Environment;

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -34,7 +34,7 @@ namespace node {
 
 #define NODE_ASYNC_ID_OFFSET 0xA1C
 
-#define NODE_ASYNC_NO_CRYPTO_PROVIDER_TYPES(V)                                \
+#define NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                               \
   V(NONE)                                                                     \
   V(FSEVENTWRAP)                                                              \
   V(FSREQWRAP)                                                                \
@@ -69,7 +69,7 @@ namespace node {
 #endif  // HAVE_OPENSSL
 
 #define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
-  NODE_ASYNC_NO_CRYPTO_PROVIDER_TYPES(V)                                      \
+  NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                                     \
   NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 
 class Environment;


### PR DESCRIPTION
When configured --without-ssl node_crypto.h will not be included but
async-wrap.h includes providers that are defined in node_crypto.h,
node_crypto.cc, and tls_wrap.cc:
AsyncWrap::PROVIDER_CONNECTION
AsyncWrap::PROVIDER_PBKDF2REQUEST
AsyncWrap::PROVIDER_RANDOMBYTESREQUEST
AsyncWrap::PROVIDER_TLSWRAP

These will be included as providers which will cause
test-async-wrap-getasyncid.js to fail.

This commit suggest adding a guard and exclude the providers that are
not available when configured --without-ssl

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src