### PR TITLE
src, async_hooks: add triggerId param to before async_hook

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -332,11 +332,11 @@ function emitInitS(asyncId, type, triggerId, resource) {
 }
 
 
-function emitBeforeN(asyncId) {
+function emitBeforeN(asyncId, triggerId) {
   processing_hook = true;
   for (var i = 0; i < active_hooks_array.length; i++) {
     if (typeof active_hooks_array[i][before_symbol] === 'function') {
-      runCallback(active_hooks_array[i][before_symbol], asyncId);
+      runCallback(active_hooks_array[i][before_symbol], asyncId, triggerId);
     }
   }
   processing_hook = false;
@@ -365,7 +365,7 @@ function emitBeforeS(asyncId, triggerId = asyncId) {
     return;
   }
 
-  emitBeforeN(asyncId);
+  emitBeforeN(asyncId, triggerId);
 }
 
 
@@ -458,9 +458,9 @@ function runInitCallback(cb, asyncId, type, triggerId, resource) {
 }
 
 
-function runCallback(cb, asyncId) {
+function runCallback(cb, asyncId, triggerId) {
   try {
-    cb(asyncId);
+    cb(asyncId, triggerId);
   } catch (e) {
     fatalError(e);
   }

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -420,6 +420,8 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
   Local<Object> context = object();
   Local<Object> domain;
   Local<Value> uid;
+  Local<Value> triggerId;
+
   bool has_domain = false;
 
   Environment::AsyncCallbackScope callback_scope(env());
@@ -449,10 +451,12 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 
   if (async_hooks->fields()[AsyncHooks::kBefore] > 0) {
     uid = Number::New(env()->isolate(), get_id());
+    triggerId = Number::New(env()->isolate(), get_trigger_id());
+    Local<Value> argv[] = { uid, triggerId };
     Local<Function> fn = env()->async_hooks_before_function();
     TryCatch try_catch(env()->isolate());
     MaybeLocal<Value> ar = fn->Call(
-        env()->context(), Undefined(env()->isolate()), 1, &uid);
+        env()->context(), Undefined(env()->isolate()), 2, argv);
     if (ar.IsEmpty()) {
       ClearFatalExceptionHandlers(env());
       FatalException(env()->isolate(), try_catch);

--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -170,11 +170,11 @@ class ActivityCollector {
     this.oninit(uid, type, triggerId, handle);
   }
 
-  _before(uid) {
+  _before(uid, triggerId) {
     const h = this._getActivity(uid, 'before');
     this._stamp(h, 'before');
     this._maybeLog(uid, h && h.type, 'before');
-    this.onbefore(uid);
+    this.onbefore(uid, triggerId);
   }
 
   _after(uid) {


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

It's not clear to me whether the async_hooks before hook is supposed to receive both an async_id and a trigger_id (parent async_id), so I plumbed both all the way through in this PR to start a discussion. According to the original Node-EP only an async_id is passed, but the trigger_id is available and used in some calls already. Is there a use for it? What is the use in the init hook?

If we are to accept this, could someone help me add a better test? Thanks!