### PR TITLE
benchmark: fix some RegExp nits

### DIFF
--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -52,7 +52,7 @@ function main(conf) {
   var buff = new clazz(8);
   var fn = `write${conf.type}`;
 
-  if (fn.match(/Int/))
+  if (/Int/.test(fn))
     benchInt(buff, fn, len, noAssert);
   else
     benchFloat(buff, fn, len, noAssert);

--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -40,9 +40,10 @@ function Benchmark(fn, configs, options) {
 Benchmark.prototype._parseArgs = function(argv, configs) {
   const cliOptions = {};
   const extraOptions = {};
+  const validArgRE = /^(.+?)=([\s\S]*)$/;
   // Parse configuration arguments
   for (const arg of argv) {
-    const match = arg.match(/^(.+?)=([\s\S]*)$/);
+    const match = arg.match(validArgRE);
     if (!match) {
       console.error(`bad argument: ${arg}`);
       process.exit(1);

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -11,7 +11,7 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   var api = conf.api;
-  if (api === 'stream' && process.version.match(/^v0\.[0-8]\./)) {
+  if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
     api = 'legacy';

--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -15,7 +15,7 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   var api = conf.api;
-  if (api === 'stream' && process.version.match(/^v0\.[0-8]\./)) {
+  if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
     api = 'legacy';

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -14,7 +14,7 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   var api = conf.api;
-  if (api === 'stream' && process.version.match(/^v0\.[0-8]\./)) {
+  if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // use the legacy, just so that we can compare them.
     api = 'legacy';


### PR DESCRIPTION
##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
benchmark

* Take `RegExp` instance creation out of a cycle.
* Use `test()`, not `match()` in a boolean context.
