### PR TITLE
child_process: improve ipc performance

### DIFF
--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const cluster = require('cluster');
+if (cluster.isMaster) {
+  const common = require('../common.js');
+  const bench = common.createBenchmark(main, {
+    workers: [1],
+    payload: ['string', 'object'],
+    sendsPerBroadcast: [1, 10],
+    n: [1e5]
+  });
+
+  function main(conf) {
+    var n = +conf.n;
+    var workers = +conf.workers;
+    var sends = +conf.sendsPerBroadcast;
+    var expectedPerBroadcast = sends * workers;
+    var payload;
+    var readies = 0;
+    var broadcasts = 0;
+    var msgCount = 0;
+
+    switch (conf.payload) {
+      case 'string':
+        payload = 'hello world!';
+        break;
+      case 'object':
+        payload = { action: 'pewpewpew', powerLevel: 9001 };
+        break;
+      default:
+        throw new Error('Unsupported payload type');
+    }
+
+    for (var i = 0; i < workers; ++i)
+      cluster.fork().on('online', onOnline).on('message', onMessage);
+
+    function onOnline(msg) {
+      if (++readies === workers) {
+        bench.start();
+        broadcast();
+      }
+    }
+
+    function broadcast() {
+      var id;
+      if (broadcasts++ === n) {
+        bench.end(n);
+        for (id in cluster.workers)
+          cluster.workers[id].disconnect();
+        return;
+      }
+      for (id in cluster.workers) {
+        const worker = cluster.workers[id];
+        for (var i = 0; i < sends; ++i)
+          worker.send(payload);
+      }
+    }
+
+    function onMessage(msg) {
+      if (++msgCount === expectedPerBroadcast) {
+        msgCount = 0;
+        broadcast();
+      }
+    }
+  }
+} else {
+  process.on('message', function(msg) {
+    process.send(msg);
+  });
+}

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -456,16 +456,22 @@ function setupChannel(target, channel) {
       }
       chunks[0] = jsonBuffer + chunks[0];
 
+      var nextTick = false;
       for (var i = 0; i < numCompleteChunks; i++) {
         var message = JSON.parse(chunks[i]);
 
         // There will be at most one NODE_HANDLE message in every chunk we
         // read because SCM_RIGHTS messages don't get coalesced. Make sure
         // that we deliver the handle with the right message however.
-        if (message && message.cmd === 'NODE_HANDLE')
-          handleMessage(target, message, recvHandle);
-        else
-          handleMessage(target, message, undefined);
+        if (isInternal(message)) {
+          if (message.cmd === 'NODE_HANDLE')
+            handleMessage(message, recvHandle, true, false);
+          else
+            handleMessage(message, undefined, true, false);
+        } else {
+          handleMessage(message, undefined, false, nextTick);
+          nextTick = true;
+        }
       }
       jsonBuffer = incompleteChunk;
       this.buffering = jsonBuffer.length !== 0;
@@ -526,7 +532,7 @@ function setupChannel(target, channel) {
 
     // Convert handle object
     obj.got.call(this, message, handle, function(handle) {
-      handleMessage(target, message.msg, handle);
+      handleMessage(message.msg, handle, isInternal(message.msg), false);
     });
   });
 
@@ -732,27 +738,32 @@ function setupChannel(target, channel) {
     process.nextTick(finish);
   };
 
+  function emit(event, message, handle) {
+    target.emit(event, message, handle);
+  }
+
+  function handleMessage(message, handle, internal, nextTick) {
+    if (!target.channel)
+      return;
+
+    var eventName = (internal ? 'internalMessage' : 'message');
+    if (nextTick)
+      process.nextTick(emit, eventName, message, handle);
+    else
+      target.emit(eventName, message, handle);
+  }
+
   channel.readStart();
   return control;
 }
 
-
 const INTERNAL_PREFIX = 'NODE_';
-function handleMessage(target, message, handle) {
-  if (!target.channel)
-    return;
-
-  var eventName = 'message';
-  if (message !== null &&
-      typeof message === 'object' &&
-      typeof message.cmd === 'string' &&
-      message.cmd.length > INTERNAL_PREFIX.length &&
-      message.cmd.slice(0, INTERNAL_PREFIX.length) === INTERNAL_PREFIX) {
-    eventName = 'internalMessage';
-  }
-  process.nextTick(() => {
-    target.emit(eventName, message, handle);
-  });
+function isInternal(message) {
+  return (message !== null &&
+          typeof message === 'object' &&
+          typeof message.cmd === 'string' &&
+          message.cmd.length > INTERNAL_PREFIX.length &&
+          message.cmd.slice(0, INTERNAL_PREFIX.length) === INTERNAL_PREFIX);
 }
 
 function nop() { }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -645,16 +645,15 @@ function setupChannel(target, channel) {
           obj.postSend(handle, options, target);
       }
 
-      req.oncomplete = function() {
-        if (this.async === true)
+      if (req.async) {
+        req.oncomplete = function() {
           control.unref();
-        if (typeof callback === 'function')
-          callback(null);
-      };
-      if (req.async === true) {
+          if (typeof callback === 'function')
+            callback(null);
+        };
         control.ref();
-      } else {
-        process.nextTick(function() { req.oncomplete(); });
+      } else if (typeof callback === 'function') {
+        process.nextTick(callback, null);
       }
     } else {
       // Cleanup handle on error


### PR DESCRIPTION
These commits reduce/improve `nextTick()` usage in the `child_process` IPC implementation.

I should point out that I wasn't sure if we should ever need `nextTick()` when receiving/emitting messages, so for now I just made sure that both all internal messages *and* only the first non-internal message in a group are emitted within the same tick.

There is a substantial performance improvement when removing `nextTick()` altogether for emitted messages. My thought was that these messages should always happen on at least the next tick anyway, so perhaps it would be safe to remove it completely? All tests pass with `nextTick()` completely removed from `handleMessage()`.

Results with the current changes with the included benchmark:

```
                                                                           improvement confidence      p.value
 cluster/echo.js n=100000 sendsPerBroadcast=1 payload="object" workers=1      15.62 %        *** 1.440552e-08
 cluster/echo.js n=100000 sendsPerBroadcast=1 payload="string" workers=1      18.59 %        *** 3.478095e-10
 cluster/echo.js n=100000 sendsPerBroadcast=10 payload="object" workers=1     25.71 %        *** 6.436977e-26
 cluster/echo.js n=100000 sendsPerBroadcast=10 payload="string" workers=1     33.88 %        *** 1.812799e-22
```

CI: https://ci.nodejs.org/job/node-test-pull-request/8473/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* child_process
