### PR TITLE
readline, repl, url, util: remove needless RegExp capturing

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -51,7 +51,7 @@ const IteratorPrototype = Object.getPrototypeOf(
 );
 
 const unpairedSurrogateRe =
-    /([^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+    /(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
 function toUSVString(val) {
   const str = `${val}`;
   // As of V8 5.5, `str.search()` (and `unpairedSurrogateRe[@@search]()`) are

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -551,7 +551,7 @@ function commonPrefix(strings) {
 Interface.prototype._wordLeft = function() {
   if (this.cursor > 0) {
     var leading = this.line.slice(0, this.cursor);
-    var match = leading.match(/([^\w\s]+|\w+|)\s*$/);
+    var match = leading.match(/(?:[^\w\s]+|\w+|)\s*$/);
     this._moveCursor(-match[0].length);
   }
 };
@@ -560,7 +560,7 @@ Interface.prototype._wordLeft = function() {
 Interface.prototype._wordRight = function() {
   if (this.cursor < this.line.length) {
     var trailing = this.line.slice(this.cursor);
-    var match = trailing.match(/^(\s+|\W+|\w+)\s*/);
+    var match = trailing.match(/^(?:\s+|\W+|\w+)\s*/);
     this._moveCursor(match[0].length);
   }
 };
@@ -587,7 +587,7 @@ Interface.prototype._deleteRight = function() {
 Interface.prototype._deleteWordLeft = function() {
   if (this.cursor > 0) {
     var leading = this.line.slice(0, this.cursor);
-    var match = leading.match(/([^\w\s]+|\w+|)\s*$/);
+    var match = leading.match(/(?:[^\w\s]+|\w+|)\s*$/);
     leading = leading.slice(0, leading.length - match[0].length);
     this.line = leading + this.line.slice(this.cursor, this.line.length);
     this.cursor = leading.length;
@@ -599,7 +599,7 @@ Interface.prototype._deleteWordLeft = function() {
 Interface.prototype._deleteWordRight = function() {
   if (this.cursor < this.line.length) {
     var trailing = this.line.slice(this.cursor);
-    var match = trailing.match(/^(\s+|\W+|\w+)\s*/);
+    var match = trailing.match(/^(?:\s+|\W+|\w+)\s*/);
     this.line = this.line.slice(0, this.cursor) +
                 trailing.slice(match[0].length);
     this._refreshLine();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -680,9 +680,9 @@ ArrayStream.prototype.writable = true;
 ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
-const requireRE = /\brequire\s*\(['"](([\w@./-]+\/)?([\w@./-]*))/;
+const requireRE = /\brequire\s*\(['"](([\w@./-]+\/)?(?:[\w@./-]*))/;
 const simpleExpressionRE =
-    /(([a-zA-Z_$](?:\w|\$)*)\.)*([a-zA-Z_$](?:\w|\$)*)\.?$/;
+    /(?:[a-zA-Z_$](?:\w|\$)*\.)*[a-zA-Z_$](?:\w|\$)*\.?$/;
 
 function intFilter(item) {
   // filters out anything not starting with A-Z, a-z, $ or _
@@ -753,7 +753,7 @@ function complete(line, callback) {
   } else if (match = line.match(requireRE)) {
     // require('...<Tab>')
     const exts = Object.keys(this.context.require.extensions);
-    var indexRe = new RegExp('^index(' + exts.map(regexpEscape).join('|') +
+    var indexRe = new RegExp('^index(?:' + exts.map(regexpEscape).join('|') +
                              ')$');
     var versionedFileNamesRe = /-\d+\.\d+/;
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -56,7 +56,7 @@ function Url() {
 
 // define these here so at least they only have to be
 // compiled once on the first module load.
-const protocolPattern = /^([a-z0-9.+-]+:)/i;
+const protocolPattern = /^[a-z0-9.+-]+:/i;
 const portPattern = /:[0-9]*$/;
 const hostPattern = /^\/\/[^@/]+@[^@/]+/;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -792,7 +792,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
         if (array) {
           str = str.replace(/\n/g, '\n  ');
         } else {
-          str = str.replace(/(^|\n)/g, '\n   ');
+          str = str.replace(/^|\n/g, '\n   ');
         }
       }
     } else {
@@ -804,13 +804,13 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
       return str;
     }
     name = JSON.stringify('' + key);
-    if (/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/.test(name)) {
+    if (/^"[a-zA-Z_][a-zA-Z_0-9]*"$/.test(name)) {
       name = name.substr(1, name.length - 2);
       name = ctx.stylize(name, 'name');
     } else {
       name = name.replace(/'/g, "\\'")
                  .replace(/\\"/g, '"')
-                 .replace(/(^"|"$)/g, "'")
+                 .replace(/^"|"$/g, "'")
                  .replace(/\\\\/g, '\\');
       name = ctx.stylize(name, 'string');
     }


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
readline, repl, url, util

Use non-capturing grouping or remove capturing completely when:

* capturing is useless per se, e.g. in test() check;
* captured groups are not used afterward at all;
* some of the later captured groups are not used afterward.