### PR TITLE
net: fix abort on bad address input

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -42,6 +42,7 @@ const WriteWrap = process.binding('stream_wrap').WriteWrap;
 const async_id_symbol = process.binding('async_wrap').async_id_symbol;
 const { newUid, setInitTriggerId } = require('async_hooks');
 const nextTick = require('internal/process/next_tick').nextTick;
+const errors = require('internal/errors');
 
 var cluster;
 var dns;
@@ -873,7 +874,7 @@ function internalConnect(
   var err;
 
   if (typeof address !== 'string') {
-    throw new TypeError('Invalid address: ' + address);
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'address', 'string');
   }
 
   if (localAddress || localPort) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -985,7 +985,10 @@ Socket.prototype.connect = function() {
 
   if (pipe) {
     if (typeof path !== 'string') {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.path', 'string', path);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+        'options.path',
+        'string',
+        path);
     }
     internalConnect(this, path);
   } else {

--- a/lib/net.js
+++ b/lib/net.js
@@ -872,6 +872,10 @@ function internalConnect(
 
   var err;
 
+  if (typeof address !== 'string') {
+    throw new TypeError('Invalid address: ' + address);
+  }
+
   if (localAddress || localPort) {
     debug('binding to localAddress: %s and localPort: %d (addressType: %d)',
           localAddress, localPort, addressType);

--- a/lib/net.js
+++ b/lib/net.js
@@ -873,10 +873,6 @@ function internalConnect(
 
   var err;
 
-  if (typeof address !== 'string') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'address', 'string');
-  }
-
   if (localAddress || localPort) {
     debug('binding to localAddress: %s and localPort: %d (addressType: %d)',
           localAddress, localPort, addressType);
@@ -969,8 +965,9 @@ Socket.prototype.connect = function() {
     this._sockname = null;
   }
 
-  var pipe = !!options.path;
-  debug('pipe', pipe, options.path);
+  const path = options.path;
+  var pipe = !!path;
+  debug('pipe', pipe, path);
 
   if (!this._handle) {
     this._handle = pipe ? new Pipe() : new TCP();
@@ -987,7 +984,10 @@ Socket.prototype.connect = function() {
   this.writable = true;
 
   if (pipe) {
-    internalConnect(this, options.path);
+    if (typeof path !== 'string') {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.path', 'string', path);
+    }
+    internalConnect(this, path);
   } else {
     lookupAndConnect(this, options);
   }

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -15,10 +15,7 @@ const assert = require('assert');
 }
 
 {
-  try {
+  assert.throws(() => {
     net.createConnection({ path: {} });
-    throw new Error('UNREACHABLE');
-  } catch (e) {
-    assert.strictEqual(e.message, 'Invalid address: [object Object]');
-  }
+  }, TypeError);
 }

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -2,12 +2,23 @@
 const common = require('../common');
 const net = require('net');
 const assert = require('assert');
-const fp = '/tmp/fadagagsdfgsdf';
-const c = net.connect(fp);
 
-c.on('connect', common.mustNotCall());
+{
+  const fp = '/tmp/fadagagsdfgsdf';
+  const c = net.connect(fp);
 
-c.on('error', common.mustCall(function(e) {
-  assert.strictEqual(e.code, 'ENOENT');
-  assert.strictEqual(e.message, `connect ENOENT ${fp}`);
-}));
+  c.on('connect', common.mustNotCall());
+  c.on('error', common.mustCall(function(e) {
+    assert.strictEqual(e.code, 'ENOENT');
+    assert.strictEqual(e.message, `connect ENOENT ${fp}`);
+  }));
+}
+
+{
+  try {
+    net.createConnection({ path: {} });
+    throw new Error('UNREACHABLE');
+  } catch (e) {
+    assert.strictEqual(e.message, 'Invalid address: [object Object]');
+  }
+}

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -8,14 +8,15 @@ const assert = require('assert');
   const c = net.connect(fp);
 
   c.on('connect', common.mustNotCall());
-  c.on('error', common.mustCall(function(e) {
-    assert.strictEqual(e.code, 'ENOENT');
-    assert.strictEqual(e.message, `connect ENOENT ${fp}`);
+  c.on('error', common.expectsError({
+    code: 'ENOENT',
+    message: `connect ENOENT ${fp}`
   }));
 }
 
 {
-  assert.throws(() => {
-    net.createConnection({ path: {} });
-  }, TypeError);
+  assert.throws(
+    () => net.createConnection({ path: {} }),
+    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE' })
+  );
 }


### PR DESCRIPTION
Calling `net.createConnection` with a bad path results in a segfault. This fixes this by checking for the type and by throwing a TypeError in case it's not a string.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
net
