### PR TITLE
crypto: remove unnecessary template class

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -155,7 +155,6 @@ std::string extra_root_certs_file;  // NOLINT(runtime/string)
 X509_STORE* root_cert_store;
 
 // Just to generate static methods
-template class SSLWrap<TLSWrap>;
 template void SSLWrap<TLSWrap>::AddMethods(Environment* env,
                                            Local<FunctionTemplate> t);
 template void SSLWrap<TLSWrap>::InitNPN(SecureContext* sc);


### PR DESCRIPTION
I came across this template class but I don't understand why it is
there. It is not used in the template specialization following it.

I just wanted to bring it up just in case this is something that
has been overlooked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto