### PR TITLE
test: add hasCrypto check to https-agent-constructor

### DIFF
--- a/test/parallel/test-https-agent-constructor.js
+++ b/test/parallel/test-https-agent-constructor.js
@@ -1,5 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 const assert = require('assert');
 const https = require('https');
 


### PR DESCRIPTION
Currently this test will fail with the following error message when
configured --without-ssl:
```console
Error: Node.js is not compiled with openssl crypto support
```
This commit checks for crypto and skips this tests if such support
is not available.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test