### PR TITLE
test: check zlib version for createDeflateRaw

### DIFF
--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -10,7 +10,7 @@ const zlib = require('zlib');
 // This check was introduced in vesion 1.2.9 and prior to that there was
 // no such rejection which is the reason for the version check below
 // (http://zlib.net/ChangeLog.txt).
-if (process.versions.zlib.match(/^\d+\.\d+\.[9]|\d{2,}$/)) {
+if (/^\d+\.\d+\.[9]|\d{2,}$/.test(process.versions.zlib)) {
   assert.throws(() => {
     zlib.createDeflateRaw({ windowBits: 8 });
   }, /^Error: Init error$/);

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -8,9 +8,11 @@ const zlib = require('zlib');
 // For raw deflate encoding, requests for 256-byte windows are rejected as
 // invalid by zlib.
 // (http://zlib.net/manual.html#Advanced)
-assert.throws(() => {
-  zlib.createDeflateRaw({ windowBits: 8 });
-}, /^Error: Init error$/);
+if (process.versions.zlib.match(/^\d+\.\d+\.[9]|\d{2,}$/)) {
+  assert.throws(() => {
+    zlib.createDeflateRaw({ windowBits: 8 });
+  }, /^Error: Init error$/);
+}
 
 // Regression tests for bugs in the validation logic.
 

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -7,7 +7,7 @@ const zlib = require('zlib');
 
 // For raw deflate encoding, requests for 256-byte windows are rejected as
 // invalid by zlib (http://zlib.net/manual.html#Advanced).
-// This check was introduced in vesion 1.2.9 and prior to that there was
+// This check was introduced in version 1.2.9 and prior to that there was
 // no such rejection which is the reason for the version check below
 // (http://zlib.net/ChangeLog.txt).
 if (!/^1\.2\.[0-8]$/.test(process.versions.zlib)) {

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -10,7 +10,7 @@ const zlib = require('zlib');
 // This check was introduced in vesion 1.2.9 and prior to that there was
 // no such rejection which is the reason for the version check below
 // (http://zlib.net/ChangeLog.txt).
-if ((/^(?!1\.2\.[0-8]$)/.test(process.versions.zlib))) {
+if (!/^1\.2\.[0-8]$/.test(process.versions.zlib)) {
   assert.throws(() => {
     zlib.createDeflateRaw({ windowBits: 8 });
   }, /^Error: Init error$/);

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -6,8 +6,10 @@ const assert = require('assert');
 const zlib = require('zlib');
 
 // For raw deflate encoding, requests for 256-byte windows are rejected as
-// invalid by zlib.
-// (http://zlib.net/manual.html#Advanced)
+// invalid by zlib (http://zlib.net/manual.html#Advanced).
+// This check was introduced in vesion 1.2.9 and prior to that there was
+// no such rejection which is the reason for the version check below
+// (http://zlib.net/ChangeLog.txt).
 if (process.versions.zlib.match(/^\d+\.\d+\.[9]|\d{2,}$/)) {
   assert.throws(() => {
     zlib.createDeflateRaw({ windowBits: 8 });

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -10,7 +10,7 @@ const zlib = require('zlib');
 // This check was introduced in vesion 1.2.9 and prior to that there was
 // no such rejection which is the reason for the version check below
 // (http://zlib.net/ChangeLog.txt).
-if (/^\d+\.\d+\.[9]|\d{2,}$/.test(process.versions.zlib)) {
+if ((/^(?!1\.2\.[0-8]$)/.test(process.versions.zlib))) {
   assert.throws(() => {
     zlib.createDeflateRaw({ windowBits: 8 });
   }, /^Error: Init error$/);


### PR DESCRIPTION
We are currenly builing Node with `--shared-zlib` which happens to be
version `1.2.8`. The test for zlib.createDeflateRaw is expected to fail
but does not when using version `1.2.8`.

As far as I can tell the fix referred to in the comments was
introduced in version `1.2.9`:
```
- Reject a window size of 256 bytes if not using the zlib wrapper
```

This commit suggests adding a check for the version and skipping this
assert if the version is less than `1.2.9`.

Refs: http://zlib.net/ChangeLog.txt

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test