### PR TITLE
async_hooks: reduce code duplication by using a factory

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -368,6 +368,8 @@ function emitHookFactory(symbol, name) {
       restoreTmpHooks();
     }
   };
+  // Set the name property of the anonymous function as it looks good in the
+  // stack trace.
   Object.defineProperty(fn, 'name', {
     value: name
   });

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -328,8 +328,8 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
     triggerAsyncId = initTriggerId();
   }
 
-  // I'd prefer allowing these checks to not exist, or only throw in a debug
-  // build, in order to improve performance.
+  // TODO(trevnorris): I'd prefer allowing these checks to not exist, or only
+  // throw in a debug build, in order to improve performance.
   if (!Number.isSafeInteger(asyncId) || asyncId < 0)
     throw new RangeError('asyncId must be an unsigned integer');
   if (typeof type !== 'string' || type.length <= 0)

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -49,9 +49,9 @@ const init_symbol = Symbol('init');
 const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
 const destroy_symbol = Symbol('destroy');
-const emitBeforeN = hookFactory(before_symbol);
-const emitAfterN = hookFactory(after_symbol);
-const emitDestroyN = hookFactory(destroy_symbol);
+const emitBeforeN = emitHookFactory(before_symbol);
+const emitAfterN = emitHookFactory(after_symbol);
+const emitDestroyN = emitHookFactory(destroy_symbol);
 
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
@@ -345,7 +345,7 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
   }
 }
 
