### PR TITLE
test: use mustNotCall in test-http-eof-on-connect

### DIFF
--- a/test/parallel/test-http-eof-on-connect.js
+++ b/test/parallel/test-http-eof-on-connect.js
@@ -29,7 +29,7 @@ const http = require('http');
 // It is separate from test-http-malformed-request.js because it is only
 // reproduceable on the first packet on the first connection to a server.
 
-const server = http.createServer(common.noop);
+const server = http.createServer(common.mustNotCall());
 server.listen(0);
 
 server.on('listening', function() {


### PR DESCRIPTION
Confirm that callback is not being invoked in
test-http-eof-on-connect.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http