### PR TITLE
stream: remove dup property

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -61,9 +61,6 @@ function WritableState(options, stream) {
   // if _final has been called
   this.finalCalled = false;
 
-  // if _final has been called
-  this.finalCalled = false;
-
   // drain event flag.
   this.needDrain = false;
   // at the start of calling end()


### PR DESCRIPTION
looks like #12828 accidentally got a double property definition, as mentioned [here](https://github.com/nodejs/node/pull/12828#issuecomment-303925595), this removes that