### PR TITLE
doc: make socket IPC examples more robust

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1141,8 +1141,9 @@ handle connections with "normal" or "special" priority:
 const normal = require('child_process').fork('child.js', ['normal']);
 const special = require('child_process').fork('child.js', ['special']);
 
-// Open up the server and send sockets to child
-const server = require('net').createServer();
+// Open up the server and send sockets to child. Use pauseOnConnect to prevent
+// the sockets from being read before they are sent to the child process.
+const server = require('net').createServer({ pauseOnConnect: true });
 server.on('connection', (socket) => {
 
   // If this is special priority
@@ -1162,7 +1163,12 @@ to the event callback function:
 ```js
 process.on('message', (m, socket) => {
   if (m === 'socket') {
-    socket.end(`Request handled with ${process.argv[2]} priority`);
+    if (socket) {
+      // Check that the client socket exists.
+      // It is possible for the socket to be closed between the time it is
+      // sent and the time it is received in the child process.
+      socket.end(`Request handled with ${process.argv[2]} priority`);
+    }
   }
 });
 ```
@@ -1171,6 +1177,10 @@ Once a socket has been passed to a child, the parent is no longer capable of
 tracking when the socket is destroyed. To indicate this, the `.connections`
 property becomes `null`. It is recommended not to use `.maxConnections` when
 this occurs.
+
+It is also recommended that any `'message'` handlers in the child process
+verify that `socket` exists, as the connection may have been closed during the
+time it takes to send the connection to the child.
 
 *Note*: This function uses [`JSON.stringify()`][] internally to serialize the
 `message`.


### PR DESCRIPTION
This commit aims to improve the documentation examples that send sockets over IPC channels. Specifically, `pauseOnConnect` is added to a server that inspects the socket before sending and a
`'message'` handler adds a check that the socket still exists.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

R= @santigimeno 