### PR TITLE
errors,_stream_wrap: change _stream_wrap.js to use internal/errors.js

### DIFF
--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -9,6 +9,7 @@ const JSStream = process.binding('js_stream').JSStream;
 var Buffer = require('buffer').Buffer;
 const uv = process.binding('uv');
 const debug = util.debuglog('stream_wrap');
+const errors = require('internal/errors');
 
 function StreamWrap(stream) {
   const handle = new JSStream();
@@ -51,7 +52,7 @@ function StreamWrap(stream) {
       this.pause();
       this.removeListener('data', ondata);
 
-      self.emit('error', new Error('Stream has StringDecoder'));
+      self.emit('error', new errors.Error('ERR_STREAM_HAS_STRINGDECODER'));
       return;
     }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -157,6 +157,7 @@ E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
+E('ERR_STREAM_HAS_STRINGDECODER', 'Stream has StringDecoder');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_MULTIPLE_CALLBACK', 'Callback called multiple times');


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/11273

@jasnell, pinging you for mentoring as this is my first PR to this project, thank you!

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
_stream_wrap.js