### PR TITLE
n-api: avoid crash in napi_escape_scope()

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -17,6 +17,7 @@
 #include <vector>
 #include "uv.h"
 #include "node_api.h"
+#include "node_internals.h"
 
 #define NAPI_VERSION  1
 
@@ -156,8 +157,8 @@ class HandleScopeWrapper {
 // across different versions.
 class EscapableHandleScopeWrapper {
  public:
-  explicit EscapableHandleScopeWrapper(v8::Isolate* isolate) :
-    scope(isolate), escape_called_(false) {}
+  explicit EscapableHandleScopeWrapper(v8::Isolate* isolate)
+      : scope(isolate), escape_called_(false) {}
   bool escape_called() const {
     return escape_called_;
   }
@@ -758,8 +759,7 @@ napi_status napi_get_last_error_info(napi_env env,
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.
   static_assert(
-      (sizeof (error_messages) / sizeof (*error_messages)) ==
-         napi_escape_called_twice + 1,
+      node::arraysize(error_messages) == napi_escape_called_twice + 1,
       "Count of error messages must match count of error values");
   assert(env->last_error.error_code <= napi_escape_called_twice);
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -157,19 +157,19 @@ class HandleScopeWrapper {
 class EscapableHandleScopeWrapper {
  public:
   explicit EscapableHandleScopeWrapper(v8::Isolate* isolate) :
-    scope(isolate), _escapeCalled(false) {}
-  bool escapeAlreadyCalled(void) {
-    return _escapeCalled;
+    scope(isolate), escape_called_(false) {}
+  bool escape_called() const {
+    return escape_called_;
   }
   template <typename T>
   v8::Local<T> Escape(v8::Local<T> handle) {
-    _escapeCalled = true;
+    escape_called_ = true;
     return scope.Escape(handle);
   }
 
  private:
   v8::EscapableHandleScope scope;
-  bool _escapeCalled;
+  bool escape_called_;
 };
 
 napi_handle_scope JsHandleScopeFromV8HandleScope(HandleScopeWrapper* s) {
@@ -2218,7 +2218,7 @@ napi_status napi_escape_handle(napi_env env,
 
   v8impl::EscapableHandleScopeWrapper* s =
       v8impl::V8EscapableHandleScopeFromJsEscapableHandleScope(scope);
-  if (!s->escapeAlreadyCalled()) {
+  if (!s->escape_called()) {
     *result = v8impl::JsValueFromV8LocalValue(
         s->Escape(v8impl::V8LocalValueFromJsValue(escapee)));
     return napi_clear_last_error(env);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -157,19 +157,19 @@ class HandleScopeWrapper {
 class EscapableHandleScopeWrapper {
  public:
   explicit EscapableHandleScopeWrapper(v8::Isolate* isolate) :
-    scope(isolate), escapeCalled(false) {}
-  bool escapeAllreadyCalled(void) {
-    return escapeCalled;
+    scope(isolate), _escapeCalled(false) {}
+  bool escapeAlreadyCalled(void) {
+    return _escapeCalled;
   }
   template <typename T>
   v8::Local<T> Escape(v8::Local<T> handle) {
-    escapeCalled = true;
+    _escapeCalled = true;
     return scope.Escape(handle);
   }
 
  private:
   v8::EscapableHandleScope scope;
-  bool escapeCalled;
+  bool _escapeCalled;
 };
 
 napi_handle_scope JsHandleScopeFromV8HandleScope(HandleScopeWrapper* s) {
@@ -2218,7 +2218,7 @@ napi_status napi_escape_handle(napi_env env,
 
   v8impl::EscapableHandleScopeWrapper* s =
       v8impl::V8EscapableHandleScopeFromJsEscapableHandleScope(scope);
-  if (!s->escapeAllreadyCalled()) {
+  if (!s->escapeAlreadyCalled()) {
     *result = v8impl::JsValueFromV8LocalValue(
         s->Escape(v8impl::V8LocalValueFromJsValue(escapee)));
     return napi_clear_last_error(env);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -753,10 +753,15 @@ napi_status napi_get_last_error_info(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
+  // you must udpate this assert to reference the last message
+  // in the napi_status enum each time a new error message is added.
+  // We don't have a napi_status_last as this would result in an ABI
+  // change each time a message was added.
   static_assert(
-      (sizeof (error_messages) / sizeof (*error_messages)) == napi_status_last,
+      (sizeof (error_messages) / sizeof (*error_messages)) ==
+         napi_escape_called_twice + 1,
       "Count of error messages must match count of error values");
-  assert(env->last_error.error_code < napi_status_last);
+  assert(env->last_error.error_code <= napi_escape_called_twice);
 
   // Wait until someone requests the last error information to fetch the error
   // message string

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -754,7 +754,7 @@ napi_status napi_get_last_error_info(napi_env env,
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 
-  // you must udpate this assert to reference the last message
+  // you must update this assert to reference the last message
   // in the napi_status enum each time a new error message is added.
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -67,6 +67,7 @@ typedef enum {
   napi_generic_failure,
   napi_pending_exception,
   napi_cancelled,
+  napi_escape_called_twice,
   napi_status_last
 } napi_status;
 

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -67,8 +67,7 @@ typedef enum {
   napi_generic_failure,
   napi_pending_exception,
   napi_cancelled,
-  napi_escape_called_twice,
-  napi_status_last
+  napi_escape_called_twice
 } napi_status;
 
 typedef napi_value (*napi_callback)(napi_env env,

--- a/test/addons-napi/test_handle_scope/test.js
+++ b/test/addons-napi/test_handle_scope/test.js
@@ -12,6 +12,12 @@ assert.ok(testHandleScope.NewScopeEscape() instanceof Object);
 
 assert.throws(
   () => {
+    testHandleScope.NewScopeEscapeTwice();
+  },
+  Error);
+
+assert.throws(
+  () => {
     testHandleScope.NewScopeWithException(() => { throw new RangeError(); });
   },
   RangeError);

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -29,6 +29,19 @@ napi_value NewScopeEscape(napi_env env, napi_callback_info info) {
   return escapee;
 }
 
+napi_value NewScopeEscapeTwice(napi_env env, napi_callback_info info) {
+  napi_escapable_handle_scope scope;
+  napi_value output = NULL;
+  napi_value escapee = NULL;
+
+  NAPI_CALL(env, napi_open_escapable_handle_scope(env, &scope));
+  NAPI_CALL(env, napi_create_object(env, &output));
+  NAPI_CALL(env, napi_escape_handle(env, scope, output, &escapee));
+  NAPI_CALL(env, napi_escape_handle(env, scope, output, &escapee));
+  NAPI_CALL(env, napi_close_escapable_handle_scope(env, scope));
+  return escapee;
+}
+
 napi_value NewScopeWithException(napi_env env, napi_callback_info info) {
   napi_handle_scope scope;
   size_t argc;
@@ -57,6 +70,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("NewScope", NewScope),
     DECLARE_NAPI_PROPERTY("NewScopeEscape", NewScopeEscape),
+    DECLARE_NAPI_PROPERTY("NewScopeEscapeTwice", NewScopeEscapeTwice),
     DECLARE_NAPI_PROPERTY("NewScopeWithException", NewScopeWithException),
   };
 


### PR DESCRIPTION
V8 will crash if escape is called twice on the same
scope.

Add checks to avoid crashing if napi_escape_scope() is
called to try and do this.

Add test that tries to call napi_create_scope() twice.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
n-api