### PR TITLE
(v6.x backport) tools: enforce two arguments in assert.throws

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -146,7 +146,7 @@ rules:
 
   # Custom rules in tools/eslint-rules
   align-multiline-assignment: 2
-  assert-throws-arguments: [2, { requireTwo: false }]
+  assert-throws-arguments: [2, { requireTwo: true }]
   no-useless-regex-char-class-escape: [2, { override: ['[', ']'] }]
 
 # Global scoped method and vars

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -240,7 +240,8 @@ assert.throws(
 {
   const re1 = /a/;
   re1.lastIndex = 3;
-  assert.throws(makeBlock(a.deepStrictEqual, re1, /a/));
+  assert.throws(makeBlock(a.deepStrictEqual, re1, /a/),
+                /^AssertionError: \/a\/ deepStrictEqual \/a\/$/);
 }
 
 // 7.4 - strict
@@ -262,10 +263,12 @@ assert.doesNotThrow(makeBlock(a.deepStrictEqual, {a: 4}, {a: 4}));
 assert.doesNotThrow(makeBlock(a.deepStrictEqual,
                               {a: 4, b: '2'},
                               {a: 4, b: '2'}));
-assert.throws(makeBlock(a.deepStrictEqual, [4], ['4']));
+assert.throws(makeBlock(a.deepStrictEqual, [4], ['4']),
+              /^AssertionError: \[ 4 ] deepStrictEqual \[ '4' ]$/);
 assert.throws(makeBlock(a.deepStrictEqual, {a: 4}, {a: 4, b: true}),
-              a.AssertionError);
-assert.throws(makeBlock(a.deepStrictEqual, ['a'], {0: 'a'}));
+              /^AssertionError: { a: 4 } deepStrictEqual { a: 4, b: true }$/);
+assert.throws(makeBlock(a.deepStrictEqual, ['a'], {0: 'a'}),
+              /^AssertionError: \[ 'a' ] deepStrictEqual { '0': 'a' }$/);
 //(although not necessarily the same order),
 assert.doesNotThrow(makeBlock(a.deepStrictEqual,
                               {a: 4, b: '1'},
@@ -342,9 +345,11 @@ function thrower(errorConstructor) {
 assert.throws(makeBlock(thrower, a.AssertionError),
               a.AssertionError, 'message');
 assert.throws(makeBlock(thrower, a.AssertionError), a.AssertionError);
+// eslint-disable-next-line assert-throws-arguments
 assert.throws(makeBlock(thrower, a.AssertionError));
 
 // if not passing an error, catch all.
+// eslint-disable-next-line assert-throws-arguments
 assert.throws(makeBlock(thrower, TypeError));
 
 // when passing a type, only catch errors of the appropriate type
@@ -517,6 +522,7 @@ testAssertionMessage({a: NaN, b: Infinity, c: -Infinity},
 
 // #2893
 try {
+  // eslint-disable-next-line assert-throws-arguments
   assert.throws(function() {
     assert.ifError(null);
   });

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -23,8 +23,11 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'));
+assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'),
+              /^TypeError: Arguments must be Buffers$/);
 
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)));
+assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)),
+              /^TypeError: Arguments must be Buffers$/);
 
-assert.throws(() => Buffer.alloc(1).compare('abc'));
+assert.throws(() => Buffer.alloc(1).compare('abc'),
+              /^TypeError: Argument must be a Buffer$/);

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -13,4 +13,5 @@ assert.ok(!c.equals(d));
 assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
 
-assert.throws(() => Buffer.alloc(1).equals('abc'));
+assert.throws(() => Buffer.alloc(1).equals('abc'),
+              /^TypeError: Argument must be a Buffer$/);

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -273,15 +273,17 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
   }
 }
 
-assert.throws(function() {
-  b.includes(function() { });
-});
-assert.throws(function() {
+const expectedError =
+  /^TypeError: "val" argument must be string, number or Buffer$/;
+assert.throws(() => {
+  b.includes(() => {});
+}, expectedError);
+assert.throws(() => {
   b.includes({});
-});
-assert.throws(function() {
+}, expectedError);
+assert.throws(() => {
   b.includes([]);
-});
+}, expectedError);
 
 // test truncation of Number arguments to uint8
 {

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -346,15 +346,20 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
   }
 }
 
-assert.throws(function() {
-  b.indexOf(function() { });
-});
-assert.throws(function() {
+const argumentExpected =
+    /^TypeError: "val" argument must be string, number or Buffer$/;
+
+assert.throws(() => {
+  b.indexOf(() => { });
+}, argumentExpected);
+
+assert.throws(() => {
   b.indexOf({});
-});
-assert.throws(function() {
+}, argumentExpected);
+
+assert.throws(() => {
   b.indexOf([]);
-});
+}, argumentExpected);
 
 // Test weird offset arguments.
 // The following offsets coerce to NaN or 0, searching the whole Buffer

