### PR TITLE
test: add coverage for napi_property_descriptor

### DIFF
--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -25,6 +25,7 @@ assert.ok(propertyNames.includes('echo'));
 assert.ok(propertyNames.includes('readwriteValue'));
 assert.ok(propertyNames.includes('readonlyValue'));
 assert.ok(!propertyNames.includes('hiddenValue'));
+assert.ok(propertyNames.includes('NameKeyValue'));
 assert.ok(!propertyNames.includes('readwriteAccessor1'));
 assert.ok(!propertyNames.includes('readwriteAccessor2'));
 assert.ok(!propertyNames.includes('readonlyAccessor1'));

--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -31,6 +31,13 @@ assert.ok(!propertyNames.includes('readwriteAccessor2'));
 assert.ok(!propertyNames.includes('readonlyAccessor1'));
 assert.ok(!propertyNames.includes('readonlyAccessor2'));
 
+// validate property created with symbol
+const start = 'Symbol('.length;
+const end = start + 'NameKeySymbol'.length;
+const symbolDescription =
+    String(Object.getOwnPropertySymbols(test_object)[0]).slice(start, end);
+assert.strictEqual(symbolDescription, 'NameKeySymbol');
+
 // The napi_writable attribute should be ignored for accessors.
 test_object.readwriteAccessor1 = 1;
 assert.strictEqual(test_object.readwriteAccessor1, 1);

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -63,11 +63,15 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_value number;
   NAPI_CALL_RETURN_VOID(env, napi_create_number(env, value_, &number));
 
+  napi_value name_value;
+  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env, "NameKeyValue", -1, &name_value));
+
   napi_property_descriptor properties[] = {
     { "echo", 0, Echo, 0, 0, 0, napi_enumerable, 0 },
     { "readwriteValue", 0, 0, 0, 0, number, napi_enumerable | napi_writable, 0 },
     { "readonlyValue", 0, 0, 0, 0, number, napi_enumerable, 0},
     { "hiddenValue", 0, 0, 0, 0, number, napi_default, 0},
+    { NULL, name_value, 0, 0, 0, number, napi_enumerable, 0},
     { "readwriteAccessor1", 0, 0, GetValue, SetValue, 0, napi_default, 0},
     { "readwriteAccessor2", 0, 0, GetValue, SetValue, 0, napi_writable, 0},
     { "readonlyAccessor1", 0, 0, GetValue, NULL, 0, napi_default, 0},

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -64,7 +64,20 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_create_number(env, value_, &number));
 
   napi_value name_value;
-  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env, "NameKeyValue", -1, &name_value));
+  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env,
+                                                     "NameKeyValue",
+                                                     -1,
+                                                     &name_value));
+
+  napi_value symbol_description;
+  napi_value name_symbol;
+  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env,
+                                                     "NameKeySymbol",
+                                                      -1,
+                                                     &symbol_description));
+  NAPI_CALL_RETURN_VOID(env, napi_create_symbol(env,
+                                                symbol_description,
+                                                &name_symbol));
 
   napi_property_descriptor properties[] = {
     { "echo", 0, Echo, 0, 0, 0, napi_enumerable, 0 },
@@ -72,6 +85,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     { "readonlyValue", 0, 0, 0, 0, number, napi_enumerable, 0},
     { "hiddenValue", 0, 0, 0, 0, number, napi_default, 0},
     { NULL, name_value, 0, 0, 0, number, napi_enumerable, 0},
+    { NULL, name_symbol, 0, 0, 0, number, napi_enumerable, 0},
     { "readwriteAccessor1", 0, 0, GetValue, SetValue, 0, napi_default, 0},
     { "readwriteAccessor2", 0, 0, GetValue, SetValue, 0, napi_writable, 0},
     { "readonlyAccessor1", 0, 0, GetValue, NULL, 0, napi_default, 0},


### PR DESCRIPTION
We did not have test coverage for using a napi_value
pointing to a string or symbol for the name when
creating a property.  Add that coverage.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test, n-api