### PR TITLE
test: track callback invocations

### DIFF
--- a/test/sequential/test-net-listen-shared-ports.js
+++ b/test/sequential/test-net-listen-shared-ports.js
@@ -28,19 +28,19 @@ const net = require('net');
 if (cluster.isMaster) {
   const worker1 = cluster.fork();
 
-  worker1.on('message', function(msg) {
+  worker1.on('message', common.mustCall(function(msg) {
     assert.strictEqual(msg, 'success');
     const worker2 = cluster.fork();
 
-    worker2.on('message', function(msg) {
+    worker2.on('message', common.mustCall(function(msg) {
       assert.strictEqual(msg, 'server2:EADDRINUSE');
       worker1.kill();
       worker2.kill();
-    });
-  });
+    }));
+  }));
 } else {
-  const server1 = net.createServer(common.noop);
-  const server2 = net.createServer(common.noop);
+  const server1 = net.createServer(common.mustNotCall());
+  const server2 = net.createServer(common.mustNotCall());
 
   server1.on('error', function(err) {
     // no errors expected
@@ -56,10 +56,12 @@ if (cluster.isMaster) {
     host: 'localhost',
     port: common.PORT,
     exclusive: false
-  }, function() {
-    server2.listen({port: common.PORT + 1, exclusive: true}, function() {
-      // the first worker should succeed
-      process.send('success');
-    });
-  });
+  }, common.mustCall(function() {
+    server2.listen({port: common.PORT + 1, exclusive: true},
+                   common.mustCall(function() {
+                     // the first worker should succeed
+                     process.send('success');
+                   })
+    );
+  }));
 }


### PR DESCRIPTION
Use `common.mustCall()` and `common.mustNotCall()` to check that
callbacks are invoked the expected number of times in
test-net-listen-shared-ports.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net