### PR TITLE
test: remove `require('buffer')` on 4 test files

### DIFF
--- a/test/parallel/test-buffer-fakes.js
+++ b/test/parallel/test-buffer-fakes.js
@@ -2,7 +2,6 @@
 
 require('../common');
 const assert = require('assert');
-const Buffer = require('buffer').Buffer;
 
 function FakeBuffer() { }
 Object.setPrototypeOf(FakeBuffer, Buffer);

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -2,8 +2,6 @@
 const common = require('../common');
 const assert = require('assert');
 
-const Buffer = require('buffer').Buffer;
-
 const b = Buffer.from('abcdef');
 const buf_a = Buffer.from('a');
 const buf_bc = Buffer.from('bc');

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -2,8 +2,6 @@
 require('../common');
 const assert = require('assert');
 
-const Buffer = require('buffer').Buffer;
-
 const b = Buffer.from('abcdef');
 const buf_a = Buffer.from('a');
 const buf_bc = Buffer.from('bc');

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -2,6 +2,5 @@
 
 require('../common');
 const assert = require('assert');
-const Buffer = require('buffer').Buffer;
 
 assert.throws(() => new Buffer(42, 'utf8'), /first argument must be a string/);


### PR DESCRIPTION
* test/parallel/test-buffer-fakes.js
* test/parallel/test-buffer-includes.js
* test/parallel/test-buffer-indexof.js
* test/parallel/test-buffer-new.js

Refs: https://github.com/nodejs/node/issues/13836

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, buffer