### PR TITLE
test: move net reconnect error test to sequential

### DIFF
--- a/test/sequential/test-net-reconnect-error.js
+++ b/test/sequential/test-net-reconnect-error.js
@@ -27,22 +27,19 @@ const N = 20;
 let client_error_count = 0;
 let disconnect_count = 0;
 
-// Hopefully nothing is running on common.PORT
 const c = net.createConnection(common.PORT);
 
 c.on('connect', common.mustNotCall('client should not have connected'));
 
-c.on('error', function(e) {
-  console.error(`CLIENT error: ${e.code}`);
+c.on('error', common.mustCall((e) => {
   client_error_count++;
   assert.strictEqual('ECONNREFUSED', e.code);
-});
+}, N + 1));
 
-c.on('close', function() {
-  console.log('CLIENT disconnect');
+c.on('close', common.mustCall(() => {
   if (disconnect_count++ < N)
     c.connect(common.PORT); // reconnect
-});
+}, N + 1));
 
 process.on('exit', function() {
   assert.strictEqual(N + 1, disconnect_count);


### PR DESCRIPTION
The usage of common.PORT could cause undesired port collisions when run
in parallel. The following test was moved to sequential.
test-net-reconnect-error.js

Ref: nodejs#12376

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net