### PR TITLE
tools: apply stricter indentation rules to tools     

### DIFF
--- a/tools/.eslintrc.yaml
+++ b/tools/.eslintrc.yaml
@@ -1,0 +1,12 @@
+## Tools-specific linter rules
+
+rules:
+  # Stylistic Issues
+  # http://eslint.org/docs/rules/#stylistic-issues
+  indent: [2, 2, {ArrayExpression: first,
+                  CallExpression: {arguments: first},
+                  FunctionDeclaration: {parameters: first},
+                  FunctionExpression: {parameters: first},
+                  MemberExpression: off,
+                  ObjectExpression: first,
+                  SwitchCase: 1}]

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -75,7 +75,7 @@ module.exports = function(context) {
       if (foundModules.length < requiredModules.length) {
         var missingModules = requiredModules.filter(
           function(module) {
-            return foundModules.indexOf(module === -1);
+            return foundModules.indexOf(module) === -1;
           }
         );
         missingModules.forEach(function(moduleName) {

--- a/tools/eslint-rules/required-modules.js
+++ b/tools/eslint-rules/required-modules.js
@@ -77,13 +77,13 @@ module.exports = function(context) {
           function(module) {
             return foundModules.indexOf(module === -1);
           }
-          );
+        );
         missingModules.forEach(function(moduleName) {
           context.report(
             node,
             'Mandatory module "{{moduleName}}" must be loaded.',
             { moduleName: moduleName }
-            );
+          );
         });
       }
     }


### PR DESCRIPTION
ESLint 4.0.0 provides stricter (and more granular) indentation checking
than previous versions. Apply the stricter indentation rules to the
tools directory.

In preparation for applying the more strict indentation linting
available in ESLint 4.0.0, correct minor indentation issues in
tools/eslint-rules/required-modules.js.
    
This is the only file with indentation that does not conform to the
stricter checks.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools