### PR TITLE
doc: update code example for Windows in stream.md

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -134,7 +134,7 @@ const server = http.createServer((req, res) => {
       res.write(typeof data);
       res.end();
     } catch (er) {
-      // uh oh!  bad json!
+      // uh oh! bad json!
       res.statusCode = 400;
       return res.end(`error: ${er.message}`);
     }
@@ -143,12 +143,12 @@ const server = http.createServer((req, res) => {
 
 server.listen(1337);
 
-// $ curl localhost:1337 -d '{}'
+// $ curl localhost:1337 -d "{}"
 // object
-// $ curl localhost:1337 -d '"foo"'
+// $ curl localhost:1337 -d "\"foo\""
 // string
-// $ curl localhost:1337 -d 'not json'
-// error: Unexpected token o
+// $ curl localhost:1337 -d "not json"
+// error: Unexpected token o in JSON at position 1
 ```
 
 [Writable][] streams (such as `res` in the example) expose methods such as


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, stream

Commands with single quotes fail in `cmd.exe` shell (while being OK in Git Bash for Windows):
```console
> curl localhost:1337 -d '{}'
error: Unexpected token ' in JSON at position 0
> curl localhost:1337 -d '"foo"'
error: Unexpected token ' in JSON at position 0
> curl localhost:1337 -d 'not json'
error: Unexpected token ' in JSON at position 0curl: (6) Couldn't resolve host 'json''
```
Commands with double quotes are OK in both `cmd.exe` shell and Git Bash for Windows.