### PR TITLE
v8: patch API to be compatible with v8 6.0

### DIFF
--- a/deps/v8/include/v8-debug.h
+++ b/deps/v8/include/v8-debug.h
@@ -8,7 +8,9 @@
 #include "v8.h"  // NOLINT(build/include)
 
 /**
- * Debugger support for the V8 JavaScript engine.
+ * ATTENTION: The debugger API exposed by this file is deprecated and will be
+ *            removed by the end of 2017. Please use the V8 inspector declared
+ *            in include/v8-inspector.h instead.
  */
 namespace v8 {
 
@@ -140,21 +142,19 @@ class V8_EXPORT Debug {
    */
   typedef void (*MessageHandler)(const Message& message);
 
-  /**
-   * This is now a no-op.
-   */
-  typedef void (*DebugMessageDispatchHandler)();
-
-  static bool SetDebugEventListener(Isolate* isolate, EventCallback that,
-                                    Local<Value> data = Local<Value>());
+  V8_DEPRECATED("No longer supported", static bool SetDebugEventListener(
+                                           Isolate* isolate, EventCallback that,
+                                           Local<Value> data = Local<Value>()));
 
   // Schedule a debugger break to happen when JavaScript code is run
   // in the given isolate.
-  static void DebugBreak(Isolate* isolate);
+  V8_DEPRECATED("No longer supported",
+                static void DebugBreak(Isolate* isolate));
 
   // Remove scheduled debugger break in given isolate if it has not
   // happened yet.
-  static void CancelDebugBreak(Isolate* isolate);
+  V8_DEPRECATED("No longer supported",
+                static void CancelDebugBreak(Isolate* isolate));
 
   // Check if a debugger break is scheduled in the given isolate.
   V8_DEPRECATED("No longer supported",
@@ -189,10 +189,10 @@ class V8_EXPORT Debug {
    *   }
    * \endcode
    */
-  // TODO(dcarney): data arg should be a MaybeLocal
-  static MaybeLocal<Value> Call(Local<Context> context,
-                                v8::Local<v8::Function> fun,
-                                Local<Value> data = Local<Value>());
+  V8_DEPRECATED("No longer supported",
+                static MaybeLocal<Value> Call(
+                    Local<Context> context, v8::Local<v8::Function> fun,
+                    Local<Value> data = Local<Value>()));
 
   // This is now a no-op.
   V8_DEPRECATED("No longer supported",
@@ -221,23 +221,28 @@ class V8_EXPORT Debug {
    * (default Isolate if not provided). V8 will abort if LiveEdit is
    * unexpectedly used. LiveEdit is enabled by default.
    */
-  static void SetLiveEditEnabled(Isolate* isolate, bool enable);
+  V8_DEPRECATED("No longer supported",
+                static void SetLiveEditEnabled(Isolate* isolate, bool enable));
 
   /**
    * Returns array of internal properties specific to the value type. Result has
    * the following format: [<name>, <value>,...,<name>, <value>]. Result array
    * will be allocated in the current context.
    */
-  static MaybeLocal<Array> GetInternalProperties(Isolate* isolate,
-                                                 Local<Value> value);
+  V8_DEPRECATED("No longer supported",
+                static MaybeLocal<Array> GetInternalProperties(
+                    Isolate* isolate, Local<Value> value));
 
   /**
    * Defines if the ES2015 tail call elimination feature is enabled or not.
    * The change of this flag triggers deoptimization of all functions that
    * contain calls at tail position.
    */
-  static bool IsTailCallEliminationEnabled(Isolate* isolate);
-  static void SetTailCallEliminationEnabled(Isolate* isolate, bool enabled);
+  V8_DEPRECATED("No longer supported",
+                static bool IsTailCallEliminationEnabled(Isolate* isolate));
+  V8_DEPRECATED("No longer supported",
+                static void SetTailCallEliminationEnabled(Isolate* isolate,
+                                                          bool enabled));
 };
 
 

--- a/deps/v8/include/v8-inspector.h
+++ b/deps/v8/include/v8-inspector.h
@@ -224,8 +224,6 @@ class V8_EXPORT V8Inspector {
   virtual void resetContextGroup(int contextGroupId) = 0;
 
   // Various instrumentation.
-  virtual void willExecuteScript(v8::Local<v8::Context>, int scriptId) = 0;
-  virtual void didExecuteScript(v8::Local<v8::Context>) = 0;
   virtual void idleStarted() = 0;
   virtual void idleFinished() = 0;
 

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -5723,8 +5723,12 @@ class V8_EXPORT ResourceConstraints {
   void set_max_old_space_size(int limit_in_mb) {
     max_old_space_size_ = limit_in_mb;
   }
-  int max_executable_size() const { return max_executable_size_; }
-  void set_max_executable_size(int limit_in_mb) {
+  V8_DEPRECATE_SOON("max_executable_size_ is subsumed by max_old_space_size_",
+                    int max_executable_size() const) {
+    return max_executable_size_;
+  }
+  V8_DEPRECATE_SOON("max_executable_size_ is subsumed by max_old_space_size_",
+                    void set_max_executable_size(int limit_in_mb)) {
     max_executable_size_ = limit_in_mb;
   }
   uint32_t* stack_limit() const { return stack_limit_; }

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -6015,6 +6015,8 @@ enum GCType {
  *   - kGCCallbackFlagCollectAllAvailableGarbage: The GC callback is called
  *     in a phase where V8 is trying to collect all available garbage
  *     (e.g., handling a low memory notification).
+ *   - kGCCallbackScheduleIdleCollectGarbage: The GC callback is called to
+ *     trigger an idle garbage collection.
  */
 enum GCCallbackFlags {
   kNoGCCallbackFlags = 0,
@@ -6023,6 +6025,7 @@ enum GCCallbackFlags {
   kGCCallbackFlagSynchronousPhantomCallbackProcessing = 1 << 3,
   kGCCallbackFlagCollectAllAvailableGarbage = 1 << 4,
   kGCCallbackFlagCollectAllExternalMemory = 1 << 5,
+  kGCCallbackScheduleIdleCollectGarbage = 1 << 6,
 };
 
 typedef void (*GCCallback)(GCType type, GCCallbackFlags flags);

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -4008,11 +4008,19 @@ class V8_EXPORT ArrayBuffer : public Object {
      */
     virtual void* AllocateUninitialized(size_t length) = 0;
 
+    virtual void* Reserve(size_t length);
+
     /**
      * Free the memory block of size |length|, pointed to by |data|.
      * That memory is guaranteed to be previously allocated by |Allocate|.
      */
     virtual void Free(void* data, size_t length) = 0;
+
+    enum class AllocationMode { kNormal, kReservation };
+    virtual void Free(void* data, size_t length, AllocationMode mode);
+    enum class Protection { kNoAccess, kReadWrite };
+    virtual void SetProtection(void* data, size_t length,
+                               Protection protection);
 
     /**
      * malloc/free based convenience allocator.

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -2973,12 +2973,12 @@ class V8_EXPORT Object : public Value {
       Local<Context> context, Local<Value> key);
 
   /**
-   * Returns Object.getOwnPropertyDescriptor as per ES5 section 15.2.3.3.
+   * Returns Object.getOwnPropertyDescriptor as per ES2016 section 19.1.2.6.
    */
   V8_DEPRECATED("Use maybe version",
-                Local<Value> GetOwnPropertyDescriptor(Local<String> key));
+                Local<Value> GetOwnPropertyDescriptor(Local<Name> key));
   V8_WARN_UNUSED_RESULT MaybeLocal<Value> GetOwnPropertyDescriptor(
-      Local<Context> context, Local<String> key);
+      Local<Context> context, Local<Name> key);
 
   V8_DEPRECATE_SOON("Use maybe version", bool Has(Local<Value> key));
   /**

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -6015,7 +6015,7 @@ enum GCType {
  *   - kGCCallbackFlagCollectAllAvailableGarbage: The GC callback is called
  *     in a phase where V8 is trying to collect all available garbage
  *     (e.g., handling a low memory notification).
- *   - kGCCallbackScheduleIdleCollectGarbage: The GC callback is called to
+ *   - kGCCallbackScheduleIdleGarbageCollection: The GC callback is called to
  *     trigger an idle garbage collection.
  */
 enum GCCallbackFlags {
@@ -6025,7 +6025,7 @@ enum GCCallbackFlags {
   kGCCallbackFlagSynchronousPhantomCallbackProcessing = 1 << 3,
   kGCCallbackFlagCollectAllAvailableGarbage = 1 << 4,
   kGCCallbackFlagCollectAllExternalMemory = 1 << 5,
-  kGCCallbackScheduleIdleCollectGarbage = 1 << 6,
+  kGCCallbackScheduleIdleGarbageCollection = 1 << 6,
 };
 
 typedef void (*GCCallback)(GCType type, GCCallbackFlags flags);

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -437,6 +437,19 @@ void V8::SetSnapshotDataBlob(StartupData* snapshot_blob) {
   i::V8::SetSnapshotBlob(snapshot_blob);
 }
 
+void* v8::ArrayBuffer::Allocator::Reserve(size_t length) { UNIMPLEMENTED(); }
+
+void v8::ArrayBuffer::Allocator::Free(void* data, size_t length,
+                                      AllocationMode mode) {
+  UNIMPLEMENTED();
+}
+
+void v8::ArrayBuffer::Allocator::SetProtection(
+    void* data, size_t length,
+    v8::ArrayBuffer::Allocator::Protection protection) {
+  UNIMPLEMENTED();
+}
+
 namespace {
 
 class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -4443,12 +4443,11 @@ PropertyAttribute v8::Object::GetPropertyAttributes(v8::Local<Value> key) {
       .FromMaybe(static_cast<PropertyAttribute>(i::NONE));
 }
 
-
 MaybeLocal<Value> v8::Object::GetOwnPropertyDescriptor(Local<Context> context,
-                                                       Local<String> key) {
+                                                       Local<Name> key) {
   PREPARE_FOR_EXECUTION(context, Object, GetOwnPropertyDescriptor, Value);
   i::Handle<i::JSReceiver> obj = Utils::OpenHandle(this);
-  i::Handle<i::String> key_name = Utils::OpenHandle(*key);
+  i::Handle<i::Name> key_name = Utils::OpenHandle(*key);
 
   i::PropertyDescriptor desc;
   Maybe<bool> found =
@@ -4461,8 +4460,7 @@ MaybeLocal<Value> v8::Object::GetOwnPropertyDescriptor(Local<Context> context,
   RETURN_ESCAPED(Utils::ToLocal(desc.ToObject(isolate)));
 }
 
-
-Local<Value> v8::Object::GetOwnPropertyDescriptor(Local<String> key) {
+Local<Value> v8::Object::GetOwnPropertyDescriptor(Local<Name> key) {
   auto context = ContextFromHeapObject(Utils::OpenHandle(this));
   RETURN_TO_LOCAL_UNCHECKED(GetOwnPropertyDescriptor(context, key), Value);
 }

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -798,7 +798,6 @@ Extension::Extension(const char* name,
 ResourceConstraints::ResourceConstraints()
     : max_semi_space_size_(0),
       max_old_space_size_(0),
-      max_executable_size_(0),
       stack_limit_(NULL),
       code_range_size_(0),
       max_zone_pool_size_(0) {}
@@ -820,24 +819,20 @@ void ResourceConstraints::ConfigureDefaults(uint64_t physical_memory,
   if (physical_memory <= low_limit) {
     set_max_semi_space_size(i::Heap::kMaxSemiSpaceSizeLowMemoryDevice);
     set_max_old_space_size(i::Heap::kMaxOldSpaceSizeLowMemoryDevice);
-    set_max_executable_size(i::Heap::kMaxExecutableSizeLowMemoryDevice);
     set_max_zone_pool_size(i::AccountingAllocator::kMaxPoolSizeLowMemoryDevice);
   } else if (physical_memory <= medium_limit) {
     set_max_semi_space_size(i::Heap::kMaxSemiSpaceSizeMediumMemoryDevice);
     set_max_old_space_size(i::Heap::kMaxOldSpaceSizeMediumMemoryDevice);
-    set_max_executable_size(i::Heap::kMaxExecutableSizeMediumMemoryDevice);
     set_max_zone_pool_size(
         i::AccountingAllocator::kMaxPoolSizeMediumMemoryDevice);
   } else if (physical_memory <= high_limit) {
     set_max_semi_space_size(i::Heap::kMaxSemiSpaceSizeHighMemoryDevice);
     set_max_old_space_size(i::Heap::kMaxOldSpaceSizeHighMemoryDevice);
-    set_max_executable_size(i::Heap::kMaxExecutableSizeHighMemoryDevice);
     set_max_zone_pool_size(
         i::AccountingAllocator::kMaxPoolSizeHighMemoryDevice);
   } else {
     set_max_semi_space_size(i::Heap::kMaxSemiSpaceSizeHugeMemoryDevice);
     set_max_old_space_size(i::Heap::kMaxOldSpaceSizeHugeMemoryDevice);
-    set_max_executable_size(i::Heap::kMaxExecutableSizeHugeMemoryDevice);
     set_max_zone_pool_size(
         i::AccountingAllocator::kMaxPoolSizeHugeMemoryDevice);
   }
@@ -856,13 +851,11 @@ void SetResourceConstraints(i::Isolate* isolate,
                             const ResourceConstraints& constraints) {
   int semi_space_size = constraints.max_semi_space_size();
   int old_space_size = constraints.max_old_space_size();
-  int max_executable_size = constraints.max_executable_size();
   size_t code_range_size = constraints.code_range_size();
   size_t max_pool_size = constraints.max_zone_pool_size();
-  if (semi_space_size != 0 || old_space_size != 0 ||
-      max_executable_size != 0 || code_range_size != 0) {
+  if (semi_space_size != 0 || old_space_size != 0 || code_range_size != 0) {
     isolate->heap()->ConfigureHeap(semi_space_size, old_space_size,
-                                   max_executable_size, code_range_size);
+                                   0 /*max_executable_size*/, code_range_size);
   }
   isolate->allocator()->ConfigureSegmentPool(max_pool_size);
 

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -604,7 +604,6 @@ DEFINE_BOOL(experimental_new_space_growth_heuristic, false,
             "of their absolute value.")
 DEFINE_INT(max_old_space_size, 0, "max size of the old space (in Mbytes)")
 DEFINE_INT(initial_old_space_size, 0, "initial old space size (in Mbytes)")
-DEFINE_INT(max_executable_size, 0, "max size of executable memory (in Mbytes)")
 DEFINE_BOOL(gc_global, false, "always perform global GCs")
 DEFINE_INT(gc_interval, -1, "garbage collect after <n> allocations")
 DEFINE_INT(retain_maps_for_n_gc, 2,

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -5077,9 +5077,6 @@ bool Heap::ConfigureHeap(size_t max_semi_space_size, size_t max_old_space_size,
     max_old_generation_size_ =
         static_cast<size_t>(FLAG_max_old_space_size) * MB;
   }
-  if (FLAG_max_executable_size > 0) {
-    max_executable_size_ = static_cast<size_t>(FLAG_max_executable_size) * MB;
-  }
 
   if (Page::kPageSize > MB) {
     max_semi_space_size_ = ROUND_UP(max_semi_space_size_, Page::kPageSize);

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -614,16 +614,6 @@ class Heap {
   static const int kMaxOldSpaceSizeHighMemoryDevice = 512 * kPointerMultiplier;
   static const int kMaxOldSpaceSizeHugeMemoryDevice = 1024 * kPointerMultiplier;
 
-  // The executable size has to be a multiple of Page::kPageSize.
-  // Sizes are in MB.
-  static const int kMaxExecutableSizeLowMemoryDevice = 96 * kPointerMultiplier;
-  static const int kMaxExecutableSizeMediumMemoryDevice =
-      192 * kPointerMultiplier;
-  static const int kMaxExecutableSizeHighMemoryDevice =
-      256 * kPointerMultiplier;
-  static const int kMaxExecutableSizeHugeMemoryDevice =
-      256 * kPointerMultiplier;
-
   static const int kTraceRingBufferSize = 512;
   static const int kStacktraceBufferSize = 512;
 

--- a/deps/v8/src/inspector/v8-inspector-impl.cc
+++ b/deps/v8/src/inspector/v8-inspector-impl.cc
@@ -285,21 +285,6 @@ void V8InspectorImpl::resetContextGroup(int contextGroupId) {
   m_debugger->wasmTranslation()->Clear();
 }
 
-void V8InspectorImpl::willExecuteScript(v8::Local<v8::Context> context,
-                                        int scriptId) {
-  if (V8DebuggerAgentImpl* agent =
-          enabledDebuggerAgentForGroup(contextGroupId(context))) {
-    agent->willExecuteScript(scriptId);
-  }
-}
-
-void V8InspectorImpl::didExecuteScript(v8::Local<v8::Context> context) {
-  if (V8DebuggerAgentImpl* agent =
-          enabledDebuggerAgentForGroup(contextGroupId(context))) {
-    agent->didExecuteScript();
-  }
-}
-
 void V8InspectorImpl::idleStarted() {
   for (auto it = m_sessions.begin(); it != m_sessions.end(); ++it) {
     if (it->second->profilerAgent()->idleStarted()) return;

--- a/deps/v8/src/inspector/v8-inspector-impl.h
+++ b/deps/v8/src/inspector/v8-inspector-impl.h
@@ -85,8 +85,6 @@ class V8InspectorImpl : public V8Inspector {
   void contextCreated(const V8ContextInfo&) override;
   void contextDestroyed(v8::Local<v8::Context>) override;
   void resetContextGroup(int contextGroupId) override;
-  void willExecuteScript(v8::Local<v8::Context>, int scriptId) override;
-  void didExecuteScript(v8::Local<v8::Context>) override;
   void idleStarted() override;
   void idleFinished() override;
   unsigned exceptionThrown(v8::Local<v8::Context>, const StringView& message,

--- a/deps/v8/test/cctest/cctest.h
+++ b/deps/v8/test/cctest/cctest.h
@@ -31,7 +31,7 @@
 #include <memory>
 
 #include "include/libplatform/libplatform.h"
-#include "include/v8-debug.h"
+#include "src/debug/debug-interface.h"
 #include "src/utils.h"
 #include "src/v8.h"
 #include "src/zone/accounting-allocator.h"
@@ -547,18 +547,15 @@ static inline void CheckDoubleEquals(double expected, double actual) {
   CHECK_GE(expected, actual - kEpsilon);
 }
 
-
-static void DummyDebugEventListener(
-    const v8::Debug::EventDetails& event_details) {}
-
+static v8::debug::DebugDelegate dummy_delegate;
 
 static inline void EnableDebugger(v8::Isolate* isolate) {
-  v8::Debug::SetDebugEventListener(isolate, &DummyDebugEventListener);
+  v8::debug::SetDebugDelegate(isolate, &dummy_delegate);
 }
 
 
 static inline void DisableDebugger(v8::Isolate* isolate) {
-  v8::Debug::SetDebugEventListener(isolate, nullptr);
+  v8::debug::SetDebugDelegate(isolate, nullptr);
 }
 
 

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -24375,12 +24375,13 @@ TEST(GetOwnPropertyDescriptor) {
   v8::Isolate* isolate = env->GetIsolate();
   v8::HandleScope scope(isolate);
   CompileRun(
-    "var x = { value : 13};"
-    "Object.defineProperty(x, 'p0', {value : 12});"
-    "Object.defineProperty(x, 'p1', {"
-    "  set : function(value) { this.value = value; },"
-    "  get : function() { return this.value; },"
-    "});");
+      "var x = { value : 13};"
+      "Object.defineProperty(x, 'p0', {value : 12});"
+      "Object.defineProperty(x, Symbol.toStringTag, {value: 'foo'});"
+      "Object.defineProperty(x, 'p1', {"
+      "  set : function(value) { this.value = value; },"
+      "  get : function() { return this.value; },"
+      "});");
   Local<Object> x = Local<Object>::Cast(
       env->Global()->Get(env.local(), v8_str("x")).ToLocalChecked());
   Local<Value> desc =
@@ -24413,6 +24414,14 @@ TEST(GetOwnPropertyDescriptor) {
   CHECK(v8_num(14)
             ->Equals(env.local(),
                      get->Call(env.local(), x, 0, NULL).ToLocalChecked())
+            .FromJust());
+  desc =
+      x->GetOwnPropertyDescriptor(env.local(), Symbol::GetToStringTag(isolate))
+          .ToLocalChecked();
+  CHECK(v8_str("foo")
+            ->Equals(env.local(), Local<Object>::Cast(desc)
+                                      ->Get(env.local(), v8_str("value"))
+                                      .ToLocalChecked())
             .FromJust());
 }
 


### PR DESCRIPTION
This is an extension of #12875 which takes into account more recent V8 API changes on the 6.0 branch. V8 6.0 should not have any more API changes, so this should be the final piece to make the Node 8.x branch API compatible with V8 6.0.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

@addaleax @MylesBorins 

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps/v8