### PR TITLE
http: fix timeout reset after keep-alive timeout

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -443,7 +443,6 @@ function socketOnData(server, socket, parser, state, d) {
 function onParserExecute(server, socket, parser, state, ret, d) {
   socket._unrefTimer();
   debug('SERVER socketOnParserExecute %d', ret);
-  resetSocketTimeout(server, socket, state);
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
 }
 
@@ -457,6 +456,8 @@ function socketOnError(e) {
 }
 
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
+  resetSocketTimeout(server, socket, state);
+
   if (ret instanceof Error) {
     debug('parse error', ret);
     socketOnError.call(socket, ret);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -436,14 +436,6 @@ function socketOnData(server, socket, parser, state, d) {
   assert(!socket._paused);
   debug('SERVER socketOnData %d', d.length);
 
-  if (state.keepAliveTimeoutSet) {
-    socket.setTimeout(0);
-    if (server.timeout) {
-      socket.setTimeout(server.timeout);
-    }
-    state.keepAliveTimeoutSet = false;
-  }
-
   var ret = parser.execute(d);
   onParserExecuteCommon(server, socket, parser, state, ret, d);
 }
@@ -451,6 +443,7 @@ function socketOnData(server, socket, parser, state, d) {
 function onParserExecute(server, socket, parser, state, ret, d) {
   socket._unrefTimer();
   debug('SERVER socketOnParserExecute %d', ret);
+  resetSocketTimeout(server, socket, state);
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
 }
 
@@ -545,6 +538,8 @@ function resOnFinish(req, res, socket, state, server) {
 // new message. In this callback we setup the response object and pass it
 // to the user.
 function parserOnIncoming(server, socket, state, req, keepAlive) {
+  resetSocketTimeout(server, socket, state);
+
   state.incoming.push(req);
 
   // If the writable end isn't consuming, then stop reading
@@ -604,6 +599,14 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     server.emit('request', req, res);
   }
   return false; // Not a HEAD response. (Not even a response!)
+}
+
+function resetSocketTimeout(server, socket, state) {
+  if (!state.keepAliveTimeoutSet)
+    return;
+
+  socket.setTimeout(server.timeout || 0);
+  state.keepAliveTimeoutSet = false;
 }
 
 function onSocketResume() {

--- a/test/parallel/test-http-server-keep-alive-timeout-slow-client-headers.js
+++ b/test/parallel/test-http-server-keep-alive-timeout-slow-client-headers.js
@@ -9,7 +9,7 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end();
 }, 2));
 
-server.keepAliveTimeout = 100;
+server.keepAliveTimeout = common.platformTimeout(100);
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
@@ -38,7 +38,7 @@ server.listen(0, common.mustCall(() => {
     setTimeout(() => {
       socket.write('Connection: keep-alive\r\n' +
                    '\r\n');
-    }, 200);
+    }, common.platformTimeout(300));
 
     function onData(chunk) {
       response += chunk;

--- a/test/parallel/test-http-server-keep-alive-timeout-slow-client-headers.js
+++ b/test/parallel/test-http-server-keep-alive-timeout-slow-client-headers.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.end();
+}, 2));
+
+server.keepAliveTimeout = 100;
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const socket = net.connect({ port }, common.mustCall(() => {
+    request(common.mustCall(() => {
+      // Make a second request on the same socket, after the keep-alive timeout
+      // has been set on the server side.
+      request(common.mustCall());
+    }));
+  }));
+
+  server.on('timeout', common.mustCall(() => {
+    socket.end();
+    server.close();
+  }));
+
+  function request(callback) {
+    socket.setEncoding('utf8');
+    socket.on('data', onData);
+    let response = '';
+
+    // Simulate a client that sends headers slowly (with a period of inactivity
+    // that is longer than the keep-alive timeout).
+    socket.write('GET / HTTP/1.1\r\n' +
+                 `Host: localhost:${port}\r\n`);
+    setTimeout(() => {
+      socket.write('Connection: keep-alive\r\n' +
+                   '\r\n');
+    }, 200);
+
+    function onData(chunk) {
+      response += chunk;
+      if (chunk.includes('\r\n')) {
+        socket.removeListener('data', onData);
+        onHeaders();
+      }
+    }
+
+    function onHeaders() {
+      assert.ok(response.includes('HTTP/1.1 200 OK\r\n'));
+      assert.ok(response.includes('Connection: keep-alive\r\n'));
+      callback();
+    }
+  }
+}));

--- a/test/parallel/test-http-server-keep-alive-timeout-slow-server.js
+++ b/test/parallel/test-http-server-keep-alive-timeout-slow-server.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  if (req.url === '/first') {
+    res.end('ok');
+    return;
+  }
+  setTimeout(() => {
+    res.end('ok');
+  }, 200);
+}, 2));
+
+server.keepAliveTimeout = 100;
+
+const agent = new http.Agent({
+  keepAlive: true,
+  maxSockets: 1
+});
+
+function request(path, callback) {
+  const port = server.address().port;
+  const req = http.request({ agent, path, port }, common.mustCall((res) => {
+    assert.strictEqual(res.statusCode, 200);
+
+    res.setEncoding('utf8');
+
+    let result = '';
+    res.on('data', (chunk) => {
+      result += chunk;
+    });
+
+    res.on('end', common.mustCall(() => {
+      assert.strictEqual(result, 'ok');
+      callback();
+    }));
+  }));
+  req.end();
+}
+
+server.listen(0, common.mustCall(() => {
+  request('/first', () => {
+    request('/second', () => {
+      server.close();
+    });
+  });
+}));

--- a/test/parallel/test-http-server-keep-alive-timeout-slow-server.js
+++ b/test/parallel/test-http-server-keep-alive-timeout-slow-server.js
@@ -11,10 +11,10 @@ const server = http.createServer(common.mustCall((req, res) => {
   }
   setTimeout(() => {
     res.end('ok');
-  }, 200);
+  }, common.platformTimeout(500));
 }, 2));
 
-server.keepAliveTimeout = 100;
+server.keepAliveTimeout = common.platformTimeout(200);
 
 const agent = new http.Agent({
   keepAlive: true,


### PR DESCRIPTION
`socketOnData` is not called for headers, the HTTP parser consumes
the stream at that moment. Move the timeout reset logic to
`onParserExecute` and add two tests:

* `test-http-server-keep-alive-timeout-slow-server` is a regression test
  for GH-13391.  It ensures that the server-side keep-alive timeout will
  not fire during processing of a request.

* `test-http-server-keep-alive-timeout-slow-headers` ensures that the
  regular socket timeout is restored as soon as a client starts sending
  a new request, not as soon as the whole message is received, so that
  the keep-alive timeout will not fire while, e.g., the client is
  sending large cookies.

Fixes: https://github.com/nodejs/node/issues/13391

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http