### PR TITLE
test: add coverage for napi_has_named_property

### DIFF
--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -40,6 +40,8 @@ assert.strictEqual(test_object.readwriteAccessor2, 2);
 assert.strictEqual(test_object.readonlyAccessor2, 2);
 assert.throws(() => { test_object.readonlyAccessor2 = 3; }, TypeError);
 
-assert.ok(test_object.hasNamedProperty(test_object, 'echo'));
-assert.ok(test_object.hasNamedProperty(test_object, 'hiddenValue'));
-assert.ok(!test_object.hasNamedProperty(test_object, 'doesnotexist'));
+assert.strictEqual(test_object.hasNamedProperty(test_object, 'echo'), true);
+assert.strictEqual(test_object.hasNamedProperty(test_object, 'hiddenValue'),
+                   true);
+assert.strictEqual(test_object.hasNamedProperty(test_object, 'doesnotexist'),
+                   false);

--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -39,3 +39,7 @@ test_object.readwriteAccessor2 = 2;
 assert.strictEqual(test_object.readwriteAccessor2, 2);
 assert.strictEqual(test_object.readonlyAccessor2, 2);
 assert.throws(() => { test_object.readonlyAccessor2 = 3; }, TypeError);
+
+assert.ok(test_object.hasNamedProperty(test_object, 'echo'));
+assert.ok(test_object.hasNamedProperty(test_object, 'hiddenValue'));
+assert.ok(!test_object.hasNamedProperty(test_object, 'doesnotexist'));

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -46,13 +46,11 @@ napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
 
   // Extract the name of the property to check
   char buffer[128];
-  size_t buffer_size = 128;
   size_t copied;
-  buffer[buffer_size - 1] = 0;
   NAPI_CALL(env,
-    napi_get_value_string_utf8(env, args[1], buffer, buffer_size - 1, &copied));
+    napi_get_value_string_utf8(env, args[1], buffer, sizeof(buffer), &copied));
 
-  // do the check and create the boolean retutn value
+  // do the check and create the boolean return value
   bool value;
   napi_value result;
   NAPI_CALL(env, napi_has_named_property(env, args[0], buffer, &value));

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -37,6 +37,30 @@ napi_value Echo(napi_env env, napi_callback_info info) {
   return args[0];
 }
 
+napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+
+  // Extract the name of the property to check
+  char buffer[128];
+  size_t buffer_size = 128;
+  size_t copied;
+  buffer[buffer_size - 1] = 0;
+  NAPI_CALL(env,
+    napi_get_value_string_utf8(env, args[1], buffer, buffer_size - 1, &copied));
+
+  // do the check and create the boolean retutn value
+  bool value;
+  napi_value result;
+  NAPI_CALL(env, napi_has_named_property(env, args[0], buffer, &value));
+  NAPI_CALL(env, napi_get_boolean(env, value, &result));
+
+  return result;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_value number;
   NAPI_CALL_RETURN_VOID(env, napi_create_number(env, value_, &number));
@@ -50,6 +74,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     { "readwriteAccessor2", 0, 0, GetValue, SetValue, 0, napi_writable, 0},
     { "readonlyAccessor1", 0, 0, GetValue, NULL, 0, napi_default, 0},
     { "readonlyAccessor2", 0, 0, GetValue, NULL, 0, napi_writable, 0},
+    { "hasNamedProperty", 0, HasNamedProperty, 0, 0, 0, napi_default, 0 },
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(


### PR DESCRIPTION
Add test to cover napi_has_named_property

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](

##### Affected core subsystem(s)
test, n-api