### PR TITLE
build: remove duplicated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,28 +487,25 @@ out/doc/%: doc/%
 
 # check if ./node is actually set, else use user pre-installed binary
 gen-json = tools/doc/generate.js --format=json $< > $@
-out/doc/api/%.json: doc/api/%.md
-	@[ -e tools/doc/node_modules/js-yaml/package.json ] || \
-		[ -e tools/eslint/node_modules/js-yaml/package.json ] || \
-		if [ -x $(NODE) ]; then \
-			cd tools/doc && ../../$(NODE) ../../$(NPM) install; \
-		else \
-			cd tools/doc && node ../../$(NPM) install; \
-		fi
-	[ -x $(NODE) ] && $(NODE) $(gen-json) || node $(gen-json)
-
-# check if ./node is actually set, else use user pre-installed binary
 gen-html = tools/doc/generate.js --node-version=$(FULLVERSION) --format=html \
 			--template=doc/template.html --analytics=$(DOCS_ANALYTICS) $< > $@
-out/doc/api/%.html: doc/api/%.md
-	@[ -e tools/doc/node_modules/js-yaml/package.json ] || \
+
+gen-doc =	\
+	[ -e tools/doc/node_modules/js-yaml/package.json ] || \
 		[ -e tools/eslint/node_modules/js-yaml/package.json ] || \
 		if [ -x $(NODE) ]; then \
 			cd tools/doc && ../../$(NODE) ../../$(NPM) install; \
 		else \
 			cd tools/doc && node ../../$(NPM) install; \
-		fi
-	[ -x $(NODE) ] && $(NODE) $(gen-html) || node $(gen-html)
+		fi;\
+	[ -x $(NODE) ] && $(NODE) $(gen-json) || node
+
+out/doc/api/%.json: doc/api/%.md
+	$(gen-doc) $(gen-json)
+
+# check if ./node is actually set, else use user pre-installed binary
+out/doc/api/%.html: doc/api/%.md
+	$(gen-doc) $(gen-html)
 
 docopen: $(apidocs_html)
 	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html
@@ -866,15 +863,17 @@ bench: bench-net bench-http bench-fs bench-tls
 
 bench-ci: bench
 
+JSLINT_TARGETS = benchmark doc lib test tools
+
 jslint:
 	@echo "Running JS linter..."
 	$(NODE) tools/eslint/bin/eslint.js --cache --rulesdir=tools/eslint-rules --ext=.js,.md \
-	  benchmark doc lib test tools
+	  $(JSLINT_TARGETS)
 
 jslint-ci:
 	@echo "Running JS linter..."
 	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
-		benchmark doc lib test tools
+		$(JSLINT_TARGETS)
 
 CPPLINT_EXCLUDE ?=
 CPPLINT_EXCLUDE += src/node_root_certs.h


### PR DESCRIPTION
Hi :)

I noticed that `Makefile` contains duplicated code in some places and in this PR I tired to move this code to variable where possible. 

Here is exactly what I did:

- `jslint` and `jslint-ci` had (and probably should have) the same list of directories to lint. This list was copy/pasted from one target to another. Just moved it to separated variable.

- targets that generates `json` and `html` docs. There was pretty big bash script with very small difference for these targets. Again, the command was just moved to separated variable. 

There is no issue filled for this, but I hope the change can be useful. 
Thank you. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build