### PR TITLE
n-api: remove compiler warning

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2781,7 +2781,7 @@ class Work {
       // report it as a fatal exception. (There is no JavaScript on the
       // callstack that can possibly handle it.)
       if (!env->last_exception.IsEmpty()) {
-        v8::TryCatch try_catch;
+        v8::TryCatch try_catch(env->isolate);
         env->isolate->ThrowException(
           v8::Local<v8::Value>::New(env->isolate, env->last_exception));
         node::FatalException(env->isolate, try_catch);


### PR DESCRIPTION
`TryCatch` without an `Isolate*` argument is deprecated, so add one.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

n-api