### PR TITLE
v8: fix RegExp nits in v8_prof_polyfill.js

### DIFF
--- a/lib/internal/v8_prof_polyfill.js
+++ b/lib/internal/v8_prof_polyfill.js
@@ -105,12 +105,13 @@ function versionCheck() {
 function macCppfiltNm(out) {
   // Re-grouped copy-paste from `tickprocessor.js`
   const FUNC_RE = /^([0-9a-fA-F]{8,16} [iItT] )(.*)$/gm;
+  const CLEAN_RE = /^[0-9a-fA-F]{8,16} [iItT] /;
   let entries = out.match(FUNC_RE);
   if (entries === null)
     return out;
 
   entries = entries.map((entry) => {
-    return entry.replace(/^[0-9a-fA-F]{8,16} [iItT] /, '')
+    return entry.replace(CLEAN_RE, '')
   });
 
   let filtered;
@@ -123,7 +124,7 @@ function macCppfiltNm(out) {
   }
 
   let i = 0;
-  filtered = filtered.split(/\n/g);
+  filtered = filtered.split('\n');
   return out.replace(FUNC_RE, (all, prefix, postfix) => {
     return prefix + (filtered[i++] || postfix);
   });


### PR DESCRIPTION
##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
v8

* Do not repeat RegExp creation in a cycle.
* Use sufficient string instead of RegExp in `split()`.

I am not sure about the status of this lib file (it is excluded from linting and is not tested in common CI). I've stumbled upon these fragments in some recent overall RegExp checks. The fixes seem rather simple and safe, but please suggest the ways we should test them if needed.