### PR TITLE
test: test async-hook triggerId invariant

### DIFF
--- a/test/parallel/test-async-wrap-trigger-id.js
+++ b/test/parallel/test-async-wrap-trigger-id.js
@@ -1,0 +1,28 @@
+'use strict';
+require('../common');
+
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const triggerId = async_hooks.triggerId;
+
+const triggerId0 = triggerId();
+let triggerId1;
+
+process.nextTick(() => {
+  process.nextTick(() => {
+    triggerId1 = triggerId();
+    assert.notStrictEqual(
+      triggerId0,
+      triggerId1,
+      'Async resources having different causal ancestry ' +
+      'should have different triggerIds');
+  });
+  process.nextTick(() => {
+    const triggerId2 = triggerId();
+    assert.strictEqual(
+      triggerId1,
+      triggerId2,
+      'Async resources having the same causal ancestry ' +
+      'should have the same triggerId');
+  });
+});


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

Adds two tests to check that the `triggerId` invariant is satisfied, that is async resources with the same cause have the same `triggerId`, while those with different cause have different `triggerId`s.