### PR TITLE
repl: make REPLServer.bufferedCommand private

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -645,6 +645,14 @@ with inappropriate names has been deprecated.
 *Note*: As the original API was undocumented and not generally useful for
 non-internal code, no replacement API is provided.
 
+<a id="DEP00XX"></a>
+### DEP00XX: REPLServer.bufferedCommand
+
+Type: Runtime
+
+The `REPLServer.bufferedCommand` property was deprecated in favor of
+[`REPLServer.clearBufferedCommand()`][].
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
@@ -708,3 +716,4 @@ non-internal code, no replacement API is provided.
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [from_arraybuffer]: buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length
 [from_string_encoding]: buffer.html#buffer_class_method_buffer_from_string_encoding
+[`REPLServer.clearBufferedCommand()`]: repl.html#repl_replserver_clearbufferedcommand

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -335,7 +335,7 @@ const replServer = repl.start({ prompt: '> ' });
 replServer.defineCommand('sayhello', {
   help: 'Say hello',
   action(name) {
-    this.bufferedCommand = '';
+    this.clearBufferedCommand();
     console.log(`Hello, ${name}!`);
     this.displayPrompt();
   }
@@ -373,6 +373,16 @@ When `preserveCursor` is `true`, the cursor placement will not be reset to `0`.
 
 The `replServer.displayPrompt` method is primarily intended to be called from
 within the action function for commands registered using the
+`replServer.defineCommand()` method.
+
+### replServer.clearBufferedCommand()
+<!-- YAML
+added: v8.1.0
+-->
+
+The `replServer.clearBufferedComand()` method clears any command that has been
+buffered but not yet executed.This method is primarily intended to be 
+called from within the action function for commands registered using the 
 `replServer.defineCommand()` method.
 
 ## repl.start([options])

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -377,11 +377,11 @@ within the action function for commands registered using the
 
 ### replServer.clearBufferedCommand()
 <!-- YAML
-added: v8.1.0
+added: REPLACEME
 -->
 
 The `replServer.clearBufferedComand()` method clears any command that has been
-buffered but not yet executed.This method is primarily intended to be 
+buffered but not yet executed. This method is primarily intended to be 
 called from within the action function for commands registered using the 
 `replServer.defineCommand()` method.
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -73,6 +73,7 @@ for (var n = 0; n < GLOBAL_OBJECT_PROPERTIES.length; n++) {
   GLOBAL_OBJECT_PROPERTY_MAP[GLOBAL_OBJECT_PROPERTIES[n]] =
     GLOBAL_OBJECT_PROPERTIES[n];
 }
+const BUFFERED_COMMAND = Symbol('bufferedCommand');
 
 try {
   // hack for require.resolve("./relative") to work properly.
@@ -300,7 +301,7 @@ function REPLServer(prompt,
     } else {
       top.outputStream.write(`Thrown: ${String(e)}\n`);
     }
-    top.bufferedCommand = '';
+    top.clearBufferedCommand();
     top.lines.level = [];
     top.displayPrompt();
   });
@@ -326,8 +327,19 @@ function REPLServer(prompt,
   self.outputStream = output;
 
   self.resetContext();
-  self.bufferedCommand = '';
   self.lines.level = [];
+
+  self.clearBufferedCommand = function clearBufferedCommand() {
+    self[BUFFERED_COMMAND] = '';
+  };
+
+  self.clearBufferedCommand();
+  Object.defineProperty(this, 'bufferedCommand', {
+    get: util.deprecate(() => self[BUFFERED_COMMAND],
+                        'REPLServer.bufferedCommand is deprecated'),
+    set: util.deprecate((val) => self[BUFFERED_COMMAND] = val,
+                        'REPLServer.bufferedCommand is deprecated')
+  });
 
   // Figure out which "complete" function to use.
   self.completer = (typeof options.completer === 'function') ?
@@ -376,7 +388,8 @@ function REPLServer(prompt,
     self.clearLine();
     self.turnOffEditorMode();
 
-    if (!(self.bufferedCommand && self.bufferedCommand.length > 0) && empty) {
+    const cmd = self[BUFFERED_COMMAND];
+    if (!(cmd && cmd.length > 0) && empty) {
       if (sawSIGINT) {
         self.close();
         sawSIGINT = false;
@@ -388,7 +401,7 @@ function REPLServer(prompt,
       sawSIGINT = false;
     }
 
-    self.bufferedCommand = '';
+    self.clearBufferedCommand();
     self.lines.level = [];
     self.displayPrompt();
   });
@@ -399,7 +412,7 @@ function REPLServer(prompt,
     sawSIGINT = false;
 
     if (self.editorMode) {
-      self.bufferedCommand += cmd + '\n';
+      self[BUFFERED_COMMAND] += cmd + '\n';
 
       // code alignment
       const matches = self._sawKeyPress ? cmd.match(/^\s+/) : null;
@@ -426,7 +439,7 @@ function REPLServer(prompt,
         if (self.parseREPLKeyword(keyword, rest) === true) {
           return;
         }
-        if (!self.bufferedCommand) {
+        if (!self[BUFFERED_COMMAND]) {
           self.outputStream.write('Invalid REPL keyword\n');
           finish(null);
           return;
@@ -434,7 +447,7 @@ function REPLServer(prompt,
       }
     }
 
-    const evalCmd = self.bufferedCommand + cmd + '\n';
+    const evalCmd = self[BUFFERED_COMMAND] + cmd + '\n';
 
     debug('eval %j', evalCmd);
     self.eval(evalCmd, self.context, 'repl', finish);
@@ -443,11 +456,11 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
-      if (e && !self.bufferedCommand && cmd.trim().startsWith('npm ')) {
+      if (e && !self[BUFFERED_COMMAND] && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
-        self.bufferedCommand = '';
+        self.clearBufferedCommand();
         self.displayPrompt();
         return;
       }
@@ -459,7 +472,7 @@ function REPLServer(prompt,
           // {
           // ...  x: 1
           // ... }
-          self.bufferedCommand += cmd + '\n';
+          self[BUFFERED_COMMAND] += cmd + '\n';
           self.displayPrompt();
           return;
         } else {
@@ -468,7 +481,7 @@ function REPLServer(prompt,
       }
 
       // Clear buffer if no SyntaxErrors
-      self.bufferedCommand = '';
+      self.clearBufferedCommand();
       sawCtrlD = false;
 
       // If we got any output - print it (if no error)
@@ -494,7 +507,7 @@ function REPLServer(prompt,
       self.outputStream.write(`${self._initialPrompt}.editor\n`);
       self.outputStream.write(
         '// Entering editor mode (^D to finish, ^C to cancel)\n');
-      self.outputStream.write(`${self.bufferedCommand}\n`);
+      self.outputStream.write(`${self[BUFFERED_COMMAND]}\n`);
       self.prompt(true);
     } else {
       self.displayPrompt(true);
@@ -646,7 +659,7 @@ REPLServer.prototype.resetContext = function() {
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
   var prompt = this._initialPrompt;
-  if (this.bufferedCommand.length) {
+  if (this[BUFFERED_COMMAND].length) {
     prompt = '...';
     const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
     const levelInd = '..'.repeat(len);
@@ -741,7 +754,7 @@ REPLServer.prototype.complete = function() {
 // getter code.
 function complete(line, callback) {
   // There may be local variables to evaluate, try a nested REPL
-  if (this.bufferedCommand !== undefined && this.bufferedCommand.length) {
+  if (this[BUFFERED_COMMAND] !== undefined && this[BUFFERED_COMMAND].length) {
     // Get a new array of inputted lines
     var tmp = this.lines.slice();
     // Kill off all function declarations to push all local variables into
@@ -758,7 +771,7 @@ function complete(line, callback) {
     flat.run(tmp);                        // eval the flattened code
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
-    if (!magic.bufferedCommand) {
+    if (!magic[BUFFERED_COMMAND]) {
       return magic.complete(line, callback);
     }
   }
@@ -1171,7 +1184,7 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {
-      this.bufferedCommand = '';
+      this.clearBufferedCommand();
       this.displayPrompt();
     }
   });
@@ -1185,7 +1198,7 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('clear', {
     help: clearMessage,
     action: function() {
-      this.bufferedCommand = '';
+      this.clearBufferedCommand();
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
         this.resetContext();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -73,7 +73,7 @@ for (var n = 0; n < GLOBAL_OBJECT_PROPERTIES.length; n++) {
   GLOBAL_OBJECT_PROPERTY_MAP[GLOBAL_OBJECT_PROPERTIES[n]] =
     GLOBAL_OBJECT_PROPERTIES[n];
 }
-const BUFFERED_COMMAND = Symbol('bufferedCommand');
+const kBufferedCommandSymbol = Symbol('bufferedCommand');
 
 try {
   // hack for require.resolve("./relative") to work properly.
@@ -329,15 +329,11 @@ function REPLServer(prompt,
   self.resetContext();
   self.lines.level = [];
 
-  self.clearBufferedCommand = function clearBufferedCommand() {
-    self[BUFFERED_COMMAND] = '';
-  };
-
   self.clearBufferedCommand();
   Object.defineProperty(this, 'bufferedCommand', {
-    get: util.deprecate(() => self[BUFFERED_COMMAND],
+    get: util.deprecate(() => self[kBufferedCommandSymbol],
                         'REPLServer.bufferedCommand is deprecated'),
-    set: util.deprecate((val) => self[BUFFERED_COMMAND] = val,
+    set: util.deprecate((val) => self[kBufferedCommandSymbol] = val,
                         'REPLServer.bufferedCommand is deprecated')
   });
 
@@ -388,7 +384,7 @@ function REPLServer(prompt,
     self.clearLine();
     self.turnOffEditorMode();
 
-    const cmd = self[BUFFERED_COMMAND];
+    const cmd = self[kBufferedCommandSymbol];
     if (!(cmd && cmd.length > 0) && empty) {
       if (sawSIGINT) {
         self.close();
@@ -412,7 +408,7 @@ function REPLServer(prompt,
     sawSIGINT = false;
 
     if (self.editorMode) {
-      self[BUFFERED_COMMAND] += cmd + '\n';
+      self[kBufferedCommandSymbol] += cmd + '\n';
 
       // code alignment
       const matches = self._sawKeyPress ? cmd.match(/^\s+/) : null;
@@ -439,7 +435,7 @@ function REPLServer(prompt,
         if (self.parseREPLKeyword(keyword, rest) === true) {
           return;
         }
-        if (!self[BUFFERED_COMMAND]) {
+        if (!self[kBufferedCommandSymbol]) {
           self.outputStream.write('Invalid REPL keyword\n');
           finish(null);
           return;
@@ -447,7 +443,7 @@ function REPLServer(prompt,
       }
     }
 
-    const evalCmd = self[BUFFERED_COMMAND] + cmd + '\n';
+    const evalCmd = self[kBufferedCommandSymbol] + cmd + '\n';
 
     debug('eval %j', evalCmd);
     self.eval(evalCmd, self.context, 'repl', finish);
@@ -456,7 +452,7 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
-      if (e && !self[BUFFERED_COMMAND] && cmd.trim().startsWith('npm ')) {
+      if (e && !self[kBufferedCommandSymbol] && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
@@ -472,7 +468,7 @@ function REPLServer(prompt,
           // {
           // ...  x: 1
           // ... }
-          self[BUFFERED_COMMAND] += cmd + '\n';
+          self[kBufferedCommandSymbol] += cmd + '\n';
           self.displayPrompt();
           return;
         } else {
@@ -507,7 +503,7 @@ function REPLServer(prompt,
       self.outputStream.write(`${self._initialPrompt}.editor\n`);
       self.outputStream.write(
         '// Entering editor mode (^D to finish, ^C to cancel)\n');
-      self.outputStream.write(`${self[BUFFERED_COMMAND]}\n`);
+      self.outputStream.write(`${self[kBufferedCommandSymbol]}\n`);
       self.prompt(true);
     } else {
       self.displayPrompt(true);
@@ -579,6 +575,10 @@ exports.start = function(prompt,
   if (!exports.repl) exports.repl = repl;
   replMap.set(repl, repl);
   return repl;
+};
+
+REPLServer.prototype.clearBufferedCommand = function clearBufferedCommand() {
+  this[kBufferedCommandSymbol] = '';
 };
 
 REPLServer.prototype.close = function close() {
@@ -659,7 +659,7 @@ REPLServer.prototype.resetContext = function() {
 
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
   var prompt = this._initialPrompt;
-  if (this[BUFFERED_COMMAND].length) {
+  if (this[kBufferedCommandSymbol].length) {
     prompt = '...';
     const len = this.lines.level.length ? this.lines.level.length - 1 : 0;
     const levelInd = '..'.repeat(len);
@@ -754,7 +754,8 @@ REPLServer.prototype.complete = function() {
 // getter code.
 function complete(line, callback) {
   // There may be local variables to evaluate, try a nested REPL
-  if (this[BUFFERED_COMMAND] !== undefined && this[BUFFERED_COMMAND].length) {
+  if (this[kBufferedCommandSymbol] !== undefined &&
+      this[kBufferedCommandSymbol].length) {
     // Get a new array of inputted lines
     var tmp = this.lines.slice();
     // Kill off all function declarations to push all local variables into
@@ -771,7 +772,7 @@ function complete(line, callback) {
     flat.run(tmp);                        // eval the flattened code
     // all this is only profitable if the nested REPL
     // does not have a bufferedCommand
-    if (!magic[BUFFERED_COMMAND]) {
+    if (!magic[kBufferedCommandSymbol]) {
       return magic.complete(line, callback);
     }
   }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -332,9 +332,10 @@ function REPLServer(prompt,
   self.clearBufferedCommand();
   Object.defineProperty(this, 'bufferedCommand', {
     get: util.deprecate(() => self[kBufferedCommandSymbol],
-                        'REPLServer.bufferedCommand is deprecated'),
+                        'REPLServer.bufferedCommand is deprecated', 'DEP00XX'),
     set: util.deprecate((val) => self[kBufferedCommandSymbol] = val,
-                        'REPLServer.bufferedCommand is deprecated')
+                        'REPLServer.bufferedCommand is deprecated', 'DEP00XX'),
+    enumerable: true
   });
 
   // Figure out which "complete" function to use.


### PR DESCRIPTION
The `REPLServer.bufferedCommand` property was undocumented, except
for its usage appearing, unexplained, in an example for
`REPLServer.defineCommand`. This commit deprecates that property,
privatizes it, and adds a `REPLServer.clearBufferedCommand()`
function that will clear the buffer.

Refs: https://github.com/nodejs/node/issues/12686

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl, doc
