### PR TITLE
async_hooks: fix Promises with later enabled hooks

### DIFF
--- a/configure
+++ b/configure
@@ -954,6 +954,7 @@ def configure_v8(o):
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
+  o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -293,13 +293,14 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
                         Local<Value> parent, void* arg) {
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
-  if (type == PromiseHookType::kInit) {
-    PromiseWrap* wrap = new PromiseWrap(env, promise);
+  PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
+  if (type == PromiseHookType::kInit ||
+      wrap == nullptr) {
+    wrap = new PromiseWrap(env, promise);
     wrap->MakeWeak(wrap);
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
-  PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
   CHECK_NE(wrap, nullptr);
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap, false);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -295,12 +295,11 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   Environment* env = Environment::GetCurrent(context);
   if (type == PromiseHookType::kInit) {
     PromiseWrap* wrap = new PromiseWrap(env, promise);
-    promise->SetAlignedPointerInInternalField(0, wrap);
+    wrap->MakeWeak(wrap);
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
-  PromiseWrap* wrap =
-    static_cast<PromiseWrap*>(promise->GetAlignedPointerFromInternalField(0));
+  PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
   CHECK_NE(wrap, nullptr);
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap, false);

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -516,7 +516,6 @@ AsyncWrap::~AsyncWrap() {
 // and reused over their lifetime. This way a new uid can be assigned when
 // the resource is pulled out of the pool and put back into use.
 void AsyncWrap::AsyncReset(bool silent) {
-  AsyncHooks* async_hooks = env()->async_hooks();
   async_id_ = env()->new_async_id();
   trigger_id_ = env()->get_init_trigger_id();
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -283,8 +283,8 @@ bool AsyncWrap::EmitAfter(Environment* env, double async_id) {
 
 class PromiseWrap : public AsyncWrap {
  public:
-  PromiseWrap(Environment* env, Local<Object> object)
-    : AsyncWrap(env, object, PROVIDER_PROMISE) {}
+  PromiseWrap(Environment* env, Local<Object> object, bool silent)
+    : AsyncWrap(env, object, PROVIDER_PROMISE, silent) {}
   size_t self_size() const override { return sizeof(*this); }
 };
 
@@ -294,19 +294,10 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
   PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
-  if (type == PromiseHookType::kInit ||
-      wrap == nullptr) {
-    uint32_t stored_init_field;
-    if (type != PromiseHookType::kInit) {
-      // Do not emit an init event.
-      stored_init_field = env->async_hooks()->fields()[AsyncHooks::kInit];
-      env->async_hooks()->fields()[AsyncHooks::kInit] = 0;
-    }
-    wrap = new PromiseWrap(env, promise);
+  if (type == PromiseHookType::kInit || wrap == nullptr) {
+    bool silent = type != PromiseHookType::kInit;
+    wrap = new PromiseWrap(env, promise, silent);
     wrap->MakeWeak(wrap);
-    if (type != PromiseHookType::kInit) {
-      env->async_hooks()->fields()[AsyncHooks::kInit] = stored_init_field;
-    }
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
@@ -501,7 +492,8 @@ void LoadAsyncWrapperInfo(Environment* env) {
 
 AsyncWrap::AsyncWrap(Environment* env,
                      Local<Object> object,
-                     ProviderType provider)
+                     ProviderType provider,
+                     bool silent)
     : BaseObject(env, object),
       provider_type_(provider) {
   CHECK_NE(provider, PROVIDER_NONE);
@@ -511,7 +503,7 @@ AsyncWrap::AsyncWrap(Environment* env,
   persistent().SetWrapperClassId(NODE_ASYNC_ID_OFFSET + provider);
 
   // Use AsyncReset() call to execute the init() callbacks.
-  AsyncReset();
+  AsyncReset(silent);
 }
 
 
@@ -523,9 +515,12 @@ AsyncWrap::~AsyncWrap() {
 // Generalized call for both the constructor and for handles that are pooled
 // and reused over their lifetime. This way a new uid can be assigned when
 // the resource is pulled out of the pool and put back into use.
-void AsyncWrap::AsyncReset() {
+void AsyncWrap::AsyncReset(bool silent) {
+  AsyncHooks* async_hooks = env()->async_hooks();
   async_id_ = env()->new_async_id();
   trigger_id_ = env()->get_init_trigger_id();
+
+  if (silent) return;
 
   EmitAsyncInit(env(), object(),
                 env()->async_hooks()->provider_string(provider_type()),

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -296,8 +296,17 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
   if (type == PromiseHookType::kInit ||
       wrap == nullptr) {
+    uint32_t stored_init_field;
+    if (type != PromiseHookType::kInit) {
+      // Do not emit an init event.
+      stored_init_field = env->async_hooks()->fields()[AsyncHooks::kInit];
+      env->async_hooks()->fields()[AsyncHooks::kInit] = 0;
+    }
     wrap = new PromiseWrap(env, promise);
     wrap->MakeWeak(wrap);
+    if (type != PromiseHookType::kInit) {
+      env->async_hooks()->fields()[AsyncHooks::kInit] = stored_init_field;
+    }
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -294,32 +294,13 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   Local<Context> context = promise->CreationContext();
   Environment* env = Environment::GetCurrent(context);
   if (type == PromiseHookType::kInit) {
-    // Unfortunately, promises don't have internal fields. Need a surrogate that
-    // async wrap can wrap.
-    Local<Object> obj =
-      env->async_hooks_promise_object()->NewInstance(context).ToLocalChecked();
-    PromiseWrap* wrap = new PromiseWrap(env, obj);
-    v8::PropertyAttribute hidden =
-      static_cast<v8::PropertyAttribute>(v8::ReadOnly
-                                         | v8::DontDelete
-                                         | v8::DontEnum);
-    promise->DefineOwnProperty(context,
-              env->promise_wrap(),
-              v8::External::New(env->isolate(), wrap),
-              hidden).FromJust();
-    // The async tag will be destroyed at the same time as the promise as the
-    // only reference to it is held by the promise. This allows the promise
-    // wrap instance to be notified when the promise is destroyed.
-    promise->DefineOwnProperty(context,
-              env->promise_async_tag(),
-              obj, hidden).FromJust();
+    PromiseWrap* wrap = new PromiseWrap(env, promise);
+    promise->SetAlignedPointerInInternalField(0, wrap);
   } else if (type == PromiseHookType::kResolve) {
     // TODO(matthewloring): need to expose this through the async hooks api.
   }
-  Local<v8::Value> external_wrap =
-      promise->Get(context, env->promise_wrap()).ToLocalChecked();
   PromiseWrap* wrap =
-    static_cast<PromiseWrap*>(external_wrap.As<v8::External>()->Value());
+    static_cast<PromiseWrap*>(promise->GetAlignedPointerFromInternalField(0));
   CHECK_NE(wrap, nullptr);
   if (type == PromiseHookType::kBefore) {
     PreCallbackExecution(wrap, false);
@@ -414,11 +395,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "popAsyncIds", PopAsyncIds);
   env->SetMethod(target, "clearIdStack", ClearIdStack);
   env->SetMethod(target, "addIdToDestroyList", QueueDestroyId);
-
-  Local<v8::ObjectTemplate> promise_object_template =
-    v8::ObjectTemplate::New(env->isolate());
-  promise_object_template->SetInternalFieldCount(1);
-  env->set_async_hooks_promise_object(promise_object_template);
 
   v8::PropertyAttribute ReadOnlyDontDelete =
       static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -86,7 +86,8 @@ class AsyncWrap : public BaseObject {
 
   AsyncWrap(Environment* env,
             v8::Local<v8::Object> object,
-            ProviderType provider);
+            ProviderType provider,
+            bool silent = false);
 
   virtual ~AsyncWrap();
 
@@ -116,7 +117,7 @@ class AsyncWrap : public BaseObject {
 
   inline double get_trigger_id() const;
 
-  void AsyncReset();
+  void AsyncReset(bool silent = false);
 
   // Only call these within a valid HandleScope.
   // TODO(trevnorris): These should return a MaybeLocal.

--- a/src/env.h
+++ b/src/env.h
@@ -195,8 +195,6 @@ namespace node {
   V(preference_string, "preference")                                          \
   V(priority_string, "priority")                                              \
   V(produce_cached_data_string, "produceCachedData")                          \
-  V(promise_wrap, "_promise_async_wrap")                                      \
-  V(promise_async_tag, "_promise_async_wrap_tag")                             \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \
   V(readable_string, "readable")                                              \
@@ -258,7 +256,6 @@ namespace node {
   V(async_hooks_init_function, v8::Function)                                  \
   V(async_hooks_before_function, v8::Function)                                \
   V(async_hooks_after_function, v8::Function)                                 \
-  V(async_hooks_promise_object, v8::ObjectTemplate)                           \
   V(binding_cache_object, v8::Object)                                         \
   V(buffer_constructor_function, v8::Function)                                \
   V(buffer_prototype_object, v8::Object)                                      \

--- a/test/parallel/test-async-wrap-promise-after-enabled.js
+++ b/test/parallel/test-async-wrap-promise-after-enabled.js
@@ -13,6 +13,8 @@ const p = new Promise((resolve) => resolve(1));
 p.then(() => seenEvents.push('then'));
 
 const hooks = async_hooks.createHook({
+  init: common.mustNotCall(),
+
   before: common.mustCall((id) => {
     assert.ok(id > 1);
     seenEvents.push('before');
@@ -23,8 +25,10 @@ const hooks = async_hooks.createHook({
     seenEvents.push('after');
     hooks.disable();
   })
-}).enable();
+});
 
 setImmediate(() => {
   assert.deepStrictEqual(seenEvents, ['before', 'then', 'after']);
 });
+
+hooks.enable(); // After `setImmediate` in order to not catch its init event.

--- a/test/parallel/test-async-wrap-promise-after-enabled.js
+++ b/test/parallel/test-async-wrap-promise-after-enabled.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/13237
+
+const common = require('../common');
+const assert = require('assert');
+
+const async_hooks = require('async_hooks');
+
+const seenEvents = [];
+
+const p = new Promise((resolve) => resolve(1));
+p.then(() => seenEvents.push('then'));
+
+const hooks = async_hooks.createHook({
+  before: common.mustCall((id) => {
+    assert.ok(id > 1);
+    seenEvents.push('before');
+  }),
+
+  after: common.mustCall((id) => {
+    assert.ok(id > 1);
+    seenEvents.push('after');
+    hooks.disable();
+  })
+}).enable();
+
+setImmediate(() => {
+  assert.deepStrictEqual(seenEvents, ['before', 'then', 'after']);
+});


### PR DESCRIPTION
Based on https://github.com/nodejs/node/pull/13224

Fixes: https://github.com/nodejs/node/issues/13237

/cc @AndreasMadsen @matthewloring @Fishrock123 @nodejs/diagnostics 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks