### PR TITLE
doc: fix code examples in zlib.md

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -119,7 +119,7 @@ By default, the `zlib` methods will throw an error when decompressing
 truncated data. However, if it is known that the data is incomplete, or
 the desire is to inspect only the beginning of a compressed file, it is
 possible to suppress the default error handling by changing the flushing
-method that is used to compressed the last chunk of input data:
+method that is used to decompress the last chunk of input data:
 
 ```js
 // This is a truncated version of the buffer from the above examples

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -127,7 +127,7 @@ const buffer = Buffer.from('eJzT0yMA', 'base64');
 
 zlib.unzip(
   buffer,
-  {finishFlush: zlib.constants.Z_SYNC_FLUSH},
+  { finishFlush: zlib.constants.Z_SYNC_FLUSH },
   (err, buffer) => {
     if (!err) {
       console.log(buffer.toString());

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -102,10 +102,10 @@ http.createServer((request, response) => {
 
   // Note: This is not a conformant accept-encoding parser.
   // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-  if (acceptEncoding.match(/\bdeflate\b/)) {
+  if (/\bdeflate\b/.test(acceptEncoding)) {
     response.writeHead(200, { 'Content-Encoding': 'deflate' });
     raw.pipe(zlib.createDeflate()).pipe(response);
-  } else if (acceptEncoding.match(/\bgzip\b/)) {
+  } else if (/\bgzip\b/.test(acceptEncoding)) {
     response.writeHead(200, { 'Content-Encoding': 'gzip' });
     raw.pipe(zlib.createGzip()).pipe(response);
   } else {


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, zlib

* Use `test()` instead of `match()` in boolean context.
* Add spaces in code example.
* Fix a typo.