### PR TITLE
dgram: change parameter name in set(Multicast)TTL

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -526,9 +526,7 @@ Socket.prototype.setBroadcast = function(arg) {
 
 Socket.prototype.setTTL = function(ttl) {
   if (typeof ttl !== 'number') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'ttl',
-                               'number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ttl', 'number', ttl);
   }
 
   var err = this._handle.setTTL(ttl);
@@ -542,9 +540,7 @@ Socket.prototype.setTTL = function(ttl) {
 
 Socket.prototype.setMulticastTTL = function(ttl) {
   if (typeof ttl !== 'number') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'ttl',
-                               'number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ttl', 'number', ttl);
   }
 
   var err = this._handle.setMulticastTTL(ttl);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -524,35 +524,35 @@ Socket.prototype.setBroadcast = function(arg) {
 };
 
 
-Socket.prototype.setTTL = function(arg) {
-  if (typeof arg !== 'number') {
+Socket.prototype.setTTL = function(ttl) {
+  if (typeof ttl !== 'number') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'arg',
+                               'ttl',
                                'number');
   }
 
-  var err = this._handle.setTTL(arg);
+  var err = this._handle.setTTL(ttl);
   if (err) {
     throw errnoException(err, 'setTTL');
   }
 
-  return arg;
+  return ttl;
 };
 
 
-Socket.prototype.setMulticastTTL = function(arg) {
-  if (typeof arg !== 'number') {
+Socket.prototype.setMulticastTTL = function(ttl) {
+  if (typeof ttl !== 'number') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'arg',
+                               'ttl',
                                'number');
   }
 
-  var err = this._handle.setMulticastTTL(arg);
+  var err = this._handle.setMulticastTTL(ttl);
   if (err) {
     throw errnoException(err, 'setMulticastTTL');
   }
 
-  return arg;
+  return ttl;
 };
 
 

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -40,7 +40,7 @@ socket.on('listening', common.mustCall(() => {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "ttl" argument must be of type number$/
+    message: 'The "ttl" argument must be of type number. Received type string'
   }));
 
   //close the socket

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -40,7 +40,7 @@ socket.on('listening', common.mustCall(() => {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "arg" argument must be of type number$/
+    message: /^The "ttl" argument must be of type number$/
   }));
 
   //close the socket

--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -14,7 +14,7 @@ socket.on('listening', common.mustCall(() => {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "ttl" argument must be of type number$/
+    message: 'The "ttl" argument must be of type number. Received type string'
   }));
 
   // TTL must be a number from > 0 to < 256

--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -14,7 +14,7 @@ socket.on('listening', common.mustCall(() => {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "arg" argument must be of type number$/
+    message: /^The "ttl" argument must be of type number$/
   }));
 
   // TTL must be a number from > 0 to < 256


### PR DESCRIPTION
Changed the parameter name in set(Multicast)TTL from "arg" to "ttl" both within code and error messages. The documentation already contains the correct parameter name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dgram

---

For consideration of the @nodejs/ctc due to being semver-major.