### PR TITLE
Stream pump

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -46,7 +46,7 @@ There are four fundamental stream types within Node.js:
 * [Transform][] - Duplex streams that can modify or transform the data as it
   is written and read (for example [`zlib.createDeflate()`][]).
 
-Additionally this module inclues a utility function [pump][].
+Additionally this module includes the utility function [pump][].
 
 ### Object Mode
 
@@ -1247,9 +1247,13 @@ implementors should not override this method, but instead implement
 The default implementation of `_destroy` for `Transform` also emit `'close'`.
 
 #### Class Method: stream.pump(...streams[, callback])
+<!-- YAML
+added: REPLACEME
+-->
 
-* two or more streams to pipe between
-* optional callback
+* `...streams` {Stream} Two or more streams to pipe between.
+* `callback` {Function} A callback function that takes an optional error
+  argument.
 
 A class method to pipe between streams forwarding errors and properly cleaning
 up.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -46,6 +46,8 @@ There are four fundamental stream types within Node.js:
 * [Transform][] - Duplex streams that can modify or transform the data as it
   is written and read (for example [`zlib.createDeflate()`][]).
 
+Additionally this module inclues a utility function [pump][].
+
 ### Object Mode
 
 All streams created by Node.js APIs operate exclusively on strings and `Buffer`
@@ -89,7 +91,7 @@ total size of the internal write buffer is below the threshold set by
 the size of the internal buffer reaches or exceeds the `highWaterMark`, `false`
 will be returned.
 
-A key goal of the `stream` API, particularly the [`stream.pipe()`] method,
+A key goal of the `stream` API, particularly the [`stream.pump()`] function,
 is to limit the buffering of data to acceptable levels such that sources and
 destinations of differing speeds will not overwhelm the available memory.
 
@@ -1244,6 +1246,14 @@ implementors should not override this method, but instead implement
 [`readable._destroy`][readable-_destroy].
 The default implementation of `_destroy` for `Transform` also emit `'close'`.
 
+#### Class Method: stream.pump(...streams[, callback])
+
+* two or more streams to pipe between
+* optional callback
+
+A class method to pipe between streams forwarding errors and properly cleaning
+up.
+
 ## API for Stream Implementers
 
 <!--type=misc-->
@@ -2334,14 +2344,15 @@ contain multi-byte characters.
 [TCP sockets]: net.html#net_class_net_socket
 [Transform]: #stream_class_stream_transform
 [Writable]: #stream_class_stream_writable
+[async-iterator]: https://github.com/tc39/proposal-async-iteration
 [child process stdin]: child_process.html#child_process_subprocess_stdin
 [child process stdout and stderr]: child_process.html#child_process_subprocess_stdout
 [crypto]: crypto.html
 [fs read streams]: fs.html#fs_class_fs_readstream
 [fs write streams]: fs.html#fs_class_fs_writestream
 [http-incoming-message]: http.html#http_class_http_incomingmessage
-[zlib]: zlib.html
 [hwm-gotcha]: #stream_highwatermark_discrepancy_after_calling_readable_setencoding
+[pump]: #stream_class_method_pump
 [stream-_flush]: #stream_transform_flush_callback
 [stream-_read]: #stream_readable_read_size_1
 [stream-_transform]: #stream_transform_transform_chunk_encoding_callback
@@ -2358,4 +2369,4 @@ contain multi-byte characters.
 [readable-destroy]: #stream_readable_destroy_error
 [writable-_destroy]: #stream_writable_destroy_err_callback
 [writable-destroy]: #stream_writable_destroy_error
-[async-iterator]: https://github.com/tc39/proposal-async-iteration
+[zlib]: zlib.html

--- a/lib/_stream_pump.js
+++ b/lib/_stream_pump.js
@@ -1,0 +1,169 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2014 Mathias Buus
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+function noop() {}
+
+function isRequest(stream) {
+  return stream.setHeader && isFn(stream.abort)
+}
+
+function isChildProcess(stream) {
+	return stream.stdio && Array.isArray(stream.stdio) && stream.stdio.length === 3
+}
+
+function isFn(fn) {
+  return typeof fn === 'function'
+}
+
+function eos(stream, opts, _callback) {
+	if (typeof opts === 'function') return eos(stream, null, opts);
+	if (!opts) opts = {};
+  let callbackCalled = false;
+	const callback = err => {
+    if (!_callback || callbackCalled) {
+      return;
+    }
+    callbackCalled = true;
+    _callback.call(stream, err)
+  }
+
+	const ws = stream._writableState;
+	const rs = stream._readableState;
+	const readable = opts.readable || (opts.readable !== false && stream.readable);
+	const writable = opts.writable || (opts.writable !== false && stream.writable);
+
+	const onlegacyfinish = () => if (!stream.writable) onfinish();
+
+	const onfinish = () => {
+		writable = false;
+		if (!readable) callback();
+	};
+
+	const onend = () => {
+		readable = false;
+		if (!writable) callback();
+	};
+
+	const onexit = exitCode =>
+		callback(exitCode ? new Error('exited with error code: ' + exitCode) : null);
+
+	const onclose = () => {
+		if (readable && !(rs && rs.ended)) return callback(new Error('premature close'));
+		if (writable && !(ws && ws.ended)) return callback(new Error('premature close'));
+	};
+
+	const onrequest = () =>
+		stream.req.on('finish', onfinish);
+
+	if (isRequest(stream)) {
+		stream.on('complete', onfinish);
+		stream.on('abort', onclose);
+		if (stream.req) onrequest();
+		else stream.on('request', onrequest);
+	} else if (writable && !ws) { // legacy streams
+		stream.on('end', onlegacyfinish);
+		stream.on('close', onlegacyfinish);
+	}
+
+	if (isChildProcess(stream)) stream.on('exit', onexit);
+
+	stream.on('end', onend);
+	stream.on('finish', onfinish);
+	if (opts.error !== false) stream.on('error', callback);
+	stream.on('close', onclose);
+
+	return () => {
+		stream.removeListener('complete', onfinish);
+		stream.removeListener('abort', onclose);
+		stream.removeListener('request', onrequest);
+		if (stream.req) stream.req.removeListener('finish', onfinish);
+		stream.removeListener('end', onlegacyfinish);
+		stream.removeListener('close', onlegacyfinish);
+		stream.removeListener('finish', onfinish);
+		stream.removeListener('exit', onexit);
+		stream.removeListener('end', onend);
+		stream.removeListener('error', callback);
+		stream.removeListener('close', onclose);
+	};
+};
+
+function destroyer(stream, reading, writing, _callback) {
+  let callbackCalled = false;
+  const callback => {
+    if (callbackCalled) return;
+
+    callbackCalled = true;
+
+    return _callback(err);
+  }
+  let closed = false
+  stream.on('close', function () {
+    closed = true
+  })
+
+  eos(stream, {readable: reading, writable: writing}, function (err) {
+    if (err) return callback(err)
+    closed = true
+    callback()
+  })
+
+  var destroyed = false
+  return err => {
+    if (closed) return
+    if (destroyed) return
+    destroyed = true
+
+    if (isRequest(stream)) return stream.abort() // request.destroy just do .end - .abort is what we want
+
+    if (isFn(stream.destroy)) return stream.destroy()
+
+    callback(err || new Error('stream was destroyed'))
+  }
+}
+
+const call =  fn => fn();
+
+const pipe = (from, to) => from.pipe(to);
+
+function pump (...streams) {
+  const callback = isFn(streams[streams.length - 1] || noop) && streams.pop() || noop
+
+  if (Array.isArray(streams[0])) streams = streams[0]
+  if (streams.length < 2) throw new Error('pump requires two streams per minimum')
+
+  let error
+  const destroys = streams.map((stream, i) => {
+    var reading = i < streams.length - 1
+    var writing = i > 0
+    return destroyer(stream, reading, writing, err => {
+      if (!error) error = err
+      if (err) destroys.forEach(call)
+      if (reading) return
+      destroys.forEach(call)
+      callback(error)
+    });
+  });
+
+  return streams.reduce(pipe)
+}
+
+module.exports = pump

--- a/lib/_stream_pump.js
+++ b/lib/_stream_pump.js
@@ -20,150 +20,172 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+'use strict';
+
 function noop() {}
 
 function isRequest(stream) {
-  return stream.setHeader && isFn(stream.abort)
+  return stream.setHeader && isFn(stream.abort);
 }
 
 function isChildProcess(stream) {
-	return stream.stdio && Array.isArray(stream.stdio) && stream.stdio.length === 3
+  return stream.stdio &&
+    Array.isArray(stream.stdio) && stream.stdio.length === 3;
 }
 
 function isFn(fn) {
-  return typeof fn === 'function'
+  return typeof fn === 'function';
 }
 
 function eos(stream, opts, _callback) {
-	if (typeof opts === 'function') return eos(stream, null, opts);
-	if (!opts) opts = {};
+  if (typeof opts === 'function') return eos(stream, null, opts);
+  if (!opts) opts = {};
   let callbackCalled = false;
-	const callback = err => {
+  const callback = (err) => {
     if (!_callback || callbackCalled) {
       return;
     }
     callbackCalled = true;
-    _callback.call(stream, err)
+    _callback.call(stream, err);
+  };
+  const ws = stream._writableState;
+  const rs = stream._readableState;
+  let readable = opts.readable ||
+    (opts.readable !== false && stream.readable);
+  let writable = opts.writable ||
+    (opts.writable !== false && stream.writable);
+
+  const onlegacyfinish = () => {
+    if (!stream.writable) onfinish();
+  };
+
+  const onfinish = () => {
+    writable = false;
+    if (!readable) callback();
+  };
+
+  const onend = () => {
+    readable = false;
+    if (!writable) callback();
+  };
+
+  const onexit = (exitCode) => {
+    if (exitCode) {
+      callback(new Error('exited with error code: ' + exitCode));
+    } else {
+      callback();
+    }
+  };
+
+  const onclose = () => {
+    if (readable && !(rs && rs.ended))
+      return callback(new Error('premature close'));
+
+    if (writable && !(ws && ws.ended))
+      return callback(new Error('premature close'));
+  };
+
+  const onrequest = () =>
+    stream.req.on('finish', onfinish);
+
+  if (isRequest(stream)) {
+    stream.on('complete', onfinish);
+    stream.on('abort', onclose);
+    if (stream.req) onrequest();
+    else stream.on('request', onrequest);
+  } else if (writable && !ws) { // legacy streams
+    stream.on('end', onlegacyfinish);
+    stream.on('close', onlegacyfinish);
   }
 
-	const ws = stream._writableState;
-	const rs = stream._readableState;
-	const readable = opts.readable || (opts.readable !== false && stream.readable);
-	const writable = opts.writable || (opts.writable !== false && stream.writable);
+  if (isChildProcess(stream)) stream.on('exit', onexit);
 
-	const onlegacyfinish = () => if (!stream.writable) onfinish();
+  stream.on('end', onend);
+  stream.on('finish', onfinish);
+  if (opts.error !== false) stream.on('error', callback);
+  stream.on('close', onclose);
 
-	const onfinish = () => {
-		writable = false;
-		if (!readable) callback();
-	};
-
-	const onend = () => {
-		readable = false;
-		if (!writable) callback();
-	};
-
-	const onexit = exitCode =>
-		callback(exitCode ? new Error('exited with error code: ' + exitCode) : null);
-
-	const onclose = () => {
-		if (readable && !(rs && rs.ended)) return callback(new Error('premature close'));
-		if (writable && !(ws && ws.ended)) return callback(new Error('premature close'));
-	};
-
-	const onrequest = () =>
-		stream.req.on('finish', onfinish);
-
-	if (isRequest(stream)) {
-		stream.on('complete', onfinish);
-		stream.on('abort', onclose);
-		if (stream.req) onrequest();
-		else stream.on('request', onrequest);
-	} else if (writable && !ws) { // legacy streams
-		stream.on('end', onlegacyfinish);
-		stream.on('close', onlegacyfinish);
-	}
-
-	if (isChildProcess(stream)) stream.on('exit', onexit);
-
-	stream.on('end', onend);
-	stream.on('finish', onfinish);
-	if (opts.error !== false) stream.on('error', callback);
-	stream.on('close', onclose);
-
-	return () => {
-		stream.removeListener('complete', onfinish);
-		stream.removeListener('abort', onclose);
-		stream.removeListener('request', onrequest);
-		if (stream.req) stream.req.removeListener('finish', onfinish);
-		stream.removeListener('end', onlegacyfinish);
-		stream.removeListener('close', onlegacyfinish);
-		stream.removeListener('finish', onfinish);
-		stream.removeListener('exit', onexit);
-		stream.removeListener('end', onend);
-		stream.removeListener('error', callback);
-		stream.removeListener('close', onclose);
-	};
-};
+  return () => {
+    stream.removeListener('complete', onfinish);
+    stream.removeListener('abort', onclose);
+    stream.removeListener('request', onrequest);
+    if (stream.req) stream.req.removeListener('finish', onfinish);
+    stream.removeListener('end', onlegacyfinish);
+    stream.removeListener('close', onlegacyfinish);
+    stream.removeListener('finish', onfinish);
+    stream.removeListener('exit', onexit);
+    stream.removeListener('end', onend);
+    stream.removeListener('error', callback);
+    stream.removeListener('close', onclose);
+  };
+}
 
 function destroyer(stream, reading, writing, _callback) {
   let callbackCalled = false;
-  const callback => {
+  const callback = (err) => {
     if (callbackCalled) return;
 
     callbackCalled = true;
 
     return _callback(err);
-  }
-  let closed = false
-  stream.on('close', function () {
-    closed = true
-  })
+  };
+  let closed = false;
+  stream.on('close', () => {
+    closed = true;
+  });
 
-  eos(stream, {readable: reading, writable: writing}, function (err) {
-    if (err) return callback(err)
-    closed = true
-    callback()
-  })
+  eos(stream, {readable: reading, writable: writing}, (err) => {
+    if (err) return callback(err);
+    closed = true;
+    callback();
+  });
 
-  var destroyed = false
-  return err => {
-    if (closed) return
-    if (destroyed) return
-    destroyed = true
+  var destroyed = false;
+  return (err) => {
+    if (closed) return;
+    if (destroyed) return;
+    destroyed = true;
 
-    if (isRequest(stream)) return stream.abort() // request.destroy just do .end - .abort is what we want
+    if (isRequest(stream))
+      return stream.abort();
+      // request.destroy just do .end - .abort is what we want
 
-    if (isFn(stream.destroy)) return stream.destroy()
+    if (isFn(stream.destroy)) return stream.destroy();
 
-    callback(err || new Error('stream was destroyed'))
-  }
+    callback(err || new Error('stream was destroyed'));
+  };
 }
 
