### PR TITLE
src, inspector: clean up base64_encode

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -129,12 +129,6 @@ static size_t base64_encode(const char* src,
                             size_t slen,
                             char* dst,
                             size_t dlen) {
-  // We know how much we'll write, just make sure that there's space.
-  CHECK(dlen >= base64_encoded_size(slen) &&
-        "not enough space provided for base64 encode");
-
-  dlen = base64_encoded_size(slen);
-
   unsigned a;
   unsigned b;
   unsigned c;

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -390,7 +390,8 @@ static void generate_accept_string(const std::string& client_key,
   char hash[SHA_DIGEST_LENGTH];
   SHA1(reinterpret_cast<const unsigned char*>(&input[0]), input.size(),
        reinterpret_cast<unsigned char*>(hash));
-  node::base64_encode(hash, sizeof(hash), *buffer, sizeof(*buffer));
+  size_t bufferlen = base64_encoded_size(sizeof(*buffer));
+  node::base64_encode(hash, sizeof(hash), *buffer, bufferlen);
 }
 
 static int header_value_cb(http_parser* parser, const char* at, size_t length) {


### PR DESCRIPTION
Hi, 
Please correct me if I didn't understand how it works but
`base64_encode` already accepts `dlen` (dst length). 
Unfortunately I was unable to understand why do we calculate it again, and then one more time. 
Is there any reason for this? 

`base64_encoded_size` - is macro with pretty fast calculation so it is definitely should not improve performance but I hope it can make code a bit clearer (if it is correct of course). 

P.S.
I've also changed `inspector_socket.cc` to make it similar to `string_bytes.cc` in terms of `base64_encode` usage. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, inspector