### PR TITLE
doc: add reference to node_api.h in docs

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -52,8 +52,10 @@ for the N-API C based functions exported by Node.js. These wrappers are not
 part of N-API, nor will they be maintained as part of Node.js. One such
 example is: [node-api](https://github.com/nodejs/node-api).
 
-In order to use the N-API functions, include the file "node_api.h" which
-is located in the src directory in the node development tree.  For example:
+In order to use the N-API functions, include the file
+[node_api.h](https://github.com/nodejs/node/blob/master/src/node_api.h)
+which is located in the src directory in the node development tree.
+For example:
 ```C
 #include <node_api.h>
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -52,6 +52,13 @@ for the N-API C based functions exported by Node.js. These wrappers are not
 part of N-API, nor will they be maintained as part of Node.js. One such
 example is: [node-api](https://github.com/nodejs/node-api).
 
+In order to use the N-API functions, include the file "node_api.h" which
+is located in the src directory in the node development tree.  For example:
+```C
+#include <node_api.h>
+
+```
+
 ## Basic N-API Data Types
 
 N-API exposes the following fundamental datatypes as abstractions that are


### PR DESCRIPTION
Realized that we don't actually point people to the file to
include in order to access N-API functions.  Add that.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines].
##### Affected core subsystem(s)
doc, n-api