-const call =  fn => fn();
+const call = (fn) => fn();
 
 const pipe = (from, to) => from.pipe(to);
 
-function pump (...streams) {
-  const callback = isFn(streams[streams.length - 1] || noop) && streams.pop() || noop
+function pump(...streams) {
+  const callback = isFn(streams[streams.length - 1] || noop) &&
+    streams.pop() || noop;
 
-  if (Array.isArray(streams[0])) streams = streams[0]
-  if (streams.length < 2) throw new Error('pump requires two streams per minimum')
+  if (Array.isArray(streams[0])) streams = streams[0];
 
-  let error
+  if (streams.length < 2)
+    throw new Error('pump requires two streams per minimum');
+
+  let error;
   const destroys = streams.map((stream, i) => {
-    var reading = i < streams.length - 1
-    var writing = i > 0
-    return destroyer(stream, reading, writing, err => {
-      if (!error) error = err
-      if (err) destroys.forEach(call)
-      if (reading) return
-      destroys.forEach(call)
-      callback(error)
+    var reading = i < streams.length - 1;
+    var writing = i > 0;
+    return destroyer(stream, reading, writing, (err) => {
+      if (!error) error = err;
+
+      if (err) destroys.forEach(call);
+
+      if (reading) return;
+
+      destroys.forEach(call);
+      callback(error);
     });
   });
 
-  return streams.reduce(pipe)
+  return streams.reduce(pipe);
 }
 
-module.exports = pump
+module.exports = pump;

--- a/lib/_stream_pump.js
+++ b/lib/_stream_pump.js
@@ -150,14 +150,14 @@ function destroyer(stream, reading, writing, _callback) {
       return stream.abort();
       // request.destroy just do .end - .abort is what we want
 
-    if (isFn(stream.destroy)) return stream.destroy();
+    if (isFn(stream.destroy)) return stream.destroy(err);
 
     callback(err || new Error('stream was destroyed'));
   };
 }
 
 const call = (fn) => fn();
-
+const callErr = (err) => (fn) => fn(err);
 const pipe = (from, to) => from.pipe(to);
 
 function pump(...streams) {
@@ -176,7 +176,7 @@ function pump(...streams) {
     return destroyer(stream, reading, writing, (err) => {
       if (!error) error = err;
 
-      if (err) destroys.forEach(call);
+      if (err) destroys.forEach(callErr(err));
 
       if (reading) return;
 

--- a/lib/_stream_pump.js
+++ b/lib/_stream_pump.js
@@ -1,31 +1,9 @@
-// The MIT License (MIT)
-//
-// Copyright (c) 2014 Mathias Buus
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 'use strict';
 
 function noop() {}
 
 function isRequest(stream) {
-  return stream.setHeader && isFn(stream.abort);
+  return stream.setHeader && typeof stream.abort === 'function';
 }
 
 function isChildProcess(stream) {
@@ -33,13 +11,10 @@ function isChildProcess(stream) {
     Array.isArray(stream.stdio) && stream.stdio.length === 3;
 }
 
-function isFn(fn) {
-  return typeof fn === 'function';
-}
-
 function eos(stream, opts, _callback) {
   if (typeof opts === 'function') return eos(stream, null, opts);
   if (!opts) opts = {};
+
   let callbackCalled = false;
   const callback = (err) => {
     if (!_callback || callbackCalled) {
@@ -48,12 +23,11 @@ function eos(stream, opts, _callback) {
     callbackCalled = true;
     _callback.call(stream, err);
   };
+
   const ws = stream._writableState;
   const rs = stream._readableState;
-  let readable = opts.readable ||
-    (opts.readable !== false && stream.readable);
-  let writable = opts.writable ||
-    (opts.writable !== false && stream.writable);
+  let readable = opts.readable || opts.readable !== false && stream.readable;
+  let writable = opts.writable || opts.writable !== false && stream.writable;
 
   const onlegacyfinish = () => {
     if (!stream.writable) onfinish();
@@ -71,18 +45,15 @@ function eos(stream, opts, _callback) {
 
   const onexit = (exitCode) => {
     if (exitCode) {
-      callback(new Error('exited with error code: ' + exitCode));
+      callback(new Error(`Exited with error code: ${exitCode}`));
     } else {
-      callback();
+      callback(null);
     }
   };
 
   const onclose = () => {
-    if (readable && !(rs && rs.ended))
-      return callback(new Error('premature close'));
-
-    if (writable && !(ws && ws.ended))
-      return callback(new Error('premature close'));
+    if (readable && !(rs && rs.ended) || writable && !(ws && ws.ended))
+      return callback(new Error('Premature close'));
   };
 
   const onrequest = () =>
@@ -120,13 +91,11 @@ function eos(stream, opts, _callback) {
   };
 }
 
-function destroyer(stream, reading, writing, _callback) {
+function destroyer(stream, readable, writable, _callback) {
   let callbackCalled = false;
   const callback = (err) => {
     if (callbackCalled) return;
-
     callbackCalled = true;
-
     return _callback(err);
   };
   let closed = false;
@@ -134,25 +103,23 @@ function destroyer(stream, reading, writing, _callback) {
     closed = true;
   });
 
-  eos(stream, {readable: reading, writable: writing}, (err) => {
+  eos(stream, { readable, writable }, (err) => {
     if (err) return callback(err);
     closed = true;
     callback();
   });
 
-  var destroyed = false;
+  let destroyed = false;
   return (err) => {
-    if (closed) return;
-    if (destroyed) return;
+    if (closed || destroyed) return;
     destroyed = true;
 
     if (isRequest(stream))
       return stream.abort();
-      // request.destroy just do .end - .abort is what we want
 
-    if (isFn(stream.destroy)) return stream.destroy(err);
+    if (typeof stream.destroy === 'function') return stream.destroy(err);
 
-    callback(err || new Error('stream was destroyed'));
+    callback(err || new Error('Stream was destroyed'));
   };
 }
 
@@ -161,27 +128,26 @@ const callErr = (err) => (fn) => fn(err);
 const pipe = (from, to) => from.pipe(to);
 
 function pump(...streams) {
-  const callback = isFn(streams[streams.length - 1] || noop) &&
-    streams.pop() || noop;
+  const callback = streams.pop() || noop;
 
   if (Array.isArray(streams[0])) streams = streams[0];
 
   if (streams.length < 2)
-    throw new Error('pump requires two streams per minimum');
+    throw new Error('Pump requires two streams per minimum.');
 
-  let error;
+  let firstError;
   const destroys = streams.map((stream, i) => {
     var reading = i < streams.length - 1;
     var writing = i > 0;
     return destroyer(stream, reading, writing, (err) => {
-      if (!error) error = err;
+      if (!firstError) firstError = err;
 
       if (err) destroys.forEach(callErr(err));
 
       if (reading) return;
 
       destroys.forEach(call);
-      callback(error);
+      callback(firstError);
     });
   });
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -32,6 +32,7 @@ Stream.Writable = require('_stream_writable');
 Stream.Duplex = require('_stream_duplex');
 Stream.Transform = require('_stream_transform');
 Stream.PassThrough = require('_stream_passthrough');
+Stream.pump = require('_stream_pump');
 
 // Backwards-compat with node 0.4.x
 Stream.Stream = Stream;

--- a/node.gyp
+++ b/node.gyp
@@ -66,6 +66,7 @@
       'lib/_stream_duplex.js',
       'lib/_stream_transform.js',
       'lib/_stream_passthrough.js',
+      'lib/_stream_pump.js',
       'lib/_stream_wrap.js',
       'lib/string_decoder.js',
       'lib/sys.js',

--- a/test/parallel/test-stream-pump.js
+++ b/test/parallel/test-stream-pump.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const stream = require('stream');
-require('../common');
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
 const assert = require('assert');
 const crypto = require('crypto');
 const pump = stream.pump;

--- a/test/parallel/test-stream-pump.js
+++ b/test/parallel/test-stream-pump.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const stream = require('stream');
+require('../common');
+const assert = require('assert');
+const crypto = require('crypto');
+const pump = stream.pump;
+// tiny node-tap lookalike.
+const tests = [];
+let count = 0;
+
+function test(name, fn) {
+  count++;
+  tests.push([name, fn]);
+}
+
+function run() {
+  const next = tests.shift();
+  if (!next)
+    return console.error('ok');
+
+  const name = next[0];
+  const fn = next[1];
+  console.log('# %s', name);
+  fn({
+    same: assert.deepStrictEqual,
+    equal: assert.strictEqual,
+    end: function() {
+      count--;
+      run();
+    }
+  });
+}
+
+// ensure all tests have run
+process.on('exit', function() {
+  assert.strictEqual(count, 0);
+});
+
+process.nextTick(run);
+
+test('basic pump', (t) => {
+  const rs = new stream.Readable({
+    read(size) {
+      this.push(crypto.randomBytes(size));
+    }
+  });
+  const ws = new stream.Writable({
+    write(chunk, enc, next) {
+      setImmediate(next);
+    }
+  });
+
+  function toHex() {
+    const reverse = new stream.Transform();
+
+    reverse._transform = function(chunk, enc, callback) {
+      reverse.push(chunk.toString('hex'));
+      callback();
+    };
+
+    return reverse;
+  }
+
+  let wsClosed = false;
+  let rsClosed = false;
+  let callbackCalled = false;
+  const timeout = setTimeout(function() {
+    throw new Error('timeout');
+  }, 5000);
+  function check() {
+    if (wsClosed && rsClosed && callbackCalled) {
+      clearTimeout(timeout);
+      t.end();
+    }
+  }
+
+  ws.on('finish', function() {
+    wsClosed = true;
+    check();
+  });
+
+  rs.on('end', function() {
+    rsClosed = true;
+    check();
+  });
+
+  pump(rs, toHex(), toHex(), toHex(), ws, function() {
+    callbackCalled = true;
+    check();
+  });
+
+  setTimeout(function() {
+    rs.push(null);
+  }, 1000);
+});
+test('call destroy if error', (t) => {
+  let wsDestroyCalled = false;
+  let rsDestroyCalled = false;
+  let callbackCalled = false;
+  const rs = new stream.Readable({
+    read(size) {
+      this.push(crypto.randomBytes(size));
+    }
+  });
+  rs.destroy = function() {
+    this.emit('close');
+    rsDestroyCalled = true;
+    check();
+  };
+  const ws = new stream.Writable({
+    write(chunk, enc, next) {
+      setImmediate(next);
+    }
+  });
+  ws.destroy = function() {
+    this.emit('close');
+    wsDestroyCalled = true;
+    check();
+  };
+  function throwError() {
+    const reverse = new stream.Transform();
+    let i = 0;
+    reverse._transform = function(chunk, enc, callback) {
+      i++;
+      if (i > 5) {
+        return callback(new Error('lets end this'));
+      }
+      reverse.push(chunk.toString('hex'));
+      callback();
+    };
+
+    return reverse;
+  }
+  function toHex() {
+    const reverse = new stream.Transform();
+
+    reverse._transform = function(chunk, enc, callback) {
+      reverse.push(chunk.toString('hex'));
+      callback();
+    };
+
+    return reverse;
+  }
+
+  function check() {
+    if (wsDestroyCalled && rsDestroyCalled && callbackCalled) {
+      t.end();
+    }
+  }
+
+  pump(rs, toHex(), throwError(), toHex(), toHex(), ws, function(err) {
+    t.equal(err && err.message, 'lets end this');
+    callbackCalled = true;
+    check();
+  });
+});


### PR DESCRIPTION
Docs not finished.

As discussed at the streams working group face to face in Berlin we wanted to bring @mafintosh's pump module into core.  The reason being that pipe is fundamentally broken since it doesn't forward errors or clean up so the advice given is always not use it and instead use the pump module.  The consensus at the meeting was that if a  user land module is mandatory to use streams, it should probably be part of streams.

see nodejs/readable-stream#283, mafintosh/pump#17

cc @nodejs/streams 