### PR TITLE
http: always cork outgoing writes

### DIFF
--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -6,8 +6,9 @@ var bench = common.createBenchmark(main, {
   // unicode confuses ab on os x.
   type: ['bytes', 'buffer'],
   len: [4, 1024, 102400],
-  chunks: [0, 1, 4],  // chunks=0 means 'no chunked encoding'.
+  chunks: [1, 4],
   c: [50, 500],
+  chunkedEnc: ['true', 'false'],
   res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
@@ -16,7 +17,8 @@ function main(conf) {
   var server = require('../fixtures/simple-http-server.js')
   .listen(process.env.PORT || common.PORT)
   .on('listening', function() {
-    var path = `/${conf.type}/${conf.len}/${conf.chunks}/${conf.res}`;
+    var path =
+      `/${conf.type}/${conf.len}/${conf.chunks}/${conf.res}/${conf.chunkedEnc}`;
 
     bench.http({
       path: path,

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -660,17 +660,17 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
   // signal the user to keep writing.
   if (chunk.length === 0) return true;
 
+  if (!fromEnd && msg.connection && !msg.connection.corked) {
+    msg.connection.cork();
+    process.nextTick(connectionCorkNT, msg.connection);
+  }
+
   var len, ret;
   if (msg.chunkedEncoding) {
     if (typeof chunk === 'string')
       len = Buffer.byteLength(chunk, encoding);
     else
       len = chunk.length;
-
-    if (msg.connection && !msg.connection.corked) {
-      msg.connection.cork();
-      process.nextTick(connectionCorkNT, msg.connection);
-    }
 
     msg._send(len.toString(16), 'latin1', null);
     msg._send(crlf_buf, null, null);


### PR DESCRIPTION
This PR always corks outgoing writes, no matter whether it's using chunked encoding or has a `Content-Length` set. Previously it was only enabled for chunked encoding writes.

Some benchmark results:

```
                                                                                                          improvement confidence      p.value
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=1024 type="buffer" benchmarker="wrk"       -0.86 %            1.738663e-01
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=102400 type="buffer" benchmarker="wrk"     -1.38 %          * 1.096846e-02
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=4 type="buffer" benchmarker="wrk"           4.46 %        *** 1.601082e-05
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=1024 type="buffer" benchmarker="wrk"     1662.88 %        *** 2.753497e-48
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=102400 type="buffer" benchmarker="wrk"    987.47 %        *** 1.450546e-35
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=4 type="buffer" benchmarker="wrk"        1691.00 %        *** 1.523719e-50
```

The single chunk write results here that are < 0% will be even less of a problem once the nextTick performance improvements in https://github.com/nodejs/node/pull/13446 land:

```
                                                                                                          improvement confidence      p.value
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=1024 type="buffer" benchmarker="wrk"        0.62 %            2.106693e-01
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=102400 type="buffer" benchmarker="wrk"     -1.11 %            5.027460e-02
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=1 len=4 type="buffer" benchmarker="wrk"           5.28 %        *** 1.522987e-05
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=1024 type="buffer" benchmarker="wrk"     1679.19 %        *** 1.692272e-53
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=102400 type="buffer" benchmarker="wrk"   1010.63 %        *** 1.096472e-38
 http/simple.js res="normal" chunkedEnc="false" c=50 chunks=4 len=4 type="buffer" benchmarker="wrk"        1703.22 %        *** 1.768577e-51
```

CI: https://ci.nodejs.org/job/node-test-pull-request/8532/

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* http
