### PR TITLE
cli: accept /dev/stdin as input file on Linux

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -195,6 +195,8 @@ Module._findPath = function(request, paths, isMain) {
         if (exts === undefined)
           exts = Object.keys(Module._extensions);
         filename = tryPackage(basePath, exts, isMain);
+      } else if (rc === 2) {
+        filename = basePath;
       }
 
       if (!filename) {

--- a/test/parallel/test-cli-arg-devstdin-posix.js
+++ b/test/parallel/test-cli-arg-devstdin-posix.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+
+if (common.isWindows) {
+  common.skip('This test does not apply to Windows.');
+  return;
+}
+
+const assert = require('assert');
+
+const expected = '--option-to-be-seen-on-child';
+
+const { spawn } = require('child_process');
+const child = spawn(process.execPath, ['/dev/stdin', expected], { stdio: 'pipe' });
+
+child.stdin.end('console.log(process.argv[2])');
+
+let actual = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (chunk) => actual += chunk);
+child.stdout.on('end', common.mustCall(() => {
+  assert.strictEqual(actual.trim(), expected);
+}));


### PR DESCRIPTION
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
cli

As mentioned above, tests will be added but for now, test it *on Linux* (macOS is OK) like this which with current version is broken:

`make && echo "console.log(process.argv[2])" | ./node /dev/stdin --option-for-stdin-script`