### PR TITLE
doc: use prefer-rest-params eslint rule in docs

### DIFF
--- a/doc/.eslintrc.yaml
+++ b/doc/.eslintrc.yaml
@@ -10,3 +10,4 @@ rules:
   # add new ECMAScript features gradually
   no-var: 2
   prefer-const: 2
+  prefer-rest-params: 2

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -119,9 +119,9 @@ not invoke AsyncHooks recursively because it is synchronous.
 const fs = require('fs');
 const util = require('util');
 
-function debug() {
+function debug(...args) {
   // use a function like this one when debugging inside an AsyncHooks callback
-  fs.writeSync(1, util.format.apply(null, arguments));
+  fs.writeSync(1, `${util.format(...args)}\n`);
 }
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -55,6 +55,7 @@ added: v0.8.0
 The `util.deprecate()` method wraps the given `function` or class in such a way that
 it is marked as deprecated.
 
+<!-- eslint-disable prefer-rest-params -->
 ```js
 const util = require('util');
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, tools

Do not promote using of `arguments`.

One fragment is left as is because of history nature: it uses a real deprecated code from libs.

Refs: http://eslint.org/docs/rules/prefer-rest-params
Refs: https://github.com/nodejs/node/blob/99da8e8e02a874a0a044889f863c45700509d02c/lib/util.js#L1002-L1006
