### PR TITLE
deps: add example of comparing OpenSSL changes

### DIFF
--- a/deps/openssl/doc/UPGRADING.md
+++ b/deps/openssl/doc/UPGRADING.md
@@ -282,7 +282,7 @@ In the case of upgrading 1.0.2f there were no changes to the asm files.
 
 Files changed between two tags can be manually inspected using:
 ```
-https://github.com/openssl/openssl/compare/OpenSSL_1_0_2k...OpenSSL_1_0_2l#files_bucket
+https://github.com/openssl/openssl/compare/OpenSSL_1_0_2e...OpenSSL_1_0_2f#files_bucket
 ```
 If any source files in `asm` directory were changed then please follow the rest of the
 steps in this section otherwise these steps can be skipped.

--- a/deps/openssl/doc/UPGRADING.md
+++ b/deps/openssl/doc/UPGRADING.md
@@ -280,6 +280,13 @@ and the other is the older one. sections 6.1 and 6.2 describe the two
 types of files. Section 6.3 explains the steps to update the files.
 In the case of upgrading 1.0.2f there were no changes to the asm files.
 
+Files changed between two tags can be manually inspected using:
+```
+https://github.com/openssl/openssl/compare/OpenSSL_1_0_2k...OpenSSL_1_0_2l#files_bucket
+```
+If any source files in `asm` directory were changed then please follow the rest of the
+steps in this section otherwise these steps can be skipped.
+
 ### 6.1. asm files for the latest compiler
 This was made in `deps/openssl/asm/Makefile`
 - Updated asm files for each platforms which are required in


### PR DESCRIPTION
When upgrading OpenSSL, Step 6 in upgrading guide explains the steps
that need to be taken if asm files need updating. This might not
always be the case and something that needs to be checked from
release to release.

This commit adds an example of using github to manually compare two tags
to see if any changes were made to asm files.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps