### PR TITLE
util: ignore invalid format specifiers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -113,6 +113,12 @@ exports.format = function(f) {
             str += f.slice(lastPos, i);
           str += '%';
           break;
+        default: // any other character is not a correct placeholder
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += '%';
+          lastPos = i = i + 1;
+          continue;
       }
       lastPos = i = i + 2;
       continue;

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -126,6 +126,11 @@ assert.strictEqual(util.format('o: %j, a: %j', {}, []), 'o: {}, a: []');
 assert.strictEqual(util.format('o: %j, a: %j', {}), 'o: {}, a: %j');
 assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
 
+// Invalid format specifiers
+assert.strictEqual(util.format('a% b', 'x'), 'a% b x');
+assert.strictEqual(util.format('percent: %d%, fraction: %d', 10, 0.1),
+                   'percent: 10%, fraction: 0.1');
+
 {
   const o = {};
   o.o = o;


### PR DESCRIPTION
In util.format, if a percent sign without a known type is encountered,
just print it instead of silently ignoring it and the next character.

Fixes: https://github.com/nodejs/node/issues/13665

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

util