### PR TITLE
(v8.x) src: update NODE_MODULE_VERSION to 57

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -73,6 +73,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 55 /* Node.js v8.0.0 */
+#define NODE_MODULE_VERSION 57 /* Node.js v8.0.0 */
 
 #endif  // SRC_NODE_VERSION_H_


### PR DESCRIPTION
Node.js 8.0.0 is API/ABI forward-compatible with V8 6.0.
The current module version is 55 and corresponds to V8 5.8. This
increments the number by two to prevent incompatibility with modules
compiled from Node master.

/cc @nodejs/v8 @jasnell @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
