### PR TITLE
doc: add ref to option to enable n-api

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -11,6 +11,13 @@ changes in the underlying JavaScript engine and allow modules
 compiled for one version to run on later versions of Node.js without
 recompilation.
 
+As the feature is currently experimental it must be enabled with the
+following command line option:
+
+```bash
+--napi-modules
+```
+
 Addons are built/packaged with the same approach/tools
 outlined in the section titled  [C++ Addons](addons.html).
 The only difference is the set of APIs that are used by the native code.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -11,13 +11,6 @@ changes in the underlying JavaScript engine and allow modules
 compiled for one version to run on later versions of Node.js without
 recompilation.
 
-As the feature is currently experimental it must be enabled with the
-following command line option:
-
-```bash
---napi-modules
-```
-
 Addons are built/packaged with the same approach/tools
 outlined in the section titled  [C++ Addons](addons.html).
 The only difference is the set of APIs that are used by the native code.
@@ -65,6 +58,14 @@ which is located in the src directory in the node development tree.
 For example:
 ```C
 #include <node_api.h>
+```
+
+As the feature is experimental it must be enabled with the
+following command line
+[option](https://nodejs.org/dist/latest-v8.x/docs/api/cli.html#cli_napi_modules):
+
+```bash
+--napi-modules
 ```
 
 ## Basic N-API Data Types


### PR DESCRIPTION
Since its guarded in by a command line option say
that in the docs and provide the option that needs
to be used to enable it.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api