### PR TITLE
test: add coverage for socket write after close

### DIFF
--- a/test/parallel/test-net-socket-write-after-close.js
+++ b/test/parallel/test-net-socket-write-after-close.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+{
+  const server = net.createServer();
+
+  server.listen(common.mustCall(() => {
+    const port = server.address().port;
+    const client = net.connect({port}, common.mustCall(() => {
+      client.on('error', common.mustCall((err) => {
+        server.close();
+        assert.strictEqual(err.constructor, Error);
+        assert.strictEqual(err.message, 'write EBADF');
+      }));
+      client._handle.close();
+      client.write('foo');
+    }));
+  }));
+}
+
+{
+  const server = net.createServer();
+
+  server.listen(common.mustCall(() => {
+    const port = server.address().port;
+    const client = net.connect({port}, common.mustCall(() => {
+      client.on('error', common.mustCall((err) => {
+        server.close();
+        assert.strictEqual(err.constructor, Error);
+        assert.strictEqual(err.message, 'This socket is closed');
+      }));
+      client._handle.close();
+      client._handle = null;
+      client.write('foo');
+    }));
+  }));
+}


### PR DESCRIPTION
This commit adds test coverage for the scenario where a socket's
handle has been closed prior to writing.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test