### PR TITLE
n-api: use Maybe version of SetPrototype

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1963,8 +1963,8 @@ napi_status napi_wrap(napi_env env,
 
   // Insert the wrapper into the object's prototype chain.
   v8::Local<v8::Value> proto = obj->GetPrototype();
-  wrapper->SetPrototype(proto);
-  obj->SetPrototype(wrapper);
+  wrapper->SetPrototype(context, proto).ToChecked();
+  obj->SetPrototype(context, wrapper).ToChecked();
 
   if (result != nullptr) {
     // The returned reference should be deleted via napi_delete_reference()


### PR DESCRIPTION
Currently the following two warnings are displayed when compiling:
```console
../src/node_api.cc:1966:12: warning: 'SetPrototype' is deprecated
[-Wdeprecated-declarations]
  wrapper->SetPrototype(proto);
           ^

../src/node_api.cc:1967:8: warning: 'SetPrototype' is deprecated
[-Wdeprecated-declarations]
  obj->SetPrototype(wrapper);
```
This commit changes these calls to use the Maybe<bool> version.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api