### PR TITLE
doc: emphasize Collaborators in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,27 +1,12 @@
 # Node.js Project Governance
 
-## Core Technical Committee
-
-The Node.js project is governed by a Core Technical Committee (CTC) which is
-responsible for high-level guidance of the project.
-
-The CTC has final authority over this project including:
-
-* Technical direction
-* Project governance and process (including this policy)
-* Contribution policy
-* GitHub repository hosting
-* Conduct guidelines
-* Maintaining the list of additional Collaborators
-
-For the current list of CTC members, see the project
-[README.md](./README.md#current-project-team-members).
+The Node.js project is governed by its Collaborators, including a Core Technical
+Committee (CTC) which is responsible for high-level guidance of the project.
 
 ## Collaborators
 
 The [nodejs/node](https://github.com/nodejs/node) GitHub repository is
-maintained by the CTC and additional Collaborators who are added by the
-CTC on an ongoing basis.
+maintained by Collaborators who are added by the CTC on an ongoing basis.
 
 Individuals identified by the CTC as making significant and valuable
 contributions are made Collaborators and given commit access to the project. If
@@ -44,18 +29,15 @@ be accepted unless:
   the change. Previously-objecting Collaborators do not necessarily have to
   sign-off on the change, but they should not be opposed to it.
 * The change is escalated to the CTC and the CTC votes to approve the change.
-  This should be used only after other options (especially discussion among
-  the disagreeing Collaborators) have been exhausted.
+  This should only happen if disagreements between Collaborators cannot be
+  resolved through discussion.
 
 Collaborators may opt to elevate significant or controversial modifications to
 the CTC by assigning the `ctc-review` label to a pull request or issue. The
 CTC should serve as the final arbiter where required.
 
-For the current list of Collaborators, see the project
-[README.md](./README.md#current-project-team-members).
-
-A guide for Collaborators is maintained in
-[COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md).
+* [Current list of Collaborators](./README.md#current-project-team-members)
+* [A guide for Collaborators](./COLLABORATOR_GUIDE.md)
 
 ### Collaborator Activities
 
@@ -71,6 +53,20 @@ The CTC periodically reviews the Collaborator list to identify inactive
 Collaborators. Past Collaborators are typically given _Emeritus_ status. Emeriti
 may request that the CTC restore them to active status.
 
+## Core Technical Committee
+
+The Core Technical Committee (CTC) has final authority over this project
+including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of additional Collaborators
+
+* [Current list of CTC members](./README.md#current-project-team-members)
+
 ## CTC Membership
 
 CTC seats are not time-limited. There is no fixed size of the CTC. The CTC
@@ -82,9 +78,10 @@ membership beyond these rules.
 
 The CTC may add additional members to the CTC by a standard CTC motion.
 
-When a CTC member's participation in [CTC activities](#ctc-activities) has become
-minimal for a sustained period of time, the CTC will request that the member
-either indicate an intention to increase participation or voluntarily resign.
+When a CTC member's participation in [CTC activities](#ctc-activities) has
+become minimal for a sustained period of time, the CTC will request that the
+member either indicate an intention to increase participation or voluntarily
+resign.
 
 CTC members may only be removed by voluntary resignation or through a standard
 CTC motion.


### PR DESCRIPTION
Put information about Collaborators in GOVERNANCE.md before information
about the CTC. For most things, the CTC is the last place to go, not the
first and Collaborators have a lot of decision-making power in the
project. The governance doc should reflect that.

(There's also one paragraph re-formatted to wrap at 80 chars.)

@nodejs/ctc 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc