### PR TITLE
test: refactor test-fs-read-*

### DIFF
--- a/test/parallel/test-fs-read-file-assert-encoding.js
+++ b/test/parallel/test-fs-read-file-assert-encoding.js
@@ -8,6 +8,6 @@ const encoding = 'foo-8';
 const filename = 'bar.txt';
 
 assert.throws(
-  fs.readFile.bind(fs, filename, { encoding }, common.noop),
-  new RegExp(`Error: Unknown encoding: ${encoding}$`)
+  fs.readFile.bind(fs, filename, { encoding }, common.mustNotCall()),
+  new RegExp(`^Error: Unknown encoding: ${encoding}$`)
 );

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -13,9 +13,9 @@ assert.throws(() => {
           expected.length,
           0,
           'utf-8',
-          common.noop);
-}, /Second argument needs to be a buffer/);
+          common.mustNotCall());
+}, /^TypeError: Second argument needs to be a buffer$/);
 
 assert.throws(() => {
   fs.readSync(fd, expected.length, 0, 'utf-8');
-}, /Second argument needs to be a buffer/);
+}, /^TypeError: Second argument needs to be a buffer$/);


### PR DESCRIPTION
* Use `common.mustNotCall()` in place of `common.noop` where appropriate
* Increase specificity of regular expressions (that is, make them match
  the whole error string rather than part of the error string) in
  `assert.throws()` calls

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs