### PR TITLE
test: fix typo in test-cli-node-options.js

### DIFF
--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -72,8 +72,8 @@ function expect(opt, want) {
     assert.ifError(err);
     if (!RegExp(want).test(stdout)) {
       console.error('For %j, failed to find %j in: <\n%s\n>',
-                    opt, expect, stdout);
-      assert(false, `Expected ${expect}`);
+                    opt, want, stdout);
+      assert.fail(`Expected ${want}`);
     }
   }));
 }


### PR DESCRIPTION
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, cli

`expect` was probably a typo, as it is a function and will always be `undefined` as JSON.

The previous `test()` check infers it should be `want`.

cc @sam-github