### PR TITLE
test: remove `require('buffer')` on 6 test files

### DIFF
--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -4,7 +4,6 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const Buffer = require('buffer').Buffer;
 
 common.refreshTmpDir();
 

--- a/test/parallel/test-fs-read-zero-length.js
+++ b/test/parallel/test-fs-read-zero-length.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
-const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 const filepath = path.join(common.fixturesDir, 'x.txt');
 const fd = fs.openSync(filepath, 'r');

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
-const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 const filepath = path.join(common.fixturesDir, 'x.txt');
 const fd = fs.openSync(filepath, 'r');

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -6,7 +6,6 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const URL = require('url').URL;
-const Buffer = require('buffer').Buffer;
 
 function pathToFileURL(p) {
   if (!path.isAbsolute(p))

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
-const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 
 common.refreshTmpDir();

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const assert = require('assert');
 const path = require('path');
-const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 const fn = path.join(common.tmpDir, 'write.txt');
 const fn2 = path.join(common.tmpDir, 'write2.txt');


### PR DESCRIPTION
* test/parallel/test-fs-mkdtemp.js
* test/parallel/test-fs-read-zero-length.js
* test/parallel/test-fs-read.js
* test/parallel/test-fs-whatwg-url.js
* test/parallel/test-fs-write-string-coerce.js
* test/parallel/test-fs-write.js

Refs: https://github.com/nodejs/node/issues/13836

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, buffer
