### PR TITLE
stream: check type and range of highWaterMark

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -68,11 +68,21 @@ function ReadableState(options, stream) {
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
+  if (hwm == null) {
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = defaultHwm;
+  } else {
+    if (typeof hwm !== 'number') {
+      throw new TypeError('"highWaterMark" must be a number');
+    }
 
-  // cast to ints.
-  this.highWaterMark = Math.floor(this.highWaterMark);
+    if (hwm < 0) {
+      throw new RangeError('"highWaterMark" must not be negative');
+    }
+
+    // cast to ints.
+    this.highWaterMark = Math.floor(hwm);
+  }
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -69,8 +69,7 @@ function ReadableState(options, stream) {
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
   if (hwm == null) {
-    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-    this.highWaterMark = defaultHwm;
+    this.highWaterMark = this.objectMode ? 16 : 16 * 1024;
   } else {
     if (typeof hwm !== 'number') {
       throw new TypeError('"highWaterMark" must be a number');

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -51,11 +51,21 @@ function WritableState(options, stream) {
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = (hwm || hwm === 0) ? hwm : defaultHwm;
+  if (hwm == null) {
+    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
+    this.highWaterMark = defaultHwm;
+  } else {
+    if (typeof hwm !== 'number') {
+      throw new TypeError('"highWaterMark" must be a number');
+    }
 
-  // cast to ints.
-  this.highWaterMark = Math.floor(this.highWaterMark);
+    if (hwm < 0) {
+      throw new RangeError('"highWaterMark" must not be negative');
+    }
+
+    // cast to ints.
+    this.highWaterMark = Math.floor(hwm);
+  }
 
   // drain event flag.
   this.needDrain = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -52,8 +52,7 @@ function WritableState(options, stream) {
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
   if (hwm == null) {
-    var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-    this.highWaterMark = defaultHwm;
+    this.highWaterMark = this.objectMode ? 16 : 16 * 1024;
   } else {
     if (typeof hwm !== 'number') {
       throw new TypeError('"highWaterMark" must be a number');

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -2,7 +2,8 @@
 require('../common');
 
 // This test ensures that the stream implementation correctly handles values
-// for highWaterMark which exceed the range of signed 32 bit integers.
+// for highWaterMark which exceed the range of signed 32 bit integers and
+// rejects invalid values.
 
 const assert = require('assert');
 const stream = require('stream');
@@ -16,3 +17,21 @@ assert.strictEqual(readable._readableState.highWaterMark, ovfl);
 
 const writable = stream.Writable({ highWaterMark: ovfl });
 assert.strictEqual(writable._writableState.highWaterMark, ovfl);
+
+[true, false, '5', {}].forEach((invalidValue) => {
+  assert.throws(() => {
+    stream.Readable({ highWaterMark: invalidValue });
+  }, /^TypeError: "highWaterMark" must be a number$/);
+
+  assert.throws(() => {
+    stream.Writable({ highWaterMark: invalidValue });
+  }, /^TypeError: "highWaterMark" must be a number$/);
+});
+
+assert.throws(() => {
+  stream.Readable({ highWaterMark: -5 });
+}, /^RangeError: "highWaterMark" must not be negative$/);
+
+assert.throws(() => {
+  stream.Writable({ highWaterMark: -5 });
+}, /^RangeError: "highWaterMark" must not be negative$/);


### PR DESCRIPTION
Adds checks for the type of "highWaterMark" and restricts it to non-negative values as suggested [here](https://github.com/nodejs/node/pull/12593#issuecomment-296447615) by @mscdex.

Refs: https://github.com/nodejs/node/pull/12593

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream