### PR TITLE
zlib: option for engine in convenience methods

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -301,7 +301,7 @@ ignored by the decompression classes.
 * `strategy` {integer} (compression only)
 * `dictionary` {Buffer|TypedArray|DataView} (deflate/inflate only, empty dictionary by
   default)
-* `info` {boolean} (It `true`, returns object with buffer and engine)
+* `info` {boolean} (If `true`, returns an object with `buffer` and `engine`)
 
 See the description of `deflateInit2` and `inflateInit2` at
 <http://zlib.net/manual.html#Advanced> for more information on these.

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -301,6 +301,7 @@ ignored by the decompression classes.
 * `strategy` {integer} (compression only)
 * `dictionary` {Buffer|TypedArray|DataView} (deflate/inflate only, empty dictionary by
   default)
+* `info` {boolean} (It `true`, returns object with buffer and engine)
 
 See the description of `deflateInit2` and `inflateInit2` at
 <http://zlib.net/manual.html#Advanced> for more information on these.

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -77,6 +77,13 @@ function isInvalidStrategy(strategy) {
   //         constants.Z_DEFAULT_STRATEGY (0)
 }
 
+function responseData(engine, buffer) {
+  if (engine._opts.info) {
+    return { buffer, engine };
+  }
+  return buffer;
+}
+
 function zlibBuffer(engine, buffer, callback) {
   // Streams do not support non-Buffer ArrayBufferViews yet. Convert it to a
   // Buffer without copying.
@@ -121,7 +128,7 @@ function zlibBuffer(engine, buffer, callback) {
 
     buffers = [];
     engine.close();
-    callback(err, buf);
+    callback(err, responseData(engine, buf));
   }
 }
 
@@ -134,7 +141,7 @@ function zlibBufferSync(engine, buffer) {
 
   var flushFlag = engine._finishFlushFlag;
 
-  return engine._processChunk(buffer, flushFlag);
+  return responseData(engine, engine._processChunk(buffer, flushFlag));
 }
 
 function zlibOnError(message, errno) {


### PR DESCRIPTION
Added option to expose engine to convenience methods

Refs: https://github.com/nodejs/node/issues/8874

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- zlib

Alternative to Pull Request https://github.com/nodejs/node/pull/12939, broken into 2 separate commits.
