### PR TITLE
doc: fix api docs style

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -195,7 +195,7 @@ The `type` is a string that represents the type of resource that caused
 `init` to be called. Generally it will correspond the name of the resource's
 constructor.
 
-```
+```text
 FSEVENTWRAP, FSREQWRAP, GETADDRINFOREQWRAP, GETNAMEINFOREQWRAP, HTTPPARSER,
 JSSTREAM, PIPECONNECTWRAP, PIPEWRAP, PROCESSWRAP, QUERYWRAP, SHUTDOWNWRAP,
 SIGNALWRAP, STATWATCHER, TCPCONNECTWRAP, TCPWRAP, TIMERWRAP, TTYWRAP,
@@ -236,7 +236,7 @@ require('net').createServer((conn) => {}).listen(8080);
 
 Output when hitting the server with `nc localhost 8080`:
 
-```
+```console
 TCPWRAP(2): trigger: 1 execution: 1
 TCPWRAP(4): trigger: 2 execution: 0
 ```
@@ -314,7 +314,7 @@ require('net').createServer(() => {}).listen(8080, () => {
 
 Output from only starting the server:
 
-```
+```console
 TCPWRAP(2): trigger: 1 execution: 1
 TickObject(3): trigger: 2 execution: 1
 before:  3
@@ -344,7 +344,7 @@ calls to `before` and `after`.
 
 Only using `execution` to graph resource allocation results in the following:
 
-```
+```console
 TTYWRAP(6) -> Timeout(4) -> TIMERWRAP(5) -> TickObject(3) -> root(1)
 ```
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2854,7 +2854,6 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [Caveats]: #fs_caveats
 [Common System Errors]: errors.html#errors_common_system_errors
 [FS Constants]: #fs_fs_constants_1
-[MDN-Date-getTime]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime
 [MDN-Date]: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
 [MDN-Number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type
 [MSDN-Rel-Path]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx#fully_qualified_vs._relative_paths


### PR DESCRIPTION
##### Summary

doc/api/async_hooks.md
  + L198: Missing code-language flag
  + L239: Missing code-language flag
  + L317: Missing code-language flag
  + L347: Missing code-language flag

doc/api/fs.md
  + L2857: Unused definition

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc