### PR TITLE
Revert "lib: lazy instantiation of fs.Stats dates"

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -196,80 +196,12 @@ function Stats(
   this.ino = ino;
   this.size = size;
   this.blocks = blocks;
-  this._atim_msec = atim_msec;
-  this._mtim_msec = mtim_msec;
-  this._ctim_msec = ctim_msec;
-  this._birthtim_msec = birthtim_msec;
+  this.atime = new Date(atim_msec + 0.5);
+  this.mtime = new Date(mtim_msec + 0.5);
+  this.ctime = new Date(ctim_msec + 0.5);
+  this.birthtime = new Date(birthtim_msec + 0.5);
 }
 fs.Stats = Stats;
-
-// defining the properties in this fashion (explicitly with no loop or factory)
-// has been shown to be the most performant on V8 contemp.
-// Ref: https://github.com/nodejs/node/pull/12818
-// + 0.5 is added to the Dates to protect values from being rounded down
-// Ref: https://github.com/nodejs/node/pull/12607
-Object.defineProperties(Stats.prototype, {
-  atime: {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return this._atime !== undefined ?
-          this._atime :
-          (this._atime = new Date(this._atim_msec + 0.5));
-    },
-    set(value) { return this._atime = value; }
-  },
-  mtime: {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return this._mtime !== undefined ?
-          this._mtime :
-          (this._mtime = new Date(this._mtim_msec + 0.5));
-    },
-    set(value) { return this._mtime = value; }
-  },
-  ctime: {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return this._ctime !== undefined ?
-        this._ctime :
-        (this._ctime = new Date(this._ctim_msec + 0.5));
-    },
-    set(value) { return this._ctime = value; }
-  },
-  birthtime: {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return this._birthtime !== undefined ?
-        this._birthtime :
-        (this._birthtime = new Date(this._birthtim_msec + 0.5));
-    },
-    set(value) { return this._birthtime = value; }
-  },
-});
-
-Stats.prototype.toJSON = function toJSON() {
-  return {
-    dev: this.dev,
-    mode: this.mode,
-    nlink: this.nlink,
-    uid: this.uid,
-    gid: this.gid,
-    rdev: this.rdev,
-    blksize: this.blksize,
-    ino: this.ino,
-    size: this.size,
-    blocks: this.blocks,
-    atime: this.atime,
-    ctime: this.ctime,
-    mtime: this.mtime,
-    birthtime: this.birthtime
-  };
-};
-
 
 Stats.prototype._checkModeProperty = function(property) {
   return ((this.mode & S_IFMT) === property);

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -98,27 +98,5 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   console.log(`isSymbolicLink: ${JSON.stringify(s.isSymbolicLink())}`);
   assert.strictEqual(false, s.isSymbolicLink());
 
-  assert.ok(s.atime instanceof Date);
   assert.ok(s.mtime instanceof Date);
-  assert.ok(s.ctime instanceof Date);
-  assert.ok(s.birthtime instanceof Date);
-}));
-
-fs.stat(__filename, common.mustCall(function(err, s) {
-  const json = JSON.parse(JSON.stringify(s));
-  const keys = [
-    'dev', 'mode', 'nlink', 'uid',
-    'gid', 'rdev', 'ino',
-    'size', 'atime', 'mtime',
-    'ctime', 'birthtime'
-  ];
-  if (!common.isWindows) {
-    keys.push('blocks', 'blksize');
-  }
-  keys.forEach(function(k) {
-    assert.ok(
-      json[k] !== undefined && json[k] !== null,
-      k + ' should not be null or undefined'
-    );
-  });
 }));


### PR DESCRIPTION
This reverts commit 9836cf571708a82396218957cacb3ed1ed468d05.

Ref: https://github.com/npm/npm/issues/16734

@sciolist @refack @nodejs/ctc

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

fs