### PR TITLE
test: remove needless RegExp flags

### DIFF
--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -42,7 +42,7 @@ function runAb(opts, callback) {
   const command = `ab ${opts} http://127.0.0.1:${server.address().port}/`;
   exec(command, function(err, stdout, stderr) {
     if (err) {
-      if (/ab|apr/mi.test(stderr)) {
+      if (/ab|apr/i.test(stderr)) {
         common.skip(`problem spawning \`ab\`.\n${stderr}`);
         process.reallyExit(0);
       }
@@ -50,13 +50,13 @@ function runAb(opts, callback) {
       return;
     }
 
-    let m = /Document Length:\s*(\d+) bytes/mi.exec(stdout);
+    let m = /Document Length:\s*(\d+) bytes/i.exec(stdout);
     const documentLength = parseInt(m[1]);
 
-    m = /Complete requests:\s*(\d+)/mi.exec(stdout);
+    m = /Complete requests:\s*(\d+)/i.exec(stdout);
     const completeRequests = parseInt(m[1]);
 
-    m = /HTML transferred:\s*(\d+) bytes/mi.exec(stdout);
+    m = /HTML transferred:\s*(\d+) bytes/i.exec(stdout);
     const htmlTransfered = parseInt(m[1]);
 
     assert.strictEqual(bodyLength, documentLength);

--- a/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
+++ b/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
@@ -24,7 +24,7 @@ for (const enc of ['utf8', 'utf16le', 'latin1', 'UTF-8']) {
       const headerEnd = received.indexOf('\r\n\r\n', 'utf8');
       assert.notStrictEqual(headerEnd, -1);
 
-      const header = received.toString('utf8', 0, headerEnd).split(/\r\n/g);
+      const header = received.toString('utf8', 0, headerEnd).split(/\r\n/);
       const body = received.toString(enc, headerEnd + 4);
 
       assert.strictEqual(header[0], 'HTTP/1.1 200 OK');

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -31,7 +31,7 @@ const tls = require('tls');
 
 const fs = require('fs');
 
-const hosterr = /Hostname\/IP doesn't match certificate's altnames/g;
+const hosterr = /Hostname\/IP doesn't match certificate's altnames/;
 const testCases =
   [{ ca: ['ca1-cert'],
      key: 'agent2-key',

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -217,7 +217,7 @@ function runClient(prefix, port, options, cb) {
   client.stdout.on('data', function(d) {
     out += d;
 
-    if (!goodbye && /_unauthed/g.test(out)) {
+    if (!goodbye && /_unauthed/.test(out)) {
       console.error(`${prefix}  * unauthed`);
       goodbye = true;
       client.kill();
@@ -225,7 +225,7 @@ function runClient(prefix, port, options, cb) {
       rejected = false;
     }
 
-    if (!goodbye && /_authed/g.test(out)) {
+    if (!goodbye && /_authed/.test(out)) {
       console.error(`${prefix}  * authed`);
       goodbye = true;
       client.kill();

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -205,7 +205,7 @@ const values = [
       assert.strictEqual(err.code, 1);
       assert.strictEqual(Object.getPrototypeOf(err).name, 'Error');
       assert.strictEqual(stdout, '');
-      const errLines = stderr.trim().split(/[\r\n]+/g);
+      const errLines = stderr.trim().split(/[\r\n]+/);
       const errLine = errLines.find((l) => /^Error/.exec(l));
       assert.strictEqual(errLine, `Error: ${fixture}`);
     })

--- a/test/pummel/test-keep-alive.js
+++ b/test/pummel/test-keep-alive.js
@@ -79,10 +79,10 @@ function runAb(opts, callback) {
       return;
     }
 
-    let matches = /Requests\/sec:\s*(\d+)\./mi.exec(stdout);
+    let matches = /Requests\/sec:\s*(\d+)\./i.exec(stdout);
     const reqSec = parseInt(matches[1]);
 
-    matches = /Keep-Alive requests:\s*(\d+)/mi.exec(stdout);
+    matches = /Keep-Alive requests:\s*(\d+)/i.exec(stdout);
     let keepAliveRequests;
     if (matches) {
       keepAliveRequests = parseInt(matches[1]);

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -84,7 +84,7 @@ function test(keyfn, certfn, check, next) {
     console.error(state);
     switch (state) {
       case 'WAIT-ACCEPT':
-        if (/ACCEPT/g.test(serverStdoutBuffer)) {
+        if (/ACCEPT/.test(serverStdoutBuffer)) {
           // Give s_server half a second to start up.
           setTimeout(startClient, 500);
           state = 'WAIT-HELLO';
@@ -92,7 +92,7 @@ function test(keyfn, certfn, check, next) {
         break;
 
       case 'WAIT-HELLO':
-        if (/hello/g.test(serverStdoutBuffer)) {
+        if (/hello/.test(serverStdoutBuffer)) {
 
           // End the current SSL connection and exit.
           // See s_server(1ssl).


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

* `/m` is needless if `^` and `$` are not used
* `/g` is needless in `split()`
* `/g` is needless in `test()` with one-time `RegExp`/`String`