### PR TITLE
Calling require with null char as first char of the path component causes crash

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -511,7 +511,9 @@ Module.prototype.require = function(path) {
   assert(path, 'missing path');
   assert(typeof path === 'string', 'path must be a string');
   // Ignore part of the path after null character if it exists
-  path = path.split('\u0000')[0];
+  if (path.indexOf('\u0000') != -1) {
+    path = path.split('\u0000')[0];
+  }
   return Module._load(path, this, /* isMain */ false);
 };
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -510,6 +510,8 @@ Module.prototype.load = function(filename) {
 Module.prototype.require = function(path) {
   assert(path, 'missing path');
   assert(typeof path === 'string', 'path must be a string');
+  // Ignore part of the path after null character if it exists
+  path = path.split('\u0000')[0];
   return Module._load(path, this, /* isMain */ false);
 };
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -511,7 +511,7 @@ Module.prototype.require = function(path) {
   assert(path, 'missing path');
   assert(typeof path === 'string', 'path must be a string');
   // Ignore part of the path after null character if it exists
-  if (path.indexOf('\u0000') != -1) {
+  if (path.indexOf('\u0000') !== -1) {
     path = path.split('\u0000')[0];
   }
   return Module._load(path, this, /* isMain */ false);

--- a/test/parallel/test-require-exceptions.js
+++ b/test/parallel/test-require-exceptions.js
@@ -33,6 +33,11 @@ assert.throws(function() {
   require(`${common.fixturesDir}/throws_error`);
 }, /^Error: blah$/);
 
+// Requiring the module with null character
+assert.throws(function() {
+  require('../\u0000on');
+}, /^Error: blah$/); //TODO: Fix the acual error
+
 // Requiring a module that does not exist should throw an
 // error with its `code` set to MODULE_NOT_FOUND
 assertModuleNotFound('/DOES_NOT_EXIST');

--- a/test/parallel/test-require-exceptions.js
+++ b/test/parallel/test-require-exceptions.js
@@ -33,10 +33,11 @@ assert.throws(function() {
   require(`${common.fixturesDir}/throws_error`);
 }, /^Error: blah$/);
 
-// Requiring the module with null character
+// Requiring the module with null character in
+// path as first character of a component
 assert.throws(function() {
   require('../\u0000on');
-}, /^Error: blah$/); //TODO: Fix the acual error
+}, /^Error: Cannot find module '[.]{2}\/'$/);
 
 // Requiring a module that does not exist should throw an
 // error with its `code` set to MODULE_NOT_FOUND


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
