### PR TITLE
src: fix InspectorStarted macro guard

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -295,10 +295,13 @@ static struct {
                     "so event tracing is not available.\n");
   }
   void StopTracingAgent() {}
+#endif  // !NODE_USE_V8_PLATFORM
+
+#if !NODE_USE_V8_PLATFORM || !HAVE_INSPECTOR
   bool InspectorStarted(Environment *env) {
     return false;
   }
-#endif  // !NODE_USE_V8_PLATFORM
+#endif  //  !NODE_USE_V8_PLATFORM || !HAVE_INSPECTOR
 } v8_platform;
 
 #ifdef __POSIX__


### PR DESCRIPTION
Currently the InspectorStarted function is guarded by the else clause of
the NODE_USE_V8_PLATFORM macro. If node is configured --without-ssl then
NODE_USE_V8_PLATFORM will be 1 but the nested HAVE_INSPECTOR macro
will not be 0 which will lead to that there will be no InspectorStarted
function defined.

If building --without-inspector or --without-ssl the following
compilation error will occur:
```console
../src/node.cc:4470:57: error: no member named 'InspectorStarted' in
'node::(anonymous struct at ../src/node.cc:241:8)'
  if (debug_options.inspector_enabled() &&
!v8_platform.InspectorStarted(&env))
                                            ~~~~~~~~~~~ ^
../src/node.cc:4470:57: error: no member named 'InspectorStarted' in
'node::(anonymous struct at ../src/node.cc:241:8)'
  if (debug_options.inspector_enabled() &&
!v8_platform.InspectorStarted(&env))
                                            ~~~~~~~~~~~ ^
1 error generated.
```
This commit adds a separate if preprocessor directive to catch the case
when either --without-ssl/--without-inspector and --without-v8-platform
combinations are used to configure node.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
