### PR TITLE
test: accommodate AIX by watching file

### DIFF
--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -1,6 +1,6 @@
 'use strict';
-
 require('../common');
+
 const assert = require('assert');
 const initHooks = require('./init-hooks');
 const tick = require('./tick');
@@ -10,7 +10,7 @@ const fs = require('fs');
 const hooks = initHooks();
 
 hooks.enable();
-const watcher = fs.watch(__dirname, onwatcherChanged);
+const watcher = fs.watch(__filename, onwatcherChanged);
 function onwatcherChanged() { }
 
 watcher.close();


### PR DESCRIPTION
Watching directories has limited support on AIX. This is documented.
Watch a file in test/async-hooks/test-fseventwrap.js to accommodate AIX.

Refs: https://github.com/nodejs/node/issues/13577#issuecomment-308038674

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs async_hooks