--- a/test/parallel/test-buffer.js
+++ b/test/parallel/test-buffer.js
@@ -41,11 +41,11 @@ for (const [key, value] of e.entries()) {
 
 assert.throws(function() {
   Buffer(8).fill('a', -1);
-});
+}, /^RangeError: Out of range index$/);
 
 assert.throws(function() {
   Buffer(8).fill('a', 0, 9);
-});
+}, /^RangeError: Out of range index$/);
 
 // Make sure this doesn't hang indefinitely.
 Buffer(8).fill('');
@@ -1433,17 +1433,17 @@ if (common.hasCrypto) {
 assert.throws(function() {
   const b = Buffer(1);
   Buffer.compare(b, 'abc');
-});
+}, /^TypeError: Arguments must be Buffers$/);
 
 assert.throws(function() {
   const b = Buffer(1);
   Buffer.compare('abc', b);
-});
+}, /^TypeError: Arguments must be Buffers$/);
 
 assert.throws(function() {
   const b = Buffer(1);
   b.compare('abc');
-});
+}, /^TypeError: Argument must be a Buffer$/);
 
 // Test Equals
 {
@@ -1461,10 +1461,12 @@ assert.throws(function() {
 assert.throws(function() {
   const b = Buffer(1);
   b.equals('abc');
-});
+}, /^TypeError: Argument must be a Buffer$/);
 
 // Regression test for https://github.com/nodejs/node/issues/649.
-assert.throws(function() { Buffer(1422561062959).toString('utf8'); });
+assert.throws(function() {
+  Buffer(1422561062959).toString('utf8');
+}, /^RangeError: Invalid typed array length$/);
 
 const ps = Buffer.poolSize;
 Buffer.poolSize = 0;
@@ -1474,7 +1476,7 @@ Buffer.poolSize = ps;
 // Test Buffer.copy() segfault
 assert.throws(function() {
   Buffer(10).copy();
-});
+}, /^TypeError: argument should be a Buffer$/);
 
 const regErrorMsg = new RegExp('First argument must be a string, Buffer, ' +
                                'ArrayBuffer, Array, or array-like object.');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -19,25 +19,28 @@ let key2 = dh2.generateKeys('hex');
 let secret1 = dh1.computeSecret(key2, 'hex', 'base64');
 let secret2 = dh2.computeSecret(key1, 'latin1', 'buffer');
 
-assert.strictEqual(secret1, secret2.toString('base64'));
+assert.strictEqual(secret2.toString('base64'), secret1);
 assert.strictEqual(dh1.verifyError, 0);
 assert.strictEqual(dh2.verifyError, 0);
 
-assert.throws(function() {
+const argumentsError =
+  /^TypeError: First argument should be number, string or Buffer$/;
+
+assert.throws(() => {
   crypto.createDiffieHellman([0x1, 0x2]);
-});
+}, argumentsError);
 
-assert.throws(function() {
-  crypto.createDiffieHellman(function() { });
-});
+assert.throws(() => {
+  crypto.createDiffieHellman(() => { });
+}, argumentsError);
 
-assert.throws(function() {
+assert.throws(() => {
   crypto.createDiffieHellman(/abc/);
-});
+}, argumentsError);
 
-assert.throws(function() {
+assert.throws(() => {
   crypto.createDiffieHellman({});
-});
+}, argumentsError);
 
 // Create "another dh1" using generated keys from dh1,
 // and compute secret again
@@ -56,20 +59,28 @@ const secret3 = dh3.computeSecret(key2, 'hex', 'base64');
 
 assert.strictEqual(secret1, secret3);
 
+const wrongBlockLength =
+    new RegExp('^Error: error:0606506D:digital envelope' +
+    ' routines:EVP_DecryptFinal_ex:wrong final block length$');
+
 // Run this one twice to make sure that the dh3 clears its error properly
 {
   const c = crypto.createDecipheriv('aes-128-ecb', crypto.randomBytes(16), '');
-  assert.throws(function() { c.final('utf8'); }, /wrong final block length/);
+  assert.throws(() => {
+    c.final('utf8');
+  }, wrongBlockLength);
 }
-
-assert.throws(function() {
-  dh3.computeSecret('');
-}, /key is too small/i);
 
 {
   const c = crypto.createDecipheriv('aes-128-ecb', crypto.randomBytes(16), '');
-  assert.throws(function() { c.final('utf8'); }, /wrong final block length/);
+  assert.throws(() => {
+    c.final('utf8');
+  }, wrongBlockLength);
 }
