### PR TITLE
test: improve async hooks test error messages

### DIFF
--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -1,11 +1,11 @@
 'use strict';
 // Flags: --expose-gc
 
+require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');
 const util = require('util');
 const print = process._rawDebug;
-require('../common');
 
 if (typeof global.gc === 'function') {
   (function exity(cntr) {
@@ -109,7 +109,7 @@ class ActivityCollector {
     }
     if (violations.length) {
       console.error(violations.join('\n'));
-      assert.fail(violations.length, 0, 'Failed sanity check');
+      assert.fail(violations.length, 0, `Failed sanity checks: ${violations}`);
     }
   }
 
@@ -151,8 +151,8 @@ class ActivityCollector {
         this._activities.set(uid, stub);
         return stub;
       } else {
-        const err = new Error('Found a handle who\'s ' + hook +
-                              ' hook was invoked but not it\'s init hook');
+        const err = new Error(`Found a handle whose ${hook}` +
+                              ' hook was invoked but not its init hook');
         // Don't throw if we see invocations due to an assertion in a test
         // failing since we want to list the assertion failure instead
         if (/process\._fatalException/.test(err.stack)) return null;

--- a/test/async-hooks/test-connection.ssl.js
+++ b/test/async-hooks/test-connection.ssl.js
@@ -38,24 +38,22 @@ function createServerConnection(
 const sc1 = createServerConnection(common.mustCall(onfirstHandShake));
 
 let as = hooks.activitiesOfTypes('SSLCONNECTION');
-assert.strictEqual(as.length, 1,
-                   'one CONNECTION after first connection created');
+assert.strictEqual(as.length, 1);
 const f1 = as[0];
-assert.strictEqual(f1.type, 'SSLCONNECTION', 'connection');
-assert.strictEqual(typeof f1.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof f1.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(f1.type, 'SSLCONNECTION');
+assert.strictEqual(typeof f1.uid, 'number');
+assert.strictEqual(typeof f1.triggerId, 'number');
 checkInvocations(f1, { init: 1 }, 'first connection, when first created');
 
 // creating second server connection
 const sc2 = createServerConnection(common.mustCall(onsecondHandShake));
 
 as = hooks.activitiesOfTypes('SSLCONNECTION');
-assert.strictEqual(as.length, 2,
-                   'two SSLCONNECTIONs after second connection created');
+assert.strictEqual(as.length, 2);
 const f2 = as[1];
-assert.strictEqual(f2.type, 'SSLCONNECTION', 'connection');
-assert.strictEqual(typeof f2.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof f2.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(f2.type, 'SSLCONNECTION');
+assert.strictEqual(typeof f2.uid, 'number');
+assert.strictEqual(typeof f2.triggerId, 'number');
 checkInvocations(f1, { init: 1 }, 'first connection, when second created');
 checkInvocations(f2, { init: 1 }, 'second connection, when second created');
 

--- a/test/async-hooks/test-crypto-pbkdf2.js
+++ b/test/async-hooks/test-crypto-pbkdf2.js
@@ -31,12 +31,12 @@ function onexit() {
   hooks.sanityCheck('PBKDF2REQUEST');
 
   const as = hooks.activitiesOfTypes('PBKDF2REQUEST');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'PBKDF2REQUEST', 'random byte request');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(a.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a.type, 'PBKDF2REQUEST');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(a.triggerId, 1);
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-crypto-randomBytes.js
+++ b/test/async-hooks/test-crypto-randomBytes.js
@@ -32,12 +32,12 @@ function onexit() {
   hooks.sanityCheck('RANDOMBYTESREQUEST');
 
   const as = hooks.activitiesOfTypes('RANDOMBYTESREQUEST');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'RANDOMBYTESREQUEST', 'random byte request');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(a.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a.type, 'RANDOMBYTESREQUEST');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(a.triggerId, 1);
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-embedder.api.async-event.after-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-event.after-on-destroyed.js
@@ -39,10 +39,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1, 'exit code 1');
+    assert.strictEqual(code, 1);
     assert.ok(heartbeatMsg.test(outData.toString()),
-              'did not crash until we reached offending line of code');
+              'did not crash until we reached offending line of code ' +
+              `(found ${outData})`);
     assert.ok(corruptedMsg.test(errData.toString()),
-              'printed error contains corrupted message');
+              'printed error contains corrupted message ' +
+              `(found ${errData})`);
   }));
 }

--- a/test/async-hooks/test-embedder.api.async-event.before-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-event.before-on-destroyed.js
@@ -39,10 +39,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1, 'exit code 1');
+    assert.strictEqual(code, 1);
     assert.ok(heartbeatMsg.test(outData.toString()),
-              'did not crash until we reached offending line of code');
+              'did not crash until we reached offending line of code ' +
+              `(found ${outData})`);
     assert.ok(corruptedMsg.test(errData.toString()),
-              'printed error contains corrupted message');
+              'printed error contains corrupted message ' +
+              `(found ${errData})`);
   }));
 }

--- a/test/async-hooks/test-embedder.api.async-event.improper-order.js
+++ b/test/async-hooks/test-embedder.api.async-event.improper-order.js
@@ -37,10 +37,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1, 'exit code 1');
+    assert.strictEqual(code, 1);
     assert.ok(heartbeatMsg.test(outData.toString()),
-              'did not crash until we reached offending line of code');
+              'did not crash until we reached offending line of code ' +
+              `(found ${outData})`);
     assert.ok(corruptedMsg.test(errData.toString()),
-              'printed error contains corrupted message');
+              'printed error contains corrupted message ' +
+              `(found ${errData})`);
   }));
 }

--- a/test/async-hooks/test-embedder.api.async-event.improper-unwind.js
+++ b/test/async-hooks/test-embedder.api.async-event.improper-unwind.js
@@ -46,10 +46,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1, 'exit code 1');
+    assert.strictEqual(code, 1);
     assert.ok(heartbeatMsg.test(outData.toString()),
-              'did not crash until we reached offending line of code');
+              'did not crash until we reached offending line of code ' +
+              `(found ${outData})`);
     assert.ok(corruptedMsg.test(errData.toString()),
-              'printed error contains corrupted message');
+              'printed error contains corrupted message ' +
+              `(found ${errData})`);
   }));
 }

--- a/test/async-hooks/test-embedder.api.async-event.js
+++ b/test/async-hooks/test-embedder.api.async-event.js
@@ -19,13 +19,11 @@ const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
 const alcazaresActivities = hooks.activitiesOfTypes([ 'alcazares' ]);
 
 // alcazares event was constructed and thus only has an `init` call
