### PR TITLE
net: remove net.Socket.prototype.listen

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -380,15 +380,6 @@ Socket.prototype.read = function(n) {
   return this.read(n);
 };
 
-
-// FIXME(joyeecheung): this method is neither documented nor tested
-Socket.prototype.listen = function() {
-  debug('socket.listen');
-  this.on('connection', arguments[0]);
-  listenInCluster(this, null, null, null);
-};
-
-
 Socket.prototype.setTimeout = function(msecs, callback) {
   if (msecs === 0) {
     timers.unenroll(this);


### PR DESCRIPTION
<s>I suggest to deprecate this function. It was never documented even though it was already added in [2011](https://github.com/nodejs/node/commit/187fe27a6e7da9d1f5ec9896af51a16c69d4c6c2). I am not sure what it was for and maybe @bnoordhuis might have a look as a original reviewer? </s>
The function is defunct and shout simply be removed. As it was never documented there should not be a problem about it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net