### PR TITLE
Added inspect port overriding in cluster

### DIFF
--- a/lib/internal/cluster/master.js
+++ b/lib/internal/cluster/master.js
@@ -26,6 +26,7 @@ cluster.SCHED_RR = SCHED_RR;      // Master distributes connections.
 var ids = 0;
 var debugPortOffset = 1;
 var initialized = false;
+let debugSettingsOverriden = false;
 
 // XXX(bnoordhuis) Fold cluster.schedulingPolicy into cluster.settings?
 var schedulingPolicy = {
@@ -41,7 +42,7 @@ if (schedulingPolicy === undefined) {
 
 cluster.schedulingPolicy = schedulingPolicy;
 
-cluster.setupMaster = function(options) {
+cluster.setupMaster = function(options = {}) {
   var settings = {
     args: process.argv.slice(2),
     exec: process.argv[1],
@@ -49,7 +50,7 @@ cluster.setupMaster = function(options) {
     silent: false
   };
   util._extend(settings, cluster.settings);
-  util._extend(settings, options || {});
+  util._extend(settings, options);
 
   // Tell V8 to write profile data for each process to a separate file.
   // Without --logfile=v8-%p.log, everything ends up in a single, unusable
@@ -58,6 +59,14 @@ cluster.setupMaster = function(options) {
   if (settings.execArgv.some((s) => s.startsWith('--prof')) &&
       !settings.execArgv.some((s) => s.startsWith('--logfile='))) {
     settings.execArgv = settings.execArgv.concat(['--logfile=v8-%p.log']);
+  }
+
+  // This allows user to override inspect port for workers.
+  const debugPortArgsRegex = /--inspect(=|-port=)|--debug-port=/;
+
+  if (!debugSettingsOverriden && options.execArgv &&
+      options.execArgv.some((arg) => arg.match(debugPortArgsRegex))) {
+    debugSettingsOverriden = true;
   }
 
   cluster.settings = settings;
@@ -103,7 +112,8 @@ function createWorkerProcess(id, env) {
   util._extend(workerEnv, env);
   workerEnv.NODE_UNIQUE_ID = '' + id;
 
-  if (execArgv.some((arg) => arg.match(debugArgRegex))) {
+  if (!debugSettingsOverriden &&
+      execArgv.some((arg) => arg.match(debugArgRegex))) {
     execArgv.push(`--inspect-port=${process.debugPort + debugPortOffset}`);
     debugPortOffset++;
   }


### PR DESCRIPTION
This is third part that I've mentioned in https://github.com/nodejs/node/pull/9659#issuecomment-307211154

Current cluster inspect port logic doen't let user to manually set inspect port for workers.
After this commit, adding any `--inspect*` options to `cluster.settings.execArgv` will disable port autoincrement.

Fixes #8495 and #12941.

I've got a problem with these cases:
1. If user starts master with `--inspect-port` but adds `--inspect` to `cluster.settings.execArgv` (set the base port, but don't run master with inspector), autoincrementing logic will be disabled. I can't say if this behavior is good or bad. Probably, port overriding should take place only if `--inspect=*` or `--(inspect|debug)-port=` are passed.
2. This approach doesn't fix the case if master starts on zero port and user wants workers to work on zero port too, instead of listening on ports **incremented from some port**: `cluster.settings.execArgv` will already contain everything in `process.execArgv` and adding `--inspect=0` to `cluster.settings` doesn't change anything. (link: https://github.com/nodejs/node/pull/13373#issuecomment-308831044)

So maybe instead of this, I should just add `inspectPort` option right to `cluster.settings`?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
