### PR TITLE
child_process: fix IPC 'message' event regression

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -457,7 +457,6 @@ function setupChannel(target, channel) {
       }
       chunks[0] = jsonBuffer + chunks[0];
 
-      var nextTick = false;
       for (var i = 0; i < numCompleteChunks; i++) {
         var message = JSON.parse(chunks[i]);
 
@@ -466,12 +465,11 @@ function setupChannel(target, channel) {
         // that we deliver the handle with the right message however.
         if (isInternal(message)) {
           if (message.cmd === 'NODE_HANDLE')
-            handleMessage(message, recvHandle, true, false);
+            handleMessage(message, recvHandle, true);
           else
-            handleMessage(message, undefined, true, false);
+            handleMessage(message, undefined, true);
         } else {
-          handleMessage(message, undefined, false, nextTick);
-          nextTick = true;
+          handleMessage(message, undefined, false);
         }
       }
       jsonBuffer = incompleteChunk;
@@ -533,7 +531,7 @@ function setupChannel(target, channel) {
 
     // Convert handle object
     obj.got.call(this, message, handle, function(handle) {
-      handleMessage(message.msg, handle, isInternal(message.msg), false);
+      handleMessage(message.msg, handle, isInternal(message.msg));
     });
   });
 
@@ -743,15 +741,13 @@ function setupChannel(target, channel) {
     target.emit(event, message, handle);
   }
 
-  function handleMessage(message, handle, internal, nextTick) {
+  function handleMessage(message, handle, internal) {
     if (!target.channel)
       return;
 
     var eventName = (internal ? 'internalMessage' : 'message');
-    if (nextTick)
-      process.nextTick(emit, eventName, message, handle);
-    else
-      target.emit(eventName, message, handle);
+
+    process.nextTick(emit, eventName, message, handle);
   }
 
   channel.readStart();

--- a/test/parallel/test-child-process-ipc-next-tick.js
+++ b/test/parallel/test-child-process-ipc-next-tick.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const NUM_MESSAGES = 10;
+const values = [];
+
+for (let i = 0; i < NUM_MESSAGES; ++i) {
+  values[i] = i;
+}
+
+if (process.argv[2] === 'child') {
+  const received = values.map(() => { return false; });
+
+  process.on('uncaughtException', common.mustCall((err) => {
+    received[err] = true;
+    const done = received.every((element) => { return element === true; });
+
+    if (done)
+      process.disconnect();
+  }, NUM_MESSAGES));
+
+  process.on('message', (msg) => {
+    // If messages are handled synchronously, throwing should break the IPC
+    // message processing.
+    throw msg;
+  });
+
+  process.send('ready');
+} else {
+  const child = cp.fork(__filename, ['child']);
+
+  child.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'ready');
+    values.forEach((value) => {
+      child.send(value);
+    });
+  }));
+}


### PR DESCRIPTION
This PR reverts 8208fdae2be11ff3c1126dc669ca63b6d08b0cb1 from #13459. When IPC messages are not emitted in the next tick, a `'message'` handler that throws can break the IPC read loop. This was originally fixed in #6909.

The second commit in this PR adds a regression test that fails with 8208fdae2be11ff3c1126dc669ca63b6d08b0cb1, but passes with the revert (at least on my machine).

Note: I believe this can be fixed without a full revert of 8208fdae2be11ff3c1126dc669ca63b6d08b0cb1, but wanted to use that as a starting point for this PR.

Refs: https://github.com/nodejs/node/pull/6909
Refs: https://github.com/nodejs/node/pull/13459
Refs: https://github.com/nodejs/node/pull/13648

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
child_process, test