### PR TITLE
errors,repl: migrate to use internal/errors.js

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -134,11 +134,15 @@ E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple');
 E('ERR_INVALID_URL', 'Invalid URL: %s');
 E('ERR_INVALID_URL_SCHEME',
   (expected) => `The URL must be ${oneOf(expected, 'scheme')}`);
+E('ERR_INVALID_REPL_HISTORY',
+  (repl_history) => `Expected array, got ${repl_history}`);
 E('ERR_IPC_CHANNEL_CLOSED', 'channel closed');
 E('ERR_IPC_DISCONNECTED', 'IPC channel is already disconnected');
 E('ERR_IPC_ONE_PIPE', 'Child process can have only one IPC pipe');
 E('ERR_IPC_SYNC_FORK', 'IPC cannot be used with synchronous forks');
 E('ERR_MISSING_ARGS', missingArgs);
+E('ERR_PARSE_HISTORY_DATA',
+  (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 const debug = util.debuglog('repl');
+const errors = require('internal/errors');
 
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
@@ -153,13 +154,14 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
         if (oldReplJSONHistory) repl.history = JSON.parse(oldReplJSONHistory);
 
         if (!Array.isArray(repl.history)) {
-          throw new Error('Expected array, got ' + typeof repl.history);
+          throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                     typeof repl.history, 'Array');
         }
         repl.history = repl.history.slice(0, repl.historySize);
       } catch (err) {
         if (err.code !== 'ENOENT') {
           return ready(
-            new Error(`Could not parse history data in ${oldHistoryPath}.`));
+            new errors.Error('ERR_PARSE_HISTORY_DATA', oldHistoryPath));
         }
       }
     }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internal/repl.js
lib/internal/errors.js

ref: #11273