### PR TITLE
async_hooks: expose list of types

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -131,6 +131,16 @@ provided by AsyncHooks itself. The logging should then be skipped when
 it was the logging itself that caused AsyncHooks callback to call. By
 doing this the otherwise infinite recursion is broken.
 
+#### `async_hooks.getTypes()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: `{Array}` list of async resource type names
+
+Return the list of async resource type names. Names are simple strings.
+
 #### `asyncHook.enable()`
 
 * Returns {AsyncHook} A reference to `asyncHook`.
@@ -427,6 +437,13 @@ const server = net.createServer(function onConnection(conn) {
   async_hooks.currentId();
 });
 ```
+
+#### `async_hooks.registerTypeName(type)`
+
+* `type` {string} a new type of async resource
+* Returns {string} the type name to use
+
+Registers the type name for a new async resource.
 
 #### `async_hooks.triggerId()`
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -461,6 +461,21 @@ function init(asyncId, type, triggerId, resource) {
   processing_hook = false;
 }
 
+const JSSideProviders = {
+  Timeout: 'timers Timeout',
+  Immediate: 'timers Immediate',
+  TickObject: 'next_tick TickObject'
+};
+
+function _getTypeName(module, type) {
+  return Object.keys(JSSideProviders)
+    .find((k) => JSSideProviders[k] === `${module} ${type}`);
+}
+
+function getTypes() {
+  return Object.keys(async_wrap.Providers)
+    .concat(Object.keys(JSSideProviders));
+}
 
 // Placing all exports down here because the exported classes won't export
 // otherwise.
@@ -469,6 +484,7 @@ module.exports = {
   createHook,
   currentId,
   triggerId,
+  getTypes,
   // Embedder API
   AsyncResource,
   runInAsyncIdScope,
@@ -480,4 +496,6 @@ module.exports = {
   emitBefore: emitBeforeS,
   emitAfter: emitAfterS,
   emitDestroy: emitDestroyS,
+  // internal
+  _getTypeName,
 };

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const errors = require('internal/errors');
 const async_wrap = process.binding('async_wrap');
 /* Both these arrays are used to communicate between JS and C++ with as little
  * overhead as possible.
@@ -461,20 +462,18 @@ function init(asyncId, type, triggerId, resource) {
   processing_hook = false;
 }
 
-const JSSideProviders = {
-  Timeout: 'timers Timeout',
-  Immediate: 'timers Immediate',
-  TickObject: 'next_tick TickObject'
-};
+const JSProviders = new Set();
 
-function _getTypeName(module, type) {
-  return Object.keys(JSSideProviders)
-    .find((k) => JSSideProviders[k] === `${module} ${type}`);
+function registerTypeName(type) {
+  if (JSProviders.has(type))
+    throw new errors.TypeError('ERR_ASYNC_PROVIDER_NAME', type);
+  JSProviders.add(type);
+  return type;
 }
 
 function getTypes() {
   return Object.keys(async_wrap.Providers)
-    .concat(Object.keys(JSSideProviders));
+    .concat(...JSProviders.values());
 }
 
 // Placing all exports down here because the exported classes won't export
@@ -485,6 +484,7 @@ module.exports = {
   currentId,
   triggerId,
   getTypes,
+  registerTypeName,
   // Embedder API
   AsyncResource,
   runInAsyncIdScope,
@@ -496,6 +496,4 @@ module.exports = {
   emitBefore: emitBeforeS,
   emitAfter: emitAfterS,
   emitDestroy: emitDestroyS,
-  // internal
-  _getTypeName,
 };

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -463,7 +463,6 @@ function init(asyncId, type, triggerId, resource) {
 }
 
 const JSProviders = new Set();
-
 function registerTypeName(type) {
   if (JSProviders.has(type))
     throw new errors.TypeError('ERR_ASYNC_PROVIDER_NAME', type);
@@ -473,7 +472,7 @@ function registerTypeName(type) {
 
 function getTypes() {
   return Object.keys(async_wrap.Providers)
-    .concat(...JSProviders.values());
+    .concat(...JSProviders.keys());
 }
 
 // Placing all exports down here because the exported classes won't export

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,6 +112,7 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
+E('ERR_ASYNC_PROVIDER_NAME', '%s type name already registered');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,7 +112,7 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', (msg) => msg);
-E('ERR_ASYNC_PROVIDER_NAME', '%s type name already registered');
+E('ERR_ASYNC_PROVIDER_NAME', '"%s" type name already registered');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   (name) => `Console expects a writable stream instance for ${name}`);
 E('ERR_CPU_USAGE', (errMsg) => `Unable to obtain cpu usage ${errMsg}`);

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -27,7 +27,7 @@ function setupNextTick() {
   const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr, kInitTriggerId } =
       async_wrap.constants;
   const { async_id_symbol, trigger_id_symbol } = async_wrap;
-  const asyncTypeTO = async_hooks.registerTypeName('TickObject');
+  const kTickObjectType = async_hooks.registerTypeName('TickObject');
   var nextTickQueue = [];
   var microtasksScheduled = false;
 
@@ -224,7 +224,7 @@ function setupNextTick() {
     tickObject[trigger_id_symbol] = triggerId || initTriggerId();
     if (async_hook_fields[kInit] > 0) {
       emitInit(tickObject[async_id_symbol],
-               asyncTypeTO,
+               kTickObjectType,
                tickObject[trigger_id_symbol],
                tickObject);
     }

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -27,6 +27,7 @@ function setupNextTick() {
   const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr, kInitTriggerId } =
       async_wrap.constants;
   const { async_id_symbol, trigger_id_symbol } = async_wrap;
+  const asyncTypeTO = async_hooks._getTypeName('next_tick', 'TickObject');
   var nextTickQueue = [];
   var microtasksScheduled = false;
 
@@ -223,7 +224,7 @@ function setupNextTick() {
     tickObject[trigger_id_symbol] = triggerId || initTriggerId();
     if (async_hook_fields[kInit] > 0) {
       emitInit(tickObject[async_id_symbol],
-               'TickObject',
+               asyncTypeTO,
                tickObject[trigger_id_symbol],
                tickObject);
     }

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -27,7 +27,7 @@ function setupNextTick() {
   const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr, kInitTriggerId } =
       async_wrap.constants;
   const { async_id_symbol, trigger_id_symbol } = async_wrap;
-  const asyncTypeTO = async_hooks._getTypeName('next_tick', 'TickObject');
+  const asyncTypeTO = async_hooks.registerTypeName('TickObject');
   var nextTickQueue = [];
   var microtasksScheduled = false;
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -44,8 +44,8 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
 // Symbols for storing async id state.
 const async_id_symbol = Symbol('asyncId');
 const trigger_id_symbol = Symbol('triggerId');
-const asyncTypeTO = async_hooks._getTypeName('timers', 'Timeout');
-const asyncTypeIm = async_hooks._getTypeName('timers', 'Immediate');
+const asyncTypeTO = async_hooks.registerTypeName('Timeout');
+const asyncTypeIm = async_hooks.registerTypeName('Immediate');
 
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -44,8 +44,8 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
 // Symbols for storing async id state.
 const async_id_symbol = Symbol('asyncId');
 const trigger_id_symbol = Symbol('triggerId');
-const asyncTypeTO = async_hooks.registerTypeName('Timeout');
-const asyncTypeIm = async_hooks.registerTypeName('Immediate');
+const kTimeoutType = async_hooks.registerTypeName('Timeout');
+const kImmediateType = async_hooks.registerTypeName('Immediate');
 
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1
@@ -192,7 +192,7 @@ function insert(item, unrefed) {
     item[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
     item[trigger_id_symbol] = initTriggerId();
     if (async_hook_fields[kInit] > 0)
-      emitInit(item[async_id_symbol], asyncTypeTO, item[trigger_id_symbol],
+      emitInit(item[async_id_symbol], kTimeoutType, item[trigger_id_symbol],
                item);
   }
 
@@ -592,7 +592,7 @@ function Timeout(after, callback, args) {
   this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
   this[trigger_id_symbol] = initTriggerId();
   if (async_hook_fields[kInit] > 0)
-    emitInit(this[async_id_symbol], asyncTypeTO, this[trigger_id_symbol], this);
+    emitInit(this[async_id_symbol], kTimeoutType, this[trigger_id_symbol], this);
 }
 
 
@@ -827,7 +827,7 @@ function Immediate() {
   this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
   this[trigger_id_symbol] = initTriggerId();
   if (async_hook_fields[kInit] > 0)
-    emitInit(this[async_id_symbol], asyncTypeIm, this[trigger_id_symbol], this);
+    emitInit(this[async_id_symbol], kImmediateType, this[trigger_id_symbol], this);
 }
 
 function setImmediate(callback, arg1, arg2, arg3) {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -44,6 +44,8 @@ const { kInit, kBefore, kAfter, kDestroy, kAsyncUidCntr } =
 // Symbols for storing async id state.
 const async_id_symbol = Symbol('asyncId');
 const trigger_id_symbol = Symbol('triggerId');
+const asyncTypeTO = async_hooks._getTypeName('timers', 'Timeout');
+const asyncTypeIm = async_hooks._getTypeName('timers', 'Immediate');
 
 // Timeout values > TIMEOUT_MAX are set to 1.
 const TIMEOUT_MAX = 2147483647; // 2^31-1
@@ -190,7 +192,8 @@ function insert(item, unrefed) {
     item[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
     item[trigger_id_symbol] = initTriggerId();
     if (async_hook_fields[kInit] > 0)
-      emitInit(item[async_id_symbol], 'Timeout', item[trigger_id_symbol], item);
+      emitInit(item[async_id_symbol], asyncTypeTO, item[trigger_id_symbol],
+               item);
   }
 
   L.append(list, item);
@@ -589,7 +592,7 @@ function Timeout(after, callback, args) {
   this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
   this[trigger_id_symbol] = initTriggerId();
   if (async_hook_fields[kInit] > 0)
-    emitInit(this[async_id_symbol], 'Timeout', this[trigger_id_symbol], this);
+    emitInit(this[async_id_symbol], asyncTypeTO, this[trigger_id_symbol], this);
 }
 
 
@@ -824,7 +827,7 @@ function Immediate() {
   this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
   this[trigger_id_symbol] = initTriggerId();
   if (async_hook_fields[kInit] > 0)
-    emitInit(this[async_id_symbol], 'Immediate', this[trigger_id_symbol], this);
+    emitInit(this[async_id_symbol], asyncTypeIm, this[trigger_id_symbol], this);
 }
 
 function setImmediate(callback, arg1, arg2, arg3) {

--- a/test/parallel/test-async-hooks-type-registry.js
+++ b/test/parallel/test-async-hooks-type-registry.js
@@ -11,20 +11,23 @@ types1.forEach((v, k) => assert.strictEqual(
 );
 
 const sillyName = 'gaga';
-const newType = async_hooks.getTypes(sillyName);
+const newType = async_hooks.registerTypeName(sillyName);
 assert.strictEqual(
   typeof newType,
   'string',
   `${newType} should be a string`
 );
 assert.strictEqual(newType, sillyName);
-
-assert.throws(() => async_hooks.getTypes(sillyName),
-              common.expectsError(
-                'ERR_ASYNC_PROVIDER_NAME',
-                TypeError,
-                `${sillyName} type name already registered`
-              ));
+assert.throws(
+  () => async_hooks.registerTypeName(sillyName),
+  common.expectsError(
+    {
+      code: 'ERR_ASYNC_PROVIDER_NAME',
+      type: TypeError,
+      message: `"${sillyName}" type name already registered`
+    }
+  )
+);
 
 const types2 = async_hooks.getTypes();
 assert.strictEqual(types2.length, types1 + 1);

--- a/test/parallel/test-async-hooks-type-registry.js
+++ b/test/parallel/test-async-hooks-type-registry.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+const types1 = async_hooks.getTypes();
+types1.forEach((v, k) => assert.strictEqual(
+  typeof v,
+  'string',
+  `${v} from types[${k}] should be a string`)
+);
+
+const sillyName = 'gaga';
+const newType = async_hooks.getTypes(sillyName);
+assert.strictEqual(
+  typeof newType,
+  'string',
+  `${newType} should be a string`
+);
+assert.strictEqual(newType, sillyName);
+
+assert.throws(() => async_hooks.getTypes(sillyName),
+              common.expectsError(
+                'ERR_ASYNC_PROVIDER_NAME',
+                TypeError,
+                `${sillyName} type name already registered`
+              ));
+
+const types2 = async_hooks.getTypes();
+assert.strictEqual(types2.length, types1 + 1);
+assert.strictEqual(types2.includes(newType), true);

--- a/test/parallel/test-async-hooks-type-registry.js
+++ b/test/parallel/test-async-hooks-type-registry.js
@@ -30,5 +30,5 @@ assert.throws(
 );
 
 const types2 = async_hooks.getTypes();
-assert.strictEqual(types2.length, types1 + 1);
+assert.strictEqual(types2.length, types1.length + 1);
 assert.strictEqual(types2.includes(newType), true);


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/13561#issuecomment-307555956

Also refactor JS type names allocation, so it provided by `asunc_hooks`

/cc @nodejs/async_hooks 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks,timers,process
