### PR TITLE
src,lib,test,doc: correct misspellings

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -426,7 +426,7 @@ added: v8.0.0
 -->
 
 `options...` are interpreted as if they had been specified on the command line
-before the actual command line (so they can be overriden).  Node will exit with
+before the actual command line (so they can be overridden).  Node will exit with
 an error if an option that is not allowed in the environment is used, such as
 `-p` or a script file.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -239,7 +239,7 @@ typedef struct napi_extended_error_info {
   napi_status error_code;
 };
 ```
-- `error_message`: Textual representation of the error that occured.
+- `error_message`: Textual representation of the error that occurred.
 - `engine_reserved`: Opaque handle reserved for engine use only.
 - `engine_error_code`: VM specific error code.
 - `error_code`: n-api status code for the last error.
@@ -267,7 +267,7 @@ information about the error.
 Returns `napi_ok` if the API succeeded.
 
 This API retrieves a `napi_extended_error_info` structure with information
-about the last error that occured.
+about the last error that occurred.
 
 *Note*: Do not rely on the content or format of any of the extended
 information as it is not subject to SemVer and may change at any time.

--- a/doc/node.1
+++ b/doc/node.1
@@ -275,7 +275,7 @@ When set to \fI1\fR, process warnings are silenced.
 .TP
 .BR NODE_OPTIONS =\fIoptions...\fR
 \fBoptions...\fR are interpreted as if they had been specified on the command
-line before the actual command line (so they can be overriden).  Node will exit
+line before the actual command line (so they can be overridden).  Node will exit
 with an error if an option that is not allowed in the environment is used, such
 as \fB-p\fR or a script file.
 

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -2,7 +2,7 @@
 
 // This value is used to prevent the nextTickQueue from becoming too
 // large and cause the process to run out of memory. When this value
-// is reached the nextTimeQueue array will be shortend (see tickDone
+// is reached the nextTimeQueue array will be shortened (see tickDone
 // for details).
 const kMaxCallbacksPerLoop = 1e4;
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -109,9 +109,9 @@ function connect() {
 
 
 // Returns an array [options, cb], where options is an object,
-// cb is either a funciton or null.
+// cb is either a function or null.
 // Used to normalize arguments of Socket.prototype.connect() and
-// Server.prototype.listen(). Possible combinations of paramters:
+// Server.prototype.listen(). Possible combinations of parameters:
 //   (options[...][, cb])
 //   (path[...][, cb])
 //   ([port][, host][...][, cb])

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2546,7 +2546,7 @@ napi_status napi_create_arraybuffer(napi_env env,
       v8::ArrayBuffer::New(isolate, byte_length);
 
   // Optionally return a pointer to the buffer's data, to avoid another call to
-  // retreive it.
+  // retrieve it.
   if (data != nullptr) {
     *data = buffer->GetContents().Data();
   }

--- a/src/node_debug_options.cc
+++ b/src/node_debug_options.cc
@@ -78,7 +78,7 @@ bool DebugOptions::ParseOption(const char* argv0, const std::string& option) {
       argument.clear();
   }
 
-  // Note that --debug-port and --debug-brk in conjuction with --inspect
+  // Note that --debug-port and --debug-brk in conjunction with --inspect
   // work but are undocumented.
   // --debug is no longer valid.
   // Ref: https://github.com/nodejs/node/issues/12630

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -515,7 +515,7 @@ int32_t ToASCII(MaybeStackBuffer<char>* buf,
 
   // In UTS #46 which specifies ToASCII, certain error conditions are
   // configurable through options, and the WHATWG URL Standard promptly elects
-  // to disable some of them to accomodate for real-world use cases.
+  // to disable some of them to accommodate for real-world use cases.
   // Unfortunately, ICU4C's IDNA module does not support disabling some of
   // these options through `options` above, and thus continues throwing
   // unnecessary errors. To counter this situation, we just filter out the

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -396,13 +396,13 @@ static inline uint64_t AddTraceEventImpl(
     const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
     const char** arg_names, const uint8_t* arg_types,
     const uint64_t* arg_values, unsigned int flags) {
-  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertables[2];
+  std::unique_ptr<v8::ConvertableToTraceFormat> arg_convertibles[2];
   if (num_args > 0 && arg_types[0] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertables[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertibles[0].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[0])));
   }
   if (num_args > 1 && arg_types[1] == TRACE_VALUE_TYPE_CONVERTABLE) {
-    arg_convertables[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
+    arg_convertibles[1].reset(reinterpret_cast<v8::ConvertableToTraceFormat*>(
         static_cast<intptr_t>(arg_values[1])));
   }
   // DCHECK(num_args <= 2);
@@ -410,7 +410,7 @@ static inline uint64_t AddTraceEventImpl(
       node::tracing::TraceEventHelper::GetCurrentPlatform();
   return platform->AddTraceEvent(phase, category_group_enabled, name, scope, id,
                                  bind_id, num_args, arg_names, arg_types,
-                                 arg_values, arg_convertables, flags);
+                                 arg_values, arg_convertibles, flags);
 }
 
 // Define SetTraceValue for each allowed type. It stores the type and

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@ This directory contains code and data used to test the Node.js implementation.
 For a detailed guide on how to write tests in this
 directory, see [the guide on writing tests](../doc/guides/writing-tests.md).
 
-On how to run tests in this direcotry, see
+On how to run tests in this directory, see
 [the contributing guide](../CONTRIBUTING.md#step-5-test).
 
 ## Test Directories

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -31,6 +31,6 @@ assert.ok(test_general.testGetPrototype(baseObject) !==
           test_general.testGetPrototype(extendedObject),
           'Prototypes for base and extended should be different');
 
-// test version management funcitons
+// test version management functions
 // expected version is currently 1
 assert.strictEqual(test_general.testGetVersion(), 1);

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -47,6 +47,6 @@ function onexit() {
   assert.strictEqual(a1.type, 'PROMISE');
   assert.strictEqual(typeof a1.uid, 'number');
   assert.strictEqual(a1.triggerAsyncId, a0.uid);
-  // We expect a destroy hook as well but we cannot guarentee predictable gc.
+  // We expect a destroy hook as well but we cannot guarantee predictable gc.
   checkInvocations(a1, { init: 1, before: 1, after: 1 }, 'when process exits');
 }

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -37,6 +37,6 @@ process.on('exit', function onexit() {
   // immediately before the child promise, thus there should only be one
   // difference in id.
   assert.strictEqual(a0.triggerAsyncId, a0.uid - 1);
-  // We expect a destroy hook as well but we cannot guarentee predictable gc.
+  // We expect a destroy hook as well but we cannot guarantee predictable gc.
   checkInvocations(a0, { init: 1, before: 1, after: 1 }, 'when process exits');
 });

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -21,7 +21,7 @@ function onlistening() {
     new Buffer(2), 0, 2, sock.address().port,
     undefined, common.mustCall(onsent));
 
-  // init not called synchronously because dns lookup alwasy wraps
+  // init not called synchronously because dns lookup always wraps
   // callback in a next tick even if no lookup is needed
   // TODO (trevnorris) submit patch to fix creation of tick objects and instead
   // create the send wrap synchronously.

--- a/test/parallel/test-async-wrap-getasyncid.js
+++ b/test/parallel/test-async-wrap-getasyncid.js
@@ -68,7 +68,7 @@ function testInitialized(req, ctor_name) {
 
 {
   // We don't want to expose getAsyncId for promises but we need to construct
-  // one so that the cooresponding provider type is removed from the
+  // one so that the corresponding provider type is removed from the
   // providers list.
   new Promise((res) => res(5));
 }

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -11,7 +11,7 @@ common.refreshTmpDir();
 
 const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
 
-// Verify constructing the instance with defualt options.
+// Verify constructing the instance with default options.
 {
   const stream = new SyncWriteStream(1);
 
@@ -31,7 +31,7 @@ const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
   assert.strictEqual(stream.listenerCount('end'), 1);
 }
 
-// Verfiy that the file will be writen synchronously.
+// Verfiy that the file will be written synchronously.
 {
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);
@@ -41,7 +41,7 @@ const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
   assert.strictEqual(fs.readFileSync(filename).equals(chunk), true);
 }
 
-// Verify that the stream will unset the fd after destory().
+// Verify that the stream will unset the fd after destroy().
 {
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd);

--- a/test/parallel/test-net-connect-options-allowhalfopen.js
+++ b/test/parallel/test-net-connect-options-allowhalfopen.js
@@ -65,7 +65,7 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
     }));
     socket.on('end', common.mustCall(function() {
       serverReceivedFIN++;
-      console.error(`Server recieved FIN sent by No. ${clientId}`);
+      console.error(`Server received FIN sent by No. ${clientId}`);
       if (serverReceivedFIN === CLIENT_VARIANTS) {
         setTimeout(() => {
           server.close();

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -6051,7 +6051,7 @@ def ParseArguments(args):
       try:
           _valid_extensions = set(val.split(','))
       except ValueError:
-          PrintUsage('Extensions must be comma seperated list.')
+          PrintUsage('Extensions must be comma separated list.')
     elif opt == '--logfile':
       logger.addHandler(logging.FileHandler(val, mode='wb'))
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -55,7 +55,7 @@ if /i "%1"=="clean"         set target=Clean&goto arg-ok
 if /i "%1"=="ia32"          set target_arch=x86&goto arg-ok
 if /i "%1"=="x86"           set target_arch=x86&goto arg-ok
 if /i "%1"=="x64"           set target_arch=x64&goto arg-ok
-@rem args should be vs2017 and vs2015. keeping vc2015 for backward combatibility (undocumented)
+@rem args should be vs2017 and vs2015. keeping vc2015 for backward compatibility (undocumented)
 if /i "%1"=="vc2015"        set target_env=vs2015&goto arg-ok
 if /i "%1"=="vs2015"        set target_env=vs2015&goto arg-ok
 if /i "%1"=="vs2017"        set target_env=vs2017&goto arg-ok
@@ -157,7 +157,7 @@ if defined noprojgen if defined nobuild if not defined sign if not defined msi g
 set msvs_host_arch=x86
 if _%PROCESSOR_ARCHITECTURE%_==_AMD64_ set msvs_host_arch=amd64
 if _%PROCESSOR_ARCHITEW6432%_==_AMD64_ set msvs_host_arch=amd64
-@rem usualy vcvarsall takes an argument: host + '_' + target
+@rem usually vcvarsall takes an argument: host + '_' + target
 set vcvarsall_arg=%msvs_host_arch%_%target_arch%
 @rem unless both host and target are x64
 if %target_arch%==x64 if %msvs_host_arch%==amd64 set vcvarsall_arg=amd64


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src, lib, test, doc

Fixed a number of misspellings all over the code base as identified by [misspell](https://github.com/client9/misspell). The only relevant code change in this commit is on `src/tracing/trace_event.h`.