### PR TITLE
zlib: expose amount of data read for engines

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -386,6 +386,9 @@ Not exported by the `zlib` module. It is documented here because it is the base
 class of the compressor/decompressor classes.
 
 ### zlib.bytesRead
+<!-- YAML
+added: REPLACEME
+-->
 
 * {number}
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -389,7 +389,9 @@ class of the compressor/decompressor classes.
 
 * {number}
 
-The `zlib.bytesRead` property specifies the number of bytes read by the engine.
+The `zlib.bytesRead` property specifies the number of bytes read by the engine
+before the bytes are processed (compressed or decompressed, as appropriate for
+the derived class).
 
 ### zlib.flush([kind], callback)
 <!-- YAML

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -385,6 +385,12 @@ added: v0.5.8
 Not exported by the `zlib` module. It is documented here because it is the base
 class of the compressor/decompressor classes.
 
+### zlib.bytesRead
+
+* {number}
+
+The `zlib.bytesRead` property specifies the number of bytes read by the engine.
+
 ### zlib.flush([kind], callback)
 <!-- YAML
 added: v0.5.8

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -168,6 +168,8 @@ class Zlib extends Transform {
     opts = opts || {};
     super(opts);
 
+    this.bytesRead = 0;
+
     this._opts = opts;
     this._chunkSize = opts.chunkSize || constants.Z_DEFAULT_CHUNK;
 
@@ -407,6 +409,8 @@ class Zlib extends Transform {
 
       var have = availOutBefore - availOutAfter;
       assert(have >= 0, 'have should not go down');
+
+      self.bytesRead += availInBefore - availInAfter;
 
       if (have > 0) {
         var out = self._buffer.slice(self._offset, self._offset + have);

--- a/test/parallel/test-zlib-bytes-read.js
+++ b/test/parallel/test-zlib-bytes-read.js
@@ -1,0 +1,92 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+const expectStr = 'abcdefghijklmnopqrstuvwxyz'.repeat(2);
+const expectBuf = Buffer.from(expectStr);
+
+function createWriter(target, buffer) {
+  const writer = { size: 0 };
+  const write = () => {
+    target.write(Buffer.from([buffer[writer.size++]]));
+    if (writer.size < buffer.length) {
+      setTimeout(write, 25);
+    } else {
+      target.end();
+    }
+  };
+  write();
+  return writer;
+}
+
+for (const method of [
+  ['createGzip', 'createGunzip', false],
+  ['createGzip', 'createUnzip', false],
+  ['createDeflate', 'createInflate', true],
+  ['createDeflateRaw', 'createInflateRaw', true]
+]) {
+  let compWriter;
+  let compData = new Buffer(0);
+
+  const comp = zlib[method[0]]();
+  comp.on('data', function(d) {
+    compData = Buffer.concat([compData, d]);
+    assert.strictEqual(this.bytesRead, compWriter.size,
+                       `Should get write size on ${method[0]} data.`);
+  });
+  comp.on('end', common.mustCall(function() {
+    assert.strictEqual(this.bytesRead, compWriter.size,
+                       `Should get write size on ${method[0]} end.`);
+    assert.strictEqual(this.bytesRead, expectStr.length,
+                       `Should get data size on ${method[0]} end.`);
+
+    {
+      let decompWriter;
+      let decompData = new Buffer(0);
+
+      const decomp = zlib[method[1]]();
+      decomp.on('data', function(d) {
+        decompData = Buffer.concat([decompData, d]);
+        assert.strictEqual(this.bytesRead, decompWriter.size,
+                           `Should get write size on ${method[0]}/` +
+                           `${method[1]} data.`);
+      });
+      decomp.on('end', common.mustCall(function() {
+        assert.strictEqual(this.bytesRead, compData.length,
+                           `Should get compressed size on ${method[0]}/` +
+                           `${method[1]} end.`);
+        assert.strictEqual(decompData.toString(), expectStr,
+                           `Should get original string on ${method[0]}/` +
+                           `${method[1]} end.`);
+      }));
+      decompWriter = createWriter(decomp, compData);
+    }
+
+    // Some methods should allow extra data after the compressed data
+    if (method[2]) {
+      const compDataExtra = Buffer.concat([compData, new Buffer('extra')]);
+
+      let decompWriter;
+      let decompData = new Buffer(0);
+
+      const decomp = zlib[method[1]]();
+      decomp.on('data', function(d) {
+        decompData = Buffer.concat([decompData, d]);
+        assert.strictEqual(this.bytesRead, decompWriter.size,
+                           `Should get write size on ${method[0]}/` +
+                           `${method[1]} data.`);
+      });
+      decomp.on('end', common.mustCall(function() {
+        assert.strictEqual(this.bytesRead, compData.length,
+                           `Should get compressed size on ${method[0]}/` +
+                           `${method[1]} end.`);
+        assert.strictEqual(decompData.toString(), expectStr,
+                           `Should get original string on ${method[0]}/` +
+                           `${method[1]} end.`);
+      }));
+      decompWriter = createWriter(decomp, compDataExtra);
+    }
+  }));
+  compWriter = createWriter(comp, expectBuf);
+}

--- a/test/parallel/test-zlib-bytes-read.js
+++ b/test/parallel/test-zlib-bytes-read.js
@@ -9,12 +9,13 @@ const expectBuf = Buffer.from(expectStr);
 function createWriter(target, buffer) {
   const writer = { size: 0 };
   const write = () => {
-    target.write(Buffer.from([buffer[writer.size++]]));
-    if (writer.size < buffer.length) {
-      setTimeout(write, 25);
-    } else {
-      target.end();
-    }
+    target.write(Buffer.from([buffer[writer.size++]]), () => {
+      if (writer.size < buffer.length) {
+        target.flush(write);
+      } else {
+        target.end();
+      }
+    });
   };
   write();
   return writer;


### PR DESCRIPTION
Added bytesRead property to Zlib engines

Refs: https://github.com/nodejs/node/issues/8874

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- zlib

Alternative to Pull Request https://github.com/nodejs/node/pull/12939, broken into 2 separate commits.

