### PR TITLE
process: fix error message of hrtime()

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -122,6 +122,15 @@ E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
 E('ERR_HTTP_INVALID_STATUS_CODE',
   (originalStatusCode) => `Invalid status code: ${originalStatusCode}`);
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
+E('ERR_INVALID_ARRAY_LENGTH',
+  (name, length, actual) => {
+    let msg = `The "${name}" array must have a length of ${length}`;
+    if (arguments.length > 2) {
+      const len = Array.isArray(actual) ? actual.length : actual;
+      msg += `. Received length ${len}`;
+    }
+    return msg;
+  });
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_CALLBACK', 'callback must be a function');
 E('ERR_INVALID_FD', (fd) => `"fd" must be a positive integer: ${fd}`);

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -78,14 +78,19 @@ function setup_hrtime() {
     _hrtime(hrValues);
 
     if (time !== undefined) {
-      if (Array.isArray(time) && time.length === 2) {
-        const sec = (hrValues[0] * 0x100000000 + hrValues[1]) - time[0];
-        const nsec = hrValues[2] - time[1];
-        const needsBorrow = nsec < 0;
-        return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
+      if (!Array.isArray(time)) {
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'time', 'Array',
+                                   time);
       }
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'time', 'Array',
-                                 time);
+      if (time.length !== 2) {
+        throw new errors.TypeError('ERR_INVALID_ARRAY_LENGTH', 'time', 2,
+                                   time);
+      }
+
+      const sec = (hrValues[0] * 0x100000000 + hrValues[1]) - time[0];
+      const nsec = hrValues[2] - time[1];
+      const needsBorrow = nsec < 0;
+      return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
     }
 
     return [

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -84,8 +84,7 @@ function setup_hrtime() {
         const needsBorrow = nsec < 0;
         return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
       }
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                                 'process.hrtime()', 'Array');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'time', 'Array');
     }
 
     return [

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -84,7 +84,8 @@ function setup_hrtime() {
         const needsBorrow = nsec < 0;
         return [needsBorrow ? sec - 1 : sec, needsBorrow ? nsec + 1e9 : nsec];
       }
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'time', 'Array');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'time', 'Array',
+                                 time);
     }
 
     return [

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -32,25 +32,35 @@ validateTuple(tuple);
 // validate that passing an existing tuple returns another valid tuple
 validateTuple(process.hrtime(tuple));
 
-const invalidHrtimeArgument = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "time" argument must be of type Array'
-});
-
 // test that only an Array may be passed to process.hrtime()
 assert.throws(() => {
   process.hrtime(1);
-}, invalidHrtimeArgument);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "time" argument must be of type Array. Received type number'
+}));
 assert.throws(() => {
   process.hrtime([]);
-}, invalidHrtimeArgument);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "time" argument must be of type Array. Received type object'
+}));
 assert.throws(() => {
   process.hrtime([1]);
-}, invalidHrtimeArgument);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "time" argument must be of type Array. Received type object'
+}));
 assert.throws(() => {
   process.hrtime([1, 2, 3]);
-}, invalidHrtimeArgument);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "time" argument must be of type Array. Received type object'
+}));
 
 function validateTuple(tuple) {
   assert(Array.isArray(tuple));

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -43,23 +43,23 @@ assert.throws(() => {
 assert.throws(() => {
   process.hrtime([]);
 }, common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
+  code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" argument must be of type Array. Received type object'
+  message: 'The "time" array must have a length of 2. Received length 0'
 }));
 assert.throws(() => {
   process.hrtime([1]);
 }, common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
+  code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" argument must be of type Array. Received type object'
+  message: 'The "time" array must have a length of 2. Received length 1'
 }));
 assert.throws(() => {
   process.hrtime([1, 2, 3]);
 }, common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
+  code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" argument must be of type Array. Received type object'
+  message: 'The "time" array must have a length of 2. Received length 3'
 }));
 
 function validateTuple(tuple) {

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -35,7 +35,7 @@ validateTuple(process.hrtime(tuple));
 const invalidHrtimeArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "process.hrtime()" argument must be of type Array'
+  message: 'The "time" argument must be of type Array'
 });
 
 // test that only an Array may be passed to process.hrtime()


### PR DESCRIPTION
`process.hrtime()` incorrectly passes the function name to `errors.TypeError` instead of the name of the argument.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process

---

I briefly discussed this with @addaleax. We assume that `process.hrtime` was passed to `errors.TypeError` due to the fact that it is easier to understand than the name of the parameter (`time`). I would still opt for consistency within our codebase and error messages, therefore this PR.

To be honest, most error messages of this type are relatively useless without the stack as we never include the function name in the message itself. We could add an argument to `ERR_INVALID_ARG_TYPE` which allows to specify the function, but that would make the error messages longer.

As always, needs to be approved by @nodejs/ctc.