### PR TITLE
async_hooks: rename currentId to currentAsyncId

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -29,11 +29,11 @@ Following is a simple overview of the public API.
 const async_hooks = require('async_hooks');
 
 // Return the ID of the current execution context.
-const cid = async_hooks.executionAsyncId();
+const eid = async_hooks.executionAsyncId();
 
 // Return the ID of the handle responsible for triggering the callback of the
 // current execution scope to call.
-const tid = async_hooks.triggerId();
+const tid = async_hooks.triggerAsyncId();
 
 // Create a new AsyncHook instance. All of these callbacks are optional.
 const asyncHook = async_hooks.createHook({ init, before, after, destroy });
@@ -53,7 +53,7 @@ asyncHook.disable();
 // init is called during object construction. The resource may not have
 // completed construction when this callback runs, therefore all fields of the
 // resource referenced by "asyncId" may not have been populated.
-function init(asyncId, type, triggerId, resource) { }
+function init(asyncId, type, triggerAsyncId, resource) { }
 
 // before is called just before the resource's callback is called. It can be
 // called 0-N times for handles (e.g. TCPWrap), and will be called exactly 1
@@ -163,11 +163,11 @@ Key events in the lifetime of asynchronous events have been categorized into
 four areas: instantiation, before/after the callback is called, and when the
 instance is destructed.
 
-##### `init(asyncId, type, triggerId, resource)`
+##### `init(asyncId, type, triggerAsyncId, resource)`
 
 * `asyncId` {number} a unique ID for the async resource
 * `type` {string} the type of the async resource
-* `triggerId` {number} the unique ID of the async resource in whose
+* `triggerAsyncId` {number} the unique ID of the async resource in whose
   execution context this async resource was created
 * `resource` {Object} reference to the resource representing the async operation,
   needs to be released during _destroy_
@@ -214,20 +214,20 @@ when listening to the hooks.
 
 ###### `triggerId`
 
-`triggerId` is the `asyncId` of the resource that caused (or "triggered") the
+`triggerAsyncId` is the `asyncId` of the resource that caused (or "triggered") the
 new resource to initialize and that caused `init` to call. This is different
 from `async_hooks.executionAsyncId()` that only shows *when* a resource was
-created, while `triggerId` shows *why* a resource was created.
+created, while `triggerAsyncId` shows *why* a resource was created.
 
 
-The following is a simple demonstration of `triggerId`:
+The following is a simple demonstration of `triggerAsyncId`:
 
 ```js
 async_hooks.createHook({
-  init(asyncId, type, triggerId) {
-    const cId = async_hooks.executionAsyncId();
+  init(asyncId, type, triggerAsyncId) {
+    const eid = async_hooks.executionAsyncId();
     fs.writeSync(
-      1, `${type}(${asyncId}): trigger: ${triggerId} scope: ${cId}\n`);
+      1, `${type}(${asyncId}): trigger: ${triggerAsyncId} execution: ${eid}\n`);
   }
 }).enable();
 
@@ -237,8 +237,8 @@ require('net').createServer((conn) => {}).listen(8080);
 Output when hitting the server with `nc localhost 8080`:
 
 ```
