### PR TITLE
dns: add resolveAny support

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -197,6 +197,7 @@ records. The type and structure of individual results varies based on `rrtype`:
 | `'SOA'`   | start of authority records     | {Object}    | [`dns.resolveSoa()`][]   |
 | `'SRV'`   | service records                | {Object}    | [`dns.resolveSrv()`][]   |
 | `'TXT'`   | text records                   | {string}    | [`dns.resolveTxt()`][]   |
+| `'ANY'`   | any records                    | {Object}    | [`dns.resolveAny()`][]   |
 
 On error, `err` is an [`Error`][] object, where `err.code` is one of the
 [DNS error codes](#dns_error_codes).
@@ -417,6 +418,51 @@ is a two-dimensional array of the text records available for `hostname` (e.g.,
 one record. Depending on the use case, these could be either joined together or
 treated separately.
 
+## dns.resolveAny(hostname, callback)
+
+- `hostname` {string}
+- `callback` {Function}
+  - `err` {Error}
+  - `ret` {Object[][]}
+
+Uses the DNS protocol to resolve any queries (`ANY` records) for the `hostname`.
+The `ret` argument passed to the `callback` function will be an array of objects
+with uncertain type of records. Each object has a property `type` that indicates
+the type of current record. And for each type of record, the object structure
+will be like:
+
+| Type | Properties |
+|------|------------|
+| `"A"` | `address` / `ttl` |
+| `"AAAA"` | `address` / `ttl` |
+| `"CNAME"` | `value` |
+| `"MX"` | Refer to [`dns.resolveMx()`][] |
+| `"NAPTR"` | Refer to [`dns.resolveNaptr()`][] |
+| `"NS"` | `value` |
+| `"PTR"` | `value` |
+| `"SOA"` | Refer to [`dns.resolveSoa()`][] |
+| `"SRV"` | Refer to [`dns.resolveSrv()`][] |
+| `"TXT"` | This is an array-liked object with `length` and `indexes`, eg. `{'0':'sth','length':1}` |
+
+Following is a example of the `ret` object passed to the callback:
+
+<!-- eslint-disable -->
+```js
+[ { address: '127.0.0.1', ttl: 299, type: 'A' },
+  { value: 'example.com', type: 'CNAME' }, // in fact, CNAME can't stay with A
+  { exchange: 'alt4.aspmx.l.example.com', priority: 50, type: 'MX' },
+  { value: 'ns1.example.com', type: 'NS' },
+  { '0': 'v=spf1 include:_spf.example.com ~all', type: 'TXT', length: 1 },
+  { nsname: 'ns1.example.com',
+    hostmaster: 'admin.example.com',
+    serial: 156696742,
+    refresh: 900,
+    retry: 900,
+    expire: 1800,
+    minttl: 60,
+    type: 'SOA' } ]
+```
+
 ## dns.reverse(ip, callback)
 <!-- YAML
 added: v0.1.16
@@ -531,6 +577,7 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [`dns.resolveSoa()`]: #dns_dns_resolvesoa_hostname_callback
 [`dns.resolveSrv()`]: #dns_dns_resolvesrv_hostname_callback
 [`dns.resolveTxt()`]: #dns_dns_resolvetxt_hostname_callback
+[`dns.resolveAny()`]: #dns_dns_resolveany_hostname_callback
 [DNS error codes]: #dns_error_codes
 [Implementation considerations section]: #dns_implementation_considerations
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -442,7 +442,7 @@ will be present on the object:
 | `"PTR"` | `value` |
 | `"SOA"` | Refer to [`dns.resolveSoa()`][] |
 | `"SRV"` | Refer to [`dns.resolveSrv()`][] |
-| `"TXT"` | This is an array-like object with `length` and `indexes`, eg. `{'0':'sth','length':1}` |
+| `"TXT"` | This type of record contains an array property called `entries` which refers to [`dns.resolveTxt()`][], eg. `{ entries: ['...'], type: 'TXT' }` |
 
 Here is a example of the `ret` object passed to the callback:
 
@@ -452,7 +452,7 @@ Here is a example of the `ret` object passed to the callback:
   { type: 'CNAME', value: 'example.com' },
   { type: 'MX', exchange: 'alt4.aspmx.l.example.com', priority: 50 },
   { type: 'NS', value: 'ns1.example.com', type: 'NS' },
-  { type: 'TXT', '0': 'v=spf1 include:_spf.example.com ~all', length: 1 },
+  { type: 'TXT', entries: [ 'v=spf1 include:_spf.example.com ~all' ] },
   { type: 'SOA',
     nsname: 'ns1.example.com',
     hostmaster: 'admin.example.com',

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -425,11 +425,11 @@ treated separately.
   - `err` {Error}
   - `ret` {Object[][]}
 
-Uses the DNS protocol to resolve any queries (`ANY` records) for the `hostname`.
+Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
 The `ret` argument passed to the `callback` function will be an array of objects
 with uncertain type of records. Each object has a property `type` that indicates
-the type of current record. And for each type of record, the object structure
-will be like:
+the type of current record. And depending on the `type`, additional properties
+will be present on the object:
 
 | Type | Properties |
 |------|------------|
@@ -444,23 +444,23 @@ will be like:
 | `"SRV"` | Refer to [`dns.resolveSrv()`][] |
 | `"TXT"` | This is an array-liked object with `length` and `indexes`, eg. `{'0':'sth','length':1}` |
 
-Following is a example of the `ret` object passed to the callback:
+Here is a example of the `ret` object passed to the callback:
 
 <!-- eslint-disable -->
 ```js
-[ { address: '127.0.0.1', ttl: 299, type: 'A' },
-  { value: 'example.com', type: 'CNAME' }, // in fact, CNAME can't stay with A
-  { exchange: 'alt4.aspmx.l.example.com', priority: 50, type: 'MX' },
-  { value: 'ns1.example.com', type: 'NS' },
-  { '0': 'v=spf1 include:_spf.example.com ~all', type: 'TXT', length: 1 },
-  { nsname: 'ns1.example.com',
+[ { type: 'A', address: '127.0.0.1', ttl: 299 },
+  { type: 'CNAME', value: 'example.com' },
+  { type: 'MX', exchange: 'alt4.aspmx.l.example.com', priority: 50 },
+  { type: 'NS', value: 'ns1.example.com', type: 'NS' },
+  { type: 'TXT', '0': 'v=spf1 include:_spf.example.com ~all', length: 1 },
+  { type: 'SOA',
+    nsname: 'ns1.example.com',
     hostmaster: 'admin.example.com',
     serial: 156696742,
     refresh: 900,
     retry: 900,
     expire: 1800,
-    minttl: 60,
-    type: 'SOA' } ]
+    minttl: 60 } ]
 ```
 
 ## dns.reverse(ip, callback)

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -426,9 +426,9 @@ treated separately.
   - `ret` {Object[][]}
 
 Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
-The `ret` argument passed to the `callback` function will be an array of objects
-with uncertain type of records. Each object has a property `type` that indicates
-the type of current record. And depending on the `type`, additional properties
+The `ret` argument passed to the `callback` function will be an array containing
+various types of records. Each object has a property `type` that indicates the
+type of the current record. And depending on the `type`, additional properties
 will be present on the object:
 
 | Type | Properties |
@@ -442,7 +442,7 @@ will be present on the object:
 | `"PTR"` | `value` |
 | `"SOA"` | Refer to [`dns.resolveSoa()`][] |
 | `"SRV"` | Refer to [`dns.resolveSrv()`][] |
-| `"TXT"` | This is an array-liked object with `length` and `indexes`, eg. `{'0':'sth','length':1}` |
+| `"TXT"` | This is an array-like object with `length` and `indexes`, eg. `{'0':'sth','length':1}` |
 
 Here is a example of the `ret` object passed to the callback:
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -279,6 +279,7 @@ function resolver(bindingName) {
 
 
 var resolveMap = Object.create(null);
+resolveMap.ANY = resolver('queryAny');
 resolveMap.A = resolver('queryA');
 resolveMap.AAAA = resolver('queryAaaa');
 resolveMap.CNAME = resolver('queryCname');
@@ -361,6 +362,7 @@ module.exports = {
   getServers,
   setServers,
   resolve,
+  resolveAny: resolveMap.ANY,
   resolve4: resolveMap.A,
   resolve6: resolveMap.AAAA,
   resolveCname: resolveMap.CNAME,

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -69,6 +69,17 @@ using v8::Value;
 
 namespace {
 
+#define CARES_16BIT(p) ((uint16_t)((unsigned int) 0xffff & \
+                         (((unsigned int)((unsigned char)(p)[0]) << 8U) | \
+                          ((unsigned int)((unsigned char)(p)[1])))))
+#define CARES_32BIT(p) ((unsigned int) \
+                         (((unsigned int)((unsigned char)(p)[0]) << 24U) | \
+                          ((unsigned int)((unsigned char)(p)[1]) << 16U) | \
+                          ((unsigned int)((unsigned char)(p)[2]) <<  8U) | \
+                          ((unsigned int)((unsigned char)(p)[3]))))
+
+const int ns_t_cname_or_a = -1;
+
 inline const char* ToErrorCodeString(int status) {
   switch (status) {
 #define V(code) case ARES_##code: return #code;
@@ -270,28 +281,36 @@ void ares_sockstate_cb(void* data,
 }
 
 
-Local<Array> HostentToAddresses(Environment* env, struct hostent* host) {
+Local<Array> HostentToAddresses(Environment* env,
+                                struct hostent* host,
+                                Local<Array> prev = Local<Array>()) {
   EscapableHandleScope scope(env->isolate());
-  Local<Array> addresses = Array::New(env->isolate());
+  bool use_prev = !prev.IsEmpty();
+  Local<Array> addresses = use_prev ? prev : Array::New(env->isolate());
+  size_t offset = addresses->Length();
 
   char ip[INET6_ADDRSTRLEN];
   for (uint32_t i = 0; host->h_addr_list[i] != nullptr; ++i) {
     uv_inet_ntop(host->h_addrtype, host->h_addr_list[i], ip, sizeof(ip));
     Local<String> address = OneByteString(env->isolate(), ip);
-    addresses->Set(i, address);
+    addresses->Set(i + offset, address);
   }
 
-  return scope.Escape(addresses);
+  return use_prev ? addresses : scope.Escape(addresses);
 }
 
 
-Local<Array> HostentToNames(Environment* env, struct hostent* host) {
+Local<Array> HostentToNames(Environment* env,
+                            struct hostent* host,
+                            Local<Array> prev = Local<Array>()) {
   EscapableHandleScope scope(env->isolate());
-  Local<Array> names = Array::New(env->isolate());
+  bool use_prev = !prev.IsEmpty();
+  Local<Array> names = use_prev ? prev : Array::New(env->isolate());
+  size_t offset = names->Length();
 
   for (uint32_t i = 0; host->h_aliases[i] != nullptr; ++i) {
     Local<String> address = OneByteString(env->isolate(), host->h_aliases[i]);
-    names->Set(i, address);
+    names->Set(i + offset, address);
   }
 
   return scope.Escape(names);
@@ -525,6 +544,573 @@ class QueryWrap : public AsyncWrap {
   }
 };
 
+Local<Array> AddrTTLToArray(Environment* env,
+                            ares_addrttl* addrttls,
+                            int naddrttls) {
+  auto isolate = env->isolate();
+  EscapableHandleScope escapable_handle_scope(isolate);
+
+  Local<Array> ttls = Array::New(isolate, naddrttls);
+  auto context = env->context();
+  for (int i = 0; i < naddrttls; i += 1) {
+    auto value = Integer::New(isolate, addrttls[i].ttl);
+    ttls->Set(context, i, value).FromJust();
+  }
+
+  return escapable_handle_scope.Escape(ttls);
+}
+
+
+Local<Array> AddrTTL6ToArray(Environment* env,
+                             ares_addr6ttl* addrttls,
+                             int naddrttls) {
+  auto isolate = env->isolate();
+  EscapableHandleScope escapable_handle_scope(isolate);
+
+  Local<Array> ttls = Array::New(isolate, naddrttls);
+  auto context = env->context();
+  for (int i = 0; i < naddrttls; i += 1) {
+    auto value = Integer::New(isolate, addrttls[i].ttl);
+    ttls->Set(context, i, value).FromJust();
+  }
+
+  return escapable_handle_scope.Escape(ttls);
+}
+
+
+int ParseGeneralReply(Environment* env,
+                      unsigned char* buf,
+                      int len,
+                      int* type,
+                      Local<Array> ret,
+                      void* addrttls = nullptr,
+                      int* naddrttls = nullptr) {
+  HandleScope handle_scope(env->isolate());
+  hostent* host;
+
+  int status;
+  switch (*type) {
+  case ns_t_a:
+  case ns_t_cname:
+  case ns_t_cname_or_a:
+    status = ares_parse_a_reply(buf,
+                                len,
+                                &host,
+                                reinterpret_cast<ares_addrttl*>(addrttls),
+                                naddrttls);
+    break;
+  case ns_t_aaaa:
+    status = ares_parse_aaaa_reply(buf,
+                                   len,
+                                   &host,
+                                   reinterpret_cast<ares_addr6ttl*>(addrttls),
+                                   naddrttls);
+    break;
+  case ns_t_ns:
+    status = ares_parse_ns_reply(buf, len, &host);
+    break;
+  case ns_t_ptr:
+    status = ares_parse_ptr_reply(buf, len, NULL, 0, AF_INET, &host);
+    break;
+  default:
+    CHECK(0 && "Bad NS type");
+  }
+
+  if (status != ARES_SUCCESS)
+    return status;
+
+  /* If it's `CNAME`, return the CNAME value */
+  /* And if it's `CNAME_OR_A` and it has value in `h_name` and `h_aliases[0]` */
+  /* We consider it's a CNAME record, otherwise we consider it's an A record */
+  if ((*type == ns_t_cname_or_a && host->h_name && host->h_aliases[0]) ||
+      *type == ns_t_cname) {
+    // A cname lookup always returns a single record but we follow the
+    // common API here.
+    *type = ns_t_cname;
+    ret->Set(ret->Length(), OneByteString(env->isolate(), host->h_name));
+    ares_free_hostent(host);
+    return ARES_SUCCESS;
+  }
+
+  if (*type == ns_t_cname_or_a)
+    *type = ns_t_a;
+
+  if (*type == ns_t_ns) {
+    HostentToNames(env, host, ret);
+  } else if (*type == ns_t_ptr) {
+    uint32_t offset = ret->Length();
+    for (uint32_t i = 0; host->h_aliases[i] != NULL; i++) {
+      ret->Set(i + offset, OneByteString(env->isolate(), host->h_aliases[i]));
+    }
+  } else {
+    HostentToAddresses(env, host, ret);
+  }
+
+  ares_free_hostent(host);
+
+  return ARES_SUCCESS;
+}
+
+
+int ParseMxReply(Environment* env,
+                 unsigned char* buf,
+                 int len,
+                 Local<Array> ret,
+                 bool need_type = false) {
+  HandleScope handle_scope(env->isolate());
+
+  struct ares_mx_reply* mx_start;
+  int status = ares_parse_mx_reply(buf, len, &mx_start);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  Local<String> exchange_symbol = env->exchange_string();
+  Local<String> priority_symbol = env->priority_string();
+  Local<String> type_symbol = env->type_string();
+  Local<String> mx_symbol = env->dns_mx_string();
+
+  uint32_t offset = ret->Length();
+  ares_mx_reply* current = mx_start;
+  for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
+    Local<Object> mx_record = Object::New(env->isolate());
+    mx_record->Set(exchange_symbol,
+                   OneByteString(env->isolate(), current->host));
+    mx_record->Set(priority_symbol,
+                   Integer::New(env->isolate(), current->priority));
+    if (need_type)
+      mx_record->Set(type_symbol, mx_symbol);
+    ret->Set(i + offset, mx_record);
+  }
+
+  ares_free_data(mx_start);
+  return ARES_SUCCESS;
+}
+
+int ParseTxtReply(Environment* env,
+                  unsigned char* buf,
+                  int len,
+                  Local<Array> ret,
+                  bool need_type = false) {
+  HandleScope handle_scope(env->isolate());
+
+  struct ares_txt_ext* txt_out;
+
+  int status = ares_parse_txt_reply_ext(buf, len, &txt_out);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  Local<Array> txt_chunk;
+  Local<Object> txt_chunk_obj;
+
+  struct ares_txt_ext* current = txt_out;
+  uint32_t i = 0, j;
+  uint32_t offset = ret->Length();
+  for (j = 0; current != nullptr; current = current->next) {
+    Local<String> txt = OneByteString(env->isolate(), current->txt);
+
+    // New record found - write out the current chunk
+    if (current->record_start) {
+      if (!need_type) {
+        if (!txt_chunk.IsEmpty())
+          ret->Set(offset + i++, txt_chunk);
+        txt_chunk = Array::New(env->isolate());
+      } else {
+        if (!txt_chunk_obj.IsEmpty()) {
+          txt_chunk_obj->Set(env->type_string(), env->dns_txt_string());
+          txt_chunk_obj->Set(env->length_string(),
+                             Integer::New(env->isolate(), j));
+          ret->Set(offset + i++, txt_chunk_obj);
+        }
+        txt_chunk_obj = Object::New(env->isolate());
+      }
+
+      j = 0;
+    }
+
+    need_type ? txt_chunk_obj->Set(j++, txt) : txt_chunk->Set(j++, txt);
+  }
+
+  // Push last chunk if it isn't empty
+  if (!need_type && !txt_chunk.IsEmpty()) {
+    ret->Set(offset + i, txt_chunk);
+  } else if (need_type && !txt_chunk_obj.IsEmpty()) {
+    txt_chunk_obj->Set(env->type_string(), env->dns_txt_string());
+    txt_chunk_obj->Set(env->length_string(), Integer::New(env->isolate(), j));
+    ret->Set(offset + i, txt_chunk_obj);
+  }
+
+  ares_free_data(txt_out);
+  return ARES_SUCCESS;
+}
+
+
+int ParseSrvReply(Environment* env,
+                  unsigned char* buf,
+                  int len,
+                  Local<Array> ret,
+                  bool need_type = false) {
+  HandleScope handle_scope(env->isolate());
+  struct ares_srv_reply* srv_start;
+  int status = ares_parse_srv_reply(buf, len, &srv_start);
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  Local<String> name_symbol = env->name_string();
+  Local<String> port_symbol = env->port_string();
+  Local<String> priority_symbol = env->priority_string();
+  Local<String> weight_symbol = env->weight_string();
+  Local<String> type_symbol = env->type_string();
+  Local<String> srv_symbol = env->dns_srv_string();
+
+  ares_srv_reply* current = srv_start;
+  int offset = ret->Length();
+  for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
+    Local<Object> srv_record = Object::New(env->isolate());
+    srv_record->Set(name_symbol,
+                    OneByteString(env->isolate(), current->host));
+    srv_record->Set(port_symbol,
+                    Integer::New(env->isolate(), current->port));
+    srv_record->Set(priority_symbol,
+                    Integer::New(env->isolate(), current->priority));
+    srv_record->Set(weight_symbol,
+                    Integer::New(env->isolate(), current->weight));
+    if (need_type)
+      srv_record->Set(type_symbol, srv_symbol);
+    ret->Set(i + offset, srv_record);
+  }
+
+  ares_free_data(srv_start);
+  return ARES_SUCCESS;
+}
+
+
+int ParseNaptrReply(Environment* env,
+                    unsigned char* buf,
+                    int len,
+                    Local<Array> ret,
+                    bool need_type = false) {
+  HandleScope handle_scope(env->isolate());
+  ares_naptr_reply* naptr_start;
+  int status = ares_parse_naptr_reply(buf, len, &naptr_start);
+
+  if (status != ARES_SUCCESS) {
+    return status;
+  }
+
+  Local<String> flags_symbol = env->flags_string();
+  Local<String> service_symbol = env->service_string();
+  Local<String> regexp_symbol = env->regexp_string();
+  Local<String> replacement_symbol = env->replacement_string();
+  Local<String> order_symbol = env->order_string();
+  Local<String> preference_symbol = env->preference_string();
+  Local<String> type_symbol = env->type_string();
+  Local<String> naptr_symbol = env->dns_naptr_string();
+
+  ares_naptr_reply* current = naptr_start;
+  int offset = ret->Length();
+  for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
+    Local<Object> naptr_record = Object::New(env->isolate());
+    naptr_record->Set(flags_symbol,
+                      OneByteString(env->isolate(), current->flags));
+    naptr_record->Set(service_symbol,
+                      OneByteString(env->isolate(), current->service));
+    naptr_record->Set(regexp_symbol,
+                      OneByteString(env->isolate(), current->regexp));
+    naptr_record->Set(replacement_symbol,
+                      OneByteString(env->isolate(), current->replacement));
+    naptr_record->Set(order_symbol,
+                      Integer::New(env->isolate(), current->order));
+    naptr_record->Set(preference_symbol,
+                      Integer::New(env->isolate(), current->preference));
+    if (need_type)
+      naptr_record->Set(type_symbol, naptr_symbol);
+    ret->Set(i + offset, naptr_record);
+  }
+
+  ares_free_data(naptr_start);
+  return ARES_SUCCESS;
+}
+
+
+int ParseSoaReply(Environment* env,
+                  unsigned char* buf,
+                  int len,
+                  Local<Object>* ret) {
+  EscapableHandleScope handle_scope(env->isolate());
+
+  /* Can't use ares_parse_soa_reply() here which can only parse single record */
+  unsigned int ancount = CARES_16BIT(buf + 6);
+  unsigned char* ptr = buf + NS_HFIXEDSZ;
+  int rr_type, rr_len;
+  char* name;
+  char* rr_name;
+  long temp_len;  // NOLINT(runtime/int)
+  int status = ares_expand_name(ptr, buf, len, &name, &temp_len);
+  if (status != ARES_SUCCESS) {
+    /* returns EBADRESP in case of invalid input */
+    return status == ARES_EBADNAME ? ARES_EBADRESP : status;
+  }
+
+  if (ptr + temp_len + NS_QFIXEDSZ > buf + len) {
+    free(name);
+    return ARES_EBADRESP;
+  }
+  ptr += temp_len + NS_QFIXEDSZ;
+
+  for (unsigned int i = 0; i < ancount; i++) {
+    status = ares_expand_name(ptr, buf, len, &rr_name, &temp_len);
+
+    if (status != ARES_SUCCESS)
+      break;
+
+    ptr += temp_len;
+    if (ptr + NS_RRFIXEDSZ > buf + len) {
+      free(rr_name);
+      status = ARES_EBADRESP;
+      break;
+    }
+
+    rr_type = CARES_16BIT(ptr);
+    rr_len = CARES_16BIT(ptr + 8);
+    ptr += NS_RRFIXEDSZ;
+
+    /* only need SOA */
+    if (rr_type == ns_t_soa) {
+      ares_soa_reply* soa = node::Malloc<ares_soa_reply>(1);
+
+      status = ares_expand_name(ptr, buf, len, &soa->nsname, &temp_len);
+      if (status != ARES_SUCCESS) {
+        free(rr_name);
+        free(soa);
+        break;
+      }
+      ptr += temp_len;
+
+      status = ares_expand_name(ptr, buf, len, &soa->hostmaster, &temp_len);
+      if (status != ARES_SUCCESS) {
+        free(rr_name);
+        free(soa->nsname);
+        free(soa);
+        break;
+      }
+      ptr += temp_len;
+
+      if (ptr + 5 * 4 > buf + len) {
+        free(rr_name);
+        free(soa->nsname);
+        free(soa->hostmaster);
+        free(soa);
+        status = ARES_EBADRESP;
+        break;
+      }
+
+      soa->serial = CARES_32BIT(ptr + 0 * 4);
+      soa->refresh = CARES_32BIT(ptr + 1 * 4);
+      soa->retry = CARES_32BIT(ptr + 2 * 4);
+      soa->expire = CARES_32BIT(ptr + 3 * 4);
+      soa->minttl = CARES_32BIT(ptr + 4 * 4);
+
+      Local<Object> soa_record = Object::New(env->isolate());
+      soa_record->Set(env->nsname_string(),
+                      OneByteString(env->isolate(), soa->nsname));
+      soa_record->Set(env->hostmaster_string(),
+                      OneByteString(env->isolate(), soa->hostmaster));
+      soa_record->Set(env->serial_string(),
+                      Integer::New(env->isolate(), soa->serial));
+      soa_record->Set(env->refresh_string(),
+                      Integer::New(env->isolate(), soa->refresh));
+      soa_record->Set(env->retry_string(),
+                      Integer::New(env->isolate(), soa->retry));
+      soa_record->Set(env->expire_string(),
+                      Integer::New(env->isolate(), soa->expire));
+      soa_record->Set(env->minttl_string(),
+                      Integer::New(env->isolate(), soa->minttl));
+      soa_record->Set(env->type_string(), env->dns_soa_string());
+
+      free(soa->nsname);
+      free(soa->hostmaster);
+      free(soa);
+      free(rr_name);
+
+      *ret = handle_scope.Escape(soa_record);
+      break;
+    }
+
+    free(rr_name);
+    ptr += rr_len;
+  }
+
+  free(name);
+
+  if (status != ARES_SUCCESS) {
+    return status == ARES_EBADNAME ? ARES_EBADRESP : status;
+  }
+
+  return ARES_SUCCESS;
+}
+
+
+class QueryAnyWrap: public QueryWrap {
+ public:
+  QueryAnyWrap(Environment* env, Local<Object> req_wrap_obj)
+    : QueryWrap(env, req_wrap_obj) {
+  }
+
+  int Send(const char* name) override {
+    ares_query(env()->cares_channel(),
+               name,
+               ns_c_in,
+               ns_t_any,
+               Callback,
+               GetQueryArg());
+    return 0;
+  }
+
+  size_t self_size() const override { return sizeof(*this); }
+
+ protected:
+  void Parse(unsigned char* buf, int len) override {
+    HandleScope handle_scope(env()->isolate());
+    Context::Scope context_scope(env()->context());
+
+    Local<Array> ret = Array::New(env()->isolate());
+    int type, status, old_count;
+
+    /* Parse A records or CNAME records */
+    ares_addrttl addrttls[256];
+    int naddrttls = arraysize(addrttls);
+
+    type = ns_t_cname_or_a;
+    status = ParseGeneralReply(env(),
+                               buf,
+                               len,
+                               &type,
+                               ret,
+                               addrttls,
+                               &naddrttls);
+    int a_count = ret->Length();
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+
+    if (type == ns_t_a) {
+      CHECK_EQ(naddrttls, a_count);
+      for (int i = 0; i < a_count; i++) {
+        Local<Object> obj = Object::New(env()->isolate());
+        obj->Set(env()->address_string(), ret->Get(i));
+        obj->Set(env()->ttl_string(),
+                 Integer::New(env()->isolate(), addrttls[i].ttl));
+        obj->Set(env()->type_string(), env()->dns_a_string());
+        ret->Set(i, obj);
+      }
+    } else {
+      for (int i = 0; i < a_count; i++) {
+        Local<Object> obj = Object::New(env()->isolate());
+        obj->Set(env()->value_string(), ret->Get(i));
+        obj->Set(env()->type_string(), env()->dns_cname_string());
+        ret->Set(i, obj);
+      }
+    }
+
+    /* Parse AAAA records */
+    ares_addr6ttl addr6ttls[256];
+    int naddr6ttls = arraysize(addr6ttls);
+
+    type = ns_t_aaaa;
+    status = ParseGeneralReply(env(),
+                               buf,
+                               len,
+                               &type,
+                               ret,
+                               addr6ttls,
+                               &naddr6ttls);
+    int aaaa_count = ret->Length() - a_count;
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+
+    CHECK_EQ(aaaa_count, naddr6ttls);
+    for (uint32_t i = a_count; i < ret->Length(); i++) {
+      Local<Object> obj = Object::New(env()->isolate());
+      obj->Set(env()->address_string(), ret->Get(i));
+      obj->Set(env()->ttl_string(), Integer::New(env()->isolate(),
+                                                 addr6ttls[i].ttl));
+      obj->Set(env()->type_string(), env()->dns_aaaa_string());
+      ret->Set(i, obj);
+    }
+
+    /* Parse MX records */
+    status = ParseMxReply(env(), buf, len, ret, true);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+
+    /* Parse NS records */
+    type = ns_t_ns;
+    old_count = ret->Length();
+    status = ParseGeneralReply(env(), buf, len, &type, ret);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+    for (uint32_t i = old_count; i < ret->Length(); i++) {
+      Local<Object> obj = Object::New(env()->isolate());
+      obj->Set(env()->value_string(), ret->Get(i));
+      obj->Set(env()->type_string(), env()->dns_ns_string());
+      ret->Set(i, obj);
+    }
+
+    /* Parse TXT records */
+    status = ParseTxtReply(env(), buf, len, ret, true);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+
+    /* Parse SRV records */
+    status = ParseSrvReply(env(), buf, len, ret, true);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      return;
+    }
+
+    /* Parse PTR records */
+    type = ns_t_ptr;
+    old_count = ret->Length();
+    status = ParseGeneralReply(env(), buf, len, &type, ret);
+    for (uint32_t i = old_count; i < ret->Length(); i++) {
+      Local<Object> obj = Object::New(env()->isolate());
+      obj->Set(env()->value_string(), ret->Get(i));
+      obj->Set(env()->type_string(), env()->dns_ptr_string());
+      ret->Set(i, obj);
+    }
+
+    /* Parse NAPTR records */
+    status = ParseNaptrReply(env(), buf, len, ret, true);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+
+    /* Parse SOA records */
+    Local<Object> soa_record = Local<Object>();
+    status = ParseSoaReply(env(), buf, len, &soa_record);
+    if (status != ARES_SUCCESS && status != ARES_ENODATA) {
+      ParseError(status);
+      return;
+    }
+    if (!soa_record.IsEmpty())
+      ret->Set(ret->Length(), soa_record);
+
+    CallOnComplete(ret);
+  }
+};
+
 
 class QueryAWrap: public QueryWrap {
  public:
@@ -549,27 +1135,26 @@ class QueryAWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    hostent* host;
     ares_addrttl addrttls[256];
-    int naddrttls = arraysize(addrttls);
+    int naddrttls = arraysize(addrttls), status;
+    Local<Array> ret = Array::New(env()->isolate());
 
-    int status = ares_parse_a_reply(buf, len, &host, addrttls, &naddrttls);
+    int type = ns_t_a;
+    status = ParseGeneralReply(env(),
+                               buf,
+                               len,
+                               &type,
+                               ret,
+                               addrttls,
+                               &naddrttls);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
 
-    Local<Array> addresses = HostentToAddresses(env(), host);
-    Local<Array> ttls = Array::New(env()->isolate(), naddrttls);
+    Local<Array> ttls = AddrTTLToArray(env(), addrttls, naddrttls);
 
-    auto context = env()->context();
-    for (int i = 0; i < naddrttls; i += 1) {
-      auto value = Integer::New(env()->isolate(), addrttls[i].ttl);
-      ttls->Set(context, i, value).FromJust();
-    }
-    ares_free_hostent(host);
-
-    CallOnComplete(addresses, ttls);
+    CallOnComplete(ret, ttls);
   }
 };
 
@@ -597,27 +1182,26 @@ class QueryAaaaWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    hostent* host;
     ares_addr6ttl addrttls[256];
-    int naddrttls = arraysize(addrttls);
+    int naddrttls = arraysize(addrttls), status;
+    Local<Array> ret = Array::New(env()->isolate());
 
-    int status = ares_parse_aaaa_reply(buf, len, &host, addrttls, &naddrttls);
+    int type = ns_t_aaaa;
+    status = ParseGeneralReply(env(),
+                               buf,
+                               len,
+                               &type,
+                               ret,
+                               addrttls,
+                               &naddrttls);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
 
-    Local<Array> addresses = HostentToAddresses(env(), host);
-    Local<Array> ttls = Array::New(env()->isolate(), naddrttls);
+    Local<Array> ttls = AddrTTL6ToArray(env(), addrttls, naddrttls);
 
-    auto context = env()->context();
-    for (int i = 0; i < naddrttls; i += 1) {
-      auto value = Integer::New(env()->isolate(), addrttls[i].ttl);
-      ttls->Set(context, i, value).FromJust();
-    }
-    ares_free_hostent(host);
-
-    CallOnComplete(addresses, ttls);
+    CallOnComplete(ret, ttls);
   }
 };
 
