### PR TITLE
doc: update repo url in license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,7 +23,7 @@ IN THE SOFTWARE.
 """
 
 This license applies to parts of Node.js originating from the
-https://github.com/joyent/node repository:
+https://github.com/nodejs/node repository:
 
 """
 Copyright Joyent, Inc. and other Node contributors. All rights reserved.


### PR DESCRIPTION
Since the project was moved to https://github.com/nodejs/node, this changes the `LICENSE` file to direct readers there instead of https://github.com/joyent/node (which redirects to a page saying the project has been moved).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc