### PR TITLE
test: Improve N-API test coverage

### DIFF
--- a/test/addons-napi/test_general/binding.gyp
+++ b/test/addons-napi/test_general/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_general",
+      "sources": [ "test_general.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -22,7 +22,7 @@ assert.ok(test_general.testStrictEquals(val1, val1));
 assert.strictEqual(test_general.testStrictEquals(val1, val2), false);
 assert.ok(test_general.testStrictEquals(val2, val3));
 
-// test napi_strict_equals
+// test napi_get_prototype
 assert.strictEqual(test_general.testGetPrototype(baseObject),
                    Object.getPrototypeOf(baseObject));
 assert.strictEqual(test_general.testGetPrototype(extendedObject),

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../../common');
+const test_general = require(`./build/${common.buildType}/test_general`);
+const assert = require('assert');
+
+const val1 = '1';
+const val2 = 1;
+const val3 = 1;
+
+class BaseClass {
+}
+
+class ExtendedClass extends BaseClass {
+}
+
+const baseObject = new BaseClass();
+const extendedObject = new ExtendedClass();
+
+// test napi_strict_equals
+assert.ok(test_general.testStrictEquals(val1, val1));
+assert.strictEqual(test_general.testStrictEquals(val1, val2), false);
+assert.ok(test_general.testStrictEquals(val2, val3));
+
+// test napi_strict_equals
+assert.strictEqual(test_general.testGetPrototype(baseObject),
+                   Object.getPrototypeOf(baseObject));
+assert.strictEqual(test_general.testGetPrototype(extendedObject),
+                   Object.getPrototypeOf(extendedObject));
+assert.ok(test_general.testGetPrototype(baseObject) !==
+          test_general.testGetPrototype(extendedObject),
+          'Prototypes for base and extended should be different');

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -1,0 +1,38 @@
+#include <node_api.h>
+#include "../common.h"
+
+napi_value testStrictEquals(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  bool bool_result;
+  napi_value result;
+  NAPI_CALL(env, napi_strict_equals(env, args[0], args[1], &bool_result));
+  NAPI_CALL(env, napi_get_boolean(env, bool_result, &result));
+
+  return result;
+}
+
+napi_value testGetPrototype(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value result;
+  NAPI_CALL(env, napi_get_prototype(env, args[0], &result));
+
+  return result;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("testStrictEquals", testStrictEquals),
+    DECLARE_NAPI_PROPERTY("testGetPrototype", testGetPrototype),
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
- add coverage for napi_get_prototype
- add coverage for napi_strict_equals

Continue to chip away at missing coverage in my spare time.

Instead of creating addons for each of these I combined
them into test_general as they did not seem naturally
group with other functions. I was thinking that we
want less rather than more test addons, as each one adds to
the overall build time.  If there is general agreement
with that I might move some of the other existing tests
into test_general in cases were there is only 1 or 2
functions being tested in the existing grouping.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test, n-api