### PR TITLE
dns: synchronize resolve() docs and code

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -291,22 +291,21 @@ resolveMap.NAPTR = resolver('queryNaptr');
 resolveMap.SOA = resolver('querySoa');
 
 
-function resolve(hostname, type_, callback_) {
-  var resolver, callback;
-  if (typeof type_ === 'string') {
-    resolver = resolveMap[type_];
-    callback = callback_;
-  } else if (typeof type_ === 'function') {
+function resolve(hostname, rrtype, callback) {
+  var resolver;
+  if (typeof rrtype === 'string') {
+    resolver = resolveMap[rrtype];
+  } else if (typeof rrtype === 'function') {
     resolver = resolveMap.A;
-    callback = type_;
+    callback = rrtype;
   } else {
-    throw new Error('"type" argument must be a string');
+    throw new TypeError('"rrtype" argument must be a string');
   }
 
   if (typeof resolver === 'function') {
     return resolver(hostname, callback);
   } else {
-    throw new Error(`Unknown type "${type_}"`);
+    throw new Error(`Unknown type "${rrtype}"`);
   }
 }
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -91,10 +91,8 @@ assert.doesNotThrow(() => dns.setServers([]));
 assert.deepStrictEqual(dns.getServers(), []);
 
 assert.throws(() => {
-  dns.resolve('test.com', [], common.mustNotCall());
-}, function(err) {
-  return !(err instanceof TypeError);
-}, 'Unexpected error');
+  dns.resolve('example.com', [], common.mustNotCall());
+}, /^TypeError: "rrtype" argument must be a string$/);
 
 // dns.lookup should accept only falsey and string values
 {


### PR DESCRIPTION
Synchronize the argument list for `dns.resolve()` with what's in the
documentation.

Improve the error for a bad `rrtype` to be a `TypeError` rather than an
`Error`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns