### PR TITLE
doc: fixed formatting issue in cli docs

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -512,7 +512,7 @@ added: v6.11.0
 
 Load an OpenSSL configuration file on startup. Among other uses, this can be
 used to enable FIPS-compliant crypto if Node.js is built with `./configure
-\-\-openssl\-fips`.
+--openssl-fips`.
 
 If the [`--openssl-config`][] command line option is used, the environment
 variable is ignored.


### PR DESCRIPTION
Removed some bad escape characters

Fixes: https://github.com/nodejs/node/issues/13805

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
