### PR TITLE
test: support candidate V8 versions

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -26,5 +26,5 @@ assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.http_parser));
 assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.node));
 assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.uv));
 assert(/^\d+\.\d+\.\d+(-.*)?$/.test(process.versions.zlib));
-assert(/^\d+\.\d+\.\d+(\.\d+)?$/.test(process.versions.v8));
+assert(/^\d+\.\d+\.\d+(\.\d+)?( \(candidate\))?$/.test(process.versions.v8));
 assert(/^\d+$/.test(process.versions.modules));


### PR DESCRIPTION
When V8 is built from its master branch, it adds a " (candidate)"
suffix to the version string. Add support for that in the tests so it
does not fail with Node canary.

Example failure: https://ci.nodejs.org/job/node-test-commit-linux/10217/nodes=centos7-64/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, V8