@@ -644,21 +1228,16 @@ class QueryCnameWrap: public QueryWrap {
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
-    struct hostent* host;
 
-    int status = ares_parse_a_reply(buf, len, &host, nullptr, nullptr);
+    Local<Array> ret = Array::New(env()->isolate());
+    int type = ns_t_cname;
+    int status = ParseGeneralReply(env(), buf, len, &type, ret);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
 
-    // A cname lookup always returns a single record but we follow the
-    // common API here.
-    Local<Array> result = Array::New(env()->isolate(), 1);
-    result->Set(0, OneByteString(env()->isolate(), host->h_name));
-    ares_free_hostent(host);
-
-    this->CallOnComplete(result);
+    this->CallOnComplete(ret);
   }
 };
 
@@ -686,28 +1265,13 @@ class QueryMxWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    struct ares_mx_reply* mx_start;
-    int status = ares_parse_mx_reply(buf, len, &mx_start);
+    Local<Array> mx_records = Array::New(env()->isolate());
+    int status = ParseMxReply(env(), buf, len, mx_records);
+
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> mx_records = Array::New(env()->isolate());
-    Local<String> exchange_symbol = env()->exchange_string();
-    Local<String> priority_symbol = env()->priority_string();
-
-    ares_mx_reply* current = mx_start;
-    for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
-      Local<Object> mx_record = Object::New(env()->isolate());
-      mx_record->Set(exchange_symbol,
-                     OneByteString(env()->isolate(), current->host));
-      mx_record->Set(priority_symbol,
-                     Integer::New(env()->isolate(), current->priority));
-      mx_records->Set(i, mx_record);
-    }
-
-    ares_free_data(mx_start);
 
     this->CallOnComplete(mx_records);
   }
