### PR TITLE
test: remove `require('buffer')` on 4 test files

### DIFF
--- a/test/parallel/test-stream-uint8array.js
+++ b/test/parallel/test-stream-uint8array.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const Buffer = require('buffer').Buffer;
 
 const { Readable, Writable } = require('stream');
 

--- a/test/parallel/test-stream2-finish-pipe.js
+++ b/test/parallel/test-stream2-finish-pipe.js
@@ -22,7 +22,6 @@
 'use strict';
 require('../common');
 const stream = require('stream');
-const Buffer = require('buffer').Buffer;
 
 const r = new stream.Readable();
 r._read = function(size) {

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -46,7 +46,6 @@ function doTest(testOptions, callback) {
   const fs = require('fs');
   const join = require('path').join;
   const spawn = require('child_process').spawn;
-  const Buffer = require('buffer').Buffer;
 
   const keyFile = join(common.fixturesDir, 'agent.key');
   const certFile = join(common.fixturesDir, 'agent.crt');

--- a/test/parallel/test-vm-cached-data.js
+++ b/test/parallel/test-vm-cached-data.js
@@ -3,7 +3,6 @@ require('../common');
 const assert = require('assert');
 const vm = require('vm');
 const spawnSync = require('child_process').spawnSync;
-const Buffer = require('buffer').Buffer;
 
 function getSource(tag) {
   return `(function ${tag}() { return '${tag}'; })`;


### PR DESCRIPTION
We don't use the global Buffer throughout the lib/ to avoid circular
dependency issues in core, but we actually don't need to require it on
test files. So remove them on:

+ test/parallel/test-stream-uint8array.js
+ test/parallel/test-stream2-finish-pipe.js
+ test/parallel/test-tls-session-cache.js
+ test/parallel/test-vm-cached-data.js

Refs: https://github.com/nodejs/node/issues/13836

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, buffer