### PR TITLE
test: shorten test-benchmark-http

### DIFF
--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -20,12 +20,13 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
-const child = fork(runjs, ['--set', 'dur=0.1',
-                           '--set', 'n=1',
-                           '--set', 'len=1',
+const child = fork(runjs, ['--set', 'benchmarker=test-double',
                            '--set', 'c=1',
                            '--set', 'chunks=0',
-                           '--set', 'benchmarker=test-double',
+                           '--set', 'dur=0.1',
+                           '--set', 'key=""',
+                           '--set', 'len=1',
+                           '--set', 'n=1',
                            'http'],
                    {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
 child.on('exit', (code, signal) => {


### PR DESCRIPTION
Add `--set key=""` to cut down the time it takes to run
test-benchmark-http by about a third.

Alphabetize options in `--set` list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark http