### PR TITLE
test: fix flaky test-fs-watchfile on macOS

### DIFF
--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -72,12 +72,15 @@ if (common.isLinux || common.isOSX || common.isWindows || common.isAix) {
     if (err) assert.fail(err);
 
     fs.watch(dir, common.mustCall(function(eventType, filename) {
+      clearInterval(interval);
       this._handle.close();
       assert.strictEqual(filename, 'foo.txt');
     }));
 
-    fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall(function(err) {
-      if (err) assert.fail(err);
-    }));
+    const interval = setInterval(() => {
+      fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall(function(err) {
+        if (err) assert.fail(err);
+      }));
+    }, 1);
   }));
 }


### PR DESCRIPTION
On macOS, a watcher created with fs.watch() does not necessarily
start receiving events immediately. So it can miss a change by
fs.writefile() if it comes very soon after the watcher is created. Fix
test flakiness caused by this by using `setInterval()` to repeat the
write action.

Fixes: https://github.com/nodejs/node/issues/13248

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs