### PR TITLE
tools,test: var to const

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -428,8 +428,7 @@ exports.allowGlobals = allowGlobals;
 function leakedGlobals() {
   const leaked = [];
 
-  // eslint-disable-next-line no-var
-  for (var val in global) {
+  for (const val in global) {
     if (!knownGlobals.includes(global[val])) {
       leaked.push(val);
     }

--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -94,7 +94,7 @@ ${files[name].replace('Release', "' + common.buildType + '")}
   fs.mkdir(dir, function() {
     // Ignore errors
 
-    var done = once(ondone);
+    const done = once(ondone);
     var waiting = files.length;
     files.forEach(function(file) {
       fs.writeFile(file.path, file.content, function(err) {

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -33,7 +33,7 @@ module.exports = toHTML;
 const STABILITY_TEXT_REG_EXP = /(.*:)\s*(\d)([\s\S]*)/;
 
 // customized heading without id attribute
-var renderer = new marked.Renderer();
+const renderer = new marked.Renderer();
 renderer.heading = function(text, level) {
   return '<h' + level + '>' + text + '</h' + level + '>\n';
 };
@@ -42,7 +42,7 @@ marked.setOptions({
 });
 
 // TODO(chrisdickinson): never stop vomitting / fix this.
-var gtocPath = path.resolve(path.join(
+const gtocPath = path.resolve(path.join(
   __dirname,
   '..',
   '..',
@@ -57,8 +57,8 @@ var gtocData = null;
  * opts: input, filename, template, nodeVersion.
  */
 function toHTML(opts, cb) {
-  var template = opts.template;
-  var nodeVersion = opts.nodeVersion || process.version;
+  const template = opts.template;
+  const nodeVersion = opts.nodeVersion || process.version;
 
   if (gtocData) {
     return onGtocLoaded();
@@ -80,7 +80,7 @@ function toHTML(opts, cb) {
   }
 
   function onGtocLoaded() {
-    var lexed = marked.lexer(opts.input);
+    const lexed = marked.lexer(opts.input);
     fs.readFile(template, 'utf8', function(er, template) {
       if (er) return cb(er);
       render({
@@ -123,10 +123,10 @@ function render(opts, cb) {
   var lexed = opts.lexed;
   var filename = opts.filename;
   var template = opts.template;
-  var nodeVersion = opts.nodeVersion || process.version;
+  const nodeVersion = opts.nodeVersion || process.version;
 
   // get the section
-  var section = getSection(lexed);
+  const section = getSection(lexed);
 
   filename = path.basename(filename, '.md');
 
@@ -138,7 +138,7 @@ function render(opts, cb) {
   buildToc(lexed, filename, function(er, toc) {
     if (er) return cb(er);
 
-    var id = toID(path.basename(filename));
+    const id = toID(path.basename(filename));
 
     template = template.replace(/__ID__/g, id);
     template = template.replace(/__FILENAME__/g, filename);
@@ -220,9 +220,9 @@ function parseText(lexed) {
 // lists that come right after a heading are what we're after.
 function parseLists(input) {
   var state = null;
-  var savedState = [];
+  const savedState = [];
   var depth = 0;
-  var output = [];
+  const output = [];
   let headingIndex = -1;
   let heading = null;
 
@@ -353,7 +353,7 @@ function parseYAML(text) {
 }
 
 // Syscalls which appear in the docs, but which only exist in BSD / OSX
-var BSD_ONLY_SYSCALLS = new Set(['lchmod']);
+const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 
 // Handle references to man pages, eg "open(2)" or "lchmod(2)"
 // Returns modified text, with such refs replace with HTML links, for example
@@ -363,7 +363,7 @@ function linkManPages(text) {
     / ([a-z.]+)\((\d)([a-z]?)\)/gm,
     (match, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
-      var displayAs = `${name}(${number}${optionalCharacter})`;
+      const displayAs = `${name}(${number}${optionalCharacter})`;
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return ` <a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
           `&sektion=${number}">${displayAs}</a>`;
@@ -375,7 +375,7 @@ function linkManPages(text) {
 }
 
 function linkJsTypeDocs(text) {
-  var parts = text.split('`');
+  const parts = text.split('`');
   var i;
   var typeMatches;
 
@@ -453,7 +453,7 @@ function buildToc(lexed, filename, cb) {
   cb(null, toc);
 }
 
-var idCounters = {};
+const idCounters = {};
 function getId(text) {
   text = text.toLowerCase();
   text = text.replace(/[^a-z0-9]+/g, '_');

--- a/tools/doc/json.js
+++ b/tools/doc/json.js
@@ -30,7 +30,7 @@ const common = require('./common.js');
 const marked = require('marked');
 
 // customized heading without id attribute
-var renderer = new marked.Renderer();
+const renderer = new marked.Renderer();
 renderer.heading = function(text, level) {
   return '<h' + level + '>' + text + '</h' + level + '>\n';
 };
@@ -39,14 +39,14 @@ marked.setOptions({
 });
 
 function doJSON(input, filename, cb) {
-  var root = {source: filename};
-  var stack = [root];
+  const root = {source: filename};
+  const stack = [root];
   var depth = 0;
   var current = root;
   var state = null;
-  var lexed = marked.lexer(input);
+  const lexed = marked.lexer(input);
   lexed.forEach(function(tok) {
-    var type = tok.type;
+    const type = tok.type;
     var text = tok.text;
 
     // <!-- type = module -->
@@ -223,14 +223,14 @@ function doJSON(input, filename, cb) {
 //          default: 'false' } ] } ]
 
 function processList(section) {
-  var list = section.list;
-  var values = [];
+  const list = section.list;
+  const values = [];
   var current;
-  var stack = [];
+  const stack = [];
 
   // for now, *just* build the heirarchical list
   list.forEach(function(tok) {
-    var type = tok.type;
+    const type = tok.type;
     if (type === 'space') return;
     if (type === 'list_item_start' || type === 'loose_item_start') {
       var n = {};
@@ -329,7 +329,7 @@ function parseSignature(text, sig) {
   params = params[1];
   params = params.split(/,/);
   var optionalLevel = 0;
-  var optionalCharDict = {'[': 1, ' ': 0, ']': -1};
+  const optionalCharDict = {'[': 1, ' ': 0, ']': -1};
   params.forEach(function(p, i) {
     p = p.trim();
     if (!p) return;
@@ -351,7 +351,7 @@ function parseSignature(text, sig) {
     }
     p = p.substring(0, pos + 1);
 
-    var eq = p.indexOf('=');
+    const eq = p.indexOf('=');
     if (eq !== -1) {
       def = p.substr(eq + 1);
       p = p.substr(0, eq);
@@ -381,8 +381,8 @@ function parseListItem(item) {
   // text = text.replace(/^(Argument|Param)s?\s*:?\s*/i, '');
 
   text = text.replace(/^, /, '').trim();
-  var retExpr = /^returns?\s*:?\s*/i;
-  var ret = text.match(retExpr);
+  const retExpr = /^returns?\s*:?\s*/i;
+  const ret = text.match(retExpr);
   if (ret) {
     item.name = 'return';
     text = text.replace(retExpr, '');
@@ -396,24 +396,24 @@ function parseListItem(item) {
   }
 
   text = text.trim();
-  var defaultExpr = /\(default\s*[:=]?\s*['"`]?([^, '"`]*)['"`]?\)/i;
-  var def = text.match(defaultExpr);
+  const defaultExpr = /\(default\s*[:=]?\s*['"`]?([^, '"`]*)['"`]?\)/i;
+  const def = text.match(defaultExpr);
   if (def) {
     item.default = def[1];
     text = text.replace(defaultExpr, '');
   }
 
   text = text.trim();
-  var typeExpr = /^\{([^}]+)\}/;
-  var type = text.match(typeExpr);
+  const typeExpr = /^\{([^}]+)\}/;
+  const type = text.match(typeExpr);
   if (type) {
     item.type = type[1];
     text = text.replace(typeExpr, '');
   }
 
   text = text.trim();
-  var optExpr = /^Optional\.|(?:, )?Optional$/;
-  var optional = text.match(optExpr);
+  const optExpr = /^Optional\.|(?:, )?Optional$/;
+  const optional = text.match(optExpr);
   if (optional) {
     item.optional = true;
     text = text.replace(optExpr, '');
@@ -556,19 +556,19 @@ function deepCopy_(src) {
 
 
 // these parse out the contents of an H# tag
-var eventExpr = /^Event(?::|\s)+['"]?([^"']+).*$/i;
-var classExpr = /^Class:\s*([^ ]+).*$/i;
-var propExpr = /^[^.]+\.([^ .()]+)\s*$/;
-var braceExpr = /^[^.[]+(\[[^\]]+\])\s*$/;
-var classMethExpr = /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*$/i;
-var methExpr = /^(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*$/;
-var newExpr = /^new ([A-Z][a-zA-Z]+)\([^)]*\)\s*$/;
+const eventExpr = /^Event(?::|\s)+['"]?([^"']+).*$/i;
+const classExpr = /^Class:\s*([^ ]+).*$/i;
+const propExpr = /^[^.]+\.([^ .()]+)\s*$/;
+const braceExpr = /^[^.[]+(\[[^\]]+\])\s*$/;
+const classMethExpr = /^class\s*method\s*:?[^.]+\.([^ .()]+)\([^)]*\)\s*$/i;
+const methExpr = /^(?:[^.]+\.)?([^ .()]+)\([^)]*\)\s*$/;
+const newExpr = /^new ([A-Z][a-zA-Z]+)\([^)]*\)\s*$/;
 var paramExpr = /\((.*)\);?$/;
 
 function newSection(tok) {
-  var section = {};
+  const section = {};
   // infer the type from the text.
-  var text = section.textRaw = tok.text;
+  const text = section.textRaw = tok.text;
   if (text.match(eventExpr)) {
     section.type = 'event';
     section.name = text.replace(eventExpr, '$1');

--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -2,11 +2,11 @@
 
 module.exports = preprocess;
 
-var path = require('path');
-var fs = require('fs');
+const path = require('path');
+const fs = require('fs');
 
-var includeExpr = /^@include\s+([A-Za-z0-9-_]+)(?:\.)?([a-zA-Z]*)$/gmi;
-var includeData = {};
+const includeExpr = /^@include\s+([A-Za-z0-9-_]+)(?:\.)?([a-zA-Z]*)$/gmi;
+const includeData = {};
 
 function preprocess(inputFile, input, cb) {
   input = stripComments(input);
@@ -22,7 +22,7 @@ function stripComments(input) {
 }
 
 function processIncludes(inputFile, input, cb) {
-  var includes = input.match(includeExpr);
+  const includes = input.match(includeExpr);
   if (includes === null) return cb(null, input);
   var errState = null;
   console.error(includes);
@@ -40,7 +40,7 @@ function processIncludes(inputFile, input, cb) {
       }
     }
 
-    var fullFname = path.resolve(path.dirname(inputFile), fname);
+    const fullFname = path.resolve(path.dirname(inputFile), fname);
     fs.readFile(fullFname, 'utf8', function(er, inc) {
       if (errState) return;
       if (er) return cb(errState = er);

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -14,7 +14,7 @@ module.exports = function(context) {
   // trim required module names
   var requiredModules = context.options;
 
-  var foundModules = [];
+  const foundModules = [];
 
   // if no modules are required we don't need to check the CallExpressions
   if (requiredModules.length === 0) {

--- a/tools/license2rtf.js
+++ b/tools/license2rtf.js
@@ -16,7 +16,7 @@ function LineSplitter() {
   this.writable = true;
 
   this.write = function(data) {
-    var lines = (buffer + data).split(/\r\n|\n\r|\n|\r/);
+    const lines = (buffer + data).split(/\r\n|\n\r|\n|\r/);
     for (var i = 0; i < lines.length - 1; i++) {
       self.emit('data', lines[i]);
     }
@@ -128,18 +128,18 @@ function ParagraphParser() {
     }
 
     // Find out indentation level and the start of a lied or numbered list;
-    var result = /^(\s*)(\d+\.|\*|-)?\s*/.exec(line);
+    const result = /^(\s*)(\d+\.|\*|-)?\s*/.exec(line);
     assert.ok(result);
     // The number of characters that will be stripped from the beginning of
     // the line.
-    var line_strip_length = result[0].length;
+    const line_strip_length = result[0].length;
     // The indentation size that will be used to detect indentation jumps.
     // Fudge by 1 space.
-    var line_indent = Math.floor(result[0].length / 2) * 2;
+    const line_indent = Math.floor(line_strip_length / 2) * 2;
     // The indentation level that will be exported
-    var level = Math.floor(result[1].length / 2);
+    const level = Math.floor(result[1].length / 2);
     // The list indicator that precedes the actual content, if any.
-    var line_li = result[2];
+    const line_li = result[2];
 
     // Flush the paragraph when there is a li or an indentation jump
     if (line_li || (line_indent !== paragraph_line_indent &&
@@ -175,14 +175,14 @@ inherits(ParagraphParser, Stream);
  * replaces multiple consecutive whitespace characters by a single one.
  */
 function Unwrapper() {
-  var self = this;
+  const self = this;
 
   Stream.call(this);
   this.writable = true;
 
   this.write = function(paragraph) {
-    var lines = paragraph.lines;
-    var break_after = [];
+    const lines = paragraph.lines;
+    const break_after = [];
     var i;
 
     for (i = 0; i < lines.length - 1; i++) {
@@ -236,15 +236,14 @@ function RtfGenerator() {
   Stream.call(this);
   this.writable = true;
 
-  this.write = function(paragraph) {
+  this.write = function({ li, level, lines, in_license_block: lic }) {
     if (!did_write_anything) {
       emitHeader();
       did_write_anything = true;
     }
 
-    var li = paragraph.li;
-    var level = paragraph.level + (li ? 1 : 0);
-    var lic = paragraph.in_license_block;
+    if (li)
+      level++;
 
     var rtf = '\\pard';
     rtf += '\\sa150\\sl300\\slmult1';
@@ -261,7 +260,7 @@ function RtfGenerator() {
     if (li)
       rtf += ' ' + li + '\\tab';
     rtf += ' ';
-    rtf += paragraph.lines.map(rtfEscape).join('\\line ');
+    rtf += lines.map(rtfEscape).join('\\line ');
     if (!lic)
       rtf += '\\b0';
     rtf += '\\par\n';


### PR DESCRIPTION
As far as I know using const is preferable in almost all situations, so this converts probably all `var` declarations to `const`, if possible.

If this is not what you want, I'm happy to close this again or split into smaller parts.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools,test