@@ -736,16 +1300,14 @@ class QueryNsWrap: public QueryWrap {
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
-    struct hostent* host;
 
-    int status = ares_parse_ns_reply(buf, len, &host);
+    int type = ns_t_ns;
+    Local<Array> names = Array::New(env()->isolate());
+    int status = ParseGeneralReply(env(), buf, len, &type, names);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> names = HostentToNames(env(), host);
-    ares_free_hostent(host);
 
     this->CallOnComplete(names);
   }
@@ -774,35 +1336,13 @@ class QueryTxtWrap: public QueryWrap {
   void Parse(unsigned char* buf, int len) override {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
-    struct ares_txt_ext* txt_out;
 
-    int status = ares_parse_txt_reply_ext(buf, len, &txt_out);
+    Local<Array> txt_records = Array::New(env()->isolate());
+    int status = ParseTxtReply(env(), buf, len, txt_records);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> txt_records = Array::New(env()->isolate());
-    Local<Array> txt_chunk;
-
-    struct ares_txt_ext* current = txt_out;
-    uint32_t i = 0;
-    for (uint32_t j = 0; current != nullptr; current = current->next) {
-      Local<String> txt = OneByteString(env()->isolate(), current->txt);
-      // New record found - write out the current chunk
-      if (current->record_start) {
-        if (!txt_chunk.IsEmpty())
-          txt_records->Set(i++, txt_chunk);
-        txt_chunk = Array::New(env()->isolate());
-        j = 0;
-      }
-      txt_chunk->Set(j++, txt);
-    }
-    // Push last chunk if it isn't empty
-    if (!txt_chunk.IsEmpty())
-      txt_records->Set(i, txt_chunk);
-
-    ares_free_data(txt_out);
 
     this->CallOnComplete(txt_records);
   }
@@ -832,34 +1372,12 @@ class QuerySrvWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    struct ares_srv_reply* srv_start;
-    int status = ares_parse_srv_reply(buf, len, &srv_start);
+    Local<Array> srv_records = Array::New(env()->isolate());
+    int status = ParseSrvReply(env(), buf, len, srv_records);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> srv_records = Array::New(env()->isolate());
-    Local<String> name_symbol = env()->name_string();
-    Local<String> port_symbol = env()->port_string();
-    Local<String> priority_symbol = env()->priority_string();
-    Local<String> weight_symbol = env()->weight_string();
-
-    ares_srv_reply* current = srv_start;
-    for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
-      Local<Object> srv_record = Object::New(env()->isolate());
-      srv_record->Set(name_symbol,
-                      OneByteString(env()->isolate(), current->host));
-      srv_record->Set(port_symbol,
-                      Integer::New(env()->isolate(), current->port));
-      srv_record->Set(priority_symbol,
-                      Integer::New(env()->isolate(), current->priority));
-      srv_record->Set(weight_symbol,
-                      Integer::New(env()->isolate(), current->weight));
-      srv_records->Set(i, srv_record);
-    }
-
-    ares_free_data(srv_start);
 
     this->CallOnComplete(srv_records);
   }
