### PR TITLE
doc: fix title/function name mismatch

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1590,7 +1590,7 @@ x is passed in it returns `napi_string_expected`.
 
 This API returns the UTF8-encoded string corresponding the value passed in.
 
-#### *napi_get_value_string_utf16_length*
+#### *napi_get_value_string_utf16*
 <!-- YAML
 added: v8.0.0
 -->


### PR DESCRIPTION
Fix mismatch in title for napi_get_value_string_utf16

Fixes: https://github.com/nodejs/abi-stable-node/issues/243

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
doc, n-api