### PR TITLE
test: refactor test-cluster-worker-isconnected.js

### DIFF
--- a/test/parallel/test-cluster-worker-isconnected.js
+++ b/test/parallel/test-cluster-worker-isconnected.js
@@ -1,38 +1,30 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const cluster = require('cluster');
 const assert = require('assert');
 
 if (cluster.isMaster) {
   const worker = cluster.fork();
 
-  assert.ok(worker.isConnected(),
-            'isConnected() should return true as soon as the worker has ' +
-            'been created.');
+  assert.strictEqual(worker.isConnected(), true);
 
-  worker.on('disconnect', function() {
-    assert.ok(!worker.isConnected(),
-              'After a disconnect event has been emitted, ' +
-              'isConncted should return false');
-  });
+  worker.on('disconnect', common.mustCall(() => {
+    assert.strictEqual(worker.isConnected(), false);
+  }));
 
   worker.on('message', function(msg) {
     if (msg === 'readyToDisconnect') {
       worker.disconnect();
     }
   });
-
 } else {
-  assert.ok(cluster.worker.isConnected(),
-            'isConnected() should return true from within a worker at all ' +
-            'times.');
+  function assertNotConnected() {
+    assert.strictEqual(cluster.worker.isConnected(), false);
+  }
 
-  cluster.worker.process.on('disconnect', function() {
-    assert.ok(!cluster.worker.isConnected(),
-              'isConnected() should return false from within a worker ' +
-              'after its underlying process has been disconnected from ' +
-              'the master');
-  });
+  assert.strictEqual(cluster.worker.isConnected(), true);
+  cluster.worker.on('disconnect', common.mustCall(assertNotConnected));
+  cluster.worker.process.on('disconnect', common.mustCall(assertNotConnected));
 
   process.send('readyToDisconnect');
 }


### PR DESCRIPTION
This commit:
- Uses `assert.strictEqual()` instead of `assert.ok()`.
- Verifies that the `'disconnect'` listeners are called using `common.mustCall()`.
- Verifies that `'disconnect'` is emitted on `cluster.worker.process` in the worker.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test