### PR TITLE
stream: improve readable push performance

### DIFF
--- a/benchmark/streams/readable-boundaryread.js
+++ b/benchmark/streams/readable-boundaryread.js
@@ -4,20 +4,22 @@ const common = require('../common');
 const Readable = require('stream').Readable;
 
 const bench = common.createBenchmark(main, {
-  n: [200e1]
+  n: [200e1],
+  type: ['string', 'buffer']
 });
 
 function main(conf) {
   const n = +conf.n;
-  const b = new Buffer(32);
   const s = new Readable();
-  function noop() {}
-  s._read = noop;
+  var data = 'a'.repeat(32);
+  if (conf.type === 'buffer')
+    data = Buffer.from(data);
+  s._read = function() {};
 
   bench.start();
   for (var k = 0; k < n; ++k) {
     for (var i = 0; i < 1e4; ++i)
-      s.push(b);
+      s.push(data);
     while (s.read(32));
   }
   bench.end(n);

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -177,79 +177,95 @@ Readable.prototype._destroy = function(err, cb) {
 // write() some more.
 Readable.prototype.push = function(chunk, encoding) {
   var state = this._readableState;
+  var skipChunkCheck;
 
-  if (!state.objectMode && typeof chunk === 'string') {
-    encoding = encoding || state.defaultEncoding;
-    if (encoding !== state.encoding) {
-      chunk = Buffer.from(chunk, encoding);
-      encoding = '';
+  if (!state.objectMode) {
+    if (typeof chunk === 'string') {
+      encoding = encoding || state.defaultEncoding;
+      if (encoding !== state.encoding) {
+        chunk = Buffer.from(chunk, encoding);
+        encoding = '';
+      }
+      skipChunkCheck = true;
     }
+  } else {
+    skipChunkCheck = true;
   }
 
-  return readableAddChunk(this, state, chunk, encoding, false);
+  return readableAddChunk(this, chunk, encoding, false, skipChunkCheck);
 };
 
 // Unshift should *always* be something directly out of read()
 Readable.prototype.unshift = function(chunk) {
-  var state = this._readableState;
-  return readableAddChunk(this, state, chunk, '', true);
+  return readableAddChunk(this, chunk, null, true, false);
 };
 
-Readable.prototype.isPaused = function() {
-  return this._readableState.flowing === false;
-};
-
-function readableAddChunk(stream, state, chunk, encoding, addToFront) {
-  var er = chunkInvalid(state, chunk);
-  if (er) {
-    stream.emit('error', er);
-  } else if (chunk === null) {
+function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
+  var state = stream._readableState;
+  if (chunk === null) {
     state.reading = false;
     onEofChunk(stream, state);
-  } else if (state.objectMode || chunk && chunk.length > 0) {
-    if (state.ended && !addToFront) {
-      const e = new Error('stream.push() after EOF');
-      stream.emit('error', e);
-    } else if (state.endEmitted && addToFront) {
-      const e = new Error('stream.unshift() after end event');
-      stream.emit('error', e);
-    } else {
-      var skipAdd;
-      if (state.decoder && !addToFront && !encoding) {
-        chunk = state.decoder.write(chunk);
-        skipAdd = (!state.objectMode && chunk.length === 0);
-      }
-
-      if (!addToFront)
+  } else {
+    var er;
+    if (!skipChunkCheck)
+      er = chunkInvalid(state, chunk);
+    if (er) {
+      stream.emit('error', er);
+    } else if (state.objectMode || chunk && chunk.length > 0) {
+      if (addToFront) {
+        if (state.endEmitted)
+          stream.emit('error', new Error('stream.unshift() after end event'));
+        else
+          addChunk(stream, state, chunk, true);
+      } else if (state.ended) {
+        stream.emit('error', new Error('stream.push() after EOF'));
+      } else {
         state.reading = false;
-
-      // Don't add to the buffer if we've decoded to an empty string chunk and
-      // we're not in object mode
-      if (!skipAdd) {
-        // if we want the data now, just emit it.
-        if (state.flowing && state.length === 0 && !state.sync) {
-          stream.emit('data', chunk);
-          stream.read(0);
-        } else {
-          // update the buffer info.
-          state.length += state.objectMode ? 1 : chunk.length;
-          if (addToFront)
-            state.buffer.unshift(chunk);
+        if (state.decoder && !encoding) {
+          chunk = state.decoder.write(chunk);
+          if (state.objectMode || chunk.length !== 0)
+            addChunk(stream, state, chunk, false);
           else
-            state.buffer.push(chunk);
-
-          if (state.needReadable)
-            emitReadable(stream);
+            maybeReadMore(stream, state);
+        } else {
+          addChunk(stream, state, chunk, false);
         }
       }
-
-      maybeReadMore(stream, state);
+    } else if (!addToFront) {
+      state.reading = false;
     }
-  } else if (!addToFront) {
-    state.reading = false;
   }
 
   return needMoreData(state);
+}
+
+function addChunk(stream, state, chunk, addToFront) {
+  if (state.flowing && state.length === 0 && !state.sync) {
+    stream.emit('data', chunk);
+    stream.read(0);
+  } else {
+    // update the buffer info.
+    state.length += state.objectMode ? 1 : chunk.length;
+    if (addToFront)
+      state.buffer.unshift(chunk);
+    else
+      state.buffer.push(chunk);
+
+    if (state.needReadable)
+      emitReadable(stream);
+  }
+  maybeReadMore(stream, state);
+}
+
+function chunkInvalid(state, chunk) {
+  var er;
+  if (!(chunk instanceof Buffer) &&
+      typeof chunk !== 'string' &&
+      chunk !== undefined &&
+      !state.objectMode) {
+    er = new TypeError('Invalid non-string/buffer chunk');
+  }
+  return er;
 }
 
 
@@ -266,6 +282,10 @@ function needMoreData(state) {
           state.length < state.highWaterMark ||
           state.length === 0);
 }
+
+Readable.prototype.isPaused = function() {
+  return this._readableState.flowing === false;
+};
 
 // backwards compatibility.
 Readable.prototype.setEncoding = function(enc) {
@@ -437,19 +457,6 @@ Readable.prototype.read = function(n) {
 
   return ret;
 };
-
-function chunkInvalid(state, chunk) {
-  var er = null;
-  if (!(chunk instanceof Buffer) &&
-      typeof chunk !== 'string' &&
-      chunk !== null &&
-      chunk !== undefined &&
-      !state.objectMode) {
-    er = new TypeError('Invalid non-string/buffer chunk');
-  }
-  return er;
-}
-
 
 function onEofChunk(stream, state) {
   if (state.ended) return;


### PR DESCRIPTION
This is mostly about improving performance when pushing strings, but pushing Buffers seems to be just a tad faster too. Specifically this PR makes two types of changes: avoid unnecessary chunk validation and reducing duplicated conditionals.

Here are results from one of the benchmark files I modified to be able to test strings:

```
                                                        improvement confidence      p.value
 streams/readable-boundaryread.js type="buffer" n=2000      3.04 %          * 3.055942e-02
 streams/readable-boundaryread.js type="string" n=2000     19.08 %        *** 2.927688e-11
```

CI: https://ci.nodejs.org/job/node-test-pull-request/8170/

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* stream
