### PR TITLE
test: refactor test-dgram-oob-buffer

### DIFF
--- a/test/parallel/test-dgram-oob-buffer.js
+++ b/test/parallel/test-dgram-oob-buffer.js
@@ -31,14 +31,14 @@ const socket = dgram.createSocket('udp4');
 const buf = Buffer.from([1, 2, 3, 4]);
 const portGetter = dgram.createSocket('udp4')
   .bind(0, 'localhost', common.mustCall(() => {
-    const address = portGetter.address();
+    const { address, port } = portGetter.address();
     portGetter.close(common.mustCall(() => {
-      socket.send(buf, 0, 0, address.port, address.address, common.noop);
-      socket.send(buf, 0, 4, address.port, address.address, common.noop);
-      socket.send(buf, 1, 3, address.port, address.address, common.noop);
-      socket.send(buf, 3, 1, address.port, address.address, common.noop);
+      socket.send(buf, 0, 0, port, address, common.mustNotCall());
+      socket.send(buf, 0, 4, port, address, common.mustNotCall());
+      socket.send(buf, 1, 3, port, address, common.mustNotCall());
+      socket.send(buf, 3, 1, port, address, common.mustNotCall());
       // Since length of zero means nothing, don't error despite OOB.
-      socket.send(buf, 4, 0, address.port, address.address, common.noop);
+      socket.send(buf, 4, 0, port, address, common.mustNotCall());
 
       socket.close();
     }));


### PR DESCRIPTION
* Change common.noop to common.mustNotCall() to verify callback is not
  invoked.
* Add destructuring assignment for clarity. Yeah, clarity. That's why.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dgram