### PR TITLE
errors,http_server: migrate to use internal/errors.js

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -35,6 +35,7 @@ const chunkExpression = common.chunkExpression;
 const httpSocketSetup = common.httpSocketSetup;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const { outHeadersKey, ondrain } = require('internal/http');
+const errors = require('internal/errors');
 
 const STATUS_CODES = {
   100: 'Continue',
@@ -185,7 +186,9 @@ function writeHead(statusCode, reason, obj) {
 
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999)
-    throw new RangeError(`Invalid status code: ${originalStatusCode}`);
+    throw new errors.RangeError('ERR_HTTP_INVALID_STATUS_CODE',
+                                 originalStatusCode);
+
 
   if (typeof reason === 'string') {
     // writeHead(statusCode, reasonPhrase[, headers])
@@ -211,8 +214,7 @@ function writeHead(statusCode, reason, obj) {
     }
     if (k === undefined) {
       if (this._header) {
-        throw new Error('Can\'t render headers after they are sent to the ' +
-                        'client');
+        throw new errors.Error('ERR_HTTP_HEADERS_SENT');
       }
     }
     // only progressive api is used
@@ -223,7 +225,8 @@ function writeHead(statusCode, reason, obj) {
   }
 
   if (common._checkInvalidHeaderChar(this.statusMessage))
-    throw new Error('Invalid character in statusMessage.');
+    throw new errors.Error('ERR_HTTP_INVALID_CHAR',
+                           'Invalid character in statusMessage.');
 
   var statusLine = 'HTTP/1.1 ' + statusCode + ' ' + this.statusMessage + CRLF;
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -114,6 +114,11 @@ E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
+E('ERR_HTTP_HEADERS_SENT',
+  'Cannot render headers after they are sent to the client');
+E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
+E('ERR_HTTP_INVALID_STATUS_CODE',
+  (originalStatusCode) => `Invalid status code: ${originalStatusCode}`);
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -7,7 +7,11 @@ const MAX_REQUESTS = 13;
 let reqNum = 0;
 
 function test(res, header, code) {
-  const errRegExp = new RegExp(`^RangeError: Invalid status code: ${code}$`);
+  const errRegExp = common.expectsError({
+    code: 'ERR_HTTP_INVALID_STATUS_CODE',
+    type: RangeError,
+    message: `Invalid status code: ${code}`
+  });
   assert.throws(() => {
     res.writeHead(header);
   }, errRegExp);
@@ -25,7 +29,7 @@ const server = http.Server(common.mustCall(function(req, res) {
       test(res, NaN, 'NaN');
       break;
     case 3:
-      test(res, {}, '\\[object Object\\]');
+      test(res, {}, '[object Object]');
       break;
     case 4:
       test(res, 99, '99');
@@ -53,7 +57,11 @@ const server = http.Server(common.mustCall(function(req, res) {
       break;
     case 12:
       assert.throws(() => { res.writeHead(); },
-                    /^RangeError: Invalid status code: undefined$/);
+                    common.expectsError({
+                      code: 'ERR_HTTP_INVALID_STATUS_CODE',
+                      type: RangeError,
+                      message: 'Invalid status code: undefined'
+                    }));
       this.close();
       break;
     default:

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -56,7 +56,12 @@ const s = http.createServer(common.mustCall((req, res) => {
 
   assert.throws(() => {
     res.writeHead(100, {});
-  }, /^Error: Can't render headers after they are sent to the client$/);
+  }, common.expectsError({
+       code: 'ERR_HTTP_HEADERS_SENT',
+       type: Error,
+       message: 'Cannot render headers after they are sent to the client'
+  })
+  );
 
   res.end();
 }));


### PR DESCRIPTION
### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
_http_server.js
internal/errors.js

ref: #11273
I read and understood the contribution guidelines, please review and suggest.
@jasnell
Thanks. 