### PR TITLE
test,async_hooks: stabilize tests on Windows

### DIFF
--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -16,13 +16,13 @@ switch (process.argv[2]) {
 }
 
 const c1 = spawnSync(process.execPath, [__filename, 'test_invalid_async_id']);
-assert.strictEqual(c1.stderr.toString().split('\n')[0],
+assert.strictEqual(c1.stderr.toString().split(/[\r\n]+/g)[0],
                    'Error: before(): asyncId or triggerAsyncId is less than ' +
                    'zero (asyncId: -1, triggerAsyncId: -1)');
 assert.strictEqual(c1.status, 1);
 
 const c2 = spawnSync(process.execPath, [__filename, 'test_invalid_trigger_id']);
-assert.strictEqual(c2.stderr.toString().split('\n')[0],
+assert.strictEqual(c2.stderr.toString().split(/[\r\n]+/g)[0],
                    'Error: before(): asyncId or triggerAsyncId is less than ' +
                    'zero (asyncId: 1, triggerAsyncId: -1)');
 assert.strictEqual(c2.status, 1);

--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const common = require('../common');
+if (common.isWindows) {
+  common.skip('no signals on Windows');
+  return;
+}
+
 const initHooks = require('./init-hooks');
 const verifyGraph = require('./verify-graph');
 const exec = require('child_process').exec;

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -1,6 +1,8 @@
 'use strict';
-
 const common = require('../common');
+
+if (common.isWindows) return common.skip('no signals in Windows');
+
 const assert = require('assert');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');

--- a/test/async-hooks/test-ttywrap.readstream.js
+++ b/test/async-hooks/test-ttywrap.readstream.js
@@ -1,7 +1,8 @@
 'use strict';
-
 const common = require('../common');
 const assert = require('assert');
+
+// general hook test setup
 const tick = require('./tick');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
@@ -9,34 +10,35 @@ const { checkInvocations } = require('./hook-checks');
 const hooks = initHooks();
 hooks.enable();
 
-const ReadStream = require('tty').ReadStream;
-const ttyStream = new ReadStream(0);
+// test specific setup
+const { ReadStream } = require('tty');
+const checkInitOpts = { init: 1 };
+const checkEndedOpts = { init: 1, before: 1, after: 1, destroy: 1 };
 
-const as = hooks.activitiesOfTypes('TTYWRAP');
-assert.strictEqual(as.length, 1);
-const tty = as[0];
+// test code
+//
+// listen to stdin except on Windows
+const targetFD = common.isWindows ? 1 : 0;
+const ttyStream = new ReadStream(targetFD);
+const activities = hooks.activitiesOfTypes('TTYWRAP');
+assert.strictEqual(activities.length, 1);
+const tty = activities[0];
 assert.strictEqual(tty.type, 'TTYWRAP');
 assert.strictEqual(typeof tty.uid, 'number');
 assert.strictEqual(typeof tty.triggerAsyncId, 'number');
-checkInvocations(tty, { init: 1 }, 'when tty created');
+checkInvocations(tty, checkInitOpts, 'when tty created');
+const delayedOnCloseHandler = common.mustCall(() => {
+  checkInvocations(tty, checkEndedOpts, 'when tty ended');
+});
+ttyStream.on('error', (err) => assert.fail(err));
+ttyStream.on('close', common.mustCall(() =>
+  tick(2, delayedOnCloseHandler)
+));
+ttyStream.destroy();
+checkInvocations(tty, checkInitOpts, 'when tty.end() was invoked');
 
-ttyStream.end(common.mustCall(onend));
-
-checkInvocations(tty, { init: 1 }, 'when tty.end() was invoked ');
-
-function onend() {
-  tick(2, common.mustCall(() =>
-    checkInvocations(
-      tty, { init: 1, before: 1, after: 1, destroy: 1 },
-      'when tty ended ')
-  ));
-}
-
-process.on('exit', onexit);
-
-function onexit() {
+process.on('exit', () => {
   hooks.disable();
   hooks.sanityCheck('TTYWRAP');
-  checkInvocations(tty, { init: 1, before: 1, after: 1, destroy: 1 },
-                   'when process exits');
-}
+  checkInvocations(tty, checkEndedOpts, 'when process exits');
+});

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,7 +44,7 @@ set enable_static=
 set build_addons_napi=
 set test_node_inspect=
 set test_check_deopts=
-set js_test_suites=inspector known_issues message parallel sequential
+set js_test_suites=async-hooks inspector known_issues message parallel sequential
 set "common_test_suites=%js_test_suites% doctool addons addons-napi&set build_addons=1&set build_addons_napi=1"
 
 :next-arg
@@ -79,6 +79,7 @@ if /i "%1"=="test-tick-processor" set test_args=%test_args% tick-processor&goto 
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
 if /i "%1"=="test-known-issues" set test_args=%test_args% known_issues&goto arg-ok
+if /i "%1"=="test-async-hooks"  set test_args=%test_args% async-hooks&goto arg-ok
 if /i "%1"=="test-all"      set test_args=%test_args% gc internet pummel %common_test_suites%&set build_testgc_addon=1&set cpplint=1&set jslint=1&goto arg-ok
 if /i "%1"=="test-node-inspect" set test_node_inspect=1&goto arg-ok
 if /i "%1"=="test-check-deopts" set test_check_deopts=1&goto arg-ok
@@ -494,7 +495,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test/test-ci/test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vs2015/vs2017] [download-all] [enable-vtune] [lint/lint-ci] [no-NODE-OPTIONS]
+echo vcbuild.bat [debug/release] [msi] [test/test-ci/test-all/test-uv/test-inspector/test-internet/test-pummel/test-simple/test-message/test-async-hooks] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vs2015/vs2017] [download-all] [enable-vtune] [lint/lint-ci] [no-NODE-OPTIONS]
 echo Examples:
 echo   vcbuild.bat                : builds release build
 echo   vcbuild.bat debug          : builds debug build


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
- [x] test-callback-error - #13559
- [x] test-fseventwrap - now pass assumed (#13336)
- [x] test-graph.signal
- [x] test-pipeconnectwrap - now pass assumed (#13336)
- [x] test-signalwrap
- [x] test-ttywrap.readstream
- [x] test-writewrap - now pass assumed (#13336)
### new
- [x] test-emit-before-after

<details><code><pre>
=== release test-fseventwrap ===
Path: async-hooks/test-fseventwrap
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Checking invocations at stage "when process exits":
    Never called "destroy", but expected 1 invocation(s).
    at checkHook (D:\code\node\test\async-hooks\hook-checks.js:45:7)
    at Array.forEach (native)
    at checkInvocations (D:\code\node\test\async-hooks\hook-checks.js:28:44)
    at process.onexit (D:\code\node\test\async-hooks\test-fseventwrap.js:32:3)
    at emitOne (events.js:120:20)
    at process.emit (events.js:210:7)
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-fseventwrap.js
=== release test-graph.signal ===
Path: async-hooks/test-graph.signal
Mismatched onsigusr2 function calls. Expected exactly 2, actual 0.
    at Object.exports.mustCall (D:\code\node\test\common\index.js:483:10)
    at Object.<anonymous> (D:\code\node\test\async-hooks\test-graph.signal.js:11:30)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-graph.signal.js
=== release test-pipeconnectwrap ===
Path: async-hooks/test-pipeconnectwrap
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Checking invocations at stage "pipe2, process exiting":
    Never called "destroy", but expected 1 invocation(s).
    at checkHook (D:\code\node\test\async-hooks\hook-checks.js:45:7)
    at Array.forEach (native)
    at checkInvocations (D:\code\node\test\async-hooks\hook-checks.js:28:44)
    at process.onexit (D:\code\node\test\async-hooks\test-pipeconnectwrap.js:98:3)
    at emitOne (events.js:120:20)
    at process.emit (events.js:210:7)
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-pipeconnectwrap.js
=== release test-signalwrap ===
Path: async-hooks/test-signalwrap
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: one signal wrap when SIGUSR2 handler is set up
    at Object.<anonymous> (D:\code\node\test\async-hooks\test-signalwrap.js:15:8)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-signalwrap.js
=== release test-ttywrap.readstream ===
Path: async-hooks/test-ttywrap.readstream
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Checking invocations at stage "when tty ended ":
    Never called "before", but expected 1 invocation(s).
    at checkHook (D:\code\node\test\async-hooks\hook-checks.js:45:7)
    at Array.forEach (native)
    at checkInvocations (D:\code\node\test\async-hooks\hook-checks.js:28:44)
    at common.mustCall (D:\code\node\test\async-hooks\test-ttywrap.readstream.js:29:5)
    at D:\code\node\test\common\index.js:517:15
    at Immediate.ontick (D:\code\node\test\async-hooks\tick.js:7:37)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-ttywrap.readstream.js
=== release test-writewrap ===
Path: async-hooks/test-writewrap
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Checking invocations at stage "when server got secure connection":
    Never called "destroy", but expected 1 invocation(s).
    at checkHook (D:\code\node\test\async-hooks\hook-checks.js:45:7)
    at Array.forEach (native)
    at checkInvocations (D:\code\node\test\async-hooks\hook-checks.js:28:44)
    at checkValidWriteWrap (D:\code\node\test\async-hooks\test-writewrap.js:56:5)
    at Array.forEach (native)
    at checkDestroyedWriteWraps (D:\code\node\test\async-hooks\test-writewrap.js:58:6)
    at Server.onsecureConnection (D:\code\node\test\async-hooks\test-writewrap.js:65:3)
    at Server.<anonymous> (D:\code\node\test\common\index.js:517:15)
    at emitOne (events.js:115:13)
    at Server.emit (events.js:210:7)
Command: D:\code\node\Release\node.exe D:\code\node\test\async-hooks\test-writewrap.js
[00:16|% 100|+  39|-   6]: Done

</pre></code></details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test,async_hooks
