### PR TITLE
test: improve test-https-server-keep-alive-timeout

### DIFF
--- a/test/parallel/test-https-server-keep-alive-timeout.js
+++ b/test/parallel/test-https-server-keep-alive-timeout.js
@@ -39,6 +39,7 @@ test(function serverKeepAliveTimeoutWithPipeline(cb) {
     res.end();
   });
   server.setTimeout(500, common.mustCall((socket) => {
+    // End this test and call `run()` for the next test (if any).
     socket.destroy();
     server.close();
     cb();
@@ -67,6 +68,7 @@ test(function serverNoEndKeepAliveTimeoutWithPipeline(cb) {
     requestCount++;
   });
   server.setTimeout(500, common.mustCall((socket) => {
+    // End this test and call `run()` for the next test (if any).
     socket.destroy();
     server.close();
     cb();


### PR DESCRIPTION
The test is flaky under load. These changes greatly improve reliability.

* Use a recurring interval to determine when the test should end rather
  than a timer.
* Increase server timeout to 500ms to allow for events being delayed by
  system load

Changing to an interval has the added benefit of reducing the test run
time from over 2 seconds to under 1 second.

Fixes: https://github.com/nodejs/node/issues/13307

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test https