### PR TITLE
src: check if --icu-data-dir= points to valid dir

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4342,8 +4342,11 @@ void Init(int* argc,
   // Initialize ICU.
   // If icu_data_dir is empty here, it will load the 'minimal' data.
   if (!i18n::InitializeICUDirectory(icu_data_dir)) {
-    FatalError(nullptr, "Could not initialize ICU "
-                     "(check NODE_ICU_DATA or --icu-data-dir parameters)");
+    fprintf(stderr,
+            "%s: could not initialize ICU "
+            "(check NODE_ICU_DATA or --icu-data-dir parameters)",
+            argv[0]);
+    exit(9);
   }
 #endif
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -55,6 +55,7 @@
 #include <unicode/utypes.h>
 #include <unicode/putil.h>
 #include <unicode/uchar.h>
+#include <unicode/uclean.h>
 #include <unicode/udata.h>
 #include <unicode/uidna.h>
 #include <unicode/ucnv.h>
@@ -418,19 +419,19 @@ void GetVersion(const FunctionCallbackInfo<Value>& args) {
 }  // anonymous namespace
 
 bool InitializeICUDirectory(const std::string& path) {
+  UErrorCode status = U_ZERO_ERROR;
   if (path.empty()) {
-    UErrorCode status = U_ZERO_ERROR;
 #ifdef NODE_HAVE_SMALL_ICU
     // install the 'small' data.
     udata_setCommonData(&SMALL_ICUDATA_ENTRY_POINT, &status);
 #else  // !NODE_HAVE_SMALL_ICU
     // no small data, so nothing to do.
 #endif  // !NODE_HAVE_SMALL_ICU
-    return (status == U_ZERO_ERROR);
   } else {
     u_setDataDirectory(path.c_str());
-    return true;  // No error.
+    u_init(&status);
   }
+  return status == U_ZERO_ERROR;
 }
 
 int32_t ToUnicode(MaybeStackBuffer<char>* buf,

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -57,7 +57,6 @@ if (common.hasCrypto) {
   expect('--use-bundled-ca', 'B\n');
   expect('--openssl-config=_ossl_cfg', 'B\n');
 }
-expect('--icu-data-dir=_d', 'B\n');
 
     // V8 options
 expect('--max_old_space_size=0', 'B\n');

--- a/test/parallel/test-icu-data-dir.js
+++ b/test/parallel/test-icu-data-dir.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const expected =
+    'could not initialize ICU ' +
+    '(check NODE_ICU_DATA or --icu-data-dir parameters)';
+
+{
+  const child = spawnSync(process.execPath, ['--icu-data-dir=/', '-e', '0']);
+  assert(child.stderr.toString().includes(expected));
+}
+
+{
+  const env = { NODE_ICU_DATA: '/' };
+  const child = spawnSync(process.execPath, ['-e', '0'], { env });
+  assert(child.stderr.toString().includes(expected));
+}

--- a/test/parallel/test-intl-no-icu-data.js
+++ b/test/parallel/test-intl-no-icu-data.js
@@ -1,8 +1,0 @@
-// Flags: --icu-data-dir=test/fixtures/empty/
-'use strict';
-require('../common');
-const assert = require('assert');
-const config = process.binding('config');
-
-assert.deepStrictEqual(Intl.NumberFormat.supportedLocalesOf('en'), []);
-assert.strictEqual(config.icuDataDir, 'test/fixtures/empty/');


### PR DESCRIPTION
Call uc_init() after u_setDataDirectory() to find out if the data
directory is actually valid.

This commit removes parallel/test-intl-no-icu-data, added in commit
46345b9 ("src: make --icu-data-dir= switch testable").  It no longer
works now that an invalid --icu-data-dir= argument is rejected.
Coverage is now provided by abort/test-abort-icu-data-dir.

Note that a bad path is now a fatal error, not a silent error.  I could make node print a warning and fall back to the builtin i18n data (if `#ifdef NODE_HAVE_SMALL_ICU`) but I don't know if ICU supports initializing twice.  It seems to works for me locally with the patch below,  /cc @srl295.
```diff
diff --git a/src/node_i18n.cc b/src/node_i18n.cc
index 30394f3..e85e115 100644
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -430,6 +430,12 @@ bool InitializeICUDirectory(const std::string& path) {
   } else {
     u_setDataDirectory(path.c_str());
     u_init(&status);
+#ifdef NODE_HAVE_SMALL_ICU
+    if (status != U_ZERO_ERROR) {
+      status = U_ZERO_ERROR;
+      udata_setCommonData(&SMALL_ICUDATA_ENTRY_POINT, &status);
+    }
+#endif  // !NODE_HAVE_SMALL_ICU
   }
   return status == U_ZERO_ERROR;
 }
```