### PR TITLE
test: remove common module from test it thwarts

### DIFF
--- a/test/parallel/test-global-console-exists.js
+++ b/test/parallel/test-global-console-exists.js
@@ -1,39 +1,46 @@
 /* eslint-disable required-modules */
-// ordinarily test files must require('common') but that action causes
-// the global console to be compiled, defeating the purpose of this test
 
 'use strict';
 
-const common = require('../common');
+// Ordinarily test files must require('common') but that action causes
+// the global console to be compiled, defeating the purpose of this test.
+
 const assert = require('assert');
 const EventEmitter = require('events');
 const leakWarning = /EventEmitter memory leak detected\. 2 hello listeners/;
 
-common.hijackStderr(common.mustCall(function(data) {
-  if (process.stderr.writeTimes === 0) {
-    assert.ok(data.match(leakWarning));
-  } else {
-    assert.fail('stderr.write should be called only once');
-  }
-}));
-
-process.on('warning', function(warning) {
+let writeTimes = 0;
+let warningTimes = 0;
+process.on('warning', () => {
   // This will be called after the default internal
   // process warning handler is called. The default
   // process warning writes to the console, which will
   // invoke the monkeypatched process.stderr.write
   // below.
-  assert.strictEqual(process.stderr.writeTimes, 1);
+  assert.strictEqual(writeTimes, 1);
   EventEmitter.defaultMaxListeners = oldDefault;
-  // when we get here, we should be done
+  warningTimes++;
 });
+
+process.on('exit', () => {
+  assert.strictEqual(warningTimes, 1);
+});
+
+process.stderr.write = (data) => {
+  if (writeTimes === 0)
+    assert.ok(data.match(leakWarning));
+  else
+    assert.fail('stderr.write should be called only once');
+
+  writeTimes++;
+};
 
 const oldDefault = EventEmitter.defaultMaxListeners;
 EventEmitter.defaultMaxListeners = 1;
 
 const e = new EventEmitter();
-e.on('hello', common.noop);
-e.on('hello', common.noop);
+e.on('hello', () => {});
+e.on('hello', () => {});
 
 // TODO: Figure out how to validate console. Currently,
 // there is no obvious way of validating that console


### PR DESCRIPTION
test-global-console-exists cannot use the common module as explained in
a comment but it was included later anyway. This change removes it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test console