### PR TITLE
src: rename CONNECTION provider to SSLCONNECTION

### DIFF
--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -60,7 +60,7 @@ namespace node {
 
 #if HAVE_OPENSSL
 #define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)                                   \
-  V(CONNECTION)                                                               \
+  V(SSLCONNECTION)                                                            \
   V(PBKDF2REQUEST)                                                            \
   V(RANDOMBYTESREQUEST)                                                       \
   V(TLSWRAP)

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -402,7 +402,7 @@ class Connection : public AsyncWrap, public SSLWrap<Connection> {
              v8::Local<v8::Object> wrap,
              SecureContext* sc,
              SSLWrap<Connection>::Kind kind)
-      : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_CONNECTION),
+      : AsyncWrap(env, wrap, AsyncWrap::PROVIDER_SSLCONNECTION),
         SSLWrap<Connection>(env, sc, kind),
         bio_read_(nullptr),
         bio_write_(nullptr),

--- a/test/async-hooks/test-connection.ssl.js
+++ b/test/async-hooks/test-connection.ssl.js
@@ -37,11 +37,11 @@ function createServerConnection(
 // creating first server connection
 const sc1 = createServerConnection(common.mustCall(onfirstHandShake));
 
-let as = hooks.activitiesOfTypes('CONNECTION');
+let as = hooks.activitiesOfTypes('SSLCONNECTION');
 assert.strictEqual(as.length, 1,
                    'one CONNECTION after first connection created');
 const f1 = as[0];
-assert.strictEqual(f1.type, 'CONNECTION', 'connection');
+assert.strictEqual(f1.type, 'SSLCONNECTION', 'connection');
 assert.strictEqual(typeof f1.uid, 'number', 'uid is a number');
 assert.strictEqual(typeof f1.triggerId, 'number', 'triggerId is a number');
 checkInvocations(f1, { init: 1 }, 'first connection, when first created');
@@ -49,11 +49,11 @@ checkInvocations(f1, { init: 1 }, 'first connection, when first created');
 // creating second server connection
 const sc2 = createServerConnection(common.mustCall(onsecondHandShake));
 
-as = hooks.activitiesOfTypes('CONNECTION');
+as = hooks.activitiesOfTypes('SSLCONNECTION');
 assert.strictEqual(as.length, 2,
-                   'two CONNECTIONs after second connection created');
+                   'two SSLCONNECTIONs after second connection created');
 const f2 = as[1];
-assert.strictEqual(f2.type, 'CONNECTION', 'connection');
+assert.strictEqual(f2.type, 'SSLCONNECTION', 'connection');
 assert.strictEqual(typeof f2.uid, 'number', 'uid is a number');
 assert.strictEqual(typeof f2.triggerId, 'number', 'triggerId is a number');
 checkInvocations(f1, { init: 1 }, 'first connection, when second created');
@@ -81,7 +81,7 @@ process.on('exit', onexit);
 
 function onexit() {
   hooks.disable();
-  hooks.sanityCheck('CONNECTION');
+  hooks.sanityCheck('SSLCONNECTION');
 
   checkInvocations(f1, { init: 1, before: 1, after: 1 },
                    'first connection, when process exits');


### PR DESCRIPTION
Currently the async provider type CONNECTION is used in node_crypto.h
and it might be clearer if it was named SSLCONNECTION as suggested by
addaleax.

This commit renames only the provider type as I was not sure if it was
alright to change the class Connection as well.

Refs: https://github.com/nodejs/node/pull/12967#discussion_r115978735

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src