-function hookFactory(symbol) {
+function emitHookFactory(symbol) {
   // Called from native. The asyncId stack handling is taken care of there
   // before this is called.
   return function(asyncId) {

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -49,9 +49,9 @@ const init_symbol = Symbol('init');
 const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
 const destroy_symbol = Symbol('destroy');
-const emitBeforeN = emitHookFactory(before_symbol);
-const emitAfterN = emitHookFactory(after_symbol);
-const emitDestroyN = emitHookFactory(destroy_symbol);
+const emitBeforeN = emitHookFactory(before_symbol, 'emitBeforeN');
+const emitAfterN = emitHookFactory(after_symbol, 'emitAfterN');
+const emitDestroyN = emitHookFactory(destroy_symbol, 'emitDestroyN');
 
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
@@ -345,10 +345,10 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
   }
 }
 
-function emitHookFactory(symbol) {
+function emitHookFactory(symbol, name) {
   // Called from native. The asyncId stack handling is taken care of there
   // before this is called.
-  return function(asyncId) {
+  const fn = function(asyncId) {
     processing_hook = true;
     // Use a single try/catch for all hook to avoid setting up one per
     // iteration.
@@ -367,6 +367,10 @@ function emitHookFactory(symbol) {
       restoreTmpHooks();
     }
   };
+  Object.defineProperty(fn, 'name', {
+    value: name
+  });
+  return fn;
 }
 
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -49,18 +49,18 @@ const init_symbol = Symbol('init');
 const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
 const destroy_symbol = Symbol('destroy');
-const emitBeforeN = emitHookFactory(before_symbol, 'emitBeforeN');
-const emitAfterN = emitHookFactory(after_symbol, 'emitAfterN');
-const emitDestroyN = emitHookFactory(destroy_symbol, 'emitDestroyN');
+const emitBeforeNative = emitHookFactory(before_symbol, 'emitBeforeNative');
+const emitAfterNative = emitHookFactory(after_symbol, 'emitAfterNative');
+const emitDestroyNative = emitHookFactory(destroy_symbol, 'emitDestroyNative');
 
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
 // are setup immediately to prevent async_wrap.setupHooks() from being hijacked
 // and the cost of doing so is negligible.
 async_wrap.setupHooks({ init,
-                        before: emitBeforeN,
-                        after: emitAfterN,
-                        destroy: emitDestroyN });
+                        before: emitBeforeNative,
+                        after: emitAfterNative,
+                        destroy: emitDestroyNative });
 
 // Used to fatally abort the process if a callback throws.
 function fatalError(e) {
@@ -391,7 +391,7 @@ function emitBeforeS(asyncId, triggerAsyncId = asyncId) {
 
   if (async_hook_fields[kBefore] === 0)
     return;
-  emitBeforeN(asyncId);
+  emitBeforeNative(asyncId);
 }
 
 
@@ -400,7 +400,7 @@ function emitBeforeS(asyncId, triggerAsyncId = asyncId) {
 // after callbacks.
 function emitAfterS(asyncId) {
   if (async_hook_fields[kAfter] > 0)
-    emitAfterN(asyncId);
+    emitAfterNative(asyncId);
 
   popAsyncIds(asyncId);
 }

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -49,6 +49,9 @@ const init_symbol = Symbol('init');
 const before_symbol = Symbol('before');
 const after_symbol = Symbol('after');
 const destroy_symbol = Symbol('destroy');
+const emitBeforeN = hookFactory(before_symbol);
+const emitAfterN = hookFactory(after_symbol);
+const emitDestroyN = hookFactory(destroy_symbol);
 
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
@@ -342,24 +345,28 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
   }
 }
 
-
-function emitBeforeN(asyncId) {
-  processing_hook = true;
-  // Use a single try/catch for all hook to avoid setting up one per iteration.
-  try {
-    for (var i = 0; i < active_hooks_array.length; i++) {
-      if (typeof active_hooks_array[i][before_symbol] === 'function') {
-        active_hooks_array[i][before_symbol](asyncId);
+function hookFactory(symbol) {
+  // Called from native. The asyncId stack handling is taken care of there
+  // before this is called.
+  return function(asyncId) {
+    processing_hook = true;
+    // Use a single try/catch for all hook to avoid setting up one per
+    // iteration.
+    try {
+      for (var i = 0; i < active_hooks_array.length; i++) {
+        if (typeof active_hooks_array[i][symbol] === 'function') {
+          active_hooks_array[i][symbol](asyncId);
+        }
       }
+    } catch (e) {
+      fatalError(e);
     }
-  } catch (e) {
-    fatalError(e);
-  }
-  processing_hook = false;
+    processing_hook = false;
 
-  if (tmp_active_hooks_array !== null) {
-    restoreTmpHooks();
-  }
+    if (tmp_active_hooks_array !== null) {
+      restoreTmpHooks();
+    }
+  };
 }
 
 
@@ -383,28 +390,6 @@ function emitBeforeS(asyncId, triggerAsyncId = asyncId) {
 }
 
 
-// Called from native. The asyncId stack handling is taken care of there before
-// this is called.
-function emitAfterN(asyncId) {
-  processing_hook = true;
-  // Use a single try/catch for all hook to avoid setting up one per iteration.
-  try {
-    for (var i = 0; i < active_hooks_array.length; i++) {
-      if (typeof active_hooks_array[i][after_symbol] === 'function') {
-        active_hooks_array[i][after_symbol](asyncId);
-      }
-    }
-  } catch (e) {
-    fatalError(e);
-  }
-  processing_hook = false;
-
-  if (tmp_active_hooks_array !== null) {
-    restoreTmpHooks();
-  }
-}
-
-
 // TODO(trevnorris): Calling emitBefore/emitAfter from native can't adjust the
 // kIdStackIndex. But what happens if the user doesn't have both before and
 // after callbacks.
@@ -422,26 +407,6 @@ function emitDestroyS(asyncId) {
   if (async_hook_fields[kDestroy] === 0 || asyncId === 0)
     return;
   async_wrap.addIdToDestroyList(asyncId);
-}
-
-
-function emitDestroyN(asyncId) {
-  processing_hook = true;
-  // Use a single try/catch for all hook to avoid setting up one per iteration.
-  try {
-    for (var i = 0; i < active_hooks_array.length; i++) {
-      if (typeof active_hooks_array[i][destroy_symbol] === 'function') {
-        active_hooks_array[i][destroy_symbol](asyncId);
-      }
-    }
-  } catch (e) {
-    fatalError(e);
-  }
-  processing_hook = false;
-
-  if (tmp_active_hooks_array !== null) {
-    restoreTmpHooks();
-  }
 }
 
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -348,6 +348,7 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
 function emitHookFactory(symbol, name) {
   // Called from native. The asyncId stack handling is taken care of there
   // before this is called.
+  // eslint-disable-next-line func-style
   const fn = function(asyncId) {
     processing_hook = true;
     // Use a single try/catch for all hook to avoid setting up one per


### PR DESCRIPTION
The difference between the hooks is only a single variable and it can be initialized in the beginning. So I think it's nicer to stick to DRY.
The `init` function is also very similar but that would require an additional check, so I kept it as it is.

I also added a `TODO` entry as the comment somewhat confused me (ping @trevnorris ).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_hooks