### PR TITLE
buffer: refactor buffer exports

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -24,7 +24,6 @@ const { compare } = process.binding('buffer');
 const util = require('util');
 const { isSet, isMap } = process.binding('util');
 const { objectToString } = require('internal/util');
-const { Buffer } = require('buffer');
 const errors = require('internal/errors');
 
 // The assert module provides functions that throw
@@ -124,6 +123,7 @@ function areSimilarRegExps(a, b) {
 // The c++ barrier takes the advantage of the faster compare otherwise.
 // 300 was the number after which compare became faster.
 function areSimilarTypedArrays(a, b) {
+  const { from } = require('buffer').Buffer;
   const len = a.byteLength;
   if (len !== b.byteLength) {
     return false;
@@ -136,12 +136,8 @@ function areSimilarTypedArrays(a, b) {
     }
     return true;
   }
-  return compare(Buffer.from(a.buffer,
-                             a.byteOffset,
-                             len),
-                 Buffer.from(b.buffer,
-                             b.byteOffset,
-                             b.byteLength)) === 0;
+  return compare(from(a.buffer, a.byteOffset, len),
+                 from(b.buffer, b.byteOffset, b.byteLength)) === 0;
 }
 
 function isFloatTypedArrayTag(tag) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -21,14 +21,48 @@
 
 'use strict';
 
-const binding = process.binding('buffer');
-const config = process.binding('config');
-const { compare: compare_, compareOffset } = binding;
-const { isAnyArrayBuffer, isUint8Array } = process.binding('util');
-const bindingObj = {};
-const internalUtil = require('internal/util');
-const pendingDeprecation = !!config.pendingDeprecation;
+const {
+  byteLengthUtf8,
+  copy: _copy,
+  compare: _compare,
+  compareOffset,
+  createFromString,
+  fill: _fill,
+  indexOfBuffer,
+  indexOfNumber,
+  indexOfString,
+  readDoubleBE: _readDoubleBE,
+  readDoubleLE: _readDoubleLE,
+  readFloatBE: _readFloatBE,
+  readFloatLE: _readFloatLE,
+  setupBufferJS,
+  swap16: _swap16,
+  swap32: _swap32,
+  swap64: _swap64,
+  writeDoubleBE: _writeDoubleBE,
+  writeDoubleLE: _writeDoubleLE,
+  writeFloatBE: _writeFloatBE,
+  writeFloatLE: _writeFloatLE,
+  kMaxLength,
+  kStringMaxLength
+} = process.binding('buffer');
+const {
+  isAnyArrayBuffer,
+  isUint8Array
+} = process.binding('util');
+const {
+  customInspectSymbol,
+  normalizeEncoding,
+  kIsEncodingSymbol
+} = require('internal/util');
+const {
+  pendingDeprecation
+} = process.binding('config');
 const errors = require('internal/errors');
+
+const internalBuffer = require('internal/buffer');
+
+const bindingObj = {};
 
 class FastBuffer extends Uint8Array {
   constructor(arg1, arg2, arg3) {
@@ -36,44 +70,30 @@ class FastBuffer extends Uint8Array {
   }
 }
 FastBuffer.prototype.constructor = Buffer;
+internalBuffer.FastBuffer = FastBuffer;
 
 Buffer.prototype = FastBuffer.prototype;
 
-exports.Buffer = Buffer;
-exports.SlowBuffer = SlowBuffer;
-exports.INSPECT_MAX_BYTES = 50;
-
-// Legacy.
-exports.kMaxLength = binding.kMaxLength;
-
 const constants = Object.defineProperties({}, {
   MAX_LENGTH: {
-    value: binding.kStringMaxLength,
+    value: kStringMaxLength,
     writable: false,
     enumerable: true
   },
   MAX_STRING_LENGTH: {
-    value: binding.kStringMaxLength,
+    value: kStringMaxLength,
     writable: false,
     enumerable: true
   }
 });
 
-Object.defineProperty(exports, 'constants', {
-  configurable: false,
-  enumerable: true,
-  value: constants
-});
-
-exports.kStringMaxLength = binding.kStringMaxLength;
-
 Buffer.poolSize = 8 * 1024;
 var poolSize, poolOffset, allocPool;
 
 
-binding.setupBufferJS(Buffer.prototype, bindingObj);
+setupBufferJS(Buffer.prototype, bindingObj);
 
-// |binding.zeroFill| can be undefined when running inside an isolate where we
+// |zeroFill| can be undefined when running inside an isolate where we
 // do not own the ArrayBuffer allocator.  Zero fill is always on in that case.
 const zeroFill = bindingObj.zeroFill || [0];
 
@@ -166,7 +186,7 @@ Object.defineProperty(Buffer, Symbol.species, {
  * Buffer.from(buffer)
  * Buffer.from(arrayBuffer[, byteOffset[, length]])
  **/
-Buffer.from = function(value, encodingOrOffset, length) {
+Buffer.from = function from(value, encodingOrOffset, length) {
   if (typeof value === 'string')
     return fromString(value, encodingOrOffset);
 
@@ -220,7 +240,7 @@ function assertSize(size) {
     err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number', size);
   } else if (size < 0) {
     err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
-  } else if (size > binding.kMaxLength) {
+  } else if (size > kMaxLength) {
     err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
   }
 
@@ -234,7 +254,7 @@ function assertSize(size) {
  * Creates a new filled Buffer instance.
  * alloc(size[, fill[, encoding]])
  **/
-Buffer.alloc = function(size, fill, encoding) {
+Buffer.alloc = function alloc(size, fill, encoding) {
   assertSize(size);
   if (size > 0 && fill !== undefined) {
     // Since we are filling anyway, don't zero fill initially.
@@ -252,7 +272,7 @@ Buffer.alloc = function(size, fill, encoding) {
  * Equivalent to Buffer(num), by default creates a non-zero-filled Buffer
  * instance. If `--zero-fill-buffers` is set, will zero-fill the buffer.
  **/
-Buffer.allocUnsafe = function(size) {
+Buffer.allocUnsafe = function allocUnsafe(size) {
   assertSize(size);
   return allocate(size);
 };
@@ -262,7 +282,7 @@ Buffer.allocUnsafe = function(size) {
  * Buffer instance that is not allocated off the pre-initialized pool.
  * If `--zero-fill-buffers` is set, will zero-fill the buffer.
  **/
-Buffer.allocUnsafeSlow = function(size) {
+Buffer.allocUnsafeSlow = function allocUnsafeSlow(size) {
   assertSize(size);
   return createUnsafeBuffer(size);
 };
@@ -304,7 +324,7 @@ function fromString(string, encoding) {
     encoding = 'utf8';
     if (string.length === 0)
       return new FastBuffer();
-    length = binding.byteLengthUtf8(string);
+    length = byteLengthUtf8(string);
   } else {
     length = byteLength(string, encoding, true);
     if (length === -1)
@@ -314,7 +334,7 @@ function fromString(string, encoding) {
   }
 
   if (length >= (Buffer.poolSize >>> 1))
-    return binding.createFromString(string, encoding);
+    return createFromString(string, encoding);
 
   if (length > (poolSize - poolOffset))
     createPool();
@@ -379,7 +399,7 @@ function fromObject(obj) {
     if (b.length === 0)
       return b;
 
-    binding.copy(obj, b, 0, 0, obj.length);
+    _copy(obj, b, 0, 0, obj.length);
     return b;
   }
 
@@ -416,21 +436,21 @@ Buffer.compare = function compare(a, b) {
     return 0;
   }
 
-  return binding.compare(a, b);
+  return _compare(a, b);
 };
 
 
-Buffer.isEncoding = function(encoding) {
+Buffer.isEncoding = function isEncoding(encoding) {
   return typeof encoding === 'string' &&
-         typeof internalUtil.normalizeEncoding(encoding) === 'string';
+         typeof normalizeEncoding(encoding) === 'string';
 };
-Buffer[internalUtil.kIsEncodingSymbol] = Buffer.isEncoding;
+Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 
 const kConcatErr = new errors.TypeError(
   'ERR_INVALID_ARG_TYPE', 'list', ['array', 'buffer', 'uint8Array']
 );
 
-Buffer.concat = function(list, length) {
+Buffer.concat = function concat(list, length) {
   var i;
   if (!Array.isArray(list))
     throw kConcatErr;
@@ -452,7 +472,7 @@ Buffer.concat = function(list, length) {
     var buf = list[i];
     if (!isUint8Array(buf))
       throw kConcatErr;
-    binding.copy(buf, buffer, pos);
+    _copy(buf, buffer, pos);
     pos += buf.length;
   }
 
@@ -497,23 +517,23 @@ function byteLength(string, encoding) {
     return 0;
 
   if (!encoding)
-    return (mustMatch ? -1 : binding.byteLengthUtf8(string));
+    return (mustMatch ? -1 : byteLengthUtf8(string));
 
   encoding += '';
   switch (encoding.length) {
     case 4:
-      if (encoding === 'utf8') return binding.byteLengthUtf8(string);
+      if (encoding === 'utf8') return byteLengthUtf8(string);
       if (encoding === 'ucs2') return len * 2;
       encoding = encoding.toLowerCase();
-      if (encoding === 'utf8') return binding.byteLengthUtf8(string);
+      if (encoding === 'utf8') return byteLengthUtf8(string);
       if (encoding === 'ucs2') return len * 2;
       break;
     case 5:
-      if (encoding === 'utf-8') return binding.byteLengthUtf8(string);
+      if (encoding === 'utf-8') return byteLengthUtf8(string);
       if (encoding === 'ascii') return len;
       if (encoding === 'ucs-2') return len * 2;
       encoding = encoding.toLowerCase();
-      if (encoding === 'utf-8') return binding.byteLengthUtf8(string);
+      if (encoding === 'utf-8') return byteLengthUtf8(string);
       if (encoding === 'ascii') return len;
       if (encoding === 'ucs-2') return len * 2;
       break;
@@ -537,7 +557,7 @@ function byteLength(string, encoding) {
         return len >>> 1;
       break;
   }
-  return (mustMatch ? -1 : binding.byteLengthUtf8(string));
+  return (mustMatch ? -1 : byteLengthUtf8(string));
 }
 
 Buffer.byteLength = byteLength;
@@ -546,7 +566,7 @@ Buffer.byteLength = byteLength;
 // For backwards compatibility.
 Object.defineProperty(Buffer.prototype, 'parent', {
   enumerable: true,
-  get: function() {
+  get() {
     if (!(this instanceof Buffer))
       return undefined;
     return this.buffer;
@@ -554,7 +574,7 @@ Object.defineProperty(Buffer.prototype, 'parent', {
 });
 Object.defineProperty(Buffer.prototype, 'offset', {
   enumerable: true,
-  get: function() {
+  get() {
     if (!(this instanceof Buffer))
       return undefined;
     return this.byteOffset;
@@ -608,15 +628,16 @@ function stringSlice(buf, encoding, start, end) {
 }
 
 
-Buffer.prototype.copy = function(target, targetStart, sourceStart, sourceEnd) {
-  return binding.copy(this, target, targetStart, sourceStart, sourceEnd);
-};
+Buffer.prototype.copy =
+  function copy(target, targetStart, sourceStart, sourceEnd) {
+    return _copy(this, target, targetStart, sourceStart, sourceEnd);
+  };
 
 // No need to verify that "buf.length <= MAX_UINT32" since it's a read-only
 // property of a typed array.
 // This behaves neither like String nor Uint8Array in that we set start/end
 // to their upper/lower bounds if the value passed is out of range.
-Buffer.prototype.toString = function(encoding, start, end) {
+Buffer.prototype.toString = function toString(encoding, start, end) {
   if (arguments.length === 0) {
     return this.utf8Slice(0, this.length);
   }
@@ -653,12 +674,12 @@ Buffer.prototype.equals = function equals(b) {
   if (this === b)
     return true;
 
-  return binding.compare(this, b) === 0;
+  return _compare(this, b) === 0;
 };
 
 
 // Override how buffers are presented by util.inspect().
-Buffer.prototype[internalUtil.customInspectSymbol] = function inspect() {
+Buffer.prototype[customInspectSymbol] = function inspect() {
   var str = '';
   var max = exports.INSPECT_MAX_BYTES;
   str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim();
@@ -666,7 +687,7 @@ Buffer.prototype[internalUtil.customInspectSymbol] = function inspect() {
     str += ' ... ';
   return `<${this.constructor.name} ${str}>`;
 };
-Buffer.prototype.inspect = Buffer.prototype[internalUtil.customInspectSymbol];
+Buffer.prototype.inspect = Buffer.prototype[customInspectSymbol];
 
 Buffer.prototype.compare = function compare(target,
                                             start,
@@ -679,7 +700,7 @@ Buffer.prototype.compare = function compare(target,
     );
   }
   if (arguments.length === 1)
-    return compare_(this, target);
+    return _compare(this, target);
 
   if (start === undefined)
     start = 0;
@@ -747,13 +768,13 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
 
   if (typeof val === 'string') {
     if (encoding === undefined) {
-      return binding.indexOfString(buffer, val, byteOffset, encoding, dir);
+      return indexOfString(buffer, val, byteOffset, encoding, dir);
     }
     return slowIndexOf(buffer, val, byteOffset, encoding, dir);
   } else if (isUint8Array(val)) {
-    return binding.indexOfBuffer(buffer, val, byteOffset, encoding, dir);
+    return indexOfBuffer(buffer, val, byteOffset, encoding, dir);
   } else if (typeof val === 'number') {
-    return binding.indexOfNumber(buffer, val, byteOffset, dir);
+    return indexOfNumber(buffer, val, byteOffset, dir);
   }
 
   throw new errors.TypeError(
@@ -774,12 +795,12 @@ function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
       case 'utf-16le':
       case 'latin1':
       case 'binary':
-        return binding.indexOfString(buffer, val, byteOffset, encoding, dir);
+        return indexOfString(buffer, val, byteOffset, encoding, dir);
 
       case 'base64':
       case 'ascii':
       case 'hex':
-        return binding.indexOfBuffer(
+        return indexOfBuffer(
           buffer, Buffer.from(val, encoding), byteOffset, encoding, dir);
 
       default:
@@ -828,7 +849,7 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
     if (encoding !== undefined && typeof encoding !== 'string') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'encoding', 'string');
     }
-    var normalizedEncoding = internalUtil.normalizeEncoding(encoding);
+    var normalizedEncoding = normalizeEncoding(encoding);
     if (normalizedEncoding === undefined) {
       throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
     }
@@ -859,13 +880,13 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
   start = start >>> 0;
   end = end === undefined ? this.length : end >>> 0;
 
-  binding.fill(this, val, start, end, encoding);
+  _fill(this, val, start, end, encoding);
 
   return this;
 };
 
 
-Buffer.prototype.write = function(string, offset, length, encoding) {
+Buffer.prototype.write = function write(string, offset, length, encoding) {
   // Buffer#write(string);
   if (offset === undefined) {
     return this.utf8Write(string, 0, this.length);
@@ -950,7 +971,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
 };
 
 
-Buffer.prototype.toJSON = function() {
+Buffer.prototype.toJSON = function toJSON() {
   if (this.length > 0) {
     const data = new Array(this.length);
     for (var i = 0; i < this.length; ++i)
@@ -993,38 +1014,40 @@ function checkOffset(offset, ext, length) {
 }
 
 
-Buffer.prototype.readUIntLE = function(offset, byteLength, noAssert) {
-  offset = offset >>> 0;
-  byteLength = byteLength >>> 0;
-  if (!noAssert)
-    checkOffset(offset, byteLength, this.length);
+Buffer.prototype.readUIntLE =
+  function readUIntLE(offset, byteLength, noAssert) {
+    offset = offset >>> 0;
+    byteLength = byteLength >>> 0;
+    if (!noAssert)
+      checkOffset(offset, byteLength, this.length);
 
-  var val = this[offset];
-  var mul = 1;
-  var i = 0;
-  while (++i < byteLength && (mul *= 0x100))
-    val += this[offset + i] * mul;
+    var val = this[offset];
+    var mul = 1;
+    var i = 0;
+    while (++i < byteLength && (mul *= 0x100))
+      val += this[offset + i] * mul;
 
-  return val;
-};
-
-
-Buffer.prototype.readUIntBE = function(offset, byteLength, noAssert) {
-  offset = offset >>> 0;
-  byteLength = byteLength >>> 0;
-  if (!noAssert)
-    checkOffset(offset, byteLength, this.length);
-
-  var val = this[offset + --byteLength];
-  var mul = 1;
-  while (byteLength > 0 && (mul *= 0x100))
-    val += this[offset + --byteLength] * mul;
-
-  return val;
-};
+    return val;
+  };
 
 
-Buffer.prototype.readUInt8 = function(offset, noAssert) {
+Buffer.prototype.readUIntBE =
+  function readUIntBE(offset, byteLength, noAssert) {
+    offset = offset >>> 0;
+    byteLength = byteLength >>> 0;
+    if (!noAssert)
+      checkOffset(offset, byteLength, this.length);
+
+    var val = this[offset + --byteLength];
+    var mul = 1;
+    while (byteLength > 0 && (mul *= 0x100))
+      val += this[offset + --byteLength] * mul;
+
+    return val;
+  };
+
+
+Buffer.prototype.readUInt8 = function readUInt8(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 1, this.length);
@@ -1032,7 +1055,7 @@ Buffer.prototype.readUInt8 = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readUInt16LE = function(offset, noAssert) {
+Buffer.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 2, this.length);
@@ -1040,7 +1063,7 @@ Buffer.prototype.readUInt16LE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readUInt16BE = function(offset, noAssert) {
+Buffer.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 2, this.length);
@@ -1048,7 +1071,7 @@ Buffer.prototype.readUInt16BE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readUInt32LE = function(offset, noAssert) {
+Buffer.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
@@ -1060,7 +1083,7 @@ Buffer.prototype.readUInt32LE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readUInt32BE = function(offset, noAssert) {
+Buffer.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
@@ -1072,7 +1095,7 @@ Buffer.prototype.readUInt32BE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
+Buffer.prototype.readIntLE = function readIntLE(offset, byteLength, noAssert) {
   offset = offset >>> 0;
   byteLength = byteLength >>> 0;
   if (!noAssert)
@@ -1092,7 +1115,7 @@ Buffer.prototype.readIntLE = function(offset, byteLength, noAssert) {
 };
 
 
-Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
+Buffer.prototype.readIntBE = function readIntBE(offset, byteLength, noAssert) {
   offset = offset >>> 0;
   byteLength = byteLength >>> 0;
   if (!noAssert)
@@ -1112,7 +1135,7 @@ Buffer.prototype.readIntBE = function(offset, byteLength, noAssert) {
 };
 
 
-Buffer.prototype.readInt8 = function(offset, noAssert) {
+Buffer.prototype.readInt8 = function readInt8(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 1, this.length);
@@ -1121,7 +1144,7 @@ Buffer.prototype.readInt8 = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readInt16LE = function(offset, noAssert) {
+Buffer.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 2, this.length);
@@ -1130,7 +1153,7 @@ Buffer.prototype.readInt16LE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readInt16BE = function(offset, noAssert) {
+Buffer.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 2, this.length);
@@ -1139,7 +1162,7 @@ Buffer.prototype.readInt16BE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readInt32LE = function(offset, noAssert) {
+Buffer.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
@@ -1151,7 +1174,7 @@ Buffer.prototype.readInt32LE = function(offset, noAssert) {
 };
 
 
-Buffer.prototype.readInt32BE = function(offset, noAssert) {
+Buffer.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
@@ -1167,7 +1190,7 @@ Buffer.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return binding.readFloatLE(this, offset);
+  return _readFloatLE(this, offset);
 };
 
 
@@ -1175,7 +1198,7 @@ Buffer.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 4, this.length);
-  return binding.readFloatBE(this, offset);
+  return _readFloatBE(this, offset);
 };
 
 
@@ -1183,7 +1206,7 @@ Buffer.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 8, this.length);
-  return binding.readDoubleLE(this, offset);
+  return _readDoubleLE(this, offset);
 };
 
 
@@ -1191,7 +1214,7 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
   offset = offset >>> 0;
   if (!noAssert)
     checkOffset(offset, 8, this.length);
-  return binding.readDoubleBE(this, offset);
+  return _readDoubleBE(this, offset);
 };
 
 
@@ -1203,155 +1226,164 @@ function checkInt(buffer, value, offset, ext, max, min) {
 }
 
 
-Buffer.prototype.writeUIntLE = function(value, offset, byteLength, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  byteLength = byteLength >>> 0;
-  if (!noAssert) {
-    const maxBytes = Math.pow(2, 8 * byteLength) - 1;
-    checkInt(this, value, offset, byteLength, maxBytes, 0);
-  }
+Buffer.prototype.writeUIntLE =
+  function writeUIntLE(value, offset, byteLength, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    byteLength = byteLength >>> 0;
+    if (!noAssert) {
+      const maxBytes = Math.pow(2, 8 * byteLength) - 1;
+      checkInt(this, value, offset, byteLength, maxBytes, 0);
+    }
 
-  var mul = 1;
-  var i = 0;
-  this[offset] = value;
-  while (++i < byteLength && (mul *= 0x100))
-    this[offset + i] = (value / mul) >>> 0;
+    var mul = 1;
+    var i = 0;
+    this[offset] = value;
+    while (++i < byteLength && (mul *= 0x100))
+      this[offset + i] = (value / mul) >>> 0;
 
-  return offset + byteLength;
-};
-
-
-Buffer.prototype.writeUIntBE = function(value, offset, byteLength, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  byteLength = byteLength >>> 0;
-  if (!noAssert) {
-    const maxBytes = Math.pow(2, 8 * byteLength) - 1;
-    checkInt(this, value, offset, byteLength, maxBytes, 0);
-  }
-
-  var i = byteLength - 1;
-  var mul = 1;
-  this[offset + i] = value;
-  while (--i >= 0 && (mul *= 0x100))
-    this[offset + i] = (value / mul) >>> 0;
-
-  return offset + byteLength;
-};
+    return offset + byteLength;
+  };
 
 
-Buffer.prototype.writeUInt8 = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 1, 0xff, 0);
-  this[offset] = value;
-  return offset + 1;
-};
+Buffer.prototype.writeUIntBE =
+  function writeUIntBE(value, offset, byteLength, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    byteLength = byteLength >>> 0;
+    if (!noAssert) {
+      const maxBytes = Math.pow(2, 8 * byteLength) - 1;
+      checkInt(this, value, offset, byteLength, maxBytes, 0);
+    }
+
+    var i = byteLength - 1;
+    var mul = 1;
+    this[offset + i] = value;
+    while (--i >= 0 && (mul *= 0x100))
+      this[offset + i] = (value / mul) >>> 0;
+
+    return offset + byteLength;
+  };
 
 
-Buffer.prototype.writeUInt16LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = value;
-  this[offset + 1] = (value >>> 8);
-  return offset + 2;
-};
+Buffer.prototype.writeUInt8 =
+  function writeUInt8(value, offset, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert)
+      checkInt(this, value, offset, 1, 0xff, 0);
+    this[offset] = value;
+    return offset + 1;
+  };
 
 
-Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 2, 0xffff, 0);
-  this[offset] = (value >>> 8);
-  this[offset + 1] = value;
-  return offset + 2;
-};
+Buffer.prototype.writeUInt16LE =
+  function writeUInt16LE(value, offset, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert)
+      checkInt(this, value, offset, 2, 0xffff, 0);
+    this[offset] = value;
+    this[offset + 1] = (value >>> 8);
+    return offset + 2;
+  };
 
 
-Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset + 3] = (value >>> 24);
-  this[offset + 2] = (value >>> 16);
-  this[offset + 1] = (value >>> 8);
-  this[offset] = value;
-  return offset + 4;
-};
+Buffer.prototype.writeUInt16BE =
+  function writeUInt16BE(value, offset, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert)
+      checkInt(this, value, offset, 2, 0xffff, 0);
+    this[offset] = (value >>> 8);
+    this[offset + 1] = value;
+    return offset + 2;
+  };
 
 
-Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert)
-    checkInt(this, value, offset, 4, 0xffffffff, 0);
-  this[offset] = (value >>> 24);
-  this[offset + 1] = (value >>> 16);
-  this[offset + 2] = (value >>> 8);
-  this[offset + 3] = value;
-  return offset + 4;
-};
+Buffer.prototype.writeUInt32LE =
+  function writeUInt32LE(value, offset, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert)
+      checkInt(this, value, offset, 4, 0xffffffff, 0);
+    this[offset + 3] = (value >>> 24);
+    this[offset + 2] = (value >>> 16);
+    this[offset + 1] = (value >>> 8);
+    this[offset] = value;
+    return offset + 4;
+  };
 
 
-Buffer.prototype.writeIntLE = function(value, offset, byteLength, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert) {
-    checkInt(this,
-             value,
-             offset,
-             byteLength,
-             Math.pow(2, 8 * byteLength - 1) - 1,
-             -Math.pow(2, 8 * byteLength - 1));
-  }
-
-  var i = 0;
-  var mul = 1;
-  var sub = 0;
-  this[offset] = value;
-  while (++i < byteLength && (mul *= 0x100)) {
-    if (value < 0 && sub === 0 && this[offset + i - 1] !== 0)
-      sub = 1;
-    this[offset + i] = ((value / mul) >> 0) - sub;
-  }
-
-  return offset + byteLength;
-};
+Buffer.prototype.writeUInt32BE =
+  function writeUInt32BE(value, offset, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert)
+      checkInt(this, value, offset, 4, 0xffffffff, 0);
+    this[offset] = (value >>> 24);
+    this[offset + 1] = (value >>> 16);
+    this[offset + 2] = (value >>> 8);
+    this[offset + 3] = value;
+    return offset + 4;
+  };
 
 
-Buffer.prototype.writeIntBE = function(value, offset, byteLength, noAssert) {
-  value = +value;
-  offset = offset >>> 0;
-  if (!noAssert) {
-    checkInt(this,
-             value,
-             offset,
-             byteLength,
-             Math.pow(2, 8 * byteLength - 1) - 1,
-             -Math.pow(2, 8 * byteLength - 1));
-  }
+Buffer.prototype.writeIntLE =
+  function writeIntLE(value, offset, byteLength, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert) {
+      checkInt(this,
+               value,
+               offset,
+               byteLength,
+               Math.pow(2, 8 * byteLength - 1) - 1,
+               -Math.pow(2, 8 * byteLength - 1));
+    }
 
-  var i = byteLength - 1;
-  var mul = 1;
-  var sub = 0;
-  this[offset + i] = value;
-  while (--i >= 0 && (mul *= 0x100)) {
-    if (value < 0 && sub === 0 && this[offset + i + 1] !== 0)
-      sub = 1;
-    this[offset + i] = ((value / mul) >> 0) - sub;
-  }
+    var i = 0;
+    var mul = 1;
+    var sub = 0;
+    this[offset] = value;
+    while (++i < byteLength && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i - 1] !== 0)
+        sub = 1;
+      this[offset + i] = ((value / mul) >> 0) - sub;
+    }
 
-  return offset + byteLength;
-};
+    return offset + byteLength;
+  };
 
 
-Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
+Buffer.prototype.writeIntBE =
+  function writeIntBE(value, offset, byteLength, noAssert) {
+    value = +value;
+    offset = offset >>> 0;
+    if (!noAssert) {
+      checkInt(this,
+               value,
+               offset,
+               byteLength,
+               Math.pow(2, 8 * byteLength - 1) - 1,
+               -Math.pow(2, 8 * byteLength - 1));
+    }
+
+    var i = byteLength - 1;
+    var mul = 1;
+    var sub = 0;
+    this[offset + i] = value;
+    while (--i >= 0 && (mul *= 0x100)) {
+      if (value < 0 && sub === 0 && this[offset + i + 1] !== 0)
+        sub = 1;
+      this[offset + i] = ((value / mul) >> 0) - sub;
+    }
+
+    return offset + byteLength;
+  };
+
+
+Buffer.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
@@ -1361,7 +1393,7 @@ Buffer.prototype.writeInt8 = function(value, offset, noAssert) {
 };
 
 
-Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
+Buffer.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
@@ -1372,7 +1404,7 @@ Buffer.prototype.writeInt16LE = function(value, offset, noAssert) {
 };
 
 
-Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
+Buffer.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
@@ -1383,7 +1415,7 @@ Buffer.prototype.writeInt16BE = function(value, offset, noAssert) {
 };
 
 
-Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
+Buffer.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
@@ -1396,7 +1428,7 @@ Buffer.prototype.writeInt32LE = function(value, offset, noAssert) {
 };
 
 
-Buffer.prototype.writeInt32BE = function(value, offset, noAssert) {
+Buffer.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
   value = +value;
   offset = offset >>> 0;
   if (!noAssert)
@@ -1413,9 +1445,9 @@ Buffer.prototype.writeFloatLE = function writeFloatLE(val, offset, noAssert) {
   val = +val;
   offset = offset >>> 0;
   if (!noAssert)
-    binding.writeFloatLE(this, val, offset);
+    _writeFloatLE(this, val, offset);
   else
-    binding.writeFloatLE(this, val, offset, true);
+    _writeFloatLE(this, val, offset, true);
   return offset + 4;
 };
 
@@ -1424,9 +1456,9 @@ Buffer.prototype.writeFloatBE = function writeFloatBE(val, offset, noAssert) {
   val = +val;
   offset = offset >>> 0;
   if (!noAssert)
-    binding.writeFloatBE(this, val, offset);
+    _writeFloatBE(this, val, offset);
   else
-    binding.writeFloatBE(this, val, offset, true);
+    _writeFloatBE(this, val, offset, true);
   return offset + 4;
 };
 
@@ -1435,9 +1467,9 @@ Buffer.prototype.writeDoubleLE = function writeDoubleLE(val, offset, noAssert) {
   val = +val;
   offset = offset >>> 0;
   if (!noAssert)
-    binding.writeDoubleLE(this, val, offset);
+    _writeDoubleLE(this, val, offset);
   else
-    binding.writeDoubleLE(this, val, offset, true);
+    _writeDoubleLE(this, val, offset, true);
   return offset + 8;
 };
 
@@ -1446,15 +1478,11 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE(val, offset, noAssert) {
   val = +val;
   offset = offset >>> 0;
   if (!noAssert)
-    binding.writeDoubleBE(this, val, offset);
+    _writeDoubleBE(this, val, offset);
   else
-    binding.writeDoubleBE(this, val, offset, true);
+    _writeDoubleBE(this, val, offset, true);
   return offset + 8;
 };
-
-const swap16n = binding.swap16;
-const swap32n = binding.swap32;
-const swap64n = binding.swap64;
 
 function swap(b, n, m) {
   const i = b[n];
@@ -1475,7 +1503,7 @@ Buffer.prototype.swap16 = function swap16() {
       swap(this, i, i + 1);
     return this;
   }
-  return swap16n(this);
+  return _swap16(this);
 };
 
 
@@ -1493,7 +1521,7 @@ Buffer.prototype.swap32 = function swap32() {
     }
     return this;
   }
-  return swap32n(this);
+  return _swap32(this);
 };
 
 
@@ -1513,13 +1541,52 @@ Buffer.prototype.swap64 = function swap64() {
     }
     return this;
   }
-  return swap64n(this);
+  return _swap64(this);
 };
 
 Buffer.prototype.toLocaleString = Buffer.prototype.toString;
 
-// Put this at the end because internal/buffer has a circular
-// dependency on Buffer.
-const internalBuffer = require('internal/buffer');
-exports.transcode = internalBuffer.transcode;
-internalBuffer.FastBuffer = FastBuffer;
+let transcode;
+if (process.binding('config').hasIntl) {
+  const {
+    icuErrName,
+    transcode: _transcode
+  } = process.binding('icu');
+
+  // Transcodes the Buffer from one encoding to another, returning a new
+  // Buffer instance.
+  transcode = function transcode(source, fromEncoding, toEncoding) {
+    if (!isUint8Array(source))
+      throw new TypeError('"source" argument must be a Buffer or Uint8Array');
+    if (source.length === 0) return Buffer.alloc(0);
+
+    fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;
+    toEncoding = normalizeEncoding(toEncoding) || toEncoding;
+    const result = _transcode(source, fromEncoding, toEncoding);
+    if (typeof result !== 'number')
+      return result;
+
+    const code = icuErrName(result);
+    const err = new Error(`Unable to transcode Buffer [${code}]`);
+    err.code = code;
+    err.errno = result;
+    throw err;
+  };
+}
+
+module.exports = exports = {
+  Buffer,
+  SlowBuffer,
+  transcode,
+  INSPECT_MAX_BYTES: 50,
+
+  // Legacy
+  kMaxLength,
+  kStringMaxLength
+};
+
+Object.defineProperty(exports, 'constants', {
+  configurable: false,
+  enumerable: true,
+  value: constants
+});

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1,35 +1,4 @@
 'use strict';
 
-if (!process.binding('config').hasIntl) {
-  return;
-}
-
-const normalizeEncoding = require('internal/util').normalizeEncoding;
-const Buffer = require('buffer').Buffer;
-
-const icu = process.binding('icu');
-const { isUint8Array } = process.binding('util');
-
-// Transcodes the Buffer from one encoding to another, returning a new
-// Buffer instance.
-function transcode(source, fromEncoding, toEncoding) {
-  if (!isUint8Array(source))
-    throw new TypeError('"source" argument must be a Buffer or Uint8Array');
-  if (source.length === 0) return Buffer.alloc(0);
-
-  fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;
-  toEncoding = normalizeEncoding(toEncoding) || toEncoding;
-  const result = icu.transcode(source, fromEncoding, toEncoding);
-  if (typeof result !== 'number')
-    return result;
-
-  const code = icu.icuErrName(result);
-  const err = new Error(`Unable to transcode Buffer [${code}]`);
-  err.code = code;
-  err.errno = result;
-  throw err;
-}
-
-module.exports = {
-  transcode
-};
+// This is needed still for FastBuffer
+module.exports = {};


### PR DESCRIPTION
* Refactor buffer exports to use module.exports = {} pattern
* ~Migrate most errors to use internal/errors~ <sub>refack: crossed off, as this was done in #13976</sub>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer