### PR TITLE
doc: fix api docs style

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -311,7 +311,7 @@ synchronous counterparts are of this type.
 For a regular file [`util.inspect(stats)`][] would return a string very
 similar to this:
 
-```
+```console
 Stats {
   dev: 2114,
   ino: 48064969,

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2145,6 +2145,3 @@ readable buffer so there is nothing for a user to consume.
 [stream-write]: #stream_writable_write_chunk_encoding_callback
 [readable-_destroy]: #stream_readable_destroy_err_callback
 [writable-_destroy]: #stream_writable_destroy_err_callback
-[TCP sockets]: net.html#net_class_net_socket
-[Transform]: #stream_class_stream_transform
-[Writable]: #stream_class_stream_writable

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -154,11 +154,6 @@ v8.setFlagsFromString('--trace_gc');
 setTimeout(function() { v8.setFlagsFromString('--notrace_gc'); }, 60e3);
 ```
 
-[V8]: https://developers.google.com/v8/
-[`vm.Script`]: vm.html#vm_new_vm_script_code_options
-[here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md
-[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-5.0/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4
-
 ## Serialization API
 
 > Stability: 1 - Experimental
@@ -409,3 +404,7 @@ A subclass of [`Deserializer`][] corresponding to the format written by
 [`serializer.transferArrayBuffer()`]: #v8_serializer_transferarraybuffer_id_arraybuffer
 [`serializer.writeRawBytes()`]: #v8_serializer_writerawbytes_buffer
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+[V8]: https://developers.google.com/v8/
+[`vm.Script`]: vm.html#vm_new_vm_script_code_options
+[here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md
+[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-5.0/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4


### PR DESCRIPTION
Same with this: https://github.com/nodejs/node/pull/13066. To avoid more conflicts at https://github.com/nodejs/node/pull/12756, it's better to fix `mdlint` errors in upstream.

##### Summary
doc/api/fs.md
  + L314: Missing code-language flag

doc/api/stream.md
  + L2120: Do not use definitions with the same identifier
  + L2121: Do not use definitions with the same identifier
  + L2122: Do not use definitions with the same identifier

doc/api/v8.md
  + L157: Move definitions to the end of the file
  + L158: Move definitions to the end of the file
  + L159: Move definitions to the end of the file
  + L160: Move definitions to the end of the file

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc