### PR TITLE
test: increase util.callbackify() coverage

### DIFF
--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -225,3 +225,37 @@ const values = [
     })
   );
 }
+
+{
+  // Verify that non-function inputs throw.
+  ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
+    assert.throws(() => {
+      callbackify(value);
+    }, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "original" argument must be of type function'
+    }));
+  });
+}
+
+{
+  async function asyncFn() {
+    return await Promise.resolve(42);
+  }
+
+  const cb = callbackify(asyncFn);
+  const args = [];
+
+  // Verify that the last argument to the callbackified function is a function.
+  ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
+    args.push(value);
+    assert.throws(() => {
+      cb(...args);
+    }, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "last argument" argument must be of type function'
+    }));
+  });
+}


### PR DESCRIPTION
This commit adds coverage for `util.callbackify()` type checking.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test