### PR TITLE
http: suppress data event if req aborted

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -314,6 +314,9 @@ function _addHeaderLine(field, value, dest) {
 IncomingMessage.prototype._dump = function _dump() {
   if (!this._dumped) {
     this._dumped = true;
+    // If there is buffered data, it may trigger 'data' events.
+    // Remove 'data' event listeners explicitly.
+    this.removeAllListeners('data');
     this.resume();
   }
 };

--- a/test/parallel/test-http-abort-stream-end.js
+++ b/test/parallel/test-http-abort-stream-end.js
@@ -20,27 +20,27 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const http = require('http');
 
-var maxSize = 1024;
-var size = 0;
+const maxSize = 1024;
+let size = 0;
 
-var s = http.createServer(function(req, res) {
+const s = http.createServer(function(req, res) {
   this.close();
 
   res.writeHead(200, {'Content-Type': 'text/plain'});
-  for (var i = 0; i < maxSize; i++) {
+  for (let i = 0; i < maxSize; i++) {
     res.write('x' + i);
   }
   res.end();
 });
 
-var aborted = false;
-s.listen(common.PORT, function() {
-  var req = http.get('http://localhost:' + common.PORT, function(res) {
+let aborted = false;
+s.listen(0, function() {
+  const req = http.get('http://localhost:' + s.address().port, function(res) {
     res.on('data', function(chunk) {
       size += chunk.length;
       assert(!aborted, 'got data after abort');
@@ -51,8 +51,6 @@ s.listen(common.PORT, function() {
       }
     });
   });
-
-  req.end();
 });
 
 process.on('exit', function() {


### PR DESCRIPTION
Re-enable test-http-abort-stream-end and put it into parallel
category. Use system random port when calling server.listen()
and fix eslint errors.

Since request.abort() turns on the '_dumped' flag in the
IncomingMessage, Readable.prototype.read() needs to check
the '_dumped' flag before calling the emit('data').
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, streams