### PR TITLE
inspector: Allows reentry when paused

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -203,7 +203,7 @@ class JsBindingsSessionDelegate : public InspectorSessionDelegate {
     callback_.Reset();
   }
 
-  bool WaitForFrontendMessage() override {
+  bool WaitForFrontendMessageWhilePaused() override {
     return false;
   }
 
@@ -393,7 +393,7 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel {
   }
 
   bool waitForFrontendMessage() {
-    return delegate_->WaitForFrontendMessage();
+    return delegate_->WaitForFrontendMessageWhilePaused();
   }
 
   void schedulePauseOnNextStatement(const std::string& reason) {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -38,7 +38,7 @@ namespace inspector {
 class InspectorSessionDelegate {
  public:
   virtual ~InspectorSessionDelegate() = default;
-  virtual bool WaitForFrontendMessage() = 0;
+  virtual bool WaitForFrontendMessageWhilePaused() = 0;
   virtual void SendMessageToFrontend(const v8_inspector::StringView& message)
                                      = 0;
 };

--- a/src/inspector_io.h
+++ b/src/inspector_io.h
@@ -6,9 +6,9 @@
 #include "node_mutex.h"
 #include "uv.h"
 
+#include <deque>
 #include <memory>
 #include <stddef.h>
-#include <vector>
 
 #if !HAVE_INSPECTOR
 #error("This header can only be used when inspector is enabled")
@@ -76,7 +76,7 @@ class InspectorIo {
  private:
   template <typename Action>
   using MessageQueue =
-      std::vector<std::tuple<Action, int,
+      std::deque<std::tuple<Action, int,
                   std::unique_ptr<v8_inspector::StringBuffer>>>;
   enum class State {
     kNew,
@@ -115,7 +115,7 @@ class InspectorIo {
   void SwapBehindLock(MessageQueue<ActionType>* vector1,
                       MessageQueue<ActionType>* vector2);
   // Wait on incoming_message_cond_
-  void WaitForIncomingMessage();
+  void WaitForFrontendMessageWhilePaused();
   // Broadcast incoming_message_cond_
   void NotifyMessageReceived();
 
@@ -145,6 +145,7 @@ class InspectorIo {
   Mutex state_lock_;  // Locked before mutating either queue.
   MessageQueue<InspectorAction> incoming_message_queue_;
   MessageQueue<TransportAction> outgoing_message_queue_;
+  MessageQueue<InspectorAction> dispatching_message_queue_;
 
   bool dispatching_messages_;
   int session_id_;

--- a/test/inspector/global-function.js
+++ b/test/inspector/global-function.js
@@ -1,0 +1,13 @@
+'use strict'; // eslint-disable-line required-modules
+let invocations = 0;
+const interval = setInterval(() => {}, 1000);
+
+global.sum = function() {
+  const a = 1;
+  const b = 2;
+  const c = a + b;
+  clearInterval(interval);
+  console.log(invocations++, c);
+};
+
+console.log('Ready!');

--- a/test/inspector/test-inspector-break-when-eval.js
+++ b/test/inspector/test-inspector-break-when-eval.js
@@ -1,0 +1,128 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+const assert = require('assert');
+const helper = require('./inspector-helper.js');
+const path = require('path');
+
+const script = path.join(path.dirname(module.filename), 'global-function.js');
+
+
+function setupExpectBreakOnLine(line, url, session) {
+  return function(message) {
+    if ('Debugger.paused' === message['method']) {
+      const callFrame = message['params']['callFrames'][0];
+      const location = callFrame['location'];
+      assert.strictEqual(url, session.scriptUrlForId(location['scriptId']));
+      assert.strictEqual(line, location['lineNumber']);
+      return true;
+    }
+  };
+}
+
+function setupExpectConsoleOutputAndBreak(type, values) {
+  if (!(values instanceof Array))
+    values = [ values ];
+  let consoleLog = false;
+  function matchConsoleLog(message) {
+    if ('Runtime.consoleAPICalled' === message['method']) {
+      const params = message['params'];
+      if (params['type'] === type) {
+        let i = 0;
+        for (const value of params['args']) {
+          if (value['value'] !== values[i++])
+            return false;
+        }
+        return i === values.length;
+      }
+    }
+  }
+
+  return function(message) {
+    if (consoleLog)
+      return message['method'] === 'Debugger.paused';
+    consoleLog = matchConsoleLog(message);
+    return false;
+  };
+}
+
+function setupExpectContextDestroyed(id) {
+  return function(message) {
+    if ('Runtime.executionContextDestroyed' === message['method'])
+      return message['params']['executionContextId'] === id;
+  };
+}
+
+function setupDebugger(session) {
+  console.log('[test]', 'Setting up a debugger');
+  const commands = [
+    { 'method': 'Runtime.enable' },
+    { 'method': 'Debugger.enable' },
+    { 'method': 'Debugger.setAsyncCallStackDepth',
+      'params': {'maxDepth': 0} },
+    { 'method': 'Runtime.runIfWaitingForDebugger' },
+  ];
+
+  session
+    .sendInspectorCommands(commands)
+    .expectMessages((message) => 'Runtime.consoleAPICalled' === message.method);
+}
+
+function breakOnLine(session) {
+  console.log('[test]', 'Breaking in the code');
+  const commands = [
+    { 'method': 'Debugger.setBreakpointByUrl',
+      'params': { 'lineNumber': 9,
+                  'url': script,
+                  'columnNumber': 0,
+                  'condition': ''
+      }
+    },
+    { 'method': 'Runtime.evaluate',
+      'params': { 'expression': 'sum()',
+                  'objectGroup': 'console',
+                  'includeCommandLineAPI': true,
+                  'silent': false,
+                  'contextId': 1,
+                  'returnByValue': false,
+                  'generatePreview': true,
+                  'userGesture': true,
+                  'awaitPromise': false
+      }
+    }
+  ];
+  helper.markMessageNoResponse(commands[1]);
+  session
+    .sendInspectorCommands(commands)
+    .expectMessages(setupExpectBreakOnLine(9, script, session));
+}
+
+function stepOverConsoleStatement(session) {
+  console.log('[test]', 'Step over console statement and test output');
+  session
+    .sendInspectorCommands({ 'method': 'Debugger.stepOver' })
+    .expectMessages(setupExpectConsoleOutputAndBreak('log', [0, 3]));
+}
+
+function testWaitsForFrontendDisconnect(session, harness) {
+  console.log('[test]', 'Verify node waits for the frontend to disconnect');
+  session.sendInspectorCommands({ 'method': 'Debugger.resume'})
+    .expectMessages(setupExpectContextDestroyed(1))
+    .expectStderrOutput('Waiting for the debugger to disconnect...')
+    .disconnect(true);
+}
+
+function runTests(harness) {
+  harness
+    .runFrontendSession([
+      setupDebugger,
+      breakOnLine,
+      stepOverConsoleStatement,
+      testWaitsForFrontendDisconnect
+    ]).expectShutDown(0);
+}
+
+helper.startNodeForInspectorTest(runTests,
+                                 ['--inspect'],
+                                 undefined,
+                                 script);


### PR DESCRIPTION
This change allows reentering the message dispatch loop when the Node is
paused. This is necessary when the pause happened as a result of the
message sent by a debug frontend, such as evaluating a function with a
breakpoint inside.

Fixes: https://github.com/nodejs/node/issues/13320

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
inspector, test
