### PR TITLE
src: fix coverity warnings

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -534,7 +534,9 @@ class QueryWrap : public AsyncWrap {
     data->len = answer_len;
 
     uv_async_t* async_handle = &data->async_handle;
-    uv_async_init(wrap->env()->event_loop(), async_handle, CaresAsyncCb);
+    CHECK_EQ(0, uv_async_init(wrap->env()->event_loop(),
+                              async_handle,
+                              CaresAsyncCb));
 
     wrap->env()->set_cares_query_last_ok(status != ARES_ECONNREFUSED);
     async_handle->data = data;
@@ -558,7 +560,9 @@ class QueryWrap : public AsyncWrap {
     data->is_host = true;
 
     uv_async_t* async_handle = &data->async_handle;
-    uv_async_init(wrap->env()->event_loop(), async_handle, CaresAsyncCb);
+    CHECK_EQ(0, uv_async_init(wrap->env()->event_loop(),
+                              async_handle,
+                              CaresAsyncCb));
 
     wrap->env()->set_cares_query_last_ok(status != ARES_ECONNREFUSED);
     async_handle->data = data;


### PR DESCRIPTION
This commit checks the return value of two calls to `uv_async_init()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src