### PR TITLE
doc: refine spaces in example from vm.md

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -442,18 +442,17 @@ to the `http` module passed to it. For instance:
 'use strict';
 const vm = require('vm');
 
-const code =
-`(function(require) {
+const code = `
+(function(require) {
+  const http = require('http');
 
-   const http = require('http');
+  http.createServer((request, response) => {
+    response.writeHead(200, { 'Content-Type': 'text/plain' });
+    response.end('Hello World\\n');
+  }).listen(8124);
 
-   http.createServer( (request, response) => {
-     response.writeHead(200, {'Content-Type': 'text/plain'});
-     response.end('Hello World\\n');
-   }).listen(8124);
-
-   console.log('Server running at http://127.0.0.1:8124/');
- })`;
+  console.log('Server running at http://127.0.0.1:8124/');
+})`;
 
 vm.runInThisContext(code)(require);
  ```


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, vm

GitHub diff has gone a bit awry: I've just deleted one empty padding line, replaced 3 indent spaces with 2 and added/deleted some spaces within the code.
