### PR TITLE
src: add newline in --help message

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3632,7 +3632,7 @@ static void PrintHelp() {
          "  -r, --require              module to preload (option can be "
          "repeated)\n"
          "  -                          script read from stdin (default; "
-         "interactive mode if a tty)"
+         "interactive mode if a tty)\n"
 #if HAVE_INSPECTOR
          "  --inspect[=[host:]port]    activate inspector on host:port\n"
          "                             (default: 127.0.0.1:9229)\n"


### PR DESCRIPTION
In the current node.js 8.0.0 release, there is a missing newline in the --help command line flag message. I've added a newline where appropriate. Screenshots attached showing the change.
before:
<img width="1047" alt="screen shot 2017-05-30 at 3 22 26 pm" src="https://cloud.githubusercontent.com/assets/1976777/26606312/b24e3be2-454e-11e7-8caa-8350356eba02.png">
after:
<img width="663" alt="screen shot 2017-05-30 at 3 40 15 pm" src="https://cloud.githubusercontent.com/assets/1976777/26606313/b251bd62-454e-11e7-8637-c85a01783067.png">



##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]
##### Affected core subsystem(s)
src