### PR TITLE
test: add coverage for AsyncResource constructor

### DIFF
--- a/test/parallel/test-async-wrap-asyncresource-constructor.js
+++ b/test/parallel/test-async-wrap-asyncresource-constructor.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+
+// This tests that AsyncResource throws an error if bad parameters are passed
+
+const assert = require('assert');
+const AsyncResource = require('async_hooks').AsyncResource;
+const async_wrap = process.binding('async_wrap');
+
+assert.throws(() => {
+  return new AsyncResource();
+}, new RegExp('^TypeError: type must be a string with length > 0$'));
+
+assert.throws(() => {
+  new AsyncResource('');
+}, new RegExp('^TypeError: type must be a string with length > 0$'));
+
+assert.throws(() => {
+  new AsyncResource('type', -4);
+}, new RegExp('^RangeError: triggerId must be an unsigned integer$'));
+
+assert.throws(() => {
+  new AsyncResource('type', Math.PI);
+}, new RegExp('^RangeError: triggerId must be an unsigned integer$'));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks
