### PR TITLE
doc: add notice about useGlobal option in repl docs

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -405,7 +405,8 @@ changes:
      REPL instances `terminal` value.
   * `useGlobal` {boolean} If `true`, specifies that the default evaluation
      function will use the JavaScript `global` as the context as opposed to
-     creating a new separate context for the REPL instance. Defaults to `false`.
+     creating a new separate context for the REPL instance. The node CLI REPL
+     sets this value to `true`. Defaults to `false`.
   * `ignoreUndefined` {boolean} If `true`, specifies that the default writer
      will not output the return value of a command if it evaluates to
      `undefined`. Defaults to `false`.


### PR DESCRIPTION
Add notice about the useGlobal option in repl docs.

Fixes: [#13827](https://github.com/nodejs/node/issues/13827)

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
