### PR TITLE
test: make the rest of tests path-independent

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -285,8 +285,8 @@ exports.childShouldThrowAndAbort = function() {
     // continuous testing and developers' machines
     testCmd += 'ulimit -c 0 && ';
   }
-  testCmd += `${process.argv[0]} --abort-on-uncaught-exception `;
-  testCmd += `${process.argv[1]} child`;
+  testCmd += `"${process.argv[0]}" --abort-on-uncaught-exception `;
+  testCmd += `"${process.argv[1]}" child`;
   const child = child_process.exec(testCmd);
   child.on('exit', function onExit(exitCode, signal) {
     const errMsg = 'Test should have aborted ' +

--- a/test/known_issues/test-stdout-buffer-flush-on-exit.js
+++ b/test/known_issues/test-stdout-buffer-flush-on-exit.js
@@ -18,7 +18,8 @@ if (process.argv[2] === 'child') {
 [22, 21, 20, 19, 18, 17, 16, 16, 17, 18, 19, 20, 21, 22].forEach((exponent) => {
   const bigNum = Math.pow(2, exponent);
   const longLine = lineSeed.repeat(bigNum);
-  const cmd = `${process.execPath} ${__filename} child ${exponent} ${bigNum}`;
+  const cmd =
+    `"${process.execPath}" "${__filename}" child ${exponent} ${bigNum}`;
   const stdout = execSync(cmd).toString().trim();
 
   assert.strictEqual(stdout, longLine, `failed with exponent ${exponent}`);

--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -27,7 +27,7 @@ ChildProcess.prototype.spawn = function() {
 };
 
 function createChild(options, callback) {
-  const cmd = `${process.execPath} ${__filename} child`;
+  const cmd = `"${process.execPath}" "${__filename}" child`;
 
   return cp.exec(cmd, options, common.mustCall(callback));
 }

--- a/test/parallel/test-child-process-exec-encoding.js
+++ b/test/parallel/test-child-process-exec-encoding.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
   console.error(stderrData);
 } else {
   function run(options, callback) {
-    const cmd = `${process.execPath} ${__filename} child`;
+    const cmd = `"${process.execPath}" "${__filename}" child`;
 
     cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
       assert.ifError(err);

--- a/test/parallel/test-child-process-exec-kill-throws.js
+++ b/test/parallel/test-child-process-exec-kill-throws.js
@@ -18,7 +18,7 @@ if (process.argv[2] === 'child') {
     throw new Error('mock error');
   };
 
-  const cmd = `${process.execPath} ${__filename} child`;
+  const cmd = `"${process.execPath}" "${__filename}" child`;
   const options = { maxBuffer: 0 };
   const child = cp.exec(cmd, options, common.mustCall((err, stdout, stderr) => {
     // Verify that if ChildProcess#kill() throws, the error is reported.

--- a/test/parallel/test-child-process-exec-timeout.js
+++ b/test/parallel/test-child-process-exec-timeout.js
@@ -12,7 +12,7 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const cmd = `${process.execPath} ${__filename} child`;
+const cmd = `"${process.execPath}" "${__filename}" child`;
 
 // Test the case where a timeout is set, and it expires.
 cp.exec(cmd, { timeout: 1 }, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -220,7 +220,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
   // Ensure that arguments are successfully passed to a script.
   // The first argument after '--' should be interpreted as a script
   // filename.
-  const filecmd = `${nodejs} -- ${__filename} ${args}`;
+  const filecmd = `${nodejs} -- "${__filename}" ${args}`;
   child.exec(filecmd, common.mustCall(function(err, stdout, stderr) {
     assert.strictEqual(stdout, `${args}\n`);
     assert.strictEqual(stderr, '');

--- a/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
+++ b/test/parallel/test-domain-throw-error-then-throw-from-uncaught-exception-handler.js
@@ -90,13 +90,13 @@ function createTestCmdLine(options) {
     testCmd += 'ulimit -c 0 && ';
   }
 
-  testCmd += process.argv[0];
+  testCmd += `"${process.argv[0]}"`;
 
   if (options && options.withAbortOnUncaughtException) {
     testCmd += ' --abort-on-uncaught-exception';
   }
 
-  testCmd += ` ${process.argv[1]} child`;
+  testCmd += ` "${process.argv[1]}" child`;
 
   return testCmd;
 }

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -103,8 +103,8 @@ if (process.argv[2] === 'child') {
     if (options.useTryCatch)
       useTryCatchOpt = 'useTryCatch';
 
-    cmdToExec += `${process.argv[0]} ${cmdLineOption ? cmdLineOption : ''} ${
-      process.argv[1]} child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
+    cmdToExec += `"${process.argv[0]}" ${cmdLineOption ? cmdLineOption : ''} "${
+      process.argv[1]}" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
 
     const child = exec(cmdToExec);
 

--- a/test/parallel/test-env-var-no-warnings.js
+++ b/test/parallel/test-env-var-no-warnings.js
@@ -7,7 +7,7 @@ if (process.argv[2] === 'child') {
   process.emitWarning('foo');
 } else {
   function test(env) {
-    const cmd = `${process.execPath} ${__filename} child`;
+    const cmd = `"${process.execPath}" "${__filename}" child`;
 
     cp.exec(cmd, { env }, common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err, null);

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -42,13 +42,13 @@ const filename = require('path').join(common.tmpDir, 'big');
 let server;
 
 function executeRequest(cb) {
-  cp.exec([process.execPath,
-           __filename,
+  cp.exec([`"${process.execPath}"`,
+           `"${__filename}"`,
            'request',
            server.address().port,
            '|',
-           process.execPath,
-           __filename,
+           `"${process.execPath}"`,
+           `"${__filename}"`,
            'shasum' ].join(' '),
           (err, stdout, stderr) => {
             assert.ifError(err);

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -16,7 +16,7 @@ const nodeBinary = process.argv[0];
 const preloadOption = (preloads) => {
   let option = '';
   preloads.forEach(function(preload, index) {
-    option += `-r ${preload} `;
+    option += `-r "${preload}" `;
   });
   return option;
 };
@@ -30,7 +30,7 @@ const fixtureD = fixture('define-global.js');
 const fixtureThrows = fixture('throws_error4.js');
 
 // test preloading a single module works
-childProcess.exec(`${nodeBinary} ${preloadOption([fixtureA])} ${fixtureB}`,
+childProcess.exec(`"${nodeBinary}" ${preloadOption([fixtureA])} "${fixtureB}"`,
                   function(err, stdout, stderr) {
                     assert.ifError(err);
                     assert.strictEqual(stdout, 'A\nB\n');
@@ -38,7 +38,7 @@ childProcess.exec(`${nodeBinary} ${preloadOption([fixtureA])} ${fixtureB}`,
 
 // test preloading multiple modules works
 childProcess.exec(
-  `${nodeBinary} ${preloadOption([fixtureA, fixtureB])} ${fixtureC}`,
+  `"${nodeBinary}" ${preloadOption([fixtureA, fixtureB])} "${fixtureC}"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\nC\n');
@@ -47,7 +47,7 @@ childProcess.exec(
 
 // test that preloading a throwing module aborts
 childProcess.exec(
-  `${nodeBinary} ${preloadOption([fixtureA, fixtureThrows])} ${fixtureB}`,
+  `"${nodeBinary}" ${preloadOption([fixtureA, fixtureThrows])} "${fixtureB}"`,
   function(err, stdout, stderr) {
     if (err) {
       assert.strictEqual(stdout, 'A\n');
@@ -59,7 +59,7 @@ childProcess.exec(
 
 // test that preload can be used with --eval
 childProcess.exec(
-  `${nodeBinary} ${preloadOption([fixtureA])}-e "console.log('hello');"`,
+  `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nhello\n');
@@ -105,7 +105,7 @@ replProc.on('close', function(code) {
 // test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
 childProcess.exec(
-  `${nodeBinary} ${preloadOption([fixtureA])}-e "console.log('hello');" ${
+  `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');" ${
   preloadOption([fixtureA, fixtureB])}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
@@ -115,7 +115,7 @@ childProcess.exec(
 
 // test that preload works with -i
 const interactive = childProcess.exec(
-  `${nodeBinary} ${preloadOption([fixtureD])}-i`,
+  `"${nodeBinary}" ${preloadOption([fixtureD])}-i`,
   common.mustCall(function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, "> 'test'\n> ");
@@ -126,8 +126,8 @@ interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
 childProcess.exec(
-  `${nodeBinary} --require ${fixture('cluster-preload.js')} ${
-  fixture('cluster-preload-test.js')}`,
+  `"${nodeBinary}" --require "${fixture('cluster-preload.js')}" "${
+  fixture('cluster-preload-test.js')}"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));
@@ -137,8 +137,8 @@ childProcess.exec(
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
 childProcess.exec(
-  `${nodeBinary} --expose_natives_as=v8natives --require ` +
-     `${fixture('cluster-preload.js')} cluster-preload-test.js`,
+  `"${nodeBinary}" --expose_natives_as=v8natives --require ` +
+     `"${fixture('cluster-preload.js')}" cluster-preload-test.js`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/sequential/test-domain-abort-on-uncaught.js
+++ b/test/sequential/test-domain-abort-on-uncaught.js
@@ -239,8 +239,8 @@ if (process.argv[2] === 'child') {
       testCmd += 'ulimit -c 0 && ';
     }
 
-    testCmd += `${process.argv[0]} --abort-on-uncaught-exception ` +
-               `${process.argv[1]} child ${testIndex}`;
+    testCmd += `"${process.argv[0]}" --abort-on-uncaught-exception ` +
+               `"${process.argv[1]}" child ${testIndex}`;
 
     const child = child_process.exec(testCmd);
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -103,7 +103,7 @@ assert.throws(
   function() {
     require('../fixtures/packages/invalid');
   },
-  /^SyntaxError: Error parsing \S+: Unexpected token , in JSON at position 1$/
+  /^SyntaxError: Error parsing .+: Unexpected token , in JSON at position 1$/
 );
 
 assert.strictEqual(require('../fixtures/packages/index').ok, 'ok',


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

Permit spaces in paths to a Node.js executable and test scripts.

Fixes: https://github.com/nodejs/node/issues/12773
