### PR TITLE
test: check number of message events

### DIFF
--- a/test/parallel/test-child-process-fork-ref2.js
+++ b/test/parallel/test-child-process-fork-ref2.js
@@ -29,7 +29,7 @@ if (process.argv[2] === 'child') {
 
   setTimeout(function() {
     console.log('child -> will this keep it alive?');
-    process.on('message', common.noop);
+    process.on('message', common.mustNotCall());
   }, 400);
 
 } else {

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -45,7 +45,7 @@ if (process.argv[2] !== 'child') {
   // the only thing keeping this worker alive will be IPC. This is important,
   // because it means a worker with no parent will have no referenced handles,
   // thus no work to do, and will exit immediately, preventing process leaks.
-  process.on('message', common.noop);
+  process.on('message', common.mustCall());
 
   const server = net.createServer((c) => {
     process.once('message', function(msg) {


### PR DESCRIPTION
When a no-op message event handler is used in a test, make it clear what
is expected by using `common.mustCall()` and `common.mustNotCall()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process