### PR TITLE
test: check noop invocation with mustNotCall()

### DIFF
--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -31,7 +31,7 @@ function fail(option, value, message) {
   fail('cwd', false, err);
   fail('cwd', [], err);
   fail('cwd', {}, err);
-  fail('cwd', common.noop, err);
+  fail('cwd', common.mustNotCall(), err);
 }
 
 {
@@ -47,7 +47,7 @@ function fail(option, value, message) {
   fail('detached', __dirname, err);
   fail('detached', [], err);
   fail('detached', {}, err);
-  fail('detached', common.noop, err);
+  fail('detached', common.mustNotCall(), err);
 }
 
 if (!common.isWindows) {
@@ -64,7 +64,7 @@ if (!common.isWindows) {
       fail('uid', false, err);
       fail('uid', [], err);
       fail('uid', {}, err);
-      fail('uid', common.noop, err);
+      fail('uid', common.mustNotCall(), err);
       fail('uid', NaN, err);
       fail('uid', Infinity, err);
       fail('uid', 3.1, err);
@@ -85,7 +85,7 @@ if (!common.isWindows) {
       fail('gid', false, err);
       fail('gid', [], err);
       fail('gid', {}, err);
-      fail('gid', common.noop, err);
+      fail('gid', common.mustNotCall(), err);
       fail('gid', NaN, err);
       fail('gid', Infinity, err);
       fail('gid', 3.1, err);
@@ -105,7 +105,7 @@ if (!common.isWindows) {
   fail('shell', 1, err);
   fail('shell', [], err);
   fail('shell', {}, err);
-  fail('shell', common.noop, err);
+  fail('shell', common.mustNotCall(), err);
 }
 
 {
@@ -121,7 +121,7 @@ if (!common.isWindows) {
   fail('argv0', false, err);
   fail('argv0', [], err);
   fail('argv0', {}, err);
-  fail('argv0', common.noop, err);
+  fail('argv0', common.mustNotCall(), err);
 }
 
 {
@@ -137,7 +137,7 @@ if (!common.isWindows) {
   fail('windowsVerbatimArguments', __dirname, err);
   fail('windowsVerbatimArguments', [], err);
   fail('windowsVerbatimArguments', {}, err);
-  fail('windowsVerbatimArguments', common.noop, err);
+  fail('windowsVerbatimArguments', common.mustNotCall(), err);
 }
 
 {
@@ -154,7 +154,7 @@ if (!common.isWindows) {
   fail('timeout', __dirname, err);
   fail('timeout', [], err);
   fail('timeout', {}, err);
-  fail('timeout', common.noop, err);
+  fail('timeout', common.mustNotCall(), err);
   fail('timeout', NaN, err);
   fail('timeout', Infinity, err);
   fail('timeout', 3.1, err);
@@ -179,7 +179,7 @@ if (!common.isWindows) {
   fail('maxBuffer', __dirname, err);
   fail('maxBuffer', [], err);
   fail('maxBuffer', {}, err);
-  fail('maxBuffer', common.noop, err);
+  fail('maxBuffer', common.mustNotCall(), err);
 }
 
 {
@@ -196,7 +196,7 @@ if (!common.isWindows) {
   fail('killSignal', false, typeErr);
   fail('killSignal', [], typeErr);
   fail('killSignal', {}, typeErr);
-  fail('killSignal', common.noop, typeErr);
+  fail('killSignal', common.mustNotCall(), typeErr);
 
   // Invalid signal names and numbers should fail
   fail('killSignal', 500, unknownSignalErr);


### PR DESCRIPTION
In test-child-process-spawnsync-validation-errors, check that functions
used inappropriately as options are not invoked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process