### PR TITLE
libs: fix some RegExp nits

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -963,7 +963,7 @@ function SNICallback(servername, callback) {
   var ctx;
 
   this.server._contexts.some(function(elem) {
-    if (servername.match(elem[0]) !== null) {
+    if (elem[0].test(servername)) {
       ctx = elem[1];
       return true;
     }

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -309,13 +309,15 @@ function setServers(servers) {
   // servers cares won't have any servers available for resolution
   const orig = cares.getServers();
   const newSet = [];
+  const IPv6RE = /\[(.*)\](?::\d+)?/;
+  const addrSplitRE = /:\d+$/;
 
   servers.forEach((serv) => {
     var ipVersion = isIP(serv);
     if (ipVersion !== 0)
       return newSet.push([ipVersion, serv]);
 
-    const match = serv.match(/\[(.*)\](?::\d+)?/);
+    const match = serv.match(IPv6RE);
     // we have an IPv6 in brackets
     if (match) {
       ipVersion = isIP(match[1]);
@@ -323,7 +325,7 @@ function setServers(servers) {
         return newSet.push([ipVersion, match[1]]);
     }
 
-    const s = serv.split(/:\d+$/)[0];
+    const s = serv.split(addrSplitRE)[0];
     ipVersion = isIP(s);
 
     if (ipVersion !== 0)

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -309,7 +309,7 @@ function setServers(servers) {
   // servers cares won't have any servers available for resolution
   const orig = cares.getServers();
   const newSet = [];
-  const IPv6RE = /\[(.*)\](?::\d+)?/;
+  const IPv6RE = /\[(.*)\]/;
   const addrSplitRE = /:\d+$/;
 
   servers.forEach((serv) => {

--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -99,14 +99,14 @@ function createWorkerProcess(id, env) {
   var workerEnv = util._extend({}, process.env);
   var execArgv = cluster.settings.execArgv.slice();
   var debugPort = 0;
+  var debugArgvRE =
+    /^(--inspect|--inspect-(brk|port)|--debug|--debug-(brk|port))(=\d+)?$/;
 
   util._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
   for (var i = 0; i < execArgv.length; i++) {
-    const match = execArgv[i].match(
-      /^(--inspect|--inspect-(brk|port)|--debug|--debug-(brk|port))(=\d+)?$/
-    );
+    const match = execArgv[i].match(debugArgvRE);
 
     if (match) {
       if (debugPort === 0) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -754,7 +754,7 @@ function complete(line, callback) {
     const exts = Object.keys(this.context.require.extensions);
     var indexRe = new RegExp('^index(' + exts.map(regexpEscape).join('|') +
                              ')$');
-    var versionedFileNamesRe = /-\d+\.\d+(\.\d+)?/;
+    var versionedFileNamesRe = /-\d+\.\d+/;
 
     completeOn = match[1];
     var subdir = match[2] || '';
@@ -1068,7 +1068,7 @@ REPLServer.prototype.memory = function memory(cmd) {
           self.lines.level.push({
             line: self.lines.length - 1,
             depth: depth,
-            isFunction: /\s*function\s*/.test(cmd)
+            isFunction: /\bfunction\b/.test(cmd)
           });
         } else if (depth < 0) {
           // going... up.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -773,7 +773,7 @@ function complete(line, callback) {
         name = files[f];
         ext = path.extname(name);
         base = name.slice(0, -ext.length);
-        if (base.match(versionedFileNamesRe) || name === '.npm') {
+        if (versionedFileNamesRe.test(base) || name === '.npm') {
           // Exclude versioned names that 'npm' installs.
           continue;
         }
@@ -817,7 +817,7 @@ function complete(line, callback) {
   //   spam.eggs.<|>  # completions for 'spam.eggs' with filter ''
   //   foo<|>         # all scope vars with filter 'foo'
   //   foo.<|>        # completions for 'foo' with filter ''
-  } else if (line.length === 0 || line[line.length - 1].match(/\w|\.|\$/)) {
+  } else if (line.length === 0 || /\w|\.|\$/.test(line[line.length - 1])) {
     match = simpleExpressionRE.exec(line);
     if (line.length === 0 || match) {
       var expr;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -754,6 +754,7 @@ function complete(line, callback) {
     const exts = Object.keys(this.context.require.extensions);
     var indexRe = new RegExp('^index(' + exts.map(regexpEscape).join('|') +
                              ')$');
+    var versionedFileNamesRe = /-\d+\.\d+(\.\d+)?/;
 
     completeOn = match[1];
     var subdir = match[2] || '';
@@ -772,7 +773,7 @@ function complete(line, callback) {
         name = files[f];
         ext = path.extname(name);
         base = name.slice(0, -ext.length);
-        if (base.match(/-\d+\.\d+(\.\d+)?/) || name === '.npm') {
+        if (base.match(versionedFileNamesRe) || name === '.npm') {
           // Exclude versioned names that 'npm' installs.
           continue;
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -666,7 +666,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   }
   for (var n = 0; n < keys.length; n++) {
     var key = keys[n];
-    if (typeof key === 'symbol' || !key.match(numbersOnlyRE)) {
+    if (typeof key === 'symbol' || !numbersOnlyRE.test(key)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                  key, true));
     }
@@ -685,7 +685,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }
   for (const key of keys) {
-    if (typeof key === 'symbol' || !key.match(numbersOnlyRE)) {
+    if (typeof key === 'symbol' || !numbersOnlyRE.test(key)) {
       output.push(
           formatProperty(ctx, value, recurseTimes, visibleKeys, key, true));
     }
@@ -800,11 +800,11 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (name === undefined) {
-    if (array && key.match(numbersOnlyRE)) {
+    if (array && numbersOnlyRE.test(key)) {
       return str;
     }
     name = JSON.stringify('' + key);
-    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
+    if (/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/.test(name)) {
       name = name.substr(1, name.length - 2);
       name = ctx.stylize(name, 'name');
     } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -39,6 +39,8 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
+const numbersOnlyRE = /^\d+$/;
+
 var CIRCULAR_ERROR_MESSAGE;
 var Debug;
 
@@ -664,7 +666,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   }
   for (var n = 0; n < keys.length; n++) {
     var key = keys[n];
-    if (typeof key === 'symbol' || !key.match(/^\d+$/)) {
+    if (typeof key === 'symbol' || !key.match(numbersOnlyRE)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                  key, true));
     }
@@ -683,7 +685,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }
   for (const key of keys) {
-    if (typeof key === 'symbol' || !key.match(/^\d+$/)) {
+    if (typeof key === 'symbol' || !key.match(numbersOnlyRE)) {
       output.push(
           formatProperty(ctx, value, recurseTimes, visibleKeys, key, true));
     }
@@ -798,7 +800,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (name === undefined) {
-    if (array && key.match(/^\d+$/)) {
+    if (array && key.match(numbersOnlyRE)) {
       return str;
     }
     name = JSON.stringify('' + key);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
cluster, dns, repl, tls, util

1. Take `RegExp` creation out of cycles.

    I am not sure if v8 fully optimizes this now (= makes some `RegExp`s an identical one in cycles), so I've addressed this to be on the safe side. As long as the `RegExp` does not use `g` flag and match indices, we are safe here.

2. Use `test()`, not `match()` in boolean context.

    `match()` returns a complicated object, unneeded in a boolean context.

3. Remove redundant `RegExp` parts.

    If I get this correctly, a RegExp part with a quantifier '0 or more' is redundant if:
    
    * it is used at the very beginning or the very end of the RegExp;
    * it is used in a boolean context (`test()`);
    * or it is not captured in `match()`/`exec()` results (full or partial) or does not affect match indices.
    <br>
    However, these parts may improve readability and comprehensibility. If this is the case for the changed fragments, feel free to reject the change.

These are rather trivial changes to cause any regressions, and I've tried not to cause any accidental deopts (being consistent with `var` / `const` environment style in creating variables). If anybody believes some benchmarks are needed, please, tell me which of them I should run.

It is easier to review this PR commit by commit, as the changes are interwoven and this may be confusing.