### PR TITLE
doc: list macOS as supporting filename argument

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2405,10 +2405,10 @@ this improves the usability of file watching. This is expected behavior.
 
 <!--type=misc-->
 
-Providing `filename` argument in the callback is only supported on Linux and
-Windows.  Even on supported platforms, `filename` is not always guaranteed to
-be provided. Therefore, don't assume that `filename` argument is always
-provided in the callback, and have some fallback logic if it is null.
+Providing `filename` argument in the callback is only supported on Linux, 
+macOS, and Windows.  Even on supported platforms, `filename` is not always 
+guaranteed to be provided. Therefore, don't assume that `filename` argument is 
+always provided in the callback, and have some fallback logic if it is null.
 
 ```js
 fs.watch('somedir', (eventType, filename) => {

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2406,7 +2406,7 @@ this improves the usability of file watching. This is expected behavior.
 <!--type=misc-->
 
 Providing `filename` argument in the callback is only supported on Linux, 
-macOS, and Windows.  Even on supported platforms, `filename` is not always 
+macOS, Windows, and AIX.  Even on supported platforms, `filename` is not always 
 guaranteed to be provided. Therefore, don't assume that `filename` argument is 
 always provided in the callback, and have some fallback logic if it is null.
 

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -64,24 +64,20 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
   }
 }, 2));
 
-// Watch events should callback with a filename
-if (common.isLinux || common.isOSX) {
+// Watch events should callback with a filename on supported systems
+if (common.isLinux || common.isOSX || common.isWindows || common.isAix) {
   const dir = common.tmpDir + '/watch';
 
   fs.mkdir(dir, common.mustCall(function(err) {
-    assert(!err);
+    if (err) assert.fail(err);
 
     fs.watch(dir, common.mustCall(function(eventType, filename) {
       this._handle.close();
-      common.refreshTmpDir();
       assert.strictEqual(filename, 'foo.txt');
     }));
 
-    fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall((err) => {
-      if (err) {
-        common.refreshTmpDir();
-        assert(!err);
-      }
+    fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall(function(err) {
+      if (err) assert.fail(err);
     }));
   }));
 }

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -63,3 +63,25 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
     fs.unwatchFile(enoentFile);
   }
 }, 2));
+
+// Watch events should callback with a filename
+if (common.isLinux || common.isOSX) {
+  const dir = common.tmpDir + '/watch';
+
+  fs.mkdir(dir, common.mustCall(function(err) {
+    assert(!err);
+
+    fs.watch(dir, common.mustCall(function(eventType, filename) {
+      this._handle.close();
+      common.refreshTmpDir();
+      assert.strictEqual(filename, 'foo.txt');
+    }));
+
+    fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall((err) => {
+      if (err) {
+        common.refreshTmpDir();
+        assert(!err);
+      }
+    }));
+  }));
+}


### PR DESCRIPTION
macOS is not currently listed as a supported os for the fs.watch filename argument, but it does work. This commit updates the documentation to reflect that.

Fixes: https://github.com/nodejs/node/issues/13108

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
docs, tests
