### PR TITLE
readline: numeric strings converted to integers in cursorTo

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -439,7 +439,7 @@ added: v0.7.7
 * `y` {number}
 
 The `readline.cursorTo()` method moves cursor to the specified position in a
-given [TTY][] `stream`.
+given [TTY][] `stream`. `x` and `y` can be numeric strings.
 
 ## readline.emitKeypressEvents(stream[, interface])
 <!-- YAML

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1052,11 +1052,17 @@ function cursorTo(stream, x, y) {
   let X = x;
   if (typeof X !== 'number') {
     X = parseInt(X);
+    if (isNaN(X)) {
+      X = x;
+    }
   }
 
   let Y = y;
   if (typeof Y !== 'number') {
     Y = parseInt(Y);
+    if (isNaN(Y)) {
+      Y = y;
+    }
   }
 
   if (typeof X !== 'number' && typeof Y !== 'number')

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -1049,16 +1049,26 @@ function cursorTo(stream, x, y) {
   if (stream === null || stream === undefined)
     return;
 
-  if (typeof x !== 'number' && typeof y !== 'number')
+  let X = x;
+  if (typeof X !== 'number') {
+    X = parseInt(X);
+  }
+
+  let Y = y;
+  if (typeof Y !== 'number') {
+    Y = parseInt(Y);
+  }
+
+  if (typeof X !== 'number' && typeof Y !== 'number')
     return;
 
-  if (typeof x !== 'number')
+  if (typeof X !== 'number')
     throw new Error('Can\'t set cursor row without also setting it\'s column');
 
-  if (typeof y !== 'number') {
-    stream.write(CSI`${x + 1}G`);
+  if (typeof Y !== 'number') {
+    stream.write(CSI`${X + 1}G`);
   } else {
-    stream.write(CSI`${y + 1};${x + 1}H`);
+    stream.write(CSI`${Y + 1};${X + 1}H`);
   }
 }
 

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -88,3 +88,15 @@ assert.strictEqual(writable.data, '\x1b[2G');
 writable.data = '';
 assert.doesNotThrow(() => readline.cursorTo(writable, 1, 2));
 assert.strictEqual(writable.data, '\x1b[3;2H');
+
+writable.data = '';
+assert.doesNotThrow(() => readline.cursorTo(writable, '1', 2));
+assert.strictEqual(writable.data, '\x1b[3;2H');
+
+writable.data = '';
+assert.doesNotThrow(() => readline.cursorTo(writable, 1, '2'));
+assert.strictEqual(writable.data, '\x1b[3;2H');
+
+writable.data = '';
+assert.doesNotThrow(() => readline.cursorTo(writable, '1', '2'));
+assert.strictEqual(writable.data, '\x1b[3;2H');


### PR DESCRIPTION
Attempt to convert x and y in cursorTo to integers if they are not of type number
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline