### PR TITLE
dns: fix `resolve` failed starts without network

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -386,6 +386,69 @@ struct CaresAsyncData {
   uv_async_t async_handle;
 };
 
+void SetupCaresChannel(Environment* env) {
+  struct ares_options options;
+  memset(&options, 0, sizeof(options));
+  options.flags = ARES_FLAG_NOCHECKRESP;
+  options.sock_state_cb = ares_sockstate_cb;
+  options.sock_state_cb_data = env;
+
+  /* We do the call to ares_init_option for caller. */
+  int r = ares_init_options(env->cares_channel_ptr(),
+                            &options,
+                            ARES_OPT_FLAGS | ARES_OPT_SOCK_STATE_CB);
+
+  if (r != ARES_SUCCESS) {
+    ares_library_cleanup();
+    return env->ThrowError(ToErrorCodeString(r));
+  }
+}
+
+
+/**
+ * This function is to check whether current servers are fallback servers
+ * when cares initialized.
+ *
+ * The fallback servers of cares is [ "127.0.0.1" ] with no user additional
+ * setting.
+ */
+void AresEnsureServers(Environment* env) {
+  /* if last query is OK or servers are set by user self, do not check */
+  if (env->cares_query_last_ok() || !env->cares_is_servers_default()) {
+    return;
+  }
+
+  ares_channel channel = env->cares_channel();
+  ares_addr_node* servers = nullptr;
+
+  ares_get_servers(channel, &servers);
+
+  /* if no server or multi-servers, ignore */
+  if (servers == nullptr) return;
+  if (servers->next != nullptr) {
+    ares_free_data(servers);
+    env->set_cares_is_servers_default(false);
+    return;
+  }
+
+  /* if the only server is not 127.0.0.1, ignore */
+  if (servers[0].family != AF_INET ||
+      servers[0].addr.addr4.s_addr != htonl(INADDR_LOOPBACK)) {
+    ares_free_data(servers);
+    env->set_cares_is_servers_default(false);
+    return;
+  }
+
+  ares_free_data(servers);
+  servers = nullptr;
+
+  /* destroy channel and reset channel */
+  ares_destroy(channel);
+
+  SetupCaresChannel(env);
+}
+
+
 class QueryWrap : public AsyncWrap {
  public:
   QueryWrap(Environment* env, Local<Object> req_wrap_obj)
@@ -415,6 +478,13 @@ class QueryWrap : public AsyncWrap {
  protected:
   void* GetQueryArg() {
     return static_cast<void*>(this);
+  }
+
+  static void AresQuery(Environment* env, const char* name,
+                        int dnsclass, int type, ares_callback callback,
+                        void* arg) {
+    AresEnsureServers(env);
+    ares_query(env->cares_channel(), name, dnsclass, type, callback, arg);
   }
 
   static void CaresAsyncClose(uv_handle_t* handle) {
@@ -466,6 +536,7 @@ class QueryWrap : public AsyncWrap {
     uv_async_t* async_handle = &data->async_handle;
     uv_async_init(wrap->env()->event_loop(), async_handle, CaresAsyncCb);
 
+    wrap->env()->set_cares_query_last_ok(status != ARES_ECONNREFUSED);
     async_handle->data = data;
     uv_async_send(async_handle);
   }
@@ -489,6 +560,7 @@ class QueryWrap : public AsyncWrap {
     uv_async_t* async_handle = &data->async_handle;
     uv_async_init(wrap->env()->event_loop(), async_handle, CaresAsyncCb);
 
+    wrap->env()->set_cares_query_last_ok(status != ARES_ECONNREFUSED);
     async_handle->data = data;
     uv_async_send(async_handle);
   }
@@ -533,12 +605,7 @@ class QueryAWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_a,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_a, Callback, GetQueryArg());
     return 0;
   }
 
@@ -581,12 +648,7 @@ class QueryAaaaWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_aaaa,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(),  name, ns_c_in, ns_t_aaaa, Callback, GetQueryArg());
     return 0;
   }
 
@@ -629,12 +691,7 @@ class QueryCnameWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_cname,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_cname, Callback, GetQueryArg());
     return 0;
   }
 
@@ -670,12 +727,7 @@ class QueryMxWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_mx,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_mx, Callback, GetQueryArg());
     return 0;
   }
 
@@ -721,12 +773,7 @@ class QueryNsWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_ns,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_ns, Callback, GetQueryArg());
     return 0;
   }
 
@@ -759,12 +806,7 @@ class QueryTxtWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_txt,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_txt, Callback, GetQueryArg());
     return 0;
   }
 
@@ -816,12 +858,7 @@ class QuerySrvWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_srv,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_srv, Callback, GetQueryArg());
     return 0;
   }
 
@@ -872,12 +909,7 @@ class QueryPtrWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_ptr,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_ptr, Callback, GetQueryArg());
     return 0;
   }
 
@@ -915,12 +947,7 @@ class QueryNaptrWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_naptr,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_naptr, Callback, GetQueryArg());
     return 0;
   }
 
@@ -979,12 +1006,7 @@ class QuerySoaWrap: public QueryWrap {
   }
 
   int Send(const char* name) override {
-    ares_query(env()->cares_channel(),
-               name,
-               ns_c_in,
-               ns_t_soa,
-               Callback,
-               GetQueryArg());
+    AresQuery(env(), name, ns_c_in, ns_t_soa, Callback, GetQueryArg());
     return 0;
   }
 
@@ -1445,6 +1467,9 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
 
   delete[] servers;
 
+  if (err == ARES_SUCCESS)
+    env->set_cares_is_servers_default(false);
+
   args.GetReturnValue().Set(err);
 }
 
@@ -1479,20 +1504,7 @@ void Initialize(Local<Object> target,
   if (r != ARES_SUCCESS)
     return env->ThrowError(ToErrorCodeString(r));
 
-  struct ares_options options;
-  memset(&options, 0, sizeof(options));
-  options.flags = ARES_FLAG_NOCHECKRESP;
-  options.sock_state_cb = ares_sockstate_cb;
-  options.sock_state_cb_data = env;
-
-  /* We do the call to ares_init_option for caller. */
-  r = ares_init_options(env->cares_channel_ptr(),
-                        &options,
-                        ARES_OPT_FLAGS | ARES_OPT_SOCK_STATE_CB);
-  if (r != ARES_SUCCESS) {
-    ares_library_cleanup();
-    return env->ThrowError(ToErrorCodeString(r));
-  }
+  SetupCaresChannel(env);
 
   /* Initialize the timeout timer. The timer won't be started until the */
   /* first socket is opened. */

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -292,6 +292,8 @@ inline Environment::Environment(IsolateData* isolate_data,
       isolate_data_(isolate_data),
       async_hooks_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
+      cares_query_last_ok_(true),
+      cares_is_servers_default_(true),
       using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
@@ -503,6 +505,22 @@ inline ares_channel Environment::cares_channel() {
 // Only used in the call to ares_init_options().
 inline ares_channel* Environment::cares_channel_ptr() {
   return &cares_channel_;
+}
+
+inline bool Environment::cares_query_last_ok() {
+  return cares_query_last_ok_;
+}
+
+inline void Environment::set_cares_query_last_ok(bool ok) {
+  cares_query_last_ok_ = ok;
+}
+
+inline bool Environment::cares_is_servers_default() {
+  return cares_is_servers_default_;
+}
+
+inline void Environment::set_cares_is_servers_default(bool is_default) {
+  cares_is_servers_default_ = is_default;
 }
 
 inline node_ares_task_list* Environment::cares_task_list() {

--- a/src/env.h
+++ b/src/env.h
@@ -546,6 +546,10 @@ class Environment {
   inline uv_timer_t* cares_timer_handle();
   inline ares_channel cares_channel();
   inline ares_channel* cares_channel_ptr();
+  inline bool cares_query_last_ok();
+  inline void set_cares_query_last_ok(bool ok);
+  inline bool cares_is_servers_default();
+  inline void set_cares_is_servers_default(bool is_default);
   inline node_ares_task_list* cares_task_list();
   inline IsolateData* isolate_data() const;
 
@@ -667,6 +671,8 @@ class Environment {
   const uint64_t timer_base_;
   uv_timer_t cares_timer_handle_;
   ares_channel cares_channel_;
+  bool cares_query_last_ok_;
+  bool cares_is_servers_default_;
   node_ares_task_list cares_task_list_;
   bool using_domains_;
   bool printed_error_;


### PR DESCRIPTION
Fix the bug that you start process without network at first, but it connected lately, `dns.resolve` will stay failed with ECONNREFUSED because c-ares servers fallback to 127.0.0.1 at the very beginning.

If c-ares servers "127.0.0.1" is detected and its not set by user self, and last query is not OK, recreating `ares_channel` operation will be triggered to reload servers.

You can test with this script:

```javascript
const dns = require("dns");

function test() {
    dns.resolve("google.com", function(err, ret) {
        console.log(err, ret, dns.getServers());
        setTimeout(test, 10000);
    });
}

test();
```

**Turn off your network at first before starting this script. Then try to open the network and then turn off. Make the steps above in a loop and you will get the result.**

Fixes: https://github.com/nodejs/node/issues/1644

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Solutaion

DNS server matches follow conditions is considered as a fallback server of c-ares:

1. caused last query ECONNREFUSED; (the fallback server very likely to have this error)
2. is exactly `[ "127.0.0.1" ]`; (the fallback server is exactly this value)
3. haven't set by users or developers by `dns.setServers`.

> Because users or developers may do `dns.setServers([ "127.0.0.1" ])` or theirs /etc/resolv.conf is 127.0.0.1.
>
> As a result, I gathered those 3 conditions.

I created two flags at the process start up.

+ `cares_query_last_ok_` indicates that is last dns query succeeded or not;
+ `cares_is_servers_use_default_` indicates that whether current dns servers is the fallback 127.0.0.1 that c-ares initialized at the beginning.

If `cares_query_last_ok_` is `true` or `cares_is_servers_use_default_` is `false`, everything will be OK.

If not, the code will check current dns servers to see if it's 127.0.0.1 (maybe c-ares' fallback server). When it's 127.0.0.1, old `ares_channel` will be released and a new one will be created.

Once one query succeeded or not ECONNREFUSED, `cares_query_last_ok_` will be marked as `true`. And once user set dns servers via `dns.setServers`, `cares_is_servers_use_default_` will be marked as `false`. And what's more, once the first check found the dns servers is not 127.0.0.1, `cares_is_servers_use_default_` also will be marked as `false`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns