### PR TITLE
src: rename process._inspectorEnbale

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3400,13 +3400,7 @@ void SetupProcessObject(Environment* env,
     READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
   }
 
-  // TODO(refack): move the following 4 to `node_config`
-  // --inspect
-  if (debug_options.inspector_enabled()) {
-    READONLY_DONT_ENUM_PROPERTY(process,
-                                "_inspectorEnbale", True(env->isolate()));
-  }
-
+  // TODO(refack): move the following 3 to `node_config`
   // --inspect-brk
   if (debug_options.wait_for_connect()) {
     READONLY_DONT_ENUM_PROPERTY(process,


### PR DESCRIPTION
This seems like a typo. This commit changes the property to `process._inspectorEnable`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src