### PR TITLE
lib: simplify the readonly properties of icu

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -440,28 +440,13 @@
     // of possible types.
     const versionTypes = icu.getVersion().split(',');
 
-    function makeGetter(name) {
-      return () => {
-        // With an argument, getVersion(type) returns
-        // the actual version string.
-        const version = icu.getVersion(name);
-        // Replace the current getter with a new property.
-        delete process.versions[name];
-        Object.defineProperty(process.versions, name, {
-          value: version,
-          writable: false,
-          enumerable: true
-        });
-        return version;
-      };
-    }
-
     for (var n = 0; n < versionTypes.length; n++) {
       var name = versionTypes[n];
+      const version = icu.getVersion(name);
       Object.defineProperty(process.versions, name, {
-        configurable: true,
+        writable: false,
         enumerable: true,
-        get: makeGetter(name)
+        value: version
       });
     }
   }

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -32,3 +32,9 @@ assert(commonTemplate.test(process.versions.zlib));
 assert(/^\d+\.\d+\.\d+(?:\.\d+)?(?: \(candidate\))?$/
   .test(process.versions.v8));
 assert(/^\d+$/.test(process.versions.modules));
+
+for (let i = 0; i < expected_keys.length; i++) {
+  const key = expected_keys[i];
+  const descriptor = Object.getOwnPropertyDescriptor(process.versions, key);
+  assert.strictEqual(descriptor.writable, false);
+}


### PR DESCRIPTION
Call Object.defineProperty() twice to set readonly property is
unnecessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internal/bootstrap_node