### PR TITLE
doc: fix out of date napi_callback doc

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -161,11 +161,9 @@ For more details, review the [Object Lifetime Management][].
 
 ### N-API Callback types
 #### *napi_callback_info*
-Opaque datatype that is passed to a callback function. It can be used for two
-purposes:
-- Get additional information about the context in which the callback was
-  invoked.
-- Set the return value of the callback.
+Opaque datatype that is passed to a callback function. It can be used for
+getting additional information about the context in which the callback was
+invoked.
 
 #### *napi_callback*
 Function pointer type for user-provided native functions which are to be

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -172,7 +172,7 @@ Function pointer type for user-provided native functions which are to be
 exposed to JavaScript via N-API. Callback functions should satisfy the
 following signature:
 ```C
-typedef void (*napi_callback)(napi_env, napi_callback_info);
+typedef napi_value (*napi_callback)(napi_env, napi_callback_info);
 ```
 
 #### *napi_finalize*
@@ -2521,8 +2521,9 @@ In order to expose a function as part of the
 add-on's module exports, set the newly created function on the exports
 object. A sample module might look as follows:
 ```C
-void SayHello(napi_env env, napi_callback_info info) {
+napi_value SayHello(napi_env env, napi_callback_info info) {
   printf("Hello\n");
+  return nullptr;
 }
 
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {


### PR DESCRIPTION
The earlier version `napi_callback` returns `void` but now is `napi_value`. The document of this section hasn't been modified.

Fixes: https://github.com/nodejs/node/pull/12248
Fixes: https://github.com/nodejs/node/issues/13562

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, n-api