### PR TITLE
path: fix posix.relative returns different results

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -431,6 +431,10 @@ added: v0.11.15
 The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
 
+The following functions do not support direct use on Windows.
+* path.posix.resolve
+* path.posix.relative
+
 ## path.relative(from, to)
 <!-- YAML
 added: v0.5.0
@@ -550,6 +554,10 @@ added: v0.11.15
 
 The `path.win32` property provides access to Windows-specific implementations
 of the `path` methods.
+
+The following functions do not support direct use on *nix.
+* path.win32.resolve
+* path.win32.relative
 
 [`TypeError`]: errors.html#errors_class_typeerror
 [`path.parse()`]: #path_path_parse_path

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -431,9 +431,38 @@ added: v0.11.15
 The `path.posix` property provides access to POSIX specific implementations
 of the `path` methods.
 
-The following functions do not support direct use on Windows.
-* path.posix.resolve
-* path.posix.relative
+*Note*: Be careful when using the following functions directly on Windows.
+
+### path.posix.resolve([...path])
+If after processing all given `path` segments an absolute path has not yet
+been generated, `path.posix.resolve` will throw [`UNSUPPORTED_PLATFORM`] error.
+
+### path.posix.relative(from, to)
+If `from` and `to` are both relative path, `path.posix.relative` will use the
+path `/fakepath/` as the current working path to generate the result.
+
+For example
+
+```
+path.posix.relative('a/b/c', '../../x');
+
+// 'from' will be '/fakepath/a/b/c'
+// 'to' will be '/fakepath/../../x', then will be normalized to '/x'
+// Returns: '../../../../x'
+```
+
+If one of `from` and `to` is relative path, `path.posix.relative` will use the
+other absolute path as the current working path to generate the result.
+
+For example
+
+```
+path.posix.relative('/a/b/c', '../../x');
+
+// 'from' will be '/a/b/c'
+// 'to' will be '/a/b/c/../../x', then will be normalized to '/a/x'
+// Returns: '../../x'
+```
 
 ## path.relative(from, to)
 <!-- YAML
@@ -555,9 +584,38 @@ added: v0.11.15
 The `path.win32` property provides access to Windows-specific implementations
 of the `path` methods.
 
-The following functions do not support direct use on *nix.
-* path.win32.resolve
-* path.win32.relative
+*Note*: Be careful when using the following functions directly on POSIX.
+
+### path.win32.resolve([...path])
+If after processing all given `path` segments an absolute path has not yet
+been generated, `path.win32.resolve` will throw [`UNSUPPORTED_PLATFORM`] error.
+
+### path.win32.relative(from, to)
+If `from` and `to` are both relative path, `path.win32.relative` will use the
+path `c:\\fakepath\\` as the current working path to generate the result.
+
+For example
+
+```
+path.win32.relative('a\\b\\c', '..\\..\\x');
+
+// 'from' will be 'c:\\fakepath\\a\\b\\c'
+// 'to' will be 'c:\\fakepath\\..\\..\\x', then will be normalized to 'c:\\x'
+// Returns: '..\\..\\..\\..\\x'
+```
+
+If one of `from` and `to` is relative path, `path.win32.relative` will use the
+other absolute path as the current working path to generate the result.
+
+For example
+
+```
+path.win32.relative('c:\\a\\b\\c', '..\\..\\x');
+
+// 'from' will be 'c:\\a\\b\\c'
+// 'to' will be 'c:\\a\\b\\c\\..\\..\\x', then will be normalized to 'c:\\a\\x'
+// Returns: '..\\..\\x'
+```
 
 [`TypeError`]: errors.html#errors_class_typeerror
 [`path.parse()`]: #path_path_parse_path

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -179,6 +179,7 @@ E('ERR_UNKNOWN_BUILTIN_MODULE', (id) => `No such built-in module: ${id}`);
 E('ERR_UNKNOWN_SIGNAL', (signal) => `Unknown signal: ${signal}`);
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
+E('ERR_UNSUPPORTED_PLATFORM', 'Unsupported platform');
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
 E('ERR_SOCKET_BAD_TYPE',
   'Bad socket type specified. Valid types are: udp4, udp6');

--- a/lib/path.js
+++ b/lib/path.js
@@ -29,6 +29,18 @@ function assertPath(path) {
   }
 }
 
+function assertWindowsPlatform(platform) {
+  // throw an error if direct use the function on *nix platform
+  if (process.platform !== 'win32')
+    throw new errors.Error('ERR_UNSUPPORTED_PLATFORM');
+}
+
+function assertPosixPlatform(platform) {
+  // throw an error if direct use the function on windows platform
+  if (process.process === 'win32')
+    throw new errors.Error('ERR_UNSUPPORTED_PLATFORM');
+}
+
 // Resolves . and .. elements in a path with directory names
 function normalizeStringWin32(path, allowAboveRoot) {
   var res = '';
@@ -205,6 +217,7 @@ const win32 = {
       }
 
       assertPath(path);
+      assertWindowsPlatform(process.platform);
 
       // Skip empty entries
       if (path.length === 0) {
@@ -1164,6 +1177,7 @@ const posix = {
       }
 
       assertPath(path);
+      assertPosixPlatform(process.platform);
 
       // Skip empty entries
       if (path.length === 0) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -199,6 +199,10 @@ const win32 = {
         path = arguments[i];
       } else if (!resolvedDevice) {
         path = process.cwd();
+
+        // If you use the current working directory,
+        // it is necessary to check whether the current platform support.
+        assertWindowsPlatform(process.platform);
       } else {
         // Windows has the concept of drive-specific current working
         // directories. If we've resolved a drive letter but not yet an
@@ -213,11 +217,14 @@ const win32 = {
             path.slice(0, 3).toLowerCase() !==
               resolvedDevice.toLowerCase() + '\\') {
           path = resolvedDevice + '\\';
+        } else {
+          // If you use the current working directory,
+          // it is necessary to check whether the current platform support.
+          assertWindowsPlatform(process.platform);
         }
       }
 
       assertPath(path);
-      assertWindowsPlatform(process.platform);
 
       // Skip empty entries
       if (path.length === 0) {
@@ -575,8 +582,38 @@ const win32 = {
     if (from === to)
       return '';
 
-    var fromOrig = win32.resolve(from);
-    var toOrig = win32.resolve(to);
+    var fromOrig;
+    var toOrig;
+    var isFromAbsolute = true;
+    var isToAbsolute = true;
+
+    try {
+      fromOrig = win32.resolve(from);
+    } catch (err) {
+      if (err.code === 'ERR_UNSUPPORTED_PLATFORM')
+        isFromAbsolute = false;
+    }
+    try {
+      toOrig = win32.resolve(to);
+    } catch (err) {
+      if (err.code === 'ERR_UNSUPPORTED_PLATFORM')
+        isToAbsolute = false;
+    }
+
+    if (process.platform !== 'win32') {
+      if (!isFromAbsolute && !isToAbsolute) {
+        from = 'c:\\fakepath\\' + from;
+        to = 'c:\\fakepath\\' + to;
+        fromOrig = win32.resolve(from);
+        toOrig = win32.resolve(to);
+      } else if (isFromAbsolute && !isToAbsolute) {
+        to = from + '\\' + to;
+        toOrig = win32.resolve(to);
+      } else if (!isFromAbsolute && isToAbsolute) {
+        from = to + '\\' + from;
+        fromOrig = win32.resolve(from);
+      }
+    }
 
     if (fromOrig === toOrig)
       return '';
@@ -1177,7 +1214,6 @@ const posix = {
       }
 
       assertPath(path);
-      assertPosixPlatform(process.platform);
 
       // Skip empty entries
       if (path.length === 0) {
@@ -1187,6 +1223,11 @@ const posix = {
       resolvedPath = path + '/' + resolvedPath;
       resolvedAbsolute = path.charCodeAt(0) === 47/*/*/;
     }
+
+    // If you use the current working directory,
+    // it is necessary to check whether the current platform support.
+    if (cwd)
+      assertPosixPlatform(process.platform);
 
     // At this point the path should be resolved to a full absolute path, but
     // handle relative paths to be safe (might happen when process.cwd() fails)
@@ -1263,8 +1304,35 @@ const posix = {
     if (from === to)
       return '';
 
-    from = posix.resolve(from);
-    to = posix.resolve(to);
+    var isFromAbsolute = true;
+    var isToAbsolute = true;
+    try {
+      from = posix.resolve(from);
+    } catch (err) {
+      if (err.code === 'ERR_UNSUPPORTED_PLATFORM')
+        isFromAbsolute = false;
+    }
+    try {
+      to = posix.resolve(to);
+    } catch (err) {
+      if (err.code === 'ERR_UNSUPPORTED_PLATFORM')
+        isToAbsolute = false;
+    }
+
+    if (process.platform === 'win32') {
+      if (!isFromAbsolute && !isToAbsolute) {
+        from = '/fakepath/' + from;
+        to = '/fakepath/' + to;
+        from = posix.resolve(from);
+        to = posix.resolve(to);
+      } else if (isFromAbsolute && !isToAbsolute) {
+        to = from + '/' + to;
+        to = posix.resolve(to);
+      } else if (!isFromAbsolute && isToAbsolute) {
+        from = to + '/' + from;
+        from = posix.resolve(from);
+      }
+    }
 
     if (from === to)
       return '';

--- a/lib/path.js
+++ b/lib/path.js
@@ -31,13 +31,13 @@ function assertPath(path) {
 
 function assertWindowsPlatform(platform) {
   // throw an error if direct use the function on *nix platform
-  if (process.platform !== 'win32')
+  if (platform !== 'win32')
     throw new errors.Error('ERR_UNSUPPORTED_PLATFORM');
 }
 
 function assertPosixPlatform(platform) {
   // throw an error if direct use the function on windows platform
-  if (process.process === 'win32')
+  if (platform === 'win32')
     throw new errors.Error('ERR_UNSUPPORTED_PLATFORM');
 }
 

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -419,71 +419,79 @@ assert.strictEqual(path.posix.normalize('///..//./foo/.//bar'), '/foo/bar');
 
 // path.resolve tests
 const resolveTest = {
-  win32: {
-    resolve: path.win32.resolve,
-    tests:
-    // arguments                               result
-    [[['c:/blah\\blah', 'd:/games', 'c:../a'], 'c:\\blah\\a'],
-      [['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'], 'd:\\e.exe'],
-      [['c:/ignore', 'c:/some/file'], 'c:\\some\\file'],
-      [['d:/ignore', 'd:some/dir//'], 'd:\\ignore\\some\\dir'],
-      [['.'], process.cwd()],
-      [['//server/share', '..', 'relative\\'], '\\\\server\\share\\relative'],
-      [['c:/', '//'], 'c:\\'],
-      [['c:/', '//dir'], 'c:\\dir'],
-      [['c:/', '//server/share'], '\\\\server\\share\\'],
-      [['c:/', '//server//share'], '\\\\server\\share\\'],
-      [['c:/', '///some//dir'], 'c:\\some\\dir'],
-     [['C:\\foo\\tmp.3\\', '..\\tmp.3\\cycles\\root.js'],
-      'C:\\foo\\tmp.3\\cycles\\root.js']
+  win32: [
+    [ path.win32.resolve,
+      // arguments                               result
+      [[['c:/blah\\blah', 'd:/games', 'c:../a'], 'c:\\blah\\a'],
+       [['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'], 'd:\\e.exe'],
+       [['c:/ignore', 'c:/some/file'], 'c:\\some\\file'],
+       [['d:/ignore', 'd:some/dir//'], 'd:\\ignore\\some\\dir'],
+       [['.'], process.cwd()],
+       [['//server/share', '..', 'relative\\'], '\\\\server\\share\\relative'],
+       [['c:/', '//'], 'c:\\'],
+       [['c:/', '//dir'], 'c:\\dir'],
+       [['c:/', '//server/share'], '\\\\server\\share\\'],
+       [['c:/', '//server//share'], '\\\\server\\share\\'],
+       [['c:/', '///some//dir'], 'c:\\some\\dir'],
+       [['C:\\foo\\tmp.3\\', '..\\tmp.3\\cycles\\root.js'],
+        'C:\\foo\\tmp.3\\cycles\\root.js']
+      ]
     ]
-  },
-  posix: {
-    resolve: path.posix.resolve,
-    tests:
-    // arguments                    result
-    [[['/var/lib', '../', 'file/'], '/var/file'],
-      [['/var/lib', '/../', 'file/'], '/file'],
-      [['a/b/c/', '../../..'], process.cwd()],
-      [['.'], process.cwd()],
-      [['/some/dir', '.', '/absolute/'], '/absolute'],
-      [['/foo/tmp.3/', '../tmp.3/cycles/root.js'], '/foo/tmp.3/cycles/root.js']
+  ],
+  posix: [
+    [ path.posix.resolve,
+      // arguments                    result
+      [[['/var/lib', '../', 'file/'], '/var/file'],
+       [['/var/lib', '/../', 'file/'], '/file'],
+       [['a/b/c/', '../../..'], process.cwd()],
+       [['.'], process.cwd()],
+       [['/some/dir', '.', '/absolute/'], '/absolute'],
+       [['/foo/tmp.3/', '../tmp.3/cycles/root.js'], '/foo/tmp.3/cycles/root.js']
+      ]
     ]
-  }
+  ]
 };
+
 {
-  let resolve;
   let tests;
+
   if (common.isWindows) {
-    resolve = resolveTest.win32.resolve;
-    tests = resolveTest.win32.tests;
-    // direct use path.posix.resolve on windows will throw error
+    tests = resolveTest.win32;
+
+    // direct use path.posix.resolve with relative path param
+    // on windows will throw error
     assert.throws(() => {
       path.posix.resolve('foo/bar');
     }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
   } else {
-    resolve = resolveTest.posix.resolve;
-    tests = resolveTest.posix.tests;
-    // direct use path.win32.resolve on *nix will throw error
+    tests = resolveTest.posix;
+
+    // direct use path.win32.resolve with relative path param
+    // on *nix will throw error
     assert.throws(() => {
       path.win32.resolve('foo\\bar');
     }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
   }
-  tests.forEach((test) => {
-    const actual = resolve.apply(null, test[0]);
-    let actualAlt;
-    const os = resolve === path.win32.resolve ? 'win32' : 'posix';
-    if (resolve === path.win32.resolve && !common.isWindows)
-      actualAlt = actual.replace(backslashRE, '/');
-    else if (resolve !== path.win32.resolve && common.isWindows)
-      actualAlt = actual.replace(slashRE, '\\');
 
-    const expected = test[1];
-    const message =
-      `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
-    if (actual !== expected && actualAlt !== expected)
-      failures.push(`\n${message}`);
+  tests.forEach((test) => {
+    const resolve = test[0];
+    test[1].forEach((test) => {
+      const actual = resolve.apply(null, test[0]);
+      let actualAlt;
+      const os = resolve === path.win32.resolve ? 'win32' : 'posix';
+      if (resolve === path.win32.resolve && !common.isWindows)
+        actualAlt = actual.replace(backslashRE, '/');
+      else if (resolve !== path.win32.resolve && common.isWindows)
+        actualAlt = actual.replace(slashRE, '\\');
+
+      const expected = test[1];
+      const message =
+        `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})
+          \n  expect=${JSON.stringify(expected)}
+          \n  actual=${JSON.stringify(actual)}`;
+      if (actual !== expected && actualAlt !== expected)
+        failures.push(`\n${message}`);
+    });
   });
 }
 assert.strictEqual(failures.length, 0, failures.join(''));
@@ -528,85 +536,97 @@ assert.strictEqual(path.posix.isAbsolute('./baz'), false);
 
 // path.relative tests
 const relativeTest = {
-  win32: {
-    relative: path.win32.relative,
-    tests:
-    // arguments                     result
-    [['c:/blah\\blah', 'd:/games', 'd:\\games'],
-      ['c:/aaaa/bbbb', 'c:/aaaa', '..'],
-      ['c:/aaaa/bbbb', 'c:/cccc', '..\\..\\cccc'],
-      ['c:/aaaa/bbbb', 'c:/aaaa/bbbb', ''],
-      ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '..\\cccc'],
-      ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
-      ['c:/', 'c:\\aaaa\\bbbb', 'aaaa\\bbbb'],
-      ['c:/aaaa/bbbb', 'd:\\', 'd:\\'],
-      ['c:/AaAa/bbbb', 'c:/aaaa/bbbb', ''],
-      ['c:/aaaaa/', 'c:/aaaa/cccc', '..\\aaaa\\cccc'],
-      ['C:\\foo\\bar\\baz\\quux', 'C:\\', '..\\..\\..\\..'],
-     [
-       'C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json',
-       'bar\\package.json'
-     ],
-      ['C:\\foo\\bar\\baz-quux', 'C:\\foo\\bar\\baz', '..\\baz'],
-      ['C:\\foo\\bar\\baz', 'C:\\foo\\bar\\baz-quux', '..\\baz-quux'],
-      ['\\\\foo\\bar', '\\\\foo\\bar\\baz', 'baz'],
-      ['\\\\foo\\bar\\baz', '\\\\foo\\bar', '..'],
-      ['\\\\foo\\bar\\baz-quux', '\\\\foo\\bar\\baz', '..\\baz'],
-      ['\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz-quux', '..\\baz-quux'],
-      ['C:\\baz-quux', 'C:\\baz', '..\\baz'],
-      ['C:\\baz', 'C:\\baz-quux', '..\\baz-quux'],
-      ['\\\\foo\\baz-quux', '\\\\foo\\baz', '..\\baz'],
-      ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux'],
-      ['C:\\baz', '\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz'],
-      ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz']
+  win32: [
+    [ path.win32.relative,
+      // arguments                     result
+      [['c:/blah\\blah', 'd:/games', 'd:\\games'],
+       ['c:/aaaa/bbbb', 'c:/aaaa', '..'],
+       ['c:/aaaa/bbbb', 'c:/cccc', '..\\..\\cccc'],
+       ['c:/aaaa/bbbb', 'c:/aaaa/bbbb', ''],
+       ['c:/aaaa/bbbb', 'c:/aaaa/cccc', '..\\cccc'],
+       ['c:/aaaa/', 'c:/aaaa/cccc', 'cccc'],
+       ['c:/', 'c:\\aaaa\\bbbb', 'aaaa\\bbbb'],
+       ['c:/aaaa/bbbb', 'd:\\', 'd:\\'],
+       ['c:/AaAa/bbbb', 'c:/aaaa/bbbb', ''],
+       ['c:/aaaaa/', 'c:/aaaa/cccc', '..\\aaaa\\cccc'],
+       ['C:\\foo\\bar\\baz\\quux', 'C:\\', '..\\..\\..\\..'],
+       [
+         'C:\\foo\\test', 'C:\\foo\\test\\bar\\package.json',
+         'bar\\package.json'
+       ],
+       ['C:\\foo\\bar\\baz-quux', 'C:\\foo\\bar\\baz', '..\\baz'],
+       ['C:\\foo\\bar\\baz', 'C:\\foo\\bar\\baz-quux', '..\\baz-quux'],
+       ['\\\\foo\\bar', '\\\\foo\\bar\\baz', 'baz'],
+       ['\\\\foo\\bar\\baz', '\\\\foo\\bar', '..'],
+       ['\\\\foo\\bar\\baz-quux', '\\\\foo\\bar\\baz', '..\\baz'],
+       ['\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz-quux', '..\\baz-quux'],
+       ['C:\\baz-quux', 'C:\\baz', '..\\baz'],
+       ['C:\\baz', 'C:\\baz-quux', '..\\baz-quux'],
+       ['\\\\foo\\baz-quux', '\\\\foo\\baz', '..\\baz'],
+       ['\\\\foo\\baz', '\\\\foo\\baz-quux', '..\\baz-quux'],
+       ['C:\\baz', '\\\\foo\\bar\\baz', '\\\\foo\\bar\\baz'],
+       ['\\\\foo\\bar\\baz', 'C:\\baz', 'C:\\baz']
+      ]
+    ],
+    [ path.posix.relative,
+      // arguments          result
+      [['a/b/c', '../../x', '../../../../x'],
+       ['../../x', 'a/b/c', '../fakepath/a/b/c'],
+       ['/a/b/c', '../../x', '../../x'],
+       ['../../x', '/a/b/c', '../b/c'],
+       ['/a/b/c', '/d/e/f', '../../../d/e/f']
+      ]
     ]
-  },
-  posix: {
-    relative: path.posix.relative,
-    tests:
-    // arguments          result
-    [['/var/lib', '/var', '..'],
-      ['/var/lib', '/bin', '../../bin'],
-      ['/var/lib', '/var/lib', ''],
-      ['/var/lib', '/var/apache', '../apache'],
-      ['/var/', '/var/lib', 'lib'],
-      ['/', '/var/lib', 'var/lib'],
-      ['/foo/test', '/foo/test/bar/package.json', 'bar/package.json'],
-      ['/Users/a/web/b/test/mails', '/Users/a/web/b', '../..'],
-      ['/foo/bar/baz-quux', '/foo/bar/baz', '../baz'],
-      ['/foo/bar/baz', '/foo/bar/baz-quux', '../baz-quux'],
-      ['/baz-quux', '/baz', '../baz'],
-      ['/baz', '/baz-quux', '../baz-quux']
+  ],
+  posix: [
+    [ path.posix.relative,
+      // arguments          result
+      [['/var/lib', '/var', '..'],
+       ['/var/lib', '/bin', '../../bin'],
+       ['/var/lib', '/var/lib', ''],
+       ['/var/lib', '/var/apache', '../apache'],
+       ['/var/', '/var/lib', 'lib'],
+       ['/', '/var/lib', 'var/lib'],
+       ['/foo/test', '/foo/test/bar/package.json', 'bar/package.json'],
+       ['/Users/a/web/b/test/mails', '/Users/a/web/b', '../..'],
+       ['/foo/bar/baz-quux', '/foo/bar/baz', '../baz'],
+       ['/foo/bar/baz', '/foo/bar/baz-quux', '../baz-quux'],
+       ['/baz-quux', '/baz', '../baz'],
+       ['/baz', '/baz-quux', '../baz-quux']
+      ]
+    ],
+    [ path.win32.relative,
+      // arguments              result
+      [['a\\b\\c', '..\\..\\x', '..\\..\\..\\..\\x'],
+       ['..\\..\\x', 'a\\b\\c', '..\\fakepath\\a\\b\\c'],
+       ['c:\\a\\b\\c', '..\\..\\x', '..\\..\\x'],
+       ['..\\..\\x', 'c:\\a\\b\\c', '..\\b\\c'],
+       ['c:\\a\\b\\c', 'c:\\d\\e\\f', '..\\..\\..\\d\\e\\f']
+      ]
     ]
-  }
+  ]
 };
 {
-  let relative;
   let tests;
+
   if (common.isWindows) {
-    relative = relativeTest.win32.relative;
-    tests = relativeTest.win32.tests;
-    // direct use path.posix.relative on windows will throw error
-    assert.throws(() => {
-      path.posix.relative('foo/bar', 'foo');
-    }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
+    tests = relativeTest.win32;
   } else {
-    relative = relativeTest.posix.relative;
-    tests = relativeTest.posix.tests;
-    // direct use path.win32.relative on *nix will throw error
-    assert.throws(() => {
-      path.win32.relative('foo\\bar', 'foo');
-    }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
+    tests = relativeTest.posix;
   }
+
   tests.forEach((test) => {
-    const actual = relative(test[0], test[1]);
-    const expected = test[2];
-    const os = relative === path.win32.relative ? 'win32' : 'posix';
-    const message = `path.${os}.relative(${
-      test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
-    if (actual !== expected)
-      failures.push(`\n${message}`);
+    const relative = test[0];
+    test[1].forEach((test) => {
+      const actual = relative(test[0], test[1]);
+      const expected = test[2];
+      const os = relative === path.win32.relative ? 'win32' : 'posix';
+      const message = `path.${os}.relative(${
+        test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
+        JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+      if (actual !== expected)
+        failures.push(`\n${message}`);
+    });
   });
 }
 assert.strictEqual(failures.length, 0, failures.join(''));
@@ -627,7 +647,16 @@ assert.strictEqual(path.posix.delimiter, ':');
 
 // path._makeLong tests
 const emptyObj = {};
+assert.strictEqual(path.posix._makeLong('/foo/bar'), '/foo/bar');
+assert.strictEqual(path.posix._makeLong('foo/bar'), 'foo/bar');
+assert.strictEqual(path.posix._makeLong(null), null);
+assert.strictEqual(path.posix._makeLong(true), true);
+assert.strictEqual(path.posix._makeLong(1), 1);
+assert.strictEqual(path.posix._makeLong(), undefined);
+assert.strictEqual(path.posix._makeLong(emptyObj), emptyObj);
 if (common.isWindows) {
+  // These tests cause resolve() to insert the cwd, so we cannot test them from
+  // non-Windows platforms (easily)
   assert.strictEqual(path.win32._makeLong('foo\\bar').toLowerCase(),
                      `\\\\?\\${process.cwd().toLowerCase()}\\foo\\bar`);
   assert.strictEqual(path.win32._makeLong('foo/bar').toLowerCase(),
@@ -637,31 +666,19 @@ if (common.isWindows) {
                      `\\\\?\\${process.cwd().toLowerCase()}`);
   assert.strictEqual(path.win32._makeLong('C').toLowerCase(),
                      `\\\\?\\${process.cwd().toLowerCase()}\\c`);
-  assert.strictEqual(path.win32._makeLong('C:\\foo'), '\\\\?\\C:\\foo');
-  assert.strictEqual(path.win32._makeLong('C:/foo'), '\\\\?\\C:\\foo');
-  assert.strictEqual(path.win32._makeLong('\\\\foo\\bar'),
-                     '\\\\?\\UNC\\foo\\bar\\');
-  assert.strictEqual(path.win32._makeLong('//foo//bar'),
-                     '\\\\?\\UNC\\foo\\bar\\');
-  assert.strictEqual(path.win32._makeLong('\\\\?\\foo'), '\\\\?\\foo');
-  assert.strictEqual(path.win32._makeLong(null), null);
-  assert.strictEqual(path.win32._makeLong(true), true);
-  assert.strictEqual(path.win32._makeLong(1), 1);
-  assert.strictEqual(path.win32._makeLong(), undefined);
-  assert.strictEqual(path.win32._makeLong(emptyObj), emptyObj);
-} else {
-  assert.strictEqual(path.posix._makeLong('/foo/bar'), '/foo/bar');
-  assert.strictEqual(path.posix._makeLong('foo/bar'), 'foo/bar');
-  assert.strictEqual(path.posix._makeLong(null), null);
-  assert.strictEqual(path.posix._makeLong(true), true);
-  assert.strictEqual(path.posix._makeLong(1), 1);
-  assert.strictEqual(path.posix._makeLong(), undefined);
-  assert.strictEqual(path.posix._makeLong(emptyObj), emptyObj);
-  // direct use path.win32._makeLong on *nix will throw error
-  assert.throws(() => {
-    path.win32._makeLong('\\\\?\\foo');
-  }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
 }
+assert.strictEqual(path.win32._makeLong('C:\\foo'), '\\\\?\\C:\\foo');
+assert.strictEqual(path.win32._makeLong('C:/foo'), '\\\\?\\C:\\foo');
+assert.strictEqual(path.win32._makeLong('\\\\foo\\bar'),
+                   '\\\\?\\UNC\\foo\\bar\\');
+assert.strictEqual(path.win32._makeLong('//foo//bar'),
+                   '\\\\?\\UNC\\foo\\bar\\');
+assert.strictEqual(path.win32._makeLong('\\\\?\\foo'), '\\\\?\\foo');
+assert.strictEqual(path.win32._makeLong(null), null);
+assert.strictEqual(path.win32._makeLong(true), true);
+assert.strictEqual(path.win32._makeLong(1), 1);
+assert.strictEqual(path.win32._makeLong(), undefined);
+assert.strictEqual(path.win32._makeLong(emptyObj), emptyObj);
 
 
 if (common.isWindows)

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -649,10 +649,6 @@ if (common.isWindows) {
   assert.strictEqual(path.win32._makeLong(1), 1);
   assert.strictEqual(path.win32._makeLong(), undefined);
   assert.strictEqual(path.win32._makeLong(emptyObj), emptyObj);
-  // direct use path.posix._makeLong on windows will throw error
-  assert.throws(() => {
-    path.posix._makeLong('/foo/bar');
-  }, common.expectsError({code: 'ERR_UNSUPPORTED_PLATFORM', type: Error}));
 } else {
   assert.strictEqual(path.posix._makeLong('/foo/bar'), '/foo/bar');
   assert.strictEqual(path.posix._makeLong('foo/bar'), 'foo/bar');


### PR DESCRIPTION
Throw an error `ERR_UNSUPPORTED_PLATFOMR` when direct use
`path.posix.resolve` on Windows or direct use `path.win32.resolve`
on *nix.

Update docs, list win32 functions do not support direct use on
*nix and posix functions do not support direct use on Windows.

Update tests, only run current platform type test.

Fixes: https://github.com/nodejs/node/issues/13683
Refs: https://github.com/nodejs/node/pull/13714

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, path