### PR TITLE
test: add override to ServerDone function

### DIFF
--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -139,7 +139,7 @@ class TestInspectorServerDelegate : public SocketServerDelegate {
     server_->Send(session_id_, message);
   }
 
-  void ServerDone() {
+  void ServerDone() override {
     done = true;
   }
 


### PR DESCRIPTION
Currently the following compiler warning is displayed when building:
```console
../test/cctest/test_inspector_socket_server.cc:142:8: warning:
'ServerDone' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]
  void ServerDone() {
       ^
../src/inspector_socket_server.h:30:16: note: overridden virtual
function is here
  virtual void ServerDone() = 0;
               ^
```
This commit marks ServerDone with override to get rid of the warning.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test