### PR TITLE
(v6.x backport) v8: fix build errors with g++ 7

### DIFF
--- a/deps/v8/src/objects-body-descriptors.h
+++ b/deps/v8/src/objects-body-descriptors.h
@@ -99,7 +99,7 @@ class FixedBodyDescriptor final : public BodyDescriptorBase {
 
   template <typename StaticVisitor>
   static inline void IterateBody(HeapObject* obj, int object_size) {
-    IterateBody(obj);
+    IterateBody<StaticVisitor>(obj);
   }
 };
 

--- a/deps/v8/src/objects-inl.h
+++ b/deps/v8/src/objects-inl.h
@@ -36,6 +36,27 @@
 namespace v8 {
 namespace internal {
 
+template <typename Derived, typename Shape, typename Key>
+uint32_t HashTable<Derived, Shape, Key>::Hash(Key key) {
+  if (Shape::UsesSeed) {
+    return Shape::SeededHash(key, GetHeap()->HashSeed());
+  } else {
+    return Shape::Hash(key);
+  }
+}
+
+
+template <typename Derived, typename Shape, typename Key>
+uint32_t HashTable<Derived, Shape, Key>::HashForObject(Key key,
+                                                       Object* object) {
+  if (Shape::UsesSeed) {
+    return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
+  } else {
+    return Shape::HashForObject(key, object);
+  }
+}
+
+
 PropertyDetails::PropertyDetails(Smi* smi) {
   value_ = smi->value();
 }

--- a/deps/v8/src/objects.h
+++ b/deps/v8/src/objects.h
@@ -3261,22 +3261,10 @@ class HashTableBase : public FixedArray {
 template <typename Derived, typename Shape, typename Key>
 class HashTable : public HashTableBase {
  public:
-  // Wrapper methods
-  inline uint32_t Hash(Key key) {
-    if (Shape::UsesSeed) {
-      return Shape::SeededHash(key, GetHeap()->HashSeed());
-    } else {
-      return Shape::Hash(key);
-    }
-  }
-
-  inline uint32_t HashForObject(Key key, Object* object) {
-    if (Shape::UsesSeed) {
-      return Shape::SeededHashForObject(key, GetHeap()->HashSeed(), object);
-    } else {
-      return Shape::HashForObject(key, object);
-    }
-  }
+  // Wrapper methods.  Defined in src/objects-inl.h
+  // to break a cycle with src/heap/heap.h.
+  inline uint32_t Hash(Key key);
+  inline uint32_t HashForObject(Key key, Object* object);
 
   // Returns a new HashTable object.
   MUST_USE_RESULT static Handle<Derived> New(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
This is patch from fedora rawhide to fix gcc 7 build errors, same as 2a2a5565c298639b823250b571101f51210c50e8

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
