### PR TITLE
test: check inspector support in test/inspector

### DIFF
--- a/test/inspector/test-inspector-port-zero-cluster.js
+++ b/test/inspector/test-inspector-port-zero-cluster.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const common = require('../common');
+common.skipIfInspectorDisabled();
 const assert = require('assert');
 const cluster = require('cluster');
 

--- a/test/inspector/test-inspector-port-zero.js
+++ b/test/inspector/test-inspector-port-zero.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { mustCall } = require('../common');
+const { mustCall, skipIfInspectorDisabled } = require('../common');
+skipIfInspectorDisabled();
 const assert = require('assert');
 const { URL } = require('url');
 const { spawn } = require('child_process');


### PR DESCRIPTION
When configuring node --without-ssl or --without-inspector these test
will fail. The underlying issue will be:
```console
Inspector support is not available with this Node.js build
/work/nodejs/node/out/Release/node: bad option: --inspect=0
```
This commit adds checks to see if inspector support is enabled and if
not skips these tests.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test