### PR TITLE
doc: update debugger.md

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -11,14 +11,20 @@ will be displayed indicating successful launch of the debugger:
 
 ```txt
 $ node debug myscript.js
-< Debugger listening on 127.0.0.1:5858
-connecting to 127.0.0.1:5858 ... ok
-break in /home/indutny/Code/git/indutny/myscript.js:1
-> 1 global.x = 5;
+(node:8468) [DEP0068] DeprecationWarning: `node debug` is deprecated.
+Please use `node inspect` instead.
+< Debugger listening on ws://127.0.0.1:9229/ebf2d19a-5300-4b1f-a60d-1ed8326a9049
+< For help see https://nodejs.org/en/docs/inspector
+Break on start in /home/indutny/Code/git/indutny/myscript.js:1
+> 1 (function (exports, require, module, __filename, __dirname) { global.x = 5;
   2 setTimeout(() => {
   3   debugger;
 debug>
 ```
+
+(In the example above, the UUID ebf2d19a-5300-4b1f-a60d-1ed8326a9049
+at the end of the URL is generated on the fly, it varies in different
+debugging sessions.)
 
 Node.js's debugger client is not a full-featured debugger, but simple step and
 inspection are possible.
@@ -40,17 +46,18 @@ console.log('hello');
 Once the debugger is run, a breakpoint will occur at line 3:
 
 ```txt
-$ node debug myscript.js
-< Debugger listening on 127.0.0.1:5858
-connecting to 127.0.0.1:5858 ... ok
-break in /home/indutny/Code/git/indutny/myscript.js:1
-> 1 global.x = 5;
+(node:8468) [DEP0068] DeprecationWarning: `node debug` is deprecated.
+Please use `node inspect` instead.
+< Debugger listening on ws://127.0.0.1:9229/ebf2d19a-5300-4b1f-a60d-1ed8326a9049
+< For help see https://nodejs.org/en/docs/inspector
+Break on start in /home/indutny/Code/git/indutny/myscript.js:1
+> 1 (function (exports, require, module, __filename, __dirname) { global.x = 5;
   2 setTimeout(() => {
   3   debugger;
 debug> cont
 < hello
 break in /home/indutny/Code/git/indutny/myscript.js:3
-  1 global.x = 5;
+  1 (function (exports, require, module, __filename, __dirname) { global.x = 5;
   2 setTimeout(() => {
 > 3   debugger;
   4   console.log('world');
@@ -69,14 +76,14 @@ Press Ctrl + C to leave debug repl
 > 2+2
 4
 debug> next
-break in /home/indutny/Code/git/indutny/myscript.js:5
 < world
+break in /home/indutny/Code/git/indutny/myscript.js:5
   3   debugger;
   4   console.log('world');
 > 5 }, 1000);
   6 console.log('hello');
   7
-debug> quit
+debug> .exit
 ```
 
 The `repl` command allows code to be evaluated remotely. The `next` command
@@ -122,26 +129,23 @@ is not loaded yet:
 
 ```txt
 $ node debug test/fixtures/break-in-module/main.js
-< Debugger listening on 127.0.0.1:5858
-connecting to 127.0.0.1:5858 ... ok
+(node:8564) [DEP0068] DeprecationWarning: `node debug` is deprecated.
+Please use `node inspect` instead.
+< Debugger listening on ws://127.0.0.1:9229/773f22ce-49a7-450f-85be-81bfb92e02d3
+< For help see https://nodejs.org/en/docs/inspector
 break in test/fixtures/break-in-module/main.js:1
-> 1 const mod = require('./mod.js');
+> 1 (function (exports, require, module, __filename, __dirname) { const mod = require('./mod.js');
   2 mod.hello();
   3 mod.hello();
-debug> setBreakpoint('mod.js', 2)
+debug> setBreakpoint('mod.js', 23)
 Warning: script 'mod.js' was not loaded yet.
-> 1 const mod = require('./mod.js');
-  2 mod.hello();
-  3 mod.hello();
-  4 debugger;
-  5
-  6 });
 debug> c
-break in test/fixtures/break-in-module/mod.js:2
-  1 exports.hello = function() {
-> 2   return 'hello from module';
-  3 };
-  4
+break in test/fixtures/break-in-module/mod.js:23
+ 21
+ 22 exports.hello = function() {
+>23   return 'hello from module';
+ 24 };
+ 25
 debug>
 ```
 
@@ -184,14 +188,13 @@ flag instead of `--inspect`.
 
 ```txt
 $ node --inspect index.js
-Debugger listening on 127.0.0.1:9229.
-To start debugging, open the following URL in Chrome:
-    chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
+Debugger listening on ws://127.0.0.1:9229/10b81040-7534-4c13-8aba-78e9f50d70f8
+For help see https://nodejs.org/en/docs/inspector
 ```
 
-(In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
+(In the example above, the UUID 10b81040-7534-4c13-8aba-78e9f50d70f8
 at the end of the URL is generated on the fly, it varies in different
 debugging sessions.)
 
-[Chrome Debugging Protocol]: https://chromedevtools.github.io/debugger-protocol-viewer/
+[Chrome Debugging Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [TCP-based protocol]: #debugger_tcp_based_protocol


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, debugger

1. Some output seems weird, but that is what we have in the Nod.js 8.1.1.

2. Considering `DeprecationWarning` in the outputs, is `Stability: 2 - Stable` still valid?

3. I've duplicated the note about UUID as it is a part of the `debug` output now.

4. `quit` command from the old output throws now:

    ```console
    debug> quit
    repl:1
    quit
    ^

    ReferenceError: quit is not defined
        at repl:1:1
        at ContextifyScript.Script.runInContext (vm.js:53:29)
        at Object.runInContext (vm.js:108:6)
        at REPLServer.controlEval [as eval] (node-inspect/lib/internal/inspect_repl.js:521:25)
        at REPLServer.onLine (repl.js:433:10)
        at emitOne (events.js:115:13)
        at REPLServer.emit (events.js:210:7)
        at REPLServer.Interface._onLine (readline.js:278:10)
        at REPLServer.Interface._line (readline.js:625:8)
        at REPLServer.Interface._ttyWrite (readline.js:904:14)
    debug>
    ```
    In the output of the `help` command there is only this suitable command:
     ```console
    kill                  Kill a running application or disconnect
    ````
    but its behavior is weird: first, it duplicates header lines, then does nothing:
    ```console
    debug> kill
    < Debugger attached.
    < Debugger listening on ws://127.0.0.1:9229/1af5b6a5-eb79-43be-9f15-f7ba31f8147e
    < For help see https://nodejs.org/en/docs/inspector

    debug> kill
    debug>
    ```
    `.exit` seems OK, so I've  added it instead.

    I am not sure if some of these nits are bugs that should be addressed.

5. `test/fixtures/break-in-module/mod.js` seems to be changed recently again (copyright added), so the corresponding example is also updated along with other changes in `debug` behavior.

6. Inspector output is also updated.

7. 'Chrome Debugging Protocol' link is replaced according to the current redirection.