### PR TITLE
deps: backport 6d38f89d from upstream V8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 8
 #define V8_BUILD_NUMBER 283
-#define V8_PATCH_LEVEL 39
+#define V8_PATCH_LEVEL 40
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/compiler/js-builtin-reducer.h
+++ b/deps/v8/src/compiler/js-builtin-reducer.h
@@ -57,6 +57,7 @@ class V8_EXPORT_PRIVATE JSBuiltinReducer final
                                          IterationKind kind);
   Reduction ReduceArrayPop(Node* node);
   Reduction ReduceArrayPush(Node* node);
+  Reduction ReduceArrayShift(Node* node);
   Reduction ReduceDateNow(Node* node);
   Reduction ReduceDateGetTime(Node* node);
   Reduction ReduceGlobalIsFinite(Node* node);

--- a/deps/v8/src/crankshaft/hydrogen.cc
+++ b/deps/v8/src/crankshaft/hydrogen.cc
@@ -8818,7 +8818,7 @@ bool HOptimizedGraphBuilder::TryInlineBuiltinMethodCall(
           Handle<JSObject>::null(), true);
 
       // Threshold for fast inlined Array.shift().
-      HConstant* inline_threshold = Add<HConstant>(static_cast<int32_t>(16));
+      HConstant* inline_threshold = Add<HConstant>(JSArray::kMaxCopyElements);
 
       Drop(args_count_no_receiver);
       HValue* result;

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -10926,6 +10926,9 @@ class JSArray: public JSObject {
   static const int kLengthOffset = JSObject::kHeaderSize;
   static const int kSize = kLengthOffset + kPointerSize;
 
+  // Max. number of elements being copied in Array builtins.
+  static const int kMaxCopyElements = 16;
+
   static const int kInitialMaxFastElementArray =
       (kMaxRegularHeapObjectSize - FixedArray::kHeaderSize - kSize -
        AllocationMemento::kSize) /

--- a/deps/v8/test/mjsunit/array-shift5.js
+++ b/deps/v8/test/mjsunit/array-shift5.js
@@ -1,0 +1,50 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+(function() {
+  function doShift(a) { return a.shift(); }
+
+  function test() {
+    var a = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16];
+    assertEquals(0, doShift(a));
+    assertEquals([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16], a);
+  }
+
+  test();
+  test();
+  %OptimizeFunctionOnNextCall(doShift);
+  test();
+})();
+
+(function() {
+  function doShift(a) { return a.shift(); }
+
+  function test() {
+    var a = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16.1];
+    assertEquals(0, doShift(a));
+    assertEquals([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16.1], a);
+  }
+
+  test();
+  test();
+  %OptimizeFunctionOnNextCall(doShift);
+  test();
+})();
+
+(function() {
+  function doShift(a) { return a.shift(); }
+
+  function test() {
+    var a = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,"16"];
+    assertEquals(0, doShift(a));
+    assertEquals([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,"16"], a);
+  }
+
+  test();
+  test();
+  %OptimizeFunctionOnNextCall(doShift);
+  test();
+})();


### PR DESCRIPTION
This fixes some of the regressions in #12657. Since upstream doesn't backport things other than bug / security fixes, we will have to float this patch on Node.js 8.x until V8 6.0 lands on `master`.

One problem here is that since 5.8 and 5.9 are still stable/beta, we cannot bump the V8 version number in our copy of V8. This might make reasoning about precise versions between us and upstream a bit tricky. (/cc @targos).

The fixup needed for the backport to V8 5.8 were fairly minimal.

Original commit message:
>   [turbofan] Boost performance of Array.prototype.shift by 4x.
> 
>   For small arrays, it's way faster to just move the elements instead of
>   doing the fairly complex and heavy-weight left-trimming. Crankshaft has
>   had this optimization for small arrays already; this CL more or less
>   ports this functionality to TurboFan, which yields a 4x speed-up when
>   using shift on small arrays (with up to 16 elements).
> 
>   This should recover some of the regressions reported in the Node.js issues
> 
>     https://github.com/nodejs/node/issues/12657
> 
>   and discovered for the syncthrough module using
> 
>     https://github.com/mcollina/syncthrough/blob/master/benchmarks/basic.js
> 
>   as benchmark.
> 
>   R=jarin@chromium.org
>   BUG=v8:6376

>  Review-Url: https://codereview.chromium.org/2874453002
>  Cr-Commit-Position: refs/heads/master@{#45216}

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:v8

/cc @nodejs/v8 @bmeurer 

EDIT: CI: https://ci.nodejs.org/job/node-test-pull-request/8242/
V8 CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/710/