### PR TITLE
(v7.x backport) zlib: fix node crashing on invalid options

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -436,6 +436,10 @@ added: v0.5.8
 
 Returns a new [DeflateRaw][] object with an [options][].
 
+*Note*: The zlib library rejects requests for 256-byte windows (i.e.,
+`{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating a
+[DeflateRaw][] object with this specific value of the `windowBits` option.
+
 ## zlib.createGunzip([options])
 <!-- YAML
 added: v0.5.8

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -364,9 +364,15 @@ function Zlib(opts, mode) {
   var strategy = constants.Z_DEFAULT_STRATEGY;
   if (typeof opts.strategy === 'number') strategy = opts.strategy;
 
-  this._handle.init(opts.windowBits || constants.Z_DEFAULT_WINDOWBITS,
+  var windowBits = constants.Z_DEFAULT_WINDOWBITS;
+  if (typeof opts.windowBits === 'number') windowBits = opts.windowBits;
+
+  var memLevel = constants.Z_DEFAULT_MEMLEVEL;
+  if (typeof opts.memLevel === 'number') memLevel = opts.memLevel;
+
+  this._handle.init(windowBits || constants.Z_DEFAULT_WINDOWBITS,
                     level,
-                    opts.memLevel || constants.Z_DEFAULT_MEMLEVEL,
+                    memLevel || constants.Z_DEFAULT_MEMLEVEL,
                     strategy,
                     opts.dictionary);
 

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -365,14 +365,18 @@ function Zlib(opts, mode) {
   if (typeof opts.strategy === 'number') strategy = opts.strategy;
 
   var windowBits = constants.Z_DEFAULT_WINDOWBITS;
-  if (typeof opts.windowBits === 'number') windowBits = opts.windowBits;
+  if (opts.windowBits && typeof opts.windowBits === 'number') {
+    windowBits = opts.windowBits;
+  }
 
   var memLevel = constants.Z_DEFAULT_MEMLEVEL;
-  if (typeof opts.memLevel === 'number') memLevel = opts.memLevel;
+  if (opts.memLevel && typeof opts.memLevel === 'number') {
+    memLevel = opts.memLevel;
+  }
 
-  this._handle.init(windowBits || constants.Z_DEFAULT_WINDOWBITS,
+  this._handle.init(windowBits,
                     level,
-                    memLevel || constants.Z_DEFAULT_MEMLEVEL,
+                    memLevel,
                     strategy,
                     opts.dictionary);
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -530,16 +530,19 @@ class ZCtx : public AsyncWrap {
         CHECK(0 && "wtf?");
     }
 
-    if (ctx->err_ != Z_OK) {
-      ZCtx::Error(ctx, "Init error");
-    }
-
-
     ctx->dictionary_ = reinterpret_cast<Bytef *>(dictionary);
     ctx->dictionary_len_ = dictionary_len;
 
     ctx->write_in_progress_ = false;
     ctx->init_done_ = true;
+
+    if (ctx->err_ != Z_OK) {
+      if (dictionary != nullptr) {
+        delete[] dictionary;
+        ctx->dictionary_ = nullptr;
+      }
+      ctx->env()->ThrowError("Init error");
+    }
   }
 
   static void SetDictionary(ZCtx* ctx) {

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const zlib = require('zlib');
+
+// For raw deflate encoding, requests for 256-byte windows are rejected as
+// invalid by zlib.
+// (http://zlib.net/manual.html#Advanced)
+assert.throws(() => {
+  zlib.createDeflateRaw({ windowBits: 8 });
+}, /^Error: Init error$/);


### PR DESCRIPTION
This is a partial backport of semver-patch bits of 9e4660b5187d4be6a1484e705dc735c0e76ffafa.

This commit fixes the Node process crashing when constructors of classes
of the zlib module are given invalid options.

* Throw an Error when the zlib library rejects the value of windowBits,
  instead of crashing with an assertion.

* Treat windowBits and memLevel options consistently with other ones and
  don't crash when non-numeric values are given.

Refs: https://github.com/nodejs/node/pull/13098

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib