### PR TITLE
async_wrap,src: wrap promises directly

### DIFF
--- a/configure
+++ b/configure
@@ -954,6 +954,7 @@ def configure_v8(o):
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
+  o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -38,6 +38,9 @@ declare_args() {
   # Sets -dENABLE_DISASSEMBLER.
   v8_enable_disassembler = ""
 
+  # Sets the number of internal fields on promise objects.
+  v8_promise_internal_field_count = 0
+
   # Sets -dENABLE_GDB_JIT_INTERFACE.
   v8_enable_gdbjit = ""
 
@@ -196,6 +199,10 @@ config("features") {
 
   if (v8_enable_disassembler) {
     defines += [ "ENABLE_DISASSEMBLER" ]
+  }
+  if (v8_promise_internal_field_count != 0) {
+    defines +=
+        [ "V8_PROMISE_INTERNAL_FIELD_COUNT=${v8_promise_internal_field_count}" ]
   }
   if (v8_enable_gdbjit) {
     defines += [ "ENABLE_GDB_JIT_INTERFACE" ]

--- a/deps/v8/gypfiles/features.gypi
+++ b/deps/v8/gypfiles/features.gypi
@@ -31,6 +31,8 @@
   'variables': {
     'v8_enable_disassembler%': 0,
 
+    'v8_promise_internal_field_count%': 0,
+
     'v8_enable_gdbjit%': 0,
 
     'v8_enable_verify_csa%': 0,
@@ -76,6 +78,9 @@
     'conditions': [
       ['v8_enable_disassembler==1', {
         'defines': ['ENABLE_DISASSEMBLER',],
+      }],
+      ['v8_promise_internal_field_count!=0', {
+        'defines': ['V8_PROMISE_INTERNAL_FIELD_COUNT','v8_promise_internal_field_count'],
       }],
       ['v8_enable_gdbjit==1', {
         'defines': ['ENABLE_GDB_JIT_INTERFACE',],

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 8
 #define V8_BUILD_NUMBER 283
-#define V8_PATCH_LEVEL 40
+#define V8_PATCH_LEVEL 41
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -3741,6 +3741,10 @@ class V8_EXPORT Function : public Object {
   static void CheckCast(Value* obj);
 };
 
+#ifndef V8_PROMISE_INTERNAL_FIELD_COUNT
+// The number of required internal fields can be defined by embedder.
+#define V8_PROMISE_INTERNAL_FIELD_COUNT 0
+#endif
 
 /**
  * An instance of the built-in Promise constructor (ES6 draft).
@@ -3821,6 +3825,8 @@ class V8_EXPORT Promise : public Object {
   PromiseState State();
 
   V8_INLINE static Promise* Cast(Value* obj);
+
+  static const int kEmbedderFieldCount = V8_PROMISE_INTERNAL_FIELD_COUNT;
 
  private:
   Promise();

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -1945,9 +1945,9 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
 
     Handle<JSObject> prototype =
         factory->NewJSObject(isolate->object_function(), TENURED);
-    Handle<JSFunction> promise_fun =
-        InstallFunction(global, "Promise", JS_PROMISE_TYPE, JSPromise::kSize,
-                        prototype, Builtins::kPromiseConstructor);
+    Handle<JSFunction> promise_fun = InstallFunction(
+        global, "Promise", JS_PROMISE_TYPE, JSPromise::kSizeWithEmbedderFields,
+        prototype, Builtins::kPromiseConstructor);
     InstallWithIntrinsicDefaultProto(isolate, promise_fun,
                                      Context::PROMISE_FUNCTION_INDEX);
 

--- a/deps/v8/src/builtins/builtins-promise.cc
+++ b/deps/v8/src/builtins/builtins-promise.cc
@@ -31,6 +31,10 @@ void PromiseBuiltinsAssembler::PromiseInit(Node* promise) {
   StoreObjectField(promise, JSPromise::kStatusOffset,
                    SmiConstant(v8::Promise::kPending));
   StoreObjectField(promise, JSPromise::kFlagsOffset, SmiConstant(0));
+  for (int i = 0; i < v8::Promise::kEmbedderFieldCount; i++) {
+    int offset = JSPromise::kSize + i * kPointerSize;
+    StoreObjectFieldNoWriteBarrier(promise, offset, SmiConstant(Smi::kZero));
+  }
 }
 
 Node* PromiseBuiltinsAssembler::AllocateAndInitJSPromise(Node* context) {
@@ -62,6 +66,10 @@ Node* PromiseBuiltinsAssembler::AllocateAndSetJSPromise(Node* context,
   StoreObjectFieldNoWriteBarrier(instance, JSPromise::kResultOffset, result);
   StoreObjectFieldNoWriteBarrier(instance, JSPromise::kFlagsOffset,
                                  SmiConstant(0));
+  for (int i = 0; i < v8::Promise::kEmbedderFieldCount; i++) {
+    int offset = JSPromise::kSize + i * kPointerSize;
+    StoreObjectFieldNoWriteBarrier(instance, offset, SmiConstant(Smi::kZero));
+  }
 
   Label out(this);
   GotoIfNot(IsPromiseHookEnabledOrDebugIsActive(), &out);

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -8443,6 +8443,8 @@ class JSPromise : public JSObject {
       kFulfillReactionsOffset + kPointerSize;
   static const int kFlagsOffset = kRejectReactionsOffset + kPointerSize;
   static const int kSize = kFlagsOffset + kPointerSize;
+  static const int kSizeWithEmbedderFields =
+      kSize + v8::Promise::kEmbedderFieldCount * kPointerSize;
 
   // Flags layout.
   static const int kHasHandlerBit = 0;

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -281,32 +281,13 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
   if (type == PromiseHookType::kInit) {
-    // Unfortunately, promises don't have internal fields. Need a surrogate that
-    // async wrap can wrap.
-    Local<Object> obj =
-      env->async_hooks_promise_object()->NewInstance(context).ToLocalChecked();
-    PromiseWrap* wrap = new PromiseWrap(env, obj);
-    v8::PropertyAttribute hidden =
-      static_cast<v8::PropertyAttribute>(v8::ReadOnly
-                                         | v8::DontDelete
-                                         | v8::DontEnum);
-    promise->DefineOwnProperty(context,
-              env->promise_wrap(),
-              v8::External::New(env->isolate(), wrap),
-              hidden).FromJust();
-    // The async tag will be destroyed at the same time as the promise as the
-    // only reference to it is held by the promise. This allows the promise
-    // wrap instance to be notified when the promise is destroyed.
-    promise->DefineOwnProperty(context,
-              env->promise_async_tag(),
-              obj, hidden).FromJust();
+    PromiseWrap* wrap = new PromiseWrap(env, promise);
+    promise->SetAlignedPointerInInternalField(0, wrap);
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
-  Local<v8::Value> external_wrap =
-      promise->Get(context, env->promise_wrap()).ToLocalChecked();
   PromiseWrap* wrap =
-    static_cast<PromiseWrap*>(external_wrap.As<v8::External>()->Value());
+    static_cast<PromiseWrap*>(promise->GetAlignedPointerFromInternalField(0));
   CHECK_NE(wrap, nullptr);
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap, false);
@@ -401,11 +382,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "popAsyncIds", PopAsyncIds);
   env->SetMethod(target, "clearIdStack", ClearIdStack);
   env->SetMethod(target, "addIdToDestroyList", QueueDestroyId);
-
-  Local<v8::ObjectTemplate> promise_object_template =
-    v8::ObjectTemplate::New(env->isolate());
-  promise_object_template->SetInternalFieldCount(1);
-  env->set_async_hooks_promise_object(promise_object_template);
 
   v8::PropertyAttribute ReadOnlyDontDelete =
       static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);

--- a/src/env.h
+++ b/src/env.h
@@ -195,8 +195,6 @@ namespace node {
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(produce_cached_data_string, "produceCachedData")                          \
-  V(promise_wrap, "_promise_async_wrap")                                      \
-  V(promise_async_tag, "_promise_async_wrap_tag")                             \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \
   V(readable_string, "readable")                                              \
@@ -258,7 +256,6 @@ namespace node {
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_before_function, v8::Function)                                \
   V(async_hooks_after_function, v8::Function)                                 \
-  V(async_hooks_promise_object, v8::ObjectTemplate)                           \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
   V(buffer_prototype_object, v8::Object)                                      \


### PR DESCRIPTION
Promises do not have any internal fields by default. V8 recently added
the capability of configuring the number of internal fields on promises.
This change adds an internal field to promises allowing promises to be
wrapped directly by the PromiseWrap object. In addition to cleaner code
this avoids an extra object allocation per promise and speeds up promise
creation with async_hooks enabled by ~2x.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_wrap, src
