### PR TITLE
dns: fix crash while using dns.setServers after dns.resolve4

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -482,9 +482,12 @@ class QueryWrap : public AsyncWrap {
       unsigned char* answer_buf, int answer_len) {
     QueryWrap* wrap = static_cast<QueryWrap*>(arg);
 
-    unsigned char* buf_copy = (unsigned char*)node::Malloc(
-        sizeof(unsigned char) * answer_len);
-    memcpy(buf_copy, answer_buf, sizeof(unsigned char) * answer_len);
+    unsigned char* buf_copy = nullptr;
+    if (status == ARES_SUCCESS) {
+      buf_copy = (unsigned char*)node::Malloc(
+          sizeof(unsigned char) * answer_len);
+      memcpy(buf_copy, answer_buf, sizeof(unsigned char) * answer_len);
+    }
 
     struct CaresAsyncData* data = new struct CaresAsyncData();
     data->status = status;
@@ -504,11 +507,16 @@ class QueryWrap : public AsyncWrap {
       struct hostent* host) {
     QueryWrap* wrap = static_cast<QueryWrap*>(arg);
 
-    struct hostent* host_copy = (struct hostent*)node::Malloc(sizeof(hostent));
-    int ret = cares_wrap_hostent_cpy(host_copy, host);
+    struct hostent* host_copy = nullptr;
+    int copy_ret = 0;
+
+    if (status == ARES_SUCCESS) {
+      host_copy = (struct hostent*)node::Malloc(sizeof(hostent));
+      copy_ret = cares_wrap_hostent_cpy(host_copy, host);
+    }
 
     struct CaresAsyncData* data = new struct CaresAsyncData();
-    if (ret == 0) {
+    if (copy_ret == 0) {
       data->status = status;
       data->buf = host_copy;
     } else {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -351,6 +351,7 @@ void cares_wrap_hostent_cpy(struct hostent* dest, struct hostent* src) {
     dest->h_aliases[i] = node::Malloc(cur_alias_length + 1);
     memcpy(dest->h_aliases[i], src->h_aliases[i], cur_alias_length + 1);
   }
+  dest->h_aliases[alias_count] = nullptr;
 
   /* copy `h_addr_list` */
   size_t list_count;
@@ -364,6 +365,7 @@ void cares_wrap_hostent_cpy(struct hostent* dest, struct hostent* src) {
     dest->h_addr_list[i] = node::Malloc(src->h_length);
     memcpy(dest->h_addr_list[i], src->h_addr_list[i], src->h_length);
   }
+  dest->h_addr_list[list_count] = nullptr;
 
   /* work after work */
   dest->h_length = src->h_length;

--- a/test/internet/test-dns-setserver-in-callback-of-resolve4.js
+++ b/test/internet/test-dns-setserver-in-callback-of-resolve4.js
@@ -1,9 +1,8 @@
 'use strict';
 
-// Refs: https://github.com/nodejs/node/pull/13050
-// We don't care about `err` in the callback function of `dns.resolve4` here.
-// We just want to test whether `dns.setServers` here in the callback of
-// `resolve4` will crash or not. If no crashing here, the test is succeeded.
+// We don't care about `err` in the callback function of `dns.resolve4`. We just
+// want to test whether `dns.setServers` that is run after `resolve4` will cause
+// a crash or not. If it doesn't crash, the test succeeded.
 
 const common = require('../common');
 const dns = require('dns');

--- a/test/internet/test-dns-setserver-in-callback-of-resolve4.js
+++ b/test/internet/test-dns-setserver-in-callback-of-resolve4.js
@@ -1,17 +1,13 @@
 'use strict';
 
+// Refs: https://github.com/nodejs/node/pull/13050
+// We don't care about `err` in the callback function of `dns.resolve4` here.
+// We just want to test whether `dns.setServers` here in the callback of
+// `resolve4` will crash or not. If no crashing here, the test is succeeded.
+
 const common = require('../common');
 const dns = require('dns');
 
 dns.resolve4('google.com', common.mustCall(function(/* err, nameServers */) {
-  // do not care about `err` and `nameServers`,
-  // both failed and succeeded would be OK.
-  //
-  // just to test crash
-
   dns.setServers([ '8.8.8.8' ]);
-
-  // the test case shouldn't crash here
-  // see https://github.com/nodejs/node/pull/13050 and
-  // https://github.com/nodejs/node/issues/894
 }));

--- a/test/internet/test-dns-setserver-in-callback-of-resolve4.js
+++ b/test/internet/test-dns-setserver-in-callback-of-resolve4.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const dns = require('dns');
+
+dns.resolve4('google.com', common.mustCall(function(/* err, nameServers */) {
+  // do not care about `err` and `nameServers`,
+  // both failed and succeeded would be OK.
+  //
+  // just to test crash
+
+  dns.setServers([ '8.8.8.8' ]);
+
+  // the test case shouldn't crash here
+  // see https://github.com/nodejs/node/pull/13050 and
+  // https://github.com/nodejs/node/issues/894
+}));


### PR DESCRIPTION
The callback function in `cares_query` is synchronous and called before closed. So `dns.setServers` in the synchronous callback before closed will occur crashing.

This PR makes the real callback of `dns.resolve4` or some other functions in `dns` asynchronous to resolve this problem.

##### Solution

I use `uv_async_t` to send the `callback` task to next loop. And the task data is created from `CaresAsyncData`.

Because `Callback` has two functions with parameters `hostent*` or `unsigned char*, int`, `CaresAsyncData` has a flag `is_host` to distinguish them.

In the `Callback` function, whether `hostent*` or `unsigned char*` will be destroyed after this function is done. So I make a copy for those buffers for asynchronous use. In the asynchronous function and asynchronous done callback, I delete some related pointers.

Related Issue: #894 #1071

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

dns