### PR TITLE
win, doc: document per-drive current working dir

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -94,10 +94,10 @@ Error: EISDIR: illegal operation on a directory, read
     <stack trace.>
 ```
 
-*Note:* On Windows Node follows the concept of per-drive working directory.
-This behavior can be observed when using a drive path without backslash, e.g.
-`fs.readdirSync('c:\\')` can potentially return different result than
-`fs.readdirSync('c:')`. For more information see
+*Note:* On Windows Node.js follows the concept of per-drive working directory.
+This behavior can be observed when using a drive path without a backslash. For
+example `fs.readdirSync('c:\\')` can potentially return a different result than
+`fs.readdirSync('c:')`. For more information, see
 [this MSDN page][MSDN-Rel-Path].
 
 ## WHATWG URL object support

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -94,6 +94,12 @@ Error: EISDIR: illegal operation on a directory, read
     <stack trace.>
 ```
 
+*Note:* On Windows Node follows the concept of per-drive working directory.
+This behavior can be observed when using a drive path without backslash, e.g.
+`fs.readdirSync('c:\\')` can potentially return different result than
+`fs.readdirSync('c:')`. For more information see
+[this MSDN page][MSDN-Rel-Path].
+
 ## WHATWG URL object support
 <!-- YAML
 added: v7.6.0
@@ -2835,6 +2841,7 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [FS Constants]: #fs_fs_constants_1
 [MDN-Date-getTime]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime
 [MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
+[MSDN-Rel-Path]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx#fully_qualified_vs._relative_paths
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
 [inode]: https://en.wikipedia.org/wiki/Inode

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -54,6 +54,11 @@ path.posix.basename('/tmp/myfile.html');
 // Returns: 'myfile.html'
 ```
 
+*Note:* On Windows Node follows the concept of per-drive working directory.
+This behavior can be observed when using a drive path without backslash, e.g.
+`path.resolve('c:\\')` can potentially return different result than
+`path.resolve('c:')`. For more information see [this MSDN page][MSDN-Rel-Path].
+
 ## path.basename(path[, ext])
 <!-- YAML
 added: v0.1.25
@@ -550,3 +555,4 @@ of the `path` methods.
 [`path.posix`]: #path_path_posix
 [`path.sep`]: #path_path_sep
 [`path.win32`]: #path_path_win32
+[MSDN-Rel-Path]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx#fully_qualified_vs._relative_paths

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -54,10 +54,11 @@ path.posix.basename('/tmp/myfile.html');
 // Returns: 'myfile.html'
 ```
 
-*Note:* On Windows Node follows the concept of per-drive working directory.
-This behavior can be observed when using a drive path without backslash, e.g.
-`path.resolve('c:\\')` can potentially return different result than
-`path.resolve('c:')`. For more information see [this MSDN page][MSDN-Rel-Path].
+*Note:* On Windows Node.js follows the concept of per-drive working directory.
+This behavior can be observed when using a drive path without a backslash. For
+example `path.resolve('c:\\')` can potentially return a different result than
+`path.resolve('c:')`. For more information, see
+[this MSDN page][MSDN-Rel-Path].
 
 ## path.basename(path[, ext])
 <!-- YAML


### PR DESCRIPTION
Add note to `fs.md` and `path.md` about Windows using per-drive current working directory.

Fixes: https://github.com/nodejs/node/issues/9378

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
