### PR TITLE
function to const

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -31,16 +31,12 @@ const server = require('_http_server');
 const Server = server.Server;
 const ClientRequest = client.ClientRequest;
 
-function createServer(requestListener) {
-  return new Server(requestListener);
-}
+const createServer = (requestListener) => new Server(requestListener);
 
-function request(options, cb) {
-  return new ClientRequest(options, cb);
-}
+const request = (options, cb) => new ClientRequest(options, cb);
 
-function get(options, cb) {
-  var req = request(options, cb);
+const get = (options, cb) => {
+  let req = request(options, cb);
   req.end();
   return req;
 }


### PR DESCRIPTION
Why do not declare as const & arrow func instead function?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
