### PR TITLE
src: check whether inspector is doing io

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3059,8 +3059,8 @@ static void DebugPortGetter(Local<Name> property,
 #if HAVE_INSPECTOR
   if (port == 0) {
     Environment* env = Environment::GetCurrent(info);
-    if (env->inspector_agent()->IsStarted())
-      port = env->inspector_agent()->io()->port();
+    if (auto io = env->inspector_agent()->io())
+      port = io->port();
   }
 #endif  // HAVE_INSPECTOR
   info.GetReturnValue().Set(port);

--- a/test/inspector/test-inspector-port-zero.js
+++ b/test/inspector/test-inspector-port-zero.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const { URL } = require('url');
 const { spawn } = require('child_process');
 
-function test(arg) {
+function test(arg, port = '') {
   const args = [arg, '-p', 'process.debugPort'];
   const proc = spawn(process.execPath, args);
   proc.stdout.setEncoding('utf8');
@@ -18,7 +18,6 @@ function test(arg) {
   proc.stderr.on('data', (data) => stderr += data);
   proc.stdout.on('close', assert.ifError);
   proc.stderr.on('close', assert.ifError);
-  let port = '';
   proc.stderr.on('data', () => {
     if (!stderr.includes('\n')) return;
     assert(/Debugger listening on (.+)/.test(stderr));
@@ -46,3 +45,9 @@ test('--inspect=localhost:0');
 test('--inspect-brk=0');
 test('--inspect-brk=127.0.0.1:0');
 test('--inspect-brk=localhost:0');
+
+// In these cases, the inspector doesn't listen, so an ephemeral port is not
+// allocated and the expected value of `process.debugPort` is `0`.
+test('--inspect-port=0', '0');
+test('--inspect-port=127.0.0.1:0', '0');
+test('--inspect-port=localhost:0', '0');


### PR DESCRIPTION
Inspector start means that it exists, but doesn't mean it is listening
on a port, that only happens if it is doing I/O (i.e. has an io object).

Fixes: https://github.com/nodejs/node/issues/13499

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src,inspector
