### PR TITLE
async_hooks: use parent promise as triggerId in init hook

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -296,6 +296,23 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
   PromiseWrap* wrap = Unwrap<PromiseWrap>(promise);
   if (type == PromiseHookType::kInit || wrap == nullptr) {
     bool silent = type != PromiseHookType::kInit;
+    // set parent promise's async Id as this promise's triggerId
+    if (parent->IsPromise()) {
+      // parent promise exists, current promise
+      // is a chained promise, so we set parent promise's id as
+      // current promise's triggerId
+      Local<Promise> parent_promise = parent.As<Promise>();
+      auto parent_wrap = Unwrap<PromiseWrap>(parent_promise);
+
+      if (parent_wrap == nullptr) {
+        // create a new PromiseWrap for parent promise with silent parameter
+        parent_wrap = new PromiseWrap(env, parent_promise, true);
+        parent_wrap->MakeWeak(parent_wrap);
+      }
+      // get id from parentWrap
+      double trigger_id = parent_wrap->get_id();
+      env->set_init_trigger_id(trigger_id);
+    }
     wrap = new PromiseWrap(env, promise, silent);
     wrap->MakeWeak(wrap);
   } else if (type == PromiseHookType::kResolve) {

--- a/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
@@ -5,37 +5,34 @@ const assert = require('assert');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
 
-const p = (new Promise(common.mustCall(executor)));
-p.then(afterresolution);
+const p = new Promise(common.mustCall(function executor(resolve, reject) {
+  resolve(5);
+}));
+
+p.then(function afterresolution(val) {
+  assert.strictEqual(val, 5);
+  return val;
+});
 
 // init hooks after chained promise is created
 const hooks = initHooks();
 hooks._allowNoInit = true;
 hooks.enable();
 
-function executor(resolve, reject) {
-  resolve(5);
-}
 
-function afterresolution(val) {
-  assert.strictEqual(val, 5);
-  return val;
-}
-
-process.on('exit', onexit);
-function onexit() {
+process.on('exit', function onexit() {
   hooks.disable();
   hooks.sanityCheck('PROMISE');
 
+  // Because the init event was never emitted the hooks listener doesn't
+  // know what the type was. Thus check for Unknown rather than PROMISE.
   const as = hooks.activitiesOfTypes('PROMISE');
   const unknown = hooks.activitiesOfTypes('Unknown');
-  assert.strictEqual(as.length, 0, 'no activities with PROMISE type');
-  assert.strictEqual(unknown.length, 1,
-                     'one activity with Unknown type which in fact is PROMISE');
+  assert.strictEqual(as.length, 0);
+  assert.strictEqual(unknown.length, 1);
 
   const a0 = unknown[0];
-  assert.strictEqual(a0.type, 'Unknown',
-                     'unknown request which in fact is PROMISE');
-  assert.strictEqual(typeof a0.uid, 'number', 'uid is a number');
+  assert.strictEqual(a0.type, 'Unknown');
+  assert.strictEqual(typeof a0.uid, 'number');
   checkInvocations(a0, { before: 1, after: 1 }, 'when process exits');
-}
+});

--- a/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const initHooks = require('./init-hooks');
+const { checkInvocations } = require('./hook-checks');
+
+const p = (new Promise(common.mustCall(executor)));
+p.then(afterresolution);
+
+// init hooks after chained promise is created
+const hooks = initHooks();
+hooks._allowNoInit = true;
+hooks.enable();
+
+function executor(resolve, reject) {
+  resolve(5);
+}
+
+function afterresolution(val) {
+  assert.strictEqual(val, 5);
+  return val;
+}
+
+process.on('exit', onexit);
+function onexit() {
+  hooks.disable();
+  hooks.sanityCheck('PROMISE');
+
+  const as = hooks.activitiesOfTypes('PROMISE');
+  const unknown = hooks.activitiesOfTypes('Unknown');
+  assert.strictEqual(as.length, 0, 'no activities with PROMISE type');
+  assert.strictEqual(unknown.length, 1,
+                     'one activity with Unknown type which in fact is PROMISE');
+
+  const a0 = unknown[0];
+  assert.strictEqual(a0.type, 'Unknown',
+                     'unknown request which in fact is PROMISE');
+  assert.strictEqual(typeof a0.uid, 'number', 'uid is a number');
+  checkInvocations(a0, { before: 1, after: 1 }, 'when process exits');
+}

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -14,7 +14,7 @@ p.then(afterresolution);
 
 function executor(resolve, reject) {
   const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 1, 'one activity');
+  assert.strictEqual(as.length, 1, 'one activities');
   const a = as[0];
   checkInvocations(a, { init: 1 }, 'while in promise executor');
   resolve(5);
@@ -46,8 +46,7 @@ function onexit() {
   const a1 = as[1];
   assert.strictEqual(a1.type, 'PROMISE', 'promise request');
   assert.strictEqual(typeof a1.uid, 'number', 'uid is a number');
-  assert.strictEqual(a1.triggerId, a0.uid,
-                     'child promise should use parent uid as triggerId');
+  assert.strictEqual(a1.triggerId, a0.uid);
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -46,7 +46,7 @@ function onexit() {
   const a1 = as[1];
   assert.strictEqual(a1.type, 'PROMISE', 'promise request');
   assert.strictEqual(typeof a1.uid, 'number', 'uid is a number');
-  assert.strictEqual(a1.triggerId, 1, 'parent uid 1');
+  assert.strictEqual(a1.triggerId, 2, 'parent triggerId 2');
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -5,43 +5,38 @@ const assert = require('assert');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
 
-const p = (new Promise(common.mustCall(executor)));
+const p = new Promise(common.mustCall(function executor(resolve, reject) {
+  resolve(5);
+}));
 
 // init hooks after promise was created
-const hooks = initHooks();
-hooks._allowNoInit = true;
+const hooks = initHooks({allowNoInit: true});
 hooks.enable();
 
-p.then(afterresolution);
-
-function executor(resolve, reject) {
-  resolve(5);
-}
-
-function afterresolution(val) {
+p.then(function afterresolution(val) {
   assert.strictEqual(val, 5);
   const as = hooks.activitiesOfTypes('PROMISE');
   assert.strictEqual(as.length, 1, 'one activity');
   checkInvocations(as[0], { init: 1, before: 1 },
                    'after resolution child promise');
   return val;
-}
+});
 
-process.on('exit', onexit);
-function onexit() {
+process.on('exit', function onexit() {
   hooks.disable();
   hooks.sanityCheck('PROMISE');
 
   const as = hooks.activitiesOfTypes('PROMISE');
-  assert.strictEqual(as.length, 1,
-                     'should only get one activity(child promise)');
+  assert.strictEqual(as.length, 1);
 
   const a0 = as[0];
-  assert.strictEqual(a0.type, 'PROMISE', 'promise request');
-  assert.strictEqual(typeof a0.uid, 'number', 'uid is a number');
-  // we can't get the triggerId dynamically, we have to use static number here
-  assert.strictEqual(a0.triggerId - (a0.uid - 3), 2,
-                     'child promise should use parent uid as triggerId');
+  assert.strictEqual(a0.type, 'PROMISE');
+  assert.strictEqual(typeof a0.uid, 'number');
+  // we can't get the asyncId from the parent dynamically, since init was
+  // never called. However, it is known that the parent promise was created
+  // immediately before the child promise, thus there should only be one
+  // difference in id.
+  assert.strictEqual(a0.triggerId, a0.uid - 1);
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a0, { init: 1, before: 1, after: 1 }, 'when process exits');
-}
+});


### PR DESCRIPTION
async_hooks init callback will be triggered when promise newly created,
in previous version, the parent promise which pass from chrome V8 PromiseHook
is ignored, so we can't tell the promise is a pure new promise or a
chained promise.

In this commit, we use the parent promise's id as triggerId to
trigger the init callback.

Fixes: https://github.com/nodejs/node/issues/13302

Thanks for @AndreasMadsen and @addaleax 's great help! 

Please review.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
