### PR TITLE
test: use string instead of RegExp in split() when it is sufficient

### DIFF
--- a/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
+++ b/test/parallel/test-http-outgoing-first-chunk-singlebyte-encoding.js
@@ -24,7 +24,7 @@ for (const enc of ['utf8', 'utf16le', 'latin1', 'UTF-8']) {
       const headerEnd = received.indexOf('\r\n\r\n', 'utf8');
       assert.notStrictEqual(headerEnd, -1);
 
-      const header = received.toString('utf8', 0, headerEnd).split(/\r\n/);
+      const header = received.toString('utf8', 0, headerEnd).split('\r\n');
       const body = received.toString(enc, headerEnd + 4);
 
       assert.strictEqual(header[0], 'HTTP/1.1 200 OK');

--- a/test/parallel/test-repl-setprompt.js
+++ b/test/parallel/test-repl-setprompt.js
@@ -44,6 +44,6 @@ child.stdin.end(`e.setPrompt("${p}");${os.EOL}`);
 child.on('close', function(code, signal) {
   assert.strictEqual(code, 0);
   assert.ok(!signal);
-  const lines = data.split(/\n/);
+  const lines = data.split('\n');
   assert.strictEqual(lines.pop(), p);
 });

--- a/test/parallel/test-stdin-script-child.js
+++ b/test/parallel/test-stdin-script-child.js
@@ -19,7 +19,7 @@ for (const args of [[], ['-']]) {
 
   child.stderr.setEncoding('utf8');
   child.stderr.on('data', function(c) {
-    console.error(`> ${c.trim().split(/\n/).join('\n> ')}`);
+    console.error(`> ${c.trim().split('\n').join('\n> ')}`);
   });
 
   child.on('close', common.mustCall(function(c) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
