### PR TITLE
test: skip test-bindings if inspector is disabled

### DIFF
--- a/test/inspector/test-bindings.js
+++ b/test/inspector/test-bindings.js
@@ -82,7 +82,7 @@ function testSampleDebugSession() {
   }, TypeError);
   session.post('Debugger.enable', () => cbAsSecondArgCalled = true);
   session.post('Debugger.setBreakpointByUrl', {
-    'lineNumber': 11,
+    'lineNumber': 12,
     'url': path.resolve(__dirname, __filename),
     'columnNumber': 0,
     'condition': ''

--- a/test/inspector/test-bindings.js
+++ b/test/inspector/test-bindings.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const inspector = require('inspector');
 const path = require('path');


### PR DESCRIPTION
If node is configured --without-inspector/--without-ssl this test will
fail with the following error:
```console
Path: inspector/test-bindings
inspector.js:8
  throw new Error('Inspector is not available');
  ^

Error: Inspector is not available
    at inspector.js:8:9
    at NativeModule.compile (bootstrap_node.js:549:7)
```
This commit skips this test if the inspector is disabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test