### PR TITLE
src: remove void casts for clear_error_on_return

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -768,7 +768,6 @@ void SecureContext::AddCACert(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   if (args.Length() != 1) {
     return env->ThrowTypeError("CA certificate argument is mandatory");
@@ -806,7 +805,6 @@ void SecureContext::AddCRL(const FunctionCallbackInfo<Value>& args) {
   }
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   BIO *bio = LoadBIO(env, args[0]);
   if (!bio)
@@ -872,7 +870,6 @@ void SecureContext::AddRootCerts(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   if (!root_cert_store) {
     root_cert_store = NewRootCertStore();
@@ -901,7 +898,6 @@ void SecureContext::SetCiphers(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
   Environment* env = sc->env();
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   if (args.Length() != 1) {
     return env->ThrowTypeError("Ciphers argument is mandatory");
@@ -948,7 +944,6 @@ void SecureContext::SetDHParam(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   Environment* env = sc->env();
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   // Auto DH is not supported in openssl 1.0.1, so dhparam needs
   // to be specified explicitly
@@ -1073,7 +1068,6 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   if (args.Length() < 1) {
     return env->ThrowTypeError("PFX certificate argument is mandatory");
@@ -1697,7 +1691,6 @@ void SSLWrap<Base>::GetPeerCertificate(
   Environment* env = w->ssl_env();
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence unused variable warning.
 
   Local<Object> result;
   Local<Object> info;
@@ -1894,7 +1887,6 @@ void SSLWrap<Base>::Renegotiate(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&w, args.Holder());
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence unused variable warning.
 
   bool yes = SSL_renegotiate(w->ssl_) == 1;
   args.GetReturnValue().Set(yes);
@@ -2644,7 +2636,6 @@ int Connection::HandleSSLError(const char* func,
                                ZeroStatus zs,
                                SyscallStatus ss) {
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence unused variable warning.
 
   if (rv > 0)
     return rv;
@@ -4259,7 +4250,6 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
   md_value = new unsigned char[md_len];
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   Error err = sign->SignFinal(
       buf,
@@ -4382,7 +4372,6 @@ SignBase::Error Verify::VerifyFinal(const char* key_pem,
     return kSignNotInitialised;
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   EVP_PKEY* pkey = nullptr;
   BIO* bp = nullptr;
@@ -4614,7 +4603,6 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   size_t out_len = 0;
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   bool r = Cipher<operation, EVP_PKEY_cipher_init, EVP_PKEY_cipher>(
       kbuf,
@@ -4922,7 +4910,6 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   }
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
   BIGNUM* key = nullptr;
 
   if (args.Length() == 0) {
@@ -6165,7 +6152,6 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
   unsigned int flags = args[1]->Uint32Value();
 
   ClearErrorOnReturn clear_error_on_return;
-  (void) &clear_error_on_return;  // Silence compiler warning.
 
   const node::Utf8Value engine_id(env->isolate(), args[0]);
   ENGINE* engine = ENGINE_by_id(*engine_id);


### PR DESCRIPTION
There are a number of void casts of clear_error_on_return which is a
usage of the RAII idiom. The ClearErrorOnReturn struct only has a
destructor and no constructor which I believe was an issue in GCC
prior to version 4.8.0, which lead to a unused variable warning.

I'm wondering if these cast could be removed since GCC 4.8.5 or newer
is required now. An alternative solution would be to add an empty
constructor which should work allowing the compiler to detect that a
variable is used only for its side-effects.

Not sure if this was the sole reason for having these casts but wanted
to bring it up just in case.

Refs: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10416

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, crypto