### PR TITLE
test: fix sequential test-net-connect-local-error

### DIFF
--- a/test/sequential/test-net-connect-local-error.js
+++ b/test/sequential/test-net-connect-local-error.js
@@ -3,28 +3,23 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
+// EADDRINUSE is expected to occur on FreeBSD
+// Please see https://github.com/nodejs/node/issues/13055 for more details
+const expectedErrorCodes = ['ECONNREFUSED', 'EADDRINUSE'];
 const client = net.connect({
-  port: common.PORT + 1,
-  localPort: common.PORT,
+  port: common.PORT,
+  localPort: common.PORT + 1,
   localAddress: common.localhostIPv4
 });
 
 client.on('error', common.mustCall(function onError(err) {
+  assert.ok(expectedErrorCodes.includes(err.code));
   assert.strictEqual(err.syscall, 'connect');
-  assert.strictEqual(err.code, 'ECONNREFUSED');
-  assert.strictEqual(
-    err.localPort,
-    common.PORT,
-    `${err.localPort} !== ${common.PORT} in ${err}`
-  );
-  assert.strictEqual(
-    err.localAddress,
-    common.localhostIPv4,
-    `${err.localAddress} !== ${common.localhostIPv4} in ${err}`
-  );
+  assert.strictEqual(err.localPort, common.PORT + 1);
+  assert.strictEqual(err.localAddress, common.localhostIPv4);
   assert.strictEqual(
     err.message,
-    `connect ECONNREFUSED ${err.address}:${err.port} ` +
+    `connect ${err.code} ${err.address}:${err.port} ` +
     `- Local (${err.localAddress}:${err.localPort})`
   );
 }));


### PR DESCRIPTION
Fixed sequential test-net-connect-local-error by swapping port and localPort in net.connect options.

Fixes: https://github.com/nodejs/node/issues/13055

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
