### PR TITLE
test: fix nits in test-fs-mkdir-rmdir.js

### DIFF
--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -24,14 +24,15 @@ fs.rmdirSync(d);
 assert(!common.fileExists(d));
 
 // Similarly test the Async version
-fs.mkdir(d, 0o666, function(err) {
+fs.mkdir(d, 0o666, common.mustCall(function(err) {
   assert.ifError(err);
 
-  fs.mkdir(d, 0o666, function(err) {
-    assert.ok(err.message.match(/^EEXIST/), 'got EEXIST message');
-    assert.strictEqual(err.code, 'EEXIST', 'got EEXIST code');
-    assert.strictEqual(err.path, d, 'got proper path for EEXIST');
+  fs.mkdir(d, 0o666, common.mustCall(function(err) {
+    assert.ok(err, 'got no error');
+    assert.ok(/^EEXIST/.test(err.message), 'got no EEXIST message');
+    assert.strictEqual(err.code, 'EEXIST', 'got no EEXIST code');
+    assert.strictEqual(err.path, d, 'got no proper path for EEXIST');
 
     fs.rmdir(d, assert.ifError);
-  });
-});
+  }));
+}));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, fs

* Add `common.mustCall()`.
* Add check for error existence, not only for error details.
* Use `test()`, not `match()` in a boolean context.
* Properly reverse meanings of assert messages.

Sorry, GitHub diff is disoriented a bit.