### PR TITLE
internal/errors: improve ERR_INVALID_ARG_TYPE

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -192,7 +192,8 @@ E('ERR_V8BREAKITERATOR', 'full ICU data not installed. ' +
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();
   assert(name, 'name is required');
-  var msg = `The "${name}" argument must be ${oneOf(expected, 'type')}`;
+  const type = name.includes('.') ? 'property' : 'argument';
+  var msg = `The "${name}" ${type} must be ${oneOf(expected, 'type')}`;
   if (arguments.length >= 3) {
     msg += `. Received type ${actual !== null ? typeof actual : 'null'}`;
   }

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -34,13 +34,13 @@ for (let i = 0; i < 10; i++) {
 const invalidUserArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "preValue.user" argument must be of type Number'
+  message: 'The "preValue.user" property must be of type Number'
 });
 
 const invalidSystemArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "preValue.system" argument must be of type Number'
+  message: 'The "preValue.system" property must be of type Number'
 });
 
 

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -85,7 +85,7 @@ assert.throws(function() {
 }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "superCtor.prototype" argument must be of type function'
+    message: 'The "superCtor.prototype" property must be of type function'
 })
 );
 assert.throws(function() {


### PR DESCRIPTION
The error message might be misleading if a object property
was the issue and not the argument itself.

Fix this by checking if a argument or a property is passed
to the handler function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
internal/errors