### PR TITLE
tools, test: update test-npm-package paths

### DIFF
--- a/tools/test-npm-package.js
+++ b/tools/test-npm-package.js
@@ -24,7 +24,7 @@ const path = require('path');
 const common = require('../test/common');
 
 const projectDir = path.resolve(__dirname, '..');
-const npmBin = path.join(projectDir, 'deps', 'npm', 'cli.js');
+const npmBin = path.join(projectDir, 'deps', 'npm', 'bin', 'npm-cli.js');
 const nodePath = path.dirname(process.execPath);
 
 function spawnCopyDeepSync(source, destination) {
@@ -82,6 +82,7 @@ function runNPMPackageTests({ srcDir, install, rebuild, testArgs, logfile }) {
       npmBin,
       'install',
       '--ignore-scripts',
+      '--no-save',
     ], npmOptions);
   }
 


### PR DESCRIPTION
Makes the same changes as https://github.com/nodejs/node/commit/994617370e8e66f3ea9488fec32fd912e7902396 to update the test runner for npm5.

Refs: https://github.com/nodejs/node/pull/12936

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, test