### PR TITLE
test: remove node-tap lookalike

### DIFF
--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -26,33 +26,6 @@ const assert = require('assert');
 const fromList = require('_stream_readable')._fromList;
 const BufferList = require('internal/streams/BufferList');
 
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
 function bufferListFromArray(arr) {
   const bl = new BufferList();
   for (let i = 0; i < arr.length; ++i)
@@ -60,15 +33,8 @@ function bufferListFromArray(arr) {
   return bl;
 }
 
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-
-test('buffers', function(t) {
+{
+  // Verify behavior with buffers
   let list = [ Buffer.from('foog'),
                Buffer.from('bark'),
                Buffer.from('bazy'),
@@ -77,27 +43,26 @@ test('buffers', function(t) {
 
   // read more than the first element.
   let ret = fromList(6, { buffer: list, length: 16 });
-  t.equal(ret.toString(), 'foogba');
+  assert.strictEqual(ret.toString(), 'foogba');
 
   // read exactly the first element.
   ret = fromList(2, { buffer: list, length: 10 });
-  t.equal(ret.toString(), 'rk');
+  assert.strictEqual(ret.toString(), 'rk');
 
   // read less than the first element.
   ret = fromList(2, { buffer: list, length: 8 });
-  t.equal(ret.toString(), 'ba');
+  assert.strictEqual(ret.toString(), 'ba');
 
   // read more than we have.
   ret = fromList(100, { buffer: list, length: 6 });
-  t.equal(ret.toString(), 'zykuel');
+  assert.strictEqual(ret.toString(), 'zykuel');
 
   // all consumed.
-  t.same(list, new BufferList());
+  assert.deepStrictEqual(list, new BufferList());
+}
 
-  t.end();
-});
-
-test('strings', function(t) {
+{
+  // Verify behavior with strings
   let list = [ 'foog',
                'bark',
                'bazy',
@@ -106,22 +71,20 @@ test('strings', function(t) {
 
   // read more than the first element.
   let ret = fromList(6, { buffer: list, length: 16, decoder: true });
-  t.equal(ret, 'foogba');
+  assert.strictEqual(ret, 'foogba');
 
   // read exactly the first element.
   ret = fromList(2, { buffer: list, length: 10, decoder: true });
-  t.equal(ret, 'rk');
+  assert.strictEqual(ret, 'rk');
 
   // read less than the first element.
   ret = fromList(2, { buffer: list, length: 8, decoder: true });
-  t.equal(ret, 'ba');
+  assert.strictEqual(ret, 'ba');
 
   // read more than we have.
   ret = fromList(100, { buffer: list, length: 6, decoder: true });
-  t.equal(ret, 'zykuel');
+  assert.strictEqual(ret, 'zykuel');
 
   // all consumed.
-  t.same(list, new BufferList());
-
-  t.end();
-});
+  assert.deepStrictEqual(list, new BufferList());
+}

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -20,46 +20,10 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const R = require('_stream_readable');
 const util = require('util');
-
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-/////
 
 util.inherits(TestReader, R);
 
@@ -89,13 +53,12 @@ TestReader.prototype._read = function(n) {
     this.pos += n;
     const ret = Buffer.alloc(n, 'a');
 
-    console.log('this.push(ret)', ret);
-
     return this.push(ret);
   }.bind(this), 1);
 };
 
-test('setEncoding utf8', function(t) {
+{
+  // Verify utf8 encoding
   const tr = new TestReader(100);
   tr.setEncoding('utf8');
   const out = [];
@@ -117,14 +80,14 @@ test('setEncoding utf8', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
 
-test('setEncoding hex', function(t) {
+{
+  // Verify hex encoding
   const tr = new TestReader(100);
   tr.setEncoding('hex');
   const out = [];
@@ -156,13 +119,13 @@ test('setEncoding hex', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('setEncoding hex with read(13)', function(t) {
+{
+  // Verify hex encoding with read(13)
   const tr = new TestReader(100);
   tr.setEncoding('hex');
   const out = [];
@@ -185,20 +148,18 @@ test('setEncoding hex with read(13)', function(t) {
       '16161' ];
 
   tr.on('readable', function flow() {
-    console.log('readable once');
     let chunk;
     while (null !== (chunk = tr.read(13)))
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    console.log('END');
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('setEncoding base64', function(t) {
+{
+  // Verify base64 encoding
   const tr = new TestReader(100);
   tr.setEncoding('base64');
   const out = [];
@@ -224,13 +185,13 @@ test('setEncoding base64', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: utf8', function(t) {
+{
+  // Verify utf8 encoding
   const tr = new TestReader(100, { encoding: 'utf8' });
   const out = [];
   const expect =
@@ -251,14 +212,14 @@ test('encoding: utf8', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
 
-test('encoding: hex', function(t) {
+{
+  // Verify hex encoding
   const tr = new TestReader(100, { encoding: 'hex' });
   const out = [];
   const expect =
@@ -289,13 +250,13 @@ test('encoding: hex', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: hex with read(13)', function(t) {
+{
+  // Verify hex encoding with read(13)
   const tr = new TestReader(100, { encoding: 'hex' });
   const out = [];
   const expect =
@@ -322,13 +283,13 @@ test('encoding: hex with read(13)', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: base64', function(t) {
+{
+  // Verify base64 encoding
   const tr = new TestReader(100, { encoding: 'base64' });
   const out = [];
   const expect =
@@ -353,14 +314,13 @@ test('encoding: base64', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('chainable', function(t) {
+{
+  // Verify chaining behavior
   const tr = new TestReader(100);
-  t.equal(tr.setEncoding('utf8'), tr);
-  t.end();
-});
+  assert.deepStrictEqual(tr.setEncoding('utf8'), tr);
+}


### PR DESCRIPTION
This commit removes the small node-tap lookalike from several of the streams2 tests. It's only used by six tests, and is inconsistent with all other tests.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test