### PR TITLE
test: add hasIntl to failing test

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -106,6 +106,11 @@ Checks for 'openssl'.
 
 Checks `hasCrypto` and `crypto` with fips.
 
+### hasIntl
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks if [internationalization] is supported.
+
 ### hasIPv6
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 
@@ -322,3 +327,4 @@ implementation with tests from
 [W3C Web Platform Tests](https://github.com/w3c/web-platform-tests).
 
 [MDN-Function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Normal_objects_and_functions
+[internationalization]: https://github.com/nodejs/node/wiki/Intl

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -111,6 +111,11 @@ Checks `hasCrypto` and `crypto` with fips.
 
 Checks if [internationalization] is supported.
 
+### hasSmallICU
+* return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Checks `hasIntl` and `small-icu` is supported.
+
 ### hasIPv6
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -689,6 +689,12 @@ Object.defineProperty(exports, 'hasIntl', {
   }
 });
 
+Object.defineProperty(exports, 'hasSmallICU', {
+  get: function() {
+    return process.binding('config').hasSmallICU;
+  }
+});
+
 // Useful for testing expected internal/error objects
 exports.expectsError = function expectsError({code, type, message}) {
   return function(error) {

--- a/test/parallel/test-icu-data-dir.js
+++ b/test/parallel/test-icu-data-dir.js
@@ -1,5 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
+if (!(common.hasIntl && common.hasSmallICU)) {
+  common.skip('missing Intl');
+  return;
+}
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 

--- a/test/parallel/test-url-domain-ascii-unicode.js
+++ b/test/parallel/test-url-domain-ascii-unicode.js
@@ -1,6 +1,10 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasIntl) {
+  common.skip('missing Intl');
+  return;
+}
 const strictEqual = require('assert').strictEqual;
 const url = require('url');
 

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasIntl) {
+  common.skip('missing Intl');
+  return;
+}
 const assert = require('assert');
 const url = require('url');
 const URL = url.URL;


### PR DESCRIPTION
Currently when node is configured `--without-intl` the tests in this
commit fail. This commit adds checks for internationalization for these
tests

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test