### PR TITLE
errors,util: migrate to use internal/errors.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -25,6 +25,7 @@ const uv = process.binding('uv');
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
 const binding = process.binding('util');
+const errors = require('internal/errors');
 
 const isError = internalUtil.isError;
 
@@ -194,7 +195,7 @@ Object.defineProperty(inspect, 'defaultOptions', {
   },
   set: function(options) {
     if (options === null || typeof options !== 'object') {
-      throw new TypeError('"options" must be an object');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
     }
     Object.assign(inspectDefaultOptions, options);
     return inspectDefaultOptions;
@@ -946,17 +947,14 @@ exports.log = function() {
 exports.inherits = function(ctor, superCtor) {
 
   if (ctor === undefined || ctor === null)
-    throw new TypeError('The constructor to "inherits" must not be ' +
-                        'null or undefined');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ctor', 'function');
 
   if (superCtor === undefined || superCtor === null)
-    throw new TypeError('The super constructor to "inherits" must not ' +
-                        'be null or undefined');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor', 'function');
 
   if (superCtor.prototype === undefined)
-    throw new TypeError('The super constructor to "inherits" must ' +
-                        'have a prototype');
-
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor.prototype',
+                               'function');
   ctor.super_ = superCtor;
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
 };

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -1,11 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const inherits = require('util').inherits;
-const errCheck =
-  /^TypeError: The super constructor to "inherits" must not be null or undefined$/;
-
+const errCheck = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "superCtor" argument must be of type function'
+});
 
 // super constructor
 function A() {
@@ -80,10 +82,20 @@ assert.strictEqual(e.constructor, E);
 // should throw with invalid arguments
 assert.throws(function() {
   inherits(A, {});
-}, /^TypeError: The super constructor to "inherits" must have a prototype$/);
+}, common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "superCtor.prototype" argument must be of type function'
+})
+);
 assert.throws(function() {
   inherits(A, null);
 }, errCheck);
 assert.throws(function() {
   inherits(null, A);
-}, /^TypeError: The constructor to "inherits" must not be null or undefined$/);
+}, common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "ctor" argument must be of type function'
+})
+);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1028,11 +1028,21 @@ if (typeof Symbol !== 'undefined') {
 
   assert.throws(() => {
     util.inspect.defaultOptions = null;
-  }, /"options" must be an object/);
+  }, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "options" argument must be of type object'
+  })
+  );
 
   assert.throws(() => {
     util.inspect.defaultOptions = 'bad';
-  }, /"options" must be an object/);
+  }, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "options" argument must be of type object'
+  })
+  );
 }
 
 assert.doesNotThrow(() => util.inspect(process));


### PR DESCRIPTION
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util.js

ref: #11273

This is my first contribution in node. I read and understood the contribution guidelines, please review and suggest.
@jasnell
Thanks.
