### PR TITLE
util: fixup internal util exports

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -198,28 +198,6 @@ function getConstructorOf(obj) {
   return null;
 }
 
-module.exports = exports = {
-  assertCrypto,
-  cachedResult,
-  convertToValidSignal,
-  createClassWrapper,
-  decorateErrorStack,
-  deprecate,
-  filterDuplicateStrings,
-  getConstructorOf,
-  isError,
-  normalizeEncoding,
-  objectToString,
-
-  // Symbol used to provide a custom inspect function for an object as an
-  // alternative to using 'inspect'
-  customInspectSymbol: Symbol('util.inspect.custom'),
-
-  // Used by the buffer module to capture an internal reference to the
-  // default isEncoding implementation, just in case userland overrides it.
-  kIsEncodingSymbol: Symbol('node.isEncoding')
-};
-
 const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
@@ -276,5 +254,28 @@ function promisify(orig) {
 
 promisify.custom = kCustomPromisifiedSymbol;
 
-exports.promisify = promisify;
-exports.customPromisifyArgs = kCustomPromisifyArgsSymbol;
+module.exports = {
+  assertCrypto,
+  cachedResult,
+  convertToValidSignal,
+  createClassWrapper,
+  decorateErrorStack,
+  deprecate,
+  filterDuplicateStrings,
+  getConstructorOf,
+  isError,
+  normalizeEncoding,
+  objectToString,
+  promisify,
+
+  // Symbol used to customize promisify conversion
+  customPromisifyArgs: kCustomPromisifyArgsSymbol,
+
+  // Symbol used to provide a custom inspect function for an object as an
+  // alternative to using 'inspect'
+  customInspectSymbol: Symbol('util.inspect.custom'),
+
+  // Used by the buffer module to capture an internal reference to the
+  // default isEncoding implementation, just in case userland overrides it.
+  kIsEncodingSymbol: Symbol('node.isEncoding')
+};


### PR DESCRIPTION
util.promisify landed without using the module.exports = {} pattern. This fixes it up for consistency

/cc @addaleax @refack 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util