### PR TITLE
test: removed unnecessary Buffer import

### DIFF
--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -62,8 +62,8 @@ var DATA = {
 };
 
 var SOCK_PATH = path.join(__dirname,
-  '..',
-  path.basename(__filename, '.js') + '.sock');
+                          '..',
+                          path.basename(__filename, '.js') + '.sock');
 
 var logChild = function(d) {
   if (typeof d == 'object') {

--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -8,7 +8,7 @@
 // persons to whom the Software is furnished to do so, subject to the
 // following conditions:
 //
-// The above copyright notice and this permission notice shall be included
+// The above copnotice and this permission notice shall be included
 // in all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
@@ -50,7 +50,6 @@
 const common = require('../common');
 const assert = require('assert');
 
-const buffer = require('buffer');
 const child_process = require('child_process');
 const fs = require('fs');
 const net = require('net');
@@ -58,13 +57,13 @@ var netBinding = process.binding('net');
 const path = require('path');
 
 var DATA = {
-  'ppid' : process.pid,
-  'ord' : 0
+  'ppid': process.pid,
+  'ord': 0
 };
 
 var SOCK_PATH = path.join(__dirname,
-                          '..',
-                          path.basename(__filename, '.js') + '.sock');
+  '..',
+  path.basename(__filename, '.js') + '.sock');
 
 var logChild = function(d) {
   if (typeof d == 'object') {
@@ -112,7 +111,7 @@ var srv = net.createServer(function(s) {
   var str = JSON.stringify(DATA) + '\n';
 
   DATA.ord = DATA.ord + 1;
-  var buf = buffer.Buffer.allocUnsafe(str.length);
+  var buf = Buffer.allocUnsafe(str.length);
   buf.write(JSON.stringify(DATA) + '\n', 'utf8');
 
   s.write(str, 'utf8', pipeFDs[1]);
@@ -127,9 +126,9 @@ var srv = net.createServer(function(s) {
 srv.listen(SOCK_PATH);
 
 // Spawn a child running test/fixtures/recvfd.js
-var cp = child_process.spawn(process.argv[0],
-                             [path.join(common.fixturesDir, 'recvfd.js'),
-                              SOCK_PATH]);
+var cp = child_process.spawn(process.argv[0], [path.join(common.fixturesDir, 'recvfd.js'),
+  SOCK_PATH
+]);
 
 cp.stdout.on('data', logChild);
 cp.stderr.on('data', logChild);

--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -57,8 +57,8 @@ var netBinding = process.binding('net');
 const path = require('path');
 
 var DATA = {
-  'ppid': process.pid,
-  'ord': 0
+  'ppid' : process.pid,
+  'ord' : 0
 };
 
 var SOCK_PATH = path.join(__dirname,

--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -126,9 +126,9 @@ var srv = net.createServer(function(s) {
 srv.listen(SOCK_PATH);
 
 // Spawn a child running test/fixtures/recvfd.js
-var cp = child_process.spawn(process.argv[0], [path.join(common.fixturesDir, 'recvfd.js'),
-  SOCK_PATH
-]);
+var cp = child_process.spawn(process.argv[0],
+                             [path.join(common.fixturesDir, 'recvfd.js'),
+                              SOCK_PATH]);
 
 cp.stdout.on('data', logChild);
 cp.stderr.on('data', logChild);

--- a/test/disabled/test-sendfd.js
+++ b/test/disabled/test-sendfd.js
@@ -8,7 +8,7 @@
 // persons to whom the Software is furnished to do so, subject to the
 // following conditions:
 //
-// The above copnotice and this permission notice shall be included
+// The above copyright notice and this permission notice shall be included
 // in all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS

--- a/test/internet/test-dgram-broadcast-multi-process.js
+++ b/test/internet/test-dgram-broadcast-multi-process.js
@@ -25,7 +25,6 @@ const assert = require('assert');
 const dgram = require('dgram');
 const util = require('util');
 const networkInterfaces = require('os').networkInterfaces();
-const Buffer = require('buffer').Buffer;
 const fork = require('child_process').fork;
 const LOCAL_BROADCAST_HOST = '255.255.255.255';
 const TIMEOUT = common.platformTimeout(5000);

--- a/test/pummel/test-https-no-reader.js
+++ b/test/pummel/test-https-no-reader.js
@@ -29,7 +29,6 @@ if (!common.hasCrypto) {
 }
 const https = require('https');
 
-const Buffer = require('buffer').Buffer;
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
no need to `require('buffer')` in test files, so removed from:

- test\disabled\test-sendfd.js
- test\internet\test-dgram-broadcast-multi-process.js
- test\pummel\test-https-no-reader.js

first ever contribution :-)
thanks to #goodnessSquad for the support and vision!

Refs: https://github.com/nodejs/node/issues/13836

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test
