### PR TITLE
libs: remove redundant RegExp parts

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -315,7 +315,7 @@ function setServers(servers) {
     if (ipVersion !== 0)
       return newSet.push([ipVersion, serv]);
 
-    const match = serv.match(/\[(.*)\](?::\d+)?/);
+    const match = serv.match(/\[(.*)\]/);
     // we have an IPv6 in brackets
     if (match) {
       ipVersion = isIP(match[1]);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -772,7 +772,7 @@ function complete(line, callback) {
         name = files[f];
         ext = path.extname(name);
         base = name.slice(0, -ext.length);
-        if (base.match(/-\d+\.\d+(\.\d+)?/) || name === '.npm') {
+        if (/-\d+\.\d+/.test(base) || name === '.npm') {
           // Exclude versioned names that 'npm' installs.
           continue;
         }
@@ -1067,7 +1067,7 @@ REPLServer.prototype.memory = function memory(cmd) {
           self.lines.level.push({
             line: self.lines.length - 1,
             depth: depth,
-            isFunction: /\s*function\s*/.test(cmd)
+            isFunction: /\bfunction\b/.test(cmd)
           });
         } else if (depth < 0) {
           // going... up.


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dns, repl

If I get this correctly, a RegExp part with a quantifier '0 or more' is redundant if:

* it is used at the very beginning or the very end of the RegExp;
* it is used in a boolean context (`test()`);
* or it is not captured in `match()`/`exec()` results (full or partial) or does not affect match indices.

However, these parts may improve readability and comprehensibility. If this is the case for the changed fragments, feel free to reject this PR.

Also, I can miss some other nuances, so, please, correct me.