### PR TITLE
readline: clean up event listener in onNewListener

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1030,6 +1030,7 @@ function emitKeypressEvents(stream, iface) {
   function onNewListener(event) {
     if (event === 'keypress') {
       stream.on('data', onData);
+      iface.once('close', () => { stream.removeListener('data', onData); });
       stream.removeListener('newListener', onNewListener);
     }
   }

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1030,7 +1030,6 @@ function emitKeypressEvents(stream, iface) {
   function onNewListener(event) {
     if (event === 'keypress') {
       stream.on('data', onData);
-      iface.once('close', () => { stream.removeListener('data', onData); });
       stream.removeListener('newListener', onNewListener);
     }
   }
@@ -1039,6 +1038,9 @@ function emitKeypressEvents(stream, iface) {
     stream.on('data', onData);
   } else {
     stream.on('newListener', onNewListener);
+  }
+  if (iface) {
+    iface.once('close', () => { stream.removeListener('data', onData); });
   }
 }
 

--- a/test/parallel/test-readline-set-raw-mode.js
+++ b/test/parallel/test-readline-set-raw-mode.js
@@ -74,6 +74,8 @@ assert(!rawModeCalled);
 assert(resumeCalled);
 assert(!pauseCalled);
 
+// One data listener for the keypress events.
+assert.strictEqual(stream.listeners('data').length, 1);
 
 // close() should call setRawMode(false)
 expectedRawMode = false;
@@ -86,5 +88,5 @@ assert(!resumeCalled);
 assert(pauseCalled);
 
 assert.deepStrictEqual(stream.listeners('keypress'), []);
-// one data listener for the keypress events.
-assert.strictEqual(stream.listeners('data').length, 1);
+// Data listener is removed once interface is closed.
+assert.strictEqual(stream.listeners('data').length, 0);


### PR DESCRIPTION
If this is a bug, then let's just fix it.

Refs: https://github.com/nodejs/node/pull/9447#discussion_r86599214

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline