### PR TITLE
promises: improve unhandledrejection warnings

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -88,12 +88,13 @@ function setupPromises(scheduleMicrotasks) {
 
   function emitWarning(uid, reason) {
     const warning = new Error('Unhandled promise rejection ' +
-                              `(rejection id: ${uid}): ${String(reason)}`);
+                              `(rejection id: ${uid})`);
     warning.name = 'UnhandledPromiseRejectionWarning';
     warning.id = uid;
     if (reason instanceof Error) {
-      warning.stack = reason.stack;
+      warning.detail = reason.stack;
     }
+    warning.reason = reason;
     process.emitWarning(warning);
     if (!deprecationWarned) {
       deprecationWarned = true;

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const promiseRejectEvent = process._promiseRejectEvent;
-const hasBeenNotifiedProperty = new WeakMap();
-const promiseToGuidProperty = new WeakMap();
+
+const kNotified = Symbol('node-unhandledrejection-notified');
+const kGuid = Symbol('node-unhandledrejection-uid');
 const pendingUnhandledRejections = [];
 let lastPromiseId = 1;
 
@@ -24,17 +25,27 @@ function setupPromises(scheduleMicrotasks) {
   });
 
   function unhandledRejection(promise, reason) {
-    hasBeenNotifiedProperty.set(promise, false);
-    promiseToGuidProperty.set(promise, lastPromiseId++);
+    Object.defineProperties(promise, {
+      [kNotified]: {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: false
+      },
+      [kGuid]: {
+        enumerable: false,
+        configurable: true,
+        value: lastPromiseId++
+      }
+    });
     addPendingUnhandledRejection(promise, reason);
   }
 
   function rejectionHandled(promise) {
-    const hasBeenNotified = hasBeenNotifiedProperty.get(promise);
+    const hasBeenNotified = promise[kNotified];
     if (hasBeenNotified !== undefined) {
-      hasBeenNotifiedProperty.delete(promise);
-      const uid = promiseToGuidProperty.get(promise);
-      promiseToGuidProperty.delete(promise);
+      promise[kNotified] = undefined;
+      const uid = promise[kGuid];
       if (hasBeenNotified === true) {
         let warning = null;
         if (!process.listenerCount('rejectionHandled')) {
@@ -79,9 +90,9 @@ function setupPromises(scheduleMicrotasks) {
     while (pendingUnhandledRejections.length > 0) {
       const promise = pendingUnhandledRejections.shift();
       const reason = pendingUnhandledRejections.shift();
-      if (hasBeenNotifiedProperty.get(promise) === false) {
-        hasBeenNotifiedProperty.set(promise, true);
-        const uid = promiseToGuidProperty.get(promise);
+      if (promise[kNotified] === false) {
+        promise[kNotified] = true;
+        const uid = promise[kGuid];
         if (!process.emit('unhandledRejection', reason, promise)) {
           emitWarning(uid, reason);
         } else {

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -4,10 +4,30 @@ const promiseRejectEvent = process._promiseRejectEvent;
 
 const kNotified = Symbol('node-unhandledrejection-notified');
 const kGuid = Symbol('node-unhandledrejection-uid');
-const pendingUnhandledRejections = [];
 let lastPromiseId = 1;
 
-exports.setup = setupPromises;
+class RejectedList {
+  push(promise, reason) {
+    if (this.tail === undefined) {
+      this.head = this.tail = {promise, reason, next: undefined};
+    } else {
+      this.tail.next = {promise, reason, next: undefined};
+      this.tail = this.tail.next;
+    }
+  }
+
+  shift() {
+    var item = this.head;
+    if (item === undefined)
+      return;
+    this.head = item.next;
+    if (this.head === undefined)
+      this.tail = undefined;
+    return item;
+  }
+}
+
+const pendingUnhandledRejections = new RejectedList();
 
 function getAsynchronousRejectionWarningObject(uid) {
   return new Error('Promise rejection was handled ' +
@@ -87,9 +107,9 @@ function setupPromises(scheduleMicrotasks) {
   var deprecationWarned = false;
   function emitPendingUnhandledRejections() {
     let hadListeners = false;
-    while (pendingUnhandledRejections.length > 0) {
-      const promise = pendingUnhandledRejections.shift();
-      const reason = pendingUnhandledRejections.shift();
+    let item;
+    while ((item = pendingUnhandledRejections.shift()) !== undefined) {
+      const { promise, reason } = item;
       if (promise[kNotified] === false) {
         promise[kNotified] = true;
         const uid = promise[kGuid];
@@ -110,3 +130,5 @@ function setupPromises(scheduleMicrotasks) {
 
   return emitPendingUnhandledRejections;
 }
+
+exports.setup = setupPromises;

--- a/test/message/unhandled_promise.js
+++ b/test/message/unhandled_promise.js
@@ -1,0 +1,4 @@
+'use strict';
+const common = require('../common');
+const p = Promise.reject(new Error('This was rejected'));
+setImmediate(() => p.catch(common.noop));

--- a/test/message/unhandled_promise.out
+++ b/test/message/unhandled_promise.out
@@ -1,12 +1,4 @@
 (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1)
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
 Error: This was rejected
     at *
     at *
@@ -18,21 +10,4 @@ Error: This was rejected
     at *
     at *
 (node:*) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
 (node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *

--- a/test/parallel/test-promises-unhandled-symbol-rejections.js
+++ b/test/parallel/test-promises-unhandled-symbol-rejections.js
@@ -6,8 +6,7 @@ const expectedDeprecationWarning = 'Unhandled promise rejections are ' +
                                    'rejections that are not handled will ' +
                                    'terminate the Node.js process with a ' +
                                    'non-zero exit code.';
-const expectedPromiseWarning = 'Unhandled promise rejection (rejection id: ' +
-                               '1): Symbol()';
+const expectedPromiseWarning = 'Unhandled promise rejection (rejection id: 1)';
 
 common.expectWarning({
   DeprecationWarning: expectedDeprecationWarning,


### PR DESCRIPTION
Per the CTC discussion around https://github.com/nodejs/node/pull/12734 ...

This takes an alternative approach than https://github.com/nodejs/node/pull/12734. Rather than adding a throw, it improves the warnings that are already there such that the stack trace for the rejection reason is always shown (assuming the reason is an Error object). It also adds a `warning.reason` property to the warning object emitted by `process.on('warning')`, allowing userland code to access the original error (and potentially throw if it wishes to do so).

other code cleanups were made while I was in there.

/cc @nodejs/ctc 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
promises