### PR TITLE
test: replace `indexOf` with `includes`

### DIFF
--- a/test/parallel/test-http-client-agent.js
+++ b/test/parallel/test-http-client-agent.js
@@ -55,7 +55,8 @@ function request(i) {
     socket.on('close', function() {
       ++count;
       if (count < max) {
-        assert.strictEqual(http.globalAgent.sockets[name].indexOf(socket), -1);
+        assert.strictEqual(http.globalAgent.sockets[name].includes(socket),
+                           false);
       } else {
         assert(!http.globalAgent.sockets.hasOwnProperty(name));
         assert(!http.globalAgent.requests.hasOwnProperty(name));

--- a/test/parallel/test-http-client-default-headers-exist.js
+++ b/test/parallel/test-http-client-default-headers-exist.js
@@ -46,9 +46,9 @@ const server = http.createServer(function(req, res) {
 
   const requestHeaders = Object.keys(req.headers);
   requestHeaders.forEach(function(header) {
-    assert.notStrictEqual(
-      expectedHeaders[req.method].indexOf(header.toLowerCase()),
-      -1,
+    assert.strictEqual(
+      expectedHeaders[req.method].includes(header.toLowerCase()),
+      true,
       `${header} should not exist for method ${req.method}`
     );
   });


### PR DESCRIPTION
Refs: #12586

Tests Updated:
- test/parallel/test-http-client-agent.js
- test/parallel/test-http-client-default-headers-exist.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test