### PR TITLE
v8: add a js class for Serializer/Dserializer

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -16,9 +16,9 @@
 
 const { Buffer } = require('buffer');
 const {
-        Serializer: _Serializer,
-        Deserializer: _Deserializer
-      } = process.binding('serdes');
+  Serializer: _Serializer,
+  Deserializer: _Deserializer
+} = process.binding('serdes');
 const { copy } = process.binding('buffer');
 const { objectToString } = require('internal/util');
 const { FastBuffer } = require('internal/buffer');

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,14 +15,20 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const serdesBindings = process.binding('serdes');
+const {
+        Serializer: _Serializer,
+        Deserializer: _Deserializer
+      } = process.binding('serdes');
 const { copy } = process.binding('buffer');
 const { objectToString } = require('internal/util');
 const { FastBuffer } = require('internal/buffer');
 
-class Serializer extends serdesBindings.Serializer {}
+// Calling exposed c++ functions directly throws exception as it expected to be
+// called with new operator and caused an assert to fire.
+// Creating JS wrapper so that it gets caught at JS layer.
+class Serializer extends _Serializer { }
 
-class Deserializer extends serdesBindings.Deserializer {}
+class Deserializer extends _Deserializer { }
 
 const {
   cachedDataVersionTag,

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,10 +15,14 @@
 'use strict';
 
 const { Buffer } = require('buffer');
-const { Serializer, Deserializer } = process.binding('serdes');
+const serdesBindings = process.binding('serdes');
 const { copy } = process.binding('buffer');
 const { objectToString } = require('internal/util');
 const { FastBuffer } = require('internal/buffer');
+
+class Serializer extends serdesBindings.Serializer {}
+
+class Deserializer extends serdesBindings.Deserializer {}
 
 const {
   cachedDataVersionTag,

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -133,17 +133,19 @@ const objects = [
 }
 
 {
-  try {
-    v8.Serializer();
-  } catch (e) {
-    const m = "Class constructor Serializer cannot be invoked without 'new'";
-    assert.strictEqual(e.message, m);
-  }
+  assert.throws(
+    () => {
+      v8.Serializer();
+    },
+    Error,
+    "Class constructor Serializer cannot be invoked without 'new'"
+  );
 
-  try {
-    v8.Deserializer();
-  } catch (e) {
-    const m = "Class constructor Deserializer cannot be invoked without 'new'";
-    assert.strictEqual(e.message, m);
-  }
+  assert.throws(
+    () => {
+      v8.Derializer();
+    },
+    Error,
+    "Class constructor Deserializer cannot be invoked without 'new'"
+  );
 }

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -131,3 +131,19 @@ const objects = [
 
   assert.deepStrictEqual(v8.deserialize(buf), expectedResult);
 }
+
+{
+  try {
+    v8.Serializer();
+  } catch (e) {
+    const m = "Class constructor Serializer cannot be invoked without 'new'";
+    assert.strictEqual(e.message, m);
+  }
+
+  try {
+    v8.Deserializer();
+  } catch (e) {
+    const m = "Class constructor Deserializer cannot be invoked without 'new'";
+    assert.strictEqual(e.message, m);
+  }
+}

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -134,18 +134,12 @@ const objects = [
 
 {
   assert.throws(
-    () => {
-      v8.Serializer();
-    },
-    Error,
-    "Class constructor Serializer cannot be invoked without 'new'"
+    () => { v8.Serializer(); },
+    /^TypeError: Class constructor Serializer cannot be invoked without 'new'$/
   );
 
   assert.throws(
-    () => {
-      v8.Derializer();
-    },
-    Error,
-    "Class constructor Deserializer cannot be invoked without 'new'"
+    () => { v8.Deserializer(); },
+    /^TypeError: Class constructor Deserializer cannot be invoked without 'new'$/
   );
 }


### PR DESCRIPTION
Calling Serializer/Deserlizer without new crashes node.
Adding a js class which just inherits cpp bindings.

Fixes: https://github.com/nodejs/node/issues/13326

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (test failing on master too)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
