### PR TITLE
deps: cherry-pick 6803eef from V8 upstream

### DIFF
--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -38,6 +38,9 @@ declare_args() {
   # Sets -dENABLE_DISASSEMBLER.
   v8_enable_disassembler = ""
 
+  # Sets the number of internal fields on promise objects.
+  v8_promise_internal_field_count = 0
+
   # Sets -dENABLE_GDB_JIT_INTERFACE.
   v8_enable_gdbjit = ""
 
@@ -196,6 +199,10 @@ config("features") {
 
   if (v8_enable_disassembler) {
     defines += [ "ENABLE_DISASSEMBLER" ]
+  }
+  if (v8_promise_internal_field_count != 0) {
+    defines +=
+        [ "V8_PROMISE_INTERNAL_FIELD_COUNT=${v8_promise_internal_field_count}" ]
   }
   if (v8_enable_gdbjit) {
     defines += [ "ENABLE_GDB_JIT_INTERFACE" ]

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -31,6 +31,8 @@
   'variables': {
     'v8_enable_disassembler%': 0,
 
+    'v8_promise_internal_field_count%': 0,
+
     'v8_enable_gdbjit%': 0,
 
     'v8_enable_verify_csa%': 0,
@@ -76,6 +78,9 @@
     'conditions': [
       ['v8_enable_disassembler==1', {
         'defines': ['ENABLE_DISASSEMBLER',],
+      }],
+      ['v8_promise_internal_field_count!=0', {
+        'defines': ['V8_PROMISE_INTERNAL_FIELD_COUNT','v8_promise_internal_field_count'],
       }],
       ['v8_enable_gdbjit==1', {
         'defines': ['ENABLE_GDB_JIT_INTERFACE',],

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 8
 #define V8_BUILD_NUMBER 283
-#define V8_PATCH_LEVEL 40
+#define V8_PATCH_LEVEL 41
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -3741,6 +3741,10 @@ class V8_EXPORT Function : public Object {
   static void CheckCast(Value* obj);
 };
 
+#ifndef V8_PROMISE_INTERNAL_FIELD_COUNT
+// The number of required internal fields can be defined by embedder.
+#define V8_PROMISE_INTERNAL_FIELD_COUNT 0
+#endif
 
 /**
  * An instance of the built-in Promise constructor (ES6 draft).
@@ -3821,6 +3825,8 @@ class V8_EXPORT Promise : public Object {
   PromiseState State();
 
   V8_INLINE static Promise* Cast(Value* obj);
+
+  static const int kEmbedderFieldCount = V8_PROMISE_INTERNAL_FIELD_COUNT;
 
  private:
   Promise();

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -1945,9 +1945,9 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
 
     Handle<JSObject> prototype =
         factory->NewJSObject(isolate->object_function(), TENURED);
-    Handle<JSFunction> promise_fun =
-        InstallFunction(global, "Promise", JS_PROMISE_TYPE, JSPromise::kSize,
-                        prototype, Builtins::kPromiseConstructor);
+    Handle<JSFunction> promise_fun = InstallFunction(
+        global, "Promise", JS_PROMISE_TYPE, JSPromise::kSizeWithEmbedderFields,
+        prototype, Builtins::kPromiseConstructor);
     InstallWithIntrinsicDefaultProto(isolate, promise_fun,
                                      Context::PROMISE_FUNCTION_INDEX);
 

--- a/deps/v8/src/builtins/builtins-promise.cc
+++ b/deps/v8/src/builtins/builtins-promise.cc
@@ -31,6 +31,10 @@ void PromiseBuiltinsAssembler::PromiseInit(Node* promise) {
   StoreObjectField(promise, JSPromise::kStatusOffset,
                    SmiConstant(v8::Promise::kPending));
   StoreObjectField(promise, JSPromise::kFlagsOffset, SmiConstant(0));
+  for (int i = 0; i < v8::Promise::kEmbedderFieldCount; i++) {
+    int offset = JSPromise::kSize + i * kPointerSize;
+    StoreObjectFieldNoWriteBarrier(promise, offset, SmiConstant(Smi::kZero));
+  }
 }
 
 Node* PromiseBuiltinsAssembler::AllocateAndInitJSPromise(Node* context) {
@@ -62,6 +66,10 @@ Node* PromiseBuiltinsAssembler::AllocateAndSetJSPromise(Node* context,
   StoreObjectFieldNoWriteBarrier(instance, JSPromise::kResultOffset, result);
   StoreObjectFieldNoWriteBarrier(instance, JSPromise::kFlagsOffset,
                                  SmiConstant(0));
+  for (int i = 0; i < v8::Promise::kEmbedderFieldCount; i++) {
+    int offset = JSPromise::kSize + i * kPointerSize;
+    StoreObjectFieldNoWriteBarrier(instance, offset, SmiConstant(Smi::kZero));
+  }
 
   Label out(this);
   GotoIfNot(IsPromiseHookEnabledOrDebugIsActive(), &out);

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -8443,6 +8443,8 @@ class JSPromise : public JSObject {
       kFulfillReactionsOffset + kPointerSize;
   static const int kFlagsOffset = kRejectReactionsOffset + kPointerSize;
   static const int kSize = kFlagsOffset + kPointerSize;
+  static const int kSizeWithEmbedderFields =
+      kSize + v8::Promise::kEmbedderFieldCount * kPointerSize;
 
   // Flags layout.
   static const int kHasHandlerBit = 0;


### PR DESCRIPTION
Original commit message:
Allow embedder to set promise internal field count

Asynchronous context tracking mechanisms in Node.js need to store some
state on all promise objects. This change will allow embedders to
configure the number of internal fields on promises as is already done
for ArrayBuffers.

BUG=v8:6435

Review-Url: https://codereview.chromium.org/2889863002
Cr-Commit-Position: refs/heads/master@{#45496}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
