### PR TITLE
crypto: remove root_cert_store from node_crypto.h

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -152,7 +152,7 @@ const char* const root_certs[] = {
 
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
-X509_STORE* root_cert_store;
+static X509_STORE* root_cert_store;
 
 // Just to generate static methods
 template void SSLWrap<TLSWrap>::AddMethods(Environment* env,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -84,8 +84,6 @@ enum CheckResult {
 
 extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 
-extern X509_STORE* root_cert_store;
-
 extern void UseExtraCaCerts(const std::string& file);
 
 class SecureContext : public BaseObject {


### PR DESCRIPTION
root_cert_store is defined as extern in node_crypto.h but only used in
node_crypto.cc. It is then set using SSL_CTX_set_cert_store. The only
usages of SSL_CTX_get_cert_store are in node_crypto.cc which would all
be accessing the same X509_STORE through the root_cert_store pointer as
far as I can tell. Am I missing something here?

This commit suggests removing it from the header and making it static
in node_crypto.cc.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto