### PR TITLE
build: clean up config_fips.gypi

### DIFF
--- a/configure
+++ b/configure
@@ -984,8 +984,10 @@ def configure_openssl(o):
     ]
   else:
     o['variables']['openssl_fips'] = ''
-    os.remove('config_fips.gypi')
-
+    try:
+      os.remove('config_fips.gypi')
+    except OSError:
+      pass
 
   if options.without_ssl:
     def without_ssl_error(option):

--- a/configure
+++ b/configure
@@ -984,6 +984,7 @@ def configure_openssl(o):
     ]
   else:
     o['variables']['openssl_fips'] = ''
+    os.remove('config_fips.gypi')
 
 
   if options.without_ssl:


### PR DESCRIPTION
Currently when configuring the project using --openssl-fips a gyp
include file name config_fips.gypi will be created. If the project is
later configured but without the --openssl-fips flag an error will
occur. For example:
```console
  $ ./configure --openssl-fips=bogus
  $ ./configure && make -j8
  ...
  /node/deps/openssl/fips/fipsld:
  line 8: /bin/fipsld: No such file or directory
  Error 127
```
This commit suggests removing the generate config_fips.gypi when the
--openssl-fips flag is not give on the command line.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build