### PR TITLE
test: add constructor test to async-hooks

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -77,13 +77,13 @@ function fatalError(e) {
 
 class AsyncHook {
   constructor({ init, before, after, destroy }) {
-    if (init && typeof init !== 'function')
+    if (init !== undefined && typeof init !== 'function')
       throw new TypeError('init must be a function');
-    if (before && typeof before !== 'function')
+    if (before !== undefined && typeof before !== 'function')
       throw new TypeError('before must be a function');
-    if (after && typeof after !== 'function')
+    if (after !== undefined && typeof after !== 'function')
       throw new TypeError('after must be a function');
-    if (destroy && typeof destroy !== 'function')
+    if (destroy !== undefined && typeof destroy !== 'function')
       throw new TypeError('destroy must be a function');
 
     this[init_symbol] = init;

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+for (const badArg of [0, 1, false, true, null, 'hello']) {
+  for (const field of ['init', 'before', 'after', 'destroy']) {
+    assert.throws(() => {
+      async_hooks.createHook({ [field]: badArg });
+    }, new RegExp(`^TypeError: ${field} must be a function$`));
+  }
+}


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async-hooks

[refack edit: removed documentation checkbox, as it seems it is not needed for this PR]