### PR TITLE
fix `common.expectsError` type checking

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -744,6 +744,11 @@ exports.expectsError = function expectsError(fn, settings, exact) {
       }
       assert(error instanceof type,
              `${error.name} is not instance of ${type.name}`);
+      let typeName = error.constructor.name;
+      if (typeName === 'NodeError' && type.name !== 'NodeError') {
+        typeName = Object.getPrototypeOf(error.constructor).name;
+      }
+      assert.strictEqual(typeName, type.name);
     }
     if ('message' in settings) {
       const message = settings.message;

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -36,7 +36,7 @@ common.expectsError(
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
-    type: Error,
+    type: TypeError,
     message: 'The value "undefined" is invalid for option "padding"'
   });
 
@@ -47,7 +47,7 @@ common.expectsError(
   }, ''),
   {
     code: 'ERR_INVALID_OPT_VALUE',
-    type: Error,
+    type: TypeError,
     message: 'The value "undefined" is invalid for option "saltLength"'
   });
 

--- a/test/parallel/test-fs-timestamp-parsing-error.js
+++ b/test/parallel/test-fs-timestamp-parsing-error.js
@@ -10,7 +10,7 @@ const assert = require('assert');
     },
     {
       code: 'ERR_INVALID_ARG_TYPE',
-      type: Error
+      type: TypeError
     });
 });
 
@@ -20,7 +20,7 @@ common.expectsError(
   },
   {
     code: 'ERR_INVALID_ARG_TYPE',
-    type: Error
+    type: TypeError
   });
 
 const okInputs = [1, -1, '1', '-1', Date.now()];

--- a/test/parallel/test-http2-client-http1-server.js
+++ b/test/parallel/test-http2-client-http1-server.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 if (!common.hasCrypto)
@@ -6,6 +7,7 @@ if (!common.hasCrypto)
 
 const http = require('http');
 const http2 = require('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // Creating an http1 server here...
 const server = http.createServer(common.mustNotCall());
@@ -18,13 +20,14 @@ server.listen(0, common.mustCall(() => {
 
   req.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
-    type: Error,
+    type: NghttpError,
     message: 'Protocol error'
   }));
 
   client.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
-    type: Error,
+    type: NghttpError,
+    name: 'Error [ERR_HTTP2_ERROR]',
     message: 'Protocol error'
   }));
 

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 if (!common.hasCrypto)
@@ -10,6 +11,7 @@ const {
   nghttp2ErrorString
 } = process.binding('http2');
 const http2 = require('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within requestOnConnect
 // - NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE (should emit session error)
@@ -51,7 +53,8 @@ const genericTests = Object.getOwnPropertyNames(constants)
     ngError: constants[key],
     error: {
       code: 'ERR_HTTP2_ERROR',
-      type: Error,
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'session'

--- a/test/parallel/test-http2-info-headers-errors.js
+++ b/test/parallel/test-http2-info-headers-errors.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 if (!common.hasCrypto)
@@ -9,6 +10,7 @@ const {
   Http2Stream,
   nghttp2ErrorString
 } = process.binding('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within additionalHeaders
 // - every other NGHTTP2 error from binding (should emit stream error)
@@ -24,7 +26,8 @@ const genericTests = Object.getOwnPropertyNames(constants)
     ngError: constants[key],
     error: {
       code: 'ERR_HTTP2_ERROR',
-      type: Error,
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-respond-errors.js
+++ b/test/parallel/test-http2-respond-errors.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 if (!common.hasCrypto)
@@ -9,6 +10,7 @@ const {
   Http2Stream,
   nghttp2ErrorString
 } = process.binding('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within respond
 // - every other NGHTTP2 error from binding (should emit stream error)
@@ -25,7 +27,8 @@ const genericTests = Object.getOwnPropertyNames(constants)
     ngError: constants[key],
     error: {
       code: 'ERR_HTTP2_ERROR',
-      type: Error,
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 
@@ -14,6 +15,7 @@ const {
   Http2Stream,
   nghttp2ErrorString
 } = process.binding('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within processRespondWithFD
 // (called by respondWithFD & respondWithFile)
@@ -32,7 +34,8 @@ const genericTests = Object.getOwnPropertyNames(constants)
     ngError: constants[key],
     error: {
       code: 'ERR_HTTP2_ERROR',
-      type: Error,
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-http2-server-http1-client.js
+++ b/test/parallel/test-http2-server-http1-client.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 
@@ -7,6 +8,7 @@ if (!common.hasCrypto)
 
 const http = require('http');
 const http2 = require('http2');
+const { NghttpError } = require('internal/http2/util');
 
 const server = http2.createServer();
 server.on('stream', common.mustNotCall());
@@ -14,7 +16,7 @@ server.on('session', common.mustCall((session) => {
   session.on('close', common.mustCall());
   session.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',
-    type: Error,
+    type: NghttpError,
     message: 'Received bad client magic byte string'
   }));
 }));

--- a/test/parallel/test-http2-server-push-stream-errors.js
+++ b/test/parallel/test-http2-server-push-stream-errors.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --expose-internals
 
 const common = require('../common');
 if (!common.hasCrypto)
@@ -9,6 +10,7 @@ const {
   Http2Stream,
   nghttp2ErrorString
 } = process.binding('http2');
+const { NghttpError } = require('internal/http2/util');
 
 // tests error handling within pushStream
 // - NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE (should emit session error)
@@ -49,7 +51,8 @@ const genericTests = Object.getOwnPropertyNames(constants)
     ngError: constants[key],
     error: {
       code: 'ERR_HTTP2_ERROR',
-      type: Error,
+      type: NghttpError,
+      name: 'Error [ERR_HTTP2_ERROR]',
       message: nghttp2ErrorString(constants[key])
     },
     type: 'stream'

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -163,7 +163,11 @@ assert.doesNotThrow(() => {
 assert.doesNotThrow(() => {
   common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, { code: 'TEST_ERROR_1', type: Error });
+  }, {
+    code: 'TEST_ERROR_1',
+    type: TypeError,
+    message: 'Error for testing purposes: a'
+  });
 });
 
 common.expectsError(() => {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -187,6 +187,7 @@ common.expectsError(() => {
        message: /^Error for testing 2/ });
 }, {
   code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
   message: /.+ does not match \S/
 });
 
@@ -237,6 +238,7 @@ common.expectsError(
   () => errors.message('ERR_INVALID_URL_SCHEME', [[]]),
   {
     code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
     message: /^At least one expected value needs to be specified$/
   });
 
@@ -251,6 +253,7 @@ common.expectsError(
   () => errors.message('ERR_MISSING_ARGS'),
   {
     code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
     message: /^At least one arg needs to be specified$/
   });
 

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -1,7 +1,10 @@
 'use strict';
+// Flags: --expose-internals
+
 const common = require('../common');
 const fs = require('fs');
 const tty = require('tty');
+const { SystemError } = require('internal/errors');
 
 common.expectsError(
   () => new tty.WriteStream(-1),
@@ -27,7 +30,7 @@ common.expectsError(
       new tty.WriteStream(fd);
     }, {
       code: 'ERR_SYSTEM_ERROR',
-      type: Error,
+      type: SystemError,
       message
     }
   );
@@ -42,7 +45,7 @@ common.expectsError(
       new tty.ReadStream(fd);
     }, {
       code: 'ERR_SYSTEM_ERROR',
-      type: Error,
+      type: SystemError,
       message
     });
 }


### PR DESCRIPTION
Fixes: #13682

* More exact types for Errors in the tests
* fix common.expectsError type checking

/cc @cjihrig @nodejs/testing 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
