### PR TITLE
child_process: fix handleless NODE_HANDLE handling

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -24,6 +24,8 @@ const errnoException = util._errnoException;
 const SocketListSend = SocketList.SocketListSend;
 const SocketListReceive = SocketList.SocketListReceive;
 
+const MAX_HANDLE_RETRANSMISSIONS = 3;
+
 // this object contain function to convert TCP objects to native handle objects
 // and back again.
 const handleConversion = {
@@ -89,17 +91,18 @@ const handleConversion = {
       return handle;
     },
 
-    postSend: function(handle, options, target) {
+    postSend: function(message, handle, options, callback, target) {
       // Store the handle after successfully sending it, so it can be closed
       // when the NODE_HANDLE_ACK is received. If the handle could not be sent,
       // just close it.
       if (handle && !options.keepOpen) {
         if (target) {
-          // There can only be one _pendingHandle as passing handles are
+          // There can only be one _pendingMessage as passing handles are
           // processed one at a time: handles are stored in _handleQueue while
           // waiting for the NODE_HANDLE_ACK of the current passing handle.
-          assert(!target._pendingHandle);
-          target._pendingHandle = handle;
+          assert(!target._pendingMessage);
+          target._pendingMessage =
+              { callback, message, handle, options, retransmissions: 0 };
         } else {
           handle.close();
         }
@@ -248,6 +251,11 @@ function getHandleWrapType(stream) {
   if (stream instanceof UDP) return 'udp';
 
   return false;
+}
+
+function closePendingHandle(target) {
+  target._pendingMessage.handle.close();
+  target._pendingMessage = null;
 }
 
 
@@ -435,7 +443,7 @@ function setupChannel(target, channel) {
   });
 
   target._handleQueue = null;
-  target._pendingHandle = null;
+  target._pendingMessage = null;
 
   const control = new Control(channel);
 
@@ -491,15 +499,30 @@ function setupChannel(target, channel) {
   // handlers will go through this
   target.on('internalMessage', function(message, handle) {
     // Once acknowledged - continue sending handles.
-    if (message.cmd === 'NODE_HANDLE_ACK') {
-      if (target._pendingHandle) {
-        target._pendingHandle.close();
-        target._pendingHandle = null;
+    if (message.cmd === 'NODE_HANDLE_ACK' ||
+        message.cmd === 'NODE_HANDLE_NACK') {
+
+      if (target._pendingMessage) {
+        if (message.cmd === 'NODE_HANDLE_ACK') {
+          closePendingHandle(target);
+        } else if (target._pendingMessage.retransmissions++ ===
+                   MAX_HANDLE_RETRANSMISSIONS) {
+          closePendingHandle(target);
+          process.emitWarning('Handle did not reach the receiving process ' +
+                              'correctly', 'SentHandleNotReceivedWarning');
+        }
       }
 
       assert(Array.isArray(target._handleQueue));
       var queue = target._handleQueue;
       target._handleQueue = null;
+
+      if (target._pendingMessage) {
+        target._send(target._pendingMessage.message,
+                     target._pendingMessage.handle,
+                     target._pendingMessage.options,
+                     target._pendingMessage.callback);
+      }
 
       for (var i = 0; i < queue.length; i++) {
         var args = queue[i];
@@ -514,6 +537,12 @@ function setupChannel(target, channel) {
     }
 
     if (message.cmd !== 'NODE_HANDLE') return;
+
+    // It is possible that the handle is not received because of some error on
+    // ancillary data reception such as MSG_CTRUNC. In this case, report the
+    // sender about it by sending a NODE_HANDLE_NACK message.
+    if (!handle)
+      return target._send({ cmd: 'NODE_HANDLE_NACK' }, null, true);
 
     // Acknowledge handle receival. Don't emit error events (for example if
     // the other side has disconnected) because this call to send() is not
@@ -625,7 +654,8 @@ function setupChannel(target, channel) {
         net._setSimultaneousAccepts(handle);
       }
     } else if (this._handleQueue &&
-               !(message && message.cmd === 'NODE_HANDLE_ACK')) {
+               !(message && (message.cmd === 'NODE_HANDLE_ACK' ||
+                             message.cmd === 'NODE_HANDLE_NACK'))) {
       // Queue request anyway to avoid out-of-order messages.
       this._handleQueue.push({
         callback: callback,
@@ -647,7 +677,7 @@ function setupChannel(target, channel) {
         if (!this._handleQueue)
           this._handleQueue = [];
         if (obj && obj.postSend)
-          obj.postSend(handle, options, target);
+          obj.postSend(message, handle, options, callback, target);
       }
 
       if (req.async) {
@@ -663,7 +693,7 @@ function setupChannel(target, channel) {
     } else {
       // Cleanup handle on error
       if (obj && obj.postSend)
-        obj.postSend(handle, options);
+        obj.postSend(message, handle, options, callback);
 
       if (!options.swallowErrors) {
         const ex = errnoException(err, 'write');
@@ -712,10 +742,8 @@ function setupChannel(target, channel) {
     // This marks the fact that the channel is actually disconnected.
     this.channel = null;
 
-    if (this._pendingHandle) {
-      this._pendingHandle.close();
-      this._pendingHandle = null;
-    }
+    if (this._pendingMessage)
+      closePendingHandle(this);
 
     var fired = false;
     function finish() {


### PR DESCRIPTION
It can happen that `recvmsg()` may return an error on ancillary data
reception when receiving a `NODE_HANDLE` message (for example
`MSG_CTRUNC`). This would end up, if the handle type was `net.Socket`,
on a `message` event with a non null but invalid `sendHandle`. Avoid
this by checking the `handle` validity before performing the
`handleConversion`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process