-TCPWRAP(2): trigger: 1 scope: 1
-TCPWRAP(4): trigger: 2 scope: 0
+TCPWRAP(2): trigger: 1 execution: 1
+TCPWRAP(4): trigger: 2 execution: 0
 ```
 
 The first `TCPWRAP` is the server which receives the connections.
@@ -248,7 +248,7 @@ connection is made the `TCPWrap` instance is immediately constructed. This
 happens outside of any JavaScript stack (side note: a `executionAsyncId()` of `0`
 means it's being executed from C++, with no JavaScript stack above it).
 With only that information it would be impossible to link resources together in
-terms of what caused them to be created, so `triggerId` is given the task of
+terms of what caused them to be created, so `triggerAsyncId` is given the task of
 propagating what resource is responsible for the new resource's existence.
 
 ###### `resource`
@@ -280,12 +280,13 @@ elaborate to make calling context easier to see.
 ```js
 let indent = 0;
 async_hooks.createHook({
-  init(asyncId, type, triggerId) {
-    const cId = async_hooks.executionAsyncId();
+  init(asyncId, type, triggerAsyncId) {
+    const eid = async_hooks.executionAsyncId();
     const indentStr = ' '.repeat(indent);
     fs.writeSync(
       1,
-      `${indentStr}${type}(${asyncId}): trigger: ${triggerId} scope: ${cId}\n`);
+      `${indentStr}${type}(${asyncId}):` +
+      ` trigger: ${triggerAsyncId} execution: ${eid}\n`);
   },
   before(asyncId) {
     const indentStr = ' '.repeat(indent);
@@ -314,20 +315,20 @@ require('net').createServer(() => {}).listen(8080, () => {
 Output from only starting the server:
 
 ```
-TCPWRAP(2): trigger: 1 scope: 1
-TickObject(3): trigger: 2 scope: 1
+TCPWRAP(2): trigger: 1 execution: 1
+TickObject(3): trigger: 2 execution: 1
 before:  3
-  Timeout(4): trigger: 3 scope: 3
-  TIMERWRAP(5): trigger: 3 scope: 3
+  Timeout(4): trigger: 3 execution: 3
+  TIMERWRAP(5): trigger: 3 execution: 3
 after:   3
 destroy: 3
 before:  5
   before:  4
-    TTYWRAP(6): trigger: 4 scope: 4
-    SIGNALWRAP(7): trigger: 4 scope: 4
-    TTYWRAP(8): trigger: 4 scope: 4
+    TTYWRAP(6): trigger: 4 execution: 4
+    SIGNALWRAP(7): trigger: 4 execution: 4
+    TTYWRAP(8): trigger: 4 execution: 4
 >>> 4
-    TickObject(9): trigger: 4 scope: 4
+    TickObject(9): trigger: 4 execution: 4
   after:   4
 after:   5
 before:  9
@@ -337,11 +338,11 @@ destroy: 9
 destroy: 5
 ```
 
-*Note*: As illustrated in the example, `executionAsyncId()` and `scope` each
-specify the value of the current execution context; which is delineated by
+*Note*: As illustrated in the example, `executionAsyncId()` and `execution`
+each specify the value of the current execution context; which is delineated by
 calls to `before` and `after`.
 
-Only using `scope` to graph resource allocation results in the following:
+Only using `execution` to graph resource allocation results in the following:
 
 ```
 TTYWRAP(6) -> Timeout(4) -> TIMERWRAP(5) -> TickObject(3) -> root(1)
@@ -353,7 +354,7 @@ hostname is actually synchronous, but to maintain a completely asynchronous API
 the user's callback is placed in a `process.nextTick()`.
 
 The graph only shows *when* a resource was created, not *why*, so to track
-the *why* use `triggerId`.
+the *why* use `triggerAsyncId`.
 
 
 ##### `before(asyncId)`
@@ -411,7 +412,7 @@ fs.open(path, 'r', (err, fd) => {
 ```
 
 It is important to note that the ID returned fom `executionAsyncId()` is related
-to execution timing, not causality (which is covered by `triggerId()`). For
+to execution timing, not causality (which is covered by `triggerAsyncId()`). For
 example:
 
 ```js
@@ -428,7 +429,7 @@ const server = net.createServer(function onConnection(conn) {
 });
 ```
 
-#### `async_hooks.triggerId()`
+#### `async_hooks.triggerAsyncId()`
 
 * Returns {number} the ID of the resource responsible for calling the callback
   that is currently being executed.
@@ -438,15 +439,15 @@ For example:
 ```js
 const server = net.createServer((conn) => {
   // The resource that caused (or triggered) this callback to be called
-  // was that of the new connection. Thus the return value of triggerId()
+  // was that of the new connection. Thus the return value of triggerAsyncId()
   // is the asyncId of "conn".
-  async_hooks.triggerId();
+  async_hooks.triggerAsyncId();
 
 }).listen(port, () => {
   // Even though all callbacks passed to .listen() are wrapped in a nextTick()
   // the callback itself exists because the call to the server's .listen()
   // was made. So the return value would be the ID of the server.
-  async_hooks.triggerId();
+  async_hooks.triggerAsyncId();
 });
 ```
 
@@ -475,9 +476,9 @@ The following is an overview of the `AsyncResource` API.
 const { AsyncResource } = require('async_hooks');
 
 // AsyncResource() is meant to be extended. Instantiating a
-// new AsyncResource() also triggers init. If triggerId is omitted then
+// new AsyncResource() also triggers init. If triggerAsyncId is omitted then
 // async_hook.executionAsyncId() is used.
-const asyncResource = new AsyncResource(type, triggerId);
+const asyncResource = new AsyncResource(type, triggerAsyncId);
 
 // Call AsyncHooks before callbacks.
 asyncResource.emitBefore();
@@ -492,14 +493,14 @@ asyncResource.emitDestroy();
 asyncResource.asyncId();
 
 // Return the trigger ID for the AsyncResource instance.
-asyncResource.triggerId();
+asyncResource.triggerAsyncId();
 ```
 
-#### `AsyncResource(type[, triggerId])`
+#### `AsyncResource(type[, triggerAsyncId])`
 
 * arguments
   * `type` {string} the type of ascyc event
-  * `triggerId` {number} the ID of the execution context that created this async
+  * `triggerAsyncId` {number} the ID of the execution context that created this async
     event
 
 Example usage:
@@ -558,9 +559,9 @@ never be called.
 
 * Returns {number} the unique `asyncId` assigned to the resource.
 
-#### `asyncResource.triggerId()`
+#### `asyncResource.triggerAsyncId()`
 
-* Returns {number} the same `triggerId` that is passed to the `AsyncResource`
+* Returns {number} the same `triggerAsyncId` that is passed to the `AsyncResource`
 constructor.
 
 [`Hook Callbacks`]: #hook-callbacks

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -29,7 +29,7 @@ Following is a simple overview of the public API.
 const async_hooks = require('async_hooks');
 
 // Return the ID of the current execution context.
-const cid = async_hooks.currentAsyncId();
+const cid = async_hooks.executionAsyncId();
 
 // Return the ID of the handle responsible for triggering the callback of the
 // current execution scope to call.
@@ -216,7 +216,7 @@ when listening to the hooks.
 
 `triggerId` is the `asyncId` of the resource that caused (or "triggered") the
 new resource to initialize and that caused `init` to call. This is different
-from `async_hooks.currentAsyncId()` that only shows *when* a resource was
+from `async_hooks.executionAsyncId()` that only shows *when* a resource was
 created, while `triggerId` shows *why* a resource was created.
 
 
@@ -225,7 +225,7 @@ The following is a simple demonstration of `triggerId`:
 ```js
 async_hooks.createHook({
   init(asyncId, type, triggerId) {
-    const cId = async_hooks.currentAsyncId();
+    const cId = async_hooks.executionAsyncId();
     fs.writeSync(
       1, `${type}(${asyncId}): trigger: ${triggerId} scope: ${cId}\n`);
   }
@@ -245,7 +245,7 @@ The first `TCPWRAP` is the server which receives the connections.
 
 The second `TCPWRAP` is the new connection from the client. When a new
 connection is made the `TCPWrap` instance is immediately constructed. This
-happens outside of any JavaScript stack (side note: a `currentAsyncId()` of `0`
+happens outside of any JavaScript stack (side note: a `executionAsyncId()` of `0`
 means it's being executed from C++, with no JavaScript stack above it).
 With only that information it would be impossible to link resources together in
 terms of what caused them to be created, so `triggerId` is given the task of
@@ -281,7 +281,7 @@ elaborate to make calling context easier to see.
 let indent = 0;
 async_hooks.createHook({
   init(asyncId, type, triggerId) {
-    const cId = async_hooks.currentAsyncId();
+    const cId = async_hooks.executionAsyncId();
     const indentStr = ' '.repeat(indent);
     fs.writeSync(
       1,
@@ -306,7 +306,7 @@ async_hooks.createHook({
 require('net').createServer(() => {}).listen(8080, () => {
   // Let's wait 10ms before logging the server started.
   setTimeout(() => {
-    console.log('>>>', async_hooks.currentAsyncId());
+    console.log('>>>', async_hooks.executionAsyncId());
   }, 10);
 });
 ```
@@ -337,7 +337,7 @@ destroy: 9
 destroy: 5
 ```
 
-*Note*: As illustrated in the example, `currentAsyncId()` and `scope` each
+*Note*: As illustrated in the example, `executionAsyncId()` and `scope` each
 specify the value of the current execution context; which is delineated by
 calls to `before` and `after`.
 
@@ -396,7 +396,7 @@ the `resource` object passed to `init` it's possible that `destroy` is
 never called, causing a memory leak in the application. Of course if
 the resource doesn't depend on GC then this isn't an issue.
 
-#### `async_hooks.currentAsyncId()`
+#### `async_hooks.executionAsyncId()`
 
 * Returns {number} the `asyncId` of the current execution context. Useful to track
   when something calls.
@@ -404,13 +404,13 @@ the resource doesn't depend on GC then this isn't an issue.
 For example:
 
 ```js
-console.log(async_hooks.currentAsyncId());  // 1 - bootstrap
+console.log(async_hooks.executionAsyncId());  // 1 - bootstrap
 fs.open(path, 'r', (err, fd) => {
-  console.log(async_hooks.currentAsyncId());  // 6 - open()
+  console.log(async_hooks.executionAsyncId());  // 6 - open()
 });
 ```
 
-It is important to note that the ID returned fom `currentAsyncId()` is related
+It is important to note that the ID returned fom `executionAsyncId()` is related
 to execution timing, not causality (which is covered by `triggerId()`). For
 example:
 
@@ -419,12 +419,12 @@ const server = net.createServer(function onConnection(conn) {
   // Returns the ID of the server, not of the new connection, because the
   // onConnection callback runs in the execution scope of the server's
   // MakeCallback().
-  async_hooks.currentAsyncId();
+  async_hooks.executionAsyncId();
 
 }).listen(port, function onListening() {
   // Returns the ID of a TickObject (i.e. process.nextTick()) because all
   // callbacks passed to .listen() are wrapped in a nextTick().
-  async_hooks.currentAsyncId();
+  async_hooks.executionAsyncId();
 });
 ```
 
@@ -476,7 +476,7 @@ const { AsyncResource } = require('async_hooks');
 
 // AsyncResource() is meant to be extended. Instantiating a
 // new AsyncResource() also triggers init. If triggerId is omitted then
-// async_hook.currentAsyncId() is used.
+// async_hook.executionAsyncId() is used.
 const asyncResource = new AsyncResource(type, triggerId);
 
 // Call AsyncHooks before callbacks.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -216,8 +216,8 @@ when listening to the hooks.
 
 `triggerId` is the `asyncId` of the resource that caused (or "triggered") the
 new resource to initialize and that caused `init` to call. This is different
-from `async_hooks.currentAsyncId()` that only shows *when* a resource was created,
-while `triggerId` shows *why* a resource was created.
+from `async_hooks.currentAsyncId()` that only shows *when* a resource was
+created, while `triggerId` shows *why* a resource was created.
 
 
 The following is a simple demonstration of `triggerId`:
@@ -337,9 +337,9 @@ destroy: 9
 destroy: 5
 ```
 
-*Note*: As illustrated in the example, `currentAsyncId()` and `scope` each specify
-the value of the current execution context; which is delineated by calls to
-`before` and `after`.
+*Note*: As illustrated in the example, `currentAsyncId()` and `scope` each
+specify the value of the current execution context; which is delineated by
+calls to `before` and `after`.
 
 Only using `scope` to graph resource allocation results in the following:
 
@@ -410,8 +410,8 @@ fs.open(path, 'r', (err, fd) => {
 });
 ```
 
-It is important to note that the ID returned fom `currentAsyncId()` is related to
-execution timing, not causality (which is covered by `triggerId()`). For
+It is important to note that the ID returned fom `currentAsyncId()` is related
+to execution timing, not causality (which is covered by `triggerId()`). For
 example:
 
 ```js

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -600,6 +600,16 @@ The DebugContext will be removed in V8 soon and will not be available in Node
 
 *Note*: DebugContext was an experimental API.
 
+<a id="DEP0070"></a>
+### DEP0070: async_hooks.currentId()
+
+Type: Runtime
+
+`async_hooks.currentId()` was renamed to `async_hooks.currentAsyncId()` for
+clarity.
+
+*Note*: `async_hooks` was an experimental API.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -610,6 +610,26 @@ clarity.
 
 *Note*: change was made while `async_hooks` was an experimental API.
 
+<a id="DEP0071"></a>
+### DEP0071: async_hooks.triggerId()
+
+Type: Runtime
+
+`async_hooks.triggerId()` was renamed to `async_hooks.triggerAsyncId()` for
+clarity.
+
+*Note*: change was made while `async_hooks` was an experimental API.
+
+<a id="DEP0072"></a>
+### DEP0072: async_hooks.AsyncResource.triggerId()
+
+Type: Runtime
+
+`async_hooks.AsyncResource.triggerId()` was renamed to
+`async_hooks.AsyncResource.triggerAsyncId()` for clarity.
+
+*Note*: change was made while `async_hooks` was an experimental API.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -608,7 +608,7 @@ Type: Runtime
 `async_hooks.currentId()` was renamed to `async_hooks.currentAsyncId()` for
 clarity.
 
-*Note*: `async_hooks` was an experimental API.
+*Note*: change was made while `async_hooks` was an experimental API.
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -605,7 +605,7 @@ The DebugContext will be removed in V8 soon and will not be available in Node
 
 Type: Runtime
 
-`async_hooks.currentId()` was renamed to `async_hooks.currentAsyncId()` for
+`async_hooks.currentId()` was renamed to `async_hooks.executionAsyncId()` for
 clarity.
 
 *Note*: change was made while `async_hooks` was an experimental API.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -192,7 +192,7 @@ function createHook(fns) {
 }
 
 
-function currentAsyncId() {
+function executionAsyncId() {
   return async_uid_fields[kCurrentAsyncId];
 }
 
@@ -257,7 +257,7 @@ class AsyncResource {
 function runInAsyncIdScope(asyncId, cb) {
   // Store the async id now to make sure the stack is still good when the ids
   // are popped off the stack.
-  const prevId = currentAsyncId();
+  const prevId = executionAsyncId();
   pushAsyncIds(asyncId, prevId);
   try {
     cb();
@@ -468,7 +468,7 @@ function init(asyncId, type, triggerId, resource) {
 module.exports = {
   // Public API
   createHook,
-  currentAsyncId,
+  executionAsyncId,
   triggerId,
   // Embedder API
   AsyncResource,
@@ -483,12 +483,12 @@ module.exports = {
   emitDestroy: emitDestroyS,
 };
 
-// currentId was renamed to currentAsyncId. This was in 8.1.0 during the
+// currentId was renamed to executionAsyncId. This was in 8.1.0 during the
 // experimental stage so the alias can be removed at any time, we are just
 // being nice :)
 Object.defineProperty(module.exports, 'currentId', {
   get: internalUtil.deprecate(function() {
-    return currentAsyncId;
+    return executionAsyncId;
   }, 'async_hooks.currentId is deprecated. ' +
-     'Use async_hooks.currentAsyncId instead.', 'DEP0070')
+     'Use async_hooks.executionAsyncId instead.', 'DEP0070')
 });

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const internalUtil = require('internal/util');
 const async_wrap = process.binding('async_wrap');
 /* Both these arrays are used to communicate between JS and C++ with as little
  * overhead as possible.
@@ -481,3 +482,15 @@ module.exports = {
   emitAfter: emitAfterS,
   emitDestroy: emitDestroyS,
 };
+
+// currentId was renamed to currentAsyncId. This was in 8.1.0 during the
+// experimental stage so the alias can be removed at any time, we are just
+// being nice :)
+Object.defineProperty(module.exports, 'currentId', {
+  configurable: true,
+  enumerable: true,
+  get: internalUtil.deprecate(function() {
+    return currentAsyncId;
+  }, 'async_hooks.currentId is deprecated. ' +
+     'Use async_hooks.currentAsyncId instead.', 'DEP0070')
+});

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -191,7 +191,7 @@ function createHook(fns) {
 }
 
 
-function currentId() {
+function currentAsyncId() {
   return async_uid_fields[kCurrentAsyncId];
 }
 
@@ -256,7 +256,7 @@ class AsyncResource {
 function runInAsyncIdScope(asyncId, cb) {
   // Store the async id now to make sure the stack is still good when the ids
   // are popped off the stack.
-  const prevId = currentId();
+  const prevId = currentAsyncId();
   pushAsyncIds(asyncId, prevId);
   try {
     cb();
@@ -467,7 +467,7 @@ function init(asyncId, type, triggerId, resource) {
 module.exports = {
   // Public API
   createHook,
-  currentId,
+  currentAsyncId,
   triggerId,
   // Embedder API
   AsyncResource,

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -487,8 +487,6 @@ module.exports = {
 // experimental stage so the alias can be removed at any time, we are just
 // being nice :)
 Object.defineProperty(module.exports, 'currentId', {
-  configurable: true,
-  enumerable: true,
   get: internalUtil.deprecate(function() {
     return currentAsyncId;
   }, 'async_hooks.currentId is deprecated. ' +

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -197,7 +197,7 @@ function executionAsyncId() {
 }
 
 
-function triggerId() {
+function triggerAsyncId() {
   return async_uid_fields[kCurrentTriggerId];
 }
 
@@ -205,28 +205,28 @@ function triggerId() {
 // Embedder API //
 
 class AsyncResource {
-  constructor(type, triggerId) {
+  constructor(type, triggerAsyncId) {
     this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
     // Read and reset the current kInitTriggerId so that when the constructor
     // finishes the kInitTriggerId field is always 0.
-    if (triggerId === undefined) {
-      triggerId = initTriggerId();
-    // If a triggerId was passed, any kInitTriggerId still must be null'd.
+    if (triggerAsyncId === undefined) {
+      triggerAsyncId = initTriggerId();
+    // If a triggerAsyncId was passed, any kInitTriggerId still must be null'd.
     } else {
       async_uid_fields[kInitTriggerId] = 0;
     }
-    this[trigger_id_symbol] = triggerId;
+    this[trigger_id_symbol] = triggerAsyncId;
 
     if (typeof type !== 'string' || type.length <= 0)
       throw new TypeError('type must be a string with length > 0');
-    if (!Number.isSafeInteger(triggerId) || triggerId < 0)
-      throw new RangeError('triggerId must be an unsigned integer');
+    if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < 0)
+      throw new RangeError('triggerAsyncId must be an unsigned integer');
 
     // Return immediately if there's nothing to do.
     if (async_hook_fields[kInit] === 0)
       return;
 
-    init(this[async_id_symbol], type, triggerId, this);
+    init(this[async_id_symbol], type, triggerAsyncId, this);
   }
 
   emitBefore() {
@@ -248,10 +248,21 @@ class AsyncResource {
     return this[async_id_symbol];
   }
 
-  triggerId() {
+  triggerAsyncId() {
     return this[trigger_id_symbol];
   }
 }
+
+
+// triggerId was renamed to triggerAsyncId. This was in 8.2.0 during the
+// experimental stage so the alias can be removed at any time, we are just
+// being nice :)
+Object.defineProperty(AsyncResource.prototype, 'triggerId', {
+  get: internalUtil.deprecate(function() {
+    return AsyncResource.prototype.triggerAsyncId;
+  }, 'AsyncResource.triggerId is deprecated. ' +
+     'Use AsyncResource.triggerAsyncId instead.', 'DEP0072')
+});
 
 
 function runInAsyncIdScope(asyncId, cb) {
@@ -277,8 +288,8 @@ function newUid() {
 }
 
 
-// Return the triggerId meant for the constructor calling it. It's up to the
-// user to safeguard this call and make sure it's zero'd out when the
+// Return the triggerAsyncId meant for the constructor calling it. It's up to
+// the user to safeguard this call and make sure it's zero'd out when the
 // constructor is complete.
 function initTriggerId() {
   var tId = async_uid_fields[kInitTriggerId];
@@ -291,14 +302,14 @@ function initTriggerId() {
 }
 
 
-function setInitTriggerId(triggerId) {
-  // CHECK(Number.isSafeInteger(triggerId))
-  // CHECK(triggerId > 0)
-  async_uid_fields[kInitTriggerId] = triggerId;
+function setInitTriggerId(triggerAsyncId) {
+  // CHECK(Number.isSafeInteger(triggerAsyncId))
+  // CHECK(triggerAsyncId > 0)
+  async_uid_fields[kInitTriggerId] = triggerAsyncId;
 }
 
 
-function emitInitS(asyncId, type, triggerId, resource) {
+function emitInitS(asyncId, type, triggerAsyncId, resource) {
   // Short circuit all checks for the common case. Which is that no hooks have
   // been set. Do this to remove performance impact for embedders (and core).
   // Even though it bypasses all the argument checks. The performance savings
@@ -308,10 +319,10 @@ function emitInitS(asyncId, type, triggerId, resource) {
 
   // This can run after the early return check b/c running this function
   // manually means that the embedder must have used initTriggerId().
-  if (!Number.isSafeInteger(triggerId)) {
-    if (triggerId !== undefined)
-      resource = triggerId;
-    triggerId = initTriggerId();
+  if (!Number.isSafeInteger(triggerAsyncId)) {
+    if (triggerAsyncId !== undefined)
+      resource = triggerAsyncId;
+    triggerAsyncId = initTriggerId();
   }
 
   // I'd prefer allowing these checks to not exist, or only throw in a debug
@@ -320,10 +331,10 @@ function emitInitS(asyncId, type, triggerId, resource) {
     throw new RangeError('asyncId must be an unsigned integer');
   if (typeof type !== 'string' || type.length <= 0)
     throw new TypeError('type must be a string with length > 0');
-  if (!Number.isSafeInteger(triggerId) || triggerId < 0)
-    throw new RangeError('triggerId must be an unsigned integer');
+  if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < 0)
+    throw new RangeError('triggerAsyncId must be an unsigned integer');
 
-  init(asyncId, type, triggerId, resource);
+  init(asyncId, type, triggerAsyncId, resource);
 
   // Isn't null if hooks were added/removed while the hooks were running.
   if (tmp_active_hooks_array !== null) {
@@ -352,19 +363,19 @@ function emitBeforeN(asyncId) {
 }
 
 
-// Usage: emitBeforeS(asyncId[, triggerId]). If triggerId is omitted then
-// asyncId will be used instead.
-function emitBeforeS(asyncId, triggerId = asyncId) {
+// Usage: emitBeforeS(asyncId[, triggerAsyncId]). If triggerAsyncId is omitted
+// then asyncId will be used instead.
+function emitBeforeS(asyncId, triggerAsyncId = asyncId) {
   // CHECK(Number.isSafeInteger(asyncId) && asyncId > 0)
-  // CHECK(Number.isSafeInteger(triggerId) && triggerId > 0)
+  // CHECK(Number.isSafeInteger(triggerAsyncId) && triggerAsyncId > 0)
 
   // Validate the ids.
-  if (asyncId < 0 || triggerId < 0) {
-    fatalError('before(): asyncId or triggerId is less than zero ' +
-               `(asyncId: ${asyncId}, triggerId: ${triggerId})`);
+  if (asyncId < 0 || triggerAsyncId < 0) {
+    fatalError('before(): asyncId or triggerAsyncId is less than zero ' +
+               `(asyncId: ${asyncId}, triggerAsyncId: ${triggerAsyncId})`);
   }
 
-  pushAsyncIds(asyncId, triggerId);
+  pushAsyncIds(asyncId, triggerAsyncId);
 
   if (async_hook_fields[kBefore] === 0)
     return;
@@ -447,13 +458,16 @@ function emitDestroyN(asyncId) {
 // change in the future depending on whether it can be determined if there's a
 // slim chance of the application remaining stable after handling one of these
 // exceptions.
-function init(asyncId, type, triggerId, resource) {
+function init(asyncId, type, triggerAsyncId, resource) {
   processing_hook = true;
   // Use a single try/catch for all hook to avoid setting up one per iteration.
   try {
     for (var i = 0; i < active_hooks_array.length; i++) {
       if (typeof active_hooks_array[i][init_symbol] === 'function') {
-        active_hooks_array[i][init_symbol](asyncId, type, triggerId, resource);
+        active_hooks_array[i][init_symbol](
+            asyncId, type, triggerAsyncId,
+            resource
+        );
       }
     }
   } catch (e) {
@@ -469,7 +483,7 @@ module.exports = {
   // Public API
   createHook,
   executionAsyncId,
-  triggerId,
+  triggerAsyncId,
   // Embedder API
   AsyncResource,
   runInAsyncIdScope,
@@ -483,7 +497,7 @@ module.exports = {
   emitDestroy: emitDestroyS,
 };
 
-// currentId was renamed to executionAsyncId. This was in 8.1.0 during the
+// currentId was renamed to executionAsyncId. This was in 8.2.0 during the
 // experimental stage so the alias can be removed at any time, we are just
 // being nice :)
 Object.defineProperty(module.exports, 'currentId', {
@@ -491,4 +505,14 @@ Object.defineProperty(module.exports, 'currentId', {
     return executionAsyncId;
   }, 'async_hooks.currentId is deprecated. ' +
      'Use async_hooks.executionAsyncId instead.', 'DEP0070')
+});
+
+// triggerId was renamed to triggerAsyncId. This was in 8.2.0 during the
+// experimental stage so the alias can be removed at any time, we are just
+// being nice :)
+Object.defineProperty(module.exports, 'triggerId', {
+  get: internalUtil.deprecate(function() {
+    return triggerAsyncId;
+  }, 'async_hooks.triggerId is deprecated. ' +
+     'Use async_hooks.triggerAsyncId instead.', 'DEP0071')
 });

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -114,11 +114,11 @@ function setupNextTick() {
   // is much slower here than was the Float64Array stack used in a previous
   // implementation. Problem is the Float64Array stack was a bit brittle.
   // Investigate how to harden that implementation and possibly reintroduce it.
-  function nextTickEmitBefore(asyncId, triggerId) {
+  function nextTickEmitBefore(asyncId, triggerAsyncId) {
     if (async_hook_fields[kBefore] > 0)
-      emitBefore(asyncId, triggerId);
+      emitBefore(asyncId, triggerAsyncId);
     else
-      pushAsyncIds(asyncId, triggerId);
+      pushAsyncIds(asyncId, triggerAsyncId);
   }
 
   function nextTickEmitAfter(asyncId) {
@@ -218,9 +218,9 @@ function setupNextTick() {
     this[trigger_id_symbol] = -1;
   }
 
-  function setupInit(tickObject, triggerId) {
+  function setupInit(tickObject, triggerAsyncId) {
     tickObject[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
-    tickObject[trigger_id_symbol] = triggerId || initTriggerId();
+    tickObject[trigger_id_symbol] = triggerAsyncId || initTriggerId();
     if (async_hook_fields[kInit] > 0) {
       emitInit(tickObject[async_id_symbol],
                'TickObject',
@@ -249,11 +249,11 @@ function setupNextTick() {
     tickInfo[kLength]++;
   }
 
-  function internalNextTick(triggerId, callback) {
+  function internalNextTick(triggerAsyncId, callback) {
     if (typeof callback !== 'function')
       throw new TypeError('callback is not a function');
-    // CHECK(Number.isSafeInteger(triggerId) || triggerId === null)
-    // CHECK(triggerId > 0 || triggerId === null)
+    // CHECK(Number.isSafeInteger(triggerAsyncId) || triggerAsyncId === null)
+    // CHECK(triggerAsyncId > 0 || triggerAsyncId === null)
 
     if (process._exiting)
       return;
@@ -266,7 +266,7 @@ function setupNextTick() {
     }
 
     var obj = new TickObject(callback, args, process.domain || null);
-    setupInit(obj, triggerId);
+    setupInit(obj, triggerAsyncId);
     // The call to initTriggerId() was skipped, so clear kInitTriggerId.
     async_uid_fields[kInitTriggerId] = 0;
     nextTickQueue.push(obj);

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -43,7 +43,7 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
     async_wrap.constants;
 // Symbols for storing async id state.
 const async_id_symbol = Symbol('asyncId');
-const trigger_id_symbol = Symbol('triggerId');
+const trigger_id_symbol = Symbol('triggerAsyncId');
 
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1
@@ -149,11 +149,11 @@ exports._unrefActive = function(item) {
 };
 
 
-function timerEmitBefore(asyncId, triggerId) {
+function timerEmitBefore(asyncId, triggerAsyncId) {
   if (async_hook_fields[kBefore] > 0)
-    emitBefore(asyncId, triggerId);
+    emitBefore(asyncId, triggerAsyncId);
   else
-    pushAsyncIds(asyncId, triggerId);
+    pushAsyncIds(asyncId, triggerAsyncId);
 }
 
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -731,12 +731,12 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 /* Public C++ embedder API */
 
 
-async_uid AsyncHooksGetCurrentId(Isolate* isolate) {
+async_uid AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->current_async_id();
 }
 
 
-async_uid AsyncHooksGetTriggerId(Isolate* isolate) {
+async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->get_init_trigger_id();
 }
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -735,9 +735,19 @@ async_uid AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->current_async_id();
 }
 
+[[deprecated("Use AsyncHooksGetExecutionAsyncId(isolate)")]]
+async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate) {
+  return AsyncHooksGetExecutionAsyncId(isolate);
+}
+
 
 async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->get_init_trigger_id();
+}
+
+[[deprecated("Use AsyncHooksGetTriggerAsyncId(isolate)")]]
+async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate) {
+  return AsyncHooksGetTriggerAsyncId(isolate);
 }
 
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -736,7 +736,7 @@ async_uid AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
 }
 
 [[deprecated("Use AsyncHooksGetExecutionAsyncId(isolate)")]]
-async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate) {
+async_uid AsyncHooksGetCurrentId(Isolate* isolate) {
   return AsyncHooksGetExecutionAsyncId(isolate);
 }
 
@@ -746,7 +746,7 @@ async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
 }
 
 [[deprecated("Use AsyncHooksGetTriggerAsyncId(isolate)")]]
-async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate) {
+async_uid AsyncHooksGetTriggerId(Isolate* isolate) {
   return AsyncHooksGetTriggerAsyncId(isolate);
 }
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -735,7 +735,6 @@ async_uid AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->current_async_id();
 }
 
-[[deprecated("Use AsyncHooksGetExecutionAsyncId(isolate)")]]
 async_uid AsyncHooksGetCurrentId(Isolate* isolate) {
   return AsyncHooksGetExecutionAsyncId(isolate);
 }
@@ -745,7 +744,6 @@ async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->get_init_trigger_id();
 }
 
-[[deprecated("Use AsyncHooksGetTriggerAsyncId(isolate)")]]
 async_uid AsyncHooksGetTriggerId(Isolate* isolate) {
   return AsyncHooksGetTriggerAsyncId(isolate);
 }

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -350,11 +350,11 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
     bool silent = type != PromiseHookType::kInit;
     PromiseWrap* parent_wrap = nullptr;
 
-    // set parent promise's async Id as this promise's triggerId
+    // set parent promise's async Id as this promise's triggerAsyncId
     if (parent->IsPromise()) {
       // parent promise exists, current promise
       // is a chained promise, so we set parent promise's id as
-      // current promise's triggerId
+      // current promise's triggerAsyncId
       Local<Promise> parent_promise = parent.As<Promise>();
       Local<Value> parent_resource = parent_promise->GetInternalField(0);
       if (parent_resource->IsObject()) {

--- a/src/node.h
+++ b/src/node.h
@@ -530,7 +530,7 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
  * I/O from native code. */
 NODE_EXTERN async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate);
 
-/* Return same value as async_hooks.triggerId(); */
+/* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate);
 
 /* If the native API doesn't inherit from the helper class then the callbacks
@@ -554,7 +554,7 @@ NODE_EXTERN void EmitAsyncDestroy(v8::Isolate* isolate, async_uid id);
  * These methods may create handles on their own, so run them inside a
  * HandleScope.
  *
- * `asyncId` and `triggerId` should correspond to the values returned by
+ * `asyncId` and `triggerAsyncId` should correspond to the values returned by
  * `EmitAsyncInit()` and `AsyncHooksGetTriggerId()`, respectively, when the
  * invoking resource was created. If these values are unknown, 0 can be passed.
  * */
@@ -565,7 +565,7 @@ v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        int argc,
                                        v8::Local<v8::Value>* argv,
                                        async_uid asyncId,
-                                       async_uid triggerId);
+                                       async_uid triggerAsyncId);
 NODE_EXTERN
 v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        v8::Local<v8::Object> recv,
@@ -573,7 +573,7 @@ v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        int argc,
                                        v8::Local<v8::Value>* argv,
                                        async_uid asyncId,
-                                       async_uid triggerId);
+                                       async_uid triggerAsyncId);
 NODE_EXTERN
 v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        v8::Local<v8::Object> recv,
@@ -581,7 +581,7 @@ v8::MaybeLocal<v8::Value> MakeCallback(v8::Isolate* isolate,
                                        int argc,
                                        v8::Local<v8::Value>* argv,
                                        async_uid asyncId,
-                                       async_uid triggerId);
+                                       async_uid triggerAsyncId);
 
 /* Helper class users can optionally inherit from. If
  * `AsyncResource::MakeCallback()` is used, then all four callbacks will be

--- a/src/node.h
+++ b/src/node.h
@@ -528,22 +528,22 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
 /* Returns the id of the current execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
-NODE_EXTERN async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate);
+NODE_EXTERN async_uid AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 
 /* Return same value as async_hooks.triggerAsyncId(); */
-NODE_EXTERN async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate);
+NODE_EXTERN async_uid AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
 
 /* If the native API doesn't inherit from the helper class then the callbacks
  * must be triggered manually. This triggers the init() callback. The return
  * value is the uid assigned to the resource.
  *
- * The `trigger_id` parameter should correspond to the resource which is
+ * The `trigger_async_id` parameter should correspond to the resource which is
  * creating the new resource, which will usually be the return value of
- * `AsyncHooksGetTriggerId()`. */
+ * `AsyncHooksGetTriggerAsyncId()`. */
 NODE_EXTERN async_uid EmitAsyncInit(v8::Isolate* isolate,
                                     v8::Local<v8::Object> resource,
                                     const char* name,
-                                    async_uid trigger_id);
+                                    async_uid trigger_async_id);
 
 /* Emit the destroy() callback. */
 NODE_EXTERN void EmitAsyncDestroy(v8::Isolate* isolate, async_uid id);
@@ -555,7 +555,7 @@ NODE_EXTERN void EmitAsyncDestroy(v8::Isolate* isolate, async_uid id);
  * HandleScope.
  *
  * `asyncId` and `triggerAsyncId` should correspond to the values returned by
- * `EmitAsyncInit()` and `AsyncHooksGetTriggerId()`, respectively, when the
+ * `EmitAsyncInit()` and `AsyncHooksGetTriggerAsyncId()`, respectively, when the
  * invoking resource was created. If these values are unknown, 0 can be passed.
  * */
 NODE_EXTERN
@@ -591,14 +591,14 @@ class AsyncResource {
     AsyncResource(v8::Isolate* isolate,
                   v8::Local<v8::Object> resource,
                   const char* name,
-                  async_uid trigger_id = -1)
+                  async_uid trigger_async_id = -1)
         : isolate_(isolate),
           resource_(isolate, resource),
-          trigger_id_(trigger_id) {
-      if (trigger_id_ == -1)
-        trigger_id_ = AsyncHooksGetTriggerId(isolate);
+          trigger_async_id_(trigger_async_id) {
+      if (trigger_async_id_ == -1)
+        trigger_async_id_ = AsyncHooksGetTriggerAsyncId(isolate);
 
-      uid_ = EmitAsyncInit(isolate, resource, name, trigger_id_);
+      uid_ = EmitAsyncInit(isolate, resource, name, trigger_async_id_);
     }
 
     ~AsyncResource() {
@@ -611,7 +611,7 @@ class AsyncResource {
         v8::Local<v8::Value>* argv) {
       return node::MakeCallback(isolate_, get_resource(),
                                 callback, argc, argv,
-                                uid_, trigger_id_);
+                                uid_, trigger_async_id_);
     }
 
     v8::MaybeLocal<v8::Value> MakeCallback(
@@ -620,7 +620,7 @@ class AsyncResource {
         v8::Local<v8::Value>* argv) {
       return node::MakeCallback(isolate_, get_resource(),
                                 method, argc, argv,
-                                uid_, trigger_id_);
+                                uid_, trigger_async_id_);
     }
 
     v8::MaybeLocal<v8::Value> MakeCallback(
@@ -629,7 +629,7 @@ class AsyncResource {
         v8::Local<v8::Value>* argv) {
       return node::MakeCallback(isolate_, get_resource(),
                                 symbol, argc, argv,
-                                uid_, trigger_id_);
+                                uid_, trigger_async_id_);
     }
 
     v8::Local<v8::Object> get_resource() {
@@ -643,7 +643,7 @@ class AsyncResource {
     v8::Isolate* isolate_;
     v8::Persistent<v8::Object> resource_;
     async_uid uid_;
-    async_uid trigger_id_;
+    async_uid trigger_async_id_;
 };
 
 }  // namespace node

--- a/src/node.h
+++ b/src/node.h
@@ -530,14 +530,15 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
  * I/O from native code. */
 NODE_EXTERN async_uid AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 /* legacy alias */
-[[deprecated("Use AsyncHooksGetExecutionAsyncId(isolate)")]]
-NODE_EXTERN async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate);
+NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetExecutionAsyncId(isolate)",
+                async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate));
+
 
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_uid AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
 /* legacy alias */
-[[deprecated("Use AsyncHooksGetTriggerAsyncId(isolate)")]]
-NODE_EXTERN async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate);
+NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
+                async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate));
 
 
 /* If the native API doesn't inherit from the helper class then the callbacks

--- a/src/node.h
+++ b/src/node.h
@@ -530,18 +530,14 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
  * I/O from native code. */
 NODE_EXTERN async_uid AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 /* legacy alias */
-NODE_DEPRECATED("Use AsyncHooksGetExecutionAsyncId(isolate)",
-                inline async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate) {
-  return AsyncHooksGetExecutionAsyncId(isolate);
-})
+[[deprecated("Use AsyncHooksGetExecutionAsyncId(isolate)")]]
+NODE_EXTERN async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate);
 
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_uid AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
 /* legacy alias */
-NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
-                inline async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate) {
-  return AsyncHooksGetTriggerAsyncId(isolate);
-})
+[[deprecated("Use AsyncHooksGetTriggerAsyncId(isolate)")]]
+NODE_EXTERN async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate);
 
 
 /* If the native API doesn't inherit from the helper class then the callbacks

--- a/src/node.h
+++ b/src/node.h
@@ -529,9 +529,20 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
 NODE_EXTERN async_uid AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
+/* legacy alias */
+NODE_DEPRECATED("Use AsyncHooksGetExecutionAsyncId(isolate)",
+                inline async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate) {
+  return AsyncHooksGetExecutionAsyncId(isolate);
+})
 
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_uid AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
+/* legacy alias */
+NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
+                inline async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate) {
+  return AsyncHooksGetTriggerAsyncId(isolate);
+})
+
 
 /* If the native API doesn't inherit from the helper class then the callbacks
  * must be triggered manually. This triggers the init() callback. The return

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -93,7 +93,7 @@ void GetResource(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GetCurrentId(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(node::AsyncHooksGetCurrentId(args.GetIsolate()));
+  args.GetReturnValue().Set(node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
 }
 
 void Initialize(Local<Object> exports) {

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -93,7 +93,8 @@ void GetResource(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GetCurrentId(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
+  args.GetReturnValue().Set(
+    node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
 }
 
 void Initialize(Local<Object> exports) {

--- a/test/addons/async-resource/test.js
+++ b/test/addons/async-resource/test.js
@@ -14,13 +14,13 @@ let after = 0;
 let destroy = 0;
 
 async_hooks.createHook({
-  init(id, type, triggerId, resource) {
+  init(id, type, triggerAsyncId, resource) {
     assert.strictEqual(typeof id, 'number');
     assert.strictEqual(typeof resource, 'object');
     assert(id > 1);
     if (type === 'foobär') {
       assert.strictEqual(resource.kObjectTag, kObjectTag);
-      assert.strictEqual(triggerId, expectedTriggerId);
+      assert.strictEqual(triggerAsyncId, expectedTriggerId);
       bindingUids.push(id);
     }
   },

--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -162,12 +162,12 @@ class ActivityCollector {
     return h;
   }
 
-  _init(uid, type, triggerId, handle) {
-    const activity = { uid, type, triggerId };
+  _init(uid, type, triggerAsyncId, handle) {
+    const activity = { uid, type, triggerAsyncId };
     this._stamp(activity, 'init');
     this._activities.set(uid, activity);
     this._maybeLog(uid, type, 'init');
-    this.oninit(uid, type, triggerId, handle);
+    this.oninit(uid, type, triggerAsyncId, handle);
   }
 
   _before(uid) {

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -12,7 +12,7 @@ switch (process.argv[2]) {
       oninit: common.mustCall(() => { throw new Error('test_init_callback'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentId(), 'test_init_callback_type',
+    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_init_callback_type',
                          async_hooks.triggerId());
     break;
   case 'test_callback':
@@ -20,16 +20,16 @@ switch (process.argv[2]) {
       onbefore: common.mustCall(() => { throw new Error('test_callback'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentId(), 'test_callback_type',
+    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_callback_type',
                          async_hooks.triggerId());
-    async_hooks.emitBefore(async_hooks.currentId());
+    async_hooks.emitBefore(async_hooks.currentAsyncId());
     break;
   case 'test_callback_abort':
     initHooks({
       oninit: common.mustCall(() => { throw new Error('test_callback_abort'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentId(), 'test_callback_abort',
+    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_callback_abort',
                          async_hooks.triggerId());
     break;
 }

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -14,7 +14,7 @@ switch (process.argv[2]) {
 
     async_hooks.emitInit(async_hooks.executionAsyncId(),
                          'test_init_callback_type',
-                         async_hooks.triggerId());
+                         async_hooks.triggerAsyncId());
     break;
   case 'test_callback':
     initHooks({
@@ -22,7 +22,7 @@ switch (process.argv[2]) {
     }).enable();
 
     async_hooks.emitInit(async_hooks.executionAsyncId(), 'test_callback_type',
-                         async_hooks.triggerId());
+                         async_hooks.triggerAsyncId());
     async_hooks.emitBefore(async_hooks.executionAsyncId());
     break;
   case 'test_callback_abort':
@@ -31,7 +31,7 @@ switch (process.argv[2]) {
     }).enable();
 
     async_hooks.emitInit(async_hooks.executionAsyncId(), 'test_callback_abort',
-                         async_hooks.triggerId());
+                         async_hooks.triggerAsyncId());
     break;
 }
 

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -12,7 +12,8 @@ switch (process.argv[2]) {
       oninit: common.mustCall(() => { throw new Error('test_init_callback'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_init_callback_type',
+    async_hooks.emitInit(async_hooks.executionAsyncId(),
+                         'test_init_callback_type',
                          async_hooks.triggerId());
     break;
   case 'test_callback':
@@ -20,16 +21,16 @@ switch (process.argv[2]) {
       onbefore: common.mustCall(() => { throw new Error('test_callback'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_callback_type',
+    async_hooks.emitInit(async_hooks.executionAsyncId(), 'test_callback_type',
                          async_hooks.triggerId());
-    async_hooks.emitBefore(async_hooks.currentAsyncId());
+    async_hooks.emitBefore(async_hooks.executionAsyncId());
     break;
   case 'test_callback_abort':
     initHooks({
       oninit: common.mustCall(() => { throw new Error('test_callback_abort'); })
     }).enable();
 
-    async_hooks.emitInit(async_hooks.currentAsyncId(), 'test_callback_abort',
+    async_hooks.emitInit(async_hooks.executionAsyncId(), 'test_callback_abort',
                          async_hooks.triggerId());
     break;
 }

--- a/test/async-hooks/test-connection.ssl.js
+++ b/test/async-hooks/test-connection.ssl.js
@@ -42,7 +42,7 @@ assert.strictEqual(as.length, 1);
 const f1 = as[0];
 assert.strictEqual(f1.type, 'SSLCONNECTION');
 assert.strictEqual(typeof f1.uid, 'number');
-assert.strictEqual(typeof f1.triggerId, 'number');
+assert.strictEqual(typeof f1.triggerAsyncId, 'number');
 checkInvocations(f1, { init: 1 }, 'first connection, when first created');
 
 // creating second server connection
@@ -53,7 +53,7 @@ assert.strictEqual(as.length, 2);
 const f2 = as[1];
 assert.strictEqual(f2.type, 'SSLCONNECTION');
 assert.strictEqual(typeof f2.uid, 'number');
-assert.strictEqual(typeof f2.triggerId, 'number');
+assert.strictEqual(typeof f2.triggerAsyncId, 'number');
 checkInvocations(f1, { init: 1 }, 'first connection, when second created');
 checkInvocations(f2, { init: 1 }, 'second connection, when second created');
 

--- a/test/async-hooks/test-crypto-pbkdf2.js
+++ b/test/async-hooks/test-crypto-pbkdf2.js
@@ -36,7 +36,7 @@ function onexit() {
   const a = as[0];
   assert.strictEqual(a.type, 'PBKDF2REQUEST');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(a.triggerId, 1);
+  assert.strictEqual(a.triggerAsyncId, 1);
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-crypto-randomBytes.js
+++ b/test/async-hooks/test-crypto-randomBytes.js
@@ -37,7 +37,7 @@ function onexit() {
   const a = as[0];
   assert.strictEqual(a.type, 'RANDOMBYTESREQUEST');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(a.triggerId, 1);
+  assert.strictEqual(a.triggerAsyncId, 1);
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'after'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
+  const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'after' after 'destroy'
-  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
+  const event2 = new AsyncResource('event2', async_hooks.executionAsyncId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.after-on-destroyed.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'after'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncResource('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'after' after 'destroy'
-  const event2 = new AsyncResource('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'before'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncResource('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'before' after 'destroy'
-  const event2 = new AsyncResource('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
+++ b/test/async-hooks/test-embedder.api.async-resource.before-on-destroyed.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // once 'destroy' has been emitted, we can no longer emit 'before'
 
   // Emitting 'before', 'after' and then 'destroy'
-  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
+  const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());
   event1.emitBefore();
   event1.emitAfter();
   event1.emitDestroy();
 
   // Emitting 'before' after 'destroy'
-  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
+  const event2 = new AsyncResource('event2', async_hooks.executionAsyncId());
   event2.emitDestroy();
 
   console.log('heartbeat: still alive');

--- a/test/async-hooks/test-embedder.api.async-resource.improper-order.js
+++ b/test/async-hooks/test-embedder.api.async-resource.improper-order.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // async hooks enforce proper order of 'before' and 'after' invocations
 
   // Proper ordering
-  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
+  const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());
   event1.emitBefore();
   event1.emitAfter();
 
   // Improper ordering
   // Emitting 'after' without 'before' which is illegal
-  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
+  const event2 = new AsyncResource('event2', async_hooks.executionAsyncId());
 
   console.log('heartbeat: still alive');
   event2.emitAfter();

--- a/test/async-hooks/test-embedder.api.async-resource.improper-order.js
+++ b/test/async-hooks/test-embedder.api.async-resource.improper-order.js
@@ -17,13 +17,13 @@ if (process.argv[2] === 'child') {
   // async hooks enforce proper order of 'before' and 'after' invocations
 
   // Proper ordering
-  const event1 = new AsyncResource('event1', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
   event1.emitBefore();
   event1.emitAfter();
 
   // Improper ordering
   // Emitting 'after' without 'before' which is illegal
-  const event2 = new AsyncResource('event2', async_hooks.currentId());
+  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
 
   console.log('heartbeat: still alive');
   event2.emitAfter();

--- a/test/async-hooks/test-embedder.api.async-resource.improper-unwind.js
+++ b/test/async-hooks/test-embedder.api.async-resource.improper-unwind.js
@@ -21,8 +21,8 @@ if (process.argv[2] === 'child') {
   // The first test of the two below follows that rule,
   // the second one doesnt.
 
-  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
-  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
+  const event1 = new AsyncResource('event1', async_hooks.executionAsyncId());
+  const event2 = new AsyncResource('event2', async_hooks.executionAsyncId());
 
   // Proper unwind
   event1.emitBefore();

--- a/test/async-hooks/test-embedder.api.async-resource.improper-unwind.js
+++ b/test/async-hooks/test-embedder.api.async-resource.improper-unwind.js
@@ -21,8 +21,8 @@ if (process.argv[2] === 'child') {
   // The first test of the two below follows that rule,
   // the second one doesnt.
 
-  const event1 = new AsyncResource('event1', async_hooks.currentId());
-  const event2 = new AsyncResource('event2', async_hooks.currentId());
+  const event1 = new AsyncResource('event1', async_hooks.currentAsyncId());
+  const event2 = new AsyncResource('event2', async_hooks.currentAsyncId());
 
   // Proper unwind
   event1.emitBefore();

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -21,8 +21,8 @@ assert.strictEqual(typeof new AsyncResource('default_trigger_id').triggerId(),
                    'number');
 
 // create first custom event 'alcazares' with triggerId derived
-// from async_hooks currentId
-const alcaTriggerId = async_hooks.currentId();
+// from async_hooks currentAsyncId
+const alcaTriggerId = async_hooks.currentAsyncId();
 const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
 const alcazaresActivities = hooks.activitiesOfTypes([ 'alcazares' ]);
 

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -15,12 +15,14 @@ hooks.enable();
 assert.throws(() => new AsyncResource(),
               /^TypeError: type must be a string with length > 0$/);
 assert.throws(() => new AsyncResource('invalid_trigger_id', null),
-              /^RangeError: triggerId must be an unsigned integer$/);
+              /^RangeError: triggerAsyncId must be an unsigned integer$/);
 
-assert.strictEqual(typeof new AsyncResource('default_trigger_id').triggerId(),
-                   'number');
+assert.strictEqual(
+    typeof new AsyncResource('default_trigger_id').triggerAsyncId(),
+    'number'
+);
 
-// create first custom event 'alcazares' with triggerId derived
+// create first custom event 'alcazares' with triggerAsyncId derived
 // from async_hooks executionAsyncId
 const alcaTriggerId = async_hooks.executionAsyncId();
 const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
@@ -31,12 +33,12 @@ assert.strictEqual(alcazaresActivities.length, 1);
 const alcazares = alcazaresActivities[0];
 assert.strictEqual(alcazares.type, 'alcazares');
 assert.strictEqual(typeof alcazares.uid, 'number');
-assert.strictEqual(alcazares.triggerId, alcaTriggerId);
+assert.strictEqual(alcazares.triggerAsyncId, alcaTriggerId);
 checkInvocations(alcazares, { init: 1 }, 'alcazares constructed');
 
 assert.strictEqual(typeof alcaEvent.asyncId(), 'number');
 assert.notStrictEqual(alcaEvent.asyncId(), alcaTriggerId);
-assert.strictEqual(alcaEvent.triggerId(), alcaTriggerId);
+assert.strictEqual(alcaEvent.triggerAsyncId(), alcaTriggerId);
 
 alcaEvent.emitBefore();
 checkInvocations(alcazares, { init: 1, before: 1 },
@@ -64,7 +66,7 @@ function tick1() {
   const poblado = pobladoActivities[0];
   assert.strictEqual(poblado.type, 'poblado');
   assert.strictEqual(typeof poblado.uid, 'number');
-  assert.strictEqual(poblado.triggerId, pobTriggerId);
+  assert.strictEqual(poblado.triggerAsyncId, pobTriggerId);
   checkInvocations(poblado, { init: 1 }, 'poblado constructed');
   pobEvent.emitBefore();
   checkInvocations(poblado, { init: 1, before: 1 },

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -21,8 +21,8 @@ assert.strictEqual(typeof new AsyncResource('default_trigger_id').triggerId(),
                    'number');
 
 // create first custom event 'alcazares' with triggerId derived
-// from async_hooks currentAsyncId
-const alcaTriggerId = async_hooks.currentAsyncId();
+// from async_hooks executionAsyncId
+const alcaTriggerId = async_hooks.executionAsyncId();
 const alcaEvent = new AsyncResource('alcazares', alcaTriggerId);
 const alcazaresActivities = hooks.activitiesOfTypes([ 'alcazares' ]);
 

--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -17,14 +17,14 @@ switch (process.argv[2]) {
 
 const c1 = spawnSync(process.execPath, [__filename, 'test_invalid_async_id']);
 assert.strictEqual(c1.stderr.toString().split('\n')[0],
-                   'Error: before(): asyncId or triggerId is less than zero ' +
-                   '(asyncId: -1, triggerId: -1)');
+                   'Error: before(): asyncId or triggerAsyncId is less than ' +
+                   'zero (asyncId: -1, triggerAsyncId: -1)');
 assert.strictEqual(c1.status, 1);
 
 const c2 = spawnSync(process.execPath, [__filename, 'test_invalid_trigger_id']);
 assert.strictEqual(c2.stderr.toString().split('\n')[0],
-                   'Error: before(): asyncId or triggerId is less than zero ' +
-                   '(asyncId: 1, triggerId: -1)');
+                   'Error: before(): asyncId or triggerAsyncId is less than ' +
+                   'zero (asyncId: 1, triggerAsyncId: -1)');
 assert.strictEqual(c2.status, 1);
 
 const expectedId = async_hooks.newUid();

--- a/test/async-hooks/test-emit-init.js
+++ b/test/async-hooks/test-emit-init.js
@@ -15,10 +15,10 @@ const expectedType = 'test_emit_init_type';
 const expectedResource = { key: 'test_emit_init_resource' };
 
 const hooks1 = initHooks({
-  oninit: common.mustCall((id, type, triggerId, resource) => {
+  oninit: common.mustCall((id, type, triggerAsyncId, resource) => {
     assert.strictEqual(id, expectedId);
     assert.strictEqual(type, expectedType);
-    assert.strictEqual(triggerId, expectedTriggerId);
+    assert.strictEqual(triggerAsyncId, expectedTriggerId);
     assert.strictEqual(resource.key, expectedResource.key);
   })
 });
@@ -30,7 +30,7 @@ assert.throws(() => async_hooks.emitInit(),
 assert.throws(() => async_hooks.emitInit(expectedId),
               /^TypeError: type must be a string with length > 0$/);
 assert.throws(() => async_hooks.emitInit(expectedId, expectedType, -1),
-              /^RangeError: triggerId must be an unsigned integer$/);
+              /^RangeError: triggerAsyncId must be an unsigned integer$/);
 
 async_hooks.emitInit(expectedId, expectedType, expectedTriggerId,
                      expectedResource);
@@ -38,10 +38,10 @@ async_hooks.emitInit(expectedId, expectedType, expectedTriggerId,
 hooks1.disable();
 
 initHooks({
-  oninit: common.mustCall((id, type, triggerId, resource) => {
+  oninit: common.mustCall((id, type, triggerAsyncId, resource) => {
     assert.strictEqual(id, expectedId);
     assert.strictEqual(type, expectedType);
-    assert.notStrictEqual(triggerId, expectedTriggerId);
+    assert.notStrictEqual(triggerAsyncId, expectedTriggerId);
     assert.strictEqual(resource.key, expectedResource.key);
   })
 }).enable();

--- a/test/async-hooks/test-enable-disable.js
+++ b/test/async-hooks/test-enable-disable.js
@@ -159,7 +159,7 @@ function onfirstImmediate() {
   assert.strictEqual(as3[0].uid, as1[0].uid);
   assert.strictEqual(firstImmediate.type, 'Immediate');
   assert.strictEqual(typeof firstImmediate.uid, 'number');
-  assert.strictEqual(typeof firstImmediate.triggerId, 'number');
+  assert.strictEqual(typeof firstImmediate.triggerAsyncId, 'number');
   checkInvocations(as1[0], { init: 1, before: 1 },
                    'hook1[0]: on first immediate');
   checkInvocations(as3[0], { init: 1, before: 1 },
@@ -207,7 +207,7 @@ function onsecondImmediate() {
   assert.strictEqual(hook1Second.uid, hook3Second.uid);
   assert.strictEqual(secondImmediate.type, 'Immediate');
   assert.strictEqual(typeof secondImmediate.uid, 'number');
-  assert.strictEqual(typeof secondImmediate.triggerId, 'number');
+  assert.strictEqual(typeof secondImmediate.triggerAsyncId, 'number');
 
   checkInvocations(hook1First, { init: 1, before: 1, after: 1, destroy: 1 },
                    'hook1First: on second immediate');

--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -28,6 +28,6 @@ function onexit() {
   const a = as[0];
   assert.strictEqual(a.type, 'FSEVENTWRAP');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(a.triggerId, 1);
+  assert.strictEqual(a.triggerAsyncId, 1);
   checkInvocations(a, { init: 1, destroy: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-fsreqwrap-readFile.js
+++ b/test/async-hooks/test-fsreqwrap-readFile.js
@@ -19,7 +19,7 @@ function onread() {
     const a = as[i];
     assert.strictEqual(a.type, 'FSREQWRAP');
     assert.strictEqual(typeof a.uid, 'number');
-    assert.strictEqual(a.triggerId, lastParent);
+    assert.strictEqual(a.triggerAsyncId, lastParent);
     lastParent = a.uid;
   }
   checkInvocations(as[0], { init: 1, before: 1, after: 1, destroy: 1 },

--- a/test/async-hooks/test-getaddrinforeqwrap.js
+++ b/test/async-hooks/test-getaddrinforeqwrap.js
@@ -21,7 +21,7 @@ function onlookup(err_, ip, family) {
   const a = as[0];
   assert.strictEqual(a.type, 'GETADDRINFOREQWRAP');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(a.triggerId, 1);
+  assert.strictEqual(a.triggerAsyncId, 1);
   checkInvocations(a, { init: 1, before: 1 }, 'while in onlookup callback');
   tick(2);
 }

--- a/test/async-hooks/test-getnameinforeqwrap.js
+++ b/test/async-hooks/test-getnameinforeqwrap.js
@@ -21,7 +21,7 @@ function onlookupService(err_, ip, family) {
   const a = as[0];
   assert.strictEqual(a.type, 'GETNAMEINFOREQWRAP');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(a.triggerId, 1);
+  assert.strictEqual(a.triggerAsyncId, 1);
   checkInvocations(a, { init: 1, before: 1 },
                    'while in onlookupService callback');
   tick(2);

--- a/test/async-hooks/test-graph.connection.js
+++ b/test/async-hooks/test-graph.connection.js
@@ -38,7 +38,7 @@ sc1.start();
 
 function onfirstHandShake() {
   // Create second connection inside handshake of first to show
-  // that the triggerId of the second will be set to id of the first
+  // that the triggerAsyncId of the second will be set to id of the first
   const sc2 = createServerConnection(common.mustCall(onsecondHandShake));
   sc2.start();
 }
@@ -50,7 +50,8 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'CONNECTION', id: 'connection:1', triggerId: null },
-      { type: 'CONNECTION', id: 'connection:2', triggerId: 'connection:1' } ]
+    [ { type: 'CONNECTION', id: 'connection:1', triggerAsyncId: null },
+      { type: 'CONNECTION', id: 'connection:2',
+        triggerAsyncId: 'connection:1' } ]
   );
 }

--- a/test/async-hooks/test-graph.fsreq-readFile.js
+++ b/test/async-hooks/test-graph.fsreq-readFile.js
@@ -18,9 +18,9 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'FSREQWRAP', id: 'fsreq:1', triggerId: null },
-      { type: 'FSREQWRAP', id: 'fsreq:2', triggerId: 'fsreq:1' },
-      { type: 'FSREQWRAP', id: 'fsreq:3', triggerId: 'fsreq:2' },
-      { type: 'FSREQWRAP', id: 'fsreq:4', triggerId: 'fsreq:3' } ]
+    [ { type: 'FSREQWRAP', id: 'fsreq:1', triggerAsyncId: null },
+      { type: 'FSREQWRAP', id: 'fsreq:2', triggerAsyncId: 'fsreq:1' },
+      { type: 'FSREQWRAP', id: 'fsreq:3', triggerAsyncId: 'fsreq:2' },
+      { type: 'FSREQWRAP', id: 'fsreq:4', triggerAsyncId: 'fsreq:3' } ]
   );
 }

--- a/test/async-hooks/test-graph.intervals.js
+++ b/test/async-hooks/test-graph.intervals.js
@@ -29,9 +29,9 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'Timeout', id: 'timeout:1', triggerId: null },
-      { type: 'TIMERWRAP', id: 'timer:1', triggerId: null },
-      { type: 'Timeout', id: 'timeout:2', triggerId: 'timeout:1' },
-      { type: 'TIMERWRAP', id: 'timer:2', triggerId: 'timeout:1' } ]
+    [ { type: 'Timeout', id: 'timeout:1', triggerAsyncId: null },
+      { type: 'TIMERWRAP', id: 'timer:1', triggerAsyncId: null },
+      { type: 'Timeout', id: 'timeout:2', triggerAsyncId: 'timeout:1' },
+      { type: 'TIMERWRAP', id: 'timer:2', triggerAsyncId: 'timeout:1' } ]
   );
 }

--- a/test/async-hooks/test-graph.pipe.js
+++ b/test/async-hooks/test-graph.pipe.js
@@ -24,9 +24,9 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'PROCESSWRAP', id: 'process:1', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:1', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:2', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:3', triggerId: null } ]
+    [ { type: 'PROCESSWRAP', id: 'process:1', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:1', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:2', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:3', triggerAsyncId: null } ]
   );
 }

--- a/test/async-hooks/test-graph.pipeconnect.js
+++ b/test/async-hooks/test-graph.pipeconnect.js
@@ -28,10 +28,11 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'PIPEWRAP', id: 'pipe:1', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:2', triggerId: 'pipe:1' },
-      { type: 'PIPECONNECTWRAP', id: 'pipeconnect:1', triggerId: 'pipe:2' },
-      { type: 'PIPEWRAP', id: 'pipe:3', triggerId: 'pipe:1' },
-      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerId: 'pipe:3' } ]
+    [ { type: 'PIPEWRAP', id: 'pipe:1', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:2', triggerAsyncId: 'pipe:1' },
+      { type: 'PIPECONNECTWRAP', id: 'pipeconnect:1',
+        triggerAsyncId: 'pipe:2' },
+      { type: 'PIPEWRAP', id: 'pipe:3', triggerAsyncId: 'pipe:1' },
+      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerAsyncId: 'pipe:3' } ]
   );
 }

--- a/test/async-hooks/test-graph.shutdown.js
+++ b/test/async-hooks/test-graph.shutdown.js
@@ -37,13 +37,13 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'TCPWRAP', id: 'tcp:1', triggerId: null },
-      { type: 'TCPWRAP', id: 'tcp:2', triggerId: 'tcp:1' },
+    [ { type: 'TCPWRAP', id: 'tcp:1', triggerAsyncId: null },
+      { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcp:1' },
       { type: 'GETADDRINFOREQWRAP',
-        id: 'getaddrinforeq:1', triggerId: 'tcp:2' },
+        id: 'getaddrinforeq:1', triggerAsyncId: 'tcp:2' },
       { type: 'TCPCONNECTWRAP',
-        id: 'tcpconnect:1', triggerId: 'tcp:2' },
-      { type: 'TCPWRAP', id: 'tcp:3', triggerId: 'tcp:1' },
-      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerId: 'tcp:3' } ]
+        id: 'tcpconnect:1', triggerAsyncId: 'tcp:2' },
+      { type: 'TCPWRAP', id: 'tcp:3', triggerAsyncId: 'tcp:1' },
+      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerAsyncId: 'tcp:3' } ]
   );
 }

--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -36,19 +36,19 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'SIGNALWRAP', id: 'signal:1', triggerId: null },
-      { type: 'PROCESSWRAP', id: 'process:1', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:1', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:2', triggerId: null },
-      { type: 'PIPEWRAP', id: 'pipe:3', triggerId: null },
-      { type: 'PROCESSWRAP', id: 'process:2', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:4', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:5', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:6', triggerId: 'signal:1' },
-      { type: 'SIGNALWRAP', id: 'signal:2', triggerId: 'signal:1' },
-      { type: 'PROCESSWRAP', id: 'process:3', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:7', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:8', triggerId: 'signal:1' },
-      { type: 'PIPEWRAP', id: 'pipe:9', triggerId: 'signal:1' } ]
+    [ { type: 'SIGNALWRAP', id: 'signal:1', triggerAsyncId: null },
+      { type: 'PROCESSWRAP', id: 'process:1', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:1', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:2', triggerAsyncId: null },
+      { type: 'PIPEWRAP', id: 'pipe:3', triggerAsyncId: null },
+      { type: 'PROCESSWRAP', id: 'process:2', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:4', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:5', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:6', triggerAsyncId: 'signal:1' },
+      { type: 'SIGNALWRAP', id: 'signal:2', triggerAsyncId: 'signal:1' },
+      { type: 'PROCESSWRAP', id: 'process:3', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:7', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:8', triggerAsyncId: 'signal:1' },
+      { type: 'PIPEWRAP', id: 'pipe:9', triggerAsyncId: 'signal:1' } ]
   );
 }

--- a/test/async-hooks/test-graph.statwatcher.js
+++ b/test/async-hooks/test-graph.statwatcher.js
@@ -28,7 +28,7 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'STATWATCHER', id: 'statwatcher:1', triggerId: null },
-      { type: 'STATWATCHER', id: 'statwatcher:2', triggerId: null } ]
+    [ { type: 'STATWATCHER', id: 'statwatcher:1', triggerAsyncId: null },
+      { type: 'STATWATCHER', id: 'statwatcher:2', triggerAsyncId: null } ]
   );
 }

--- a/test/async-hooks/test-graph.tcp.js
+++ b/test/async-hooks/test-graph.tcp.js
@@ -41,11 +41,11 @@ function onexit() {
 
   verifyGraph(
     hooks,
-    [ { type: 'TCPWRAP', id: 'tcp:1', triggerId: null },
-      { type: 'TCPWRAP', id: 'tcp:2', triggerId: null },
+    [ { type: 'TCPWRAP', id: 'tcp:1', triggerAsyncId: null },
+      { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: null },
       { type: 'TCPCONNECTWRAP',
-        id: 'tcpconnect:1', triggerId: 'tcp:2' },
-      { type: 'TCPWRAP', id: 'tcp:3', triggerId: 'tcp:1' },
-      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerId: 'tcp:3' } ]
+        id: 'tcpconnect:1', triggerAsyncId: 'tcp:2' },
+      { type: 'TCPWRAP', id: 'tcp:3', triggerAsyncId: 'tcp:1' },
+      { type: 'SHUTDOWNWRAP', id: 'shutdown:1', triggerAsyncId: 'tcp:3' } ]
   );
 }

--- a/test/async-hooks/test-graph.timeouts.js
+++ b/test/async-hooks/test-graph.timeouts.js
@@ -25,11 +25,11 @@ function onexit() {
   hooks.disable();
   verifyGraph(
     hooks,
-    [ { type: 'Timeout', id: 'timeout:1', triggerId: null },
-      { type: 'TIMERWRAP', id: 'timer:1', triggerId: null },
-      { type: 'Timeout', id: 'timeout:2', triggerId: 'timeout:1' },
-      { type: 'TIMERWRAP', id: 'timer:2', triggerId: 'timeout:1' },
-      { type: 'Timeout', id: 'timeout:3', triggerId: 'timeout:2' },
-      { type: 'TIMERWRAP', id: 'timer:3', triggerId: 'timeout:2' } ]
+    [ { type: 'Timeout', id: 'timeout:1', triggerAsyncId: null },
+      { type: 'TIMERWRAP', id: 'timer:1', triggerAsyncId: null },
+      { type: 'Timeout', id: 'timeout:2', triggerAsyncId: 'timeout:1' },
+      { type: 'TIMERWRAP', id: 'timer:2', triggerAsyncId: 'timeout:1' },
+      { type: 'Timeout', id: 'timeout:3', triggerAsyncId: 'timeout:2' },
+      { type: 'TIMERWRAP', id: 'timer:3', triggerAsyncId: 'timeout:2' } ]
   );
 }

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -59,21 +59,21 @@ function onexit() {
 
   verifyGraph(
     hooks,
-    [ { type: 'TCPWRAP', id: 'tcp:1', triggerId: null },
-      { type: 'TCPWRAP', id: 'tcp:2', triggerId: 'tcp:1' },
-      { type: 'TLSWRAP', id: 'tls:1', triggerId: 'tcp:1' },
+    [ { type: 'TCPWRAP', id: 'tcp:1', triggerAsyncId: null },
+      { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcp:1' },
+      { type: 'TLSWRAP', id: 'tls:1', triggerAsyncId: 'tcp:1' },
       { type: 'GETADDRINFOREQWRAP',
-        id: 'getaddrinforeq:1', triggerId: 'tls:1' },
+        id: 'getaddrinforeq:1', triggerAsyncId: 'tls:1' },
       { type: 'TCPCONNECTWRAP',
-        id: 'tcpconnect:1', triggerId: 'tcp:2' },
-      { type: 'WRITEWRAP', id: 'write:1', triggerId: 'tcpconnect:1' },
-      { type: 'TCPWRAP', id: 'tcp:3', triggerId: 'tcp:1' },
-      { type: 'TLSWRAP', id: 'tls:2', triggerId: 'tcp:1' },
-      { type: 'TIMERWRAP', id: 'timer:1', triggerId: 'tcp:1' },
-      { type: 'WRITEWRAP', id: 'write:2', triggerId: null },
-      { type: 'WRITEWRAP', id: 'write:3', triggerId: null },
-      { type: 'WRITEWRAP', id: 'write:4', triggerId: null },
-      { type: 'Immediate', id: 'immediate:1', triggerId: 'tcp:2' },
-      { type: 'Immediate', id: 'immediate:2', triggerId: 'tcp:3' } ]
+        id: 'tcpconnect:1', triggerAsyncId: 'tcp:2' },
+      { type: 'WRITEWRAP', id: 'write:1', triggerAsyncId: 'tcpconnect:1' },
+      { type: 'TCPWRAP', id: 'tcp:3', triggerAsyncId: 'tcp:1' },
+      { type: 'TLSWRAP', id: 'tls:2', triggerAsyncId: 'tcp:1' },
+      { type: 'TIMERWRAP', id: 'timer:1', triggerAsyncId: 'tcp:1' },
+      { type: 'WRITEWRAP', id: 'write:2', triggerAsyncId: null },
+      { type: 'WRITEWRAP', id: 'write:3', triggerAsyncId: null },
+      { type: 'WRITEWRAP', id: 'write:4', triggerAsyncId: null },
+      { type: 'Immediate', id: 'immediate:1', triggerAsyncId: 'tcp:2' },
+      { type: 'Immediate', id: 'immediate:2', triggerAsyncId: 'tcp:3' } ]
   );
 }

--- a/test/async-hooks/test-httpparser.request.js
+++ b/test/async-hooks/test-httpparser.request.js
@@ -28,7 +28,7 @@ const httpparser = as[0];
 
 assert.strictEqual(as.length, 1);
 assert.strictEqual(typeof httpparser.uid, 'number');
-assert.strictEqual(typeof httpparser.triggerId, 'number');
+assert.strictEqual(typeof httpparser.triggerAsyncId, 'number');
 checkInvocations(httpparser, { init: 1 }, 'when created new Httphttpparser');
 
 parser[kOnHeadersComplete] = common.mustCall(onheadersComplete);

--- a/test/async-hooks/test-httpparser.response.js
+++ b/test/async-hooks/test-httpparser.response.js
@@ -32,7 +32,7 @@ const httpparser = as[0];
 
 assert.strictEqual(as.length, 1);
 assert.strictEqual(typeof httpparser.uid, 'number');
-assert.strictEqual(typeof httpparser.triggerId, 'number');
+assert.strictEqual(typeof httpparser.triggerAsyncId, 'number');
 checkInvocations(httpparser, { init: 1 }, 'when created new Httphttpparser');
 
 parser[kOnHeadersComplete] = common.mustCall(onheadersComplete);

--- a/test/async-hooks/test-immediate.js
+++ b/test/async-hooks/test-immediate.js
@@ -17,7 +17,7 @@ assert.strictEqual(as.length, 1);
 const imd1 = as[0];
 assert.strictEqual(imd1.type, 'Immediate');
 assert.strictEqual(typeof imd1.uid, 'number');
-assert.strictEqual(typeof imd1.triggerId, 'number');
+assert.strictEqual(typeof imd1.triggerAsyncId, 'number');
 checkInvocations(imd1, { init: 1 },
                  'imd1: when first set immediate installed');
 
@@ -36,7 +36,7 @@ function onimmediate() {
   imd2 = as[1];
   assert.strictEqual(imd2.type, 'Immediate');
   assert.strictEqual(typeof imd2.uid, 'number');
-  assert.strictEqual(typeof imd2.triggerId, 'number');
+  assert.strictEqual(typeof imd2.triggerAsyncId, 'number');
   checkInvocations(imd1, { init: 1, before: 1 },
                    'imd1: when second set immediate installed');
   checkInvocations(imd2, { init: 1 },

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -44,7 +44,7 @@ function onlisten() {
   assert.strictEqual(pipeconnect.type, 'PIPECONNECTWRAP');
   for (const a of [ pipe1, pipe2, pipeconnect ]) {
     assert.strictEqual(typeof a.uid, 'number');
-    assert.strictEqual(typeof a.triggerId, 'number');
+    assert.strictEqual(typeof a.triggerAsyncId, 'number');
     checkInvocations(a, { init: 1 }, 'after net.connect');
   }
 }
@@ -64,7 +64,7 @@ function maybeOnconnect(source) {
   assert.strictEqual(pipeconnects.length, 1);
   pipe3 = pipes[2];
   assert.strictEqual(typeof pipe3.uid, 'number');
-  assert.strictEqual(typeof pipe3.triggerId, 'number');
+  assert.strictEqual(typeof pipe3.triggerAsyncId, 'number');
 
   checkInvocations(pipe1, { init: 1, before: 1, after: 1 },
                    'pipe1, client connected');

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -32,13 +32,13 @@ const pipe2 = pipes[1];
 const pipe3 = pipes[2];
 
 assert.strictEqual(processwrap.type, 'PROCESSWRAP');
-assert.strictEqual(processwrap.triggerId, 1);
+assert.strictEqual(processwrap.triggerAsyncId, 1);
 checkInvocations(processwrap, { init: 1 },
                  'processwrap when sleep.spawn was called');
 
 [ pipe1, pipe2, pipe3 ].forEach((x) => {
   assert.strictEqual(x.type, 'PIPEWRAP');
-  assert.strictEqual(x.triggerId, 1);
+  assert.strictEqual(x.triggerAsyncId, 1);
   checkInvocations(x, { init: 1 }, 'pipe wrap when sleep.spawn was called');
 });
 
@@ -70,7 +70,7 @@ function onexit() {
 
   [ pipe1, pipe2, pipe3 ].forEach((x) => {
     assert.strictEqual(x.type, 'PIPEWRAP');
-    assert.strictEqual(x.triggerId, 1);
+    assert.strictEqual(x.triggerAsyncId, 1);
   });
 
   const ioEvents = Math.min(pipe2.before.length, pipe2.after.length);

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -40,13 +40,13 @@ function onexit() {
   const a0 = as[0];
   assert.strictEqual(a0.type, 'PROMISE');
   assert.strictEqual(typeof a0.uid, 'number');
-  assert.strictEqual(a0.triggerId, 1);
+  assert.strictEqual(a0.triggerAsyncId, 1);
   checkInvocations(a0, { init: 1 }, 'when process exits');
 
   const a1 = as[1];
   assert.strictEqual(a1.type, 'PROMISE');
   assert.strictEqual(typeof a1.uid, 'number');
-  assert.strictEqual(a1.triggerId, a0.uid);
+  assert.strictEqual(a1.triggerAsyncId, a0.uid);
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -36,7 +36,7 @@ process.on('exit', function onexit() {
   // never called. However, it is known that the parent promise was created
   // immediately before the child promise, thus there should only be one
   // difference in id.
-  assert.strictEqual(a0.triggerId, a0.uid - 1);
+  assert.strictEqual(a0.triggerAsyncId, a0.uid - 1);
   // We expect a destroy hook as well but we cannot guarentee predictable gc.
   checkInvocations(a0, { init: 1, before: 1, after: 1 }, 'when process exits');
 });

--- a/test/async-hooks/test-querywrap.js
+++ b/test/async-hooks/test-querywrap.js
@@ -34,7 +34,7 @@ function onexit() {
 
   assert.strictEqual(a.type, 'QUERYWRAP');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(typeof a.triggerId, 'number');
+  assert.strictEqual(typeof a.triggerAsyncId, 'number');
   checkInvocations(a, { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-shutdownwrap.js
+++ b/test/async-hooks/test-shutdownwrap.js
@@ -55,7 +55,7 @@ function onexit() {
   const a = as[0];
   assert.strictEqual(a.type, 'SHUTDOWNWRAP');
   assert.strictEqual(typeof a.uid, 'number');
-  assert.strictEqual(typeof a.triggerId, 'number');
+  assert.strictEqual(typeof a.triggerAsyncId, 'number');
   checkInvocations(as[0], { init: 1, before: 1, after: 1, destroy: 1 },
                    'when process exits');
 }

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -16,7 +16,7 @@ assert.strictEqual(as.length, 1);
 const signal1 = as[0];
 assert.strictEqual(signal1.type, 'SIGNALWRAP');
 assert.strictEqual(typeof signal1.uid, 'number');
-assert.strictEqual(typeof signal1.triggerId, 'number');
+assert.strictEqual(typeof signal1.triggerAsyncId, 'number');
 checkInvocations(signal1, { init: 1 }, 'when SIGUSR2 handler is set up');
 
 let count = 0;
@@ -50,7 +50,7 @@ function onsigusr2() {
     signal2 = as[1];
     assert.strictEqual(signal2.type, 'SIGNALWRAP');
     assert.strictEqual(typeof signal2.uid, 'number');
-    assert.strictEqual(typeof signal2.triggerId, 'number');
+    assert.strictEqual(typeof signal2.triggerAsyncId, 'number');
 
     checkInvocations(
       signal1, { init: 1, before: 2, after: 1 },

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -20,7 +20,7 @@ assert.strictEqual(as.length, 1);
 const statwatcher1 = as[0];
 assert.strictEqual(statwatcher1.type, 'STATWATCHER');
 assert.strictEqual(typeof statwatcher1.uid, 'number');
-assert.strictEqual(statwatcher1.triggerId, 1);
+assert.strictEqual(statwatcher1.triggerAsyncId, 1);
 checkInvocations(statwatcher1, { init: 1 },
                  'watcher1: when started to watch file');
 
@@ -32,7 +32,7 @@ assert.strictEqual(as.length, 2);
 const statwatcher2 = as[1];
 assert.strictEqual(statwatcher2.type, 'STATWATCHER');
 assert.strictEqual(typeof statwatcher2.uid, 'number');
-assert.strictEqual(statwatcher2.triggerId, 1);
+assert.strictEqual(statwatcher2.triggerAsyncId, 1);
 checkInvocations(statwatcher1, { init: 1 },
                  'watcher1: when started to watch second file');
 checkInvocations(statwatcher2, { init: 1 },

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -34,7 +34,7 @@ const server = net
   tcp1 = tcps[0];
   assert.strictEqual(tcp1.type, 'TCPWRAP');
   assert.strictEqual(typeof tcp1.uid, 'number');
-  assert.strictEqual(typeof tcp1.triggerId, 'number');
+  assert.strictEqual(typeof tcp1.triggerAsyncId, 'number');
   checkInvocations(tcp1, { init: 1 }, 'when calling server.listen');
 }
 
@@ -54,7 +54,7 @@ const server = net
   assert.strictEqual(tcps.length, 2);
   assert.strictEqual(tcp2.type, 'TCPWRAP');
   assert.strictEqual(typeof tcp2.uid, 'number');
-  assert.strictEqual(typeof tcp2.triggerId, 'number');
+  assert.strictEqual(typeof tcp2.triggerAsyncId, 'number');
 
   checkInvocations(tcp1, { init: 1 }, 'tcp1 when client is connecting');
   checkInvocations(tcp2, { init: 1 }, 'tcp2 when client is connecting');
@@ -86,7 +86,7 @@ function ontcpConnection(serverConnection) {
   tcpconnect = tcpconnects[0];
   assert.strictEqual(tcpconnect.type, 'TCPCONNECTWRAP');
   assert.strictEqual(typeof tcpconnect.uid, 'number');
-  assert.strictEqual(typeof tcpconnect.triggerId, 'number');
+  assert.strictEqual(typeof tcpconnect.triggerAsyncId, 'number');
   // When client receives connection first ('onconnected'), we 'before' has
   // been invoked at this point already, otherwise it only was 'init'ed
   const expected = serverConnection ? { init: 1 } : { init: 1, before: 1 };
@@ -117,7 +117,7 @@ function onconnection(c) {
   tcp3 = tcps[2];
   assert.strictEqual(tcp3.type, 'TCPWRAP');
   assert.strictEqual(typeof tcp3.uid, 'number');
-  assert.strictEqual(typeof tcp3.triggerId, 'number');
+  assert.strictEqual(typeof tcp3.triggerAsyncId, 'number');
 
   checkInvocations(tcp1, { init: 1, before: 1 },
                    'tcp1 when server receives connection');

--- a/test/async-hooks/test-timerwrap.setInterval.js
+++ b/test/async-hooks/test-timerwrap.setInterval.js
@@ -18,7 +18,7 @@ assert.strictEqual(as.length, 1);
 const t = as[0];
 assert.strictEqual(t.type, 'TIMERWRAP');
 assert.strictEqual(typeof t.uid, 'number');
-assert.strictEqual(typeof t.triggerId, 'number');
+assert.strictEqual(typeof t.triggerAsyncId, 'number');
 checkInvocations(t, { init: 1 }, 't: when first timer installed');
 
 function oninterval() {

--- a/test/async-hooks/test-timerwrap.setTimeout.js
+++ b/test/async-hooks/test-timerwrap.setTimeout.js
@@ -17,7 +17,7 @@ assert.strictEqual(as.length, 1);
 const t1 = as[0];
 assert.strictEqual(t1.type, 'TIMERWRAP');
 assert.strictEqual(typeof t1.uid, 'number');
-assert.strictEqual(typeof t1.triggerId, 'number');
+assert.strictEqual(typeof t1.triggerAsyncId, 'number');
 checkInvocations(t1, { init: 1 }, 't1: when first timer installed');
 
 function ontimeout() {
@@ -48,7 +48,7 @@ function onsecondTimeout() {
   t2 = as[1];
   assert.strictEqual(t2.type, 'TIMERWRAP');
   assert.strictEqual(typeof t2.uid, 'number');
-  assert.strictEqual(typeof t2.triggerId, 'number');
+  assert.strictEqual(typeof t2.triggerAsyncId, 'number');
   checkInvocations(t1, { init: 1, before: 2, after: 1 },
                    't1: when third timer installed');
   checkInvocations(t2, { init: 1 },

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -43,7 +43,7 @@ function onlistening() {
 
   assert.strictEqual(svr.type, 'TLSWRAP');
   assert.strictEqual(typeof svr.uid, 'number');
-  assert.strictEqual(typeof svr.triggerId, 'number');
+  assert.strictEqual(typeof svr.triggerAsyncId, 'number');
   checkInvocations(svr, { init: 1 }, 'server: when client connecting');
 }
 
@@ -56,7 +56,7 @@ function onsecureConnection() {
   client = as[1];
   assert.strictEqual(client.type, 'TLSWRAP');
   assert.strictEqual(typeof client.uid, 'number');
-  assert.strictEqual(typeof client.triggerId, 'number');
+  assert.strictEqual(typeof client.triggerAsyncId, 'number');
 
   // TODO(thlorenz) which callback did the server wrap execute that already
   // finished as well?

--- a/test/async-hooks/test-ttywrap.readstream.js
+++ b/test/async-hooks/test-ttywrap.readstream.js
@@ -17,7 +17,7 @@ assert.strictEqual(as.length, 1);
 const tty = as[0];
 assert.strictEqual(tty.type, 'TTYWRAP');
 assert.strictEqual(typeof tty.uid, 'number');
-assert.strictEqual(typeof tty.triggerId, 'number');
+assert.strictEqual(typeof tty.triggerAsyncId, 'number');
 checkInvocations(tty, { init: 1 }, 'when tty created');
 
 ttyStream.end(common.mustCall(onend));

--- a/test/async-hooks/test-ttywrap.writestream.js
+++ b/test/async-hooks/test-ttywrap.writestream.js
@@ -27,7 +27,7 @@ assert.strictEqual(as.length, 1);
 const tty = as[0];
 assert.strictEqual(tty.type, 'TTYWRAP');
 assert.strictEqual(typeof tty.uid, 'number');
-assert.strictEqual(typeof tty.triggerId, 'number');
+assert.strictEqual(typeof tty.triggerAsyncId, 'number');
 checkInvocations(tty, { init: 1 }, 'when tty created');
 
 ttyStream

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -35,7 +35,7 @@ function onsent() {
   assert.strictEqual(as.length, 1);
   assert.strictEqual(send.type, 'UDPSENDWRAP');
   assert.strictEqual(typeof send.uid, 'number');
-  assert.strictEqual(typeof send.triggerId, 'number');
+  assert.strictEqual(typeof send.triggerAsyncId, 'number');
   checkInvocations(send, { init: 1, before: 1 }, 'when message sent');
 
   sock.close(common.mustCall(onsockClosed));

--- a/test/async-hooks/test-udpwrap.js
+++ b/test/async-hooks/test-udpwrap.js
@@ -17,7 +17,7 @@ const udpwrap = as[0];
 assert.strictEqual(as.length, 1);
 assert.strictEqual(udpwrap.type, 'UDPWRAP');
 assert.strictEqual(typeof udpwrap.uid, 'number');
-assert.strictEqual(typeof udpwrap.triggerId, 'number');
+assert.strictEqual(typeof udpwrap.triggerAsyncId, 'number');
 checkInvocations(udpwrap, { init: 1 }, 'after dgram.createSocket call');
 
 sock.close(common.mustCall(onsockClosed));

--- a/test/async-hooks/test-writewrap.js
+++ b/test/async-hooks/test-writewrap.js
@@ -48,7 +48,7 @@ function checkDestroyedWriteWraps(n, stage) {
   function checkValidWriteWrap(w) {
     assert.strictEqual(w.type, 'WRITEWRAP');
     assert.strictEqual(typeof w.uid, 'number');
-    assert.strictEqual(typeof w.triggerId, 'number');
+    assert.strictEqual(typeof w.triggerAsyncId, 'number');
 
     checkInvocations(w, { init: 1 }, `when ${stage}`);
   }

--- a/test/async-hooks/test-zlib.zlib-binding.deflate.js
+++ b/test/async-hooks/test-zlib.zlib-binding.deflate.js
@@ -18,7 +18,7 @@ assert.strictEqual(as.length, 1);
 const hdl = as[0];
 assert.strictEqual(hdl.type, 'ZLIB');
 assert.strictEqual(typeof hdl.uid, 'number');
-assert.strictEqual(typeof hdl.triggerId, 'number');
+assert.strictEqual(typeof hdl.triggerAsyncId, 'number');
 checkInvocations(hdl, { init: 1 }, 'when created handle');
 
 handle.init(

--- a/test/async-hooks/verify-graph.js
+++ b/test/async-hooks/verify-graph.js
@@ -31,13 +31,13 @@ function pruneTickObjects(activities) {
     if (tickObjectIdx >= 0) {
       foundTickObject = true;
 
-      // point all triggerIds that point to the tickObject
-      // to its triggerId and findally remove it from the activities
+      // point all triggerAsyncIds that point to the tickObject
+      // to its triggerAsyncId and findally remove it from the activities
       const tickObject = activities[tickObjectIdx];
-      const newTriggerId = tickObject.triggerId;
+      const newTriggerId = tickObject.triggerAsyncId;
       const oldTriggerId = tickObject.uid;
       activities.forEach(function repointTriggerId(x) {
-        if (x.triggerId === oldTriggerId) x.triggerId = newTriggerId;
+        if (x.triggerAsyncId === oldTriggerId) x.triggerAsyncId = newTriggerId;
       });
       activities.splice(tickObjectIdx, 1);
     }
@@ -66,15 +66,15 @@ module.exports = function verifyGraph(hooks, graph) {
 
     idtouid[node.id] = x.uid;
     uidtoid[x.uid] = node.id;
-    if (node.triggerId == null) return;
+    if (node.triggerAsyncId == null) return;
 
-    const tid = idtouid[node.triggerId];
-    if (x.triggerId === tid) return;
+    const tid = idtouid[node.triggerAsyncId];
+    if (x.triggerAsyncId === tid) return;
 
     errors.push({
       id: node.id,
-      expectedTid: node.triggerId,
-      actualTid: uidtoid[x.triggerId]
+      expectedTid: node.triggerAsyncId,
+      actualTid: uidtoid[x.triggerAsyncId]
     });
   }
 
@@ -108,8 +108,8 @@ module.exports.printGraph = function printGraph(hooks) {
     if (!ids[key]) ids[key] = 1;
     const id = key + ':' + ids[key]++;
     uidtoid[x.uid] = id;
-    const triggerId = uidtoid[x.triggerId] || null;
-    graph.push({ type: x.type, id, triggerId });
+    const triggerAsyncId = uidtoid[x.triggerAsyncId] || null;
+    graph.push({ type: x.type, id, triggerAsyncId });
   }
   inspect(graph);
 };

--- a/test/parallel/test-async-hooks-close-during-destroy.js
+++ b/test/parallel/test-async-hooks-close-during-destroy.js
@@ -11,7 +11,7 @@ let destroyResCallCount = 0;
 let res2;
 
 async_hooks.createHook({
-  init: common.mustCallAtLeast((id, provider, triggerId) => {
+  init: common.mustCallAtLeast((id, provider, triggerAsyncId) => {
     if (provider === 'foobar')
       initCalls.add(id);
   }, 2),

--- a/test/parallel/test-async-hooks-run-in-async-id-scope.js
+++ b/test/parallel/test-async-hooks-run-in-async-id-scope.js
@@ -6,8 +6,8 @@ const async_hooks = require('async_hooks');
 
 const asyncId = async_hooks.newUid();
 
-assert.notStrictEqual(async_hooks.currentAsyncId(), asyncId);
+assert.notStrictEqual(async_hooks.executionAsyncId(), asyncId);
 
 async_hooks.runInAsyncIdScope(asyncId, common.mustCall(() => {
-  assert.strictEqual(async_hooks.currentAsyncId(), asyncId);
+  assert.strictEqual(async_hooks.executionAsyncId(), asyncId);
 }));

--- a/test/parallel/test-async-hooks-run-in-async-id-scope.js
+++ b/test/parallel/test-async-hooks-run-in-async-id-scope.js
@@ -6,8 +6,8 @@ const async_hooks = require('async_hooks');
 
 const asyncId = async_hooks.newUid();
 
-assert.notStrictEqual(async_hooks.currentId(), asyncId);
+assert.notStrictEqual(async_hooks.currentAsyncId(), asyncId);
 
 async_hooks.runInAsyncIdScope(asyncId, common.mustCall(() => {
-  assert.strictEqual(async_hooks.currentId(), asyncId);
+  assert.strictEqual(async_hooks.currentAsyncId(), asyncId);
 }));

--- a/test/parallel/test-async-hooks-top-level-clearimmediate.js
+++ b/test/parallel/test-async-hooks-top-level-clearimmediate.js
@@ -9,11 +9,11 @@ const async_hooks = require('async_hooks');
 let seenId, seenResource;
 
 async_hooks.createHook({
-  init: common.mustCall((id, provider, triggerId, resource) => {
+  init: common.mustCall((id, provider, triggerAsyncId, resource) => {
     seenId = id;
     seenResource = resource;
     assert.strictEqual(provider, 'Immediate');
-    assert.strictEqual(triggerId, 1);
+    assert.strictEqual(triggerAsyncId, 1);
   }),
   before: common.mustNotCall(),
   after: common.mustNotCall(),

--- a/test/parallel/test-async-wrap-asyncresource-constructor.js
+++ b/test/parallel/test-async-wrap-asyncresource-constructor.js
@@ -16,8 +16,8 @@ assert.throws(() => {
 
 assert.throws(() => {
   new AsyncResource('type', -4);
-}, /^RangeError: triggerId must be an unsigned integer$/);
+}, /^RangeError: triggerAsyncId must be an unsigned integer$/);
 
 assert.throws(() => {
   new AsyncResource('type', Math.PI);
-}, /^RangeError: triggerId must be an unsigned integer$/);
+}, /^RangeError: triggerAsyncId must be an unsigned integer$/);

--- a/test/parallel/test-async-wrap-trigger-id.js
+++ b/test/parallel/test-async-wrap-trigger-id.js
@@ -3,26 +3,26 @@ require('../common');
 
 const assert = require('assert');
 const async_hooks = require('async_hooks');
-const triggerId = async_hooks.triggerId;
+const triggerAsyncId = async_hooks.triggerAsyncId;
 
-const triggerId0 = triggerId();
-let triggerId1;
+const triggerAsyncId0 = triggerAsyncId();
+let triggerAsyncId1;
 
 process.nextTick(() => {
   process.nextTick(() => {
-    triggerId1 = triggerId();
+    triggerAsyncId1 = triggerAsyncId();
     assert.notStrictEqual(
-      triggerId0,
-      triggerId1,
+      triggerAsyncId0,
+      triggerAsyncId1,
       'Async resources having different causal ancestry ' +
-      'should have different triggerIds');
+      'should have different triggerAsyncIds');
   });
   process.nextTick(() => {
-    const triggerId2 = triggerId();
+    const triggerAsyncId2 = triggerAsyncId();
     assert.strictEqual(
-      triggerId1,
-      triggerId2,
+      triggerAsyncId1,
+      triggerAsyncId2,
       'Async resources having the same causal ancestry ' +
-      'should have the same triggerId');
+      'should have the same triggerAsyncId');
   });
 });

--- a/test/parallel/test-async-wrap-uncaughtexception.js
+++ b/test/parallel/test-async-wrap-uncaughtexception.js
@@ -35,13 +35,13 @@ hooks = async_hooks.createHook({
 
 
 process.on('uncaughtException', common.mustCall(() => {
-  assert.strictEqual(call_id, async_hooks.currentAsyncId());
+  assert.strictEqual(call_id, async_hooks.executionAsyncId());
   call_log[2]++;
 }));
 
 
 require('crypto').randomBytes(1, common.mustCall(() => {
-  assert.strictEqual(call_id, async_hooks.currentAsyncId());
+  assert.strictEqual(call_id, async_hooks.executionAsyncId());
   call_log[1]++;
   throw new Error('ah crap');
 }));

--- a/test/parallel/test-async-wrap-uncaughtexception.js
+++ b/test/parallel/test-async-wrap-uncaughtexception.js
@@ -35,13 +35,13 @@ hooks = async_hooks.createHook({
 
 
 process.on('uncaughtException', common.mustCall(() => {
-  assert.strictEqual(call_id, async_hooks.currentId());
+  assert.strictEqual(call_id, async_hooks.currentAsyncId());
   call_log[2]++;
 }));
 
 
 require('crypto').randomBytes(1, common.mustCall(() => {
-  assert.strictEqual(call_id, async_hooks.currentId());
+  assert.strictEqual(call_id, async_hooks.currentAsyncId());
   call_log[1]++;
   throw new Error('ah crap');
 }));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks

Rename rename `async_hooks.currentId()` to `async_hooks.currentAsyncId()` as requested by @trevnorris. I just did a search and replace, it appears to work.

Since `async_hooks` is an experimental API and we actually haven't published the docs, then I think this is a `semver-minor`.

---

To be completely fair to the "`make -j4 test` passes" I actually couldn't run it all, I'm getting this error:

```
Building addon /Users/Andreas/Sites/node/node-review/test/addons-napi/test_globals/
gyp: binding.gyp not found (cwd: /Users/Andreas/Sites/node/node-review/test/addons-napi/test_globals) while trying to load binding.gyp
make[1]: *** [test/addons-napi/.buildstamp] Error 1
make: *** [test] Error 2
```

I don't think it is related. I'm going to see what the CI says.
