### PR TITLE
net: use rest parameters instead of arguments

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -90,11 +90,7 @@ function createServer(options, connectionListener) {
 // connect(port, [host], [cb])
 // connect(path, [cb]);
 //
-function connect() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < arguments.length; i++)
-    args[i] = arguments[i];
-  // TODO(joyeecheung): use destructuring when V8 is fast enough
+function connect(...args) {
   var normalized = normalizeArgs(args);
   var options = normalized[0];
   debug('createConnection', normalized);
@@ -934,19 +930,15 @@ function internalConnect(
 }
 
 
-Socket.prototype.connect = function() {
+Socket.prototype.connect = function(...args) {
   let normalized;
   // If passed an array, it's treated as an array of arguments that have
   // already been normalized (so we don't normalize more than once). This has
   // been solved before in https://github.com/nodejs/node/pull/12342, but was
   // reverted as it had unintended side effects.
-  if (Array.isArray(arguments[0]) && arguments[0][normalizedArgsSymbol]) {
-    normalized = arguments[0];
+  if (Array.isArray(args[0]) && args[0][normalizedArgsSymbol]) {
+    normalized = args[0];
   } else {
-    var args = new Array(arguments.length);
-    for (var i = 0; i < arguments.length; i++)
-      args[i] = arguments[i];
-    // TODO(joyeecheung): use destructuring when V8 is fast enough
     normalized = normalizeArgs(args);
   }
   const options = normalized[0];
@@ -1395,11 +1387,7 @@ function listenInCluster(server, address, port, addressType,
 }
 
 
-Server.prototype.listen = function() {
-  var args = new Array(arguments.length);
-  for (var i = 0; i < arguments.length; i++)
-    args[i] = arguments[i];
-  // TODO(joyeecheung): use destructuring when V8 is fast enough
+Server.prototype.listen = function(...args) {
   var normalized = normalizeArgs(args);
   var options = normalized[0];
   var cb = normalized[1];


### PR DESCRIPTION
In v8 5.8, rest parameters are significantly faster than other ways to create an array of the arguments. (And it just looks better.)

Refs: https://github.com/nodejs/node/issues/13430

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net