### PR TITLE
doc: fix incorrect keyboard shortcut

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -39,7 +39,7 @@
 * When documenting APIs, note the version the API was introduced in at
   the end of the section. If an API has been deprecated, also note the first
   version that the API appeared deprecated in.
-* When using dashes, use emdashes ("—", Ctrl+Alt+"-" on macOS) surrounded by
+* When using dashes, use emdashes ("—", Option+Shift+"-" on macOS) surrounded by
   spaces, per the New York Times usage.
 * Including assets:
   * If you wish to add an illustration or full program, add it to the


### PR DESCRIPTION
This commit fixes an incorrect keyboard shortcut in `doc/STYLE_GUIDE.md`: entering em-dashes is done via Alt+Shift+"-" on macOS, not via Ctrl+Alt+"-". Besides that, Option is more canonical name of Alt on Macs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc