### PR TITLE
benchmark: allow no duration in benchmark tests

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -197,7 +197,10 @@ Benchmark.prototype.end = function(operations) {
     throw new Error('called end() with operation count <= 0');
   }
   if (elapsed[0] === 0 && elapsed[1] === 0) {
-    throw new Error('insufficient time precision for short benchmark');
+    if (!process.env.NODEJS_BENCHMARK_ZERO_ALLOWED)
+      throw new Error('insufficient clock precision for short benchmark');
+    // avoid dividing by zero
+    elapsed[1] = 1;
   }
 
   const time = elapsed[0] + elapsed[1] / 1e9;


### PR DESCRIPTION
Imprecision in process.hrtime() in some situations can result in a zero
duration being used as a denominator in benchmark tests. This would
almost certainly never happen in real benchmarks. It is only likely in
very short benchmarks like the type we run in our test suite to just
make sure that the benchmark code is runnable.

So, if the environment variable that we use in tests to indicate "allow
ludicrously short benchmarks" is set, convert a zero duration for
a benchmark to 1 nano-second.

Fixes: https://github.com/nodejs/node/issues/13102

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark http