### PR TITLE
util.inspect(obj) should avoid obj.inspect access

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -346,7 +346,8 @@ function formatValue(ctx, value, recurseTimes) {
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
   if (ctx.customInspect && value) {
-    const maybeCustomInspect = value[customInspectSymbol] || value.inspect;
+    const maybeCustomInspect = value[customInspectSymbol] ||
+      ((typeof value === 'object' && 'inspect' in value) && value.inspect);
 
     if (typeof maybeCustomInspect === 'function' &&
         // Filter out the util module, its inspect function is special

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -932,4 +932,22 @@ checkAlignment(new Map(big_array.map(function(y) { return [y, null]; })));
   }, /"options" must be an object/);
 }
 
+// util.inspect
+{
+  let inspectWasNotAccessed = true;
+  const obj = {};
+  const proxy = new Proxy(obj, {
+    get(obj, prop) {
+      if (prop === 'inspect') {
+        inspectWasNotAccessed = false;
+      }
+
+      return obj[prop];
+    }
+  });
+
+  util.inspect(proxy);
+  assert.ok(inspectWasNotAccessed, `'obj.inspect' was unexpectedly accessed`);
+}
+
 assert.doesNotThrow(() => util.inspect(process));


### PR DESCRIPTION
For your consideration:

util.inspect(obj) accessing a property to check for existence seems
strange. It is likely fine in the case of symbols. Prior to this commit
writing inspectable proxies \w a `get` trap required node specific
knowlede.

fixes: https://github.com/nodejs/node/issues/13414



##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

unsure

---

 *note: as i've pulled the thread on this, I've realized the final result may not really be that great. So if you don't feel this is important my feelings wont be hurt if this is closed*
