### PR TITLE
test: exercise once() with varying arguments

### DIFF
--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -55,3 +55,23 @@ assert.throws(() => {
 
   ee.once('foo', null);
 }, /^TypeError: "listener" argument must be a function$/);
+
+{
+  // once() has different code paths based on the number of arguments being
+  // emitted. Verify that all of the cases are covered.
+  const maxArgs = 4;
+
+  for (let i = 0; i <= maxArgs; ++i) {
+    const ee = new EventEmitter();
+    const args = ['foo'];
+
+    for (let j = 0; j < i; ++j)
+      args.push(j);
+
+    ee.once('foo', common.mustCall((...params) => {
+      assert.deepStrictEqual(params, args.slice(1));
+    }));
+
+    EventEmitter.prototype.emit.apply(ee, args);
+  }
+}


### PR DESCRIPTION
This commit regains test coverage for `EventEmitter#once()` with four or more arguments. To avoid similar regressions in the future, `once()` is called with enough arguments to cover all of the separate code paths.

Coverage appears to have been lost [here](https://github.com/nodejs/node/commit/e374e44a8a1bed599379fdcf4b5fe142c5e5187d), and shows up on [this](https://coverage.nodejs.org/coverage-2791b360c11324f7/root/events.js.html) coverage report.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test