### PR TITLE
test: refactor test-fs-watchfile

### DIFF
--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -1,21 +1,21 @@
 'use strict';
-
 const common = require('../common');
+
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const assert = require('assert');
 
 // Basic usage tests.
 assert.throws(function() {
   fs.watchFile('./some-file');
-}, /"watchFile\(\)" requires a listener function/);
+}, /^Error: "watchFile\(\)" requires a listener function$/);
 
 assert.throws(function() {
   fs.watchFile('./another-file', {}, 'bad listener');
-}, /"watchFile\(\)" requires a listener function/);
+}, /^Error: "watchFile\(\)" requires a listener function$/);
 
 assert.throws(function() {
-  fs.watchFile(new Object(), common.noop);
+  fs.watchFile(new Object(), common.mustNotCall());
 }, common.expectsError({code: 'ERR_INVALID_ARG_TYPE', type: TypeError}));
 
 const enoentFile = path.join(common.tmpDir, 'non-existent-file');


### PR DESCRIPTION
* use `common.mustNotCall()` to confirm callback is not called
* reorder modules to conform with test-writing guide
* match full error message in `assert.throws()`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs