### PR TITLE
stream: fix `undefined` in Readable object mode

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -215,8 +215,8 @@ function readableAddChunk(stream, chunk, encoding, addToFront, skipChunkCheck) {
       stream.emit('error', er);
     } else if (state.objectMode || chunk && chunk.length > 0) {
       if (typeof chunk !== 'string' &&
-          Object.getPrototypeOf(chunk) !== Buffer.prototype &&
-          !state.objectMode) {
+          !state.objectMode &&
+          Object.getPrototypeOf(chunk) !== Buffer.prototype) {
         chunk = Stream._uint8ArrayToBuffer(chunk);
       }
 

--- a/test/parallel/test-stream-objectmode-undefined.js
+++ b/test/parallel/test-stream-objectmode-undefined.js
@@ -1,0 +1,44 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Readable, Writable, Transform } = require('stream');
+
+{
+  const stream = new Readable({
+    objectMode: true,
+    read: common.mustCall(() => {
+      stream.push(undefined);
+      stream.push(null);
+    })
+  });
+
+  stream.on('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, undefined);
+  }));
+}
+
+{
+  const stream = new Writable({
+    objectMode: true,
+    write: common.mustCall((chunk) => {
+      assert.strictEqual(chunk, undefined);
+    })
+  });
+
+  stream.write(undefined);
+}
+
+{
+  const stream = new Transform({
+    objectMode: true,
+    transform: common.mustCall((chunk) => {
+      stream.push(chunk);
+    })
+  });
+
+  stream.on('data', common.mustCall((chunk) => {
+    assert.strictEqual(chunk, undefined);
+  }));
+
+  stream.write(undefined);
+}


### PR DESCRIPTION
Fixes `this.push(undefined)`.

Fixes: https://github.com/nodejs/node/issues/13753

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

stream

/cc @nodejs/streams 