### PR TITLE
test: changed test2 & test3 of test-vm-timeout.js

### DIFF
--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -32,12 +32,12 @@ assert.throws(function() {
 // Test 2: Timeout must be >= 0ms
 assert.throws(function() {
   vm.runInThisContext('', { timeout: -1 });
-}, RangeError);
+}, /^RangeError: timeout must be a positive number$/);
 
 // Test 3: Timeout of 0ms
 assert.throws(function() {
   vm.runInThisContext('', { timeout: 0 });
-}, RangeError);
+}, /^RangeError: timeout must be a positive number$/);
 
 // Test 4: Timeout of 1000ms, script finishes first
 vm.runInThisContext('', { timeout: 1000 });


### PR DESCRIPTION
Changed test2 of test-vm-timeout.js so that entire error message
would be matched in assert.throw.
Before test 2 of test-vm-timeout.js would match any RangeError,
now it looks specifically for the error message
"RangeError: timeout must be a positive number"

Changed test 3 of test-vm-timeout.js so that entire error message
would be matched in assert.throw.
Before test 3 of test-vm-timeout.js would match any RangeError,
now it looks specifically for the error message
"RangeError: timeout must be a positive number"

Ref: https://github.com/nodejs/node/issues/13454
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test,vm
