### PR TITLE
doc: remove unused/duplicated reference links

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1272,8 +1272,6 @@ to `stdout` although there are only 4 characters.
 [`Error`]: errors.html#errors_class_error
 [`EventEmitter`]: events.html#events_class_eventemitter
 [`JSON.stringify()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
-[`child.channel`]: #child_process_child_channel
 [`child.connected`]: #child_process_child_connected
 [`child.disconnect()`]: #child_process_child_disconnect
 [`child.kill()`]: #child_process_child_kill_signal

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2237,12 +2237,10 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [HTML5's `keygen` element]: http://www.w3.org/TR/html5/forms.html#the-keygen-element
 [NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
 [NIST SP 800-132]: http://csrc.nist.gov/publications/nistpubs/800-132/nist-sp800-132.pdf
-[OpenSSL cipher list format]: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT
 [OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
 [RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt
 [RFC 3526]: https://www.rfc-editor.org/rfc/rfc3526.txt
 [RFC 4055]: https://www.rfc-editor.org/rfc/rfc4055.txt
 [initialization vector]: https://en.wikipedia.org/wiki/Initialization_vector
-[publicly trusted list of CAs]: https://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt
 [stream-writable-write]: stream.html#stream_writable_write_chunk_encoding_callback
 [stream]: stream.html

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -195,4 +195,3 @@ debugging sessions.)
 
 [Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer/
 [TCP-based protocol]: #debugger_tcp_based_protocol
-[V8 Inspector Integration]: #debugger_v8_inspector_integration_for_node_js

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -499,7 +499,6 @@ and `udp6` sockets). The bound address and port can be retrieved using
 [`socket.address().address`][] and [`socket.address().port`][].
 
 [`'close'`]: #dgram_event_close
-[`Buffer`]: buffer.html
 [`Error`]: errors.html#errors_class_error
 [`EventEmitter`]: events.html
 [`close()`]: #dgram_socket_close_callback

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2911,7 +2911,6 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`ReadDirectoryChangesW`]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365465%28v=vs.85%29.aspx
 [`ReadStream`]: #fs_class_fs_readstream
 [`URL`]: url.html#url_the_whatwg_url_api
-[`Uint8Array`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
 [`WriteStream`]: #fs_class_fs_writestream
 [`event ports`]: http://illumos.org/man/port_create
 [`fs.FSWatcher`]: #fs_class_fs_fswatcher

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1770,7 +1770,6 @@ There are a few special headers that should be noted.
 [`url.parse()`]: url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
-[constructor options]: #http_new_agent_options
 [socket.unref()]: net.html#net_socket_unref
 [unspecified IPv4 address]: https://en.wikipedia.org/wiki/0.0.0.0
 [unspecified IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -228,9 +228,6 @@ const req = https.request(options, (res) => {
 ```
 
 [`Agent`]: #https_class_https_agent
-[`Buffer`]: buffer.html#buffer_buffer
-[`SSL_METHODS`]: https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
-[`globalAgent`]: #https_https_globalagent
 [`http.Agent`]: http.html#http_class_http_agent
 [`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback
 [`http.Server#timeout`]: http.html#http_server_timeout

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2963,7 +2963,6 @@ callback invocation, even if it has been successfully cancelled.
 [`napi_create_range_error`]: #n_api_napi_create_range_error
 [`napi_create_reference`]: #n_api_napi_create_reference
 [`napi_create_type_error`]: #n_api_napi_create_type_error
-[`napi_define_class`]: #n_api_napi_define_class
 [`napi_delete_async_work`]: #n_api_napi_delete_async_work
 [`napi_define_class`]: #n_api_napi_define_class
 [`napi_delete_reference`]: #n_api_napi_delete_reference

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1061,7 +1061,6 @@ Returns true if input is a version 6 IP address, otherwise returns false.
 [`net.Server`]: #net_class_net_server
 [`net.Socket`]: #net_class_net_socket
 [`net.connect()`]: #net_net_connect
-[`net.connect()`]: #net_net_connect
 [`net.connect(options)`]: #net_net_connect_options_connectlistener
 [`net.connect(path)`]: #net_net_connect_path_connectlistener
 [`net.connect(port, host)`]: #net_net_connect_port_host_connectlistener


### PR DESCRIPTION
##### Summary
I noticed some un-styled markdown at https://github.com/nodejs/node/pull/12756, and the original PR may take more time. To avoid more conflicts and make the diff a bit small, it would be nice if we can take the docs fix commits from it. Then I removed the unused/duplicated reference links.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc