### PR TITLE
buffer: support boxed strings and toPrimitive

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -908,6 +908,44 @@ console.log(buf2.toString());
 
 A `TypeError` will be thrown if `str` is not a string.
 
+### Class Method: Buffer.from(object[, offsetOrEncoding[, length]])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `object` {Object} An object supporting `Symbol.toPrimitive` or `valueOf()`
+* `offsetOrEncoding` {number|string} A byte-offset or encoding, depending on
+  the value returned either by `object.valueOf()` or
+  `object[Symbol.toPrimitive]()`.
+* `length` {number} A length, depending on the value returned either by
+  `object.valueOf()` or `object[Symbol.toPrimitive]()`.
+
+For objects whose `valueOf()` function returns a value not strictly equal to
+`object`, returns `Buffer.from(object.valueOf(), offsetOrEncoding, length)`.
+
+For example:
+
+```js
+const buf = Buffer.from(new String('this is a test'));
+// <Buffer 74 68 69 73 20 69 73 20 61 20 74 65 73 74>
+```
+
+For objects that support `Symbol.toPrimitive`, returns
+`Buffer.from(object[Symbol.toPrimitive](), offsetOrEncoding, length)`.
+
+For example:
+
+```js
+class Foo {
+  [Symbol.toPrimitive]() {
+    return 'this is a test';
+  }
+}
+
+const buf = Buffer.from(new Foo(), 'utf8');
+// <Buffer 74 68 69 73 20 69 73 20 61 20 74 65 73 74>
+```
+
 ### Class Method: Buffer.isBuffer(obj)
 <!-- YAML
 added: v0.1.101

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -176,12 +176,26 @@ Buffer.from = function(value, encodingOrOffset, length) {
   if (isAnyArrayBuffer(value))
     return fromArrayBuffer(value, encodingOrOffset, length);
 
+  if (value == null)
+    throw new TypeError(kFromErrorMsg);
+
+  if (typeof value === 'number')
+    throw new TypeError('"value" argument must not be a number');
+
+  const valueOf = value.valueOf && value.valueOf();
+  if (valueOf != null && valueOf !== value)
+    return Buffer.from(valueOf, encodingOrOffset, length);
+
   var b = fromObject(value);
   if (b)
     return b;
 
-  if (typeof value === 'number')
-    throw new TypeError('"value" argument must not be a number');
+  if (typeof value[Symbol.toPrimitive] === 'function') {
+    return Buffer.from(value[Symbol.toPrimitive]('string'),
+                       encodingOrOffset,
+                       length);
+  }
+
   throw new TypeError(kFromErrorMsg);
 };
 

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -1,0 +1,57 @@
+'use strict';
+
+require('../common');
+const { deepStrictEqual, throws } = require('assert');
+const { Buffer } = require('buffer');
+const { runInNewContext } = require('vm');
+
+const checkString = 'test';
+
+const check = Buffer.from(checkString);
+
+class MyString extends String {
+  constructor() {
+    super(checkString);
+  }
+}
+
+class MyPrimitive {
+  [Symbol.toPrimitive]() {
+    return checkString;
+  }
+}
+
+class MyBadPrimitive {
+  [Symbol.toPrimitive]() {
+    return 1;
+  }
+}
+
+deepStrictEqual(Buffer.from(new String(checkString)), check);
+deepStrictEqual(Buffer.from(new MyString()), check);
+deepStrictEqual(Buffer.from(new MyPrimitive()), check);
+deepStrictEqual(Buffer.from(
+                  runInNewContext('new String(checkString)', {checkString})),
+                check);
+
+const err = new RegExp('^TypeError: First argument must be a string, Buffer, ' +
+                       'ArrayBuffer, Array, or array-like object\\.$');
+
+[
+  {},
+  new Boolean(true),
+  { valueOf() { return null; } },
+  { valueOf() { return undefined; } },
+  { valueOf: null },
+  Object.create(null)
+].forEach((input) => {
+  throws(() => Buffer.from(input), err);
+});
+
+[
+  new Number(true),
+  new MyBadPrimitive()
+].forEach((input) => {
+  throws(() => Buffer.from(input),
+         /^TypeError: "value" argument must not be a number$/);
+});


### PR DESCRIPTION
Add support for `Buffer.from(new String('...'))` and `Buffer.from({[Symbol.toPrimitive]() { return '...'; }})`

```js
const buf1 = Buffer.from(new String('this is a test'));

class Foo {
  [Symbol.toPrimitive]() {
    return 'this is a test';
  }
}
const buf2 = Buffer.from(new Foo());
```

/cc @bnoordhuis @addaleax 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer