### PR TITLE
tools: tool to sync upstream master with local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -928,6 +928,9 @@ lint:
 lint-ci: lint
 endif
 
+sync:
+	./tools/sync.sh
+
 .PHONY: $(TARBALL)-headers \
   all \
   bench \
@@ -977,6 +980,7 @@ endif
   release-only \
   run-ci \
   staticlib \
+  sync \
   tar \
   test \
   test-addons \

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+rootdir="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+currentbranch="$(git rev-parse --abbrev-ref HEAD)"
+isrootdirty=$(git status -s)
+
+if [[ $isrootdirty ]]
+then
+    git stash -u
+fi
+
+git checkout master
+git fetch upstream
+git rebase upstream/master
+
+git checkout $currentbranch
+
+if [[ $isrootdirty ]]
+then
+    git stash pop
+fi


### PR DESCRIPTION
Hi :)
I have script that just runs `git fetch... && git rebase...` for master so I should not do this 
manually all the time. 
Just wondering if it can be useful for someone. I've changed it a bit to be more "smart" than just `git fetch... && git rebase` and added `make` target also. 
Please update me if it can be useful for you. Or if it is completely not useful and makes no sense so I'll go sad in the sunset.

Just a bit more info about how it works. 
It doesn't matter what branch you're currently on and what changes you've already made. 
It checks if worktree is dirty and do `git stash`. Then checkouts to `master`, updates it and goes back to your previous branch and runs `git stash pop`. 


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools