### PR TITLE
doc: update who to cc for async_hooks

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -22,11 +22,11 @@
 | `lib/timers` | @fishrock123, @misterdjules |
 | `lib/util` | @bnoordhuis, @cjihrig, @evanlucas |
 | `lib/zlib` | @addaleax, @bnoordhuis, @indutny |
-| `src/async-wrap.*` | @trevnorris |
+| `src/async-wrap.*` | @nodejs/async_hooks |
 | `src/node_crypto.*` | @nodejs/crypto |
 | `test/*` | @nodejs/testing |
 | `tools/eslint`, `.eslintrc` | @not-an-aardvark, @silverwind, @trott |
-| async_hooks | @nodejs/diagnostics |
+| async_hooks | @nodejs/async_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
 | performance | @nodejs/performance |
 | upgrading V8 | @nodejs/v8, @nodejs/post-mortem |
 | upgrading npm | @fishrock123, @MylesBorins |


### PR DESCRIPTION
Now that `async_hooks` is released, it makes sense to me to have a team for addressing issues with it. @nodejs/diagnostics can still be @mentioned if there are questions about the API rather than its implementation.

@nodejs/diagnostics fyi – I know it was originally requested that you are the team to ping for this kind of thing, but I think for implementation issues it’s just easier to ping the subset that actually works on them. Anybody who wants to join @nodejs/async_hooks is welcome to do so!