### PR TITLE
tools: add eslint rule for inspector checking

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -10,5 +10,6 @@ rules:
   prefer-assert-iferror: 2
   prefer-assert-methods: 2
   prefer-common-mustnotcall: 2
+  inspector-check: 2
   ## common module is mandatory in tests
   required-modules: [2, common]

--- a/tools/eslint-rules/inspector-check.js
+++ b/tools/eslint-rules/inspector-check.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Check that common.skipIfInspectorDisabled is used if
+ *               the inspector module is required.
+ * @author Daniel Bevenius <daniel.bevenius@gmail.com>
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+const msg = 'Please add a skipIfInspectorDisabled() call to allow this ' +
+            'test to be skippped when Node is built \'--without-inspector\'.';
+
+module.exports = function(context) {
+  var usesInspector = false;
+  var hasInspectorCheck = false;
+
+  function testInspectorUsage(context, node) {
+    if (node.callee.name === 'require' &&
+        node.arguments[0].value === 'inspector') {
+      usesInspector = true;
+    }
+  }
+
+  function checkMemberExpression(context, node) {
+    if (node.parent.type === 'CallExpression' &&
+        node.property.name === 'skipIfInspectorDisabled') {
+      hasInspectorCheck = true;
+    }
+  }
+
+  function reportIfMissing(context, node) {
+    if (usesInspector && !hasInspectorCheck) {
+      context.report(node, msg);
+    }
+  }
+
+  return {
+    'CallExpression': (node) => testInspectorUsage(context, node),
+    'MemberExpression': (node) => checkMemberExpression(context, node),
+    'Program:exit': (node) => reportIfMissing(context, node)
+  };
+};


### PR DESCRIPTION
The motivation for this commit is to pick up early on missing checks for
inspector support (when Node is built --without-inspector).


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools