### PR TITLE
util,console: guard against overwritten util functions

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const util = require('util');
+const {format, inspect} = require('util');
 
 function Console(stdout, stderr, ignoreErrors = true) {
   if (!(this instanceof Console)) {
@@ -103,7 +103,7 @@ function write(ignoreErrors, stream, string, errorhandler) {
 Console.prototype.log = function log(...args) {
   write(this._ignoreErrors,
         this._stdout,
-        `${util.format.apply(null, args)}\n`,
+        `${format.apply(null, args)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -114,7 +114,7 @@ Console.prototype.info = Console.prototype.log;
 Console.prototype.warn = function warn(...args) {
   write(this._ignoreErrors,
         this._stderr,
-        `${util.format.apply(null, args)}\n`,
+        `${format.apply(null, args)}\n`,
         this._stderrErrorHandler);
 };
 
@@ -126,7 +126,7 @@ Console.prototype.dir = function dir(object, options) {
   options = Object.assign({customInspect: false}, options);
   write(this._ignoreErrors,
         this._stdout,
-        `${util.inspect(object, options)}\n`,
+        `${inspect(object, options)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -154,7 +154,7 @@ Console.prototype.trace = function trace(...args) {
   // exposed.
   var err = new Error();
   err.name = 'Trace';
-  err.message = util.format.apply(null, args);
+  err.message = format.apply(null, args);
   Error.captureStackTrace(err, trace);
   this.error(err.stack);
 };
@@ -162,7 +162,7 @@ Console.prototype.trace = function trace(...args) {
 
 Console.prototype.assert = function assert(expression, ...args) {
   if (!expression) {
-    require('assert').ok(false, util.format.apply(null, args));
+    require('assert').ok(false, format.apply(null, args));
   }
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,7 @@ function tryStringify(arg) {
   }
 }
 
-exports.format = function(f) {
+function format(f) {
   if (typeof f !== 'string') {
     const objects = new Array(arguments.length);
     for (var index = 0; index < arguments.length; index++) {
@@ -141,8 +141,8 @@ exports.format = function(f) {
     }
   }
   return str;
-};
-
+}
+exports.format = format;
 
 exports.deprecate = internalUtil.deprecate;
 
@@ -157,7 +157,7 @@ exports.debuglog = function(set) {
     if (new RegExp(`\\b${set}\\b`, 'i').test(debugEnviron)) {
       var pid = process.pid;
       debugs[set] = function() {
-        var msg = exports.format.apply(exports, arguments);
+        var msg = format.apply(exports, arguments);
         console.error('%s %d: %s', set, pid, msg);
       };
     } else {
@@ -936,7 +936,7 @@ function timestamp() {
 
 // log is just a thin wrapper to console.log that prepends a timestamp
 exports.log = function() {
-  console.log('%s - %s', timestamp(), exports.format.apply(exports, arguments));
+  console.log('%s - %s', timestamp(), format.apply(exports, arguments));
 };
 
 
@@ -1056,6 +1056,6 @@ exports._exceptionWithHostPort = function(err,
 
 // process.versions needs a custom function as some values are lazy-evaluated.
 process.versions[exports.inspect.custom] =
-  (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));
+  (depth) => format(JSON.parse(JSON.stringify(process.versions)));
 
 exports.promisify = internalUtil.promisify;

--- a/test/parallel/test-util-log.js
+++ b/test/parallel/test-util-log.js
@@ -27,33 +27,50 @@ const util = require('util');
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);
 
-const stdout_write = global.process.stdout.write;
-const strings = [];
-global.process.stdout.write = function(string) {
-  strings.push(string);
+const runTests = () => {
+  const stdout_write = global.process.stdout.write;
+  const strings = [];
+  global.process.stdout.write = function(string) {
+    strings.push(string);
+  };
+  console._stderr = process.stdout;
+
+  const tests = [
+    {input: 'foo', output: 'foo'},
+    {input: undefined, output: 'undefined'},
+    {input: null, output: 'null'},
+    {input: false, output: 'false'},
+    {input: 42, output: '42'},
+    {input: function() {}, output: '[Function: input]'},
+    {input: parseInt('not a number', 10), output: 'NaN'},
+    {input: {answer: 42}, output: '{ answer: 42 }'},
+    {input: [1, 2, 3], output: '[ 1, 2, 3 ]'}
+  ];
+
+  // test util.log()
+  tests.forEach(function(test) {
+    util.log(test.input);
+    const result = strings.shift().trim();
+    const re = (/[0-9]{1,2} [A-Z][a-z]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} - (.+)$/);
+    const match = re.exec(result);
+    assert.ok(match);
+    assert.strictEqual(match[1], test.output);
+  });
+
+  global.process.stdout.write = stdout_write;
 };
-console._stderr = process.stdout;
 
-const tests = [
-  {input: 'foo', output: 'foo'},
-  {input: undefined, output: 'undefined'},
-  {input: null, output: 'null'},
-  {input: false, output: 'false'},
-  {input: 42, output: '42'},
-  {input: function() {}, output: '[Function: input]'},
-  {input: parseInt('not a number', 10), output: 'NaN'},
-  {input: {answer: 42}, output: '{ answer: 42 }'},
-  {input: [1, 2, 3], output: '[ 1, 2, 3 ]'}
-];
+runTests();
 
-// test util.log()
-tests.forEach(function(test) {
-  util.log(test.input);
-  const result = strings.shift().trim();
-  const re = (/[0-9]{1,2} [A-Z][a-z]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} - (.+)$/);
-  const match = re.exec(result);
-  assert.ok(match);
-  assert.strictEqual(match[1], test.output);
-});
+// run tests again with monkey-patched util.format()
+{
+  const saveFormat = util.format;
+  util.format = () => {
+    assert.fail('monkey-patched util.format() should not be invoked');
+  };
 
-global.process.stdout.write = stdout_write;
+  runTests();
+
+  // restore util.format to avoid side effects
+  util.format = saveFormat;
+}

--- a/test/sequential/test-util-debug-monkeypatched.js
+++ b/test/sequential/test-util-debug-monkeypatched.js
@@ -1,0 +1,92 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (process.argv[2] === 'child')
+  child();
+else
+  parent();
+
+function parent() {
+  test('foo,tud,bar', true);
+  test('foo,tud', true);
+  test('tud,bar', true);
+  test('tud', true);
+  test('foo,bar', false);
+  test('', false);
+}
+
+function test(environ, shouldWrite) {
+  let expectErr = '';
+  if (shouldWrite) {
+    expectErr = 'TUD %PID%: this { is: \'a\' } /debugging/\n' +
+                'TUD %PID%: number=1234 string=asdf obj={"foo":"bar"}\n';
+  }
+  const expectOut = 'ok\n';
+
+  const spawn = require('child_process').spawn;
+  const child = spawn(process.execPath, [__filename, 'child'], {
+    env: Object.assign(process.env, { NODE_DEBUG: environ })
+  });
+
+  expectErr = expectErr.split('%PID%').join(child.pid);
+
+  let err = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (c) => {
+    err += c;
+  });
+
+  let out = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (c) => {
+    out += c;
+  });
+
+  child.on('close', common.mustCall((c) => {
+    assert(!c);
+    assert.strictEqual(err, expectErr);
+    assert.strictEqual(out, expectOut);
+  }));
+}
+
+
+function child() {
+  const util = require('util');
+
+  // monkey-patch util.format() to confirm debuglog() will work correctly anyway
+  const saveFormat = util.format;
+  util.format = () => {
+    assert.fail('monkey-patched util.format() should not be invoked');
+  };
+
+  const debug = util.debuglog('tud');
+  debug('this', { is: 'a' }, /debugging/);
+  debug('number=%d string=%s obj=%j', 1234, 'asdf', { foo: 'bar' });
+
+  // restore util.format to avoid side effects
+  util.format = saveFormat;
+
+  console.log('ok');
+}


### PR DESCRIPTION
Some functions in util and console will happily invoke other functions
in `util` that have been overridden. The internal use of
these functions is an implementation detail and users should not be able
to indirectly affect them this way.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util console