### PR TITLE
src: remove `'` printf modifier

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -146,7 +146,7 @@ inline bool Environment::AsyncHooks::pop_ids(double async_id) {
   if (uid_fields_[kCurrentAsyncId] != async_id) {
     fprintf(stderr,
             "Error: async hook stack has become corrupted ("
-            "actual: %'.f, expected: %'.f)\n",
+            "actual: %.f, expected: %.f)\n",
             uid_fields_[kCurrentAsyncId],
             async_id);
     Environment* env = Environment::GetCurrent(isolate_);


### PR DESCRIPTION
It is not supported on Windows so it emits:
```
warning C4476: 'fprintf' : unknown type field character ''' in format specifier
warning C4474: 'fprintf' : too many arguments passed for format string
```

Fixes: https://github.com/nodejs/node/issues/13463

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src
