### PR TITLE
doc: make `path.relative` stricter

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -445,9 +445,9 @@ changes:
 * `to` {string}
 * Returns: {string}
 
-The `path.relative()` method returns the relative path from `from` to `to`.
-If `from` and `to` each resolve to the same path (after calling `path.resolve()`
-on each), a zero-length string is returned.
+The `path.relative()` method returns the relative path from `from` to `to` based
+on current working directory. If `from` and `to` each resolve to the same path
+(after calling `path.resolve()` on each), a zero-length string is returned.
 
 If a zero-length string is passed as `from` or `to`, the current working
 directory will be used instead of the zero-length strings.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -446,8 +446,8 @@ changes:
 * Returns: {string}
 
 The `path.relative()` method returns the relative path from `from` to `to` based
-on current working directory. If `from` and `to` each resolve to the same path
-(after calling `path.resolve()` on each), a zero-length string is returned.
+on the current working directory. If `from` and `to` each resolve to the same
+path (after calling `path.resolve()` on each), a zero-length string is returned.
 
 If a zero-length string is passed as `from` or `to`, the current working
 directory will be used instead of the zero-length strings.


### PR DESCRIPTION
think of this situation: you are current under root path and you do

```
path.relative('../../../../../x', '../../y');
```

`path.relative` can't fictitious a path for the result, so it's based
on current working directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, path
