### PR TITLE
v4.x backport change https://github.com/nodejs/node/pull/12839

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -425,6 +425,8 @@ Construct a new TLSSocket object from existing TCP socket.
   - `secureContext`: An optional TLS context object from
      [`tls.createSecureContext()`][]
 
+  - `lookup`: {Function} Custom lookup function. Defaults to [`dns.lookup()`][].
+
   - `isServer`: If `true` the TLS socket will be instantiated in server-mode.
     Default: `false`
 
@@ -1065,6 +1067,7 @@ console.log(ciphers); // ['AES128-SHA', 'AES256-SHA', ...]
 [Stream]: stream.html#stream_stream
 [SSL_METHODS]: https://www.openssl.org/docs/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
 [tls.Server]: #tls_class_tls_server
+[`dns.lookup()`]: dns.html#dns_dns_lookup_hostname_options_callback
 [SSL_CTX_set_timeout]: https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
 [RFC 4492]: https://www.rfc-editor.org/rfc/rfc4492.txt
 [Forward secrecy]: https://en.wikipedia.org/wiki/Perfect_forward_secrecy

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1042,7 +1042,8 @@ exports.connect = function(/* [port, host], options, cb */) {
         port: options.port,
         host: options.host,
         family: options.family,
-        localAddress: options.localAddress
+        localAddress: options.localAddress,
+        lookup: options.lookup
       };
     }
     socket.connect(connect_opt, function() {

--- a/test/parallel/test-tls-lookup.js
+++ b/test/parallel/test-tls-lookup.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const tls = require('tls');
+
+const expectedError = /^TypeError: options.lookup should be a function.$/;
+
+['foobar', 1, {}, []].forEach(function connectThrows(input) {
+  const opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input
+  };
+
+  assert.throws(function() {
+    tls.connect(opts);
+  }, expectedError);
+});
+
+connectDoesNotThrow(common.mustCall(() => {}));
+
+function connectDoesNotThrow(input) {
+  const opts = {
+    host: 'localhost',
+    port: common.PORT,
+    lookup: input
+  };
+
+  assert.doesNotThrow(function() {
+    tls.connect(opts);
+  });
+}


### PR DESCRIPTION
This is to backport  https://github.com/nodejs/node/pull/12839 to 4

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]