+
+assert.throws(() => {
+  dh3.computeSecret('');
+}, /^Error: Supplied key is too small$/);
 
 // Create a shared using a DH group.
 const alice = crypto.createDiffieHellmanGroup('modp5');
@@ -180,9 +191,9 @@ assert.throws(() => {
 const ecdh3 = crypto.createECDH('secp256k1');
 const key3 = ecdh3.generateKeys();
 
-assert.throws(function() {
+assert.throws(() => {
   ecdh2.computeSecret(key3, 'latin1', 'buffer');
-});
+}, /^Error: Failed to translate Buffer to a EC_POINT$/);
 
 // ECDH should allow .setPrivateKey()/.setPublicKey()
 const ecdh4 = crypto.createECDH('prime256v1');
@@ -190,20 +201,21 @@ const ecdh4 = crypto.createECDH('prime256v1');
 ecdh4.setPrivateKey(ecdh1.getPrivateKey());
 ecdh4.setPublicKey(ecdh1.getPublicKey());
 
-assert.throws(function() {
+assert.throws(() => {
   ecdh4.setPublicKey(ecdh3.getPublicKey());
-}, /Failed to convert Buffer to EC_POINT/);
+}, /^Error: Failed to convert Buffer to EC_POINT$/);
 
 // Verify that we can use ECDH without having to use newly generated keys.
 const ecdh5 = crypto.createECDH('secp256k1');
 
 // Verify errors are thrown when retrieving keys from an uninitialized object.
-assert.throws(function() {
+assert.throws(() => {
   ecdh5.getPublicKey();
-}, /Failed to get ECDH public key/);
-assert.throws(function() {
+}, /^Error: Failed to get ECDH public key$/);
+
+assert.throws(() => {
   ecdh5.getPrivateKey();
-}, /Failed to get ECDH private key/);
+}, /^Error: Failed to get ECDH private key$/);
 
 // A valid private key for the secp256k1 curve.
 const cafebabeKey = 'cafebabe'.repeat(8);
@@ -249,10 +261,10 @@ assert.strictEqual(ecdh5.getPublicKey('hex', 'compressed'), cafebabePubPtComp);
 // Show why allowing the public key to be set on this type does not make sense.
 ecdh5.setPublicKey(peerPubPtComp, 'hex');
 assert.strictEqual(ecdh5.getPublicKey('hex'), peerPubPtUnComp);
-assert.throws(function() {
+assert.throws(() => {
   // Error because the public key does not match the private key anymore.
   ecdh5.computeSecret(peerPubPtComp, 'hex', 'hex');
-}, /Invalid key pair/);
+}, /^Error: Invalid key pair$/);
 
 // Set to a valid key to show that later attempts to set an invalid key are
 // rejected.
@@ -262,10 +274,10 @@ ecdh5.setPrivateKey(cafebabeKey, 'hex');
   '0000000000000000000000000000000000000000000000000000000000000000',
   'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141',
   'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF',
-].forEach(function(element, index, object) {
-  assert.throws(function() {
+].forEach((element) => {
+  assert.throws(() => {
     ecdh5.setPrivateKey(element, 'hex');
-  }, /Private key is not valid for specified curve/);
+  }, /^Error: Private key is not valid for specified curve.$/);
   // Verify object state did not change.
   assert.strictEqual(ecdh5.getPrivateKey('hex'), cafebabeKey);
 });

--- a/test/parallel/test-fs-makeStatsCallback.js
+++ b/test/parallel/test-fs-makeStatsCallback.js
@@ -5,23 +5,22 @@ const fs = require('fs');
 const cbTypeError = /^TypeError: "callback" argument must be a function$/;
 const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
 
-const { sep } = require('path');
-
-common.refreshTmpDir();
-
-function testMakeCallback(cb) {
+function testMakeStatsCallback(cb) {
   return function() {
-    // fs.mkdtemp() calls makeCallback() on its third argument
-    fs.mkdtemp(`${common.tmpDir}${sep}`, {}, cb);
+    // fs.stat() calls makeStatsCallback() on its second argument
+    fs.stat(__filename, cb);
   };
 }
 
+// Verify the case where a callback function is provided
+assert.doesNotThrow(testMakeStatsCallback(common.noop));
+
 // Passing undefined/nothing calls rethrow() internally
-assert.doesNotThrow(testMakeCallback());
+assert.doesNotThrow(testMakeStatsCallback());
 
 function invalidCallbackThrowsTests() {
   callbackThrowValues.forEach((value) => {
-    assert.throws(testMakeCallback(value), cbTypeError);
+    assert.throws(testMakeStatsCallback(value), cbTypeError);
   });
 }
 

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -39,20 +39,27 @@ assert.strictEqual(fs._stringToFlags('xa+'),
 ('+ +a +r +w rw wa war raw r++ a++ w++ x +x x+ rx rx+ wxx wax xwx xxx')
   .split(' ')
   .forEach(function(flags) {
-    assert.throws(function() { fs._stringToFlags(flags); });
+    assert.throws(
+      () => fs._stringToFlags(flags),
+      new RegExp(`^Error: Unknown file open flag: ${escapeRegExp(flags)}`)
+    );
   });
 
 assert.throws(
   () => fs._stringToFlags({}),
-  /Unknown file open flag: \[object Object\]/
+  /^Error: Unknown file open flag: \[object Object\]$/
 );
 
 assert.throws(
   () => fs._stringToFlags(true),
-  /Unknown file open flag: true/
+  /^Error: Unknown file open flag: true$/
 );
 
 assert.throws(
   () => fs._stringToFlags(null),
-  /Unknown file open flag: null/
+  /Error: Unknown file open flag: null$/
 );
+
+function escapeRegExp(string) {
+  return string.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+}

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -22,10 +22,18 @@ const cookies = [
 const s = http.createServer(function(req, res) {
   switch (test) {
     case 'headers':
-      assert.throws(function() { res.setHeader(); });
-      assert.throws(function() { res.setHeader('someHeader'); });
-      assert.throws(function() { res.getHeader(); });
-      assert.throws(function() { res.removeHeader(); });
+      assert.throws(() => {
+        res.setHeader();
+      }, /^TypeError: Header name must be a valid HTTP Token \["undefined"\]$/);
+      assert.throws(() => {
+        res.setHeader('someHeader');
+      }, /^Error: "value" required in setHeader\("someHeader", value\)$/);
+      assert.throws(() => {
+        res.getHeader();
+      }, /^Error: "name" argument is required for getHeader\(name\)$/);
+      assert.throws(() => {
+        res.removeHeader();
+      }, /^Error: "name" argument is required for removeHeader\(name\)$/);
 
       res.setHeader('x-test-header', 'testing');
       res.setHeader('X-TEST-HEADER2', 'testing');

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -22,5 +22,5 @@ function testContext(repl) {
   assert.strictEqual(context.global, context);
 
   // ensure that the repl console instance does not have a setter
-  assert.throws(() => context.console = 'foo');
+  assert.throws(() => context.console = 'foo', TypeError);
 }

--- a/test/parallel/test-vm-new-script-this-context.js
+++ b/test/parallel/test-vm-new-script-this-context.js
@@ -14,7 +14,7 @@ console.error('thrown error');
 script = new Script('throw new Error(\'test\');');
 assert.throws(function() {
   script.runInThisContext(script);
-});
+}, /^Error: test$/);
 
 global.hello = 5;
 script = new Script('hello = 2');


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/12270
This includes backports of multiple other PRs that are required:

* https://github.com/nodejs/node/commit/ffdcfff3ac75addab54e0a4fa830733db8a4d32f: https://github.com/nodejs/node/pull/10807
* https://github.com/nodejs/node/commit/917e579a09f5a084d6f0024af1febe8a5a17ea4c: https://github.com/nodejs/node/pull/11215
* https://github.com/nodejs/node/commit/4056141cba4652e41b71b0344f72847667c827a6: https://github.com/nodejs/node/pull/11203
* https://github.com/nodejs/node/commit/85b17c115a6dc1b6a7e77a8726053215501be1d6: https://github.com/nodejs/node/pull/10752
* https://github.com/nodejs/node/commit/15b4be84caffe4cb2230e0eac3afa5d677c6a6af: https://github.com/nodejs/node/pull/10752
* https://github.com/nodejs/node/commit/15b4be84caffe4cb2230e0eac3afa5d677c6a6af: https://github.com/nodejs/node/pull/10734
* https://github.com/nodejs/node/commit/f40bd47065e05ac28a57ff4bc6bdc89448f9233a: https://github.com/nodejs/node/pull/10681
* https://github.com/nodejs/node/commit/0d27e357e284b09d25b8e9856dd9b8f132b59c77: https://github.com/nodejs/node/pull/12140
* https://github.com/nodejs/node/commit/d6b415322cdf76569f4eec7e1f10f48ceee4a249: https://github.com/nodejs/node/pull/10908
* https://github.com/nodejs/node/commit/593553d3f440294ba7bba95f3852ab6100120534: https://github.com/nodejs/node/pull/11622

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
