### PR TITLE
test: increase bufsize in child process write test

### DIFF
--- a/test/parallel/test-child-process-stdio-big-write-end.js
+++ b/test/parallel/test-child-process-stdio-big-write-end.js
@@ -22,7 +22,7 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const BUFSIZE = 1024;
+let bufsize = 0;
 
 switch (process.argv[2]) {
   case undefined:
@@ -51,14 +51,15 @@ function parent() {
   // Write until the buffer fills up.
   let buf;
   do {
-    buf = Buffer.alloc(BUFSIZE, '.');
-    sent += BUFSIZE;
+    bufsize += 1024;
+    buf = Buffer.alloc(bufsize, '.');
+    sent += bufsize;
   } while (child.stdin.write(buf));
 
   // then write a bunch more times.
   for (let i = 0; i < 100; i++) {
-    const buf = Buffer.alloc(BUFSIZE, '.');
-    sent += BUFSIZE;
+    const buf = Buffer.alloc(bufsize, '.');
+    sent += bufsize;
     child.stdin.write(buf);
   }
 


### PR DESCRIPTION
test-child-process-stdio-big-write-end was failing on ubuntu1604-arm64
because the while loop that was supposed to fill up the buffer ended up
being an infinite loop.

This increases the size of the writes in the loop by 1K until the buffer
fills up.

Fixes: https://github.com/nodejs/node/issues/13603

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process