### PR TITLE
inspector: support extra contexts when connected

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -259,6 +259,15 @@ inline void Environment::TickInfo::set_index(uint32_t value) {
 
 inline void Environment::AssignToContext(v8::Local<v8::Context> context) {
   context->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex, this);
+#if HAVE_INSPECTOR
+  inspector_agent()->ContextCreated(context);
+#endif  // HAVE_INSPECTOR
+}
+
+inline void Environment::UnassignFromContext(v8::Local<v8::Context> context) {
+#if HAVE_INSPECTOR
+  inspector_agent()->ContextDestroyed(context);
+#endif  // HAVE_INSPECTOR
 }
 
 inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {

--- a/src/env.h
+++ b/src/env.h
@@ -530,6 +530,7 @@ class Environment {
              const char* const* exec_argv,
              bool start_profiler_idle_notifier);
   void AssignToContext(v8::Local<v8::Context> context);
+  void UnassignFromContext(v8::Local<v8::Context> context);
   void CleanupHandles();
 
   void StartProfilerIdleNotifier();

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -11,6 +11,7 @@
 
 #include "libplatform/libplatform.h"
 
+#include <algorithm>
 #include <string.h>
 #include <sstream>
 #include <vector>
@@ -608,6 +609,13 @@ bool Agent::StartIoThread(bool wait_for_connect) {
   MakeCallback(parent_env_->isolate(), process_object, emit_fn.As<Function>(),
                arraysize(argv), argv, 0, 0);
 
+  // Send contexts to inspector client that were created before connecting
+  for (auto const& context : contexts_) {
+    std::ostringstream name;
+    name << "VM Context " << next_context_number_++;
+    client_->contextCreated(context, name.str());
+  }
+
   return true;
 }
 
@@ -672,16 +680,23 @@ void Agent::PauseOnNextJavascriptStatement(const std::string& reason) {
 }
 
 void Agent::ContextCreated(Local<Context> context) {
-  if (!IsStarted()) // This happens for a main context
+  if (!IsStarted())  // This happens for a main context
     return;
-  std::ostringstream name;
-  name << "VM Context " << next_context_number_++;
-  client_->contextCreated(context, name.str());
+  if (IsConnected()) {
+    std::ostringstream name;
+    name << "VM Context " << next_context_number_++;
+    client_->contextCreated(context, name.str());
+  }
+  contexts_.push_back(context);
 }
 
 void Agent::ContextDestroyed(Local<Context> context) {
   CHECK_NE(client_, nullptr);
-  client_->contextDestroyed(context);
+  auto it = std::find(contexts_.begin(), contexts_.end(), context);
+  if (it != contexts_.end()) {
+    client_->contextDestroyed(context);
+    contexts_.erase(it);
+  }
 }
 
 void Open(const FunctionCallbackInfo<Value>& args) {

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -2,6 +2,7 @@
 #define SRC_INSPECTOR_AGENT_H_
 
 #include <memory>
+#include <vector>
 
 #include <stddef.h>
 
@@ -108,6 +109,7 @@ class Agent {
   bool enabled_;
   std::string path_;
   DebugOptions debug_options_;
+  std::vector<v8::Local<v8::Context>> contexts_;
   int next_context_number_;
 };
 

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -79,6 +79,9 @@ class Agent {
   bool enabled() { return enabled_; }
   void PauseOnNextJavascriptStatement(const std::string& reason);
 
+  void ContextCreated(v8::Local<v8::Context> context);
+  void ContextDestroyed(v8::Local<v8::Context> context);
+
   // Initialize 'inspector' module bindings
   static void InitInspector(v8::Local<v8::Object> target,
                             v8::Local<v8::Value> unused,
@@ -105,6 +108,7 @@ class Agent {
   bool enabled_;
   std::string path_;
   DebugOptions debug_options_;
+  int next_context_number_;
 };
 
 }  // namespace inspector

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -357,6 +357,8 @@ class ContextifyContext {
 
   static void WeakCallback(const WeakCallbackInfo<ContextifyContext>& data) {
     ContextifyContext* context = data.GetParameter();
+    context->env()->UnassignFromContext(context->context());
+
     delete context;
   }
 

--- a/test/inspector/test-contexts.js
+++ b/test/inspector/test-contexts.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+const assert = require('assert');
+const helper = require('./inspector-helper.js');
+
+function setupExpectBreakInContext() {
+  return function(message) {
+    if ('Debugger.paused' === message['method']) {
+      const callFrame = message['params']['callFrames'][0];
+      assert.strictEqual(callFrame['functionName'], 'testfn');
+      return true;
+    }
+  };
+}
+
+function testBreakpointInContext(session) {
+  console.log('[test]',
+              'Verifying debugger stops on start (--inspect-brk option)');
+  const commands = [
+    { 'method': 'Runtime.enable' },
+    { 'method': 'Debugger.enable' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' }
+  ];
+  session
+    .sendInspectorCommands(commands)
+    .expectMessages(setupExpectBreakInContext());
+}
+
+function resume(session) {
+  session
+    .sendInspectorCommands({ 'method': 'Debugger.resume'})
+    .disconnect(true);
+}
+
+function runTests(harness) {
+  harness
+    .runFrontendSession([
+      testBreakpointInContext,
+      resume,
+    ]).expectShutDown(0);
+}
+
+const script = 'require("vm").runInNewContext(' +
+               '"function testfn() {debugger};testfn();")';
+
+helper.startNodeForInspectorTest(runTests, '--inspect-brk', script);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
`inspector`

This makes the inspector aware of extra contexts, enabling debugging inside `vm.Script` code.

It is based on @eugeneo's [branch](https://github.com/eugeneo/node/tree/contexts_crashing), which used to have an issue with GC crashes due to `InspectedContext`s not being destroyed in the right order, but this is no longer an issue as of V8 5.9.

The original approach sent every context to the inspector whether or not it was connected, but wrapping a context in `InspectedContext` has a side-effect of attaching `global` and `console` instances to the context, which caused test failures. The approach I took was to only call `contextCreated` if the inspector is actually connected to limit the impact of these side effects.

Fixes: #7593
Fixes: #12096
Closes: #9272 