### PR TITLE
stream: emit finish when using writev and cork

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -358,12 +358,17 @@ function doWrite(stream, state, writev, len, chunk, encoding, cb) {
 function onwriteError(stream, state, sync, er, cb) {
   --state.pendingcb;
   if (sync)
-    process.nextTick(cb, er);
+    process.nextTick(afterError, stream, state, cb, er);
   else
-    cb(er);
+    afterError(stream, state, cb, er);
 
   stream._writableState.errorEmitted = true;
   stream.emit('error', er);
+}
+
+function afterError(stream, state, cb, err) {
+  cb(err);
+  finishMaybe(stream, state);
 }
 
 function onwriteStateUpdate(state) {

--- a/test/parallel/test-stream-writable-writev-finish.js
+++ b/test/parallel/test-stream-writable-writev-finish.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const stream = require('stream');
+
+// ensure consistency between the finish event when using cork()
+// and writev and when not using them
+
+{
+  const writable = new stream.Writable();
+
+  writable._write = (chunks, encoding, cb) => {
+    cb(new Error('write test error'));
+  };
+
+  writable.on('finish', common.mustCall());
+
+  writable.on('prefinish', common.mustCall());
+
+  writable.on('error', common.mustCall((er) => {
+    assert.strictEqual(er.message, 'write test error');
+  }));
+
+  writable.end('test');
+}
+
+{
+  const writable = new stream.Writable();
+
+  writable._write = (chunks, encoding, cb) => {
+    cb(new Error('write test error'));
+  };
+
+  writable._writev = (chunks, cb) => {
+    cb(new Error('writev test error'));
+  };
+
+  writable.on('finish', common.mustCall());
+
+  writable.on('prefinish', common.mustCall());
+
+  writable.on('error', common.mustCall((er) => {
+    assert.strictEqual(er.message, 'writev test error');
+  }));
+
+  writable.cork();
+  writable.write('test');
+
+  setImmediate(function() {
+    writable.end('test');
+  });
+}


### PR DESCRIPTION
In Writable, 'finish' was not emitted when using writev() and
cork() in the event of an Error. This commit makes it consistent with the write() path,
which emits 'finish'.

Fixes: https://github.com/nodejs/node/issues/11121

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

stream