### PR TITLE
async_wrap: remove erroneous destroy list clear()

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -164,8 +164,6 @@ static void DestroyIdsCb(uv_idle_t* handle) {
       FatalException(env->isolate(), try_catch);
     }
   }
-
-  env->destroy_ids_list()->clear();
 }
 
 

--- a/test/parallel/test-async-hooks-close-during-destroy.js
+++ b/test/parallel/test-async-hooks-close-during-destroy.js
@@ -1,0 +1,42 @@
+'use strict';
+// Test that async ids that are added to the destroy queue while running a
+// `destroy` callback are handled correctly.
+
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+const initCalls = new Set();
+let destroyResCallCount = 0;
+let res2;
+
+async_hooks.createHook({
+  init: common.mustCallAtLeast((id, provider, triggerId) => {
+    if (provider === 'foobar')
+      initCalls.add(id);
+  }, 2),
+  destroy: common.mustCallAtLeast((id) => {
+    if (!initCalls.has(id)) return;
+
+    switch (destroyResCallCount++) {
+      case 0:
+        // Trigger the second `destroy` call.
+        res2.emitDestroy();
+        break;
+      case 2:
+        assert.fail('More than 2 destroy() invocations');
+        break;
+    }
+  }, 2)
+}).enable();
+
+const res1 = new async_hooks.AsyncResource('foobar');
+res2 = new async_hooks.AsyncResource('foobar');
+res1.emitDestroy();
+
+process.on('exit', () => assert.strictEqual(destroyResCallCount, 2));
+
+// Keep the event loop alive for a small bit so that the `destroy` callback
+// can run. This can be removed once https://github.com/nodejs/node/issues/13262
+// is resolved.
+setTimeout(() => {}, 100);


### PR DESCRIPTION
Breaking this out from #13286, Trevor said he had a better fix for the other problem and I believe him. :) @nodejs/async_hooks 

Remove a `.clear()` call on the list of destroy ids that may
inadvertently swallow `destroy` events.

The list is already cleared earlier in the `DestroyIdsCb` function,
so usually this was a no-op; but when the garbage collection or
its equivalent was active during a `destroy` hook itself, it was
possible that `destroy` hooks were scheduled but cleared before the
next event loop iteration in which they would have been emitted.

Ref: https://github.com/nodejs/node/pull/13286

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_wrap