### PR TITLE
src: ignore unused warning for inspector-agent.cc

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -215,7 +215,7 @@ class JsBindingsSessionDelegate : public InspectorSessionDelegate {
     Local<Value> argument = v8string.ToLocalChecked().As<Value>();
     Local<Function> callback = callback_.Get(isolate);
     Local<Object> receiver = receiver_.Get(isolate);
-    callback->Call(env_->context(), receiver, 1, &argument);
+    static_cast<void>(callback->Call(env_->context(), receiver, 1, &argument));
   }
 
   void Disconnect() {


### PR DESCRIPTION
Currently the following compiler warning is displayed:
```console
../src/inspector_agent.cc:218:5: warning: ignoring return value of
function declared with warn_unused_result attribute [-Wunused-result]
    callback->Call(env_->context(), receiver, 1, &argument);
    ^~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
This commit does a static cast of the result as there are tests that
fail if we try to do something like ToLocalChecked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src