### PR TITLE
https: make opts optional & immutable when create

### DIFF
--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -46,7 +46,7 @@ added: v8.0.0
 
 See [`http.Server#keepAliveTimeout`][].
 
-## https.createServer(options[, requestListener])
+## https.createServer([options][, requestListener])
 <!-- YAML
 added: v0.3.4
 -->

--- a/lib/https.js
+++ b/lib/https.js
@@ -38,7 +38,7 @@ function Server(opts = {}, requestListener) {
     requestListener = opts;
     opts = undefined;
   }
-  opts = opts ? Object.assign({}, opts) : {};
+  opts = util._extend({}, opts);
 
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];

--- a/lib/https.js
+++ b/lib/https.js
@@ -31,14 +31,14 @@ const inherits = util.inherits;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
 
-function Server(opts, requestListener) {
+function Server(opts = {}, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
   if (typeof opts === 'function') {
     requestListener = opts;
     opts = undefined;
   }
-  opts = opts ? util._extend({}, opts) : {};
+  opts = opts ? Object.assign({}, opts) : {};
 
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];

--- a/lib/https.js
+++ b/lib/https.js
@@ -31,7 +31,7 @@ const inherits = util.inherits;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
 
-function Server(opts = {}, requestListener) {
+function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
   if (typeof opts === 'function') {

--- a/lib/https.js
+++ b/lib/https.js
@@ -34,6 +34,12 @@ const { urlToOptions, searchParamsSymbol } = require('internal/url');
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
+  if (typeof opts === 'function') {
+    requestListener = opts;
+    opts = undefined;
+  }
+  opts = opts ? util._extend({}, opts) : {};
+
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
 
 const assert = require('assert');
 const https = require('https');

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -7,30 +7,34 @@ const https = require('https');
 const tls = require('tls');
 
 const dftProtocol = {};
-tls.convertNPNProtocols([ 'http/1.1' ], dftProtocol);
 
 // test for immutable `opts`
-const opts = { foo: 'bar', NPNProtocols: [ 'http/1.1' ] };
-const server1 = https.createServer(opts);
+{
+  const opts = { foo: 'bar', NPNProtocols: [ 'http/1.1' ] };
+  const server = https.createServer(opts);
 
-assert.deepStrictEqual(opts, { foo: 'bar', NPNProtocols: [ 'http/1.1' ] });
-assert.strictEqual(server1.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+  tls.convertNPNProtocols([ 'http/1.1' ], dftProtocol);
+  assert.deepStrictEqual(opts, { foo: 'bar', NPNProtocols: [ 'http/1.1' ] });
+  assert.strictEqual(server.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+}
 
 
 // validate that `createServer` can work with the only argument requestListener
-const mustNotCall = common.mustNotCall();
-const server2 = https.createServer(mustNotCall);
+{
+  const mustNotCall = common.mustNotCall();
+  const server = https.createServer(mustNotCall);
 
-tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
-assert.ok(server2);
-assert.strictEqual(server2.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
-assert.strictEqual(server2.listeners('request').length, 1);
-assert.strictEqual(server2.listeners('request')[0], mustNotCall);
+  tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
+  assert.strictEqual(server.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+  assert.strictEqual(server.listeners('request').length, 1);
+  assert.strictEqual(server.listeners('request')[0], mustNotCall);
+}
 
 
 // validate that `createServer` can work with no arguments
-const server3 = https.createServer();
+{
+  const server = https.createServer();
 
-assert.ok(server3);
-assert.strictEqual(server3.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
-assert.strictEqual(server3.listeners('request').length, 0);
+  assert.strictEqual(server.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+  assert.strictEqual(server.listeners('request').length, 0);
+}

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -9,18 +9,28 @@ const tls = require('tls');
 const dftProtocol = {};
 tls.convertNPNProtocols([ 'http/1.1' ], dftProtocol);
 
+// test for immutable `opts`
 const opts = { foo: 'bar', NPNProtocols: [ 'http/1.1' ] };
 const server1 = https.createServer(opts);
 
 assert.deepStrictEqual(opts, { foo: 'bar', NPNProtocols: [ 'http/1.1' ] });
 assert.strictEqual(server1.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
 
+
+// validate that `createServer` can work with the only argument requestListener
 const mustNotCall = common.mustNotCall();
 const server2 = https.createServer(mustNotCall);
 
-// validate that `createServer` can work with no arguments
 tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
 assert.ok(server2);
 assert.strictEqual(server2.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
 assert.strictEqual(server2.listeners('request').length, 1);
 assert.strictEqual(server2.listeners('request')[0], mustNotCall);
+
+
+// validate that `createServer` can work with no arguments
+const server3 = https.createServer();
+
+assert.ok(server3);
+assert.strictEqual(server3.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+assert.strictEqual(server3.listeners('request').length, 0);

--- a/test/parallel/test-https-immutable-options.js
+++ b/test/parallel/test-https-immutable-options.js
@@ -15,7 +15,7 @@ const server1 = https.createServer(opts);
 assert.deepStrictEqual(opts, { foo: 'bar' });
 assert.strictEqual(server1.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
 
-const mustNotCall = common.mustNotCall('dummy callback');
+const mustNotCall = common.mustNotCall();
 const server2 = https.createServer(mustNotCall);
 
 assert.strictEqual(server2.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);

--- a/test/parallel/test-https-immutable-options.js
+++ b/test/parallel/test-https-immutable-options.js
@@ -7,16 +7,20 @@ const https = require('https');
 const tls = require('tls');
 
 const dftProtocol = {};
-tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
+tls.convertNPNProtocols([ 'http/1.1' ], dftProtocol);
 
-const opts = { foo: 'bar' };
+const opts = { foo: 'bar', NPNProtocols: [ 'http/1.1' ] };
 const server1 = https.createServer(opts);
 
-assert.deepStrictEqual(opts, { foo: 'bar' });
+assert.deepStrictEqual(opts, { foo: 'bar', NPNProtocols: [ 'http/1.1' ] });
 assert.strictEqual(server1.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
 
 const mustNotCall = common.mustNotCall();
 const server2 = https.createServer(mustNotCall);
 
+// validate that `createServer` can work with no arguments
+tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
+assert.ok(server2);
 assert.strictEqual(server2.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
-assert.strictEqual(mustNotCall, server2._events.request);
+assert.strictEqual(server2.listeners('request').length, 1);
+assert.strictEqual(server2.listeners('request')[0], mustNotCall);

--- a/test/parallel/test-https-immutable-options.js
+++ b/test/parallel/test-https-immutable-options.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+
+const assert = require('assert');
+const https = require('https');
+const tls = require('tls');
+
+const dftProtocol = {};
+tls.convertNPNProtocols([ 'http/1.1', 'http/1.0' ], dftProtocol);
+
+const opts = { foo: 'bar' };
+const server1 = https.createServer(opts);
+
+assert.deepStrictEqual(opts, { foo: 'bar' });
+assert.strictEqual(server1.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+
+const mustNotCall = common.mustNotCall('dummy callback');
+const server2 = https.createServer(mustNotCall);
+
+assert.strictEqual(server2.NPNProtocols.compare(dftProtocol.NPNProtocols), 0);
+assert.strictEqual(mustNotCall, server2._events.request);


### PR DESCRIPTION
`opts` in `createServer` will be immutable that won't change origional
opts value. What's more, it's optional which can make `requestListener`
be the first argument.

Refs: https://github.com/nodejs/node/issues/13584

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
https