### PR TITLE
cmd: support dash as stdin alias

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -10,7 +10,7 @@ To view this documentation as a manual page in a terminal, run `man node`.
 
 ## Synopsis
 
-`node [options] [v8 options] [script.js | -e "script"] [--] [arguments]`
+`node [options] [v8 options] [script.js | -e "script" | -] [--] [arguments]`
 
 `node debug [script.js | -e "script" | <host>:<port>] …`
 
@@ -344,6 +344,17 @@ added: v0.11.15
 -->
 
 Specify ICU data load path. (overrides `NODE_ICU_DATA`)
+
+
+### `-`
+<!-- YAML
+added: REPLACEME
+-->
+
+Alias for stdin, analogous to the use of - in other command line utilities,
+meaning that the script will be read from stdin, and the rest of the options
+are passed to that script.
+
 
 ### `--`
 <!-- YAML

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -2,7 +2,7 @@
 
 <!--type=misc-->
 
-`node [options] [v8 options] [script.js | -e "script"] [arguments]`
+`node [options] [v8 options] [script.js | -e "script" | - ] [arguments]`
 
 Please see the [Command Line Options][] document for information about
 different options and ways to run scripts with Node.js.

--- a/doc/node.1
+++ b/doc/node.1
@@ -36,7 +36,10 @@ node \- Server-side JavaScript runtime
 .RI [ v8\ options ]
 .RI [ script.js \ |
 .B -e
-.RI \&" script \&"]
+.RI \&" script \&"
+.R |
+.B -
+.R ]
 .B [--]
 .RI [ arguments ]
 .br
@@ -224,6 +227,12 @@ See \fBSSL_CERT_DIR\fR and \fBSSL_CERT_FILE\fR.
 .TP
 .BR \-\-icu\-data\-dir =\fIfile\fR
 Specify ICU data load path. (overrides \fBNODE_ICU_DATA\fR)
+
+.TP
+.BR \-\fR
+Alias for stdin, analogous to the use of - in other command line utilities,
+meaning that the script will be read from stdin, and the rest of the options
+are passed to that script.
 
 .TP
 .BR \-\-\fR

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -123,7 +123,7 @@
         const internalModule = NativeModule.require('internal/module');
         internalModule.addBuiltinLibsToObject(global);
         evalScript('[eval]');
-      } else if (process.argv[1]) {
+      } else if (process.argv[1] && process.argv[1] !== '-') {
         // make process.argv[1] into a full path
         const path = NativeModule.require('path');
         process.argv[1] = path.resolve(process.argv[1]);

--- a/src/node.cc
+++ b/src/node.cc
@@ -3586,7 +3586,7 @@ void LoadEnvironment(Environment* env) {
 static void PrintHelp() {
   // XXX: If you add an option here, please also add it to doc/node.1 and
   // doc/api/cli.md
-  printf("Usage: node [options] [ -e script | script.js ] [arguments]\n"
+  printf("Usage: node [options] [ -e script | script.js | - ] [arguments]\n"
          "       node inspect script.js [arguments]\n"
          "\n"
          "Options:\n"
@@ -3598,6 +3598,8 @@ static void PrintHelp() {
          "                             does not appear to be a terminal\n"
          "  -r, --require              module to preload (option can be "
          "repeated)\n"
+         "  -                          script read from stdin (default; "
+         "interactive mode if a tty)"
 #if HAVE_INSPECTOR
          "  --inspect[=[host:]port]    activate inspector on host:port\n"
          "                             (default: 127.0.0.1:9229)\n"
@@ -3903,6 +3905,8 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       config_expose_internals = true;
+    } else if (strcmp(arg, "-") == 0) {
+      break;
     } else if (strcmp(arg, "--") == 0) {
       index += 1;
       break;

--- a/test/parallel/test-stdin-script-child-option.js
+++ b/test/parallel/test-stdin-script-child-option.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+const expected = '--option-to-be-seen-on-child';
+
+const { spawn } = require('child_process');
+const child = spawn(process.execPath, ['-', expected], { stdio: 'pipe' });
+
+child.stdin.end('console.log(process.argv[2])');
+
+let actual = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (chunk) => actual += chunk);
+child.stdout.on('end', common.mustCall(() => {
+  assert.strictEqual(actual.trim(), expected);
+}));

--- a/test/parallel/test-stdin-script-child.js
+++ b/test/parallel/test-stdin-script-child.js
@@ -2,31 +2,32 @@
 const common = require('../common');
 const assert = require('assert');
 
-const spawn = require('child_process').spawn;
-const child = spawn(process.execPath, [], {
-  env: Object.assign(process.env, {
-    NODE_DEBUG: process.argv[2]
-  })
-});
-const wanted = `${child.pid}\n`;
-let found = '';
+const { spawn } = require('child_process');
+for (const args of [[], ['-']]) {
+  const child = spawn(process.execPath, args, {
+    env: Object.assign(process.env, {
+      NODE_DEBUG: process.argv[2]
+    })
+  });
+  const wanted = `${child.pid}\n`;
+  let found = '';
 
-child.stdout.setEncoding('utf8');
-child.stdout.on('data', function(c) {
-  found += c;
-});
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', function(c) {
+    found += c;
+  });
 
-child.stderr.setEncoding('utf8');
-child.stderr.on('data', function(c) {
-  console.error(`> ${c.trim().split(/\n/).join('\n> ')}`);
-});
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', function(c) {
+    console.error(`> ${c.trim().split(/\n/).join('\n> ')}`);
+  });
 
-child.on('close', common.mustCall(function(c) {
-  assert.strictEqual(c, 0);
-  assert.strictEqual(found, wanted);
-  console.log('ok');
-}));
+  child.on('close', common.mustCall(function(c) {
+    assert.strictEqual(c, 0);
+    assert.strictEqual(found, wanted);
+  }));
 
-setTimeout(function() {
-  child.stdin.end('console.log(process.pid)');
-}, 1);
+  setTimeout(function() {
+    child.stdin.end('console.log(process.pid)');
+  }, 1);
+}


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
(some of the tests are failing regardless of my change AFAICS so I assume this as passed)
- [x] tests and/or benchmarks are included
(an available test is modified to cover this, and a more specific one also added)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
cli



Dash as stdin alias is a usual convention between unix programs https://unix.stackexchange.com/a/16364 and I believe it should be available on nodejs also.

Here I've made a change that make node ignore dash as an option so it will effectively be treated like /dev/stdin

Simply, with my change this will be made possible with node:

`echo "console.log(process.argv[2])" | node - --option-for-stdin-script`

The reason I like to have this is because of my one-file webserver http://pad.js.org which in order to be able to pass extra option to its one-linear execution command on the fly (without having to download or install the script first, which it supports that also through npm and docker). BTW, have a look at that project also, I guess you will find it interesting, specially the way its source is distributed and several features it offers :)

Interesting fact I saw during my tests is if I pass "/std/stdin" instead "-" on the above command, even without my change, it will be ran on macOS just fine but for some reasons it seems it doesn't work on Linux equally which perhaps should be filed as a bug separately (**Edited:** [proposed another patch for that](https://github.com/nodejs/node/pull/13028)). However with this change, "-" will provide a cross platform solution for achieving this goal.

For my specific case, this patch will make this functionality possible:

`curl pad.js.org | node - -h`

which as mentioned before if you have access to macOS, this is already possible with the following command, but not on Linux and obviously ever Windows:

`curl pad.js.org | node /dev/stdin -h`

Thanks.