### PR TITLE
doc: make spelling of behavior consistent

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1901,7 +1901,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
   <tr>
     <td><code>SSL_OP_CIPHER_SERVER_PREFERENCE</code></td>
     <td>Attempts to use the server's preferences instead of the client's when
-    selecting a cipher. Behaviour depends on protocol version. See
+    selecting a cipher. Behavior depends on protocol version. See
     https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html.</td>
   </tr>
   <tr>

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1635,7 +1635,7 @@ important ways:
    - TTYs (Terminals): *asynchronous* on Windows, *synchronous* on Unix
    - Pipes (and sockets): *synchronous* on Windows, *asynchronous* on Unix
 
-These behaviours are partly for historical reasons, as changing them would
+These behaviors are partly for historical reasons, as changing them would
 create backwards incompatibility, but they are also expected by some users.
 
 Synchronous writes avoid problems such as output written with `console.log()` or

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -982,7 +982,7 @@ changes:
     `"SSLv23_method"`. The possible values are listed as [SSL_METHODS][], use
     the function names as strings. For example, `"SSLv3_method"` to force SSL
     version 3.
-  * `secureOptions` {number} Optionally affect the OpenSSL protocol behaviour,
+  * `secureOptions` {number} Optionally affect the OpenSSL protocol behavior,
     which is not usually necessary. This should be used carefully if at all!
     Value is a numeric bitmask of the `SSL_OP_*` options from
     [OpenSSL Options][].

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -443,7 +443,7 @@ will return its value, see [Custom promisified functions][].
 
 `promisify()` assumes that `original` is a function taking a callback as its
 final argument in all cases, and the returned function will result in undefined
-behaviour if it does not.
+behavior if it does not.
 
 ### Custom promisified functions
 


### PR DESCRIPTION
In the api docs there were some instances of behaviour
and many more with behavior.  I was asked as part of a review
on a different PR which one to use and went with behavior
to be consistent with the majority.

Not sure if we should mandate the US or english spelling but
this makes the api docs consistent.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
doc