### PR TITLE
test: pass env vars through to test-benchmark-http

### DIFF
--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -20,6 +20,9 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
+const env = Object.assign({}, process.env,
+                          { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+
 const child = fork(runjs, ['--set', 'benchmarker=test-double',
                            '--set', 'c=1',
                            '--set', 'chunks=0',
@@ -28,7 +31,7 @@ const child = fork(runjs, ['--set', 'benchmarker=test-double',
                            '--set', 'len=1',
                            '--set', 'n=1',
                            'http'],
-                   {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
+                   {env});
 child.on('exit', (code, signal) => {
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);


### PR DESCRIPTION
Allows `NODE_TEST_DIR` to be set (necessary to avoid path length issues
with common.PIPE).

Refs: https://github.com/nodejs/node/issues/12708#issuecomment-297847882

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

cc/ @nodejs/benchmarking  

CI: https://ci.nodejs.org/job/node-test-commit/10311/