### PR TITLE
src: remove unnecessary return statement

### DIFF
--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -120,7 +120,7 @@ void ClientHelloParser::ParseHeader(const uint8_t* data, size_t avail) {
   return;
 
  fail:
-  return End();
+  End();
 }
 
 


### PR DESCRIPTION
I think the code would be a little clearer if the return statement
was removed here since End() does not return any value and neither
does ParseHeader.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, crypto