### PR TITLE
test: fix flaky test-inspector-port-zero-cluster

### DIFF
--- a/test/inspector/inspector.status
+++ b/test/inspector/inspector.status
@@ -5,6 +5,5 @@ prefix inspector
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-test-inspector-port-zero-cluster     : PASS,FLAKY
 
 [$system==win32]

--- a/test/inspector/test-inspector-port-zero-cluster.js
+++ b/test/inspector/test-inspector-port-zero-cluster.js
@@ -16,7 +16,7 @@ if (cluster.isMaster) {
       ports.push(message.debugPort);
       worker.kill();
     });
-    worker.on('exit', (code, signal) => {
+    worker.on('exit', () => {
       // If the worker exited via `worker.kill()` above, exitedAfterDisconnect
       // will be true. If the worker exited because the debug port was already
       // in use, exitedAfterDisconnect will be false. That can be expected in


### PR DESCRIPTION
With a properly functioning test, it is possible for a cluster worker to
fail to launch due to a port collision. For better or for worse, this is
working as expected and so the test now accommodates that reality.

Fixes: https://github.com/nodejs/node/issues/13343

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test inspector cluster