### PR TITLE
n-api: Retain last code when getting error info

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -755,7 +755,7 @@ napi_status napi_get_last_error_info(napi_env env,
       error_messages[env->last_error.error_code];
 
   *result = &(env->last_error);
-  return napi_clear_last_error(env);
+  return napi_ok;
 }
 
 napi_status napi_create_function(napi_env env,

--- a/test/addons-napi/test_napi_status/test_napi_status.cc
+++ b/test/addons-napi/test_napi_status/test_napi_status.cc
@@ -10,6 +10,14 @@ napi_value createNapiError(napi_env env, napi_callback_info info) {
 
   NAPI_ASSERT(env, status != napi_ok, "Failed to produce error condition");
 
+  const napi_extended_error_info *error_info = 0;
+  NAPI_CALL(env, napi_get_last_error_info(env, &error_info));
+
+  NAPI_ASSERT(env, error_info->error_code == status,
+    "Last error info code should match last status");
+  NAPI_ASSERT(env, error_info->error_message,
+    "Last error info message should not be null");
+
   return nullptr;
 }
 


### PR DESCRIPTION
Unlike most N-API functions, `napi_get_last_error_info()` should not clear the last error code when successful, because a pointer to (not a copy of) the error info structure is returned via an out parameter.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api