### PR TITLE
inspector: allow --inspect=host:port from js

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -10,6 +10,30 @@ It can be accessed using:
 const inspector = require('inspector');
 ```
 
+## inspector.open([port[, host[, wait]]])
+
+* port {number} Port to listen on for inspector connections. Optional,
+  defaults to what was specified on the CLI.
+* host {string} Host to listen on for inspector connections. Optional,
+  defaults to what was specified on the CLI.
+* wait {boolean} Block until a client has connected. Optional, defaults
+  to false.
+
+Activate inspector on host and port. Equivalent to `node
+--inspect=[[host:]port]`, but can be done programatically after node has
+started.
+
+If wait is `true`, will block until a client has connected to the inspect port
+and flow control has been passed to the debugger client.
+
+### inspector.close()
+
+Deactivate the inspector. Blocks until there are no active connections.
+
+### inspector.url()
+
+Return the URL of the active inspector, or `undefined` if there is none.
+
 ## Class: inspector.Session
 
 The `inspector.Session` is used for dispatching messages to the V8 inspector
@@ -109,6 +133,7 @@ Immediately close the session. All pending message callbacks will be called
 with an error. [`session.connect()`] will need to be called to be able to send
 messages again. Reconnected session will lose all inspector state, such as
 enabled agents or configured breakpoints.
+
 
 [`session.connect()`]: #sessionconnect
 [`Debugger.paused`]: https://chromedevtools.github.io/devtools-protocol/v8/Debugger/#event-paused

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const connect = process.binding('inspector').connect;
 const EventEmitter = require('events');
 const util = require('util');
+const { connect, open, url } = process.binding('inspector');
 
 if (!connect)
   throw new Error('Inspector is not available');
@@ -83,5 +83,8 @@ class Session extends EventEmitter {
 }
 
 module.exports = {
+  open: (port, host, wait) => open(port, host, !!wait),
+  close: process._debugEnd,
+  url: url,
   Session
 };

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -95,6 +95,8 @@ class Agent {
   // Calls StartIoThread() from off the main thread.
   void RequestIoThreadStart();
 
+  DebugOptions& options() { return debug_options_; }
+
  private:
   node::Environment* parent_env_;
   std::unique_ptr<NodeInspectorClient> client_;

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -354,6 +354,10 @@ void InspectorIo::PostIncomingMessage(InspectorAction action, int session_id,
   NotifyMessageReceived();
 }
 
+std::vector<std::string> InspectorIo::GetTargetIds() const {
+  return delegate_ ? delegate_->GetTargetIds() : std::vector<std::string>();
+}
+
 void InspectorIo::WaitForFrontendMessageWhilePaused() {
   dispatching_messages_ = false;
   Mutex::ScopedLock scoped_lock(state_lock_);

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -72,6 +72,8 @@ class InspectorIo {
   }
 
   int port() const { return port_; }
+  std::string host() const { return options_.host_name(); }
+  std::vector<std::string> GetTargetIds() const;
 
  private:
   template <typename Action>
@@ -152,7 +154,6 @@ class InspectorIo {
 
   std::string script_name_;
   std::string script_path_;
-  const std::string id_;
   const bool wait_for_connect_;
   int port_;
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -264,6 +264,9 @@ static struct {
 #if HAVE_INSPECTOR
   bool StartInspector(Environment *env, const char* script_path,
                       const node::DebugOptions& options) {
+    // Inspector agent can't fail to start, but if it was configured to listen
+    // right away on the websocket port and fails to bind/etc, this will return
+    // false.
     return env->inspector_agent()->Start(platform_, script_path, options);
   }
 

--- a/src/node_debug_options.h
+++ b/src/node_debug_options.h
@@ -21,6 +21,7 @@ class DebugOptions {
   }
   bool wait_for_connect() const { return break_first_line_; }
   std::string host_name() const { return host_name_; }
+  void set_host_name(std::string host_name) { host_name_ = host_name; }
   int port() const;
   void set_port(int port) { port_ = port; }
 

--- a/test/parallel/test-inspector-open.js
+++ b/test/parallel/test-inspector-open.js
@@ -1,0 +1,104 @@
+'use strict';
+const common = require('../common');
+
+// Test inspector open()/close()/url() API. It uses ephemeral ports so can be
+// run safely in parallel.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const net = require('net');
+const url = require('url');
+
+common.skipIfInspectorDisabled();
+
+if (process.env.BE_CHILD)
+  return beChild();
+
+const child = fork(__filename, {env: {BE_CHILD: 1}});
+
+child.once('message', common.mustCall((msg) => {
+  assert.strictEqual(msg.cmd, 'started');
+
+  child.send({cmd: 'open', args: [0]});
+  child.once('message', common.mustCall(firstOpen));
+}));
+
+let firstPort;
+
+function firstOpen(msg) {
+  assert.strictEqual(msg.cmd, 'url');
+  const port = url.parse(msg.url).port;
+  ping(port, (err) => {
+    assert.ifError(err);
+    // Inspector is already open, and won't be reopened, so args don't matter.
+    child.send({cmd: 'open', args: []});
+    child.once('message', common.mustCall(tryToOpenWhenOpen));
+    firstPort = port;
+  });
+}
+
+function tryToOpenWhenOpen(msg) {
+  assert.strictEqual(msg.cmd, 'url');
+  const port = url.parse(msg.url).port;
+  // Reopen didn't do anything, the port was already open, and has not changed.
+  assert.strictEqual(port, firstPort);
+  ping(port, (err) => {
+    assert.ifError(err);
+    child.send({cmd: 'close'});
+    child.once('message', common.mustCall(closeWhenOpen));
+  });
+}
+
+function closeWhenOpen(msg) {
+  assert.strictEqual(msg.cmd, 'url');
+  assert.strictEqual(msg.url, undefined);
+  ping(firstPort, (err) => {
+    assert(err);
+    child.send({cmd: 'close'});
+    child.once('message', common.mustCall(tryToCloseWhenClosed));
+  });
+}
+
+function tryToCloseWhenClosed(msg) {
+  assert.strictEqual(msg.cmd, 'url');
+  assert.strictEqual(msg.url, undefined);
+  child.send({cmd: 'open', args: []});
+  child.once('message', common.mustCall(reopenAfterClose));
+}
+
+function reopenAfterClose(msg) {
+  assert.strictEqual(msg.cmd, 'url');
+  const port = url.parse(msg.url).port;
+  assert.notStrictEqual(port, firstPort);
+  ping(port, (err) => {
+    assert.ifError(err);
+    process.exit();
+  });
+}
+
+function ping(port, callback) {
+  net.connect(port)
+    .on('connect', function() { close(this); })
+    .on('error', function(err) { close(this, err); });
+
+  function close(self, err) {
+    self.end();
+    self.on('close', () => callback(err));
+  }
+}
+
+function beChild() {
+  const inspector = require('inspector');
+
+  process.send({cmd: 'started'});
+
+  process.on('message', (msg) => {
+    if (msg.cmd === 'open') {
+      inspector.open(...msg.args);
+    }
+    if (msg.cmd === 'close') {
+      inspector.close();
+    }
+    process.send({cmd: 'url', url: inspector.url()});
+  });
+}


### PR DESCRIPTION
Use case is to be able to turn on/off the inspector websocket port, control the port and host it binds to, and determine the current UUID, so that information can be transmitted out-of-band to remote inspect clients.

/to @eugeneo , this builds on top of your recent work on js APIs for the inspector.
/to @nodejs/diagnostics As discussed in last WG meeting.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). --> src, inspector
