### PR TITLE
http,https: avoid instanceof for WHATWG URL

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -34,7 +34,7 @@ const debug = common.debug;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const Agent = require('_http_agent');
 const Buffer = require('buffer').Buffer;
-const urlToOptions = require('internal/url').urlToOptions;
+const { urlToOptions, searchParamsSymbol } = require('internal/url');
 const outHeadersKey = require('internal/http').outHeadersKey;
 const nextTick = require('internal/process/next_tick').nextTick;
 
@@ -82,7 +82,9 @@ function ClientRequest(options, cb) {
     if (!options.hostname) {
       throw new Error('Unable to determine the domain name');
     }
-  } else if (options instanceof url.URL) {
+  } else if (options && options[searchParamsSymbol] &&
+             options[searchParamsSymbol][searchParamsSymbol]) {
+    // url.URL instance
     options = urlToOptions(options);
   } else {
     options = util._extend({}, options);

--- a/lib/https.js
+++ b/lib/https.js
@@ -29,7 +29,7 @@ const http = require('http');
 const util = require('util');
 const inherits = util.inherits;
 const debug = util.debuglog('https');
-const urlToOptions = require('internal/url').urlToOptions;
+const { urlToOptions, searchParamsSymbol } = require('internal/url');
 
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
@@ -221,7 +221,9 @@ exports.request = function request(options, cb) {
     if (!options.hostname) {
       throw new Error('Unable to determine the domain name');
     }
-  } else if (options instanceof url.URL) {
+  } else if (options && options[searchParamsSymbol] &&
+             options[searchParamsSymbol][searchParamsSymbol]) {
+    // url.URL instance
     options = urlToOptions(options);
   } else {
     options = util._extend({}, options);


### PR DESCRIPTION
Benchmark results:

```
                                                 improvement confidence      p.value
 http/create-clientrequest.js n=1000000 len=1        7.01 %        *** 1.281605e-08
 http/create-clientrequest.js n=1000000 len=128      4.02 %        *** 6.564820e-04
 http/create-clientrequest.js n=1000000 len=16       6.01 %        *** 8.660607e-07
 http/create-clientrequest.js n=1000000 len=32       5.68 %        *** 9.863084e-06
 http/create-clientrequest.js n=1000000 len=64       6.97 %        *** 9.791414e-10
 http/create-clientrequest.js n=1000000 len=8        7.65 %        *** 1.141693e-09
```

CI: https://ci.nodejs.org/job/node-test-pull-request/8025/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* http
* https
