### PR TITLE
doc,stream: clarify 'data', pipe() and 'readable'

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -754,7 +754,8 @@ end
 ```
 
 *Note*: In general, the `readable.pipe()` and `'data'` event mechanisms are
-preferred over the use of the `'readable'` event.
+easier to understand compared to the `'readable'` event.
+However, handling `'readable'` might result in increased throughput.
 
 ##### readable.isPaused()
 <!-- YAML


### PR DESCRIPTION
We stated that 'data' and pipe() are preferred over 'readable'.
This commit clarifies that 'data' and pipe() are easier to understand,
but 'readable' might result in increased throughput.

Fixes: https://github.com/nodejs/node/issues/11587

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, stream