### PR TITLE
internal/cluster: remove obsolete todo

### DIFF
--- a/lib/internal/cluster/shared_handle.js
+++ b/lib/internal/cluster/shared_handle.js
@@ -11,9 +11,7 @@ function SharedHandle(key, address, port, addressType, fd, flags) {
   this.handle = null;
   this.errno = 0;
 
-  // FIXME(bnoordhuis) Polymorphic return type for lack of a better solution.
   var rval;
-
   if (addressType === 'udp4' || addressType === 'udp6')
     rval = dgram._createSocketHandle(address, port, addressType, fd, flags);
   else


### PR DESCRIPTION
I think it's OK to remove this ToDo. There is probably not much there can be done to improve this and the polymorphic return type should not have a real implication. 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
internal/cluster
