### PR TITLE
async_hooks: tear down hooks if none are in use

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -131,6 +131,18 @@ class AsyncHook {
     hook_fields[kAfter] -= +!!this[after_symbol];
     hook_fields[kDestroy] -= +!!this[destroy_symbol];
     hooks_array.splice(index, 1);
+
+    if (hooks_array.length === 0) {
+      if (hook_fields[kInit] + hook_fields[kBefore] +
+          hook_fields[kAfter] + hook_fields[kDestroy] !== 0) {
+        const { inspect } = require('util');
+        throw new Error(`Invalid async_hooks state: ${inspect(hook_fields)}`);
+      }
+
+      async_wrap.tearDownHooks();
+      setupHooksCalled = false;
+    }
+
     return this;
   }
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include <stdio.h>
+#include <algorithm>
 
 namespace node {
 
@@ -193,6 +194,23 @@ void Environment::AddPromiseHook(promise_hook_func fn, void* arg) {
   if (promise_hooks_.size() == 1) {
     isolate_->SetPromiseHook(EnvPromiseHook);
   }
+}
+
+bool Environment::RemovePromiseHook(promise_hook_func fn, void* arg) {
+  auto it = std::find_if(
+      promise_hooks_.begin(), promise_hooks_.end(),
+      [&](const PromiseHookCallback& hook) {
+        return hook.cb_ == fn && hook.arg_ == arg;
+      });
+
+  if (it == promise_hooks_.end()) return false;
+
+  promise_hooks_.erase(it);
+  if (promise_hooks_.empty()) {
+    isolate_->SetPromiseHook(nullptr);
+  }
+
+  return true;
 }
 
 void Environment::EnvPromiseHook(v8::PromiseHookType type,

--- a/src/env.h
+++ b/src/env.h
@@ -653,6 +653,7 @@ class Environment {
   static const int kContextEmbedderDataIndex = NODE_CONTEXT_EMBEDDER_DATA_INDEX;
 
   void AddPromiseHook(promise_hook_func fn, void* arg);
+  bool RemovePromiseHook(promise_hook_func fn, void* arg);
 
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),


### PR DESCRIPTION
Basically, reset everything into its original state once all
async hooks have been disabled as closely as possible.

This has been requested by Andreas, and I agree that it makes sense.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included (how do you test that nothing happens?)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

async_hooks

/cc @nodejs/async_hooks 