### PR TITLE
src: remove unnecessary forward declaration

### DIFF
--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -88,9 +88,6 @@ extern X509_STORE* root_cert_store;
 
 extern void UseExtraCaCerts(const std::string& file);
 
-// Forward declaration
-class Connection;
-
 class SecureContext : public BaseObject {
  public:
   ~SecureContext() override {


### PR DESCRIPTION
I can't see that the forward declaration of class Connection is needed
and wanted to raise this in case it was overlooked after a previous
change.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src