### PR TITLE
http: describe parse err in debug output

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -451,7 +451,7 @@ function socketOnData(d) {
 
   var ret = parser.execute(d);
   if (ret instanceof Error) {
-    debug('parse error');
+    debug('parse error', ret);
     freeParser(parser, req, socket);
     socket.destroy();
     req.emit('error', ret);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -453,7 +453,7 @@ function socketOnError(e) {
 
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   if (ret instanceof Error) {
-    debug('parse error');
+    debug('parse error', ret);
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT


### PR DESCRIPTION
parse errors are fairly invisible on the server, even with NODE_DEBUG, the actuall error is not reported, just that one ocurred. This patch helped me a lot.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http
