### PR TITLE
build: fail linter if linting not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -924,6 +924,7 @@ lint:
 	@echo "Linting is not available through the source tarball."
 	@echo "Use the git repo instead:" \
 		"$ git clone https://github.com/nodejs/node.git"
+	exit 1
 
 lint-ci: lint
 endif

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -485,7 +485,7 @@ goto exit
 :no-lint
 echo Linting is not available through the source tarball.
 echo Use the git repo instead: $ git clone https://github.com/nodejs/node.git
-goto exit
+exit /b 1
 
 :create-msvs-files-failed
 echo Failed to create vc project files.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/13645#issuecomment-308100452

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, lint