### PR TITLE
test: check callback not invoked on lookup error

### DIFF
--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -24,7 +24,7 @@ assert.throws(() => {
     hints: 100,
     family: 0,
     all: false
-  }, common.noop);
+  }, common.mustNotCall());
 }, /^TypeError: Invalid argument: hints must use valid flags$/);
 
 assert.throws(() => {
@@ -32,7 +32,7 @@ assert.throws(() => {
     hints: 0,
     family: 20,
     all: false
-  }, common.noop);
+  }, common.mustNotCall());
 }, /^TypeError: Invalid argument: family must be 4 or 6$/);
 
 assert.doesNotThrow(() => {


### PR DESCRIPTION
Use `common.mustNotCall()` to confirm that callback is not invoked when
`dns.lookup()` throws.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test dns