### PR TITLE
src: fix --abort_on_uncaught_exception arg parsing

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3906,8 +3906,8 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--") == 0) {
       index += 1;
       break;
-    } else if (strcmp(arg, "--abort-on-uncaught-exception") ||
-               strcmp(arg, "--abort_on_uncaught_exception")) {
+    } else if (strcmp(arg, "--abort-on-uncaught-exception") == 0 ||
+               strcmp(arg, "--abort_on_uncaught_exception") == 0) {
       abort_on_uncaught_exception = true;
       // Also a V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;


### PR DESCRIPTION
Fix c0bde73f, which inadvertently introduced a use of strcmp() without
correctly comparing its return to zero. Caught by coverity:

        >>>     CID 169223:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
        >>>     The "or" condition "strcmp(arg, "--abort-on-uncaught-exception") || strcmp(arg, "--abort_on_uncaught_exception")" will always be true because "arg" cannot be equal to two different values at the same time, so it must be not equal to at least one of them.
        3909         } else if (strcmp(arg, "--abort-on-uncaught-exception") ||
        3910                    strcmp(arg, "--abort_on_uncaught_exception")) {
        3911           abort_on_uncaught_exception = true;
        3912           // Also a V8 option.  Pass through as-is.
        3913           new_v8_argv[new_v8_argc] = arg;
        3914           new_v8_argc += 1;


See: https://github.com/nodejs/node/pull/12892/files#r116055631

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src