### PR TITLE
errors,stream-transform: migrate to use internal/errors.js

### DIFF
--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -64,7 +64,7 @@
 'use strict';
 
 module.exports = Transform;
-
+const errors = require('internal/errors');
 const Duplex = require('_stream_duplex');
 const util = require('util');
 util.inherits(Transform, Duplex);
@@ -78,7 +78,7 @@ function afterTransform(er, data) {
 
   if (!cb) {
     return this.emit('error',
-                     new Error('write callback called multiple times'));
+                     new errors.Error('ERR_TRANSFORM_MULTIPLE_CALLBACK'));
   }
 
   ts.writechunk = null;
@@ -210,10 +210,9 @@ function done(stream, er, data) {
   // if there's nothing in the write buffer, then that means
   // that nothing more will ever be provided
   if (stream._writableState.length)
-    throw new Error('Calling transform done when ws.length != 0');
+    throw new errors.Error('ERR_TRANSFORM_WITH_LENGTH_0');
 
   if (stream._transformState.transforming)
-    throw new Error('Calling transform done when still transforming');
-
+    throw new errors.Error('ERR_TRANSFORM_ALREADY_TRANSFORMING');
   return stream.push(null);
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -155,6 +155,11 @@ E('ERR_PARSE_HISTORY_DATA',
   (oldHistoryPath) => `Could not parse history data in ${oldHistoryPath}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
+E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
+  'Calling transform done when still transforming');
+E('ERR_TRANSFORM_MULTIPLE_CALLBACK', 'Callback called multiple times');
+E('ERR_TRANSFORM_WITH_LENGTH_0',
+  'Calling transform done when ws.length != 0');
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding');
 E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);

--- a/test/parallel/test-stream-transform-callback-twice.js
+++ b/test/parallel/test-stream-transform-callback-twice.js
@@ -8,7 +8,8 @@ const stream = new Transform({
 
 stream.on('error', common.mustCall((err) => {
   assert.strictEqual(err.toString(),
-                     'Error: write callback called multiple times');
+                     'Error [ERR_TRANSFORM_MULTIPLE_CALLBACK]: ' +
+                     'Callback called multiple times');
 }));
 
 stream.write('foo');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
 lib/_stream_transform.js

ref: #11273