### PR TITLE
url: do not pass WHATWG host to http.request

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1298,7 +1298,6 @@ function domainToUnicode(domain) {
 function urlToOptions(url) {
   var options = {
     protocol: url.protocol,
-    host: url.host,
     hostname: url.hostname,
     hash: url.hash,
     search: url.search,


### PR DESCRIPTION
As we explicitely state that `hostname` is an alias for `host`, we should avoid passing different (or even invalid) values for `host`, even if `hostname` is preferred. There is no reason to pass an invalid value for `host` to `http.request()`.

Ref: https://github.com/nodejs/node/pull/10638

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url