### PR TITLE
doc: update minimum g++ version to 4.9.4

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -81,7 +81,7 @@ Depending on host platform, the selection of toolchains may vary.
 Prerequisites:
 
 * `gcc` and `g++` 4.9.4 or newer, or
-* `clang` and `clang++` 3.4.2 or newer
+* `clang` and `clang++` 3.4.2 or newer (macOS: latest Xcode Command Line Tools)
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -65,7 +65,7 @@ Depending on host platform, the selection of toolchains may vary.
 
 #### Unix
 
-* GCC 4.8.5 or newer
+* GCC 4.9.4 or newer
 * Clang 3.4.2 or newer
 
 #### Windows
@@ -80,7 +80,7 @@ Depending on host platform, the selection of toolchains may vary.
 
 Prerequisites:
 
-* `gcc` and `g++` 4.8.5 or newer, or
+* `gcc` and `g++` 4.9.4 or newer, or
 * `clang` and `clang++` 3.4.2 or newer
 * Python 2.6 or 2.7
 * GNU Make 3.81 or newer


### PR DESCRIPTION
The 4.8.x releases don't fully support C++11.  Update the prerequisites
for node.js 8 so that we won't have to work around compiler bugs in the
future.

To be decided if we should also update the minimum clang version.
I believe clang 3.4.2 properly supports C++11 but am not 100% sure.

Refs: https://github.com/nodejs/node/pull/11840

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
