### PR TITLE
test: replace port in dgram send address types test

### DIFF
--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -3,49 +3,52 @@ const common = require('../common');
 const assert = require('assert');
 const dgram = require('dgram');
 
-const port = common.PORT;
 const buf = Buffer.from('test');
-const client = dgram.createSocket('udp4');
 
 const onMessage = common.mustCall((err, bytes) => {
   assert.ifError(err);
   assert.strictEqual(bytes, buf.length);
 }, 6);
 
-// valid address: false
-client.send(buf, port, false, onMessage);
-
-// valid address: empty string
-client.send(buf, port, '', onMessage);
-
-// valid address: null
-client.send(buf, port, null, onMessage);
-
-// valid address: 0
-client.send(buf, port, 0, onMessage);
-
-// valid address: undefined
-client.send(buf, port, undefined, onMessage);
-
-// valid address: not provided
-client.send(buf, port, onMessage);
-
 const expectedError =
   /^TypeError: Invalid arguments: address must be a nonempty string or falsy$/;
 
-// invalid address: object
-assert.throws(() => {
-  client.send(buf, port, []);
-}, expectedError);
+const client = dgram.createSocket('udp4').bind(0, () => {
 
-// invalid address: nonzero number
-assert.throws(() => {
-  client.send(buf, port, 1);
-}, expectedError);
+  const port = client.address().port;
 
-// invalid address: true
-assert.throws(() => {
-  client.send(buf, port, true);
-}, expectedError);
+  // valid address: false
+  client.send(buf, port, false, onMessage);
+
+  // valid address: empty string
+  client.send(buf, port, '', onMessage);
+
+  // valid address: null
+  client.send(buf, port, null, onMessage);
+
+  // valid address: 0
+  client.send(buf, port, 0, onMessage);
+
+  // valid address: undefined
+  client.send(buf, port, undefined, onMessage);
+
+  // valid address: not provided
+  client.send(buf, port, onMessage);
+
+  // invalid address: object
+  assert.throws(() => {
+    client.send(buf, port, []);
+  }, expectedError);
+
+  // invalid address: nonzero number
+  assert.throws(() => {
+    client.send(buf, port, 1);
+  }, expectedError);
+
+  // invalid address: true
+  assert.throws(() => {
+    client.send(buf, port, true);
+  }, expectedError);
+});
 
 client.unref();


### PR DESCRIPTION
Replaced common.PORT in the following test.
test-dgram-send-address-types.js

Ref: nodejs#12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram