### PR TITLE
benchmark: var to const

### DIFF
--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -3,8 +3,8 @@
 const readline = require('readline');
 
 function pad(input, minLength, fill) {
-  var result = String(input);
-  var padding = fill.repeat(Math.max(0, minLength - result.length));
+  const result = String(input);
+  const padding = fill.repeat(Math.max(0, minLength - result.length));
   return `${padding}${result}`;
 }
 

--- a/benchmark/arrays/var-int.js
+++ b/benchmark/arrays/var-int.js
@@ -23,7 +23,7 @@ function main(conf) {
   const n = +conf.n;
 
   bench.start();
-  var arr = new clazz(n * 1e6);
+  const arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
     run();
   }

--- a/benchmark/arrays/zero-float.js
+++ b/benchmark/arrays/zero-float.js
@@ -23,7 +23,7 @@ function main(conf) {
   const n = +conf.n;
 
   bench.start();
-  var arr = new clazz(n * 1e6);
+  const arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
     run();
   }

--- a/benchmark/arrays/zero-int.js
+++ b/benchmark/arrays/zero-int.js
@@ -23,7 +23,7 @@ function main(conf) {
   const n = +conf.n;
 
   bench.start();
-  var arr = new clazz(n * 1e6);
+  const arr = new clazz(n * 1e6);
   for (var i = 0; i < 10; ++i) {
     run();
   }

--- a/benchmark/buffers/buffer-base64-encode.js
+++ b/benchmark/buffers/buffer-base64-encode.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   len: [64 * 1024 * 1024],

--- a/benchmark/buffers/buffer-bytelength.js
+++ b/benchmark/buffers/buffer-bytelength.js
@@ -1,14 +1,14 @@
 'use strict';
-var common = require('../common');
+const common = require('../common');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   encoding: ['utf8', 'base64', 'buffer'],
   len: [1, 2, 4, 16, 64, 256], // x16
   n: [5e6]
 });
 
 // 16 chars each
-var chars = [
+const chars = [
   'hello brendan!!!', // 1 byte
   'ΰαβγδεζηθικλμνξο', // 2 bytes
   '挰挱挲挳挴挵挶挷挸挹挺挻挼挽挾挿', // 3 bytes
@@ -16,9 +16,9 @@ var chars = [
 ];
 
 function main(conf) {
-  var n = conf.n | 0;
-  var len = conf.len | 0;
-  var encoding = conf.encoding;
+  const n = conf.n | 0;
+  const len = conf.len | 0;
+  const encoding = conf.encoding;
 
   var strings = [];
   var results;
@@ -26,9 +26,9 @@ function main(conf) {
     strings = [ Buffer.alloc(len * 16, 'a') ];
     results = [ len * 16 ];
   } else {
-    for (var string of chars) {
+    for (const string of chars) {
       // Strings must be built differently, depending on encoding
-      var data = string.repeat(len);
+      const data = string.repeat(len);
       if (encoding === 'utf8') {
         strings.push(data);
       } else if (encoding === 'base64') {
@@ -45,9 +45,9 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    var index = n % strings.length;
+    const index = n % strings.length;
     // Go!
-    var r = Buffer.byteLength(strings[index], encoding);
+    const r = Buffer.byteLength(strings[index], encoding);
 
     if (r !== results[index])
       throw new Error('incorrect return value');

--- a/benchmark/buffers/buffer-compare.js
+++ b/benchmark/buffers/buffer-compare.js
@@ -20,9 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   size: [16, 512, 1024, 4096, 16386],
   millions: [1]
 });

--- a/benchmark/buffers/buffer-indexof.js
+++ b/benchmark/buffers/buffer-indexof.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common.js');
-var fs = require('fs');
+const common = require('../common.js');
+const fs = require('fs');
 const path = require('path');
 
 const searchStrings = [
@@ -21,7 +21,7 @@ const searchStrings = [
   '</i> to the Caterpillar'
 ];
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   search: searchStrings,
   encoding: ['undefined', 'utf8', 'ucs2', 'binary'],
   type: ['buffer', 'string'],
@@ -29,7 +29,7 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var iter = (conf.iter) * 100000;
+  const iter = (conf.iter) * 100000;
   var aliceBuffer = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/alice.html')
   );

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -1,16 +1,16 @@
 'use strict';
-var SlowBuffer = require('buffer').SlowBuffer;
-var common = require('../common.js');
-var assert = require('assert');
+const SlowBuffer = require('buffer').SlowBuffer;
+const common = require('../common.js');
+const assert = require('assert');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   size: [16, 512, 1024, 4096, 16386],
   type: ['fast', 'slow'],
   method: ['for', 'forOf', 'iterator'],
   n: [1e3]
 });
 
-var methods = {
+const methods = {
   'for': benchFor,
   'forOf': benchForOf,
   'iterator': benchIterator
@@ -43,7 +43,7 @@ function benchForOf(buffer, n) {
   bench.start();
 
   for (var k = 0; k < n; k++) {
-    for (var b of buffer) {
+    for (const b of buffer) {
       assert(b === 0);
     }
   }
@@ -54,7 +54,7 @@ function benchIterator(buffer, n) {
   bench.start();
 
   for (var k = 0; k < n; k++) {
-    var iter = buffer[Symbol.iterator]();
+    const iter = buffer[Symbol.iterator]();
     var cur = iter.next();
 
     while (!cur.done) {

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var types = [
+const types = [
   'UInt8',
   'UInt16LE',
   'UInt16BE',
@@ -18,7 +18,7 @@ var types = [
   'DoubleBE'
 ];
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   noAssert: ['false', 'true'],
   buffer: ['fast', 'slow'],
   type: types,

--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -1,18 +1,18 @@
 'use strict';
-var common = require('../common.js');
-var SlowBuffer = require('buffer').SlowBuffer;
+const common = require('../common.js');
+const SlowBuffer = require('buffer').SlowBuffer;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: ['fast', 'slow'],
   n: [1024]
 });
 
-var buf = Buffer.allocUnsafe(1024);
-var slowBuf = new SlowBuffer(1024);
+const buf = Buffer.allocUnsafe(1024);
+const slowBuf = new SlowBuffer(1024);
 
 function main(conf) {
-  var n = +conf.n;
-  var b = conf.type === 'fast' ? buf : slowBuf;
+  const n = +conf.n;
+  const b = conf.type === 'fast' ? buf : slowBuf;
   bench.start();
   for (var i = 0; i < n * 1024; i++) {
     b.slice(10, 256);

--- a/benchmark/buffers/buffer-tojson.js
+++ b/benchmark/buffers/buffer-tojson.js
@@ -8,8 +8,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var buf = Buffer.allocUnsafe(+conf.len);
+  const n = +conf.n;
+  const buf = Buffer.allocUnsafe(+conf.len);
 
   bench.start();
   for (var i = 0; i < n; ++i)

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var types = [
+const types = [
   'UInt8',
   'UInt16LE',
   'UInt16BE',
@@ -18,7 +18,7 @@ var types = [
   'DoubleBE'
 ];
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   noAssert: ['false', 'true'],
   buffer: ['fast', 'slow'],
   type: types,
@@ -32,7 +32,7 @@ const UINT8 = (INT8 * 2) + 1;
 const UINT16 = (INT16 * 2) + 1;
 const UINT32 = INT32;
 
-var mod = {
+const mod = {
   writeInt8: INT8,
   writeInt16BE: INT16,
   writeInt16LE: INT16,
@@ -60,8 +60,8 @@ function main(conf) {
 }
 
 function benchInt(buff, fn, len, noAssert) {
-  var m = mod[fn];
-  var testFunction = new Function('buff', `
+  const m = mod[fn];
+  const testFunction = new Function('buff', `
     for (var i = 0; i !== ${len}; i++) {
       buff.${fn}(i & ${m}, 0, ${JSON.stringify(noAssert)});
     }
@@ -72,7 +72,7 @@ function benchInt(buff, fn, len, noAssert) {
 }
 
 function benchFloat(buff, fn, len, noAssert) {
-  var testFunction = new Function('buff', `
+  const testFunction = new Function('buff', `
     for (var i = 0; i !== ${len}; i++) {
       buff.${fn}(i, 0, ${JSON.stringify(noAssert)});
     }

--- a/benchmark/buffers/buffer_zero.js
+++ b/benchmark/buffers/buffer_zero.js
@@ -11,7 +11,7 @@ const zeroBuffer = Buffer.alloc(0);
 const zeroString = '';
 
 function main(conf) {
-  var n = +conf.n;
+  const n = +conf.n;
   bench.start();
 
   if (conf.type === 'buffer')

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var types = [
+const types = [
   'Uint8',
   'Uint16LE',
   'Uint16BE',
@@ -18,7 +18,7 @@ var types = [
   'Float64BE'
 ];
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: types,
   millions: [1]
 });
@@ -30,7 +30,7 @@ const UINT8 = INT8 * 2;
 const UINT16 = INT16 * 2;
 const UINT32 = INT32 * 2;
 
-var mod = {
+const mod = {
   setInt8: INT8,
   setInt16: INT16,
   setInt32: INT32,

--- a/benchmark/child_process/child-process-exec-stdout.js
+++ b/benchmark/child_process/child-process-exec-stdout.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const { exec, execSync } = require('child_process');
 const isWindows = process.platform === 'win32';
 
-var messagesLength = [64, 256, 1024, 4096];
+const messagesLength = [64, 256, 1024, 4096];
 // Windows does not support command lines longer than 8191 characters
 if (!isWindows) messagesLength.push(32768);
 

--- a/benchmark/child_process/child-process-read.js
+++ b/benchmark/child_process/child-process-read.js
@@ -7,7 +7,7 @@ const common = require('../common.js');
 const os = require('os');
 const child_process = require('child_process');
 
-var messagesLength = [64, 256, 1024, 4096];
+const messagesLength = [64, 256, 1024, 4096];
 // Windows does not support that long arguments
 if (os.platform() !== 'win32')
   messagesLength.push(32768);

--- a/benchmark/child_process/spawn-echo.js
+++ b/benchmark/child_process/spawn-echo.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   n: [1000]
 });
 
-var spawn = require('child_process').spawn;
+const spawn = require('child_process').spawn;
 function main(conf) {
-  var n = +conf.n;
+  const n = +conf.n;
 
   bench.start();
   go(n, n);
@@ -16,7 +16,7 @@ function go(n, left) {
   if (--left === 0)
     return bench.end(n);
 
-  var child = spawn('echo', ['hello']);
+  const child = spawn('echo', ['hello']);
   child.on('exit', function(code) {
     if (code)
       process.exit(code);

--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -11,10 +11,10 @@ if (cluster.isMaster) {
   });
 
   function main(conf) {
-    var n = +conf.n;
-    var workers = +conf.workers;
-    var sends = +conf.sendsPerBroadcast;
-    var expectedPerBroadcast = sends * workers;
+    const n = +conf.n;
+    const workers = +conf.workers;
+    const sends = +conf.sendsPerBroadcast;
+    const expectedPerBroadcast = sends * workers;
     var payload;
     var readies = 0;
     var broadcasts = 0;

--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -1,34 +1,34 @@
 'use strict';
-var common = require('../common.js');
-var crypto = require('crypto');
-var keylen = { 'aes-128-gcm': 16, 'aes-192-gcm': 24, 'aes-256-gcm': 32 };
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const crypto = require('crypto');
+const keylen = { 'aes-128-gcm': 16, 'aes-192-gcm': 24, 'aes-256-gcm': 32 };
+const bench = common.createBenchmark(main, {
   n: [500],
   cipher: ['aes-128-gcm', 'aes-192-gcm', 'aes-256-gcm'],
   len: [1024, 4 * 1024, 16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024]
 });
 
 function main(conf) {
-  var message = Buffer.alloc(conf.len, 'b');
-  var key = crypto.randomBytes(keylen[conf.cipher]);
-  var iv = crypto.randomBytes(12);
-  var associate_data = Buffer.alloc(16, 'z');
+  const message = Buffer.alloc(conf.len, 'b');
+  const key = crypto.randomBytes(keylen[conf.cipher]);
+  const iv = crypto.randomBytes(12);
+  const associate_data = Buffer.alloc(16, 'z');
   bench.start();
   AEAD_Bench(conf.cipher, message, associate_data, key, iv, conf.n, conf.len);
 }
 
 function AEAD_Bench(cipher, message, associate_data, key, iv, n, len) {
-  var written = n * len;
-  var bits = written * 8;
-  var mbits = bits / (1024 * 1024);
+  const written = n * len;
+  const bits = written * 8;
+  const mbits = bits / (1024 * 1024);
 
   for (var i = 0; i < n; i++) {
-    var alice = crypto.createCipheriv(cipher, key, iv);
+    const alice = crypto.createCipheriv(cipher, key, iv);
     alice.setAAD(associate_data);
-    var enc = alice.update(message);
+    const enc = alice.update(message);
     alice.final();
-    var tag = alice.getAuthTag();
-    var bob = crypto.createDecipheriv(cipher, key, iv);
+    const tag = alice.getAuthTag();
+    const bob = crypto.createDecipheriv(cipher, key, iv);
     bob.setAuthTag(tag);
     bob.setAAD(associate_data);
     bob.update(enc);

--- a/benchmark/crypto/cipher-stream.js
+++ b/benchmark/crypto/cipher-stream.js
@@ -1,7 +1,7 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   writes: [500],
   cipher: [ 'AES192', 'AES256' ],
   type: ['asc', 'utf', 'buf'],
@@ -17,24 +17,24 @@ function main(conf) {
     api = 'legacy';
   }
 
-  var crypto = require('crypto');
-  var assert = require('assert');
-  var alice = crypto.getDiffieHellman('modp5');
-  var bob = crypto.getDiffieHellman('modp5');
+  const crypto = require('crypto');
+  const assert = require('assert');
+  const alice = crypto.getDiffieHellman('modp5');
+  const bob = crypto.getDiffieHellman('modp5');
 
   alice.generateKeys();
   bob.generateKeys();
 
 
-  var pubEnc = /^v0\.[0-8]/.test(process.version) ? 'binary' : null;
-  var alice_secret = alice.computeSecret(bob.getPublicKey(), pubEnc, 'hex');
-  var bob_secret = bob.computeSecret(alice.getPublicKey(), pubEnc, 'hex');
+  const pubEnc = /^v0\.[0-8]/.test(process.version) ? 'binary' : null;
+  const alice_secret = alice.computeSecret(bob.getPublicKey(), pubEnc, 'hex');
+  const bob_secret = bob.computeSecret(alice.getPublicKey(), pubEnc, 'hex');
 
   // alice_secret and bob_secret should be the same
   assert(alice_secret === bob_secret);
 
-  var alice_cipher = crypto.createCipher(conf.cipher, alice_secret);
-  var bob_cipher = crypto.createDecipher(conf.cipher, bob_secret);
+  const alice_cipher = crypto.createCipher(conf.cipher, alice_secret);
+  const bob_cipher = crypto.createDecipher(conf.cipher, bob_secret);
 
   var message;
   var encoding;
@@ -54,7 +54,7 @@ function main(conf) {
       throw new Error(`unknown message type: ${conf.type}`);
   }
 
-  var fn = api === 'stream' ? streamWrite : legacyWrite;
+  const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   // write data as fast as possible to alice, and have bob decrypt.
   // use old API for comparison to v0.8
@@ -70,8 +70,8 @@ function streamWrite(alice, bob, message, encoding, writes) {
 
   bob.on('end', function() {
     // Gbits
-    var bits = written * 8;
-    var gbits = bits / (1024 * 1024 * 1024);
+    const bits = written * 8;
+    const gbits = bits / (1024 * 1024 * 1024);
     bench.end(gbits);
   });
 
@@ -96,6 +96,6 @@ function legacyWrite(alice, bob, message, encoding, writes) {
   written += dec.length;
   dec = bob.final();
   written += dec.length;
-  var gbits = written / (1024 * 1024 * 1024);
+  const gbits = written / (1024 * 1024 * 1024);
   bench.end(gbits);
 }

--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -1,10 +1,10 @@
 // throughput benchmark
 // creates a single hasher, then pushes a bunch of data through it
 'use strict';
-var common = require('../common.js');
-var crypto = require('crypto');
+const common = require('../common.js');
+const crypto = require('crypto');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   writes: [500],
   algo: [ 'sha256', 'md5' ],
   type: ['asc', 'utf', 'buf'],
@@ -39,19 +39,19 @@ function main(conf) {
       throw new Error(`unknown message type: ${conf.type}`);
   }
 
-  var fn = api === 'stream' ? streamWrite : legacyWrite;
+  const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
   fn(conf.algo, message, encoding, conf.writes, conf.len, conf.out);
 }
 
 function legacyWrite(algo, message, encoding, writes, len, outEnc) {
-  var written = writes * len;
-  var bits = written * 8;
-  var gbits = bits / (1024 * 1024 * 1024);
+  const written = writes * len;
+  const bits = written * 8;
+  const gbits = bits / (1024 * 1024 * 1024);
 
   while (writes-- > 0) {
-    var h = crypto.createHash(algo);
+    const h = crypto.createHash(algo);
     h.update(message, encoding);
     var res = h.digest(outEnc);
 
@@ -64,12 +64,12 @@ function legacyWrite(algo, message, encoding, writes, len, outEnc) {
 }
 
 function streamWrite(algo, message, encoding, writes, len, outEnc) {
-  var written = writes * len;
-  var bits = written * 8;
-  var gbits = bits / (1024 * 1024 * 1024);
+  const written = writes * len;
+  const bits = written * 8;
+  const gbits = bits / (1024 * 1024 * 1024);
 
   while (writes-- > 0) {
-    var h = crypto.createHash(algo);
+    const h = crypto.createHash(algo);
 
     if (outEnc !== 'buffer')
       h.setEncoding(outEnc);

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -1,10 +1,10 @@
 // throughput benchmark
 // creates a single hasher, then pushes a bunch of data through it
 'use strict';
-var common = require('../common.js');
-var crypto = require('crypto');
+const common = require('../common.js');
+const crypto = require('crypto');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   writes: [500],
   algo: ['sha1', 'sha256', 'sha512'],
   type: ['asc', 'utf', 'buf'],
@@ -38,17 +38,17 @@ function main(conf) {
       throw new Error(`unknown message type: ${conf.type}`);
   }
 
-  var fn = api === 'stream' ? streamWrite : legacyWrite;
+  const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
   fn(conf.algo, message, encoding, conf.writes, conf.len);
 }
 
 function legacyWrite(algo, message, encoding, writes, len) {
-  var written = writes * len;
-  var bits = written * 8;
-  var gbits = bits / (1024 * 1024 * 1024);
-  var h = crypto.createHash(algo);
+  const written = writes * len;
+  const bits = written * 8;
+  const gbits = bits / (1024 * 1024 * 1024);
+  const h = crypto.createHash(algo);
 
   while (writes-- > 0)
     h.update(message, encoding);
@@ -59,10 +59,10 @@ function legacyWrite(algo, message, encoding, writes, len) {
 }
 
 function streamWrite(algo, message, encoding, writes, len) {
-  var written = writes * len;
-  var bits = written * 8;
-  var gbits = bits / (1024 * 1024 * 1024);
-  var h = crypto.createHash(algo);
+  const written = writes * len;
+  const bits = written * 8;
+  const gbits = bits / (1024 * 1024 * 1024);
+  const h = crypto.createHash(algo);
 
   while (writes-- > 0)
     h.write(message, encoding);

--- a/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
+++ b/benchmark/crypto/rsa-encrypt-decrypt-throughput.js
@@ -1,13 +1,13 @@
 'use strict';
 // throughput benchmark in signing and verifying
-var common = require('../common.js');
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
-var fixtures_keydir = path.resolve(__dirname, '../../test/fixtures/keys/');
-var keylen_list = ['1024', '2048', '4096'];
-var RSA_PublicPem = {};
-var RSA_PrivatePem = {};
+const common = require('../common.js');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const fixtures_keydir = path.resolve(__dirname, '../../test/fixtures/keys/');
+const keylen_list = ['1024', '2048', '4096'];
+const RSA_PublicPem = {};
+const RSA_PrivatePem = {};
 
 keylen_list.forEach(function(key) {
   RSA_PublicPem[key] =
@@ -16,27 +16,27 @@ keylen_list.forEach(function(key) {
     fs.readFileSync(`${fixtures_keydir}/rsa_private_${key}.pem`);
 });
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [500],
   keylen: keylen_list,
   len: [16, 32, 64]
 });
 
 function main(conf) {
-  var message = Buffer.alloc(conf.len, 'b');
+  const message = Buffer.alloc(conf.len, 'b');
   bench.start();
   StreamWrite(conf.algo, conf.keylen, message, conf.n, conf.len);
 }
 
 function StreamWrite(algo, keylen, message, n, len) {
-  var written = n * len;
-  var bits = written * 8;
-  var kbits = bits / (1024);
+  const written = n * len;
+  const bits = written * 8;
+  const kbits = bits / (1024);
 
-  var privateKey = RSA_PrivatePem[keylen];
-  var publicKey = RSA_PublicPem[keylen];
+  const privateKey = RSA_PrivatePem[keylen];
+  const publicKey = RSA_PublicPem[keylen];
   for (var i = 0; i < n; i++) {
-    var enc = crypto.privateEncrypt(privateKey, message);
+    const enc = crypto.privateEncrypt(privateKey, message);
     crypto.publicDecrypt(publicKey, enc);
   }
 

--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -1,13 +1,13 @@
 'use strict';
 // throughput benchmark in signing and verifying
-var common = require('../common.js');
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
-var fixtures_keydir = path.resolve(__dirname, '../../test/fixtures/keys/');
-var keylen_list = ['1024', '2048'];
-var RSA_PublicPem = {};
-var RSA_PrivatePem = {};
+const common = require('../common.js');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const fixtures_keydir = path.resolve(__dirname, '../../test/fixtures/keys/');
+const keylen_list = ['1024', '2048'];
+const RSA_PublicPem = {};
+const RSA_PrivatePem = {};
 
 keylen_list.forEach(function(key) {
   RSA_PublicPem[key] =
@@ -16,7 +16,7 @@ keylen_list.forEach(function(key) {
     fs.readFileSync(`${fixtures_keydir}/rsa_private_${key}.pem`);
 });
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   writes: [500],
   algo: ['SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512'],
   keylen: keylen_list,
@@ -24,19 +24,19 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var message = Buffer.alloc(conf.len, 'b');
+  const message = Buffer.alloc(conf.len, 'b');
   bench.start();
   StreamWrite(conf.algo, conf.keylen, message, conf.writes, conf.len);
 }
 
 function StreamWrite(algo, keylen, message, writes, len) {
-  var written = writes * len;
-  var bits = written * 8;
-  var kbits = bits / (1024);
+  const written = writes * len;
+  const bits = written * 8;
+  const kbits = bits / (1024);
 
-  var privateKey = RSA_PrivatePem[keylen];
-  var s = crypto.createSign(algo);
-  var v = crypto.createVerify(algo);
+  const privateKey = RSA_PrivatePem[keylen];
+  const s = crypto.createSign(algo);
+  const v = crypto.createVerify(algo);
 
   while (writes-- > 0) {
     s.update(message);

--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -7,7 +7,7 @@ const PORT = common.PORT;
 // `num` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [64, 256, 512, 1024],
   num: [100],
   chunks: [1, 2, 4, 8],
@@ -37,13 +37,13 @@ function main(conf) {
   server();
 }
 
-var dgram = require('dgram');
+const dgram = require('dgram');
 
 function server() {
   var sent = 0;
-  var socket = dgram.createSocket('udp4');
+  const socket = dgram.createSocket('udp4');
 
-  var onsend = type === 'concat' ? onsendConcat : onsendMulti;
+  const onsend = type === 'concat' ? onsendConcat : onsendMulti;
 
   function onsendConcat() {
     if (sent++ % num === 0) {
@@ -66,8 +66,8 @@ function server() {
     onsend();
 
     setTimeout(function() {
-      var bytes = sent * len;
-      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      const bytes = sent * len;
+      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
       process.exit(0);
     }, dur * 1000);

--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -7,7 +7,7 @@ const PORT = common.PORT;
 // `num` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [64, 256, 1024],
   num: [100],
   chunks: [1, 2, 4, 8],
@@ -37,12 +37,12 @@ function main(conf) {
   server();
 }
 
-var dgram = require('dgram');
+const dgram = require('dgram');
 
 function server() {
   var sent = 0;
   var received = 0;
-  var socket = dgram.createSocket('udp4');
+  const socket = dgram.createSocket('udp4');
 
   function onsend() {
     if (sent++ % num === 0) {
@@ -57,8 +57,8 @@ function server() {
     onsend();
 
     setTimeout(function() {
-      var bytes = (type === 'send' ? sent : received) * len;
-      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      const bytes = (type === 'send' ? sent : received) * len;
+      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
       process.exit(0);
     }, dur * 1000);

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -7,7 +7,7 @@ const PORT = common.PORT;
 // `num` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [1, 64, 256, 1024],
   num: [100],
   type: ['send', 'recv'],
@@ -29,12 +29,12 @@ function main(conf) {
   server();
 }
 
-var dgram = require('dgram');
+const dgram = require('dgram');
 
 function server() {
   var sent = 0;
   var received = 0;
-  var socket = dgram.createSocket('udp4');
+  const socket = dgram.createSocket('udp4');
 
   function onsend() {
     if (sent++ % num === 0) {
@@ -49,8 +49,8 @@ function server() {
     onsend();
 
     setTimeout(function() {
-      var bytes = (type === 'send' ? sent : received) * chunk.length;
-      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      const bytes = (type === 'send' ? sent : received) * chunk.length;
+      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
       process.exit(0);
     }, dur * 1000);

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -7,7 +7,7 @@ const PORT = common.PORT;
 // `num` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [1, 64, 256, 1024],
   num: [100],
   type: ['send', 'recv'],
@@ -29,12 +29,12 @@ function main(conf) {
   server();
 }
 
-var dgram = require('dgram');
+const dgram = require('dgram');
 
 function server() {
   var sent = 0;
   var received = 0;
-  var socket = dgram.createSocket('udp4');
+  const socket = dgram.createSocket('udp4');
 
   function onsend() {
     if (sent++ % num === 0) {
@@ -49,8 +49,8 @@ function server() {
     onsend();
 
     setTimeout(function() {
-      var bytes = (type === 'send' ? sent : received) * chunk.length;
-      var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+      const bytes = (type === 'send' ? sent : received) * chunk.length;
+      const gbits = (bytes * 8) / (1024 * 1024 * 1024);
       bench.end(gbits);
       process.exit(0);
     }, dur * 1000);

--- a/benchmark/domain/domain-fn-args.js
+++ b/benchmark/domain/domain-fn-args.js
@@ -1,19 +1,19 @@
 'use strict';
-var common = require('../common.js');
-var domain = require('domain');
+const common = require('../common.js');
+const domain = require('domain');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   arguments: [0, 1, 2, 3],
   n: [10]
 });
 
-var bdomain = domain.create();
-var gargs = [1, 2, 3];
+const bdomain = domain.create();
+const gargs = [1, 2, 3];
 
 function main(conf) {
 
-  var n = +conf.n;
-  var myArguments = gargs.slice(0, conf.arguments);
+  const n = +conf.n;
+  const myArguments = gargs.slice(0, conf.arguments);
   bench.start();
 
   bdomain.enter();

--- a/benchmark/es/destructuring-object-bench.js
+++ b/benchmark/es/destructuring-object-bench.js
@@ -9,13 +9,13 @@ const bench = common.createBenchmark(main, {
 
 function runNormal(n) {
   var i = 0;
-  var o = { x: 0, y: 1 };
+  const o = { x: 0, y: 1 };
   bench.start();
   for (; i < n; i++) {
     /* eslint-disable no-unused-vars */
-    var x = o.x;
-    var y = o.y;
-    var r = o.r || 2;
+    const x = o.x;
+    const y = o.y;
+    const r = o.r || 2;
     /* eslint-enable no-unused-vars */
   }
   bench.end(n / 1e6);
@@ -23,11 +23,11 @@ function runNormal(n) {
 
 function runDestructured(n) {
   var i = 0;
-  var o = { x: 0, y: 1 };
+  const o = { x: 0, y: 1 };
   bench.start();
   for (; i < n; i++) {
     /* eslint-disable no-unused-vars */
-    var { x, y, r = 2 } = o;
+    const { x, y, r = 2 } = o;
     /* eslint-enable no-unused-vars */
   }
   bench.end(n / 1e6);

--- a/benchmark/es/foreach-bench.js
+++ b/benchmark/es/foreach-bench.js
@@ -14,7 +14,7 @@ function useFor(n, items, count) {
   for (i = 0; i < n; i++) {
     for (j = 0; j < count; j++) {
       /* eslint-disable no-unused-vars */
-      var item = items[j];
+      const item = items[j];
       /* esline-enable no-unused-vars */
     }
   }

--- a/benchmark/es/restparams-bench.js
+++ b/benchmark/es/restparams-bench.js
@@ -9,8 +9,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function copyArguments() {
-  var len = arguments.length;
-  var args = new Array(len);
+  const len = arguments.length;
+  const args = new Array(len);
   for (var i = 0; i < len; i++)
     args[i] = arguments[i];
   assert.strictEqual(args[0], 1);

--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -1,14 +1,14 @@
 'use strict';
-var common = require('../common.js');
-var events = require('events');
+const common = require('../common.js');
+const events = require('events');
 
-var bench = common.createBenchmark(main, { n: [25e4] });
+const bench = common.createBenchmark(main, { n: [25e4] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new events.EventEmitter();
-  var listeners = [];
+  const ee = new events.EventEmitter();
+  const listeners = [];
 
   var k;
   for (k = 0; k < 10; k += 1)
@@ -16,7 +16,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
     for (k = listeners.length; --k >= 0; /* empty */) {
       ee.on(dummy, listeners[k]);
     }

--- a/benchmark/events/ee-emit-multi-args.js
+++ b/benchmark/events/ee-emit-multi-args.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [2e6] });
+const bench = common.createBenchmark(main, { n: [2e6] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
 
   for (var k = 0; k < 10; k += 1)
     ee.on('dummy', function() {});

--- a/benchmark/events/ee-emit.js
+++ b/benchmark/events/ee-emit.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [2e6] });
+const bench = common.createBenchmark(main, { n: [2e6] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
 
   for (var k = 0; k < 10; k += 1)
     ee.on('dummy', function() {});

--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [5e7] });
+const bench = common.createBenchmark(main, { n: [5e7] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {
     ee.on('dummy0', function() {});
@@ -16,7 +16,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
     ee.listenerCount(dummy);
   }
   bench.end(n);

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [5e6] });
+const bench = common.createBenchmark(main, { n: [5e6] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
   ee.setMaxListeners(101);
 
   for (var k = 0; k < 50; k += 1) {
@@ -17,7 +17,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
     ee.listeners(dummy);
   }
   bench.end(n);

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [5e6] });
+const bench = common.createBenchmark(main, { n: [5e6] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
 
   for (var k = 0; k < 5; k += 1) {
     ee.on('dummy0', function() {});
@@ -16,7 +16,7 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
     ee.listeners(dummy);
   }
   bench.end(n);

--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -1,19 +1,19 @@
 'use strict';
-var common = require('../common.js');
-var EventEmitter = require('events').EventEmitter;
+const common = require('../common.js');
+const EventEmitter = require('events').EventEmitter;
 
-var bench = common.createBenchmark(main, { n: [2e7] });
+const bench = common.createBenchmark(main, { n: [2e7] });
 
 function main(conf) {
-  var n = conf.n | 0;
+  const n = conf.n | 0;
 
-  var ee = new EventEmitter();
+  const ee = new EventEmitter();
 
   function listener() {}
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    const dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
     ee.once(dummy, listener);
     ee.emit(dummy);
   }

--- a/benchmark/fixtures/simple-http-server.js
+++ b/benchmark/fixtures/simple-http-server.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var http = require('http');
+const http = require('http');
 
-var fixed = 'C'.repeat(20 * 1024);
-var storedBytes = Object.create(null);
-var storedBuffer = Object.create(null);
-var storedUnicode = Object.create(null);
+const fixed = 'C'.repeat(20 * 1024);
+const storedBytes = Object.create(null);
+const storedBuffer = Object.create(null);
+const storedUnicode = Object.create(null);
 
-var useDomains = process.env.NODE_USE_DOMAINS;
+const useDomains = process.env.NODE_USE_DOMAINS;
 
 // set up one global domain.
 if (useDomains) {
   var domain = require('domain');
-  var gdom = domain.create();
+  const gdom = domain.create();
   gdom.on('error', function(er) {
     console.error('Error on global domain', er);
     throw er;
@@ -22,19 +22,19 @@ if (useDomains) {
 
 module.exports = http.createServer(function(req, res) {
   if (useDomains) {
-    var dom = domain.create();
+    const dom = domain.create();
     dom.add(req);
     dom.add(res);
   }
 
   // URL format: /<type>/<length>/<chunks>/<responseBehavior>/chunkedEnc
-  var params = req.url.split('/');
-  var command = params[1];
+  const params = req.url.split('/');
+  const command = params[1];
   var body = '';
-  var arg = params[2];
-  var n_chunks = parseInt(params[3], 10);
-  var resHow = (params.length >= 5 ? params[4] : 'normal');
-  var chunkedEnc = (params.length >= 6 && params[5] === 'false' ? false : true);
+  const arg = params[2];
+  const n_chunks = parseInt(params[3], 10);
+  const resHow = params.length >= 5 ? params[4] : 'normal';
+  const chunkedEnc = params.length >= 6 && params[5] === 'false' ? false : true;
   var status = 200;
 
   var n, i;
@@ -96,7 +96,7 @@ module.exports = http.createServer(function(req, res) {
 
   // example: http://localhost:port/bytes/512/4
   // sends a 512 byte body in 4 chunks of 128 bytes
-  var len = body.length;
+  const len = body.length;
   switch (resHow) {
     case 'setHeader':
       res.statusCode = status;
@@ -128,7 +128,7 @@ module.exports = http.createServer(function(req, res) {
   }
   // send body in chunks
   if (n_chunks > 1) {
-    var step = Math.floor(len / n_chunks) || 1;
+    const step = Math.floor(len / n_chunks) || 1;
     for (i = 0, n = (n_chunks - 1); i < n; ++i)
       res.write(body.slice(i * step, i * step + step));
     res.end(body.slice((n_chunks - 1) * step));

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -1,16 +1,16 @@
 // test the throughput of the fs.WriteStream class.
 'use strict';
 
-var path = require('path');
-var common = require('../common.js');
-var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
-var fs = require('fs');
-var filesize = 1000 * 1024 * 1024;
-var assert = require('assert');
+const path = require('path');
+const common = require('../common.js');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const fs = require('fs');
+const filesize = 1000 * 1024 * 1024;
+const assert = require('assert');
 
 var type, encoding, size;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: ['buf', 'asc', 'utf'],
   size: [1024, 4096, 65535, 1024 * 1024]
 });
@@ -38,7 +38,7 @@ function main(conf) {
 
 function runTest() {
   assert(fs.statSync(filename).size === filesize);
-  var rs = fs.createReadStream(filename, {
+  const rs = fs.createReadStream(filename, {
     highWaterMark: size,
     encoding: encoding
   });
@@ -60,7 +60,7 @@ function runTest() {
 }
 
 function makeFile() {
-  var buf = Buffer.allocUnsafe(filesize / 1024);
+  const buf = Buffer.allocUnsafe(filesize / 1024);
   if (encoding === 'utf8') {
     // ü
     for (var i = 0; i < buf.length; i++) {
@@ -74,7 +74,7 @@ function makeFile() {
 
   try { fs.unlinkSync(filename); } catch (e) {}
   var w = 1024;
-  var ws = fs.createWriteStream(filename);
+  const ws = fs.createWriteStream(filename);
   ws.on('close', runTest);
   ws.on('drain', write);
   write();

--- a/benchmark/fs/readFileSync.js
+++ b/benchmark/fs/readFileSync.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var common = require('../common.js');
-var fs = require('fs');
+const common = require('../common.js');
+const fs = require('fs');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [60e4]
 });
 
 function main(conf) {
-  var n = +conf.n;
+  const n = +conf.n;
 
   bench.start();
   for (var i = 0; i < n; ++i)

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -3,19 +3,19 @@
 // Yes, this is a silly benchmark.  Most benchmarks are silly.
 'use strict';
 
-var path = require('path');
-var common = require('../common.js');
-var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
-var fs = require('fs');
+const path = require('path');
+const common = require('../common.js');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const fs = require('fs');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   dur: [5],
   len: [1024, 16 * 1024 * 1024],
   concurrent: [1, 10]
 });
 
 function main(conf) {
-  var len = +conf.len;
+  const len = +conf.len;
   try { fs.unlinkSync(filename); } catch (e) {}
   var data = Buffer.alloc(len, 'x');
   fs.writeFileSync(filename, data);

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -1,21 +1,21 @@
 // test the throughput of the fs.WriteStream class.
 'use strict';
 
-var path = require('path');
-var common = require('../common.js');
-var filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
-var fs = require('fs');
+const path = require('path');
+const common = require('../common.js');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const fs = require('fs');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   dur: [5],
   type: ['buf', 'asc', 'utf'],
   size: [2, 1024, 65535, 1024 * 1024]
 });
 
 function main(conf) {
-  var dur = +conf.dur;
-  var type = conf.type;
-  var size = +conf.size;
+  const dur = +conf.dur;
+  const type = conf.type;
+  const size = +conf.size;
   var encoding;
 
   var chunk;
@@ -51,7 +51,7 @@ function main(conf) {
   f.on('close', done);
   f.on('finish', function() {
     ended = true;
-    var written = fs.statSync(filename).size / 1024;
+    const written = fs.statSync(filename).size / 1024;
     try { fs.unlinkSync(filename); } catch (e) {}
     bench.end(written / 1024);
   });

--- a/benchmark/http/_chunky_http_client.js
+++ b/benchmark/http/_chunky_http_client.js
@@ -1,10 +1,10 @@
 'use strict';
 
 // test HTTP throughput in fragmented header case
-var common = require('../common.js');
-var net = require('net');
+const common = require('../common.js');
+const net = require('net');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len:  [1, 4, 8, 16, 32, 64, 128],
   n:  [5, 50, 500, 2000],
   type: ['send'],
@@ -12,10 +12,10 @@ var bench = common.createBenchmark(main, {
 
 
 function main(conf) {
-  var len = +conf.len;
-  var num = +conf.n;
+  const len = +conf.len;
+  const num = +conf.n;
   var todo = [];
-  var headers = [];
+  const headers = [];
   // Chose 7 because 9 showed "Connection error" / "Connection closed"
   // An odd number could result in a better length dispersion.
   for (var i = 7; i <= 7 * 7 * 7; i *= 7)
@@ -42,20 +42,20 @@ function main(conf) {
     todo.push('');
     todo = todo.join('\r\n');
     // Using odd numbers in many places may increase length coverage.
-    var chunksize = 37;
+    const chunksize = 37;
     for (i = 0; i < todo.length; i += chunksize) {
-      var cur = todo.slice(i, i + chunksize);
+      const cur = todo.slice(i, i + chunksize);
       channel.write(cur);
     }
   }
 
-  var min = 10;
+  const min = 10;
   var size = 0;
-  var mod = 317;
-  var mult = 17;
-  var add = 11;
+  const mod = 317;
+  const mult = 17;
+  const add = 11;
   var count = 0;
-  var PIPE = process.env.PIPE_NAME;
+  const PIPE = process.env.PIPE_NAME;
   var socket = net.connect(PIPE, function() {
     bench.start();
     WriteHTTPHeaders(socket, 1, len);

--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -31,8 +31,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var key = conf.key;
+  const n = +conf.n;
+  const key = conf.key;
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/http/check_is_http_token.js
+++ b/benchmark/http/check_is_http_token.js
@@ -41,8 +41,8 @@ const bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var key = conf.key;
+  const n = +conf.n;
+  const key = conf.key;
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/http/chunked.js
+++ b/benchmark/http/chunked.js
@@ -8,9 +8,9 @@
 // Verify that our assumptions are valid.
 'use strict';
 
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [1, 4, 8, 16],
   len: [1, 64, 256],
   c: [100]
@@ -18,9 +18,9 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   const http = require('http');
-  var chunk = Buffer.alloc(conf.len, '8');
+  const chunk = Buffer.alloc(conf.len, '8');
 
-  var server = http.createServer(function(req, res) {
+  const server = http.createServer(function(req, res) {
     function send(left) {
       if (left === 0) return res.end();
       res.write(chunk);

--- a/benchmark/http/client-request-body.js
+++ b/benchmark/http/client-request-body.js
@@ -1,10 +1,10 @@
 // Measure the time it takes for the HTTP client to send a request body.
 'use strict';
 
-var common = require('../common.js');
-var http = require('http');
+const common = require('../common.js');
+const http = require('http');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   dur: [5],
   type: ['asc', 'utf', 'buf'],
   len: [32, 256, 1024],
@@ -12,8 +12,8 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var dur = +conf.dur;
-  var len = +conf.len;
+  const dur = +conf.dur;
+  const len = +conf.len;
 
   var encoding;
   var chunk;
@@ -31,7 +31,7 @@ function main(conf) {
   }
 
   var nreqs = 0;
-  var options = {
+  const options = {
     headers: { 'Connection': 'keep-alive', 'Transfer-Encoding': 'chunked' },
     agent: new http.Agent({ maxSockets: 1 }),
     host: '127.0.0.1',
@@ -40,7 +40,7 @@ function main(conf) {
     method: 'POST'
   };
 
-  var server = http.createServer(function(req, res) {
+  const server = http.createServer(function(req, res) {
     res.end();
   });
   server.listen(options.port, options.host, function() {
@@ -50,7 +50,7 @@ function main(conf) {
   });
 
   function pummel() {
-    var req = http.request(options, function(res) {
+    const req = http.request(options, function(res) {
       nreqs++;
       pummel();  // Line up next request.
       res.resume();

--- a/benchmark/http/cluster.js
+++ b/benchmark/http/cluster.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var cluster = require('cluster');
+const cluster = require('cluster');
 if (cluster.isMaster) {
   var bench = common.createBenchmark(main, {
     // unicode confuses ab on os x.
@@ -11,15 +11,15 @@ if (cluster.isMaster) {
     c: [50, 500]
   });
 } else {
-  var port = parseInt(process.env.PORT || PORT);
+  const port = parseInt(process.env.PORT || PORT);
   require('../fixtures/simple-http-server.js').listen(port);
 }
 
 function main(conf) {
   process.env.PORT = PORT;
   var workers = 0;
-  var w1 = cluster.fork();
-  var w2 = cluster.fork();
+  const w1 = cluster.fork();
+  const w2 = cluster.fork();
 
   cluster.on('listening', function() {
     workers++;
@@ -27,7 +27,7 @@ function main(conf) {
       return;
 
     setTimeout(function() {
-      var path = `/${conf.type}/${conf.len}`;
+      const path = `/${conf.type}/${conf.len}`;
 
       bench.http({
         path: path,

--- a/benchmark/http/create-clientrequest.js
+++ b/benchmark/http/create-clientrequest.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var common = require('../common.js');
-var ClientRequest = require('http').ClientRequest;
+const common = require('../common.js');
+const ClientRequest = require('http').ClientRequest;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [1, 8, 16, 32, 64, 128],
   n: [1e6]
 });
 
 function main(conf) {
-  var len = +conf.len;
-  var n = +conf.n;
+  const len = +conf.len;
+  const n = +conf.n;
 
-  var path = '/'.repeat(len);
-  var opts = { path: path, createConnection: function() {} };
+  const path = '/'.repeat(len);
+  const opts = { path: path, createConnection: function() {} };
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/http/end-vs-write-end.js
+++ b/benchmark/http/end-vs-write-end.js
@@ -8,9 +8,9 @@
 // Verify that our assumptions are valid.
 'use strict';
 
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: ['asc', 'utf', 'buf'],
   len: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   c: [100],
@@ -20,7 +20,7 @@ var bench = common.createBenchmark(main, {
 function main(conf) {
   const http = require('http');
   var chunk;
-  var len = conf.len;
+  const len = conf.len;
   switch (conf.type) {
     case 'buf':
       chunk = Buffer.alloc(len, 'x');
@@ -42,9 +42,9 @@ function main(conf) {
     res.end(chunk);
   }
 
-  var method = conf.method === 'write' ? write : end;
+  const method = conf.method === 'write' ? write : end;
 
-  var server = http.createServer(function(req, res) {
+  const server = http.createServer(function(req, res) {
     method(res);
   });
 

--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var assert = require('assert');
-var http = require('http');
-var fs = require('fs');
-var { fork } = require('child_process');
-var common = require('../common.js');
+const assert = require('assert');
+const http = require('http');
+const fs = require('fs');
+const { fork } = require('child_process');
+const common = require('../common.js');
 const { PIPE, tmpDir } = require('../../test/common');
 process.env.PIPE_NAME = PIPE;
 
@@ -20,7 +20,7 @@ try {
 } catch (e) { /* ignore */ }
 
 server = http.createServer(function(req, res) {
-  var headers = {
+  const headers = {
     'content-type': 'text/plain',
     'content-length': '2'
   };

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   // unicode confuses ab on os x.
   type: ['bytes', 'buffer'],
   len: [4, 1024, 102400],
@@ -17,7 +17,7 @@ function main(conf) {
   var server = require('../fixtures/simple-http-server.js')
   .listen(process.env.PORT || common.PORT)
   .on('listening', function() {
-    var path =
+    const path =
       `/${conf.type}/${conf.len}/${conf.chunks}/${conf.res}/${conf.chunkedEnc}`;
 
     bench.http({

--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [1e3],
   nheaders: [0, 10, 100, 1000],
 }, { flags: ['--expose-http2', '--no-warnings'] });

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 const file = path.join(path.resolve(__dirname, '../fixtures'), 'alice.html');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   requests: [100, 1000, 10000, 100000, 1000000],
   streams: [100, 200, 1000],
   clients: [1, 2]

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 
 const file = path.join(path.resolve(__dirname, '../fixtures'), 'alice.html');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   requests: [100, 1000, 10000, 100000],
   streams: [100, 200, 1000],
   clients: [1, 2]

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
 }, { flags: ['--expose-http2', '--no-warnings'] });

--- a/benchmark/misc/console.js
+++ b/benchmark/misc/console.js
@@ -12,7 +12,7 @@ const methods = [
   'restAndConcat'
 ];
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   method: methods,
   concat: [1, 0],
   n: [1000000]

--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [100000]
 }, {
   flags: ['--expose-internals']
@@ -10,12 +10,12 @@ var bench = common.createBenchmark(main, {
 
 function main(conf) {
   const FreeList = require('internal/freelist');
-  var n = conf.n;
-  var poolSize = 1000;
-  var list = new FreeList('test', poolSize, Object);
+  const n = conf.n;
+  const poolSize = 1000;
+  const list = new FreeList('test', poolSize, Object);
   var i;
   var j;
-  var used = [];
+  const used = [];
 
   // First, alloc `poolSize` items
   for (j = 0; j < poolSize; j++) {

--- a/benchmark/misc/function_call/index.js
+++ b/benchmark/misc/function_call/index.js
@@ -4,8 +4,8 @@
 // Note that JS speed goes up, while cxx speed stays about the same.
 'use strict';
 
-var assert = require('assert');
-var common = require('../../common.js');
+const assert = require('assert');
+const common = require('../../common.js');
 
 // this fails when we try to open with a different version of node,
 // which is quite common for benchmarks.  so in that case, just
@@ -17,7 +17,7 @@ try {
   console.error('misc/function_call.js Binding failed to load');
   process.exit(0);
 }
-var cxx = binding.hello;
+const cxx = binding.hello;
 
 var c = 0;
 function js() {
@@ -26,15 +26,15 @@ function js() {
 
 assert(js() === cxx());
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: ['js', 'cxx'],
   millions: [1, 10, 50]
 });
 
 function main(conf) {
-  var n = +conf.millions * 1e6;
+  const n = +conf.millions * 1e6;
 
-  var fn = conf.type === 'cxx' ? cxx : js;
+  const fn = conf.type === 'cxx' ? cxx : js;
   bench.start();
   for (var i = 0; i < n; i++) {
     fn();

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common.js');
-var spawn = require('child_process').spawn;
-var path = require('path');
-var emptyJsFile = path.resolve(__dirname, '../../test/fixtures/semicolon.js');
+const common = require('../common.js');
+const spawn = require('child_process').spawn;
+const path = require('path');
+const emptyJsFile = path.resolve(__dirname, '../../test/fixtures/semicolon.js');
 
-var bench = common.createBenchmark(startNode, {
+const bench = common.createBenchmark(startNode, {
   dur: [1]
 });
 
 function startNode(conf) {
-  var dur = +conf.dur;
+  const dur = +conf.dur;
   var go = true;
   var starts = 0;
 
@@ -21,7 +21,7 @@ function startNode(conf) {
   start();
 
   function start() {
-    var node = spawn(process.execPath || process.argv[0], [emptyJsFile]);
+    const node = spawn(process.execPath || process.argv[0], [emptyJsFile]);
     node.on('exit', function(exitCode) {
       if (exitCode !== 0) {
         throw new Error('Error during node startup');

--- a/benchmark/misc/util-extend-vs-object-assign.js
+++ b/benchmark/misc/util-extend-vs-object-assign.js
@@ -23,7 +23,7 @@ function main(conf) {
   for (var i = 0; i < conf.type.length * 10; i += 1)
     fn({}, process.env);
 
-  var obj = new Proxy({}, { set: function(a, b, c) { return true; } });
+  const obj = new Proxy({}, { set: function(a, b, c) { return true; } });
 
   bench.start();
   for (var j = 0; j < n; j += 1)

--- a/benchmark/misc/v8-bench.js
+++ b/benchmark/misc/v8-bench.js
@@ -1,11 +1,11 @@
 // compare with "google-chrome deps/v8/benchmarks/run.html"
 'use strict';
-var fs = require('fs');
-var path = require('path');
-var vm = require('vm');
-var common = require('../common.js');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const common = require('../common.js');
 
-var dir = path.join(__dirname, '..', '..', 'deps', 'v8', 'benchmarks');
+const dir = path.join(__dirname, '..', '..', 'deps', 'v8', 'benchmarks');
 
 function load(filename, inGlobal) {
   var source = fs.readFileSync(path.join(dir, filename), 'utf8');

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -1,19 +1,19 @@
 'use strict';
-var fs = require('fs');
-var path = require('path');
-var common = require('../common.js');
+const fs = require('fs');
+const path = require('path');
+const common = require('../common.js');
 
-var tmpDirectory = path.join(__dirname, '..', 'tmp');
-var benchmarkDirectory = path.join(tmpDirectory, 'nodejs-benchmark-module');
+const tmpDirectory = path.join(__dirname, '..', 'tmp');
+const benchmarkDirectory = path.join(tmpDirectory, 'nodejs-benchmark-module');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [50],
   fullPath: ['true', 'false'],
   useCache: ['true', 'false']
 });
 
 function main(conf) {
-  var n = +conf.thousands * 1e3;
+  const n = +conf.thousands * 1e3;
 
   rmrf(tmpDirectory);
   try { fs.mkdirSync(tmpDirectory); } catch (e) {}
@@ -69,7 +69,7 @@ function measureDir(n, useCache) {
 
 function rmrf(location) {
   try {
-    var things = fs.readdirSync(location);
+    const things = fs.readdirSync(location);
     things.forEach(function(thing) {
       var cur = path.join(location, thing),
         isDirectory = fs.statSync(cur).isDirectory();

--- a/benchmark/net/net-c2s-cork.js
+++ b/benchmark/net/net-c2s-cork.js
@@ -1,10 +1,10 @@
 // test the speed of .pipe() with sockets
 'use strict';
 
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [4, 8, 16, 32, 64, 128, 512, 1024],
   type: ['buf'],
   dur: [5],
@@ -40,7 +40,7 @@ function main(conf) {
   server();
 }
 
-var net = require('net');
+const net = require('net');
 
 function Writer() {
   this.received = 0;
@@ -65,15 +65,15 @@ Writer.prototype.emit = function() {};
 Writer.prototype.prependListener = function() {};
 
 function server() {
-  var writer = new Writer();
+  const writer = new Writer();
 
   // the actual benchmark.
-  var server = net.createServer(function(socket) {
+  const server = net.createServer(function(socket) {
     socket.pipe(writer);
   });
 
   server.listen(PORT, function() {
-    var socket = net.connect(PORT);
+    const socket = net.connect(PORT);
     socket.on('connect', function() {
       bench.start();
 
@@ -81,8 +81,8 @@ function server() {
       send();
 
       setTimeout(function() {
-        var bytes = writer.received;
-        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        const bytes = writer.received;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);
         process.exit(0);
       }, dur * 1000);

--- a/benchmark/net/net-c2s.js
+++ b/benchmark/net/net-c2s.js
@@ -1,10 +1,10 @@
 // test the speed of .pipe() with sockets
 'use strict';
 
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
@@ -40,7 +40,7 @@ function main(conf) {
   server();
 }
 
-var net = require('net');
+const net = require('net');
 
 function Writer() {
   this.received = 0;
@@ -66,8 +66,8 @@ Writer.prototype.prependListener = function() {};
 
 
 function flow() {
-  var dest = this.dest;
-  var res = dest.write(chunk, encoding);
+  const dest = this.dest;
+  const res = dest.write(chunk, encoding);
   if (!res)
     dest.once('drain', this.flow);
   else
@@ -87,24 +87,24 @@ Reader.prototype.pipe = function(dest) {
 
 
 function server() {
-  var reader = new Reader();
-  var writer = new Writer();
+  const reader = new Reader();
+  const writer = new Writer();
 
   // the actual benchmark.
-  var server = net.createServer(function(socket) {
+  const server = net.createServer(function(socket) {
     socket.pipe(writer);
   });
 
   server.listen(PORT, function() {
-    var socket = net.connect(PORT);
+    const socket = net.connect(PORT);
     socket.on('connect', function() {
       bench.start();
 
       reader.pipe(socket);
 
       setTimeout(function() {
-        var bytes = writer.received;
-        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        const bytes = writer.received;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);
         process.exit(0);
       }, dur * 1000);

--- a/benchmark/net/net-pipe.js
+++ b/benchmark/net/net-pipe.js
@@ -1,10 +1,10 @@
 // test the speed of .pipe() with sockets
 'use strict';
 
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5],
@@ -40,7 +40,7 @@ function main(conf) {
   server();
 }
 
-var net = require('net');
+const net = require('net');
 
 function Writer() {
   this.received = 0;
@@ -66,8 +66,8 @@ Writer.prototype.prependListener = function() {};
 
 
 function flow() {
-  var dest = this.dest;
-  var res = dest.write(chunk, encoding);
+  const dest = this.dest;
+  const res = dest.write(chunk, encoding);
   if (!res)
     dest.once('drain', this.flow);
   else
@@ -87,16 +87,16 @@ Reader.prototype.pipe = function(dest) {
 
 
 function server() {
-  var reader = new Reader();
-  var writer = new Writer();
+  const reader = new Reader();
+  const writer = new Writer();
 
   // the actual benchmark.
-  var server = net.createServer(function(socket) {
+  const server = net.createServer(function(socket) {
     socket.pipe(socket);
   });
 
   server.listen(PORT, function() {
-    var socket = net.connect(PORT);
+    const socket = net.connect(PORT);
     socket.on('connect', function() {
       bench.start();
 
@@ -106,8 +106,8 @@ function server() {
       setTimeout(function() {
         // multiply by 2 since we're sending it first one way
         // then then back again.
-        var bytes = writer.received * 2;
-        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        const bytes = writer.received * 2;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);
         process.exit(0);
       }, dur * 1000);

--- a/benchmark/net/net-s2c.js
+++ b/benchmark/net/net-s2c.js
@@ -1,10 +1,10 @@
 // test the speed of .pipe() with sockets
 'use strict';
 
-var common = require('../common.js');
-var PORT = common.PORT;
+const common = require('../common.js');
+const PORT = common.PORT;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
@@ -40,7 +40,7 @@ function main(conf) {
   server();
 }
 
-var net = require('net');
+const net = require('net');
 
 function Writer() {
   this.received = 0;
@@ -66,8 +66,8 @@ Writer.prototype.prependListener = function() {};
 
 
 function flow() {
-  var dest = this.dest;
-  var res = dest.write(chunk, encoding);
+  const dest = this.dest;
+  const res = dest.write(chunk, encoding);
   if (!res)
     dest.once('drain', this.flow);
   else
@@ -87,24 +87,24 @@ Reader.prototype.pipe = function(dest) {
 
 
 function server() {
-  var reader = new Reader();
-  var writer = new Writer();
+  const reader = new Reader();
+  const writer = new Writer();
 
   // the actual benchmark.
-  var server = net.createServer(function(socket) {
+  const server = net.createServer(function(socket) {
     reader.pipe(socket);
   });
 
   server.listen(PORT, function() {
-    var socket = net.connect(PORT);
+    const socket = net.connect(PORT);
     socket.on('connect', function() {
       bench.start();
 
       socket.pipe(writer);
 
       setTimeout(function() {
-        var bytes = writer.received;
-        var gbits = (bytes * 8) / (1024 * 1024 * 1024);
+        const bytes = writer.received;
+        const gbits = (bytes * 8) / (1024 * 1024 * 1024);
         bench.end(gbits);
         process.exit(0);
       }, dur * 1000);

--- a/benchmark/net/tcp-raw-c2s.js
+++ b/benchmark/net/tcp-raw-c2s.js
@@ -2,22 +2,22 @@
 // as many bytes as we can in the specified time (default = 10s)
 'use strict';
 
-var common = require('../common.js');
-var util = require('util');
+const common = require('../common.js');
+const util = require('util');
 
 // if there are --dur=N and --len=N args, then
 // run the function with those settings.
 // if not, then queue up a bunch of child processes.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 });
 
-var TCP = process.binding('tcp_wrap').TCP;
-var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
-var WriteWrap = process.binding('stream_wrap').WriteWrap;
-var PORT = common.PORT;
+const TCP = process.binding('tcp_wrap').TCP;
+const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
+const PORT = common.PORT;
 
 var dur;
 var len;
@@ -36,7 +36,7 @@ function fail(err, syscall) {
 }
 
 function server() {
-  var serverHandle = new TCP();
+  const serverHandle = new TCP();
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
@@ -92,9 +92,9 @@ function client() {
       throw new Error(`invalid type: ${type}`);
   }
 
-  var clientHandle = new TCP();
-  var connectReq = new TCPConnectWrap();
-  var err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
+  const clientHandle = new TCP();
+  const connectReq = new TCPConnectWrap();
+  const err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
 
   if (err)
     fail(err, 'connect');
@@ -110,7 +110,7 @@ function client() {
   };
 
   function write() {
-    var writeReq = new WriteWrap();
+    const writeReq = new WriteWrap();
     writeReq.oncomplete = afterWrite;
     var err;
     switch (type) {

--- a/benchmark/net/tcp-raw-pipe.js
+++ b/benchmark/net/tcp-raw-pipe.js
@@ -2,22 +2,22 @@
 // as many bytes as we can in the specified time (default = 10s)
 'use strict';
 
-var common = require('../common.js');
-var util = require('util');
+const common = require('../common.js');
+const util = require('util');
 
 // if there are --dur=N and --len=N args, then
 // run the function with those settings.
 // if not, then queue up a bunch of child processes.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 });
 
-var TCP = process.binding('tcp_wrap').TCP;
-var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
-var WriteWrap = process.binding('stream_wrap').WriteWrap;
-var PORT = common.PORT;
+const TCP = process.binding('tcp_wrap').TCP;
+const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
+const PORT = common.PORT;
 
 var dur;
 var len;
@@ -35,7 +35,7 @@ function fail(err, syscall) {
 }
 
 function server() {
-  var serverHandle = new TCP();
+  const serverHandle = new TCP();
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
@@ -54,7 +54,7 @@ function server() {
       if (nread < 0)
         fail(nread, 'read');
 
-      var writeReq = new WriteWrap();
+      const writeReq = new WriteWrap();
       writeReq.async = false;
       err = clientHandle.writeBuffer(writeReq, buffer);
 
@@ -89,9 +89,9 @@ function client() {
       throw new Error(`invalid type: ${type}`);
   }
 
-  var clientHandle = new TCP();
-  var connectReq = new TCPConnectWrap();
-  var err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
+  const clientHandle = new TCP();
+  const connectReq = new TCPConnectWrap();
+  const err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
   var bytes = 0;
 
   if (err)
@@ -124,7 +124,7 @@ function client() {
   };
 
   function write() {
-    var writeReq = new WriteWrap();
+    const writeReq = new WriteWrap();
     writeReq.oncomplete = afterWrite;
     var err;
     switch (type) {

--- a/benchmark/net/tcp-raw-s2c.js
+++ b/benchmark/net/tcp-raw-s2c.js
@@ -2,22 +2,22 @@
 // as many bytes as we can in the specified time (default = 10s)
 'use strict';
 
-var common = require('../common.js');
-var util = require('util');
+const common = require('../common.js');
+const util = require('util');
 
 // if there are dur=N and len=N args, then
 // run the function with those settings.
 // if not, then queue up a bunch of child processes.
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   len: [102400, 1024 * 1024 * 16],
   type: ['utf', 'asc', 'buf'],
   dur: [5]
 });
 
-var TCP = process.binding('tcp_wrap').TCP;
-var TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
-var WriteWrap = process.binding('stream_wrap').WriteWrap;
-var PORT = common.PORT;
+const TCP = process.binding('tcp_wrap').TCP;
+const TCPConnectWrap = process.binding('tcp_wrap').TCPConnectWrap;
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
+const PORT = common.PORT;
 
 var dur;
 var len;
@@ -35,7 +35,7 @@ function fail(err, syscall) {
 }
 
 function server() {
-  var serverHandle = new TCP();
+  const serverHandle = new TCP();
   var err = serverHandle.bind('127.0.0.1', PORT);
   if (err)
     fail(err, 'bind');
@@ -69,7 +69,7 @@ function server() {
       write();
 
     function write() {
-      var writeReq = new WriteWrap();
+      const writeReq = new WriteWrap();
       writeReq.async = false;
       writeReq.oncomplete = afterWrite;
       var err;
@@ -107,9 +107,9 @@ function server() {
 }
 
 function client() {
-  var clientHandle = new TCP();
-  var connectReq = new TCPConnectWrap();
-  var err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
+  const clientHandle = new TCP();
+  const connectReq = new TCPConnectWrap();
+  const err = clientHandle.connect(connectReq, '127.0.0.1', PORT);
 
   if (err)
     fail(err, 'connect');

--- a/benchmark/path/basename-posix.js
+++ b/benchmark/path/basename-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   pathext: [
     '',
     '/',
@@ -19,11 +19,11 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
+  const n = +conf.n;
+  const p = path.posix;
   var input = String(conf.pathext);
   var ext;
-  var extIdx = input.indexOf('|');
+  const extIdx = input.indexOf('|');
   if (extIdx !== -1) {
     ext = input.slice(extIdx + 1);
     input = input.slice(0, extIdx);

--- a/benchmark/path/basename-win32.js
+++ b/benchmark/path/basename-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   pathext: [
     '',
     'C:\\',
@@ -19,11 +19,11 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
+  const n = +conf.n;
+  const p = path.win32;
   var input = String(conf.pathext);
   var ext;
-  var extIdx = input.indexOf('|');
+  const extIdx = input.indexOf('|');
   if (extIdx !== -1) {
     ext = input.slice(extIdx + 1);
     input = input.slice(0, extIdx);

--- a/benchmark/path/dirname-posix.js
+++ b/benchmark/path/dirname-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '/',
@@ -16,9 +16,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.posix;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/dirname-win32.js
+++ b/benchmark/path/dirname-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '\\',
@@ -16,9 +16,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/extname-posix.js
+++ b/benchmark/path/extname-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '/',
@@ -19,9 +19,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.posix;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/extname-win32.js
+++ b/benchmark/path/extname-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '\\',
@@ -19,9 +19,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/format-posix.js
+++ b/benchmark/path/format-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   props: [
     ['/', '/home/user/dir', 'index.html', '.html', 'index'].join('|')
   ],
@@ -10,10 +10,10 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var props = String(conf.props).split('|');
-  var obj = {
+  const n = +conf.n;
+  const p = path.posix;
+  const props = String(conf.props).split('|');
+  const obj = {
     root: props[0] || '',
     dir: props[1] || '',
     base: props[2] || '',

--- a/benchmark/path/format-win32.js
+++ b/benchmark/path/format-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   props: [
     ['C:\\', 'C:\\path\\dir', 'index.html', '.html', 'index'].join('|')
   ],
@@ -10,10 +10,10 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var props = String(conf.props).split('|');
-  var obj = {
+  const n = +conf.n;
+  const p = path.win32;
+  const props = String(conf.props).split('|');
+  const obj = {
     root: props[0] || '',
     dir: props[1] || '',
     base: props[2] || '',

--- a/benchmark/path/isAbsolute-posix.js
+++ b/benchmark/path/isAbsolute-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '.',
@@ -14,9 +14,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.posix;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/isAbsolute-win32.js
+++ b/benchmark/path/isAbsolute-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '.',
@@ -15,9 +15,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/join-posix.js
+++ b/benchmark/path/join-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     ['/foo', 'bar', '', 'baz/asdf', 'quux', '..'].join('|')
   ],
@@ -10,9 +10,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var args = String(conf.paths).split('|');
+  const n = +conf.n;
+  const p = path.posix;
+  const args = String(conf.paths).split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/join-win32.js
+++ b/benchmark/path/join-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     ['C:\\foo', 'bar', '', 'baz\\asdf', 'quux', '..'].join('|')
   ],
@@ -10,9 +10,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var args = String(conf.paths).split('|');
+  const n = +conf.n;
+  const p = path.win32;
+  const args = String(conf.paths).split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/makeLong-win32.js
+++ b/benchmark/path/makeLong-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     'foo\\bar',
     'C:\\foo',
@@ -13,9 +13,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/normalize-posix.js
+++ b/benchmark/path/normalize-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '.',
@@ -15,9 +15,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.posix;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/normalize-win32.js
+++ b/benchmark/path/normalize-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '.',
@@ -15,9 +15,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/parse-posix.js
+++ b/benchmark/path/parse-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     '/',
@@ -16,9 +16,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.posix;
+  const input = String(conf.path);
 
   for (var i = 0; i < n; i++) {
     p.parse(input);

--- a/benchmark/path/parse-win32.js
+++ b/benchmark/path/parse-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   path: [
     '',
     'C:\\',
@@ -17,9 +17,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var input = String(conf.path);
+  const n = +conf.n;
+  const p = path.win32;
+  const input = String(conf.path);
 
   for (var i = 0; i < n; i++) {
     p.parse(input);

--- a/benchmark/path/relative-posix.js
+++ b/benchmark/path/relative-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     ['/data/orandea/test/aaa', '/data/orandea/impl/bbb'].join('|'),
     ['/', '/var'].join('|'),
@@ -16,11 +16,11 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
+  const n = +conf.n;
+  const p = path.posix;
   var from = String(conf.paths);
   var to = '';
-  var delimIdx = from.indexOf('|');
+  const delimIdx = from.indexOf('|');
   if (delimIdx > -1) {
     to = from.slice(delimIdx + 1);
     from = from.slice(0, delimIdx);

--- a/benchmark/path/relative-win32.js
+++ b/benchmark/path/relative-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     ['C:\\orandea\\test\\aaa', 'C:\\orandea\\impl\\bbb'].join('|'),
     ['C:\\', 'D:\\'].join('|'),
@@ -14,11 +14,11 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
+  const n = +conf.n;
+  const p = path.win32;
   var from = String(conf.paths);
   var to = '';
-  var delimIdx = from.indexOf('|');
+  const delimIdx = from.indexOf('|');
   if (delimIdx > -1) {
     to = from.slice(delimIdx + 1);
     from = from.slice(0, delimIdx);

--- a/benchmark/path/resolve-posix.js
+++ b/benchmark/path/resolve-posix.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     '',
     ['', ''].join('|'),
@@ -13,9 +13,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.posix;
-  var args = String(conf.paths).split('|');
+  const n = +conf.n;
+  const p = path.posix;
+  const args = String(conf.paths).split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/path/resolve-win32.js
+++ b/benchmark/path/resolve-win32.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var path = require('path');
+const common = require('../common.js');
+const path = require('path');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   paths: [
     '',
     ['', ''].join('|'),
@@ -13,9 +13,9 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var p = path.win32;
-  var args = String(conf.paths).split('|');
+  const n = +conf.n;
+  const p = path.win32;
+  const args = String(conf.paths).split('|');
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/process/memoryUsage.js
+++ b/benchmark/process/memoryUsage.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   n: [1e5]
 });
 
 function main(conf) {
-  var n = +conf.n;
+  const n = +conf.n;
 
   bench.start();
   for (var i = 0; i < n; i++) {

--- a/benchmark/process/next-tick-breadth-args.js
+++ b/benchmark/process/next-tick-breadth-args.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   millions: [2]
 });
 
 function main(conf) {
-  var N = +conf.millions * 1e6;
+  const N = +conf.millions * 1e6;
   var n = 0;
 
   function cb1(arg1) {

--- a/benchmark/process/next-tick-breadth.js
+++ b/benchmark/process/next-tick-breadth.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   millions: [2]
 });
 
 function main(conf) {
-  var N = +conf.millions * 1e6;
+  const N = +conf.millions * 1e6;
   var n = 0;
 
   function cb() {

--- a/benchmark/process/next-tick-depth-args.js
+++ b/benchmark/process/next-tick-depth-args.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   millions: [12]
 });
 

--- a/benchmark/process/next-tick-depth.js
+++ b/benchmark/process/next-tick-depth.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   millions: [12]
 });
 

--- a/benchmark/querystring/querystring-parse.js
+++ b/benchmark/querystring/querystring-parse.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common.js');
-var querystring = require('querystring');
-var inputs = require('../fixtures/url-inputs.js').searchParams;
+const common = require('../common.js');
+const querystring = require('querystring');
+const inputs = require('../fixtures/url-inputs.js').searchParams;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: Object.keys(inputs),
   n: [1e6],
 });
 
 function main(conf) {
-  var type = conf.type;
-  var n = conf.n | 0;
-  var input = inputs[type];
+  const type = conf.type;
+  const n = conf.n | 0;
+  const input = inputs[type];
   var i;
   // Execute the function a "sufficient" number of times before the timed
   // loop to ensure the function is optimized just once.

--- a/benchmark/querystring/querystring-stringify.js
+++ b/benchmark/querystring/querystring-stringify.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common.js');
-var querystring = require('querystring');
+const common = require('../common.js');
+const querystring = require('querystring');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: ['noencode', 'encodemany', 'encodelast'],
   n: [1e7],
 });
 
 function main(conf) {
-  var type = conf.type;
-  var n = conf.n | 0;
+  const type = conf.type;
+  const n = conf.n | 0;
 
-  var inputs = {
+  const inputs = {
     noencode: {
       foo: 'bar',
       baz: 'quux',
@@ -28,11 +28,11 @@ function main(conf) {
       xyzzy: 'thu\u00AC'
     }
   };
-  var input = inputs[type];
+  const input = inputs[type];
 
   // Force-optimize querystring.stringify() so that the benchmark doesn't get
   // disrupted by the optimizer kicking in halfway through.
-  for (var name in inputs)
+  for (const name in inputs)
     querystring.stringify(inputs[name]);
 
   bench.start();

--- a/benchmark/querystring/querystring-unescapebuffer.js
+++ b/benchmark/querystring/querystring-unescapebuffer.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var querystring = require('querystring');
+const common = require('../common.js');
+const querystring = require('querystring');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   input: [
     'there is nothing to unescape here',
     'there%20are%20several%20spaces%20that%20need%20to%20be%20unescaped',
@@ -13,8 +13,8 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var input = conf.input;
-  var n = conf.n | 0;
+  const input = conf.input;
+  const n = conf.n | 0;
 
   bench.start();
   for (var i = 0; i < n; i += 1)

--- a/benchmark/streams/transform-creation.js
+++ b/benchmark/streams/transform-creation.js
@@ -1,9 +1,9 @@
 'use strict';
-var common = require('../common.js');
-var Transform = require('stream').Transform;
-var inherits = require('util').inherits;
+const common = require('../common.js');
+const Transform = require('stream').Transform;
+const inherits = require('util').inherits;
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [1e6]
 });
 
@@ -14,7 +14,7 @@ inherits(MyTransform, Transform);
 MyTransform.prototype._transform = function() {};
 
 function main(conf) {
-  var n = +conf.n;
+  const n = +conf.n;
 
   bench.start();
   for (var i = 0; i < n; ++i)

--- a/benchmark/string_decoder/string-decoder.js
+++ b/benchmark/string_decoder/string-decoder.js
@@ -79,7 +79,7 @@ function main(conf) {
     }
   }
 
-  var nChunks = chunks.length;
+  const nChunks = chunks.length;
 
   bench.start();
   for (i = 0; i < n; ++i) {

--- a/benchmark/timers/immediate.js
+++ b/benchmark/timers/immediate.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [2000],
   type: ['depth', 'depth1', 'breadth', 'breadth1', 'breadth4', 'clear']
 });
 
 function main(conf) {
-  var N = +conf.thousands * 1e3;
+  const N = +conf.thousands * 1e3;
   switch (conf.type) {
     case 'depth':
       depth(N);

--- a/benchmark/timers/timers-breadth.js
+++ b/benchmark/timers/timers-breadth.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [500],
 });
 
 function main(conf) {
-  var N = +conf.thousands * 1e3;
+  const N = +conf.thousands * 1e3;
   var n = 0;
   bench.start();
   function cb() {

--- a/benchmark/timers/timers-cancel-pooled.js
+++ b/benchmark/timers/timers-cancel-pooled.js
@@ -1,13 +1,13 @@
 'use strict';
-var common = require('../common.js');
-var assert = require('assert');
+const common = require('../common.js');
+const assert = require('assert');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [500],
 });
 
 function main(conf) {
-  var iterations = +conf.thousands * 1e3;
+  const iterations = +conf.thousands * 1e3;
 
   var timer = setTimeout(() => {}, 1);
   for (var i = 0; i < iterations; i++) {

--- a/benchmark/timers/timers-cancel-unpooled.js
+++ b/benchmark/timers/timers-cancel-unpooled.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common.js');
-var assert = require('assert');
+const common = require('../common.js');
+const assert = require('assert');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [100],
 });
 
 function main(conf) {
-  var iterations = +conf.thousands * 1e3;
+  const iterations = +conf.thousands * 1e3;
 
-  var timersList = [];
+  const timersList = [];
   for (var i = 0; i < iterations; i++) {
     timersList.push(setTimeout(cb, i + 1));
   }

--- a/benchmark/timers/timers-depth.js
+++ b/benchmark/timers/timers-depth.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [1],
 });
 
 function main(conf) {
-  var N = +conf.thousands * 1e3;
+  const N = +conf.thousands * 1e3;
   var n = 0;
   bench.start();
   setTimeout(cb, 1);

--- a/benchmark/timers/timers-insert-pooled.js
+++ b/benchmark/timers/timers-insert-pooled.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [500],
 });
 
 function main(conf) {
-  var iterations = +conf.thousands * 1e3;
+  const iterations = +conf.thousands * 1e3;
 
   bench.start();
 

--- a/benchmark/timers/timers-insert-unpooled.js
+++ b/benchmark/timers/timers-insert-unpooled.js
@@ -1,15 +1,15 @@
 'use strict';
-var common = require('../common.js');
-var assert = require('assert');
+const common = require('../common.js');
+const assert = require('assert');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [100],
 });
 
 function main(conf) {
-  var iterations = +conf.thousands * 1e3;
+  const iterations = +conf.thousands * 1e3;
 
-  var timersList = [];
+  const timersList = [];
 
   bench.start();
   for (var i = 0; i < iterations; i++) {

--- a/benchmark/timers/timers-timeout-pooled.js
+++ b/benchmark/timers/timers-timeout-pooled.js
@@ -1,12 +1,12 @@
 'use strict';
-var common = require('../common.js');
+const common = require('../common.js');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   thousands: [500],
 });
 
 function main(conf) {
-  var iterations = +conf.thousands * 1e3;
+  const iterations = +conf.thousands * 1e3;
   var count = 0;
 
   for (var i = 0; i < iterations; i++) {

--- a/benchmark/tls/throughput.js
+++ b/benchmark/tls/throughput.js
@@ -1,6 +1,6 @@
 'use strict';
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   dur: [5],
   type: ['buf', 'asc', 'utf'],
   size: [2, 1024, 1024 * 1024]
@@ -9,11 +9,11 @@ var bench = common.createBenchmark(main, {
 var dur, type, encoding, size;
 var server;
 
-var path = require('path');
-var fs = require('fs');
-var cert_dir = path.resolve(__dirname, '../../test/fixtures');
+const path = require('path');
+const fs = require('fs');
+const cert_dir = path.resolve(__dirname, '../../test/fixtures');
 var options;
-var tls = require('tls');
+const tls = require('tls');
 
 function main(conf) {
   dur = +conf.dur;
@@ -48,7 +48,7 @@ function main(conf) {
   setTimeout(done, dur * 1000);
   var conn;
   server.listen(common.PORT, function() {
-    var opt = { port: common.PORT, rejectUnauthorized: false };
+    const opt = { port: common.PORT, rejectUnauthorized: false };
     conn = tls.connect(opt, function() {
       bench.start();
       conn.on('drain', write);
@@ -68,7 +68,7 @@ function main(conf) {
   }
 
   function done() {
-    var mbits = (received * 8) / (1024 * 1024);
+    const mbits = (received * 8) / (1024 * 1024);
     bench.end(mbits);
     if (conn)
       conn.destroy();

--- a/benchmark/tls/tls-connect.js
+++ b/benchmark/tls/tls-connect.js
@@ -3,8 +3,8 @@ var fs = require('fs'),
   path = require('path'),
   tls = require('tls');
 
-var common = require('../common.js');
-var bench = common.createBenchmark(main, {
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
   concurrency: [1, 10],
   dur: [5]
 });
@@ -20,8 +20,8 @@ function main(conf) {
   dur = +conf.dur;
   concurrency = +conf.concurrency;
 
-  var cert_dir = path.resolve(__dirname, '../../test/fixtures');
-  var options = {
+  const cert_dir = path.resolve(__dirname, '../../test/fixtures');
+  const options = {
     key: fs.readFileSync(`${cert_dir}/test_key.pem`),
     cert: fs.readFileSync(`${cert_dir}/test_cert.pem`),
     ca: [ fs.readFileSync(`${cert_dir}/test_ca.pem`) ],
@@ -44,7 +44,7 @@ function onConnection(conn) {
 }
 
 function makeConnection() {
-  var options = {
+  const options = {
     port: common.PORT,
     rejectUnauthorized: false
   };

--- a/benchmark/url/legacy-vs-whatwg-url-get-prop.js
+++ b/benchmark/url/legacy-vs-whatwg-url-get-prop.js
@@ -16,8 +16,8 @@ const bench = common.createBenchmark(main, {
 // remains a constant in the function, so here we must use the literal
 // instead to get a LoadNamedField.
 function useLegacy(n, input) {
-  var obj = url.parse(input);
-  var noDead = {
+  const obj = url.parse(input);
+  const noDead = {
     protocol: obj.protocol,
     auth: obj.auth,
     host: obj.host,
@@ -45,8 +45,8 @@ function useLegacy(n, input) {
 }
 
 function useWHATWG(n, input) {
-  var obj = new URL(input);
-  var noDead = {
+  const obj = new URL(input);
+  const noDead = {
     protocol: obj.protocol,
     auth: `${obj.username}:${obj.password}`,
     host: obj.host,

--- a/benchmark/url/legacy-vs-whatwg-url-serialize.js
+++ b/benchmark/url/legacy-vs-whatwg-url-serialize.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 });
 
 function useLegacy(n, input, prop) {
-  var obj = url.parse(input);
+  const obj = url.parse(input);
   var noDead = url.format(obj);
   bench.start();
   for (var i = 0; i < n; i += 1) {
@@ -23,7 +23,7 @@ function useLegacy(n, input, prop) {
 }
 
 function useWHATWG(n, input, prop) {
-  var obj = new URL(input);
+  const obj = new URL(input);
   var noDead = obj.toString();
   bench.start();
   for (var i = 0; i < n; i += 1) {

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -33,7 +33,7 @@ function iterator(n) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    for (var pair of params) {
+    for (const pair of params) {
       noDead[0] = pair[0];
       noDead[1] = pair[1];
     }

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -1,14 +1,14 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
-var common = require('../common.js');
+const common = require('../common.js');
 
 const opts = {
   showHidden: { showHidden: true },
   colors: { colors: true },
   none: undefined
 };
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   n: [2e6],
   method: [
     'Object',

--- a/benchmark/zlib/creation.js
+++ b/benchmark/zlib/creation.js
@@ -1,8 +1,8 @@
 'use strict';
-var common = require('../common.js');
-var zlib = require('zlib');
+const common = require('../common.js');
+const zlib = require('zlib');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   type: [
     'Deflate', 'DeflateRaw', 'Inflate', 'InflateRaw', 'Gzip', 'Gunzip', 'Unzip'
   ],
@@ -11,14 +11,14 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var fn = zlib['create' + conf.type];
+  const n = +conf.n;
+  const fn = zlib['create' + conf.type];
   if (typeof fn !== 'function')
     throw new Error('Invalid zlib type');
   var i = 0;
 
   if (conf.options === 'true') {
-    var opts = {};
+    const opts = {};
     bench.start();
     for (; i < n; ++i)
       fn(opts);

--- a/benchmark/zlib/deflate.js
+++ b/benchmark/zlib/deflate.js
@@ -1,17 +1,17 @@
 'use strict';
-var common = require('../common.js');
-var zlib = require('zlib');
+const common = require('../common.js');
+const zlib = require('zlib');
 
-var bench = common.createBenchmark(main, {
+const bench = common.createBenchmark(main, {
   method: ['createDeflate', 'deflate', 'deflateSync'],
   inputLen: [1024],
   n: [4e5]
 });
 
 function main(conf) {
-  var n = +conf.n;
-  var method = conf.method;
-  var chunk = Buffer.alloc(+conf.inputLen, 'a');
+  const n = +conf.n;
+  const method = conf.method;
+  const chunk = Buffer.alloc(+conf.inputLen, 'a');
 
   var i = 0;
   switch (method) {


### PR DESCRIPTION
As discussed in #13732: this will change all `var` to `const` if applicable. 
The main question is if this is wanted due to the churn.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark