### PR TITLE
lib: refactor to arrow functions instead of using self

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -68,7 +68,7 @@ util.inherits(Agent, EventEmitter);
 
 Agent.defaultMaxSockets = Infinity;
 
-function onAgentFree (socket, options) {
+function onAgentFree(socket, options) {
   var name = this.getName(options);
   debug('agent.on(free)', name);
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -46,33 +46,31 @@ function Agent(options) {
 
   EventEmitter.call(this);
 
-  var self = this;
+  this.defaultPort = 80;
+  this.protocol = 'http:';
 
-  self.defaultPort = 80;
-  self.protocol = 'http:';
-
-  self.options = util._extend({}, options);
+  this.options = util._extend({}, options);
 
   // don't confuse net and make it think that we're connecting to a pipe
-  self.options.path = null;
-  self.requests = {};
-  self.sockets = {};
-  self.freeSockets = {};
-  self.keepAliveMsecs = self.options.keepAliveMsecs || 1000;
-  self.keepAlive = self.options.keepAlive || false;
-  self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
-  self.maxFreeSockets = self.options.maxFreeSockets || 256;
+  this.options.path = null;
+  this.requests = {};
+  this.sockets = {};
+  this.freeSockets = {};
+  this.keepAliveMsecs = this.options.keepAliveMsecs || 1000;
+  this.keepAlive = this.options.keepAlive || false;
+  this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
+  this.maxFreeSockets = this.options.maxFreeSockets || 256;
 
-  self.on('free', function(socket, options) {
-    var name = self.getName(options);
+  this.on('free', (socket, options) => {
+    var name = this.getName(options);
     debug('agent.on(free)', name);
 
     if (socket.writable &&
-        self.requests[name] && self.requests[name].length) {
-      self.requests[name].shift().onSocket(socket);
-      if (self.requests[name].length === 0) {
+        this.requests[name] && this.requests[name].length) {
+      this.requests[name].shift().onSocket(socket);
+      if (this.requests[name].length === 0) {
         // don't leak
-        delete self.requests[name];
+        delete this.requests[name];
       }
     } else {
       // If there are no pending requests, then put it in
@@ -81,21 +79,21 @@ function Agent(options) {
       if (req &&
           req.shouldKeepAlive &&
           socket.writable &&
-          self.keepAlive) {
-        var freeSockets = self.freeSockets[name];
+          this.keepAlive) {
+        var freeSockets = this.freeSockets[name];
         var freeLen = freeSockets ? freeSockets.length : 0;
         var count = freeLen;
-        if (self.sockets[name])
-          count += self.sockets[name].length;
+        if (this.sockets[name])
+          count += this.sockets[name].length;
 
-        if (count > self.maxSockets || freeLen >= self.maxFreeSockets) {
+        if (count > this.maxSockets || freeLen >= this.maxFreeSockets) {
           socket.destroy();
-        } else if (self.keepSocketAlive(socket)) {
+        } else if (this.keepSocketAlive(socket)) {
           freeSockets = freeSockets || [];
-          self.freeSockets[name] = freeSockets;
+          this.freeSockets[name] = freeSockets;
           socket[async_id_symbol] = -1;
           socket._httpMessage = null;
-          self.removeSocket(socket, options);
+          this.removeSocket(socket, options);
           freeSockets.push(socket);
         } else {
           // Implementation doesn't want to keep socket alive
@@ -201,9 +199,8 @@ Agent.prototype.addRequest = function addRequest(req, options, port/*legacy*/,
 };
 
 Agent.prototype.createSocket = function createSocket(req, options, cb) {
-  var self = this;
   options = util._extend({}, options);
-  util._extend(options, self.options);
+  util._extend(options, this.options);
 
   if (!options.servername) {
     options.servername = options.host;
@@ -213,29 +210,29 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
     }
   }
 
-  var name = self.getName(options);
+  var name = this.getName(options);
   options._agentKey = name;
 
   debug('createConnection', name, options);
   options.encoding = null;
   var called = false;
-  const newSocket = self.createConnection(options, oncreate);
-  if (newSocket)
-    oncreate(null, newSocket);
-  function oncreate(err, s) {
+  const oncreate = (err, s) => {
     if (called)
       return;
     called = true;
     if (err)
       return cb(err);
-    if (!self.sockets[name]) {
-      self.sockets[name] = [];
+    if (!this.sockets[name]) {
+      this.sockets[name] = [];
     }
-    self.sockets[name].push(s);
-    debug('sockets', name, self.sockets[name].length);
-    installListeners(self, s, options);
+    this.sockets[name].push(s);
+    debug('sockets', name, this.sockets[name].length);
+    installListeners(this, s, options);
     cb(null, s);
-  }
+  };
+  const newSocket = this.createConnection(options, oncreate);
+  if (newSocket)
+    oncreate(null, newSocket);
 };
 
 function installListeners(agent, s, options) {

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -61,54 +61,56 @@ function Agent(options) {
   this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
 
-  this.on('free', (socket, options) => {
-    var name = this.getName(options);
-    debug('agent.on(free)', name);
-
-    if (socket.writable &&
-        this.requests[name] && this.requests[name].length) {
-      this.requests[name].shift().onSocket(socket);
-      if (this.requests[name].length === 0) {
-        // don't leak
-        delete this.requests[name];
-      }
-    } else {
-      // If there are no pending requests, then put it in
-      // the freeSockets pool, but only if we're allowed to do so.
-      var req = socket._httpMessage;
-      if (req &&
-          req.shouldKeepAlive &&
-          socket.writable &&
-          this.keepAlive) {
-        var freeSockets = this.freeSockets[name];
-        var freeLen = freeSockets ? freeSockets.length : 0;
-        var count = freeLen;
-        if (this.sockets[name])
-          count += this.sockets[name].length;
-
-        if (count > this.maxSockets || freeLen >= this.maxFreeSockets) {
-          socket.destroy();
-        } else if (this.keepSocketAlive(socket)) {
-          freeSockets = freeSockets || [];
-          this.freeSockets[name] = freeSockets;
-          socket[async_id_symbol] = -1;
-          socket._httpMessage = null;
-          this.removeSocket(socket, options);
-          freeSockets.push(socket);
-        } else {
-          // Implementation doesn't want to keep socket alive
-          socket.destroy();
-        }
-      } else {
-        socket.destroy();
-      }
-    }
-  });
+  this.on('free', onAgentFree);
 }
 
 util.inherits(Agent, EventEmitter);
 
 Agent.defaultMaxSockets = Infinity;
+
+function onAgentFree (socket, options) {
+  var name = this.getName(options);
+  debug('agent.on(free)', name);
+
+  if (socket.writable &&
+      this.requests[name] && this.requests[name].length) {
+    this.requests[name].shift().onSocket(socket);
+    if (this.requests[name].length === 0) {
+      // don't leak
+      delete this.requests[name];
+    }
+  } else {
+    // If there are no pending requests, then put it in
+    // the freeSockets pool, but only if we're allowed to do so.
+    var req = socket._httpMessage;
+    if (req &&
+        req.shouldKeepAlive &&
+        socket.writable &&
+        this.keepAlive) {
+      var freeSockets = this.freeSockets[name];
+      var freeLen = freeSockets ? freeSockets.length : 0;
+      var count = freeLen;
+      if (this.sockets[name])
+        count += this.sockets[name].length;
+
+      if (count > this.maxSockets || freeLen >= this.maxFreeSockets) {
+        socket.destroy();
+      } else if (this.keepSocketAlive(socket)) {
+        freeSockets = freeSockets || [];
+        this.freeSockets[name] = freeSockets;
+        socket[async_id_symbol] = -1;
+        socket._httpMessage = null;
+        this.removeSocket(socket, options);
+        freeSockets.push(socket);
+      } else {
+        // Implementation doesn't want to keep socket alive
+        socket.destroy();
+      }
+    } else {
+      socket.destroy();
+    }
+  }
+}
 
 Agent.prototype.createConnection = net.createConnection;
 

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -842,19 +842,18 @@ Readable.prototype.wrap = function(stream) {
   var state = this._readableState;
   var paused = false;
 
-  var self = this;
-  stream.on('end', function() {
+  stream.on('end', () => {
     debug('wrapped end');
     if (state.decoder && !state.ended) {
       var chunk = state.decoder.end();
       if (chunk && chunk.length)
-        self.push(chunk);
+        this.push(chunk);
     }
 
-    self.push(null);
+    this.push(null);
   });
 
-  stream.on('data', function(chunk) {
+  stream.on('data', (chunk) => {
     debug('wrapped data');
     if (state.decoder)
       chunk = state.decoder.write(chunk);
@@ -865,7 +864,7 @@ Readable.prototype.wrap = function(stream) {
     else if (!state.objectMode && (!chunk || !chunk.length))
       return;
 
-    var ret = self.push(chunk);
+    var ret = this.push(chunk);
     if (!ret) {
       paused = true;
       stream.pause();
@@ -886,12 +885,12 @@ Readable.prototype.wrap = function(stream) {
 
   // proxy certain important events.
   for (var n = 0; n < kProxyEvents.length; n++) {
-    stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    stream.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
   }
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.
-  self._read = function(n) {
+  this._read = function(n) {
     debug('wrapped _read', n);
     if (paused) {
       paused = false;
@@ -899,7 +898,7 @@ Readable.prototype.wrap = function(stream) {
     }
   };
 
-  return self;
+  return this;
 };
 
 

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -13,57 +13,44 @@ const errors = require('internal/errors');
 
 function StreamWrap(stream) {
   const handle = new JSStream();
-
-  this.stream = stream;
-
-  this._list = null;
-
-  const self = this;
-  handle.close = function(cb) {
-    debug('close');
-    self.doClose(cb);
-  };
-  handle.isAlive = function() {
-    return self.isAlive();
-  };
-  handle.isClosing = function() {
-    return self.isClosing();
-  };
-  handle.onreadstart = function() {
-    return self.readStart();
-  };
-  handle.onreadstop = function() {
-    return self.readStop();
-  };
-  handle.onshutdown = function(req) {
-    return self.doShutdown(req);
-  };
-  handle.onwrite = function(req, bufs) {
-    return self.doWrite(req, bufs);
-  };
-
-  this.stream.pause();
-  this.stream.on('error', function onerror(err) {
-    self.emit('error', err);
-  });
-  this.stream.on('data', function ondata(chunk) {
+  const onData = (chunk) => {
     if (!(chunk instanceof Buffer)) {
       // Make sure that no further `data` events will happen
-      this.pause();
-      this.removeListener('data', ondata);
+      stream.pause();
+      stream.removeListener('data', onData);
 
-      self.emit('error', new errors.Error('ERR_STREAM_HAS_STRINGDECODER'));
+      this.emit('error', new errors.Error('ERR_STREAM_HAS_STRINGDECODER'));
       return;
     }
 
     debug('data', chunk.length);
-    if (self._handle)
-      self._handle.readBuffer(chunk);
+    if (this._handle)
+      this._handle.readBuffer(chunk);
+  };
+
+  handle.close = (cb) => {
+    debug('close');
+    this.doClose(cb);
+  };
+  handle.isAlive = () => this.isAlive();
+  handle.isClosing = () => this.isClosing();
+  handle.onreadstart = () => this.readStart();
+  handle.onreadstop = () => this.readStop();
+  handle.onshutdown = (req) => this.doShutdown(req);
+  handle.onwrite = (req, bufs) => this.doWrite(req, bufs);
+
+  this._list = null;
+
+  this.stream = stream;
+  this.stream.pause();
+  this.stream.on('error', (err) => {
+    this.emit('error', err);
   });
-  this.stream.once('end', function onend() {
+  this.stream.on('data', onData);
+  this.stream.once('end', () => {
     debug('end');
-    if (self._handle)
-      self._handle.emitEOF();
+    if (this._handle)
+      this._handle.emitEOF();
   });
 
   Socket.call(this, {
@@ -95,14 +82,13 @@ StreamWrap.prototype.readStop = function readStop() {
 };
 
 StreamWrap.prototype.doShutdown = function doShutdown(req) {
-  const self = this;
   const handle = this._handle;
   const item = this._enqueue('shutdown', req);
 
-  this.stream.end(function() {
+  this.stream.end(() => {
     // Ensure that write was dispatched
-    setImmediate(function() {
-      if (!self._dequeue(item))
+    setImmediate(() => {
+      if (!this._dequeue(item))
         return;
 
       handle.finishShutdown(req, 0);
@@ -203,14 +189,13 @@ StreamWrap.prototype._dequeue = function _dequeue(item) {
 };
 
 StreamWrap.prototype.doClose = function doClose(cb) {
-  const self = this;
-  const handle = self._handle;
+  const handle = this._handle;
 
-  setImmediate(function() {
-    while (self._list !== null) {
-      const item = self._list;
+  setImmediate(() => {
+    while (this._list !== null) {
+      const item = this._list;
       const req = item.req;
-      self._dequeue(item);
+      this._dequeue(item);
 
       const errCode = uv.UV_ECANCELED;
       if (item.type === 'write') {
@@ -222,7 +207,7 @@ StreamWrap.prototype.doClose = function doClose(cb) {
     }
 
     // Should be already set by net.js
-    assert(self._handle === null);
+    assert(this._handle === null);
     cb();
   });
 };

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -151,11 +151,10 @@ function onCryptoStreamEnd() {
 
 // NOTE: Called once `this._opposite` is set.
 CryptoStream.prototype.init = function init() {
-  var self = this;
-  this._opposite.on('sslOutEnd', function() {
-    if (self._sslOutCb) {
-      var cb = self._sslOutCb;
-      self._sslOutCb = null;
+  this._opposite.on('sslOutEnd', () => {
+    if (this._sslOutCb) {
+      var cb = this._sslOutCb;
+      this._sslOutCb = null;
       cb(null);
     }
   });
@@ -613,8 +612,7 @@ EncryptedStream.prototype._internallyPendingBytes = function() {
 function onhandshakestart() {
   debug('onhandshakestart');
 
-  var self = this;
-  var ssl = self.ssl;
+  var ssl = this.ssl;
   var now = Timer.now();
 
   assert(now >= ssl.lastHandshakeTime);
@@ -631,9 +629,9 @@ function onhandshakestart() {
     // Defer the error event to the next tick. We're being called from OpenSSL's
     // state machine and OpenSSL is not re-entrant. We cannot allow the user's
     // callback to destroy the connection right now, it would crash and burn.
-    setImmediate(function() {
+    setImmediate(() => {
       var err = new Error('TLS session renegotiation attack detected');
-      if (self.cleartext) self.cleartext.emit('error', err);
+      if (this.cleartext) this.cleartext.emit('error', err);
     });
   }
 }
@@ -646,26 +644,25 @@ function onhandshakedone() {
 
 
 function onclienthello(hello) {
-  const self = this;
   var once = false;
 
   this._resumingSession = true;
-  function callback(err, session) {
+  const callback = (err, session) => {
     if (once) return;
     once = true;
 
-    if (err) return self.socket.destroy(err);
+    if (err) return this.socket.destroy(err);
 
-    setImmediate(function() {
-      self.ssl.loadSession(session);
-      self.ssl.endParser();
+    setImmediate(() => {
+      this.ssl.loadSession(session);
+      this.ssl.endParser();
 
       // Cycle data
-      self._resumingSession = false;
-      self.cleartext.read(0);
-      self.encrypted.read(0);
+      this._resumingSession = false;
+      this.cleartext.read(0);
+      this.encrypted.read(0);
     });
-  }
+  };
 
   if (hello.sessionId.length <= 0 ||
       !this.server ||

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -166,7 +166,7 @@ function requestOCSP(self, hello, ctx, cb) {
   }
 }
 
-function onclienthello (hello) {
+function onclienthello(hello) {
   loadSession(this, hello, (err) => {
     if (err)
       return this.destroy(err);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -166,7 +166,7 @@ function requestOCSP(self, hello, ctx, cb) {
   }
 }
 
-function onclienthello (hellp) {
+function onclienthello (hello) {
   loadSession(this, hello, (err) => {
     if (err)
       return this.destroy(err);

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -40,8 +40,7 @@ const Pipe = process.binding('pipe_wrap').Pipe;
 function onhandshakestart() {
   debug('onhandshakestart');
 
-  var self = this;
-  var ssl = self._handle;
+  var ssl = this._handle;
   var now = Timer.now();
 
   assert(now >= ssl.lastHandshakeTime);
@@ -58,9 +57,9 @@ function onhandshakestart() {
     // Defer the error event to the next tick. We're being called from OpenSSL's
     // state machine and OpenSSL is not re-entrant. We cannot allow the user's
     // callback to destroy the connection right now, it would crash and burn.
-    setImmediate(function() {
+    setImmediate(() => {
       var err = new Error('TLS session renegotiation attack detected');
-      self._emitTLSError(err);
+      this._emitTLSError(err);
     });
   }
 }
@@ -167,37 +166,33 @@ function requestOCSP(self, hello, ctx, cb) {
   }
 }
 
-
-function onclienthello(hello) {
-  var self = this;
-
-  loadSession(self, hello, function(err) {
+function onclienthello (hellp) {
+  loadSession(this, hello, (err) => {
     if (err)
-      return self.destroy(err);
+      return this.destroy(err);
 
-    self._handle.endParser();
+    this._handle.endParser();
   });
 }
 
 
 function oncertcb(info) {
-  var self = this;
   var servername = info.servername;
 
-  loadSNI(self, servername, function(err, ctx) {
+  loadSNI(this, servername, (err, ctx) => {
     if (err)
-      return self.destroy(err);
-    requestOCSP(self, info, ctx, function(err) {
+      return this.destroy(err);
+    requestOCSP(this, info, ctx, (err) => {
       if (err)
-        return self.destroy(err);
+        return this.destroy(err);
 
-      if (!self._handle)
-        return self.destroy(new Error('Socket is closed'));
+      if (!this._handle)
+        return this.destroy(new Error('Socket is closed'));
 
       try {
-        self._handle.certCbDone();
+        this._handle.certCbDone();
       } catch (e) {
-        self.destroy(e);
+        this.destroy(e);
       }
     });
   });
@@ -786,25 +781,23 @@ function Server(options, listener) {
 
   this._contexts = [];
 
-  var self = this;
-
   // Handle option defaults:
   this.setOptions(options);
 
   var sharedCreds = tls.createSecureContext({
-    pfx: self.pfx,
-    key: self.key,
-    passphrase: self.passphrase,
-    cert: self.cert,
-    ca: self.ca,
-    ciphers: self.ciphers,
-    ecdhCurve: self.ecdhCurve,
-    dhparam: self.dhparam,
-    secureProtocol: self.secureProtocol,
-    secureOptions: self.secureOptions,
-    honorCipherOrder: self.honorCipherOrder,
-    crl: self.crl,
-    sessionIdContext: self.sessionIdContext
+    pfx: this.pfx,
+    key: this.key,
+    passphrase: this.passphrase,
+    cert: this.cert,
+    ca: this.ca,
+    ciphers: this.ciphers,
+    ecdhCurve: this.ecdhCurve,
+    dhparam: this.dhparam,
+    secureProtocol: this.secureProtocol,
+    secureOptions: this.secureOptions,
+    honorCipherOrder: this.honorCipherOrder,
+    crl: this.crl,
+    sessionIdContext: this.sessionIdContext
   });
   this._sharedCreds = sharedCreds;
 
@@ -814,29 +807,29 @@ function Server(options, listener) {
     throw new TypeError('handshakeTimeout must be a number');
   }
 
-  if (self.sessionTimeout) {
-    sharedCreds.context.setSessionTimeout(self.sessionTimeout);
+  if (this.sessionTimeout) {
+    sharedCreds.context.setSessionTimeout(this.sessionTimeout);
   }
 
-  if (self.ticketKeys) {
-    sharedCreds.context.setTicketKeys(self.ticketKeys);
+  if (this.ticketKeys) {
+    sharedCreds.context.setTicketKeys(this.ticketKeys);
   }
 
   // constructor call
-  net.Server.call(this, function(raw_socket) {
+  net.Server.call(this, (raw_socket) => {
     var socket = new TLSSocket(raw_socket, {
       secureContext: sharedCreds,
       isServer: true,
-      server: self,
-      requestCert: self.requestCert,
-      rejectUnauthorized: self.rejectUnauthorized,
+      server: this,
+      requestCert: this.requestCert,
+      rejectUnauthorized: this.rejectUnauthorized,
       handshakeTimeout: timeout,
-      NPNProtocols: self.NPNProtocols,
-      ALPNProtocols: self.ALPNProtocols,
+      NPNProtocols: this.NPNProtocols,
+      ALPNProtocols: this.ALPNProtocols,
       SNICallback: options.SNICallback || SNICallback
     });
 
-    socket.on('secure', function() {
+    socket.on('secure', () => {
       if (socket._requestCert) {
         var verifyError = socket._handle.verifyError();
         if (verifyError) {
@@ -850,11 +843,11 @@ function Server(options, listener) {
       }
 
       if (!socket.destroyed && socket._releaseControl())
-        self.emit('secureConnection', socket);
+        this.emit('secureConnection', socket);
     });
 
     var errorEmitted = false;
-    socket.on('close', function(err) {
+    socket.on('close', (err) => {
       // Closed because of error - no need to emit it twice
       if (err)
         return;
@@ -864,14 +857,14 @@ function Server(options, listener) {
         errorEmitted = true;
         var connReset = new Error('socket hang up');
         connReset.code = 'ECONNRESET';
-        self.emit('tlsClientError', connReset, socket);
+        this.emit('tlsClientError', connReset, socket);
       }
     });
 
-    socket.on('_tlsError', function(err) {
+    socket.on('_tlsError', (err) => {
       if (!socket._controlReleased && !errorEmitted) {
         errorEmitted = true;
-        self.emit('tlsClientError', err, socket);
+        this.emit('tlsClientError', err, socket);
       }
     });
   });

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1349,21 +1349,20 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
 
-  this._handle.onchange = function(status, eventType, filename) {
+  this._handle.onchange = (status, eventType, filename) => {
     if (status < 0) {
-      self._handle.close();
+      this._handle.close();
       const error = !filename ?
           errnoException(status, 'Error watching file for changes:') :
           errnoException(status,
                          `Error watching file ${filename} for changes:`);
       error.filename = filename;
-      self.emit('error', error);
+      this.emit('error', error);
     } else {
-      self.emit('change', eventType, filename);
+      this.emit('change', eventType, filename);
     }
   };
 }
@@ -1438,24 +1437,23 @@ function statsFromPrevValues() {
 function StatWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new binding.StatWatcher();
 
   // uv_fs_poll is a little more powerful than ev_stat but we curb it for
   // the sake of backwards compatibility
   var oldStatus = -1;
 
-  this._handle.onchange = function(newStatus) {
+  this._handle.onchange = (newStatus) => {
     if (oldStatus === -1 &&
         newStatus === -1 &&
         statValues[2/*new nlink*/] === statValues[16/*old nlink*/]) return;
 
     oldStatus = newStatus;
-    self.emit('change', statsFromValues(), statsFromPrevValues());
+    this.emit('change', statsFromValues(), statsFromPrevValues());
   };
 
-  this._handle.onstop = function() {
-    process.nextTick(emitStop, self);
+  this._handle.onstop = () => {
+    process.nextTick(emitStop, this);
   };
 }
 util.inherits(StatWatcher, EventEmitter);
@@ -1933,20 +1931,19 @@ function ReadStream(path, options) {
 fs.FileReadStream = fs.ReadStream; // support the legacy name
 
 ReadStream.prototype.open = function() {
-  var self = this;
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
-      self.emit('error', er);
+      this.emit('error', er);
       return;
     }
 
-    self.fd = fd;
-    self.emit('open', fd);
+    this.fd = fd;
+    this.emit('open', fd);
     // start the flow of data.
-    self.read();
+    this.read();
   });
 };
 
@@ -2123,15 +2120,14 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     });
   }
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 
@@ -2159,7 +2155,6 @@ WriteStream.prototype._writev = function(data, cb) {
     });
   }
 
-  const self = this;
   const len = data.length;
   const chunks = new Array(len);
   var size = 0;
@@ -2171,12 +2166,12 @@ WriteStream.prototype._writev = function(data, cb) {
     size += chunk.length;
   }
 
-  writev(this.fd, chunks, this.pos, function(er, bytes) {
+  writev(this.fd, chunks, this.pos, (er, bytes) => {
     if (er) {
-      self.destroy();
+      this.destroy();
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 

--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -11,23 +11,21 @@ class SocketListSend extends EventEmitter {
   }
 
   _request(msg, cmd, callback) {
-    var self = this;
+    const onreply = (msg) => {
+      if (!(msg.cmd === cmd && msg.key === this.key)) return;
+      this.child.removeListener('disconnect', onclose);
+      this.child.removeListener('internalMessage', onreply);
+
+      callback(null, msg);
+    };
+    const onclose = () => {
+      this.child.removeListener('internalMessage', onreply);
+      callback(new Error('child closed before reply'));
+    };
 
     if (!this.child.connected) return onclose();
     this.child.send(msg);
 
-    function onclose() {
-      self.child.removeListener('internalMessage', onreply);
-      callback(new Error('child closed before reply'));
-    }
-
-    function onreply(msg) {
-      if (!(msg.cmd === cmd && msg.key === self.key)) return;
-      self.child.removeListener('disconnect', onclose);
-      self.child.removeListener('internalMessage', onreply);
-
-      callback(null, msg);
-    }
 
     this.child.once('disconnect', onclose);
     this.child.on('internalMessage', onreply);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -458,11 +458,9 @@ Interface.prototype._insertString = function(c) {
 };
 
 Interface.prototype._tabComplete = function(lastKeypressWasTab) {
-  var self = this;
-
-  self.pause();
-  self.completer(self.line.slice(0, self.cursor), function(err, rv) {
-    self.resume();
+  this.pause();
+  this.completer(this.line.slice(0, this.cursor), (err, rv) => {
+    this.resume();
 
     if (err) {
       debug('tab completion error %j', err);
@@ -474,11 +472,11 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
     if (completions && completions.length) {
       // Apply/show completions.
       if (lastKeypressWasTab) {
-        self._writeToOutput('\r\n');
-        var width = completions.reduce(function(a, b) {
+        this._writeToOutput('\r\n');
+        var width = completions.reduce((a, b) => {
           return a.length > b.length ? a : b;
         }).length + 2;  // 2 space padding
-        var maxColumns = Math.floor(self.columns / width);
+        var maxColumns = Math.floor(this.columns / width);
         if (!maxColumns || maxColumns === Infinity) {
           maxColumns = 1;
         }
@@ -486,23 +484,23 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
         for (var i = 0, compLen = completions.length; i < compLen; i++) {
           var c = completions[i];
           if (c === '') {
-            handleGroup(self, group, width, maxColumns);
+            handleGroup(this, group, width, maxColumns);
             group = [];
           } else {
             group.push(c);
           }
         }
-        handleGroup(self, group, width, maxColumns);
+        handleGroup(this, group, width, maxColumns);
       }
 
       // If there is a common prefix to all matches, then apply that portion.
-      var f = completions.filter(function(e) { if (e) return e; });
+      var f = completions.filter((e) => { if (e) return e; });
       var prefix = commonPrefix(f);
       if (prefix.length > completeOn.length) {
-        self._insertString(prefix.slice(completeOn.length));
+        this._insertString(prefix.slice(completeOn.length));
       }
 
-      self._refreshLine();
+      this._refreshLine();
     }
   });
 };


### PR DESCRIPTION
Refactor `self = this` away by using arrow functions.

I could split this into multiple PRs for each subsystem, if requested. 

 <!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
multiple
