### PR TITLE
http: handle cases where socket.server is null

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -294,6 +294,11 @@ function connectionListener(socket) {
 
   httpSocketSetup(socket);
 
+  // Ensure that the server property of the socket is correctly set.
+  // See https://github.com/nodejs/node/issues/13435
+  if (socket.server === null)
+    socket.server = this;
+
   // If the user has added a listener to the server,
   // request, or response, then it's their responsibility.
   // otherwise, destroy on timeout by default

--- a/test/parallel/test-cluster-send-socket-to-worker-http-server.js
+++ b/test/parallel/test-cluster-send-socket-to-worker-http-server.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// Regression test for https://github.com/nodejs/node/issues/13435
+// Tests that `socket.server` is correctly set when a socket is sent to a worker
+// and the `'connection'` event is emitted manually on an HTTP server.
+
 const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
@@ -8,13 +12,11 @@ const net = require('net');
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
-  const server = net.createServer({
-    pauseOnConnect: true
-  }, common.mustCall((socket) => {
+  const server = net.createServer(common.mustCall((socket) => {
     worker.send('socket', socket);
   }));
 
-  worker.on('exit', common.mustCall((code, signal) => {
+  worker.on('exit', common.mustCall((code) => {
     assert.strictEqual(code, 0);
     server.close();
   }));
@@ -25,13 +27,13 @@ if (cluster.isMaster) {
 } else {
   const server = http.createServer();
 
-  server.setTimeout(100, common.mustCall((socket) => {
+  server.on('connection', common.mustCall((socket) => {
+    assert.strictEqual(socket.server, server);
     socket.destroy();
-    cluster.worker.kill();
+    cluster.worker.disconnect();
   }));
 
   process.on('message', common.mustCall((message, socket) => {
     server.emit('connection', socket);
-    socket.resume();
   }));
 }

--- a/test/parallel/test-regress-GH-13435.js
+++ b/test/parallel/test-regress-GH-13435.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const http = require('http');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const worker = cluster.fork();
+  const server = net.createServer({
+    pauseOnConnect: true
+  }, common.mustCall((socket) => {
+    worker.send('socket', socket);
+  }));
+
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    server.close();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    net.createConnection(server.address().port);
+  }));
+} else {
+  const server = http.createServer();
+
+  server.setTimeout(100, common.mustCall((socket) => {
+    socket.destroy();
+    cluster.worker.kill();
+  }));
+
+  process.on('message', common.mustCall((message, socket) => {
+    server.emit('connection', socket);
+    socket.resume();
+  }));
+}


### PR DESCRIPTION
Fixes a regression that caused an error to be thrown when trying to emit the 'timeout' event on the server referenced by `socket.server`.

Fixes: https://github.com/nodejs/node/issues/13435
Refs: https://github.com/nodejs/node/pull/11926

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http