### PR TITLE
Dgram buffers

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -492,7 +492,6 @@ s.bind(1234, () => {
 <!-- YAML
 added: v0.11.13
 changes:
-<<<<<<< f6bf7f248e558ec49cddef9f440498c558a6574a
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/14560
     description: The `lookup` option is supported.

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -400,7 +400,7 @@ between 0 and 255. The default on most systems is `1` but can vary.
 
 ### socket.setRecvBufferSize(size)
 <!-- YAML
-added: vx.x.x
+added: REPLACEME
 -->
 
 * `size` {number} Integer
@@ -410,7 +410,7 @@ in bytes.
 
 ### socket.setSendBufferSize(size)
 <!-- YAML
-added: vx.x.x
+added: REPLACEME
 -->
 
 * `size` {number} Integer

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -481,6 +481,9 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/14560
     description: The `lookup` option is supported.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/13623
+    description: `recvBufferSize` and `sendBufferSize` options are supported now.
 -->
 
 * `options` {Object} Available options are:
@@ -489,6 +492,8 @@ changes:
   * `reuseAddr` {boolean} When `true` [`socket.bind()`][] will reuse the
     address, even if another process has already bound a socket on it. Optional.
     Defaults to `false`.
+  * `recvBufferSize` {number} - Optional. Sets the `SO_RCVBUF` socket value.
+  * `sendBufferSize` {number} - Optional. Sets the `SO_SNDBUF` socket value.
   * `lookup` {Function} Custom lookup function. Defaults to [`dns.lookup()`][].
     Optional.
 * `callback` {Function} Attached as a listener for `'message'` events. Optional.

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -398,6 +398,26 @@ decremented to 0 by a router, it will not be forwarded.
 The argument passed to to `socket.setMulticastTTL()` is a number of hops
 between 0 and 255. The default on most systems is `1` but can vary.
 
+### socket.setRecvBufferSize(size)
+<!-- YAML
+added: vx.x.x
+-->
+
+* `size` {number} Integer
+
+Sets the `SO_RCVBUF` socket option. Sets the maximum socket receive buffer
+in bytes.
+
+### socket.setSendBufferSize(size)
+<!-- YAML
+added: vx.x.x
+-->
+
+* `size` {number} Integer
+
+Sets the `SO_SNDBUF` socket option. Sets the maximum socket send buffer
+in bytes.
+
 ### socket.setTTL(ttl)
 <!-- YAML
 added: v0.1.101

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -227,6 +227,20 @@ never have reason to call this.
 If `multicastInterface` is not specified, the operating system will attempt to
 drop membership on all valid interfaces.
 
+### socket.getRecvBufferSize(size)
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns {number} the `SO_RCVBUF` socket receive buffer size in bytes.
+
+### socket.getSendBufferSize(size)
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns {number} the `SO_SNDBUF` socket send buffer size in bytes.
+
 ### socket.ref()
 <!-- YAML
 added: v0.9.1
@@ -478,6 +492,7 @@ s.bind(1234, () => {
 <!-- YAML
 added: v0.11.13
 changes:
+<<<<<<< f6bf7f248e558ec49cddef9f440498c558a6574a
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/14560
     description: The `lookup` option is supported.

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -30,7 +30,6 @@ const EventEmitter = require('events');
 const setInitTriggerId = require('async_hooks').setInitTriggerId;
 const UV_UDP_REUSEADDR = process.binding('constants').os.UV_UDP_REUSEADDR;
 const async_id_symbol = process.binding('async_wrap').async_id_symbol;
-const uv = process.binding('uv');
 const nextTick = require('internal/process/next_tick').nextTick;
 
 const UDP = process.binding('udp_wrap').UDP;
@@ -99,15 +98,19 @@ function _createSocketHandle(address, port, addressType, fd, flags) {
   return handle;
 }
 
+const kOptionSymbol = Symbol('options symbol');
 
 function Socket(type, listener) {
   EventEmitter.call(this);
   var lookup;
 
+  this[kOptionSymbol] = {};
   if (type !== null && typeof type === 'object') {
     var options = type;
     type = options.type;
     lookup = options.lookup;
+    this[kOptionSymbol].recvBufferSize = options.recvBufferSize;
+    this[kOptionSymbol].sendBufferSize = options.sendBufferSize;
   }
 
   var handle = newHandle(type, lookup);
@@ -122,12 +125,6 @@ function Socket(type, listener) {
 
   // If true - UV_UDP_REUSEADDR flag will be set
   this._reuseAddr = options && options.reuseAddr;
-  
-  if (options && options.recvBufferSize)
-    this._recvBufferSize = options.recvBufferSize;
-
-  if (options && options.sendBufferSize)
-    this._sendBufferSize = options.sendBufferSize;
 
   if (typeof listener === 'function')
     this.on('message', listener);
@@ -147,12 +144,12 @@ function startListening(socket) {
   socket._receiving = true;
   socket._bindState = BIND_STATE_BOUND;
   socket.fd = -42; // compatibility hack
-  
-  if (socket._recvBufferSize)
-    socket.setRecvBufferSize(socket._recvBufferSize);
 
-  if (socket._sendBufferSize)
-    socket.setSendBufferSize(socket._sendBufferSize);
+  if (socket[kOptionSymbol].recvBufferSize)
+    bufferSize(socket, socket[kOptionSymbol].recvBufferSize, 'recv');
+
+  if (socket[kOptionSymbol].sendBufferSize)
+    bufferSize(socket, socket[kOptionSymbol].sendBufferSize, 'send');
 
   socket.emit('listening');
 }
@@ -168,6 +165,20 @@ function replaceHandle(self, newHandle) {
   // Replace the existing handle by the handle we got from master.
   self._handle.close();
   self._handle = newHandle;
+}
+
+function bufferSize(self, size, buffer) {
+  if (!isValidSize(size))
+    throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
+
+  try {
+    if (buffer === 'recv')
+      return self._handle.bufferSize(size, 0);
+    else
+      return self._handle.bufferSize(size, 1);
+  } catch (e) {
+    throw new errors.Error('ERR_SOCKET_BUFFER_SIZE', e);
+  }
 }
 
 Socket.prototype.bind = function(port_, address_ /*, callback*/) {
@@ -341,10 +352,7 @@ function enqueue(self, toEnqueue) {
 
 
 function isValidSize(size) {
-  return Number.isFinite(size) &&
-          size <= Number.MAX_SAFE_INTEGER &&
-          size >= 0 &&
-          size >>> 0 === size;
+  return size >>> 0 === size;
 }
 
 
@@ -659,27 +667,22 @@ Socket.prototype.unref = function() {
 
 
 Socket.prototype.setRecvBufferSize = function(size) {
-  if (!isValidSize(size))
-    throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
-
-  var err = this._handle.setRecvBufferSize(size);
-
-  if (err)
-    throw new errors.TypeError('ERR_SOCKET_SET_BUFFER_SIZE',
-                               uv.errname(err));
-
+  bufferSize(this, size, 'recv');
 };
 
 
 Socket.prototype.setSendBufferSize = function(size) {
-  if (!isValidSize(size))
-    throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
+  bufferSize(this, size, 'send');
+};
 
-  var err = this._handle.setSendBufferSize(size);
 
-  if (err)
-    throw new errors.TypeError('ERR_SOCKET_SET_BUFFER_SIZE', 
-                               uv.errname(err));
+Socket.prototype.getRecvBufferSize = function() {
+  return bufferSize(this, 0, 'recv');
+};
+
+
+Socket.prototype.getSendBufferSize = function() {
+  return bufferSize(this, 0, 'send');
 };
 
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -168,7 +168,7 @@ function replaceHandle(self, newHandle) {
 }
 
 function bufferSize(self, size, buffer) {
-  if (!isValidSize(size))
+  if (size >>> 0 !== size)
     throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
 
   try {
@@ -348,11 +348,6 @@ function enqueue(self, toEnqueue) {
     self.once('listening', onListenSuccess);
   }
   self._queue.push(toEnqueue);
-}
-
-
-function isValidSize(size) {
-  return size >>> 0 === size;
 }
 
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -641,7 +641,7 @@ Socket.prototype.setRecvBufferSize = function(size) {
   var err = this._handle.setRecvBufferSize(size);
 
   if (err) {
-	throw errnoException(err, 'setRecvBufferSize');
+    throw errnoException(err, 'setRecvBufferSize');
   }
 };
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -30,6 +30,7 @@ const EventEmitter = require('events');
 const setInitTriggerId = require('async_hooks').setInitTriggerId;
 const UV_UDP_REUSEADDR = process.binding('constants').os.UV_UDP_REUSEADDR;
 const async_id_symbol = process.binding('async_wrap').async_id_symbol;
+const uv = process.binding('uv');
 const nextTick = require('internal/process/next_tick').nextTick;
 
 const UDP = process.binding('udp_wrap').UDP;
@@ -121,6 +122,12 @@ function Socket(type, listener) {
 
   // If true - UV_UDP_REUSEADDR flag will be set
   this._reuseAddr = options && options.reuseAddr;
+  
+  if (options && options.recvBufferSize)
+    this._recvBufferSize = options.recvBufferSize;
+
+  if (options && options.sendBufferSize)
+    this._sendBufferSize = options.sendBufferSize;
 
   if (typeof listener === 'function')
     this.on('message', listener);
@@ -140,6 +147,12 @@ function startListening(socket) {
   socket._receiving = true;
   socket._bindState = BIND_STATE_BOUND;
   socket.fd = -42; // compatibility hack
+  
+  if (socket._recvBufferSize)
+    socket.setRecvBufferSize(socket._recvBufferSize);
+
+  if (socket._sendBufferSize)
+    socket.setSendBufferSize(socket._sendBufferSize);
 
   socket.emit('listening');
 }
@@ -324,6 +337,14 @@ function enqueue(self, toEnqueue) {
     self.once('listening', onListenSuccess);
   }
   self._queue.push(toEnqueue);
+}
+
+
+function isValidSize(size) {
+  return Number.isFinite(size) &&
+          size <= Number.MAX_SAFE_INTEGER &&
+          size >= 0 &&
+          size >>> 0 === size;
 }
 
 
@@ -638,20 +659,27 @@ Socket.prototype.unref = function() {
 
 
 Socket.prototype.setRecvBufferSize = function(size) {
+  if (!isValidSize(size))
+    throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
+
   var err = this._handle.setRecvBufferSize(size);
 
-  if (err) {
-    throw errnoException(err, 'setRecvBufferSize');
-  }
+  if (err)
+    throw new errors.TypeError('ERR_SOCKET_SET_BUFFER_SIZE',
+                               uv.errname(err));
+
 };
 
 
 Socket.prototype.setSendBufferSize = function(size) {
+  if (!isValidSize(size))
+    throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
+
   var err = this._handle.setSendBufferSize(size);
 
-  if (err) {
-    throw errnoException(err, 'setSendBufferSize');
-  }
+  if (err)
+    throw new errors.TypeError('ERR_SOCKET_SET_BUFFER_SIZE', 
+                               uv.errname(err));
 };
 
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -636,6 +636,25 @@ Socket.prototype.unref = function() {
   return this;
 };
 
+
+Socket.prototype.setRecvBufferSize = function(size) {
+  var err = this._handle.setRecvBufferSize(size);
+
+  if (err) {
+	throw errnoException(err, 'setRecvBufferSize');
+  }
+};
+
+
+Socket.prototype.setSendBufferSize = function(size) {
+  var err = this._handle.setSendBufferSize(size);
+
+  if (err) {
+    throw errnoException(err, 'setSendBufferSize');
+  }
+};
+
+
 module.exports = {
   _createSocketHandle,
   createSocket,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -251,7 +251,7 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_CLOSED', 'Socket is closed');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
-E('ERR_SOCKET_SET_BUFFER_SIZE', (reason) => `Coud not set buffer size: ${reason}`);
+E('ERR_SOCKET_BUFFER_SIZE', (reason) => `Could not get or set buffer size: ${reason}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -245,11 +245,13 @@ E('ERR_SERVER_ALREADY_LISTEN',
   'Listen method has been called more than once without closing.');
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
+E('ERR_SOCKET_BAD_BUFFER_SIZE', 'Buffer size must be a positive integer');
 E('ERR_SOCKET_BAD_TYPE',
   'Bad socket type specified. Valid types are: udp4, udp6');
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_CLOSED', 'Socket is closed');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
+E('ERR_SOCKET_SET_BUFFER_SIZE', (reason) => `Coud not set buffer size: ${reason}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -251,7 +251,8 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_CLOSED', 'Socket is closed');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
-E('ERR_SOCKET_BUFFER_SIZE', (reason) => `Could not get or set buffer size: ${reason}`);
+E('ERR_SOCKET_BUFFER_SIZE',
+  (reason) => `Could not get or set buffer size: ${reason}`);
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -222,6 +222,36 @@ void UDPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+void UDPWrap::SetRecvBufferSize(const FunctionCallbackInfo<Value>& args) {
+  UDPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap,
+                          args.Holder(),
+                          args.GetReturnValue().Set(UV_EBADF));
+
+  CHECK(args[0]->IsUint32());
+
+  int inputSize = args[0]->Uint32Value();
+  int err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &inputSize);
+  
+  args.GetReturnValue().Set(err);  
+}
+
+
+void UDPWrap::SetSendBufferSize(const FunctionCallbackInfo<Value>& args) {
+  UDPWrap* wrap;
+  ASSIGN_OR_RETURN_UNWRAP(&wrap,
+                          args.Holder(),
+                          args.GetReturnValue().Set(UV_EBADF));
+
+  CHECK(args[0]->IsUint32());
+  
+  int inputSize = args[0]->Uint32Value();
+  int err = uv_send_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &inputSize);
+  
+  args.GetReturnValue().Set(err);  
+}
+
+
 #define X(name, fn)                                                           \
   void UDPWrap::name(const FunctionCallbackInfo<Value>& args) {               \
     UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());                           \

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -235,13 +235,21 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[1]->IsUint32());
   int size = static_cast<int>(args[0].As<Uint32>()->Value());
 
+  if (size != args[0].As<Uint32>()->Value()) {
+    if (args[1].As<Uint32>()->Value() == 0)
+      return env->ThrowUVException(EINVAL, "uv_recv_buffer_size");
+    else
+      return env->ThrowUVException(EINVAL, "uv_send_buffer_size");
+  }
+
   int err;
-  if (args[1].As<Uint32>()->Value() == 0)
+  if (args[1].As<Uint32>()->Value() == 0) {
     err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
                               &size);
-  else
+  } else {
     err = uv_send_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
                               &size);
+  }
 
   if (err != 0) {
     if (args[1].As<Uint32>()->Value() == 0)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -134,6 +134,8 @@ void UDPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setMulticastLoopback", SetMulticastLoopback);
   env->SetProtoMethod(t, "setBroadcast", SetBroadcast);
   env->SetProtoMethod(t, "setTTL", SetTTL);
+  env->SetProtoMethod(t, "setRecvBufferSize", SetRecvBufferSize);
+  env->SetProtoMethod(t, "setSendBufferSize", SetSendBufferSize);
 
   env->SetProtoMethod(t, "ref", HandleWrap::Ref);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -233,24 +233,21 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[0]->IsUint32());
   CHECK(args[1]->IsUint32());
-  int size = (int)args[0].As<Uint32>()->Value();
-  
-  int err = 0;
+  int size = static_cast<int>(args[0].As<Uint32>()->Value());
+
+  int err;
   if (args[1].As<Uint32>()->Value() == 0)
     err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
-                                &size);
+                              &size);
   else
     err = uv_send_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
-                                &size);
+                              &size);
 
   if (err != 0) {
-    std::string syscall;
     if (args[1].As<Uint32>()->Value() == 0)
-      syscall = "uv_recv_buffer_size";
+      return env->ThrowUVException(err, "uv_recv_buffer_size");
     else
-      syscall = "uv_send_buffer_size";
-
-    return env->ThrowUVException(err, syscall.c_str());
+      return env->ThrowUVException(err, "uv_send_buffer_size");
   }
   args.GetReturnValue().Set(size);
 }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -46,6 +46,7 @@ using v8::Object;
 using v8::PropertyAttribute;
 using v8::PropertyCallbackInfo;
 using v8::String;
+using v8::Uint32;
 using v8::Undefined;
 using v8::Value;
 
@@ -225,32 +226,34 @@ void UDPWrap::Bind6(const FunctionCallbackInfo<Value>& args) {
 
 
 void UDPWrap::SetRecvBufferSize(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK(args[0]->IsUint32());
+  int size =  (int)args[0].As<Uint32>()->Value();
+  int err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
+                                &size);
 
-  int inputSize = args[0]->Uint32Value();
-  int err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &inputSize);
-  
-  args.GetReturnValue().Set(err);  
+  args.GetReturnValue().Set(err);
 }
 
 
 void UDPWrap::SetSendBufferSize(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
   UDPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap,
                           args.Holder(),
                           args.GetReturnValue().Set(UV_EBADF));
 
   CHECK(args[0]->IsUint32());
-  
-  int inputSize = args[0]->Uint32Value();
-  int err = uv_send_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &inputSize);
-  
-  args.GetReturnValue().Set(err);  
+  int size =  (int)args[0].As<Uint32>()->Value();
+  int err = uv_send_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
+                                &size);
+
+  args.GetReturnValue().Set(err);
 }
 
 

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -55,8 +55,7 @@ class UDPWrap: public HandleWrap {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetBroadcast(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetTTL(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetRecvBufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetSendBufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void BufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
   uv_udp_t* UVHandle();

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -55,6 +55,8 @@ class UDPWrap: public HandleWrap {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetBroadcast(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetTTL(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetRecvBufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetSendBufferSize(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
   uv_udp_t* UVHandle();

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -39,3 +39,22 @@ validTypes.forEach((validType) => {
     socket.close();
   });
 });
+
+// Ensure buffer sizes can be set
+{
+  const socket = dgram.createSocket({ type: 'udp4',
+                                      recvBufferSize: 1300,
+                                      sendBufferSize: 1800,
+                                    });
+
+  socket.bind(common.mustCall(() => {
+    // note: linux will double the buffer size
+    assert.ok(socket.getRecvBufferSize() === 1300 ||
+              socket.getRecvBufferSize() === 2600,
+              "SO_RCVBUF not 1300 or 2600");
+    assert.ok(socket.getSendBufferSize() === 1800 ||
+              socket.getSendBufferSize() === 3600,
+              "SO_SNDVBUF not 1800 or 3600");
+    socket.close();
+  }));
+}

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -44,17 +44,17 @@ validTypes.forEach((validType) => {
 {
   const socket = dgram.createSocket({
     type: 'udp4',
-    recvBufferSize: 1300,
-    sendBufferSize: 1800
+    recvBufferSize: 10000,
+    sendBufferSize: 15000
   });
 
   socket.bind(common.mustCall(() => {
     // note: linux will double the buffer size
-    assert.ok(socket.getRecvBufferSize() === 1300 ||
-              socket.getRecvBufferSize() === 2600,
+    assert.ok(socket.getRecvBufferSize() === 10000 ||
+              socket.getRecvBufferSize() === 20000,
               'SO_RCVBUF not 1300 or 2600');
-    assert.ok(socket.getSendBufferSize() === 1800 ||
-              socket.getSendBufferSize() === 3600,
+    assert.ok(socket.getSendBufferSize() === 15000 ||
+              socket.getSendBufferSize() === 30000,
               'SO_SNDBUF not 1800 or 3600');
     socket.close();
   }));

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -42,19 +42,20 @@ validTypes.forEach((validType) => {
 
 // Ensure buffer sizes can be set
 {
-  const socket = dgram.createSocket({ type: 'udp4',
-                                      recvBufferSize: 1300,
-                                      sendBufferSize: 1800,
-                                    });
+  const socket = dgram.createSocket({
+    type: 'udp4',
+    recvBufferSize: 1300,
+    sendBufferSize: 1800
+  });
 
   socket.bind(common.mustCall(() => {
     // note: linux will double the buffer size
     assert.ok(socket.getRecvBufferSize() === 1300 ||
               socket.getRecvBufferSize() === 2600,
-              "SO_RCVBUF not 1300 or 2600");
+              'SO_RCVBUF not 1300 or 2600');
     assert.ok(socket.getSendBufferSize() === 1800 ||
               socket.getSendBufferSize() === 3600,
-              "SO_SNDBUF not 1800 or 3600");
+              'SO_SNDBUF not 1800 or 3600');
     socket.close();
   }));
 }

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -54,7 +54,7 @@ validTypes.forEach((validType) => {
               "SO_RCVBUF not 1300 or 2600");
     assert.ok(socket.getSendBufferSize() === 1800 ||
               socket.getSendBufferSize() === 3600,
-              "SO_SNDVBUF not 1800 or 3600");
+              "SO_SNDBUF not 1800 or 3600");
     socket.close();
   }));
 }

--- a/test/parallel/test-dgram-set-socket-buffer-size.js
+++ b/test/parallel/test-dgram-set-socket-buffer-size.js
@@ -5,16 +5,16 @@ const assert = require('assert');
 const dgram = require('dgram');
 
 {
-  // Should throw ENOTSOCK if the socket is never bound.
+  // Should throw error if the socket is never bound.
   const socket = dgram.createSocket('udp4');
 
   assert.throws(() => {
     socket.setRecvBufferSize(8192);
-  }, /^Error: setRecvBufferSize ENOTSOCK$/);
+  }, /^Error: setRecvBufferSize E[A-Z]+$/);
   
     assert.throws(() => {
     socket.setSendBufferSize(8192);
-  }, /^Error: setSendBufferSize ENOTSOCK$/);
+  }, /^Error: setSendBufferSize E[A-Z]+$/);
 }
 
 {

--- a/test/parallel/test-dgram-set-socket-buffer-size.js
+++ b/test/parallel/test-dgram-set-socket-buffer-size.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+
+{
+  // Should throw ENOTSOCK if the socket is never bound.
+  const socket = dgram.createSocket('udp4');
+
+  assert.throws(() => {
+    socket.setRecvBufferSize(8192);
+  }, /^Error: setRecvBufferSize ENOTSOCK$/);
+  
+    assert.throws(() => {
+    socket.setSendBufferSize(8192);
+  }, /^Error: setSendBufferSize ENOTSOCK$/);
+}
+
+{
+  // Can call setRecvBufferSize() and setRecvBufferSize() after binding the socket.
+  const socket = dgram.createSocket('udp4');
+
+  socket.bind(0, common.mustCall(() => {
+    socket.setRecvBufferSize(8192);
+    socket.setSendBufferSize(8192);
+    socket.close();
+  }));
+}

--- a/test/parallel/test-dgram-set-socket-buffer-size.js
+++ b/test/parallel/test-dgram-set-socket-buffer-size.js
@@ -10,11 +10,55 @@ const dgram = require('dgram');
 
   assert.throws(() => {
     socket.setRecvBufferSize(8192);
-  }, /^Error: setRecvBufferSize E[A-Z]+$/);
-  
-    assert.throws(() => {
+  }, common.expectsError({
+    code: 'ERR_SOCKET_SET_BUFFER_SIZE',
+    type: Error,
+    message: /^Coud not set buffer size: E[A-Z]+$/
+  }));
+
+  assert.throws(() => {
     socket.setSendBufferSize(8192);
-  }, /^Error: setSendBufferSize E[A-Z]+$/);
+  }, common.expectsError({
+    code: 'ERR_SOCKET_SET_BUFFER_SIZE',
+    type: Error,
+    message: /^Coud not set buffer size: E[A-Z]+$/
+  }));
+  
+  
+}
+
+{
+  // Should throw error if invalid buffer size is specified
+  const socket = dgram.createSocket('udp4');
+
+  socket.bind(0, common.mustCall(() => {
+
+    assert.throws(() => {
+      socket.setRecvBufferSize(-1);
+    }, common.expectsError({
+      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
+      type: Error,
+      message: /^Buffer size must be a positive integer$/
+    }));
+
+    assert.throws(() => {
+      socket.setRecvBufferSize(Infinity);
+    }, common.expectsError({
+      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
+      type: Error,
+      message: /^Buffer size must be a positive integer$/
+    }));
+
+    assert.throws(() => {
+      socket.setRecvBufferSize('Doh!');
+    }, common.expectsError({
+      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
+      type: Error,
+      message: /^Buffer size must be a positive integer$/
+    }));
+
+    socket.close();
+  }));
 }
 
 {

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -62,11 +62,11 @@ const dgram = require('dgram');
   const socket = dgram.createSocket('udp4');
 
   socket.bind(common.mustCall(() => {
-    socket.setRecvBufferSize(1200);
-    socket.setSendBufferSize(1200);
+    socket.setRecvBufferSize(10000);
+    socket.setSendBufferSize(10000);
 
     // note: linux will double the buffer size
-    const expectedBufferSize = common.isLinux ? 2400 : 1200;
+    const expectedBufferSize = common.isLinux ? 20000 : 10000;
     assert.strictEqual(socket.getRecvBufferSize(), expectedBufferSize);
     assert.strictEqual(socket.getSendBufferSize(), expectedBufferSize);
     socket.close();

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -88,7 +88,7 @@ const dgram = require('dgram');
               "SO_RCVBUF not 1200 or 2400");
     assert.ok(socket.getSendBufferSize() === 1500 ||
               socket.getSendBufferSize() === 3000,
-              "SO_SNDVBUF not 1500 or 3000");
+              "SO_SNDBUF not 1500 or 3000");
     socket.close();
   }));
 }

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -6,76 +6,60 @@ const dgram = require('dgram');
 
 {
   // Should throw error if the socket is never bound.
+  const errorObj = {
+    code: 'ERR_SOCKET_BUFFER_SIZE',
+    type: Error,
+    message: /^Could not get or set buffer size:.*$/
+  };
+
   const socket = dgram.createSocket('udp4');
 
   assert.throws(() => {
     socket.setRecvBufferSize(8192);
-  }, common.expectsError({
-    code: 'ERR_SOCKET_BUFFER_SIZE',
-    type: Error,
-    message: /^Could not get or set buffer size:.*$/
-  }));
+  }, common.expectsError(errorObj));
 
   assert.throws(() => {
     socket.setSendBufferSize(8192);
-  }, common.expectsError({
-    code: 'ERR_SOCKET_BUFFER_SIZE',
-    type: Error,
-    message: /^Could not get or set buffer size:.*$/
-  }));
+  }, common.expectsError(errorObj));
 
   assert.throws(() => {
     socket.getRecvBufferSize();
-  }, common.expectsError({
-    code: 'ERR_SOCKET_BUFFER_SIZE',
-    type: Error,
-    message: /^Could not get or set buffer size:.*$/
-  }));
+  }, common.expectsError(errorObj));
 
   assert.throws(() => {
     socket.getSendBufferSize();
-  }, common.expectsError({
-    code: 'ERR_SOCKET_BUFFER_SIZE',
-    type: Error,
-    message: /^Could not get or set buffer size:.*$/
-  }));
+  }, common.expectsError(errorObj));
 }
 
 {
   // Should throw error if invalid buffer size is specified
+  const errorObj = {
+    code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
+    type: TypeError,
+    message: /^Buffer size must be a positive integer$/
+  };
+
   const socket = dgram.createSocket('udp4');
 
   socket.bind(common.mustCall(() => {
     assert.throws(() => {
       socket.setRecvBufferSize(-1);
-    }, common.expectsError({
-      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
-      type: Error,
-      message: /^Buffer size must be a positive integer$/
-    }));
+    }, common.expectsError(errorObj));
 
     assert.throws(() => {
       socket.setRecvBufferSize(Infinity);
-    }, common.expectsError({
-      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
-      type: Error,
-      message: /^Buffer size must be a positive integer$/
-    }));
+    }, common.expectsError(errorObj));
 
     assert.throws(() => {
       socket.setRecvBufferSize('Doh!');
-    }, common.expectsError({
-      code: 'ERR_SOCKET_BAD_BUFFER_SIZE',
-      type: Error,
-      message: /^Buffer size must be a positive integer$/
-    }));
+    }, common.expectsError(errorObj));
 
     socket.close();
   }));
 }
 
-  // Can set and get buffer sizes after binding the socket.
 {
+  // Can set and get buffer sizes after binding the socket.
   const socket = dgram.createSocket('udp4');
 
   socket.bind(common.mustCall(() => {
@@ -85,10 +69,10 @@ const dgram = require('dgram');
     // note: linux will double the buffer size
     assert.ok(socket.getRecvBufferSize() === 1200 ||
               socket.getRecvBufferSize() === 2400,
-              "SO_RCVBUF not 1200 or 2400");
+              'SO_RCVBUF not 1200 or 2400');
     assert.ok(socket.getSendBufferSize() === 1500 ||
               socket.getSendBufferSize() === 3000,
-              "SO_SNDBUF not 1500 or 3000");
+              'SO_SNDBUF not 1500 or 3000');
     socket.close();
   }));
 }


### PR DESCRIPTION
Add support to allow the dgram lib to set the SO_SNDBUF & SO_RCVBUF socket buffer sizes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, dgram