### PR TITLE
async_wrap,src: promise hook integration

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -49,12 +49,7 @@ const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
 const destroy_symbol = Symbol('destroy');
 
-// Setup the callbacks that node::AsyncWrap will call when there are hooks to
-// process. They use the same functions as the JS embedder API.
-async_wrap.setupHooks({ init,
-                        before: emitBeforeN,
-                        after: emitAfterN,
-                        destroy: emitDestroyN });
+let setupHooksCalled = false;
 
 // Used to fatally abort the process if a callback throws.
 function fatalError(e) {
@@ -102,6 +97,16 @@ class AsyncHook {
     // Each hook is only allowed to be added once.
     if (hooks_array.includes(this))
       return;
+
+    if (!setupHooksCalled) {
+      setupHooksCalled = true;
+      // Setup the callbacks that node::AsyncWrap will call when there are
+      // hooks to process. They use the same functions as the JS embedder API.
+      async_wrap.setupHooks({ init,
+                              before: emitBeforeN,
+                              after: emitAfterN,
+                              destroy: emitDestroyN });
+    }
 
     // createHook() has already enforced that the callbacks are all functions,
     // so here simply increment the count of whether each callbacks exists or

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -262,8 +262,9 @@ static void GetPromiseDomain(Local<v8::Name> name,
                              const v8::PropertyCallbackInfo<v8::Value>& info) {
   Local<Context> context = info.GetIsolate()->GetCurrentContext();
   Environment* env = Environment::GetCurrent(context);
-  info.GetReturnValue().Set(Object::Cast(*info.Data())->Get(context,
-                            env->domain_string()).ToLocalChecked());
+  info.GetReturnValue().Set(
+      info.Data().As<Object>()->Get(context,
+                                    env->domain_string()).ToLocalChecked());
 }
 
 
@@ -281,11 +282,11 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     Local<Object> obj = tem->NewInstance(context).ToLocalChecked();
     PromiseWrap* wrap = new PromiseWrap(env, obj);
     promise->DefineOwnProperty(context,
-              FIXED_ONE_BYTE_STRING(env->isolate(), async_id_key),
+              env->promise_async_id(),
               v8::External::New(env->isolate(), wrap),
               v8::PropertyAttribute::DontEnum).FromJust();
     promise->DefineOwnProperty(context,
-              FIXED_ONE_BYTE_STRING(env->isolate(), tag_id_key),
+              env->promise_async_tag(),
               obj, v8::PropertyAttribute::DontEnum).FromJust();
     if (env->in_domain()) {
       obj->Set(context, env->domain_string(),
@@ -296,8 +297,8 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
-  Local<v8::Value> external_wrap = promise->Get(context, FIXED_ONE_BYTE_STRING(env->isolate(),
-               async_id_key)).ToLocalChecked();
+  Local<v8::Value> external_wrap =
+      promise->Get(context, env->promise_async_id()).ToLocalChecked();
   PromiseWrap* wrap =
     static_cast<PromiseWrap*>(v8::External::Cast(*external_wrap)->Value());
   if (type == PromiseHookType::kBefore) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -191,7 +191,7 @@ static bool PreCallbackExecution(AsyncWrap* wrap) {
       if (enter_v->IsFunction()) {
         if (enter_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
           FatalError("node::AsyncWrap::MakeCallback",
-                    "domain enter callback threw, please report this");
+                     "domain enter callback threw, please report this");
         }
       }
     }

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -276,16 +276,6 @@ class PromiseWrap : public AsyncWrap {
 };
 
 
-static void GetPromiseDomain(Local<v8::Name> name,
-                             const v8::PropertyCallbackInfo<v8::Value>& info) {
-  Local<Context> context = info.GetIsolate()->GetCurrentContext();
-  Environment* env = Environment::GetCurrent(context);
-  info.GetReturnValue().Set(
-      info.Data().As<Object>()->Get(context,
-                                    env->domain_string()).ToLocalChecked());
-}
-
-
 static void PromiseHook(PromiseHookType type, Local<Promise> promise,
                         Local<Value> parent, void* arg) {
   Local<Context> context = promise->CreationContext();
@@ -307,12 +297,6 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     promise->DefineOwnProperty(context,
               env->promise_async_tag(),
               obj, v8::PropertyAttribute::DontEnum).FromJust();
-    if (env->in_domain()) {
-      obj->Set(context, env->domain_string(),
-        env->domain_array()->Get(context, 0).ToLocalChecked()).FromJust();
-      promise->SetAccessor(context, env->domain_string(),
-                           GetPromiseDomain, NULL, obj).FromJust();
-    }
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -44,6 +44,8 @@ using v8::Local;
 using v8::MaybeLocal;
 using v8::Number;
 using v8::Object;
+using v8::Promise;
+using v8::PromiseHookType;
 using v8::RetainedObjectInfo;
 using v8::Symbol;
 using v8::TryCatch;
@@ -177,6 +179,135 @@ static void PushBackDestroyId(Environment* env, double id) {
 }
 
 
+static bool PreCallbackExecution(AsyncWrap* wrap) {
+  AsyncHooks* async_hooks = wrap->env()->async_hooks();
+  if (wrap->env()->using_domains()) {
+    Local<Value> domain_v = wrap->object()->Get(wrap->env()->domain_string());
+    if (domain_v->IsObject()) {
+      Local<Object> domain = domain_v.As<Object>();
+      if (domain->Get(wrap->env()->disposed_string())->IsTrue())
+        return false;
+      Local<Value> enter_v = domain->Get(wrap->env()->enter_string());
+      if (enter_v->IsFunction()) {
+        if (enter_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+          FatalError("node::AsyncWrap::MakeCallback",
+                    "domain enter callback threw, please report this");
+        }
+      }
+    }
+  }
+
+  if (async_hooks->fields()[AsyncHooks::kBefore] > 0) {
+    Local<Value> uid = Number::New(wrap->env()->isolate(), wrap->get_id());
+    Local<Function> fn = wrap->env()->async_hooks_before_function();
+    TryCatch try_catch(wrap->env()->isolate());
+    MaybeLocal<Value> ar = fn->Call(
+        wrap->env()->context(), Undefined(wrap->env()->isolate()), 1, &uid);
+    if (ar.IsEmpty()) {
+      ClearFatalExceptionHandlers(wrap->env());
+      FatalException(wrap->env()->isolate(), try_catch);
+      return false;
+    }
+  }
+  return true;
+}
+
+
+static bool PostCallbackExecution(AsyncWrap* wrap) {
+  AsyncHooks* async_hooks = wrap->env()->async_hooks();
+
+  // If the callback failed then the after() hooks will be called at the end
+  // of _fatalException().
+  if (async_hooks->fields()[AsyncHooks::kAfter] > 0) {
+    Local<Value> uid = Number::New(wrap->env()->isolate(), wrap->get_id());
+    Local<Function> fn = wrap->env()->async_hooks_after_function();
+    TryCatch try_catch(wrap->env()->isolate());
+    MaybeLocal<Value> ar = fn->Call(
+        wrap->env()->context(), Undefined(wrap->env()->isolate()), 1, &uid);
+    if (ar.IsEmpty()) {
+      ClearFatalExceptionHandlers(wrap->env());
+      FatalException(wrap->env()->isolate(), try_catch);
+      return false;
+    }
+  }
+
+  if (wrap->env()->using_domains()) {
+    Local<Value> domain_v = wrap->object()->Get(wrap->env()->domain_string());
+    if (domain_v->IsObject()) {
+      Local<Object> domain = domain_v.As<Object>();
+      if (domain->Get(wrap->env()->disposed_string())->IsTrue())
+        return false;
+      Local<Value> exit_v = domain->Get(wrap->env()->exit_string());
+      if (exit_v->IsFunction()) {
+        if (exit_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
+          FatalError("node::AsyncWrap::MakeCallback",
+                    "domain exit callback threw, please report this");
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+class PromiseWrap : public AsyncWrap {
+ public:
+  PromiseWrap(Environment* env, Local<Object> object)
+    : AsyncWrap(env, object, PROVIDER_PROMISE) {}
+  size_t self_size() const override { return sizeof(*this); }
+};
+
+
+static void GetPromiseDomain(Local<v8::Name> name,
+                             const v8::PropertyCallbackInfo<v8::Value>& info) {
+  Local<Context> context = info.GetIsolate()->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+  info.GetReturnValue().Set(Object::Cast(*info.Data())->Get(context,
+                            env->domain_string()).ToLocalChecked());
+}
+
+
+static void PromiseHook(PromiseHookType type, Local<Promise> promise,
+                        Local<Value> parent) {
+  Local<Context> context = promise->CreationContext();
+  Environment* env = Environment::GetCurrent(context);
+  const char async_id_key[] = "__async_wrap";
+  const char tag_id_key[] = "__async_wrap_tag";
+  if (type == PromiseHookType::kInit) {
+    // Unfortunately, promises don't have internal fields. Need a surrogate that
+    // async wrap can wrap.
+    Local<v8::ObjectTemplate> tem = v8::ObjectTemplate::New(env->isolate());
+    tem->SetInternalFieldCount(1);
+    Local<Object> obj = tem->NewInstance(context).ToLocalChecked();
+    PromiseWrap* wrap = new PromiseWrap(env, obj);
+    promise->DefineOwnProperty(context,
+              FIXED_ONE_BYTE_STRING(env->isolate(), async_id_key),
+              v8::External::New(env->isolate(), wrap),
+              v8::PropertyAttribute::DontEnum).FromJust();
+    promise->DefineOwnProperty(context,
+              FIXED_ONE_BYTE_STRING(env->isolate(), tag_id_key),
+              obj, v8::PropertyAttribute::DontEnum).FromJust();
+    if (env->in_domain()) {
+      obj->Set(context, env->domain_string(),
+        env->domain_array()->Get(context, 0).ToLocalChecked()).FromJust();
+      promise->SetAccessor(context, env->domain_string(),
+                           GetPromiseDomain, NULL, obj).FromJust();
+    }
+  } else if (type == PromiseHookType::kResolve) {
+    // TODO(matthewloring): need to expose this through the async hooks api.
+  }
+  Local<v8::Value> external_wrap = promise->Get(context, FIXED_ONE_BYTE_STRING(env->isolate(),
+               async_id_key)).ToLocalChecked();
+  PromiseWrap* wrap =
+    static_cast<PromiseWrap*>(v8::External::Cast(*external_wrap)->Value());
+  if (type == PromiseHookType::kBefore) {
+    PreCallbackExecution(wrap);
+  } else if (type == PromiseHookType::kAfter) {
+    PostCallbackExecution(wrap);
+  }
+}
+
+
 static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -201,6 +332,7 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   SET_HOOK_FN(before);
   SET_HOOK_FN(after);
   SET_HOOK_FN(destroy);
+  env->isolate()->SetPromiseHook(PromiseHook);
 #undef SET_HOOK_FN
 }
 
@@ -416,86 +548,29 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
                                      Local<Value>* argv) {
   CHECK(env()->context() == env()->isolate()->GetCurrentContext());
 
-  AsyncHooks* async_hooks = env()->async_hooks();
-  Local<Object> context = object();
-  Local<Object> domain;
-  Local<Value> uid;
-  bool has_domain = false;
-
   Environment::AsyncCallbackScope callback_scope(env());
 
-  if (env()->using_domains()) {
-    Local<Value> domain_v = context->Get(env()->domain_string());
-    has_domain = domain_v->IsObject();
-    if (has_domain) {
-      domain = domain_v.As<Object>();
-      if (domain->Get(env()->disposed_string())->IsTrue())
-        return Local<Value>();
-    }
-  }
+  Environment::AsyncHooks::ExecScope exec_scope(env(),
+                                                get_id(),
+                                                get_trigger_id());
 
-  if (has_domain) {
-    Local<Value> enter_v = domain->Get(env()->enter_string());
-    if (enter_v->IsFunction()) {
-      if (enter_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
-        FatalError("node::AsyncWrap::MakeCallback",
-                   "domain enter callback threw, please report this");
-      }
-    }
-  }
-
-  // Want currentId() to return the correct value from the callbacks.
-  AsyncHooks::ExecScope exec_scope(env(), get_id(), get_trigger_id());
-
-  if (async_hooks->fields()[AsyncHooks::kBefore] > 0) {
-    uid = Number::New(env()->isolate(), get_id());
-    Local<Function> fn = env()->async_hooks_before_function();
-    TryCatch try_catch(env()->isolate());
-    MaybeLocal<Value> ar = fn->Call(
-        env()->context(), Undefined(env()->isolate()), 1, &uid);
-    if (ar.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(env()->isolate(), try_catch);
-      return Local<Value>();
-    }
+  if (!PreCallbackExecution(this)) {
+    return Local<Value>();
   }
 
   // Finally... Get to running the user's callback.
-  MaybeLocal<Value> ret = cb->Call(env()->context(), context, argc, argv);
+  MaybeLocal<Value> ret = cb->Call(env()->context(), object(), argc, argv);
 
   Local<Value> ret_v;
   if (!ret.ToLocal(&ret_v)) {
     return Local<Value>();
   }
 
-  // If the callback failed then the after() hooks will be called at the end
-  // of _fatalException().
-  if (async_hooks->fields()[AsyncHooks::kAfter] > 0) {
-    if (uid.IsEmpty())
-      uid = Number::New(env()->isolate(), get_id());
-    Local<Function> fn = env()->async_hooks_after_function();
-    TryCatch try_catch(env()->isolate());
-    MaybeLocal<Value> ar = fn->Call(
-        env()->context(), Undefined(env()->isolate()), 1, &uid);
-    if (ar.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(env()->isolate(), try_catch);
-      return Local<Value>();
-    }
+  if (!PostCallbackExecution(this)) {
+    return Local<Value>();
   }
 
-  // The execution scope of the id and trigger_id only go this far.
   exec_scope.Dispose();
-
-  if (has_domain) {
-    Local<Value> exit_v = domain->Get(env()->exit_string());
-    if (exit_v->IsFunction()) {
-      if (exit_v.As<Function>()->Call(domain, 0, nullptr).IsEmpty()) {
-        FatalError("node::AsyncWrap::MakeCallback",
-                   "domain exit callback threw, please report this");
-      }
-    }
-  }
 
   if (callback_scope.in_makecallback()) {
     return ret_v;

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -298,7 +298,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   Local<v8::Value> external_wrap =
       promise->Get(context, env->promise_async_id()).ToLocalChecked();
   PromiseWrap* wrap =
-    static_cast<PromiseWrap*>(v8::External::Cast(*external_wrap)->Value());
+    static_cast<PromiseWrap*>(external_wrap.As<v8::External>()->Value());
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap);
   } else if (type == PromiseHookType::kAfter) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -268,7 +268,7 @@ static void GetPromiseDomain(Local<v8::Name> name,
 
 
 static void PromiseHook(PromiseHookType type, Local<Promise> promise,
-                        Local<Value> parent) {
+                        Local<Value> parent, void* arg) {
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
   const char async_id_key[] = "__async_wrap";
@@ -332,7 +332,7 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   SET_HOOK_FN(before);
   SET_HOOK_FN(after);
   SET_HOOK_FN(destroy);
-  env->isolate()->SetPromiseHook(PromiseHook);
+  env->AddPromiseHook(PromiseHook, nullptr);
 #undef SET_HOOK_FN
 }
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -299,6 +299,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
       promise->Get(context, env->promise_async_id()).ToLocalChecked();
   PromiseWrap* wrap =
     static_cast<PromiseWrap*>(external_wrap.As<v8::External>()->Value());
+  CHECK_NE(wrap, nullptr);
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap);
   } else if (type == PromiseHookType::kAfter) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -287,7 +287,9 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
       env->async_hooks_promise_object()->NewInstance(context).ToLocalChecked();
     PromiseWrap* wrap = new PromiseWrap(env, obj);
     v8::PropertyAttribute hidden =
-      static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete | v8::DontEnum);
+      static_cast<v8::PropertyAttribute>(v8::ReadOnly
+                                         | v8::DontDelete
+                                         | v8::DontEnum);
     promise->DefineOwnProperty(context,
               env->promise_wrap(),
               v8::External::New(env->isolate(), wrap),

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -272,8 +272,6 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
                         Local<Value> parent, void* arg) {
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
-  const char async_id_key[] = "__async_wrap";
-  const char tag_id_key[] = "__async_wrap_tag";
   if (type == PromiseHookType::kInit) {
     // Unfortunately, promises don't have internal fields. Need a surrogate that
     // async wrap can wrap.

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -298,9 +298,12 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     Local<Object> obj = tem->NewInstance(context).ToLocalChecked();
     PromiseWrap* wrap = new PromiseWrap(env, obj);
     promise->DefineOwnProperty(context,
-              env->promise_async_id(),
+              env->promise_wrap(),
               v8::External::New(env->isolate(), wrap),
               v8::PropertyAttribute::DontEnum).FromJust();
+    // The async tag will be destroyed at the same time as the promise as the only
+    // reference to it is held by the promise. This allows the promise wrap instance
+    // to be notified when the promise is destroyed.
     promise->DefineOwnProperty(context,
               env->promise_async_tag(),
               obj, v8::PropertyAttribute::DontEnum).FromJust();
@@ -314,7 +317,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
   Local<v8::Value> external_wrap =
-      promise->Get(context, env->promise_async_id()).ToLocalChecked();
+      promise->Get(context, env->promise_wrap()).ToLocalChecked();
   PromiseWrap* wrap =
     static_cast<PromiseWrap*>(external_wrap.As<v8::External>()->Value());
   CHECK_NE(wrap, nullptr);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -291,9 +291,9 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
               env->promise_wrap(),
               v8::External::New(env->isolate(), wrap),
               v8::PropertyAttribute::DontEnum).FromJust();
-    // The async tag will be destroyed at the same time as the promise as the only
-    // reference to it is held by the promise. This allows the promise wrap instance
-    // to be notified when the promise is destroyed.
+    // The async tag will be destroyed at the same time as the promise as the
+    // only reference to it is held by the promise. This allows the promise
+    // wrap instance to be notified when the promise is destroyed.
     promise->DefineOwnProperty(context,
               env->promise_async_tag(),
               obj, v8::PropertyAttribute::DontEnum).FromJust();

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -47,6 +47,7 @@ namespace node {
   V(PIPECONNECTWRAP)                                                          \
   V(PIPEWRAP)                                                                 \
   V(PROCESSWRAP)                                                              \
+  V(PROMISE)                                                                  \
   V(QUERYWRAP)                                                                \
   V(RANDOMBYTESREQUEST)                                                       \
   V(SHUTDOWNWRAP)                                                             \

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -124,6 +124,9 @@ class AsyncWrap : public BaseObject {
 
 void LoadAsyncWrapperInfo(Environment* env);
 
+bool DomainEnter(Environment* env, v8::Local<v8::Object> object);
+bool DomainExit(Environment* env, v8::Local<v8::Object> object);
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/env.h
+++ b/src/env.h
@@ -195,7 +195,7 @@ namespace node {
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(produce_cached_data_string, "produceCachedData")                          \
-  V(promise_async_id, "_promise_async_wrap")                                  \
+  V(promise_wrap, "_promise_async_wrap")                                      \
   V(promise_async_tag, "_promise_async_wrap_tag")                             \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \

--- a/src/env.h
+++ b/src/env.h
@@ -258,6 +258,7 @@ namespace node {
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_before_function, v8::Function)                                \
   V(async_hooks_after_function, v8::Function)                                 \
+  V(async_hooks_promise_object, v8::ObjectTemplate)                           \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
   V(buffer_prototype_object, v8::Object)                                      \

--- a/src/env.h
+++ b/src/env.h
@@ -195,6 +195,8 @@ namespace node {
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(produce_cached_data_string, "produceCachedData")                          \
+  V(promise_async_id, "_promise_async_wrap")                                  \
+  V(promise_async_tag, "_promise_async_wrap_tag")                             \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \
   V(readable_string, "readable")                                              \

--- a/src/node.cc
+++ b/src/node.cc
@@ -143,7 +143,6 @@ using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::Promise;
-using v8::PromiseHookType;
 using v8::PromiseRejectMessage;
 using v8::PropertyCallbackInfo;
 using v8::ScriptOrigin;
@@ -1117,58 +1116,6 @@ bool ShouldAbortOnUncaughtException(Isolate* isolate) {
 }
 
 
-void DomainPromiseHook(PromiseHookType type,
-                       Local<Promise> promise,
-                       Local<Value> parent,
-                       void* arg) {
-  Environment* env = static_cast<Environment*>(arg);
-  Local<Context> context = env->context();
-
-  if (type == PromiseHookType::kResolve) return;
-  if (type == PromiseHookType::kInit && env->in_domain()) {
-    promise->Set(context,
-                 env->domain_string(),
-                 env->domain_array()->Get(context,
-                                          0).ToLocalChecked()).FromJust();
-    return;
-  }
-
-  // Loosely based on node::MakeCallback().
-  Local<Value> domain_v =
-      promise->Get(context, env->domain_string()).ToLocalChecked();
-  if (!domain_v->IsObject())
-    return;
-
-  Local<Object> domain = domain_v.As<Object>();
-  if (domain->Get(context, env->disposed_string())
-          .ToLocalChecked()->IsTrue()) {
-    return;
-  }
-
-  if (type == PromiseHookType::kBefore) {
-    Local<Value> enter_v =
-        domain->Get(context, env->enter_string()).ToLocalChecked();
-    if (enter_v->IsFunction()) {
-      if (enter_v.As<Function>()->Call(context, domain, 0, nullptr).IsEmpty()) {
-        FatalError("node::PromiseHook",
-                   "domain enter callback threw, please report this "
-                   "as a bug in Node.js");
-      }
-    }
-  } else {
-    Local<Value> exit_v =
-        domain->Get(context, env->exit_string()).ToLocalChecked();
-    if (exit_v->IsFunction()) {
-      if (exit_v.As<Function>()->Call(context, domain, 0, nullptr).IsEmpty()) {
-        FatalError("node::MakeCallback",
-                   "domain exit callback threw, please report this "
-                   "as a bug in Node.js");
-      }
-    }
-  }
-}
-
-
 void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -1207,8 +1154,6 @@ void SetupDomainUse(const FunctionCallbackInfo<Value>& args) {
 
   Local<ArrayBuffer> array_buffer =
       ArrayBuffer::New(env->isolate(), fields, sizeof(*fields) * fields_count);
-
-  env->AddPromiseHook(DomainPromiseHook, static_cast<void*>(env));
 
   args.GetReturnValue().Set(Uint32Array::New(array_buffer, 0, fields_count));
 }
@@ -1289,12 +1234,6 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 }
 
 }  // anonymous namespace
-
-
-void AddPromiseHook(v8::Isolate* isolate, promise_hook_func fn, void* arg) {
-  Environment* env = Environment::GetCurrent(isolate);
-  env->AddPromiseHook(fn, arg);
-}
 
 
 Local<Value> MakeCallback(Environment* env,

--- a/src/node.cc
+++ b/src/node.cc
@@ -1236,6 +1236,12 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 }  // anonymous namespace
 
 
+void AddPromiseHook(v8::Isolate* isolate, promise_hook_func fn, void* arg) {
+  Environment* env = Environment::GetCurrent(isolate);
+  env->AddPromiseHook(fn, arg);
+}
+
+
 Local<Value> MakeCallback(Environment* env,
                           Local<Value> recv,
                           const Local<Function> callback,

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -47,5 +47,6 @@ function onexit() {
   assert.strictEqual(a1.type, 'PROMISE', 'promise request');
   assert.strictEqual(typeof a1.uid, 'number', 'uid is a number');
   assert.strictEqual(a1.triggerId, 1, 'parent uid 1');
+  // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const initHooks = require('./init-hooks');
+const { checkInvocations } = require('./hook-checks');
+
+const hooks = initHooks();
+
+hooks.enable();
+
+const p = (new Promise(common.mustCall(executor)));
+p.then(afterresolution);
+
+function executor(resolve, reject) {
+  const as = hooks.activitiesOfTypes('PROMISE');
+  assert.strictEqual(as.length, 1, 'one activities');
+  const a = as[0];
+  checkInvocations(a, { init: 1 }, 'while in promise executor');
+  resolve(5);
+}
+
+function afterresolution(val) {
+  assert.strictEqual(val, 5);
+  const as = hooks.activitiesOfTypes('PROMISE');
+  assert.strictEqual(as.length, 2, 'two activities');
+  checkInvocations(as[0], { init: 1 }, 'after resolution parent promise');
+  checkInvocations(as[1], { init: 1, before: 1 },
+                   'after resolution child promise');
+}
+
+process.on('exit', onexit);
+function onexit() {
+  hooks.disable();
+  hooks.sanityCheck('PROMISE');
+
+  const as = hooks.activitiesOfTypes('PROMISE');
+  assert.strictEqual(as.length, 2, 'two activities');
+
+  const a0 = as[0];
+  assert.strictEqual(a0.type, 'PROMISE', 'promise request');
+  assert.strictEqual(typeof a0.uid, 'number', 'uid is a number');
+  assert.strictEqual(a0.triggerId, 1, 'parent uid 1');
+  checkInvocations(a0, { init: 1 }, 'when process exits');
+
+  const a1 = as[1];
+  assert.strictEqual(a1.type, 'PROMISE', 'promise request');
+  assert.strictEqual(typeof a1.uid, 'number', 'uid is a number');
+  assert.strictEqual(a1.triggerId, 1, 'parent uid 1');
+  checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
+}

--- a/test/parallel/test-async-wrap-getasyncid.js
+++ b/test/parallel/test-async-wrap-getasyncid.js
@@ -66,6 +66,12 @@ function testInitialized(req, ctor_name) {
 }
 
 
+{
+  // TODO: determine the rigth way to expose promise wrap.
+  new Promise((res) => res(5));
+}
+
+
 if (common.hasCrypto) {
   const tls = require('tls');
   // SecurePair
@@ -136,7 +142,6 @@ if (common.hasCrypto) {
   const Process = process.binding('process_wrap').Process;
   testInitialized(new Process(), 'Process');
 }
-
 
 {
   const Signal = process.binding('signal_wrap').Signal;

--- a/test/parallel/test-async-wrap-getasyncid.js
+++ b/test/parallel/test-async-wrap-getasyncid.js
@@ -67,8 +67,9 @@ function testInitialized(req, ctor_name) {
 
 
 {
-  // We don't want to expose getAsyncId for promises but we need to construct one
-  // so that the cooresponding provider type is removed from the providers list.
+  // We don't want to expose getAsyncId for promises but we need to construct
+  // one so that the cooresponding provider type is removed from the
+  // providers list.
   new Promise((res) => res(5));
 }
 

--- a/test/parallel/test-async-wrap-getasyncid.js
+++ b/test/parallel/test-async-wrap-getasyncid.js
@@ -67,7 +67,8 @@ function testInitialized(req, ctor_name) {
 
 
 {
-  // TODO: determine the rigth way to expose promise wrap.
+  // We don't want to expose getAsyncId for promises but we need to construct one
+  // so that the cooresponding provider type is removed from the providers list.
   new Promise((res) => res(5));
 }
 


### PR DESCRIPTION
This change provides unified tracking of asynchronous promise lifecycles
for both domains and async hooks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_wrap,src
