### PR TITLE
lib: remove the unused option --remote_debugging_server

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -104,10 +104,6 @@
         NativeModule.require('node-inspect/lib/_inspect').start();
       });
 
-    } else if (process.argv[1] === '--remote_debugging_server') {
-      // Start the debugging server
-      NativeModule.require('internal/inspector/remote_debugging_server');
-
     } else if (process.argv[1] === '--debug-agent') {
       // Start the debugger agent
       NativeModule.require('_debug_agent').start();


### PR DESCRIPTION
The option --remote_debugging_server is not supported now.

And the internal/inspector/remote_debugging_server file not exists.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internal/bootstrap_node