### PR TITLE
libuv: Allow fs.symlink without being elevated administrator on Win32

### DIFF
--- a/deps/uv/src/win/fs.c
+++ b/deps/uv/src/win/fs.c
@@ -1684,9 +1684,11 @@ static void fs__symlink(uv_fs_t* req) {
   if (flags & UV_FS_SYMLINK_JUNCTION) {
     fs__create_junction(req, pathw, new_pathw);
   } else if (pCreateSymbolicLinkW) {
-    result = pCreateSymbolicLinkW(new_pathw,
-                                  pathw,
-                                  flags & UV_FS_SYMLINK_DIR ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0) ? 0 : -1;
+    int symlink_flags = flags & UV_FS_SYMLINK_DIR ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0;
+    symlink_flags |= SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+
+    result = pCreateSymbolicLinkW(new_pathw, pathw, symlink_flags) ? 0 : -1;
+
     if (result == -1) {
       SET_REQ_WIN32_ERROR(req, GetLastError());
     } else {

--- a/deps/uv/src/win/winapi.h
+++ b/deps/uv/src/win/winapi.h
@@ -4643,8 +4643,6 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
 # define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
 #endif
 
-
-
 typedef BOOL (WINAPI *sGetQueuedCompletionStatusEx)
              (HANDLE CompletionPort,
               LPOVERLAPPED_ENTRY lpCompletionPortEntries,

--- a/deps/uv/src/win/winapi.h
+++ b/deps/uv/src/win/winapi.h
@@ -4638,6 +4638,13 @@ typedef NTSTATUS (NTAPI *sNtQueryDirectoryFile)
 # define ERROR_MUI_FILE_NOT_LOADED 15105
 #endif
 
+/* See https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#C6gRguKlBZWuXPuW.97 */
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+# define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
+#endif
+
+
+
 typedef BOOL (WINAPI *sGetQueuedCompletionStatusEx)
              (HANDLE CompletionPort,
               LPOVERLAPPED_ENTRY lpCompletionPortEntries,


### PR DESCRIPTION
(Not sure if this belongs as a PR to libuv, let me know if so - if this PR is on the right track, I'll clean up the commits to match the standard etc etc)

This PR implements the changes required in https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#C6gRguKlBZWuXPuW.97, which allows `fs.symlink` with the `directory/file` parameter to create symbolic links on Windows 10 Creators Edition or higher, without requiring the process to be UAC elevated.

Note that to verify this, you'll have to be both running Win10 Creators Update, and in "Developer Mode":

![image](https://user-images.githubusercontent.com/1396/26998869-a9747a2e-4d3f-11e7-9fdb-ed8ed458c1f3.png)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

libuv