### PR TITLE
tools: be explicit about including key-id

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -20,7 +20,7 @@ signcmd=dist-sign
 
 echo "# Selecting GPG key ..."
 
-gpgkey=$(gpg --list-secret-keys | awk -F'( +|/)' '/^(sec|ssb)/{print $3}')
+gpgkey=$(gpg --list-secret-keys --keyid-format SHORT | awk -F'( +|/)' '/^(sec|ssb)/{print $3}')
 keycount=$(echo $gpgkey | wc -w)
 
 if [ $keycount -eq 0 ]; then


### PR DESCRIPTION
gpg 2.1 no longer includes the key-id by default which breaks
the release script. This makes sure we are explicit about it.