### PR TITLE
test: use mustNotCall() in test-fs-watch

### DIFF
--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -130,7 +130,7 @@ fs.watch(__filename, {persistent: false}, function() {
 // https://github.com/joyent/node/issues/6690
 let oldhandle;
 assert.throws(function() {
-  const w = fs.watch(__filename, common.noop);
+  const w = fs.watch(__filename, common.mustNotCall());
   oldhandle = w._handle;
   w._handle = { close: w._handle.close };
   w.close();
@@ -138,7 +138,7 @@ assert.throws(function() {
 oldhandle.close(); // clean up
 
 assert.throws(function() {
-  const w = fs.watchFile(__filename, {persistent: false}, common.noop);
+  const w = fs.watchFile(__filename, {persistent: false}, common.mustNotCall());
   oldhandle = w._handle;
   w._handle = { stop: w._handle.stop };
   w.stop();


### PR DESCRIPTION
Use common.mustNotCall() in test/sequential/test-fs-watch.js in
situations where the call to watch() is expected to throw.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs