### PR TITLE
(v6.x backport) build: don't create directory for NDK toolchain

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -38,13 +38,26 @@ case $ARCH in
         ;;
 esac
 
+NDK_PATH=$1
+function make_toolchain {
+    $NDK_PATH/build/tools/make-standalone-toolchain.sh \
+         --toolchain=$TOOLCHAIN_NAME-$CC_VER \
+        --arch=$ARCH \
+        --install-dir=$TOOLCHAIN \
+        --platform=android-21
+}
+
 export TOOLCHAIN=$PWD/android-toolchain
-mkdir -p $TOOLCHAIN
-$1/build/tools/make-standalone-toolchain.sh \
-    --toolchain=$TOOLCHAIN_NAME-$CC_VER \
-    --arch=$ARCH \
-    --install-dir=$TOOLCHAIN \
-    --platform=android-21
+if [ -d "$TOOLCHAIN" ]; then
+    read -r -p "NDK toolchain already exists. Replace it?  [y/N]" response
+    case "$response" in
+        [Yy])
+            rm -rf "$TOOLCHAIN"
+            make_toolchain
+    esac
+else
+    make_toolchain
+fi
 export PATH=$TOOLCHAIN/bin:$PATH
 export AR=$TOOLCHAIN/bin/$SUFFIX-ar
 export CC=$TOOLCHAIN/bin/$SUFFIX-gcc


### PR DESCRIPTION
Starting from [commit 90561a...](https://android.googlesource.com/platform/ndk/+/90561ac560710eea48a2b82bb1f69d655bb45582) in NDK make-standalone-toolchain.sh requires `--force` option to write toolchain into existing directory and will fail with `Refusing to clobber existing install directory` otherwise.
But with `--force` option script will fail on older versions of NDK. So best option should be just let make-standalone-toolchain.sh create directory.

PR-URL: #11916
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: James M Snell <jasnell@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

[commit guidelines]: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines
