### PR TITLE
build: fix openssl link error on windows

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -277,7 +277,7 @@
               # Categories to export.
               '-CAES,BF,BIO,DES,DH,DSA,EC,ECDH,ECDSA,ENGINE,EVP,HMAC,MD4,MD5,'
               'NEXTPROTONEG,PSK,RC2,RC4,RSA,SHA,SHA0,SHA1,SHA256,SHA512,SOCK,'
-              'STDIO,TLSEXT',
+              'STDIO,TLSEXT,FP_API',
               # Defines.
               '-DWIN32',
               # Symbols to filter from the export list.
@@ -671,7 +671,7 @@
                 'deps/zlib/zlib.gyp:zlib',
               ]
             }],
-            [ 'node_shared_openssl=="false"', {
+            [ 'node_shared_openssl=="false" and node_shared=="false"', {
               'dependencies': [
                 'deps/openssl/openssl.gyp:openssl'
               ]


### PR DESCRIPTION
This commit attempts to fix an issue when building on windows using the
following command line options:
```console
.\vcbuild.bat dll debug x64 vc2015
```

This will result in the following options passed to configure:
```console
configure --debug --shared --dest-cpu=x64 --tag=
```

This commit excludes the dependency to openssl if node is configured
with --shared.

Also, FP_API to the categories to export in mkssldef when generating
the module definition (openssl.def) allowing the build to compile and
link successfully.

Fixes: https://github.com/nodejs/node/issues/12952

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build