### PR TITLE
doc: minimal documentation for Emeritus status

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -68,9 +68,9 @@ Typical activities of a Collaborator include:
 * participation in working groups
 * merging pull requests
 
-While the above are typical things done by Collaborators, there are no required
-activities to retain Collaborator status. There is currently no process by which
-inactive Collaborators are removed from the project.
+The CTC periodically reviews the Collaborator list to identify inactive
+Collaborators. Past Collaborators are typically given _Emeritus_ status. Emeriti
+may request that the CTC restore them to active status.
 
 ## CTC Membership
 


### PR DESCRIPTION
Include a high-level explanation of how Collaborators are identified for
Emeritus status. This is intended to supply the minimum amount of
information to being assigning Emeritus status to inactive
Collaborators. The documentation may be expanded subsequently.

@nodejs/ctc 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc 