### PR TITLE
fs: promisify exists correctly

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -28,7 +28,7 @@ const constants = process.binding('constants').fs;
 const { S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK } = constants;
 const util = require('util');
 const pathModule = require('path');
-const { isUint8Array } = process.binding('util');
+const { isUint8Array, createPromise, promiseResolve } = process.binding('util');
 
 const binding = process.binding('fs');
 const fs = exports;
@@ -375,6 +375,15 @@ fs.exists = function(path, callback) {
     if (callback) callback(err ? false : true);
   }
 };
+
+Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
+  value: (path) => {
+    const promise = createPromise();
+    fs.exists(path, (exists) => promiseResolve(promise, exists));
+    return promise;
+  }
+});
+
 
 fs.existsSync = function(path) {
   try {

--- a/test/parallel/test-fs-promisified.js
+++ b/test/parallel/test-fs-promisified.js
@@ -9,6 +9,7 @@ common.crashOnUnhandledRejection();
 
 const read = promisify(fs.read);
 const write = promisify(fs.write);
+const exists = promisify(fs.exists);
 
 {
   const fd = fs.openSync(__filename, 'r');
@@ -27,5 +28,11 @@ common.refreshTmpDir();
     assert.strictEqual(typeof obj.bytesWritten, 'number');
     assert.strictEqual(obj.buffer.toString(), 'foobar');
     fs.closeSync(fd);
+  }));
+}
+
+{
+  exists(__filename).then(common.mustCall((x) => {
+    assert.strictEqual(x, true);
   }));
 }


### PR DESCRIPTION
Consider this sample code.

```javascript
const fs = require('fs');
const {promisify} = require('util');

const exists = promisify(fs.exists);

exists(__filename)
  .then(x => console.log(x))
  .catch(err => console.error("oh no", err));
```

Expected: The code should log `true`, because the current file exists.
Actual: It logs `oh no true`, as the promise is rejected with `err` set to `true`

This is happening because `fs.exists` does not follow the standard format of taking an error-first callback as the last argument. Luckily, `util.promisify` provides a `.custom` feature for promisifying callbacks that don't follow the nodeback style.

In this PR, we provide a custom promise implementation for `fs.exists`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs