### PR TITLE
readline: remove max limit of crlfDelay

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,7 +369,9 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced to a number no less than `100`. It can be set to `Infinity`, in which case `\r` followed by `\n` will always be considered a single newline.
+    `crlfDelay` will be coerced to a number no less than `100`. It can be set to
+    `Infinity`, in which case `\r` followed by `\n` will always be considered a
+    single newline.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,7 +369,8 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced to `100` or greater, `Infinity` is allowed.
+    `crlfDelay` will be coerced to an Integer no less than `100`, unless it is
+    `Infinity`.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,8 +369,7 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced to an Integer no less than `100`, unless it is
-    `Infinity`.
+    `crlfDelay` will be coerced to a number no less than `100`. It can be set to `Infinity`, in which case `\r` followed by `\n` will always be considered a single newline.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,7 +369,7 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced to `100` or greater.
+    `crlfDelay` will be coerced to `100` or greater, `Infinity` is allowed.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,7 +369,7 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced not less than `100` milliseconds.
+    `crlfDelay` will be coerced to `100` or greater.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -369,7 +369,7 @@ changes:
   * `crlfDelay` {number} If the delay between `\r` and `\n` exceeds
     `crlfDelay` milliseconds, both `\r` and `\n` will be treated as separate
     end-of-line input. Default to `100` milliseconds.
-    `crlfDelay` will be coerced to `[100, 2000]` range.
+    `crlfDelay` will be coerced not less than `100` milliseconds.
   * `removeHistoryDuplicates` {boolean} If `true`, when a new input line added
     to the history list duplicates an older one, this removes the older line
     from the list. Defaults to `false`.

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -124,7 +124,8 @@ function Interface(input, output, completer, terminal) {
   this.input = input;
   this.historySize = historySize;
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
-  this.crlfDelay = Math.max(kMincrlfDelay, crlfDelay >>> 0);
+  this.crlfDelay = crlfDelay === Infinity ?
+                   Infinity : Math.max(kMincrlfDelay, crlfDelay >>> 0);
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -50,7 +50,6 @@ const {
 
 const kHistorySize = 30;
 const kMincrlfDelay = 100;
-const kMaxcrlfDelay = 2000;
 // \r\n, \n, or \r followed by something other than \n
 const lineEnding = /\r?\n|\r(?!\n)/;
 
@@ -125,8 +124,7 @@ function Interface(input, output, completer, terminal) {
   this.input = input;
   this.historySize = historySize;
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
-  this.crlfDelay = Math.max(kMincrlfDelay,
-                            Math.min(kMaxcrlfDelay, crlfDelay >>> 0));
+  this.crlfDelay = Math.max(kMincrlfDelay, crlfDelay >>> 0);
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -124,8 +124,8 @@ function Interface(input, output, completer, terminal) {
   this.input = input;
   this.historySize = historySize;
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
-  this.crlfDelay = crlfDelay === Infinity ?
-    Infinity : Math.max(kMincrlfDelay, crlfDelay >>> 0);
+  this.crlfDelay = crlfDelay ?
+    Math.max(kMincrlfDelay, crlfDelay) : kMincrlfDelay;
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -125,7 +125,7 @@ function Interface(input, output, completer, terminal) {
   this.historySize = historySize;
   this.removeHistoryDuplicates = !!removeHistoryDuplicates;
   this.crlfDelay = crlfDelay === Infinity ?
-                   Infinity : Math.max(kMincrlfDelay, crlfDelay >>> 0);
+    Infinity : Math.max(kMincrlfDelay, crlfDelay >>> 0);
 
   // Check arity, 2 - for async, 1 for sync
   if (typeof completer === 'function') {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -294,6 +294,29 @@ function isWarned(emitter) {
     }), delay);
   }
 
+  // set crlfDelay to `Infinity` is allowed
+  {
+    const fi = new FakeInput();
+    const delay = 200;
+    const crlfDelay = Infinity;
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal,
+      crlfDelay
+    });
+    let callCount = 0;
+    rli.on('line', function(line) {
+      callCount++;
+    });
+    fi.emit('data', '\r');
+    setTimeout(common.mustCall(() => {
+      fi.emit('data', '\n');
+      assert.strictEqual(callCount, 1);
+      rli.close();
+    }), delay);
+  }
+
   // \t when there is no completer function should behave like an ordinary
   // character
   fi = new FakeInput();

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -63,14 +63,14 @@ function isWarned(emitter) {
 }
 
 {
-  // Maximum crlfDelay is 2000ms
+  // set crlfDelay to 5000ms
   const fi = new FakeInput();
   const rli = new readline.Interface({
     input: fi,
     output: fi,
-    crlfDelay: 1 << 30
+    crlfDelay: 5000
   });
-  assert.strictEqual(rli.crlfDelay, 2000);
+  assert.strictEqual(rli.crlfDelay, 5000);
   rli.close();
 }
 
@@ -248,7 +248,7 @@ function isWarned(emitter) {
   rli.close();
 
   // Emit two line events when the delay
-  //   between \r and \n exceeds crlfDelay
+  // between \r and \n exceeds crlfDelay
   {
     const fi = new FakeInput();
     const delay = 200;
@@ -270,8 +270,32 @@ function isWarned(emitter) {
     }), delay * 2);
   }
 
