### PR TITLE
https: support rejectUnauthorized for unix sockets

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -247,7 +247,8 @@ function ClientRequest(options, cb) {
     this.shouldKeepAlive = false;
     var optionsPath = {
       path: this.socketPath,
-      timeout: this.timeout
+      timeout: this.timeout,
+      rejectUnauthorized: !!options.rejectUnauthorized
     };
     newSocket = this.agent.createConnection(optionsPath, oncreate);
     if (newSocket && !called) {

--- a/test/parallel/test-https-unix-socket-self-signed.js
+++ b/test/parallel/test-https-unix-socket-self-signed.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+common.refreshTmpDir();
+
+const fs = require('fs');
+const https = require('https');
+const options = {
+  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
+  key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+};
+
+const server = https.createServer(options, common.mustCall((req, res) => {
+  res.end('bye\n');
+  server.close();
+}));
+
+server.listen(common.PIPE, common.mustCall(() => {
+  https.get({
+    socketPath: common.PIPE,
+    rejectUnauthorized: false
+  });
+}));


### PR DESCRIPTION
This commit allows self signed certificates to work with unix sockets by forwarding the `rejectUnauthorized` option.

Fixes: https://github.com/nodejs/node/issues/13470

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
https