### PR TITLE
async_hooks: rename AsyncEvent to AsyncResource

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -43,7 +43,7 @@ const { kInit, kBefore, kAfter, kDestroy, kCurrentAsyncId, kCurrentTriggerId,
 
 const { async_id_symbol, trigger_id_symbol } = async_wrap;
 
-// Used in AsyncHook and AsyncEvent.
+// Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
 const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
@@ -187,7 +187,7 @@ function triggerId() {
 
 // Embedder API //
 
-class AsyncEvent {
+class AsyncResource {
   constructor(type, triggerId) {
     this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
     // Read and reset the current kInitTriggerId so that when the constructor
@@ -475,7 +475,7 @@ module.exports = {
   currentId,
   triggerId,
   // Embedder API
-  AsyncEvent,
+  AsyncResource,
   runInAsyncIdScope,
   // Sensitive Embedder API
   newUid,

--- a/test/async-hooks/test-embedder.api.async-event.after-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-event.after-on-destroyed.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
-const { AsyncEvent } = async_hooks;
+const { AsyncResource } = async_hooks;
 const { spawn } = require('child_process');
 const corruptedMsg = /async hook stack has become corrupted/;
 const heartbeatMsg = /heartbeat: still alive/;
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'after'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncEvent('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'after' after 'destroy'
-  const event2 = new AsyncEvent('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-event.before-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-event.before-on-destroyed.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
-const { AsyncEvent } = async_hooks;
+const { AsyncResource } = async_hooks;
 const { spawn } = require('child_process');
 const corruptedMsg = /async hook stack has become corrupted/;
 const heartbeatMsg = /heartbeat: still alive/;
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'before'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncEvent('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'before' after 'destroy'
-  const event2 = new AsyncEvent('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-event.improper-order.js
+++ b/test/async-hooks/test-embedder.api.async-event.improper-order.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
-const { AsyncEvent } = async_hooks;
+const { AsyncResource } = async_hooks;
 const { spawn } = require('child_process');
 const corruptedMsg = /async hook stack has become corrupted/;
 const heartbeatMsg = /heartbeat: still alive/;
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // async hooks enforce proper order of 'before' and 'after' invocations
 
   // Proper ordering
-  const event1 = new AsyncEvent('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentId());
   event1.emitBefore();
   event1.emitAfter();
 
   // Improper ordering
   // Emitting 'after' without 'before' which is illegal
-  const event2 = new AsyncEvent('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentId());
 
   console.log('heartbeat: still alive');
   event2.emitAfter();

--- a/test/async-hooks/test-embedder.api.async-event.improper-unwind.js
+++ b/test/async-hooks/test-embedder.api.async-event.improper-unwind.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
-const { AsyncEvent } = async_hooks;
+const { AsyncResource } = async_hooks;
 const { spawn } = require('child_process');
 const corruptedMsg = /async hook stack has become corrupted/;
 const heartbeatMsg = /heartbeat: still alive/;
@@ -21,8 +21,8 @@ if (process.argv[2] === 'child') {
   // The first test of the two below follows that rule,
   // the second one doesnt.
 
-  const event1 = new AsyncEvent('event1', async_hooks.currentId());
-  const event2 = new AsyncEvent('event2', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentId());
 
   // Proper unwind
   event1.emitBefore();

--- a/test/async-hooks/test-embedder.api.async-event.js
+++ b/test/async-hooks/test-embedder.api.async-event.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const tick = require('./tick');
 const async_hooks = require('async_hooks');
-const { AsyncEvent } = async_hooks;
+const { AsyncResource } = async_hooks;
 
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
@@ -15,7 +15,7 @@ hooks.enable();
 // create first custom event 'alcazares' with triggerId derived
 // from async_hooks currentId
 const alcaTriggerId = async_hooks.currentId();
-const alcaEvent = new AsyncEvent('alcazares', alcaTriggerId);
+const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
 const alcazaresActivities = hooks.activitiesOfTypes([ 'alcazares' ]);
 
 // alcazares event was constructed and thus only has an `init` call
@@ -49,7 +49,7 @@ function tick1() {
 
   // The below shows that we can pass any number as a trigger id
   const pobTriggerId = 111;
-  const pobEvent = new AsyncEvent('poblado', pobTriggerId);
+  const pobEvent = new AsyncResource('poblado', pobTriggerId);
   const pobladoActivities = hooks.activitiesOfTypes([ 'poblado' ]);
   const poblado = pobladoActivities[0];
   assert.strictEqual(poblado.type, 'poblado', 'poblado');


### PR DESCRIPTION
`AsyncEvent` is not a good name given its semantics.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks