### PR TITLE
zlib: fix node crashing on invalid options

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -437,6 +437,10 @@ added: v0.5.8
 
 Returns a new [DeflateRaw][] object with an [options][].
 
+**Note:** zlib library rejects requests for 256-byte windows (i.e.,
+`{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating
+a [DeflateRaw][] object with this specific value of the `windowBits` option.
+
 ## zlib.createGunzip([options])
 <!-- YAML
 added: v0.5.8

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -437,7 +437,7 @@ added: v0.5.8
 
 Returns a new [DeflateRaw][] object with an [options][].
 
-**Note:** the zlib library rejects requests for 256-byte windows (i.e.,
+**Note:** The zlib library rejects requests for 256-byte windows (i.e.,
 `{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating
 a [DeflateRaw][] object with this specific value of the `windowBits` option.
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -437,7 +437,7 @@ added: v0.5.8
 
 Returns a new [DeflateRaw][] object with an [options][].
 
-**Note:** zlib library rejects requests for 256-byte windows (i.e.,
+**Note:** the zlib library rejects requests for 256-byte windows (i.e.,
 `{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating
 a [DeflateRaw][] object with this specific value of the `windowBits` option.
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -146,7 +146,14 @@ function zlibOnError(message, errno) {
   var error = new Error(message);
   error.errno = errno;
   error.code = codes[errno];
-  this.emit('error', error);
+
+  if (this._initSuccess) {
+    this.emit('error', error);
+  } else {
+    process.nextTick(() => {
+      this.emit('error', error);
+    });
+  }
 }
 
 function flushCallback(level, strategy, callback) {
@@ -222,6 +229,7 @@ class Zlib extends Transform {
     this._handle = new binding.Zlib(mode);
     this._handle.onerror = zlibOnError.bind(this);
     this._hadError = false;
+    this._initSuccess = false;
 
     var level = constants.Z_DEFAULT_COMPRESSION;
     if (typeof opts.level === 'number') level = opts.level;
@@ -229,13 +237,24 @@ class Zlib extends Transform {
     var strategy = constants.Z_DEFAULT_STRATEGY;
     if (typeof opts.strategy === 'number') strategy = opts.strategy;
 
-    this._handle.init(opts.windowBits || constants.Z_DEFAULT_WINDOWBITS,
-                      level,
-                      opts.memLevel || constants.Z_DEFAULT_MEMLEVEL,
-                      strategy,
-                      opts.dictionary);
+    var windowBits = constants.Z_DEFAULT_WINDOWBITS;
+    if (typeof opts.windowBits === 'number') windowBits = opts.windowBits;
 
-    this._buffer = Buffer.allocUnsafe(this._chunkSize);
+    var memLevel = constants.Z_DEFAULT_MEMLEVEL;
+    if (typeof opts.memLevel === 'number') memLevel = opts.memLevel;
+
+    this._initSuccess = this._handle.init(windowBits,
+                                          level,
+                                          memLevel,
+                                          strategy,
+                                          opts.dictionary);
+
+    if (this._initSuccess) {
+      this._buffer = Buffer.allocUnsafe(this._chunkSize);
+    } else {
+      this._buffer = null;
+    }
+
     this._offset = 0;
     this._level = level;
     this._strategy = strategy;
@@ -467,7 +486,9 @@ function _close(engine, callback) {
   if (!engine._handle)
     return;
 
-  engine._handle.close();
+  if (engine._initSuccess)
+    engine._handle.close();
+
   engine._handle = null;
 }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -182,37 +182,37 @@ class Zlib extends Transform {
     this._finishFlushFlag = opts.finishFlush !== undefined ?
       opts.finishFlush : constants.Z_FINISH;
 
-    if (opts.chunkSize) {
+    if (opts.chunkSize !== undefined) {
       if (opts.chunkSize < constants.Z_MIN_CHUNK) {
         throw new RangeError('Invalid chunk size: ' + opts.chunkSize);
       }
     }
 
-    if (opts.windowBits) {
+    if (opts.windowBits !== undefined) {
       if (opts.windowBits < constants.Z_MIN_WINDOWBITS ||
           opts.windowBits > constants.Z_MAX_WINDOWBITS) {
         throw new RangeError('Invalid windowBits: ' + opts.windowBits);
       }
     }
 
-    if (opts.level) {
+    if (opts.level !== undefined) {
       if (opts.level < constants.Z_MIN_LEVEL ||
           opts.level > constants.Z_MAX_LEVEL) {
         throw new RangeError('Invalid compression level: ' + opts.level);
       }
     }
 
-    if (opts.memLevel) {
+    if (opts.memLevel !== undefined) {
       if (opts.memLevel < constants.Z_MIN_MEMLEVEL ||
           opts.memLevel > constants.Z_MAX_MEMLEVEL) {
         throw new RangeError('Invalid memLevel: ' + opts.memLevel);
       }
     }
 
-    if (opts.strategy && isInvalidStrategy(opts.strategy))
+    if (opts.strategy !== undefined && isInvalidStrategy(opts.strategy))
       throw new TypeError('Invalid strategy: ' + opts.strategy);
 
-    if (opts.dictionary) {
+    if (opts.dictionary !== undefined) {
       if (!ArrayBuffer.isView(opts.dictionary)) {
         throw new TypeError(
           'Invalid dictionary: it should be a Buffer, TypedArray, or DataView');
@@ -224,16 +224,28 @@ class Zlib extends Transform {
     this._hadError = false;
 
     var level = constants.Z_DEFAULT_COMPRESSION;
-    if (typeof opts.level === 'number') level = opts.level;
+    if (typeof opts.level === 'number' &&
+        Number.isFinite(opts.level)) {
+      level = opts.level;
+    }
 
     var strategy = constants.Z_DEFAULT_STRATEGY;
-    if (typeof opts.strategy === 'number') strategy = opts.strategy;
+    if (typeof opts.strategy === 'number' &&
+        Number.isFinite(opts.strategy)) {
+      strategy = opts.strategy;
+    }
 
     var windowBits = constants.Z_DEFAULT_WINDOWBITS;
-    if (typeof opts.windowBits === 'number') windowBits = opts.windowBits;
+    if (typeof opts.windowBits === 'number' &&
+        Number.isFinite(opts.windowBits)) {
+      windowBits = opts.windowBits;
+    }
 
     var memLevel = constants.Z_DEFAULT_MEMLEVEL;
-    if (typeof opts.memLevel === 'number') memLevel = opts.memLevel;
+    if (typeof opts.memLevel === 'number' &&
+        Number.isFinite(opts.memLevel)) {
+      memLevel = opts.memLevel;
+    }
 
     this._handle.init(windowBits,
                       level,

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -146,14 +146,7 @@ function zlibOnError(message, errno) {
   var error = new Error(message);
   error.errno = errno;
   error.code = codes[errno];
-
-  if (this._initSuccess) {
-    this.emit('error', error);
-  } else {
-    process.nextTick(() => {
-      this.emit('error', error);
-    });
-  }
+  this.emit('error', error);
 }
 
 function flushCallback(level, strategy, callback) {
@@ -229,7 +222,6 @@ class Zlib extends Transform {
     this._handle = new binding.Zlib(mode);
     this._handle.onerror = zlibOnError.bind(this);
     this._hadError = false;
-    this._initSuccess = false;
 
     var level = constants.Z_DEFAULT_COMPRESSION;
     if (typeof opts.level === 'number') level = opts.level;
@@ -243,18 +235,13 @@ class Zlib extends Transform {
     var memLevel = constants.Z_DEFAULT_MEMLEVEL;
     if (typeof opts.memLevel === 'number') memLevel = opts.memLevel;
 
-    this._initSuccess = this._handle.init(windowBits,
-                                          level,
-                                          memLevel,
-                                          strategy,
-                                          opts.dictionary);
+    this._handle.init(windowBits,
+                      level,
+                      memLevel,
+                      strategy,
+                      opts.dictionary);
 
-    if (this._initSuccess) {
-      this._buffer = Buffer.allocUnsafe(this._chunkSize);
-    } else {
-      this._buffer = null;
-    }
-
+    this._buffer = Buffer.allocUnsafe(this._chunkSize);
     this._offset = 0;
     this._level = level;
     this._strategy = strategy;
@@ -486,9 +473,7 @@ function _close(engine, callback) {
   if (!engine._handle)
     return;
 
-  if (engine._initSuccess)
-    engine._handle.close();
-
+  engine._handle.close();
   engine._handle = null;
 }
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -224,26 +224,22 @@ class Zlib extends Transform {
     this._hadError = false;
 
     var level = constants.Z_DEFAULT_COMPRESSION;
-    if (typeof opts.level === 'number' &&
-        Number.isFinite(opts.level)) {
+    if (Number.isFinite(opts.level)) {
       level = opts.level;
     }
 
     var strategy = constants.Z_DEFAULT_STRATEGY;
-    if (typeof opts.strategy === 'number' &&
-        Number.isFinite(opts.strategy)) {
+    if (Number.isFinite(opts.strategy)) {
       strategy = opts.strategy;
     }
 
     var windowBits = constants.Z_DEFAULT_WINDOWBITS;
-    if (typeof opts.windowBits === 'number' &&
-        Number.isFinite(opts.windowBits)) {
+    if (Number.isFinite(opts.windowBits)) {
       windowBits = opts.windowBits;
     }
 
     var memLevel = constants.Z_DEFAULT_MEMLEVEL;
-    if (typeof opts.memLevel === 'number' &&
-        Number.isFinite(opts.memLevel)) {
+    if (Number.isFinite(opts.memLevel)) {
       memLevel = opts.memLevel;
     }
 

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -28,10 +28,10 @@ assert.throws(() => {
 
 {
   const stream = zlib.createGzip({ level: NaN });
-  assert.ok(!Number.isNaN(stream._level));
+  assert.strictEqual(stream._level, zlib.constants.Z_DEFAULT_COMPRESSION);
 }
 
 {
   const stream = zlib.createGzip({ strategy: NaN });
-  assert.ok(!Number.isNaN(stream._strategy));
+  assert.strictEqual(stream._strategy, zlib.constants.Z_DEFAULT_STRATEGY);
 }

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -10,4 +10,4 @@ const zlib = require('zlib');
 // (http://zlib.net/manual.html#Advanced)
 assert.throws(() => {
   zlib.createDeflateRaw({ windowBits: 8 });
-}, /Init error/);
+}, /^Error: Init error$/);

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const zlib = require('zlib');
+
+// For raw deflate or gzip encoding, a request for a 256-byte window is
+// rejected as invalid, since only zlib headers provide means of transmitting
+// the window size to the decompressor.
+// (http://zlib.net/manual.html#Advanced)
+const deflate = zlib.createDeflateRaw({ windowBits: 8 });
+deflate.on('error', common.mustCall((error) => {
+  assert.ok(/Init error/.test(error));
+}));

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const zlib = require('zlib');
 
-// For raw deflate or gzip encoding, a request for a 256-byte window is
-// rejected as invalid, since only zlib headers provide means of transmitting
-// the window size to the decompressor.
+// For raw deflate encoding, requests for 256-byte windows are rejected as
+// invalid by zlib.
 // (http://zlib.net/manual.html#Advanced)
-const deflate = zlib.createDeflateRaw({ windowBits: 8 });
-deflate.on('error', common.mustCall((error) => {
-  assert.ok(/Init error/.test(error));
-}));
+assert.throws(() => {
+  zlib.createDeflateRaw({ windowBits: 8 });
+}, /Init error/);

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -11,3 +11,27 @@ const zlib = require('zlib');
 assert.throws(() => {
   zlib.createDeflateRaw({ windowBits: 8 });
 }, /^Error: Init error$/);
+
+// Regression tests for bugs in the validation logic.
+
+assert.throws(() => {
+  zlib.createGzip({ chunkSize: 0 });
+}, /^RangeError: Invalid chunk size: 0$/);
+
+assert.throws(() => {
+  zlib.createGzip({ windowBits: 0 });
+}, /^RangeError: Invalid windowBits: 0$/);
+
+assert.throws(() => {
+  zlib.createGzip({ memLevel: 0 });
+}, /^RangeError: Invalid memLevel: 0$/);
+
+{
+  const stream = zlib.createGzip({ level: NaN });
+  assert.ok(!Number.isNaN(stream._level));
+}
+
+{
+  const stream = zlib.createGzip({ strategy: NaN });
+  assert.ok(!Number.isNaN(stream._strategy));
+}


### PR DESCRIPTION
This PR fixes the Node process crashing when constructors of classes of the `zlib` module are given invalid options.

* Throw an Error when the zlib library rejects the value of `windowBits`, instead of crashing with an assertion.
* Treat `windowBits` and `memLevel` options consistently with other ones and don't crash when non-numeric values are given.

Fixes: https://github.com/nodejs/node/issues/13082

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib