### PR TITLE
test: add hijackStdout and hijackStderr

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -116,15 +116,15 @@ Checks whether `IPv6` is supported on this platform.
 
 Checks if there are multiple localhosts available.
 
-### hijackStdout(listener)
-* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
-
-Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one then.
-
 ### hijackStderr(listener)
 * `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
 
 Hijack `process.stderr` to listen `write` action. Once `process.stderr.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stderr.writeTimes` will plus one then.
+
+### hijackStdout(listener)
+* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
+
+Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one then.
 
 ### inFreeBSDJail
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
@@ -259,6 +259,14 @@ Port tests are running on.
 * return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
 
 Deletes the 'tmp' dir and recreates it
+
+### restoreStderr
+
+Restore the original `process.stderr.write`.
+
+### restoreStdout
+
+Restore the original `process.stdout.write`.
 
 ### rootDir
 * return [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -116,25 +116,13 @@ Checks whether `IPv6` is supported on this platform.
 
 Checks if there are multiple localhosts available.
 
-### hijackStderr(listener)
-* `listener`
-[&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions):
-a listener with a single parameter called `data`.
+### hijackStderr/Stdout(listener)
+* `listener` [&lt;Function>][MDN-Function]: a listener with a single parameter called `data`.
 
-Hijack `process.stderr` to listen `write` action. Once `process.stderr.write` is
-called, `listener` will also be called and the `data` of `write` function will
-be passed to `listener`. What's more, `process.stderr.writeTimes` will plus one
-then.
-
-### hijackStdout(listener)
-* `listener`
-[&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions):
-a listener with a single parameter called `data`.
-
-Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is
-called, `listener` will also be called and the `data` of `write` function will
-be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one
-then.
+Eavesdrop to `process.stderr.write` or `process.stdout.write` calls. Once
+`process.std*.write` is called, `listener` will also be called and the `data` of
+`write` function will be passed to `listener`. What's more,
+`process.std*.writeTimes` is a count of the number of calls.
 
 ### inFreeBSDJail
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
@@ -318,3 +306,5 @@ Node.js
 [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api)
 implementation with tests from
 [W3C Web Platform Tests](https://github.com/w3c/web-platform-tests).
+
+[MDN-Function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -116,6 +116,16 @@ Checks whether `IPv6` is supported on this platform.
 
 Checks if there are multiple localhosts available.
 
+### hijackStdout(listener)
+* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
+
+Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one then.
+
+### hijackStderr(listener)
+* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
+
+Hijack `process.stderr` to listen `write` action. Once `process.stderr.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stderr.writeTimes` will plus one then.
+
 ### inFreeBSDJail
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -117,14 +117,24 @@ Checks whether `IPv6` is supported on this platform.
 Checks if there are multiple localhosts available.
 
 ### hijackStderr(listener)
-* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
+* `listener`
+[&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions):
+a listener with a single parameter called `data`.
 
-Hijack `process.stderr` to listen `write` action. Once `process.stderr.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stderr.writeTimes` will plus one then.
+Hijack `process.stderr` to listen `write` action. Once `process.stderr.write` is
+called, `listener` will also be called and the `data` of `write` function will
+be passed to `listener`. What's more, `process.stderr.writeTimes` will plus one
+then.
 
 ### hijackStdout(listener)
-* `listener` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions): An listener with a single parameter called `data`;
+* `listener`
+[&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions):
+a listener with a single parameter called `data`.
 
-Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is called, `listener` will also be called and the `data` of `write` function will be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one then.
+Hijack `process.stdout` to listen `write` action. Once `process.stdout.write` is
+called, `listener` will also be called and the `data` of `write` function will
+be passed to `listener`. What's more, `process.stdout.writeTimes` will plus one
+then.
 
 ### inFreeBSDJail
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -116,13 +116,21 @@ Checks whether `IPv6` is supported on this platform.
 
 Checks if there are multiple localhosts available.
 
-### hijackStderr/Stdout(listener)
+### hijackStderr(listener)
 * `listener` [&lt;Function>][MDN-Function]: a listener with a single parameter called `data`.
 
-Eavesdrop to `process.stderr.write` or `process.stdout.write` calls. Once
-`process.std*.write` is called, `listener` will also be called and the `data` of
-`write` function will be passed to `listener`. What's more,
-`process.std*.writeTimes` is a count of the number of calls.
+Eavesdrop to `process.stderr.write` calls. Once `process.stderr.write` is
+called, `listener` will also be called and the `data` of `write` function will
+be passed to `listener`. What's more, `process.stderr.writeTimes` is a count of
+the number of calls.
+
+### hijackStdout(listener)
+* `listener` [&lt;Function>][MDN-Function]: a listener with a single parameter called `data`.
+
+Eavesdrop to `process.stdout.write` calls. Once `process.stdout.write` is
+called, `listener` will also be called and the `data` of `write` function will
+be passed to `listener`. What's more, `process.stdout.writeTimes` is a count of
+the number of calls.
 
 ### inFreeBSDJail
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
@@ -258,11 +266,11 @@ Port tests are running on.
 
 Deletes the 'tmp' dir and recreates it
 
-### restoreStderr
+### restoreStderr()
 
 Restore the original `process.stderr.write`.
 
-### restoreStdout
+### restoreStdout()
 
 Restore the original `process.stdout.write`.
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -759,3 +759,19 @@ exports.getTTYfd = function getTTYfd() {
   }
   return tty_fd;
 };
+
+// Hijack stdout and stderr
+function hijackStdWritable(name, listener) {
+  const stream = process[name];
+  const _write = stream.write.bind(stream);
+
+  stream.writeTimes = 0;
+  stream.write = function(data) {
+    listener(data);
+    _write(data);
+    stream.writeTimes++;
+  };
+}
+
+exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
+exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -764,12 +764,12 @@ exports.getTTYfd = function getTTYfd() {
 const stdWrite = {};
 function hijackStdWritable(name, listener) {
   const stream = process[name];
-  const _write = stdWrite[name] = stream.write.bind(stream);
+  const _write = stdWrite[name] = stream.write;
 
   stream.writeTimes = 0;
   stream.write = function(data, callback) {
     listener(data);
-    _write(data, callback);
+    _write.call(stream, data, callback);
     stream.writeTimes++;
   };
 }

--- a/test/fixtures/echo-close-check.js
+++ b/test/fixtures/echo-close-check.js
@@ -26,9 +26,15 @@ const fs = require('fs');
 
 process.stdout.write('hello world\r\n');
 
-var stdin = process.openStdin();
+const stdin = process.openStdin();
+
+let current;
+common.hijackStdout(function(data) {
+  assert.equal(data, current);
+});
 
 stdin.on('data', function(data) {
+  current = data;
   process.stdout.write(data.toString());
 });
 

--- a/test/fixtures/echo-close-check.js
+++ b/test/fixtures/echo-close-check.js
@@ -28,13 +28,7 @@ process.stdout.write('hello world\r\n');
 
 const stdin = process.openStdin();
 
-let current;
-common.hijackStdout(common.mustCall(function(data) {
-  assert.strictEqual(data, current);
-}));
-
 stdin.on('data', function(data) {
-  current = data.toString();
   process.stdout.write(data.toString());
 });
 

--- a/test/fixtures/echo-close-check.js
+++ b/test/fixtures/echo-close-check.js
@@ -29,12 +29,12 @@ process.stdout.write('hello world\r\n');
 const stdin = process.openStdin();
 
 let current;
-common.hijackStdout(function(data) {
-  assert.equal(data, current);
-});
+common.hijackStdout(common.mustCall(function(data) {
+  assert.strictEqual(data, current);
+}));
 
 stdin.on('data', function(data) {
-  current = data;
+  current = data.toString();
   process.stdout.write(data.toString());
 });
 

--- a/test/fixtures/echo.js
+++ b/test/fixtures/echo.js
@@ -26,12 +26,6 @@ process.stdout.write('hello world\r\n');
 
 var stdin = process.openStdin();
 
-let current;
 stdin.on('data', function(data) {
-  current = data;
   process.stdout.write(data.toString());
-});
-
-common.hijackStdout(function(data) {
-  assert.equal(data, current);
 });

--- a/test/fixtures/echo.js
+++ b/test/fixtures/echo.js
@@ -26,6 +26,12 @@ process.stdout.write('hello world\r\n');
 
 var stdin = process.openStdin();
 
+let current;
 stdin.on('data', function(data) {
+  current = data;
   process.stdout.write(data.toString());
+});
+
+common.hijackStdout(function(data) {
+  assert.equal(data, current);
 });

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -88,3 +88,23 @@ for (const p of failFixtures) {
     assert.strictEqual(firstLine, expected);
   }));
 }
+
+// hijackStderr and hijackStdout
+const HIJACK_TEST_ARRAY = [ 'foo\n', 'bar\n', 'baz\n' ];
+[ 'err', 'out' ].forEach((txt) => {
+  const stream = process[`std${txt}`];
+  const originalWrite = stream.write;
+
+  common[`hijackStd${txt}`](common.mustCall(function(data) {
+    assert.strictEqual(data, HIJACK_TEST_ARRAY[stream.writeTimes]);
+  }, HIJACK_TEST_ARRAY.length));
+  assert.notStrictEqual(originalWrite, stream.write);
+
+  HIJACK_TEST_ARRAY.forEach((val) => {
+    stream.write(val, common.mustCall(common.noop));
+  });
+
+  assert.strictEqual(HIJACK_TEST_ARRAY.length, stream.writeTimes);
+  common[`restoreStd${txt}`]();
+  assert.strictEqual(originalWrite, stream.write);
+});

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -164,6 +164,6 @@ common.hijackStderr(common.mustCall(function(data) {
 
   // stderr.write will catch sync error, so use `process.nextTick` here
   process.nextTick(function() {
-    assert(/no such label/.test(data));
+    assert.strictEqual(data.includes('no such label'), true);
   });
 }));

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -157,7 +157,8 @@ assert.doesNotThrow(() => {
   console.assert(true, 'this should not throw');
 });
 
-// hijack stderr to catch `process.emitWarning` which using `process.nextTick`
+// hijack stderr to catch `process.emitWarning` which is using
+// `process.nextTick`
 common.hijackStderr(common.mustCall(function(data) {
   common.restoreStderr();
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -45,16 +45,14 @@ assert.doesNotThrow(function() {
 // an Object with a custom .inspect() function
 const custom_inspect = { foo: 'bar', inspect: () => 'inspect' };
 
-const stdout_write = global.process.stdout.write;
-const stderr_write = global.process.stderr.write;
 const strings = [];
 const errStrings = [];
-global.process.stdout.write = function(string) {
-  strings.push(string);
-};
-global.process.stderr.write = function(string) {
-  errStrings.push(string);
-};
+common.hijackStdout(function(data) {
+  strings.push(data);
+});
+common.hijackStderr(function(data) {
+  errStrings.push(data);
+});
 
 // test console.log() goes to stdout
 console.log('foo');
@@ -105,8 +103,10 @@ console.timeEnd('constructor');
 console.time('hasOwnProperty');
 console.timeEnd('hasOwnProperty');
 
-global.process.stdout.write = stdout_write;
-global.process.stderr.write = stderr_write;
+assert.strictEqual(strings.length, process.stdout.writeTimes);
+assert.strictEqual(errStrings.length, process.stderr.writeTimes);
+common.restoreStdout();
+common.restoreStderr();
 
 // verify that console.timeEnd() doesn't leave dead links
 const timesMapSize = console._times.size;
@@ -146,9 +146,6 @@ assert.ok(/^hasOwnProperty: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.strictEqual('Trace: This is a {"formatted":"trace"} 10 foo',
                    errStrings.shift().split('\n').shift());
 
-assert.strictEqual(strings.length, 0);
-assert.strictEqual(errStrings.length, 0);
-
 assert.throws(() => {
   console.assert(false, 'should throw');
 }, common.expectsError({
@@ -159,3 +156,13 @@ assert.throws(() => {
 assert.doesNotThrow(() => {
   console.assert(true, 'this should not throw');
 });
+
+// hijack stderr to catch `process.emitWarning` which using `process.nextTick`
+common.hijackStderr(common.mustCall(function(data) {
+  common.restoreStderr();
+
+  // stderr.write will catch sync error, so use `process.nextTick` here
+  process.nextTick(function() {
+    assert(/no such label/.test(data));
+  });
+}));

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -7,37 +7,30 @@
 const common = require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
-const leak_warning = /EventEmitter memory leak detected\. 2 hello listeners/;
+const leakWarning = /EventEmitter memory leak detected\. 2 hello listeners/;
 
-let write_calls = 0;
+common.hijackStderr(function(data) {
+  if (process.stderr.writeTimes === 0) {
+    assert.ok(data.match(leakWarning));
+  } else {
+    assert.fail('stderr.write should be called only once');
+  }
+});
 
-process.on('warning', (warning) => {
+process.on('warning', function(warning) {
   // This will be called after the default internal
   // process warning handler is called. The default
   // process warning writes to the console, which will
   // invoke the monkeypatched process.stderr.write
   // below.
-  assert.strictEqual(write_calls, 1);
-  EventEmitter.defaultMaxListeners = old_default;
+  assert.strictEqual(process.stderr.writeTimes, 1);
+  EventEmitter.defaultMaxListeners = oldDefault;
   // when we get here, we should be done
 });
 
-process.stderr.write = (data) => {
-  if (write_calls === 0)
-    assert.ok(data.match(leak_warning));
-  else
-    assert.fail('stderr.write should be called only once');
-
-  write_calls++;
-};
-
-const old_default = EventEmitter.defaultMaxListeners;
+const oldDefault = EventEmitter.defaultMaxListeners;
 EventEmitter.defaultMaxListeners = 1;
 
 const e = new EventEmitter();
 e.on('hello', common.noop);
 e.on('hello', common.noop);
-
-// TODO: Figure out how to validate console. Currently,
-// there is no obvious way of validating that console
-// exists here exactly when it should.

--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -9,13 +9,13 @@ const assert = require('assert');
 const EventEmitter = require('events');
 const leakWarning = /EventEmitter memory leak detected\. 2 hello listeners/;
 
-common.hijackStderr(function(data) {
+common.hijackStderr(common.mustCall(function(data) {
   if (process.stderr.writeTimes === 0) {
     assert.ok(data.match(leakWarning));
   } else {
     assert.fail('stderr.write should be called only once');
   }
-});
+}));
 
 process.on('warning', function(warning) {
   // This will be called after the default internal

--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const os = require('os');
 
@@ -63,10 +63,7 @@ function child() {
     throw new Error('No ticking!');
   };
 
-  const stderr = process.stderr;
-  stderr.write = function() {
-    throw new Error('No writing to stderr!');
-  };
+  common.hijackStderr(common.mustNotCall('stderr.write mustn\'t be called.'));
 
   process._rawDebug('I can still %s!', 'debug');
 }

--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -63,7 +63,7 @@ function child() {
     throw new Error('No ticking!');
   };
 
-  common.hijackStderr(common.mustNotCall('stderr.write mustn\'t be called.'));
+  common.hijackStderr(common.mustNotCall('stderr.write must not be called.'));
 
   process._rawDebug('I can still %s!', 'debug');
 }

--- a/test/parallel/test-util-log.js
+++ b/test/parallel/test-util-log.js
@@ -31,7 +31,7 @@ const strings = [];
 common.hijackStdout(function(data) {
   strings.push(data);
 });
-common.hijackStderr(common.mustNotCall('stderr.write mustn\'t be called'));
+common.hijackStderr(common.mustNotCall('stderr.write must not be called'));
 
 const tests = [
   {input: 'foo', output: 'foo'},

--- a/test/parallel/test-util-log.js
+++ b/test/parallel/test-util-log.js
@@ -20,19 +20,18 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const util = require('util');
 
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);
 
-const stdout_write = global.process.stdout.write;
 const strings = [];
-global.process.stdout.write = function(string) {
-  strings.push(string);
-};
-console._stderr = process.stdout;
+common.hijackStdout(function(data) {
+  strings.push(data);
+});
+common.hijackStderr(common.mustNotCall('stderr.write mustn\'t be called'));
 
 const tests = [
   {input: 'foo', output: 'foo'},
@@ -56,4 +55,6 @@ tests.forEach(function(test) {
   assert.strictEqual(match[1], test.output);
 });
 
-global.process.stdout.write = stdout_write;
+assert.strictEqual(process.stdout.writeTimes, tests.length);
+
+common.restoreStdout();


### PR DESCRIPTION
Add `common.hijackStdout` and `common.hijackStderr` to provide monitor
for console output.

Refs: https://github.com/nodejs/node/blob/917f86ea353e087af3bc4553219ffabaa2193d20/test/parallel/test-global-console-exists.js#L41-L43

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

<!-- ##### Affected core subsystem(s) -->
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
