### PR TITLE
doc: fixes a typo in the async_hooks documentation

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -192,7 +192,7 @@ Every new resource is assigned a unique ID.
 ###### `type`
 
 The `type` is a string that represents the type of resource that caused
-`init` to be called. Generally it will correspond with the name of the
+`init` to be called. Generally, it will correspond to the name of the
 resource's constructor.
 
 ```

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -192,8 +192,8 @@ Every new resource is assigned a unique ID.
 ###### `type`
 
 The `type` is a string that represents the type of resource that caused
-`init` to be called. Generally it will correspond the name of the resource's
-constructor.
+`init` to be called. Generally it will correspond with the name of the
+resource's constructor.
 
 ```
 FSEVENTWRAP, FSREQWRAP, GETADDRINFOREQWRAP, GETNAMEINFOREQWRAP, HTTPPARSER,


### PR DESCRIPTION
Fixes a minor typo as described by @mscdex in https://github.com/nodejs/node/issues/13663

> Generally it will correspond the name of the resource's constructor.

should read "will correspond with..."

fixes: https://github.com/nodejs/node/issues/13663

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
