### PR TITLE
test: add not-called check to heap-profiler test

### DIFF
--- a/test/addons/heap-profiler/test.js
+++ b/test/addons/heap-profiler/test.js
@@ -5,7 +5,7 @@ const common = require('../../common');
 const binding = require(`./build/${common.buildType}/binding`);
 
 // Create an AsyncWrap object.
-const timer = setTimeout(common.noop, 1);
+const timer = setTimeout(common.mustNotCall(), 1);
 timer.unref();
 
 // Stress-test the heap profiler.


### PR DESCRIPTION
Add `common.mustNotCall()` to make sure there aren't any strange
shenanians in the C++ test that would cause the function to execute when
it shouldn't.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test addons