### PR TITLE
doc: corrects reference to tlsClientError

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1025,8 +1025,8 @@ changes:
 * `options` {Object}
   * `handshakeTimeout` {number} Abort the connection if the SSL/TLS handshake
     does not finish in the specified number of milliseconds. Defaults to `120`
-    seconds. A `'clientError'` is emitted on the `tls.Server` object whenever a
-    handshake times out.
+    seconds. A `'tlsClientError'` is emitted on the `tls.Server` object whenever
+    a handshake times out.
   * `requestCert` {boolean} If `true` the server will request a certificate from
     clients that connect and attempt to verify that certificate. Defaults to
     `false`.


### PR DESCRIPTION
After the renaming of `clientError` in TLS to `tlsClientError` in https://github.com/nodejs/node/commit/1ab6b21360d97719b3101153fb164c0c3eddf08,
the docs inconsistently referred the error as `clientError`, which is now
corrected.

It can be confirmed by looking at [this line](https://github.com/tarunbatra/node/blob/master/lib/_tls_wrap.js#L874), the error generated on timeout is `tlsClientError` and not `clientError`, making the current doc wrong.

Fixes: https://github.com/nodejs/node/issues/13417
PR-URL: https://github.com/nodejs/node/pull/13533

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc