### PR TITLE
test: improve n-api coverage for typed arrays

### DIFF
--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -37,3 +37,21 @@ assert.strictEqual(externalResult.length, 3);
 assert.strictEqual(externalResult[0], 0);
 assert.strictEqual(externalResult[1], 1);
 assert.strictEqual(externalResult[2], 2);
+
+// validate creation of all kinds of TypedArrays
+const buffer = new ArrayBuffer(128);
+const arrayTypes = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array,
+                     Uint16Array, Int32Array, Uint32Array, Float32Array,
+                     Float64Array ];
+
+arrayTypes.forEach((currentType, key) => {
+  const template = Reflect.construct(currentType, buffer);
+  const theArray = test_typedarray.CreateTypedArray(template, buffer);
+
+  assert.ok(theArray instanceof currentType,
+            'Type of new array should match that of the template');
+  assert.ok(theArray !== template);
+  assert.strictEqual(theArray.buffer,
+                     buffer,
+                     'Buffer for array should match the one passed in');
+});

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -50,7 +50,9 @@ arrayTypes.forEach((currentType, key) => {
 
   assert.ok(theArray instanceof currentType,
             'Type of new array should match that of the template');
-  assert.ok(theArray !== template);
+  assert.notStrictEqual(theArray,
+                        template,
+                        'the new array should not be a copy of the template');
   assert.strictEqual(theArray.buffer,
                      buffer,
                      'Buffer for array should match the one passed in');

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -95,10 +95,58 @@ napi_value External(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
+napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_object,
+    "Wrong type of argments. Expects a typed array as first argument.");
+
+  napi_value input_array = args[0];
+  bool is_typedarray;
+  NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
+
+  NAPI_ASSERT(env, is_typedarray,
+    "Wrong type of argments. Expects a typed array as first argument.");
+
+  napi_valuetype valuetype1;
+  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+
+  NAPI_ASSERT(env, valuetype1 == napi_object,
+    "Wrong type of argments. Expects an array buffer as second argument.");
+
+  napi_value input_buffer = args[1];
+  bool is_arraybuffer;
+  NAPI_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
+
+  NAPI_ASSERT(env, is_arraybuffer,
+    "Wrong type of argments. Expects an array buffer as second argument.");
+
+  napi_typedarray_type type;
+  napi_value in_array_buffer;
+  size_t byte_offset;
+  size_t length;
+  NAPI_CALL(env, napi_get_typedarray_info(
+    env, input_array, &type, &length, NULL, &in_array_buffer, &byte_offset));
+
+  napi_value output_array;
+  NAPI_CALL(env, napi_create_typedarray(
+      env, type, length, input_buffer, byte_offset, &output_array));
+
+  return output_array;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
+    DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -102,13 +102,13 @@ napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
 
   NAPI_ASSERT(env, argc == 2, "Wrong number of arguments");
 
+  napi_value input_array = args[0];
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NAPI_CALL(env, napi_typeof(env, input_array, &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
     "Wrong type of argments. Expects a typed array as first argument.");
 
-  napi_value input_array = args[0];
   bool is_typedarray;
   NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
 
@@ -116,12 +116,12 @@ napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
     "Wrong type of argments. Expects a typed array as first argument.");
 
   napi_valuetype valuetype1;
-  NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
+  napi_value input_buffer = args[1];
+  NAPI_CALL(env, napi_typeof(env, input_buffer, &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_object,
     "Wrong type of argments. Expects an array buffer as second argument.");
 
-  napi_value input_buffer = args[1];
   bool is_arraybuffer;
   NAPI_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
 


### PR DESCRIPTION
Add testing for all types of typed arrays.
Add testing for napi_is_arraybuffer.
##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, n-api