### PR TITLE
deps: http_parser, fix a bug of double content-length checking

### DIFF
--- a/deps/http_parser/http_parser.c
+++ b/deps/http_parser/http_parser.c
@@ -1366,12 +1366,7 @@ reexecute:
                   || c != CONTENT_LENGTH[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CONTENT_LENGTH)-2) {
-                if (parser->flags & F_CONTENTLENGTH) {
-                  SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
-                  goto error;
-                }
                 parser->header_state = h_content_length;
-                parser->flags |= F_CONTENTLENGTH;
               }
               break;
 
@@ -1469,6 +1464,12 @@ reexecute:
             break;
 
           case h_content_length:
+            if (parser->flags & F_CONTENTLENGTH) {
+              SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              goto error;
+            }
+            parser->flags |= F_CONTENTLENGTH;
+
             if (UNLIKELY(!IS_NUM(ch))) {
               SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
               goto error;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
An http response whose headers contain a single _Content-Lenth_ field and a _Content-Lenth*_ field should not cause HPE_UNEXPECTED_CONTENT_LENGTH.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dept/http_parser:

* update http_parser, move the checking code to a property place.
* update the test file of http_parser, add a case that HTTP headers contain both "content-length" and a field whose name begins with "content-length", and remove an unused variable.

