### PR TITLE
lib: remove the invalid command line options

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -104,14 +104,6 @@
         NativeModule.require('node-inspect/lib/_inspect').start();
       });
 
-    } else if (process.argv[1] === '--remote_debugging_server') {
-      // Start the debugging server
-      NativeModule.require('internal/inspector/remote_debugging_server');
-
-    } else if (process.argv[1] === '--debug-agent') {
-      // Start the debugger agent
-      NativeModule.require('_debug_agent').start();
-
     } else if (process.profProcess) {
       NativeModule.require('internal/v8_prof_processor');
 


### PR DESCRIPTION
The option --remote_debugging_server and --debug-agent are
not supported now.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib/internal/bootstrap_node
