### PR TITLE
console,internal/errors: improve error perf

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -151,11 +151,10 @@ Console.prototype.timeEnd = function timeEnd(label) {
 
 
 Console.prototype.trace = function trace(...args) {
-  // TODO probably can to do this better with V8's debug object once that is
-  // exposed.
-  var err = new Error();
-  err.name = 'Trace';
-  err.message = util.format.apply(null, args);
+  const err = {
+    name: 'Trace',
+    message: util.format.apply(null, args)
+  };
   Error.captureStackTrace(err, trace);
   this.error(err.stack);
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -28,7 +28,6 @@ function makeNodeError(Base) {
     constructor(key, ...args) {
       super(message(key, args));
       this[kCode] = key;
-      Error.captureStackTrace(this, NodeError);
     }
 
     get name() {


### PR DESCRIPTION
This increases the performance for `console.trace` and creating a new NodeError by factor 2-3.

Newer v8 versions exclude the constructor from the stack trace
so the recalculation of the trace can be avoided.

Using a object instead of an Error is sufficient for console.trace as the Error
itself won't be used but only the stack trace that would
otherwise be created twice.
 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
console, internal/errors
