### PR TITLE
v7.x backport for common.crashOnUnhandledRejection

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -643,3 +643,9 @@ exports.expectsError = function expectsError({code, type, message}) {
     return true;
   };
 };
+
+// Crash the process on unhandled rejections.
+exports.crashOnUnhandledRejection = function() {
+  process.on('unhandledRejection',
+             (err) => process.nextTick(() => { throw err; }));
+};


### PR DESCRIPTION
The docs actually landed already, sorry for missing the `dont-label` on that one.