### PR TITLE
errors,tty: migrate to use internal/errors.js

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -122,6 +122,7 @@ E('ERR_HTTP_INVALID_STATUS_CODE',
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
+E('ERR_INVALID_FD', (fd) => `"fd" must be a positive integer: ${fd}`);
 E('ERR_INVALID_FILE_URL_HOST', 'File URL host %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -27,7 +27,7 @@ const TTY = process.binding('tty_wrap').TTY;
 const isTTY = process.binding('tty_wrap').isTTY;
 const inherits = util.inherits;
 const errnoException = util._errnoException;
-
+const errors = require('internal/errors');
 
 exports.isatty = function(fd) {
   return isTTY(fd);
@@ -38,7 +38,7 @@ function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);
   if (fd >> 0 !== fd || fd < 0)
-    throw new RangeError('fd must be positive integer: ' + fd);
+    throw new errors.RangeError('ERR_INVALID_FD', fd);
 
   options = util._extend({
     highWaterMark: 0,
@@ -67,7 +67,7 @@ function WriteStream(fd) {
   if (!(this instanceof WriteStream))
     return new WriteStream(fd);
   if (fd >> 0 !== fd || fd < 0)
-    throw new RangeError('fd must be positive integer: ' + fd);
+    throw new errors.RangeError('ERR_INVALID_FD', fd);
 
   net.Socket.call(this, {
     handle: new TTY(fd, false),

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -1,14 +1,17 @@
 'use strict';
-
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const tty = require('tty');
 
-
 assert.throws(() => {
   new tty.WriteStream(-1);
-}, /fd must be positive integer:/);
+}, common.expectsError({
+    code: 'ERR_INVALID_FD',
+    type: RangeError,
+    message: '"fd" must be a positive integer: -1'
+})
+);
 
 const err_regex = common.isWindows ?
                     /^Error: EBADF: bad file descriptor, uv_tty_init$/ :
@@ -24,7 +27,12 @@ assert.throws(() => {
 
 assert.throws(() => {
   new tty.ReadStream(-1);
-}, /fd must be positive integer:/);
+}, common.expectsError({
+    code: 'ERR_INVALID_FD',
+    type: RangeError,
+    message: '"fd" must be a positive integer: -1'
+})
+);
 
 assert.throws(() => {
   let fd = 2;


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tty, errors




ref: #11273
This is my first contribution I read and understood the contribution guidelines, please review and suggest.
@jasnell 
Thanks.