### PR TITLE
test: improve http test reliability

### DIFF
--- a/test/parallel/test-http-client-immediate-error.js
+++ b/test/parallel/test-http-client-immediate-error.js
@@ -5,8 +5,36 @@
 
 const common = require('../common');
 const assert = require('assert');
+const net = require('net');
 const http = require('http');
-const req = http.get({ host: '127.0.0.1', port: 1 });
-req.on('error', common.mustCall((err) => {
-  assert.strictEqual(err.code, 'ECONNREFUSED');
+const uv = process.binding('uv');
+const { async_id_symbol } = process.binding('async_wrap');
+const { newUid } = require('async_hooks');
+
+const agent = new http.Agent();
+agent.createConnection = common.mustCall((cfg) => {
+  const sock = new net.Socket();
+
+  // Fake the handle so we can enforce returning an immediate error
+  sock._handle = {
+    connect: common.mustCall((req, addr, port) => {
+      return uv.UV_ENETUNREACH;
+    }),
+    readStart() {},
+    close() {}
+  };
+
+  // Simulate just enough socket handle initialization
+  sock[async_id_symbol] = newUid();
+
+  sock.connect(cfg);
+  return sock;
+});
+
+http.get({
+  host: '127.0.0.1',
+  port: 1,
+  agent
+}).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ENETUNREACH');
 }));


### PR DESCRIPTION
Fake the socket handle to ensure an immediate error is returned uniformly across all platforms.

CI: https://ci.nodejs.org/job/node-test-pull-request/8670/

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* test
* http
