### PR TITLE
test: rearrange inspector headers into convention

### DIFF
--- a/test/inspector/test-inspector-debug-brk.js
+++ b/test/inspector/test-inspector-debug-brk.js
@@ -1,6 +1,8 @@
 'use strict';
 const common = require('../common');
+
 common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const helper = require('./inspector-helper.js');
 

--- a/test/inspector/test-inspector-ip-detection.js
+++ b/test/inspector/test-inspector-ip-detection.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+
 common.skipIfInspectorDisabled();
 
 const assert = require('assert');

--- a/test/inspector/test-inspector-port-zero-cluster.js
+++ b/test/inspector/test-inspector-port-zero-cluster.js
@@ -1,8 +1,9 @@
 // Flags: --inspect=0
 'use strict';
-
 const common = require('../common');
+
 common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const cluster = require('cluster');
 

--- a/test/inspector/test-inspector-port-zero.js
+++ b/test/inspector/test-inspector-port-zero.js
@@ -1,7 +1,8 @@
 'use strict';
-
 const { mustCall, skipIfInspectorDisabled } = require('../common');
+
 skipIfInspectorDisabled();
+
 const assert = require('assert');
 const { URL } = require('url');
 const { spawn } = require('child_process');

--- a/test/inspector/test-inspector-stops-no-file.js
+++ b/test/inspector/test-inspector-stops-no-file.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+
 const spawn = require('child_process').spawn;
 
 const child = spawn(process.execPath,

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -1,6 +1,8 @@
 'use strict';
 const common = require('../common');
+
 common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const helper = require('./inspector-helper.js');
 

--- a/test/parallel/test-cluster-inspector-debug-port.js
+++ b/test/parallel/test-cluster-inspector-debug-port.js
@@ -1,7 +1,9 @@
 'use strict';
 // Flags: --inspect={PORT}
 const common = require('../common');
+
 common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const cluster = require('cluster');
 const debuggerPort = common.PORT;

--- a/test/parallel/test-inspector-invalid-args.js
+++ b/test/parallel/test-inspector-invalid-args.js
@@ -1,10 +1,11 @@
 'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const execFile = require('child_process').execFile;
 const path = require('path');
-
-const common = require('../common');
-common.skipIfInspectorDisabled();
 
 const mainScript = path.join(common.fixturesDir, 'loop.js');
 const expected =


### PR DESCRIPTION
Test guide describes a conventional layout for test headers, review
inspector tests and reorganize to follow the convention.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test,inspector
