### PR TITLE
test: confirm callback is invoked in fs test

### DIFF
--- a/test/parallel/test-fs-makeStatsCallback.js
+++ b/test/parallel/test-fs-makeStatsCallback.js
@@ -16,7 +16,7 @@ function testMakeStatsCallback(cb) {
 common.expectWarning('DeprecationWarning', warn);
 
 // Verify the case where a callback function is provided
-assert.doesNotThrow(testMakeStatsCallback(common.noop));
+assert.doesNotThrow(testMakeStatsCallback(common.mustCall()));
 
 // Passing undefined/nothing calls rethrow() internally, which emits a warning
 assert.doesNotThrow(testMakeStatsCallback());


### PR DESCRIPTION
Use common.mustCall() in test-fs-makeStatsCallback to confirm that the
callback is invoked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs