### PR TITLE
doc: fix napi_create_*_error signatures in n-api

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -407,7 +407,9 @@ This API queries a `napi_value` to check if it represents an error object.
 added: v8.0.0
 -->
 ```C
-NODE_EXTERN napi_status napi_create_error(napi_env env, const char* msg);
+NODE_EXTERN napi_status napi_create_error(napi_env env,
+                                          const char* msg, 
+                                          napi_value* result);
 ```
 - `[in] env`: The environment that the API is invoked under.
 - `[in] msg`: C string representing the text to be associated with.
@@ -422,7 +424,9 @@ This API returns a JavaScript Error with the text provided.
 added: v8.0.0
 -->
 ```C
-NODE_EXTERN napi_status napi_create_type_error(napi_env env, const char* msg);
+NODE_EXTERN napi_status napi_create_type_error(napi_env env,
+                                               const char* msg,
+                                               napi_value* result);
 ```
 - `[in] env`: The environment that the API is invoked under.
 - `[in] msg`: C string representing the text to be associated with.
@@ -438,7 +442,9 @@ This API returns a JavaScript TypeError with the text provided.
 added: v8.0.0
 -->
 ```C
-NODE_EXTERN napi_status napi_create_range_error(napi_env env, const char* msg);
+NODE_EXTERN napi_status napi_create_range_error(napi_env env,
+                                                const char* msg,
+                                                napi_value* result);
 ```
 - `[in] env`: The environment that the API is invoked under.
 - `[in] msg`: C string representing the text to be associated with.


### PR DESCRIPTION
I think that these signatures need the `napi_value* result` of the error they are creating (as described below each one, and earlier in the docs)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
- doc
