### PR TITLE
test: improve N-API test coverage

### DIFF
--- a/test/addons-napi/test_globals/binding.gyp
+++ b/test/addons-napi/test_globals/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_globals",
+      "sources": [ "test_globals.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_globals/test.js
+++ b/test/addons-napi/test_globals/test.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+const test_globals = require(`./build/${common.buildType}/test_globals`);
+
+assert.strictEqual(test_globals.getUndefined(), undefined);
+assert.strictEqual(test_globals.getNull(), null);

--- a/test/addons-napi/test_globals/test_globals.c
+++ b/test/addons-napi/test_globals/test_globals.c
@@ -1,0 +1,26 @@
+#include <node_api.h>
+#include "../common.h"
+
+napi_value getNull(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NAPI_CALL(env, napi_get_null(env, &result));
+  return result;
+}
+
+napi_value getUndefined(napi_env env, napi_callback_info info) {
+  napi_value result;
+  NAPI_CALL(env, napi_get_undefined(env, &result));
+  return result;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("getUndefined", getUndefined),
+    DECLARE_NAPI_PROPERTY("getNull", getNull),
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
add tests top cover functions that returns globals

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, n-api