### PR TITLE
doc: modernize and fix code examples in util.md

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -326,8 +326,8 @@ class Box {
     // Five space padding because that's the size of "Box< ".
     const padding = ' '.repeat(5);
     const inner = util.inspect(this.value, newOptions)
-                      .replace(/\n/g, '\n' + padding);
-    return options.stylize('Box', 'special') + '< ' + inner + ' >';
+                      .replace(/\n/g, `\n${padding}`);
+    return `${options.stylize('Box', 'special')}< ${inner} >`;
   }
 }
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -196,9 +196,6 @@ ES6 example using `class` and `extends`
 const EventEmitter = require('events');
 
 class MyStream extends EventEmitter {
-  constructor() {
-    super();
-  }
   write(data) {
     this.emit('data', data);
   }

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -389,7 +389,7 @@ option properties directly is also supported.
 
 ```js
 const util = require('util');
-const arr = Array(101);
+const arr = Array(101).fill(0);
 
 console.log(arr); // logs the truncated array
 util.inspect.defaultOptions.maxArrayLength = null;


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, util

* Remove useless constructor.
* Use template literals.
* Update code example (now all arrays with just holes are outputted the same way; in this example, it is `[ <101 empty items> ]` twice).