### PR TITLE
errors,process: migrate to use internal/errors.js

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -114,6 +114,7 @@ E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
+E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot render headers after they are sent to the client');
 E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
@@ -160,6 +161,8 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
+E('ERR_V8BREAKITERATOR', 'full ICU data not installed.' +
+  'See https://github.com/nodejs/node/wiki/Intl');
 // Add new errors from here...
 
 function invalidArgType(name, expected, actual) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const errors = require('internal/errors');
 var _lazyConstants = null;
 
 function lazyConstants() {
@@ -10,7 +11,7 @@ function lazyConstants() {
 }
 
 const assert = process.assert = function(x, msg) {
-  if (!x) throw new Error(msg || 'assertion error');
+  if (!x) throw new errors.Error('ERR_ASSERTION', msg || 'assertion error');
 };
 
 
@@ -28,18 +29,20 @@ function setup_cpuUsage() {
     // If a previous value was passed in, ensure it has the correct shape.
     if (prevValue) {
       if (!previousValueIsValid(prevValue.user)) {
-        throw new TypeError('value of user property of argument is invalid');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                   'preValue.user', 'Number');
       }
 
       if (!previousValueIsValid(prevValue.system)) {
-        throw new TypeError('value of system property of argument is invalid');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                   'preValue.system', 'Number');
       }
     }
 
     // Call the native function to get the current values.
     const errmsg = _cpuUsage(cpuValues);
     if (errmsg) {
-      throw new Error('unable to obtain CPU usage: ' + errmsg);
+      throw new errors.Error('ERR_CPU_USAGE', errmsg);
     }
 
     // If a previous value was passed in, return diff of current from previous.
@@ -81,8 +84,8 @@ function setup_hrtime() {
         const needsBorrow = nsec < 0;
         return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
       }
-
-      throw new TypeError('process.hrtime() only accepts an Array tuple');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'process.hrtime()', 'Array');
     }
 
     return [
@@ -132,8 +135,7 @@ function setupConfig(_source) {
     des.value = require('internal/util').deprecate(function v8BreakIterator() {
       if (processConfig.hasSmallICU && !processConfig.icuDataDir) {
         // Intl.v8BreakIterator() would crash w/ fatal error, so throw instead.
-        throw new Error('v8BreakIterator: full ICU data not installed. ' +
-                        'See https://github.com/nodejs/node/wiki/Intl');
+        throw new errors.Error('ERR_V8BREAKITERATOR');
       }
       return Reflect.construct(oldV8BreakIterator, arguments);
     }, 'Intl.v8BreakIterator is deprecated and will be removed soon.',
@@ -161,7 +163,7 @@ function setupKillAndExit() {
 
     // eslint-disable-next-line eqeqeq
     if (pid != (pid | 0)) {
-      throw new TypeError('invalid pid');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pid', 'Number');
     }
 
     // preserve null signal
@@ -172,7 +174,7 @@ function setupKillAndExit() {
       if (lazyConstants()[sig]) {
         err = process._kill(pid, lazyConstants()[sig]);
       } else {
-        throw new Error(`Unknown signal: ${sig}`);
+        throw new errors.Error('ERR_UNKNOWN_SIGNAL', `${sig}`);
       }
     }
 

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -1,11 +1,21 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 assert.strictEqual(process.assert(1, 'error'), undefined);
 assert.throws(() => {
   process.assert(undefined, 'errorMessage');
-}, /^Error: errorMessage$/);
+}, common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: Error,
+    message: 'errorMessage'
+})
+);
 assert.throws(() => {
   process.assert(false);
-}, /^Error: assertion error$/);
+}, common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: Error,
+    message: 'assertion error'
+})
+);

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -1,7 +1,6 @@
 'use strict';
-require('../common');
 const assert = require('assert');
-
+const common = require('../common');
 const result = process.cpuUsage();
 
 // Validate the result of calling with no previous value argument.
@@ -32,11 +31,18 @@ for (let i = 0; i < 10; i++) {
   assert(diffUsage.user >= 0);
   assert(diffUsage.system >= 0);
 }
+const invalidUserArgument = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "preValue.user" argument must be of type Number'
+});
 
-const invalidUserArgument =
-    /^TypeError: value of user property of argument is invalid$/;
-const invalidSystemArgument =
-    /^TypeError: value of system property of argument is invalid$/;
+const invalidSystemArgument = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "preValue.system" argument must be of type Number'
+});
+
 
 // Ensure that an invalid shape for the previous value argument throws an error.
 assert.throws(() => {

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // the default behavior, return an Array "tuple" of numbers
@@ -32,19 +32,25 @@ validateTuple(tuple);
 // validate that passing an existing tuple returns another valid tuple
 validateTuple(process.hrtime(tuple));
 
+const invalidHrtimeArgument = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "process.hrtime()" argument must be of type Array'
+});
+
 // test that only an Array may be passed to process.hrtime()
 assert.throws(() => {
   process.hrtime(1);
-}, /^TypeError: process\.hrtime\(\) only accepts an Array tuple$/);
+}, invalidHrtimeArgument);
 assert.throws(() => {
   process.hrtime([]);
-}, /^TypeError: process\.hrtime\(\) only accepts an Array tuple$/);
+}, invalidHrtimeArgument);
 assert.throws(() => {
   process.hrtime([1]);
-}, /^TypeError: process\.hrtime\(\) only accepts an Array tuple$/);
+}, invalidHrtimeArgument);
 assert.throws(() => {
   process.hrtime([1, 2, 3]);
-}, /^TypeError: process\.hrtime\(\) only accepts an Array tuple$/);
+}, invalidHrtimeArgument);
 
 function validateTuple(tuple) {
   assert(Array.isArray(tuple));

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // test variants of pid
@@ -38,20 +38,35 @@ const assert = require('assert');
 //
 // process.pid, String(process.pid): ourself
 
+const invalidPidArgument = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "pid" argument must be of type Number'
+});
+
 assert.throws(function() { process.kill('SIGTERM'); },
-              /^TypeError: invalid pid$/);
-assert.throws(function() { process.kill(null); }, /^TypeError: invalid pid$/);
+              invalidPidArgument);
+assert.throws(function() { process.kill(null); },
+              invalidPidArgument);
 assert.throws(function() { process.kill(undefined); },
-              /^TypeError: invalid pid$/);
+              invalidPidArgument);
 assert.throws(function() { process.kill(+'not a number'); },
-              /^TypeError: invalid pid$/);
-assert.throws(function() { process.kill(1 / 0); }, /^TypeError: invalid pid$/);
-assert.throws(function() { process.kill(-1 / 0); }, /^TypeError: invalid pid$/);
+              invalidPidArgument);
+assert.throws(function() { process.kill(1 / 0); },
+              invalidPidArgument);
+assert.throws(function() { process.kill(-1 / 0); },
+              invalidPidArgument);
 
 // Test that kill throws an error for invalid signal
+const unknownSignal = common.expectsError({
+  code: 'ERR_UNKNOWN_SIGNAL',
+  type: Error,
+  message: 'Unknown signal: test'
+});
+
 
 assert.throws(function() { process.kill(1, 'test'); },
-              /^Error: Unknown signal: test$/);
+              unknownSignal);
 
 // Test kill argument processing in valid cases.
 //


### PR DESCRIPTION
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internal/process.js
lib/internal/errors.js

ref: #11273