### PR TITLE
test: remove unneeded HandleScope usage

### DIFF
--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -55,7 +55,6 @@ void AfterAsync(uv_work_t* r) {
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  v8::HandleScope scope(isolate);
 
   async_req* req = new async_req;
   req->req.data = req;

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -3,7 +3,6 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  v8::HandleScope scope(isolate);
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -3,7 +3,6 @@
 
 void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
-  v8::HandleScope scope(isolate);
   args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
 }
 

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -25,14 +25,12 @@
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::Local;
-using v8::HandleScope;
 using v8::Isolate;
 using v8::Object;
 using v8::Value;
 
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  HandleScope scope(isolate);
   node::MakeCallback(isolate,
                      isolate->GetCurrentContext()->Global(),
                      args[0].As<Function>(),


### PR DESCRIPTION
These methods are Javascript-accessible so they get an implicit
HandleScope. The extra scope is unneeded and can be dropped.

/cc @bnoordhuis 

##### Checklist
- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test