+  // Emit one line events when the delay between \r and \n is
+  // over the default crlfDelay but within the setting value
+  {
+    const fi = new FakeInput();
+    const delay = 200;
+    const crlfDelay = 500;
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal,
+      crlfDelay
+    });
+    let callCount = 0;
+    rli.on('line', function(line) {
+      callCount++;
+    });
+    fi.emit('data', '\r');
+    setTimeout(common.mustCall(() => {
+      fi.emit('data', '\n');
+      assert.strictEqual(callCount, 1);
+      rli.close();
+    }), delay);
+  }
+
   // \t when there is no completer function should behave like an ordinary
-  //   character
+  // character
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: fi, terminal: true });
   called = false;
@@ -513,7 +537,7 @@ function isWarned(emitter) {
     assert.strictEqual(isWarned(process.stdout._events), false);
   }
 
-  //can create a new readline Interface with a null output arugument
+  // can create a new readline Interface with a null output arugument
   fi = new FakeInput();
   rli = new readline.Interface({ input: fi, output: null, terminal: terminal });
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -63,6 +63,18 @@ function isWarned(emitter) {
 }
 
 {
+  // set crlfDelay to float 100.5ms
+  const fi = new FakeInput();
+  const rli = new readline.Interface({
+    input: fi,
+    output: fi,
+    crlfDelay: 100.5
+  });
+  assert.strictEqual(rli.crlfDelay, 100.5);
+  rli.close();
+}
+
+{
   // set crlfDelay to 5000ms
   const fi = new FakeInput();
   const rli = new readline.Interface({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline

* remove `kMaxcrlfDelay`
* modify related docs
* add one related unit test.

-----------
`crlfDelay` option of `readline.createInterface` is created by https://github.com/nodejs/node/pull/8109 .
This pull request fix `Interface.prototype._ttyWrite` \r\n problem, but `crlfDelay` make some program use `Interface.prototype._normalWrite` behavior unexpect.

For example:
``` javascript
const rl = readline.createInterface({
  input: fs.createReadStream('big.csv', {
    encoding: 'utf16le',
  }),
  crlfDelay: 2000, // const kMaxcrlfDelay = 2000
});
rl.on('line', (line) => {
  // fuzzy string matching, take a lot of time
})
```

`\r\n` in csv file happen to be written in two different chunk, call them chunk A and chunk B.
chunk A end with `\r` , chunk B start with `\n` .
chunk A split into 1000 lines, each line event cost 3ms, after 3000ms, chunk B first line event emit with empty string `''`, because two chunk time gap over 2000ms, it consider `\n` is a new line.
The time gap over `kMaxcrlfDelay` is not rare.

`kMaxcrlfDelay` is meaningless in both tty write and normal write, remove it is a better design.