### PR TITLE
test: increase n-api constructor coverage

### DIFF
--- a/test/addons-napi/test_constructor/test.js
+++ b/test/addons-napi/test_constructor/test.js
@@ -40,3 +40,8 @@ test_object.readwriteAccessor2 = 2;
 assert.strictEqual(test_object.readwriteAccessor2, 2);
 assert.strictEqual(test_object.readonlyAccessor2, 2);
 assert.throws(() => { test_object.readonlyAccessor2 = 3; }, TypeError);
+
+// validate that static properties are on the class as opposed
+// to the instance
+assert.strictEqual(TestConstructor.staticReadonlyAccessor1, 10);
+assert.strictEqual(test_object.staticReadonlyAccessor1, undefined);

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -72,7 +72,8 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     { "readwriteAccessor2", 0, 0, GetValue, SetValue, 0, napi_writable, 0},
     { "readonlyAccessor1", 0, 0, GetValue, NULL, 0, napi_default, 0},
     { "readonlyAccessor2", 0, 0, GetValue, NULL, 0, napi_writable, 0},
-    { "staticReadonlyAccessor1", 0, 0, GetStaticValue, NULL, 0, napi_default | napi_static, 0},
+    { "staticReadonlyAccessor1", 0, 0, GetStaticValue, NULL, 0,
+        napi_default | napi_static, 0},
   };
 
   napi_value cons;

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -2,6 +2,7 @@
 #include "../common.h"
 
 static double value_ = 1;
+static double static_value_ = 10;
 napi_ref constructor_;
 
 napi_value GetValue(napi_env env, napi_callback_info info) {
@@ -45,6 +46,19 @@ napi_value New(napi_env env, napi_callback_info info) {
   return _this;
 }
 
+napi_value GetStaticValue(napi_env env, napi_callback_info info) {
+  size_t argc = 0;
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, NULL, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 0, "Wrong number of arguments");
+
+  napi_value number;
+  NAPI_CALL(env, napi_create_number(env, static_value_, &number));
+
+  return number;
+}
+
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_value number;
   NAPI_CALL_RETURN_VOID(env, napi_create_number(env, value_, &number));
@@ -58,6 +72,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     { "readwriteAccessor2", 0, 0, GetValue, SetValue, 0, napi_writable, 0},
     { "readonlyAccessor1", 0, 0, GetValue, NULL, 0, napi_default, 0},
     { "readonlyAccessor2", 0, 0, GetValue, NULL, 0, napi_writable, 0},
+    { "staticReadonlyAccessor1", 0, 0, GetStaticValue, NULL, 0, napi_default | napi_static, 0},
   };
 
   napi_value cons;


### PR DESCRIPTION
Add tests to validate that properties marked as static
are available through the class as opposed to instances

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test, n-api