### PR TITLE
test: cleanup after test-fs-watchfile.js

### DIFF
--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -64,9 +64,12 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
   }
 }, 2));
 
+common.refreshTmpDir();
+
 // Watch events should callback with a filename on supported systems
 if (common.isLinux || common.isOSX || common.isWindows || common.isAix) {
   const dir = common.tmpDir + '/watch';
+  const file = `${dir}/foo.txt`;
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);
@@ -76,7 +79,7 @@ if (common.isLinux || common.isOSX || common.isWindows || common.isAix) {
       assert.strictEqual(filename, 'foo.txt');
     }));
 
-    fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall(function(err) {
+    fs.writeFile(file, 'foo', common.mustCall(function(err) {
       if (err) assert.fail(err);
     }));
   }));


### PR DESCRIPTION
cleanup before and after test-fs-watchfile
Maybe fix: #13248
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
