### PR TITLE
src: remove unused uv.h include in async-wrap.h

### DIFF
--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "base-object.h"
-#include "uv.h"
 #include "v8.h"
 
 #include <stdint.h>


### PR DESCRIPTION
I cannot find any usage of uv in the header and think that it can be
removed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src