### PR TITLE
profiler: declare missing `printErr`

### DIFF
--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -18,6 +18,11 @@ scriptFiles.forEach(function(s) {
   script += process.binding('natives')[s] + '\n';
 });
 
+// eslint-disable-next-line no-unused-vars
+function printErr(err) {
+  console.error(err);
+}
+
 const tickArguments = [];
 if (process.platform === 'darwin') {
   tickArguments.push('--mac');


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

profiler?

`v8/tools/tickprocessor.js` assumes presence of global `printErr`, which
is defined in `d8`.
