### PR TITLE
deps: cherry-pick 866ee63 from upstream V8

### DIFF
--- a/deps/v8/src/builtins/builtins-string-gen.cc
+++ b/deps/v8/src/builtins/builtins-string-gen.cc
@@ -1190,14 +1190,11 @@ TF_BUILTIN(StringPrototypeSplit, StringBuiltinsAssembler) {
       });
 
   // String and integer conversions.
-  // TODO(jgruber): The old implementation used Uint32Max instead of SmiMax -
-  // but AFAIK there should not be a difference since arrays are capped at Smi
-  // lengths.
 
   Callable tostring_callable = CodeFactory::ToString(isolate());
   Node* const subject_string = CallStub(tostring_callable, context, receiver);
   Node* const limit_number =
-      Select(IsUndefined(limit), [=]() { return SmiConstant(Smi::kMaxValue); },
+      Select(IsUndefined(limit), [=]() { return NumberConstant(kMaxUInt32); },
              [=]() { return ToUint32(context, limit); },
              MachineRepresentation::kTagged);
   Node* const separator_string =


### PR DESCRIPTION
Original commit message:

    [string] Re-enable result caching for String.p.split

    Runtime::kStringSplit's result caching is only enabled when limit equals
    kMaxUInt32.

    BUG=v8:6463

    Review-Url: https://codereview.chromium.org/2923183002
    Cr-Commit-Position: refs/heads/master@{#45724}

Fixes: https://github.com/nodejs/node/issues/13445

@nodejs/v8 

I did not update V8_PATCH_LEVEL because V8 5.9 is still supported.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

V8