### PR TITLE
test: fix flaky test-http-client-get-url

### DIFF
--- a/test/parallel/test-http-client-get-url.js
+++ b/test/parallel/test-http-client-get-url.js
@@ -25,19 +25,23 @@ const assert = require('assert');
 const http = require('http');
 const url = require('url');
 const URL = url.URL;
+const testPath = '/foo?bar';
 
-const server = http.createServer(common.mustCall(function(req, res) {
+const server = http.createServer(common.mustCall((req, res) => {
   assert.strictEqual('GET', req.method);
-  assert.strictEqual('/foo?bar', req.url);
+  assert.strictEqual(testPath, req.url);
   res.writeHead(200, {'Content-Type': 'text/plain'});
   res.write('hello\n');
   res.end();
-  server.close();
 }, 3));
 
-server.listen(0, function() {
-  const u = `http://127.0.0.1:${this.address().port}/foo?bar`;
-  http.get(u);
-  http.get(url.parse(u));
-  http.get(new URL(u));
-});
+server.listen(0, common.localhostIPv4, common.mustCall(() => {
+  const u = `http://${common.localhostIPv4}:${server.address().port}${testPath}`;
+  http.get(u, common.mustCall(() => {
+    http.get(url.parse(u), common.mustCall(() => {
+      http.get(new URL(u), common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}));


### PR DESCRIPTION
Fixed `test-http-client-get-url` by waiting on HTTP GET requests to finish before closing the server.

Fixes: https://github.com/nodejs/node/issues/13507

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
