### PR TITLE
async_hooks: make sure `.{en|dis}able() === this`

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -96,7 +96,7 @@ class AsyncHook {
 
     // Each hook is only allowed to be added once.
     if (hooks_array.includes(this))
-      return;
+      return this;
 
     if (!setupHooksCalled) {
       setupHooksCalled = true;
@@ -124,7 +124,7 @@ class AsyncHook {
 
     const index = hooks_array.indexOf(this);
     if (index === -1)
-      return;
+      return this;
 
     hook_fields[kInit] -= +!!this[init_symbol];
     hook_fields[kBefore] -= +!!this[before_symbol];

--- a/test/parallel/test-async-hooks-enable-disable.js
+++ b/test/parallel/test-async-hooks-enable-disable.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+const hook = async_hooks.createHook({
+  init: common.mustCall(() => {}, 1),
+  before: common.mustNotCall(),
+  after: common.mustNotCall(),
+  destroy: common.mustNotCall()
+});
+
+assert.strictEqual(hook.enable(), hook);
+assert.strictEqual(hook.enable(), hook);
+
+setImmediate(common.mustCall());
+
+assert.strictEqual(hook.disable(), hook);
+assert.strictEqual(hook.disable(), hook);
+assert.strictEqual(hook.disable(), hook);


### PR DESCRIPTION
Make sure that `hook.enable()` and `hook.disable()` return `hook`
consistently, as the documentation indicates.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks /cc @nodejs/async_hooks 