### PR TITLE
test: skip fips tests using OpenSSL config file

### DIFF
--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -21,6 +21,10 @@ function compiledWithFips() {
   return process.config.variables.openssl_fips ? true : false;
 }
 
+function sharedOpenSSL() {
+  return process.config.variables.node_shared_openssl;
+}
+
 function addToEnv(newVar, value) {
   const envCopy = {};
   for (const e in process.env) {
@@ -85,29 +89,43 @@ testHelper(
   'require("crypto").fips',
   process.env);
 
-// OpenSSL config file should be able to turn on FIPS mode
-testHelper(
-  'stdout',
-  [`--openssl-config=${CNF_FIPS_ON}`],
-  compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
-  'require("crypto").fips',
-  process.env);
+// If Node was configured using --shared-openssl fips support might be
+// available depending on how OpenSSL was built. If fips support is
+// available the tests that toggle the fips_mode on/off using the config
+// file option will succeed and return 1 instead of 0.
+//
+// Note that this case is different from when calling the fips setter as the
+// configuration file is handled by OpenSSL, so it is not possible for us
+// to try to call the fips setter, to try to detect this situation, as
+// that would throw an error:
+// ("Error: Cannot set FIPS mode in a non-FIPS build.").
+// Due to this uncertanty the following tests are skipped when configured
+// with --shared-openssl.
+if (!sharedOpenSSL()) {
+  // OpenSSL config file should be able to turn on FIPS mode
+  testHelper(
+    'stdout',
+    [`--openssl-config=${CNF_FIPS_ON}`],
+    compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
+    'require("crypto").fips',
+    process.env);
 
-// OPENSSL_CONF should be able to turn on FIPS mode
-testHelper(
-  'stdout',
-  [],
-  compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
-  'require("crypto").fips',
-  addToEnv('OPENSSL_CONF', CNF_FIPS_ON));
+  // OPENSSL_CONF should be able to turn on FIPS mode
+  testHelper(
+    'stdout',
+    [],
+    compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
+    'require("crypto").fips',
+    addToEnv('OPENSSL_CONF', CNF_FIPS_ON));
 
-// --openssl-config option should override OPENSSL_CONF
-testHelper(
-  'stdout',
-  [`--openssl-config=${CNF_FIPS_ON}`],
-  compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
-  'require("crypto").fips',
-  addToEnv('OPENSSL_CONF', CNF_FIPS_OFF));
+  // --openssl-config option should override OPENSSL_CONF
+  testHelper(
+    'stdout',
+    [`--openssl-config=${CNF_FIPS_ON}`],
+    compiledWithFips() ? FIPS_ENABLED : FIPS_DISABLED,
+    'require("crypto").fips',
+    addToEnv('OPENSSL_CONF', CNF_FIPS_OFF));
+}
 
 testHelper(
   'stdout',


### PR DESCRIPTION
The motivation for this commit is that we are building Node with
--shared-openssl and in our case the system OpenSSL version
supports FIPS.

The tests in test-crypto-fips that toggle fips mode on/off using the
config file option might succeed and return 1 instead of an error
being thrown from OpenSSL (which is what happens for a default build
but the error is not processed/displayed in any way at the moment):
openssl config failed: error:060B10A7:digital envelope
routines:ALG_MODULE_INIT:fips mode not supported

Note that this only concerns the test that use the configuration file
option which is different from when calling the fips setter as
the handling of the configuration file is handled by OpenSSL, so it
is not possible for us to try to call the fips setter as that would
throw an error ("Error: Cannot set FIPS mode in a non-FIPS build.").

The suggestion is to skips these tests when --shared-openssl is used.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, crypto