### PR TITLE
lib: correct typo in createSecureContext

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -91,7 +91,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   }
 
   // NOTE: It is important to set the key after the cert.
-  // `ssl_set_pkey` returns `0` when the key does not much the cert, but
+  // `ssl_set_pkey` returns `0` when the key does not match the cert, but
   // `ssl_set_cert` returns `1` and nullifies the key in the SSL structure
   // which leads to the crash later on.
   if (options.key) {


### PR DESCRIPTION
Minor correction in the comment regarding ssl_set_pkey.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib