### PR TITLE
fs: fix realpath{Sync} on resolving pipes/sockets

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1840,6 +1840,9 @@ Synchronous version of [`fs.read()`][]. Returns the number of `bytesRead`.
 <!-- YAML
 added: v0.1.31
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/13028
+    description: Pipe/Socket resolve support was added.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using
@@ -1872,10 +1875,16 @@ object with an `encoding` property specifying the character encoding to use for
 the path passed to the callback. If the `encoding` is set to `'buffer'`,
 the path returned will be passed as a `Buffer` object.
 
+*Note*: If `path` resolves to a socket or a pipe, the function will return a
+system dependent name for that object.
+
 ## fs.realpathSync(path[, options])
 <!-- YAML
 added: v0.1.31
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/13028
+    description: Pipe/Socket resolve support was added.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using
@@ -1901,6 +1910,9 @@ The optional `options` argument can be a string specifying an encoding, or an
 object with an `encoding` property specifying the character encoding to use for
 the returned value. If the `encoding` is set to `'buffer'`, the path returned
 will be passed as a `Buffer` object.
+
+*Note*: If `path` resolves to a socket or a pipe, the function will return a
+system dependent name for that object.
 
 ## fs.rename(oldPath, newPath, callback)
 <!-- YAML

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -25,7 +25,7 @@
 'use strict';
 
 const constants = process.binding('constants').fs;
-const { S_IFMT, S_IFREG, S_IFLNK } = constants;
+const { S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK } = constants;
 const util = require('util');
 const pathModule = require('path');
 const { isUint8Array } = process.binding('util');
@@ -228,11 +228,11 @@ Stats.prototype.isSymbolicLink = function() {
 };
 
 Stats.prototype.isFIFO = function() {
-  return this._checkModeProperty(constants.S_IFIFO);
+  return this._checkModeProperty(S_IFIFO);
 };
 
 Stats.prototype.isSocket = function() {
-  return this._checkModeProperty(constants.S_IFSOCK);
+  return this._checkModeProperty(S_IFSOCK);
 };
 
 const statValues = binding.getStatValues();
@@ -1625,8 +1625,12 @@ fs.realpathSync = function realpathSync(p, options) {
       pos = result + 1;
     }
 
-    // continue if not a symlink
+    // continue if not a symlink, break if a pipe/socket
     if (knownHard[base] || (cache && cache.get(base) === base)) {
+      if ((statValues[1/*mode*/] & S_IFMT) === S_IFIFO ||
+          (statValues[1/*mode*/] & S_IFMT) === S_IFSOCK) {
+        break;
+      }
       continue;
     }
 
@@ -1752,8 +1756,12 @@ fs.realpath = function realpath(p, options, callback) {
       pos = result + 1;
     }
 
-    // continue if not a symlink
+    // continue if not a symlink, break if a pipe/socket
     if (knownHard[base]) {
+      if ((statValues[1/*mode*/] & S_IFMT) === S_IFIFO ||
+          (statValues[1/*mode*/] & S_IFMT) === S_IFSOCK) {
+        return callback(null, encodeRealpathResult(p, options));
+      }
       return process.nextTick(LOOP);
     }
 

--- a/test/parallel/test-fs-realpath-pipe.js
+++ b/test/parallel/test-fs-realpath-pipe.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+
+if (common.isWindows || common.isAix) {
+  common.skip(`No /dev/stdin on ${process.platform}.`);
+  return;
+}
+
+const assert = require('assert');
+
+const { spawnSync } = require('child_process');
+
+for (const code of [
+  `require('fs').realpath('/dev/stdin', (err, resolvedPath) => {
+    if (err) {
+      process.exit(1);
+    }
+    if (resolvedPath) {
+      process.exit(2);
+    }
+  });`,
+  `try {
+    if (require('fs').realpathSync('/dev/stdin')) {
+      process.exit(2);
+    }
+  } catch (e) {
+    process.exit(1);
+  }`
+]) {
+  assert.strictEqual(spawnSync(process.execPath, ['-e', code], {
+    stdio: 'pipe'
+  }).status, 2);
+}


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs

Currently

`echo "" | node -e "require('fs').realpath('/dev/stdin', console.log)"`

and 

`echo "" | node -e "console.log(require('fs').realpathSync('/dev/stdin'))"`

are broken due to our logic of realpath and this patch changes node in a way to match python:

`echo "" | python -c "import os; print(os.path.realpath('/dev/stdin'))"`