### PR TITLE
errors: add missing ERR_ prefix on util.callbackify error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -576,6 +576,12 @@ The `ERR_CONSOLE_WRITABLE_STREAM` error code is thrown when `Console` is
 instantiated without `stdout` stream or when `stdout` or `stderr` streams
 are not writable.
 
+<a id="ERR_FALSY_VALUE_REJECTION"></a>
+### ERR_FALSY_VALUE_REJECTION
+
+The `ERR_FALSY_VALUE_REJECTION` error code is used by the `util.callbackify()`
+API when a callbackified `Promise` is rejected with a falsy value (e.g. `null`).
+
 <a id="ERR_INDEX_OUT_OF_RANGE"></a>
 ### ERR_INDEX_OUT_OF_RANGE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -115,6 +115,7 @@ E('ERR_ASSERTION', (msg) => msg);
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);
+E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot render headers after they are sent to the client');
 E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
@@ -164,7 +165,6 @@ E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
 E('ERR_V8BREAKITERATOR', 'full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
-E('FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
 // Add new errors from here...
 
 function invalidArgType(name, expected, actual) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1054,7 +1054,7 @@ function callbackifyOnRejected(reason, cb) {
   // occurred", we error-wrap so the callback consumer can distinguish between
   // "the promise rejected with null" or "the promise fulfilled with undefined".
   if (!reason) {
-    const newReason = new errors.Error('FALSY_VALUE_REJECTION');
+    const newReason = new errors.Error('ERR_FALSY_VALUE_REJECTION');
     newReason.reason = reason;
     reason = newReason;
     Error.captureStackTrace(reason, callbackifyOnRejected);

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -79,7 +79,7 @@ const values = [
       if (err instanceof Error) {
         if ('reason' in err) {
           assert(!value);
-          assert.strictEqual(err.code, 'FALSY_VALUE_REJECTION');
+          assert.strictEqual(err.code, 'ERR_FALSY_VALUE_REJECTION');
           assert.strictEqual(err.reason, value);
         } else {
           assert.strictEqual(String(value).endsWith(err.message), true);
@@ -100,7 +100,7 @@ const values = [
       if (err instanceof Error) {
         if ('reason' in err) {
           assert(!value);
-          assert.strictEqual(err.code, 'FALSY_VALUE_REJECTION');
+          assert.strictEqual(err.code, 'ERR_FALSY_VALUE_REJECTION');
           assert.strictEqual(err.reason, value);
         } else {
           assert.strictEqual(String(value).endsWith(err.message), true);
@@ -125,7 +125,7 @@ const values = [
       if (err instanceof Error) {
         if ('reason' in err) {
           assert(!value);
-          assert.strictEqual(err.code, 'FALSY_VALUE_REJECTION');
+          assert.strictEqual(err.code, 'ERR_FALSY_VALUE_REJECTION');
           assert.strictEqual(err.reason, value);
         } else {
           assert.strictEqual(String(value).endsWith(err.message), true);


### PR DESCRIPTION
The `FALSY_VALUE_REJECTION` error code added by https://github.com/nodejs/node/pull/12712 did not have the `ERR_` prefix, nor was it added to the errors.md documentation. Add the prefix in for consistency.

https://github.com/nodejs/node/pull/12712 is a semver-minor but it has not yet been shipped in a release. If it had been shipped, then this PR would have had to been semver-major. This should land in a release the same time as af3aa682ac534bb55765f5fef2755a88e5ff2580

/cc @refack @addaleax 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

util, errors