@@ -888,21 +1406,14 @@ class QueryPtrWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    struct hostent* host;
+    int type = ns_t_ptr;
+    Local<Array> aliases = Array::New(env()->isolate());
 
-    int status = ares_parse_ptr_reply(buf, len, NULL, 0, AF_INET, &host);
+    int status = ParseGeneralReply(env(), buf, len, &type, aliases);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> aliases = Array::New(env()->isolate());
-
-    for (uint32_t i = 0; host->h_aliases[i] != NULL; i++) {
-      aliases->Set(i, OneByteString(env()->isolate(), host->h_aliases[i]));
-    }
-
-    ares_free_hostent(host);
 
     this->CallOnComplete(aliases);
   }
@@ -931,41 +1442,12 @@ class QueryNaptrWrap: public QueryWrap {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());
 
-    ares_naptr_reply* naptr_start;
-    int status = ares_parse_naptr_reply(buf, len, &naptr_start);
-
+    Local<Array> naptr_records = Array::New(env()->isolate());
+    int status = ParseNaptrReply(env(), buf, len, naptr_records);
     if (status != ARES_SUCCESS) {
       ParseError(status);
       return;
     }
-
-    Local<Array> naptr_records = Array::New(env()->isolate());
-    Local<String> flags_symbol = env()->flags_string();
-    Local<String> service_symbol = env()->service_string();
-    Local<String> regexp_symbol = env()->regexp_string();
-    Local<String> replacement_symbol = env()->replacement_string();
-    Local<String> order_symbol = env()->order_string();
-    Local<String> preference_symbol = env()->preference_string();
-
-    ares_naptr_reply* current = naptr_start;
-    for (uint32_t i = 0; current != nullptr; ++i, current = current->next) {
-      Local<Object> naptr_record = Object::New(env()->isolate());
-      naptr_record->Set(flags_symbol,
-                        OneByteString(env()->isolate(), current->flags));
-      naptr_record->Set(service_symbol,
-                        OneByteString(env()->isolate(), current->service));
-      naptr_record->Set(regexp_symbol,
-                        OneByteString(env()->isolate(), current->regexp));
-      naptr_record->Set(replacement_symbol,
-                        OneByteString(env()->isolate(), current->replacement));
-      naptr_record->Set(order_symbol,
-                        Integer::New(env()->isolate(), current->order));
-      naptr_record->Set(preference_symbol,
-                        Integer::New(env()->isolate(), current->preference));
-      naptr_records->Set(i, naptr_record);
-    }
-
-    ares_free_data(naptr_start);
 
     this->CallOnComplete(naptr_records);
   }
@@ -1502,6 +1984,7 @@ void Initialize(Local<Object> target,
       CaresTimerClose,
       nullptr);
 
+  env->SetMethod(target, "queryAny", Query<QueryAnyWrap>);
   env->SetMethod(target, "queryA", Query<QueryAWrap>);
   env->SetMethod(target, "queryAaaa", Query<QueryAaaaWrap>);
   env->SetMethod(target, "queryCname", Query<QueryCnameWrap>);

--- a/src/env.h
+++ b/src/env.h
@@ -105,6 +105,16 @@ namespace node {
   V(dest_string, "dest")                                                      \
   V(detached_string, "detached")                                              \
   V(disposed_string, "_disposed")                                             \
+  V(dns_a_string, "A")                                                        \
+  V(dns_aaaa_string, "AAAA")                                                  \
+  V(dns_cname_string, "CNAME")                                                \
+  V(dns_mx_string, "MX")                                                      \
+  V(dns_naptr_string, "NAPTR")                                                \
+  V(dns_ns_string, "NS")                                                      \
+  V(dns_ptr_string, "PTR")                                                    \
+  V(dns_soa_string, "SOA")                                                    \
+  V(dns_srv_string, "SRV")                                                    \
+  V(dns_txt_string, "TXT")                                                    \
   V(domain_string, "domain")                                                  \
   V(emitting_top_level_domain_error_string, "_emittingTopLevelDomainError")   \
   V(exchange_string, "exchange")                                              \
@@ -151,6 +161,7 @@ namespace node {
   V(issuer_string, "issuer")                                                  \
   V(issuercert_string, "issuerCertificate")                                   \
   V(kill_signal_string, "killSignal")                                         \
+  V(length_string, "length")                                                  \
   V(mac_string, "mac")                                                        \
   V(max_buffer_string, "maxBuffer")                                           \
   V(message_string, "message")                                                \
@@ -231,6 +242,7 @@ namespace node {
   V(timeout_string, "timeout")                                                \
   V(times_string, "times")                                                    \
   V(tls_ticket_string, "tlsTicket")                                           \
+  V(ttl_string, "ttl")                                                        \
   V(type_string, "type")                                                      \
   V(uid_string, "uid")                                                        \
   V(unknown_string, "<unknown>")                                              \

--- a/src/env.h
+++ b/src/env.h
@@ -123,6 +123,7 @@ namespace node {
   V(irq_string, "irq")                                                        \
   V(encoding_string, "encoding")                                              \
   V(enter_string, "enter")                                                    \
+  V(entries_string, "entries")                                                \
   V(env_pairs_string, "envPairs")                                             \
   V(errno_string, "errno")                                                    \
   V(error_string, "error")                                                    \

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const dns = require('dns');
+const net = require('net');
+
+let running = false;
+const queue = [];
+
+const isIPv4 = net.isIPv4;
+const isIPv6 = net.isIPv6;
+
+dns.setServers(['8.8.8.8', '8.8.4.4']);
+
+function checkWrap(req) {
+  assert.ok(typeof req === 'object');
+}
+
+const checkers = {
+  checkA(r) {
+    assert.ok(isIPv4(r.address));
+    assert.strictEqual(typeof r.ttl, 'number');
+    assert.strictEqual(r.type, 'A');
+  },
+  checkAAAA(r) {
+    assert.ok(isIPv6(r.address));
+    assert.strictEqual(typeof r.ttl, 'number');
+    assert.strictEqual(r.type, 'AAAA');
+  },
+  checkCNAME(r) {
+    assert.ok(r.value);
+    assert.strictEqual(typeof r.value, 'string');
+    assert.strictEqual(r.type, 'CNAME');
+  },
+  checkMX(r) {
+    assert.strictEqual(typeof r.exchange, 'string');
+    assert.strictEqual(typeof r.priority, 'number');
+    assert.strictEqual(r.type, 'MX');
+  },
+  checkNAPTR(r) {
+    assert.strictEqual(typeof r.flags, 'string');
+    assert.strictEqual(typeof r.service, 'string');
+    assert.strictEqual(typeof r.regexp, 'string');
+    assert.strictEqual(typeof r.replacement, 'string');
+    assert.strictEqual(typeof r.order, 'number');
+    assert.strictEqual(typeof r.preference, 'number');
+    assert.strictEqual(r.type, 'NAPTR');
+  },
+  checkNS(r) {
+    assert.strictEqual(typeof r.value, 'string');
+    assert.strictEqual(r.type, 'NS');
+  },
+  checkPTR(r) {
+    assert.strictEqual(typeof r.value, 'string');
+    assert.strictEqual(r.type, 'PTR');
+  },
+  checkTXT(r) {
+    assert.ok(r.length > 0);
+    Array.prototype.forEach.call(r, (txt) => {
+      assert.strictEqual(txt.indexOf('v=spf1'), 0);
+    });
+    assert.strictEqual(r.type, 'TXT');
+  },
+  checkSOA(r) {
+    assert.strictEqual(typeof r.nsname, 'string');
+    assert.strictEqual(typeof r.hostmaster, 'string');
+    assert.strictEqual(typeof r.serial, 'number');
+    assert.strictEqual(typeof r.refresh, 'number');
+    assert.strictEqual(typeof r.retry, 'number');
+    assert.strictEqual(typeof r.expire, 'number');
+    assert.strictEqual(typeof r.minttl, 'number');
+    assert.strictEqual(r.type, 'SOA');
+  },
+  checkSRV(r) {
+    assert.strictEqual(typeof r.name, 'string');
+    assert.strictEqual(typeof r.port, 'number');
+    assert.strictEqual(typeof r.priority, 'number');
+    assert.strictEqual(typeof r.weight, 'number');
+    assert.strictEqual(r.type, 'SRV');
+  }
+};
+
+function TEST(f) {
+  function next() {
+    const f = queue.shift();
+    if (f) {
+      running = true;
+      f(done);
+    }
+  }
+
+  function done() {
+    running = false;
+    process.nextTick(next);
+  }
+
+  queue.push(f);
+
+  if (!running) {
+    next();
+  }
+}
+
+TEST(function test_google(done) {
+  const req = dns.resolve(
+    'google.com',
+    'ANY',
+    common.mustCall(function(err, ret) {
+      assert.ifError(err);
+      assert.ok(Array.isArray(ret));
+      assert.ok(ret.length > 0);
+
+      /* current google.com has A / AAAA / MX / NS / TXT and SOA records */
+      const types = {};
+      ret.forEach((obj) => {
+        types[obj.type] = true;
+        checkers[`check${obj.type}`](obj);
+      });
+      assert.ok(
+        types.A && types.AAAA && types.MX &&
+        types.NS && types.TXT && types.SOA);
+
+      done();
+    }));
+
+  checkWrap(req);
+});
+
+TEST(function test_sip2sip_for_naptr(done) {
+  const req = dns.resolve(
+    'sip2sip.info',
+    'ANY',
+    common.mustCall(function(err, ret) {
+      assert.ifError(err);
+      assert.ok(Array.isArray(ret));
+      assert.ok(ret.length > 0);
+
+      /* current sip2sip.info has A / NS / NAPTR and SOA records */
+      const types = {};
+      ret.forEach((obj) => {
+        types[obj.type] = true;
+        checkers[`check${obj.type}`](obj);
+      });
+      assert.ok(types.A && types.NS && types.NAPTR && types.SOA);
+
+      done();
+    }));
+
+  checkWrap(req);
+});
+
+TEST(function test_toshihikojs_for_cname_and_srv(done) {
+  const req = dns.resolve(
+    '_sipfederationtls._tcp.toshihikojs.com',
+    'ANY',
+    common.mustCall(function(err, ret) {
+      assert.ifError(err);
+      assert.ok(Array.isArray(ret));
+      assert.ok(ret.length > 0);
+
+      /* current _sipfederationtls._tcp.toshihikojs.com has SRV and */
+      /* CNAME records */
+      const types = {};
+      ret.forEach((obj) => {
+        types[obj.type] = true;
+        checkers[`check${obj.type}`](obj);
+      });
+      assert.ok(types.SRV && types.CNAME);
+
+      done();
+    }));
+
+  checkWrap(req);
+});
+
+TEST(function test_ptr(done) {
+  const req = dns.resolve(
+    '8.8.8.8.in-addr.arpa',
+    'ANY',
+    common.mustCall(function(err, ret) {
+      assert.ifError(err);
+      assert.ok(Array.isArray(ret));
+      assert.ok(ret.length > 0);
+
+      /* current 8.8.8.8.in-addr.arpa has PTR record */
+      const types = {};
+      ret.forEach((obj) => {
+        types[obj.type] = true;
+        checkers[`check${obj.type}`](obj);
+      });
+      assert.ok(types.PTR);
+
+      done();
+    }));
+
+  checkWrap(req);
+});

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -152,23 +152,21 @@ TEST(function test_sip2sip_for_naptr(done) {
   checkWrap(req);
 });
 
-TEST(function test_toshihikojs_for_cname_and_srv(done) {
+TEST(function test_google_for_cname_and_srv(done) {
   const req = dns.resolve(
-    '_sipfederationtls._tcp.toshihikojs.com',
+    '_jabber._tcp.google.com',
     'ANY',
     common.mustCall(function(err, ret) {
       assert.ifError(err);
       assert.ok(Array.isArray(ret));
       assert.ok(ret.length > 0);
 
-      /* current _sipfederationtls._tcp.toshihikojs.com has SRV and */
-      /* CNAME records */
       const types = {};
       ret.forEach((obj) => {
         types[obj.type] = true;
         checkers[`check${obj.type}`](obj);
       });
-      assert.ok(types.SRV && types.CNAME);
+      assert.ok(types.SRV);
 
       done();
     }));

--- a/test/internet/test-dns-any.js
+++ b/test/internet/test-dns-any.js
@@ -12,7 +12,7 @@ const queue = [];
 const isIPv4 = net.isIPv4;
 const isIPv6 = net.isIPv6;
 
-dns.setServers(['8.8.8.8', '8.8.4.4']);
+dns.setServers([ '8.8.8.8', '8.8.4.4' ]);
 
 function checkWrap(req) {
   assert.ok(typeof req === 'object');
@@ -57,8 +57,9 @@ const checkers = {
     assert.strictEqual(r.type, 'PTR');
   },
   checkTXT(r) {
-    assert.ok(r.length > 0);
-    Array.prototype.forEach.call(r, (txt) => {
+    assert.ok(Array.isArray(r.entries));
+    assert.ok(r.entries.length > 0);
+    r.entries.forEach((txt) => {
       assert.strictEqual(txt.indexOf('v=spf1'), 0);
     });
     assert.strictEqual(r.type, 'TXT');


### PR DESCRIPTION
`dns.resolveAny` and `dns.resolve` with `"ANY"` has the similar behavior like `$ dig <domain> any` and returns an array with several types of records.

`dns.resolveAny` parses the result packet by several rules in turn.

Refs: https://github.com/nodejs/node/issues/2848

##### Supported Types

- [x] A
- [x] AAAA
- [x] CNAME
- [x] MX
- [x] TXT
- [x] SRV
- [x] PTR
- [x] NS
- [x] SOA
- [x] NAPTR

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns