### PR TITLE
test: allow for absent nobody user in setuid test

### DIFF
--- a/test/parallel/test-process-setuid-setgid.js
+++ b/test/parallel/test-process-setuid-setgid.js
@@ -51,7 +51,7 @@ if (process.getuid() !== 0) {
 
   assert.throws(
     () => { process.setuid('nobody'); },
-    /^Error: EPERM, /
+    /^Error: (EPERM, .+|setuid user id does not exist)$/
   );
   return;
 }


### PR DESCRIPTION
Some isolated build or test VMs don't have a "nobody" user, causing the
parallel/test-process-setuid-setgid test to fail. Add logic to allow for
that situation.

Fixes: https://github.com/nodejs/node/issues/13071

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test process