### PR TITLE
fs: replace a bind() with a top-level function

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2016,7 +2016,7 @@ ReadStream.prototype.close = function(cb) {
 
   if (this.closed || typeof this.fd !== 'number') {
     if (typeof this.fd !== 'number') {
-      this.once('open', this.close.bind(this, null));
+      this.once('open', closeOnOpen);
       return;
     }
     return process.nextTick(() => this.emit('close'));
@@ -2034,6 +2034,11 @@ ReadStream.prototype.close = function(cb) {
   this.fd = null;
 };
 
+// needed because as it will be called with arguments
+// that does not match this.close() signature
+function closeOnOpen(fd) {
+  this.close();
+}
 
 fs.createWriteStream = function(path, options) {
   return new WriteStream(path, options);


### PR DESCRIPTION
#11225 introduce an unnecessary
bind() when closing a stream. This PR replaces that bind() with a
top-level function.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs

edit: updated according to @refack suggestion.