-assert.strictEqual(alcazaresActivities.length, 1,
-                   'one alcazares activity after one was constructed');
+assert.strictEqual(alcazaresActivities.length, 1);
 const alcazares = alcazaresActivities[0];
-assert.strictEqual(alcazares.type, 'alcazares', 'alcazares');
-assert.strictEqual(typeof alcazares.uid, 'number', 'uid is a number');
-assert.strictEqual(alcazares.triggerId, alcaTriggerId,
-                   'triggerId is the one supplied');
+assert.strictEqual(alcazares.type, 'alcazares');
+assert.strictEqual(typeof alcazares.uid, 'number');
+assert.strictEqual(alcazares.triggerId, alcaTriggerId);
 checkInvocations(alcazares, { init: 1 }, 'alcazares constructed');
 
 alcaEvent.emitBefore();
@@ -52,10 +50,9 @@ function tick1() {
   const pobEvent = new AsyncResource('poblado', pobTriggerId);
   const pobladoActivities = hooks.activitiesOfTypes([ 'poblado' ]);
   const poblado = pobladoActivities[0];
-  assert.strictEqual(poblado.type, 'poblado', 'poblado');
-  assert.strictEqual(typeof poblado.uid, 'number', 'uid is a number');
-  assert.strictEqual(poblado.triggerId, pobTriggerId,
-                     'triggerId is the one supplied');
+  assert.strictEqual(poblado.type, 'poblado');
+  assert.strictEqual(typeof poblado.uid, 'number');
+  assert.strictEqual(poblado.triggerId, pobTriggerId);
   checkInvocations(poblado, { init: 1 }, 'poblado constructed');
   pobEvent.emitBefore();
   checkInvocations(poblado, { init: 1, before: 1 },

--- a/test/async-hooks/test-enable-disable.js
+++ b/test/async-hooks/test-enable-disable.js
@@ -145,22 +145,17 @@ function onfirstImmediate() {
   const as1 = hook1.activitiesOfTypes(types);
   const as2 = hook2.activitiesOfTypes(types);
   const as3 = hook3.activitiesOfTypes(types);
-  assert.strictEqual(as1.length, 1,
-                     'hook1 captured one immediate on first callback');
+  assert.strictEqual(as1.length, 1);
   // hook2 was not enabled yet .. it is enabled after hook3's "before" completed
-  assert.strictEqual(as2.length, 0,
-                     'hook2 captured no immediate on first callback');
-  assert.strictEqual(as3.length, 1,
-                     'hook3 captured one immediate on first callback');
+  assert.strictEqual(as2.length, 0);
+  assert.strictEqual(as3.length, 1);
 
   // Check that hook1 and hook3 captured the same Immediate and that it is valid
   const firstImmediate = as1[0];
-  assert.strictEqual(as3[0].uid, as1[0].uid,
-                     'hook1 and hook3 captured same first immediate');
-  assert.strictEqual(firstImmediate.type, 'Immediate', 'immediate');
-  assert.strictEqual(typeof firstImmediate.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof firstImmediate.triggerId,
-                     'number', 'triggerId is a number');
+  assert.strictEqual(as3[0].uid, as1[0].uid);
+  assert.strictEqual(firstImmediate.type, 'Immediate');
+  assert.strictEqual(typeof firstImmediate.uid, 'number');
+  assert.strictEqual(typeof firstImmediate.triggerId, 'number');
   checkInvocations(as1[0], { init: 1, before: 1 },
                    'hook1[0]: on first immediate');
   checkInvocations(as3[0], { init: 1, before: 1 },
@@ -187,15 +182,9 @@ function onsecondImmediate() {
   const as1 = hook1.activitiesOfTypes(types);
   const as2 = hook2.activitiesOfTypes(types);
   const as3 = hook3.activitiesOfTypes(types);
-  assert.strictEqual(
-    as1.length, 2,
-    'hook1 captured first and second immediate on second callback');
-  assert.strictEqual(
-    as2.length, 2,
-    'hook2 captured first and second immediate on second callback');
-  assert.strictEqual(
-    as3.length, 2,
-    'hook3 captured first and second immediate on second callback');
+  assert.strictEqual(as1.length, 2);
+  assert.strictEqual(as2.length, 2);
+  assert.strictEqual(as3.length, 2);
 
   // Assign the info collected by each hook for each immediate for easier
   // reference.
@@ -210,14 +199,11 @@ function onsecondImmediate() {
 
   // Check that all hooks captured the same Immediate and that it is valid
   const secondImmediate = hook1Second;
-  assert.strictEqual(hook2Second.uid, hook3Second.uid,
-                     'hook2 and hook3 captured same second immediate');
-  assert.strictEqual(hook1Second.uid, hook3Second.uid,
-                     'hook1 and hook3 captured same second immediate');
-  assert.strictEqual(secondImmediate.type, 'Immediate', 'immediate');
-  assert.strictEqual(typeof secondImmediate.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof secondImmediate.triggerId, 'number',
-                     'triggerId is a number');
+  assert.strictEqual(hook2Second.uid, hook3Second.uid);
+  assert.strictEqual(hook1Second.uid, hook3Second.uid);
+  assert.strictEqual(secondImmediate.type, 'Immediate');
+  assert.strictEqual(typeof secondImmediate.uid, 'number');
+  assert.strictEqual(typeof secondImmediate.triggerId, 'number');
 
   checkInvocations(hook1First, { init: 1, before: 1, after: 1, destroy: 1 },
                    'hook1First: on second immediate');

--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -23,11 +23,11 @@ function onexit() {
   hooks.sanityCheck('FSEVENTWRAP');
 
   const as = hooks.activitiesOfTypes('FSEVENTWRAP');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'FSEVENTWRAP', 'fs event wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(a.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a.type, 'FSEVENTWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(a.triggerId, 1);
   checkInvocations(a, { init: 1, destroy: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-fsreqwrap-access.js
+++ b/test/async-hooks/test-fsreqwrap-access.js
@@ -27,11 +27,11 @@ function onexit() {
   hooks.sanityCheck('FSREQWRAP');
 
   const as = hooks.activitiesOfTypes('FSREQWRAP');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'FSREQWRAP', 'fs req wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
+  assert.strictEqual(a.type, 'FSREQWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-fsreqwrap-readFile.js
+++ b/test/async-hooks/test-fsreqwrap-readFile.js
@@ -17,9 +17,9 @@ function onread() {
   let lastParent = 1;
   for (let i = 0; i < as.length; i++) {
     const a = as[i];
-    assert.strictEqual(a.type, 'FSREQWRAP', 'fs req wrap');
-    assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-    assert.strictEqual(a.triggerId, lastParent, 'parent uid 1');
+    assert.strictEqual(a.type, 'FSREQWRAP');
+    assert.strictEqual(typeof a.uid, 'number');
+    assert.strictEqual(a.triggerId, lastParent);
     lastParent = a.uid;
   }
   checkInvocations(as[0], { init: 1, before: 1, after: 1, destroy: 1 },

--- a/test/async-hooks/test-getaddrinforeqwrap.js
+++ b/test/async-hooks/test-getaddrinforeqwrap.js
@@ -16,12 +16,12 @@ function onlookup(err_, ip, family) {
   // tests to run offline (lookup will fail in that case and the err be set);
 
   const as = hooks.activitiesOfTypes('GETADDRINFOREQWRAP');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'GETADDRINFOREQWRAP', 'getaddrinforeq wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(a.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a.type, 'GETADDRINFOREQWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(a.triggerId, 1);
   checkInvocations(a, { init: 1, before: 1 }, 'while in onlookup callback');
   tick(2);
 }

--- a/test/async-hooks/test-getnameinforeqwrap.js
+++ b/test/async-hooks/test-getnameinforeqwrap.js
@@ -16,12 +16,12 @@ function onlookupService(err_, ip, family) {
   // tests to run offline (lookup will fail in that case and the err be set)
 
   const as = hooks.activitiesOfTypes('GETNAMEINFOREQWRAP');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1);
 
   const a = as[0];
-  assert.strictEqual(a.type, 'GETNAMEINFOREQWRAP', 'getnameinforeq wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(a.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a.type, 'GETNAMEINFOREQWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(a.triggerId, 1);
   checkInvocations(a, { init: 1, before: 1 },
                    'while in onlookupService callback');
   tick(2);

--- a/test/async-hooks/test-httpparser.request.js
+++ b/test/async-hooks/test-httpparser.request.js
@@ -26,12 +26,9 @@ const parser = new HTTPParser(REQUEST);
 const as = hooks.activitiesOfTypes('HTTPPARSER');
 const httpparser = as[0];
 
-assert.strictEqual(
-  as.length, 1,
-  '1 httpparser created synchronously when creating new httpparser');
-assert.strictEqual(typeof httpparser.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof httpparser.triggerId,
-                   'number', 'triggerId is a number');
+assert.strictEqual(as.length, 1);
+assert.strictEqual(typeof httpparser.uid, 'number');
+assert.strictEqual(typeof httpparser.triggerId, 'number');
 checkInvocations(httpparser, { init: 1 }, 'when created new Httphttpparser');
 
 parser[kOnHeadersComplete] = common.mustCall(onheadersComplete);

--- a/test/async-hooks/test-httpparser.response.js
+++ b/test/async-hooks/test-httpparser.response.js
@@ -30,12 +30,9 @@ const parser = new HTTPParser(RESPONSE);
 const as = hooks.activitiesOfTypes('HTTPPARSER');
 const httpparser = as[0];
 
-assert.strictEqual(
-  as.length, 1,
-  '1 httpparser created synchronously when creating new httpparser');
-assert.strictEqual(typeof httpparser.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof httpparser.triggerId,
-                   'number', 'triggerId is a number');
+assert.strictEqual(as.length, 1);
+assert.strictEqual(typeof httpparser.uid, 'number');
+assert.strictEqual(typeof httpparser.triggerId, 'number');
 checkInvocations(httpparser, { init: 1 }, 'when created new Httphttpparser');
 
 parser[kOnHeadersComplete] = common.mustCall(onheadersComplete);

--- a/test/async-hooks/test-immediate.js
+++ b/test/async-hooks/test-immediate.js
@@ -13,12 +13,11 @@ hooks.enable();
 setImmediate(common.mustCall(onimmediate));
 
 const as = hooks.activitiesOfTypes('Immediate');
-assert.strictEqual(as.length, 1,
-                   'one immediate when first set immediate installed');
+assert.strictEqual(as.length, 1);
 const imd1 = as[0];
-assert.strictEqual(imd1.type, 'Immediate', 'immediate');
-assert.strictEqual(typeof imd1.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof imd1.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(imd1.type, 'Immediate');
+assert.strictEqual(typeof imd1.uid, 'number');
+assert.strictEqual(typeof imd1.triggerId, 'number');
 checkInvocations(imd1, { init: 1 },
                  'imd1: when first set immediate installed');
 
@@ -26,20 +25,18 @@ let imd2;
 
 function onimmediate() {
   let as = hooks.activitiesOfTypes('Immediate');
-  assert.strictEqual(as.length, 1,
-                     'one immediate when first set immediate triggered');
+  assert.strictEqual(as.length, 1);
   checkInvocations(imd1, { init: 1, before: 1 },
                    'imd1: when first set immediate triggered');
 
   // install second immediate
   setImmediate(common.mustCall(onimmediateTwo));
   as = hooks.activitiesOfTypes('Immediate');
-  assert.strictEqual(as.length, 2,
-                     'two immediates when second set immediate installed');
+  assert.strictEqual(as.length, 2);
   imd2 = as[1];
-  assert.strictEqual(imd2.type, 'Immediate', 'immediate');
-  assert.strictEqual(typeof imd2.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof imd2.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(imd2.type, 'Immediate');
+  assert.strictEqual(typeof imd2.uid, 'number');
+  assert.strictEqual(typeof imd2.triggerId, 'number');
   checkInvocations(imd1, { init: 1, before: 1 },
                    'imd1: when second set immediate installed');
   checkInvocations(imd2, { init: 1 },

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -24,36 +24,27 @@ net.createServer(common.mustCall(function(c) {
 function onlisten() {
   let pipes = hooks.activitiesOfTypes('PIPEWRAP');
   let pipeconnects = hooks.activitiesOfTypes('PIPECONNECTWRAP');
-  assert.strictEqual(
-    pipes.length, 1,
-    'one pipe wrap created when net server is listening');
-  assert.strictEqual(
-    pipeconnects.length, 0,
-    'no pipeconnect wrap created when net server is listening');
+  assert.strictEqual(pipes.length, 1);
+  assert.strictEqual(pipeconnects.length, 0);
 
   net.connect(common.PIPE,
               common.mustCall(maybeOnconnect.bind(null, 'client')));
 
   pipes = hooks.activitiesOfTypes('PIPEWRAP');
   pipeconnects = hooks.activitiesOfTypes('PIPECONNECTWRAP');
-  assert.strictEqual(pipes.length, 2,
-                     '2 pipe wraps created when connecting client');
-  assert.strictEqual(pipeconnects.length, 1,
-                     '1 connectwrap created when connecting client');
+  assert.strictEqual(pipes.length, 2);
+  assert.strictEqual(pipeconnects.length, 1);
 
   pipe1 = pipes[0];
   pipe2 = pipes[1];
   pipeconnect = pipeconnects[0];
 
-  assert.strictEqual(pipe1.type, 'PIPEWRAP', 'first is pipe wrap');
-  assert.strictEqual(pipe2.type, 'PIPEWRAP', 'second is pipe wrap');
-  assert.strictEqual(pipeconnect.type, 'PIPECONNECTWRAP',
-                     'third is pipeconnect wrap');
-  [ pipe1, pipe2, pipeconnect ].forEach(check);
-
-  function check(a) {
-    assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-    assert.strictEqual(typeof a.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(pipe1.type, 'PIPEWRAP');
+  assert.strictEqual(pipe2.type, 'PIPEWRAP');
+  assert.strictEqual(pipeconnect.type, 'PIPECONNECTWRAP');
+  for (const a of [ pipe1, pipe2, pipeconnect ]) {
+    assert.strictEqual(typeof a.uid, 'number');
+    assert.strictEqual(typeof a.triggerId, 'number');
     checkInvocations(a, { init: 1 }, 'after net.connect');
   }
 }
@@ -69,13 +60,11 @@ function maybeOnconnect(source) {
   const pipes = hooks.activitiesOfTypes('PIPEWRAP');
   const pipeconnects = hooks.activitiesOfTypes('PIPECONNECTWRAP');
 
-  assert.strictEqual(pipes.length, 3,
-                     '3 pipe wraps created when client connected');
-  assert.strictEqual(pipeconnects.length, 1,
-                     '1 connectwrap created when client connected');
+  assert.strictEqual(pipes.length, 3);
+  assert.strictEqual(pipeconnects.length, 1);
   pipe3 = pipes[2];
-  assert.strictEqual(typeof pipe3.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof pipe3.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(typeof pipe3.uid, 'number');
+  assert.strictEqual(typeof pipe3.triggerId, 'number');
 
   checkInvocations(pipe1, { init: 1, before: 1, after: 1 },
                    'pipe1, client connected');

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -23,24 +23,22 @@ nodeVersionSpawn
 // synchronously
 const processes = hooks.activitiesOfTypes('PROCESSWRAP');
 const pipes = hooks.activitiesOfTypes('PIPEWRAP');
-assert.strictEqual(processes.length, 1,
-                   '1 processwrap created when process created');
-assert.strictEqual(pipes.length, 3,
-                   '3 pipe wraps created when process created');
+assert.strictEqual(processes.length, 1);
+assert.strictEqual(pipes.length, 3);
 
 const processwrap = processes[0];
 const pipe1 = pipes[0];
 const pipe2 = pipes[1];
 const pipe3 = pipes[2];
 
-assert.strictEqual(processwrap.type, 'PROCESSWRAP', 'process wrap type');
-assert.strictEqual(processwrap.triggerId, 1, 'processwrap triggerId is 1');
+assert.strictEqual(processwrap.type, 'PROCESSWRAP');
+assert.strictEqual(processwrap.triggerId, 1);
 checkInvocations(processwrap, { init: 1 },
                  'processwrap when sleep.spawn was called');
 
 [ pipe1, pipe2, pipe3 ].forEach((x) => {
-  assert(x.type, 'PIPEWRAP', 'pipe wrap type');
-  assert.strictEqual(x.triggerId, 1, 'pipe wrap triggerId is 1');
+  assert.strictEqual(x.type, 'PIPEWRAP');
+  assert.strictEqual(x.triggerId, 1);
   checkInvocations(x, { init: 1 }, 'pipe wrap when sleep.spawn was called');
 });
 
@@ -71,14 +69,14 @@ function onexit() {
     'processwrap while in onsleepClose callback');
 
   [ pipe1, pipe2, pipe3 ].forEach((x) => {
-    assert(x.type, 'PIPEWRAP', 'pipe wrap type');
-    assert.strictEqual(x.triggerId, 1, 'pipe wrap triggerId is 1');
+    assert.strictEqual(x.type, 'PIPEWRAP');
+    assert.strictEqual(x.triggerId, 1);
   });
 
   const ioEvents = Math.min(pipe2.before.length, pipe2.after.length);
   // 2 events without any IO and at least one more for the node version data.
   // Usually it is just one event, but it can be more.
-  assert.ok(ioEvents >= 3, 'at least 3 stdout io events.');
+  assert.ok(ioEvents >= 3, `at least 3 stdout io events, got ${ioEvents}`);
 
   checkInvocations(pipe1, { init: 1, before: 2, after: 2 },
                    'pipe wrap when sleep.spawn was called');

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -14,7 +14,7 @@ p.then(afterresolution);
 
 function executor(resolve, reject) {
   const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 1, 'one activities');
+  assert.strictEqual(as.length, 1);
   const a = as[0];
   checkInvocations(a, { init: 1 }, 'while in promise executor');
   resolve(5);
@@ -23,7 +23,7 @@ function executor(resolve, reject) {
 function afterresolution(val) {
   assert.strictEqual(val, 5);
   const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 2, 'two activities');
+  assert.strictEqual(as.length, 2);
   checkInvocations(as[0], { init: 1 }, 'after resolution parent promise');
   checkInvocations(as[1], { init: 1, before: 1 },
                    'after resolution child promise');
@@ -35,18 +35,18 @@ function onexit() {
   hooks.sanityCheck('PROMISE');
 
   const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 2, 'two activities');
+  assert.strictEqual(as.length, 2);
 
   const a0 = as[0];
-  assert.strictEqual(a0.type, 'PROMISE', 'promise request');
-  assert.strictEqual(typeof a0.uid, 'number', 'uid is a number');
-  assert.strictEqual(a0.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a0.type, 'PROMISE');
+  assert.strictEqual(typeof a0.uid, 'number');
+  assert.strictEqual(a0.triggerId, 1);
   checkInvocations(a0, { init: 1 }, 'when process exits');
 
   const a1 = as[1];
-  assert.strictEqual(a1.type, 'PROMISE', 'promise request');
-  assert.strictEqual(typeof a1.uid, 'number', 'uid is a number');
-  assert.strictEqual(a1.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a1.type, 'PROMISE');
+  assert.strictEqual(typeof a1.uid, 'number');
+  assert.strictEqual(a1.triggerId, 1);
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-querywrap.js
+++ b/test/async-hooks/test-querywrap.js
@@ -17,7 +17,7 @@ dns.resolve('localhost', common.mustCall(onresolved));
 function onresolved() {
   const as = hooks.activitiesOfTypes('QUERYWRAP');
   const a = as[0];
-  assert.strictEqual(as.length, 1, 'one activity in onresolved callback');
+  assert.strictEqual(as.length, 1);
   checkInvocations(a, { init: 1, before: 1 }, 'while in onresolved callback');
   tick(1E4);
 }
@@ -29,12 +29,12 @@ function onexit() {
   hooks.sanityCheck('QUERYWRAP');
 
   const as = hooks.activitiesOfTypes('QUERYWRAP');
-  assert.strictEqual(as.length, 1, 'one activity on process exit');
+  assert.strictEqual(as.length, 1);
   const a = as[0];
 
-  assert.strictEqual(a.type, 'QUERYWRAP', 'query wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof a.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(a.type, 'QUERYWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(typeof a.triggerId, 'number');
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-shutdownwrap.js
+++ b/test/async-hooks/test-shutdownwrap.js
@@ -22,29 +22,21 @@ function onlistening() {
 // Therefore we track here if we ended the connection already or not.
 let endedConnection = false;
 function onconnection(c) {
-  assert.strictEqual(hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 0,
-                     'no shutdown wrap before ending the client connection');
+  assert.strictEqual(hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 0);
   c.end();
   endedConnection = true;
   const as = hooks.activitiesOfTypes('SHUTDOWNWRAP');
-  assert.strictEqual(
-    as.length, 1,
-    'one shutdown wrap created sync after ending the client connection');
+  assert.strictEqual(as.length, 1);
   checkInvocations(as[0], { init: 1 }, 'after ending client connection');
   this.close(onserverClosed);
 }
 
 function onconnected() {
   if (endedConnection) {
-    assert.strictEqual(
-      hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 1,
-      'one shutdown wrap when client connected but server ended connection');
+    assert.strictEqual(hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 1);
 
   } else {
-    assert.strictEqual(
-      hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 0,
-      'no shutdown wrap when client connected and server did not end connection'
-    );
+    assert.strictEqual(hooks.activitiesOfTypes('SHUTDOWNWRAP').length, 0);
   }
 }
 
@@ -61,9 +53,9 @@ function onexit() {
   hooks.sanityCheck('SHUTDOWNWRAP');
   const as = hooks.activitiesOfTypes('SHUTDOWNWRAP');
   const a = as[0];
-  assert.strictEqual(a.type, 'SHUTDOWNWRAP', 'shutdown wrap');
-  assert.strictEqual(typeof a.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof a.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(a.type, 'SHUTDOWNWRAP');
+  assert.strictEqual(typeof a.uid, 'number');
+  assert.strictEqual(typeof a.triggerId, 'number');
   checkInvocations(as[0], { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -12,12 +12,11 @@ hooks.enable();
 process.on('SIGUSR2', common.mustCall(onsigusr2, 2));
 
 const as = hooks.activitiesOfTypes('SIGNALWRAP');
-assert.strictEqual(as.length, 1,
-                   'one signal wrap when SIGUSR2 handler is set up');
+assert.strictEqual(as.length, 1);
 const signal1 = as[0];
-assert.strictEqual(signal1.type, 'SIGNALWRAP', 'signal wrap');
-assert.strictEqual(typeof signal1.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof signal1.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(signal1.type, 'SIGNALWRAP');
+assert.strictEqual(typeof signal1.uid, 'number');
+assert.strictEqual(typeof signal1.triggerId, 'number');
 checkInvocations(signal1, { init: 1 }, 'when SIGUSR2 handler is set up');
 
 let count = 0;
@@ -47,14 +46,11 @@ function onsigusr2() {
     process.on('SIGUSR2', common.mustCall(onsigusr2Again));
 
     const as = hooks.activitiesOfTypes('SIGNALWRAP');
-    assert.strictEqual(
-      as.length, 2,
-      'two signal wraps when second SIGUSR2 handler is set up');
+    assert.strictEqual(as.length, 2);
     signal2 = as[1];
-    assert.strictEqual(signal2.type, 'SIGNALWRAP', 'signal wrap');
-    assert.strictEqual(typeof signal2.uid, 'number', 'uid is a number');
-    assert.strictEqual(typeof signal2.triggerId, 'number',
-                       'triggerId is a number');
+    assert.strictEqual(signal2.type, 'SIGNALWRAP');
+    assert.strictEqual(typeof signal2.uid, 'number');
+    assert.strictEqual(typeof signal2.triggerId, 'number');
 
     checkInvocations(
       signal1, { init: 1, before: 2, after: 1 },

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -15,24 +15,24 @@ function onchange() {}
 fs.watchFile(__filename, onchange);
 
 let as = hooks.activitiesOfTypes('STATWATCHER');
-assert.strictEqual(as.length, 1, 'one stat watcher when watching one file');
+assert.strictEqual(as.length, 1);
 
 const statwatcher1 = as[0];
-assert.strictEqual(statwatcher1.type, 'STATWATCHER', 'stat watcher');
-assert.strictEqual(typeof statwatcher1.uid, 'number', 'uid is a number');
-assert.strictEqual(statwatcher1.triggerId, 1, 'parent uid 1');
+assert.strictEqual(statwatcher1.type, 'STATWATCHER');
+assert.strictEqual(typeof statwatcher1.uid, 'number');
+assert.strictEqual(statwatcher1.triggerId, 1);
 checkInvocations(statwatcher1, { init: 1 },
                  'watcher1: when started to watch file');
 
 // install second file watcher
 fs.watchFile(commonPath, onchange);
 as = hooks.activitiesOfTypes('STATWATCHER');
-assert.strictEqual(as.length, 2, 'two stat watchers when watching two files');
+assert.strictEqual(as.length, 2);
 
 const statwatcher2 = as[1];
-assert.strictEqual(statwatcher2.type, 'STATWATCHER', 'stat watcher');
-assert.strictEqual(typeof statwatcher2.uid, 'number', 'uid is a number');
-assert.strictEqual(statwatcher2.triggerId, 1, 'parent uid 1');
+assert.strictEqual(statwatcher2.type, 'STATWATCHER');
+assert.strictEqual(typeof statwatcher2.uid, 'number');
+assert.strictEqual(statwatcher2.triggerId, 1);
 checkInvocations(statwatcher1, { init: 1 },
                  'watcher1: when started to watch second file');
 checkInvocations(statwatcher2, { init: 1 },
@@ -41,14 +41,14 @@ checkInvocations(statwatcher2, { init: 1 },
 // remove first file watcher
 fs.unwatchFile(__filename);
 checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
-                 'watcher:1 when unwatched first file');
+                 'watcher1: when unwatched first file');
 checkInvocations(statwatcher2, { init: 1 },
                  'watcher2: when unwatched first file');
 
 // remove second file watcher
 fs.unwatchFile(commonPath);
 checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
-                 'watcher:1 when unwatched second file');
+                 'watcher1: when unwatched second file');
 checkInvocations(statwatcher2, { init: 1, before: 1, after: 1 },
                  'watcher2: when unwatched second file');
 
@@ -58,7 +58,7 @@ function onexit() {
   hooks.disable();
   hooks.sanityCheck('STATWATCHER');
   checkInvocations(statwatcher1, { init: 1, before: 1, after: 1 },
-                   'watcher:1 when process exits');
+                   'watcher1: when process exits');
   checkInvocations(statwatcher2, { init: 1, before: 1, after: 1 },
                    'watcher2: when process exits');
 }

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -29,16 +29,12 @@ const server = net
   server.listen(common.PORT);
   const tcps = hooks.activitiesOfTypes('TCPWRAP');
   const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
-  assert.strictEqual(
-    tcps.length, 1,
-    'one TCPWRAP created synchronously when calling server.listen');
-  assert.strictEqual(
-    tcpconnects.length, 0,
-    'no TCPCONNECTWRAP created synchronously when calling server.listen');
+  assert.strictEqual(tcps.length, 1);
+  assert.strictEqual(tcpconnects.length, 0);
   tcp1 = tcps[0];
-  assert.strictEqual(tcp1.type, 'TCPWRAP', 'tcp wrap');
-  assert.strictEqual(typeof tcp1.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof tcp1.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(tcp1.type, 'TCPWRAP');
+  assert.strictEqual(typeof tcp1.uid, 'number');
+  assert.strictEqual(typeof tcp1.triggerId, 'number');
   checkInvocations(tcp1, { init: 1 }, 'when calling server.listen');
 }
 
@@ -48,30 +44,24 @@ const server = net
     { port: server.address().port, host: server.address().address },
     common.mustCall(onconnected));
   const tcps = hooks.activitiesOfTypes('TCPWRAP');
-  assert.strictEqual(
-    tcps.length, 2,
-    '2 TCPWRAPs present when client is connecting');
+  assert.strictEqual(tcps.length, 2);
   process.nextTick(() => {
     const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
-    assert.strictEqual(
-      tcpconnects.length, 1,
-      '1 TCPCONNECTWRAP present when client is connecting');
+    assert.strictEqual(tcpconnects.length, 1);
   });
 
   tcp2 = tcps[1];
-  assert.strictEqual(tcps.length, 2,
-                     '2 TCPWRAP present when client is connecting');
-  assert.strictEqual(tcp2.type, 'TCPWRAP', 'tcp wrap');
-  assert.strictEqual(typeof tcp2.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof tcp2.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(tcps.length, 2);
+  assert.strictEqual(tcp2.type, 'TCPWRAP');
+  assert.strictEqual(typeof tcp2.uid, 'number');
+  assert.strictEqual(typeof tcp2.triggerId, 'number');
 
   checkInvocations(tcp1, { init: 1 }, 'tcp1 when client is connecting');
   checkInvocations(tcp2, { init: 1 }, 'tcp2 when client is connecting');
 }
 
 function onlistening() {
-  assert.strictEqual(hooks.activitiesOfTypes('TCPWRAP').length, 2,
-                     'two TCPWRAPs when server is listening');
+  assert.strictEqual(hooks.activitiesOfTypes('TCPWRAP').length, 2);
 }
 
 // Depending on timing we see client: onconnected or server: onconnection first
@@ -92,14 +82,11 @@ function ontcpConnection(serverConnection) {
 
   // only focusing on TCPCONNECTWRAP here
   const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
-  assert.strictEqual(
-    tcpconnects.length, 1,
-    'one TCPCONNECTWRAP present on tcp connection');
+  assert.strictEqual(tcpconnects.length, 1);
   tcpconnect = tcpconnects[0];
-  assert.strictEqual(tcpconnect.type, 'TCPCONNECTWRAP', 'tcpconnect wrap');
-  assert.strictEqual(typeof tcpconnect.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof tcpconnect.triggerId,
-                     'number', 'triggerId is a number');
+  assert.strictEqual(tcpconnect.type, 'TCPCONNECTWRAP');
+  assert.strictEqual(typeof tcpconnect.uid, 'number');
+  assert.strictEqual(typeof tcpconnect.triggerId, 'number');
   // When client receives connection first ('onconnected'), we 'before' has
   // been invoked at this point already, otherwise it only was 'init'ed
   const expected = serverConnection ? { init: 1 } : { init: 1, before: 1 };
@@ -125,16 +112,12 @@ function onconnection(c) {
 
   const tcps = hooks.activitiesOfTypes([ 'TCPWRAP' ]);
   const tcpconnects = hooks.activitiesOfTypes('TCPCONNECTWRAP');
-  assert.strictEqual(
-    tcps.length, 3,
-    '3 TCPWRAPs present when server receives connection');
-  assert.strictEqual(
-    tcpconnects.length, 1,
-    'one TCPCONNECTWRAP present when server receives connection');
+  assert.strictEqual(tcps.length, 3);
+  assert.strictEqual(tcpconnects.length, 1);
   tcp3 = tcps[2];
-  assert.strictEqual(tcp3.type, 'TCPWRAP', 'tcp wrap');
-  assert.strictEqual(typeof tcp3.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof tcp3.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(tcp3.type, 'TCPWRAP');
+  assert.strictEqual(typeof tcp3.uid, 'number');
+  assert.strictEqual(typeof tcp3.triggerId, 'number');
 
   checkInvocations(tcp1, { init: 1, before: 1 },
                    'tcp1 when server receives connection');

--- a/test/async-hooks/test-timerwrap.setInterval.js
+++ b/test/async-hooks/test-timerwrap.setInterval.js
@@ -14,16 +14,16 @@ let count = 0;
 const iv = setInterval(common.mustCall(oninterval, 3), TIMEOUT);
 
 const as = hooks.activitiesOfTypes('TIMERWRAP');
-assert.strictEqual(as.length, 1, 'one timer wrap when interval installed');
+assert.strictEqual(as.length, 1);
 const t = as[0];
-assert.strictEqual(t.type, 'TIMERWRAP', 'timer wrap');
-assert.strictEqual(typeof t.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof t.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(t.type, 'TIMERWRAP');
+assert.strictEqual(typeof t.uid, 'number');
+assert.strictEqual(typeof t.triggerId, 'number');
 checkInvocations(t, { init: 1 }, 't: when first timer installed');
 
 function oninterval() {
   count++;
-  assert.strictEqual(as.length, 1, 'one timer wrap when timer is triggered');
+  assert.strictEqual(as.length, 1);
   switch (count) {
     case 1: {
       checkInvocations(t, { init: 1, before: 1 },

--- a/test/async-hooks/test-timerwrap.setTimeout.js
+++ b/test/async-hooks/test-timerwrap.setTimeout.js
@@ -13,11 +13,11 @@ hooks.enable();
 // install first timeout
 setTimeout(common.mustCall(ontimeout), TIMEOUT);
 const as = hooks.activitiesOfTypes('TIMERWRAP');
-assert.strictEqual(as.length, 1, 'one timer wrap when first timeout installed');
+assert.strictEqual(as.length, 1);
 const t1 = as[0];
-assert.strictEqual(t1.type, 'TIMERWRAP', 'timer wrap');
-assert.strictEqual(typeof t1.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof t1.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(t1.type, 'TIMERWRAP');
+assert.strictEqual(typeof t1.uid, 'number');
+assert.strictEqual(typeof t1.triggerId, 'number');
 checkInvocations(t1, { init: 1 }, 't1: when first timer installed');
 
 function ontimeout() {
@@ -26,8 +26,7 @@ function ontimeout() {
   // install second timeout with same TIMEOUT to see timer wrap being reused
   setTimeout(onsecondTimeout, TIMEOUT);
   const as = hooks.activitiesOfTypes('TIMERWRAP');
-  assert.strictEqual(as.length, 1,
-                     'one timer wrap when second timer installed');
+  assert.strictEqual(as.length, 1);
   checkInvocations(t1, { init: 1, before: 1 },
                    't1: when second timer installed');
 }
@@ -38,19 +37,18 @@ let t2;
 
 function onsecondTimeout() {
   let as = hooks.activitiesOfTypes('TIMERWRAP');
-  assert.strictEqual(as.length, 1, 'one timer wrap when second timer fired');
+  assert.strictEqual(as.length, 1);
   checkInvocations(t1, { init: 1, before: 2, after: 1 },
                    't1: when second timer fired');
 
   // install third timeout with different TIMEOUT
   setTimeout(onthirdTimeout, TIMEOUT + 1);
   as = hooks.activitiesOfTypes('TIMERWRAP');
-  assert.strictEqual(as.length, 2,
-                     'two timer wraps when third timer installed');
+  assert.strictEqual(as.length, 2);
   t2 = as[1];
-  assert.strictEqual(t2.type, 'TIMERWRAP', 'timer wrap');
-  assert.strictEqual(typeof t2.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof t2.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(t2.type, 'TIMERWRAP');
+  assert.strictEqual(typeof t2.uid, 'number');
+  assert.strictEqual(typeof t2.triggerId, 'number');
   checkInvocations(t1, { init: 1, before: 2, after: 1 },
                    't1: when third timer installed');
   checkInvocations(t2, { init: 1 },

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -38,12 +38,12 @@ function onlistening() {
     .on('secureConnect', common.mustCall(onsecureConnect));
 
   const as = hooks.activitiesOfTypes('TLSWRAP');
-  assert.strictEqual(as.length, 1, 'one TLSWRAP when client connecting');
+  assert.strictEqual(as.length, 1);
   svr = as[0];
 
-  assert.strictEqual(svr.type, 'TLSWRAP', 'tls wrap');
-  assert.strictEqual(typeof svr.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof svr.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(svr.type, 'TLSWRAP');
+  assert.strictEqual(typeof svr.uid, 'number');
+  assert.strictEqual(typeof svr.triggerId, 'number');
   checkInvocations(svr, { init: 1 }, 'server: when client connecting');
 }
 
@@ -52,13 +52,11 @@ function onsecureConnection() {
   // Server received client connection
   //
   const as = hooks.activitiesOfTypes('TLSWRAP');
-  assert.strictEqual(as.length, 2,
-                     'two TLSWRAPs when server has secure connection');
+  assert.strictEqual(as.length, 2);
   client = as[1];
-  assert.strictEqual(client.type, 'TLSWRAP', 'tls wrap');
-  assert.strictEqual(typeof client.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof client.triggerId, 'number',
-                     'triggerId is a number');
+  assert.strictEqual(client.type, 'TLSWRAP');
+  assert.strictEqual(typeof client.uid, 'number');
+  assert.strictEqual(typeof client.triggerId, 'number');
 
   // TODO(thlorenz) which callback did the server wrap execute that already
   // finished as well?

--- a/test/async-hooks/test-ttywrap.readstream.js
+++ b/test/async-hooks/test-ttywrap.readstream.js
@@ -13,11 +13,11 @@ const ReadStream = require('tty').ReadStream;
 const ttyStream = new ReadStream(0);
 
 const as = hooks.activitiesOfTypes('TTYWRAP');
-assert.strictEqual(as.length, 1, 'one TTYWRAP when tty created');
+assert.strictEqual(as.length, 1);
 const tty = as[0];
-assert.strictEqual(tty.type, 'TTYWRAP', 'tty wrap');
-assert.strictEqual(typeof tty.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof tty.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(tty.type, 'TTYWRAP');
+assert.strictEqual(typeof tty.uid, 'number');
+assert.strictEqual(typeof tty.triggerId, 'number');
 checkInvocations(tty, { init: 1 }, 'when tty created');
 
 ttyStream.end(common.mustCall(onend));

--- a/test/async-hooks/test-ttywrap.writestream.js
+++ b/test/async-hooks/test-ttywrap.writestream.js
@@ -23,18 +23,18 @@ const hooks = initHooks();
 hooks.enable();
 
 const as = hooks.activitiesOfTypes('TTYWRAP');
-assert.strictEqual(as.length, 1, 'one TTYWRAP when tty created');
+assert.strictEqual(as.length, 1);
 const tty = as[0];
-assert.strictEqual(tty.type, 'TTYWRAP', 'tty wrap');
-assert.strictEqual(typeof tty.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof tty.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(tty.type, 'TTYWRAP');
+assert.strictEqual(typeof tty.uid, 'number');
+assert.strictEqual(typeof tty.triggerId, 'number');
 checkInvocations(tty, { init: 1 }, 'when tty created');
 
 ttyStream
   .on('finish', common.mustCall(onfinish))
   .end(common.mustCall(onend));
 
-checkInvocations(tty, { init: 1}, 'when tty.end() was invoked ');
+checkInvocations(tty, { init: 1 }, 'when tty.end() was invoked ');
 
 function onend() {
   tick(2, common.mustCall(() =>

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -25,20 +25,17 @@ function onlistening() {
   // callback in a next tick even if no lookup is needed
   // TODO (trevnorris) submit patch to fix creation of tick objects and instead
   // create the send wrap synchronously.
-  assert.strictEqual(
-    hooks.activitiesOfTypes('UDPSENDWRAP').length, 0,
-    'no udpsendwrap after sock connected and sock.send called');
+  assert.strictEqual(hooks.activitiesOfTypes('UDPSENDWRAP').length, 0);
 }
 
 function onsent() {
   const as = hooks.activitiesOfTypes('UDPSENDWRAP');
   send = as[0];
 
-  assert.strictEqual(as.length, 1,
-                     'one UDPSENDWRAP created synchronously when message sent');
-  assert.strictEqual(send.type, 'UDPSENDWRAP', 'send wrap');
-  assert.strictEqual(typeof send.uid, 'number', 'uid is a number');
-  assert.strictEqual(typeof send.triggerId, 'number', 'triggerId is a number');
+  assert.strictEqual(as.length, 1);
+  assert.strictEqual(send.type, 'UDPSENDWRAP');
+  assert.strictEqual(typeof send.uid, 'number');
+  assert.strictEqual(typeof send.triggerId, 'number');
   checkInvocations(send, { init: 1, before: 1 }, 'when message sent');
 
   sock.close(common.mustCall(onsockClosed));

--- a/test/async-hooks/test-udpwrap.js
+++ b/test/async-hooks/test-udpwrap.js
@@ -14,11 +14,10 @@ const sock = dgram.createSocket('udp4');
 
 const as = hooks.activitiesOfTypes('UDPWRAP');
 const udpwrap = as[0];
-assert.strictEqual(as.length, 1,
-                   'one UDPWRAP handle after dgram.createSocket call');
-assert.strictEqual(udpwrap.type, 'UDPWRAP', 'udp wrap');
-assert.strictEqual(typeof udpwrap.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof udpwrap.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(as.length, 1);
+assert.strictEqual(udpwrap.type, 'UDPWRAP');
+assert.strictEqual(typeof udpwrap.uid, 'number');
+assert.strictEqual(typeof udpwrap.triggerId, 'number');
 checkInvocations(udpwrap, { init: 1 }, 'after dgram.createSocket call');
 
 sock.close(common.mustCall(onsockClosed));

--- a/test/async-hooks/test-writewrap.js
+++ b/test/async-hooks/test-writewrap.js
@@ -27,12 +27,10 @@ const server = tls
   .on('secureConnection', common.mustCall(onsecureConnection))
   .listen(common.PORT);
 
-assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0,
-                   'no WRITEWRAP when server created');
+assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0);
 
 function onlistening() {
-  assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0,
-                     'no WRITEWRAP when server is listening');
+  assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0);
   //
   // Creating client and connecting it to server
   //
@@ -40,20 +38,19 @@ function onlistening() {
     .connect(common.PORT, { rejectUnauthorized: false })
     .on('secureConnect', common.mustCall(onsecureConnect));
 
-  assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0,
-                     'no WRITEWRAP when client created');
+  assert.strictEqual(hooks.activitiesOfTypes('WRITEWRAP').length, 0);
 }
 
 function checkDestroyedWriteWraps(n, stage) {
   const as = hooks.activitiesOfTypes('WRITEWRAP');
-  assert.strictEqual(as.length, n, n + ' WRITEWRAPs when ' + stage);
+  assert.strictEqual(as.length, n, `${n} WRITEWRAPs when ${stage}`);
 
   function checkValidWriteWrap(w) {
-    assert.strictEqual(w.type, 'WRITEWRAP', 'write wrap');
-    assert.strictEqual(typeof w.uid, 'number', 'uid is a number');
-    assert.strictEqual(typeof w.triggerId, 'number', 'triggerId is a number');
+    assert.strictEqual(w.type, 'WRITEWRAP');
+    assert.strictEqual(typeof w.uid, 'number');
+    assert.strictEqual(typeof w.triggerId, 'number');
 
-    checkInvocations(w, { init: 1 }, 'when ' + stage);
+    checkInvocations(w, { init: 1 }, `when ${stage}`);
   }
   as.forEach(checkValidWriteWrap);
 }

--- a/test/async-hooks/test-zlib.zlib-binding.deflate.js
+++ b/test/async-hooks/test-zlib.zlib-binding.deflate.js
@@ -14,11 +14,11 @@ const constants = process.binding('constants').zlib;
 const handle = new Zlib(constants.DEFLATE);
 
 const as = hooks.activitiesOfTypes('ZLIB');
-assert.strictEqual(as.length, 1, 'one zlib on when created handle');
+assert.strictEqual(as.length, 1);
 const hdl = as[0];
-assert.strictEqual(hdl.type, 'ZLIB', 'zlib');
-assert.strictEqual(typeof hdl.uid, 'number', 'uid is a number');
-assert.strictEqual(typeof hdl.triggerId, 'number', 'triggerId is a number');
+assert.strictEqual(hdl.type, 'ZLIB');
+assert.strictEqual(typeof hdl.uid, 'number');
+assert.strictEqual(typeof hdl.triggerId, 'number');
 checkInvocations(hdl, { init: 1 }, 'when created handle');
 
 handle.init(

--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const util = require('util');
 require('../common');
 
 function findInGraph(graph, type, n) {
@@ -85,14 +86,14 @@ module.exports = function verifyGraph(hooks, graph) {
       )
     );
   }
-  assert.strictEqual(errors.length, 0, 'Found errors while verifying graph.');
+  assert.strictEqual(errors.length, 0);
 };
 
 //
 // Helper to generate the input to the verifyGraph tests
 //
 function inspect(obj, depth) {
-  console.error(require('util').inspect(obj, false, depth || 5, true));
+  console.error(util.inspect(obj, false, depth || 5, true));
 }
 
 module.exports.printGraph = function printGraph(hooks) {


### PR DESCRIPTION
Improve error messages in the async hooks tests, mostly by removing
unhelpful `message` parameters for assertions.

(@Trott, maybe we could have a lint rule that forbids literals as messages if this PR is somewhat well-received?)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/async_hooks