### PR TITLE
test: use mustNotCall() in test-stream2-objects

### DIFF
--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -76,7 +76,7 @@ function toArray(callback) {
 
 function fromArray(list) {
   const r = new Readable({ objectMode: true });
-  r._read = common.noop;
+  r._read = common.mustNotCall();
   list.forEach(function(chunk) {
     r.push(chunk);
   });
@@ -164,7 +164,7 @@ test('can read strings as objects', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = common.noop;
+  r._read = common.mustNotCall();
   const list = ['one', 'two', 'three'];
   list.forEach(function(str) {
     r.push(str);
@@ -182,7 +182,7 @@ test('read(0) for object streams', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = common.noop;
+  r._read = common.mustNotCall();
 
   r.push('foobar');
   r.push(null);
@@ -198,7 +198,7 @@ test('falsey values', function(t) {
   const r = new Readable({
     objectMode: true
   });
-  r._read = common.noop;
+  r._read = common.mustNotCall();
 
   r.push(false);
   r.push(0);
@@ -249,7 +249,7 @@ test('high watermark push', function(t) {
     highWaterMark: 6,
     objectMode: true
   });
-  r._read = common.noop;
+  r._read = common.mustNotCall();
   for (let i = 0; i < 6; i++) {
     const bool = r.push(i);
     assert.strictEqual(bool, i !== 5);


### PR DESCRIPTION
Use `common.mustNotCall()` in test-stream2-objects.js to confirm that
noop function is never invoked.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test stream