### PR TITLE
test: replace port in net immediate finish test

### DIFF
--- a/test/sequential/test-net-connect-immediate-finish.js
+++ b/test/sequential/test-net-connect-immediate-finish.js
@@ -24,14 +24,16 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({host: '***', port: common.PORT});
+const unfindable_host = '***';
+// port 0 is hardcoded since this does not create a network connection
+const client = net.connect({host: unfindable_host, port: 0});
 
 client.once('error', common.mustCall((err) => {
   assert(err);
   assert.strictEqual(err.code, err.errno);
   assert.strictEqual(err.code, 'ENOTFOUND');
   assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, '***');
+  assert.strictEqual(err.host, unfindable_host);
   assert.strictEqual(err.syscall, 'getaddrinfo');
 }));
 


### PR DESCRIPTION
Replaced common.PORT in the following test.
test-net-connect-immediate-finish.js

Ref: nodejs#12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test