### PR TITLE
test: refactor test-fs-watch-stop-sync

### DIFF
--- a/test/parallel/test-fs-watch-stop-sync.js
+++ b/test/parallel/test-fs-watch-stop-sync.js
@@ -1,10 +1,21 @@
 'use strict';
-
 const common = require('../common');
-const assert = require('assert');
+
+// This test checks that the `stop` event is emitted asynchronously.
+//
+// If it isn't asynchronous, then the listener will be called during the
+// execution of `watch.stop()`. That would be a bug.
+//
+// If it is asynchronous, then the listener will be removed before the event is
+// emitted.
+
 const fs = require('fs');
 
-const watch = fs.watchFile(__filename, common.noop);
-watch.once('stop', assert.fail);  // Should not trigger.
+const listener = common.mustNotCall(
+  'listener should have been removed before the event was emitted'
+);
+
+const watch = fs.watchFile(__filename, common.mustNotCall());
+watch.once('stop', listener);
 watch.stop();
-watch.removeListener('stop', assert.fail);
+watch.removeListener('stop', listener);


### PR DESCRIPTION
* format test per project guide
* use listener that emits clear message
* use common.mustNotCall() to confirm different listener is not invoked

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs