### PR TITLE
src: make StreamBase::GetAsyncWrap pure virtual

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -54,8 +54,8 @@ int StreamBase::Shutdown(const FunctionCallbackInfo<Value>& args) {
   Local<Object> req_wrap_obj = args[0].As<Object>();
 
   AsyncWrap* wrap = GetAsyncWrap();
-  if (wrap != nullptr)
-    env->set_init_trigger_id(wrap->get_id());
+  CHECK_NE(wrap, nullptr);
+  env->set_init_trigger_id(wrap->get_id());
   ShutdownWrap* req_wrap = new ShutdownWrap(env,
                                             req_wrap_obj,
                                             this,
@@ -133,8 +133,6 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
     return UV_ENOBUFS;
 
   AsyncWrap* wrap = GetAsyncWrap();
-  // NOTE: All tests show that GetAsyncWrap() never returns nullptr here. If it
-  // can then replace the CHECK_NE() with if (wrap != nullptr).
   CHECK_NE(wrap, nullptr);
   env->set_init_trigger_id(wrap->get_id());
   WriteWrap* req_wrap = WriteWrap::New(env,
@@ -425,16 +423,9 @@ void StreamBase::EmitData(ssize_t nread,
   if (argv[2].IsEmpty())
     argv[2] = Undefined(env->isolate());
 
-  AsyncWrap* async = GetAsyncWrap();
-  if (async == nullptr) {
-    node::MakeCallback(env,
-                       GetObject(),
-                       env->onread_string(),
-                       arraysize(argv),
-                       argv);
-  } else {
-    async->MakeCallback(env->onread_string(), arraysize(argv), argv);
-  }
+  AsyncWrap* wrap = GetAsyncWrap();
+  CHECK_NE(wrap, nullptr);
+  wrap->MakeCallback(env->onread_string(), arraysize(argv), argv);
 }
 
 
@@ -445,11 +436,6 @@ bool StreamBase::IsIPCPipe() {
 
 int StreamBase::GetFD() {
   return -1;
-}
-
-
-AsyncWrap* StreamBase::GetAsyncWrap() {
-  return nullptr;
 }
 
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -248,7 +248,7 @@ class StreamBase : public StreamResource {
   virtual ~StreamBase() = default;
 
   // One of these must be implemented
-  virtual AsyncWrap* GetAsyncWrap();
+  virtual AsyncWrap* GetAsyncWrap() = 0;
   virtual v8::Local<v8::Object> GetObject();
 
   // Libuv callbacks


### PR DESCRIPTION
Splitting out from #13142, this is a bit that should be easy to review. (All remaining `GetAsyncWrap` methods never return `nullptr`.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
