### PR TITLE
process: allow modification of process.argv0

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -472,8 +472,8 @@ added: 6.4.0
 
 * {string}
 
-The `process.argv0` property stores a read-only copy of the original value of
-`argv[0]` passed when Node.js starts.
+`process.argv0` is a configurable property that stores a read-only copy of the
+original value of `argv[0]` passed when Node.js starts.
 
 ```console
 $ bash -c 'exec -a customArgv0 ./node'

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -60,7 +60,7 @@
 
     Object.defineProperty(process, 'argv0', {
       enumerable: true,
-      configurable: false,
+      configurable: true,
       value: process.argv[0]
     });
     process.argv[0] = process.execPath;

--- a/test/parallel/test-argv0-property.js
+++ b/test/parallel/test-argv0-property.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.ok(process.hasOwnProperty('argv0'));
+assert.throws(() => {
+  process.argv0 = 'anything';
+}, /^TypeError: Cannot assign to read only property 'argv0' of object '#<process>'/);
+assert.doesNotThrow(() => {
+  delete process.argv0;
+}, /^TypeError: Cannot delete property 'argv0' of object '#<process>'/);
+Object.defineProperty(process, 'argv0', {value: 'some-test-value'});
+assert.strictEqual(process.argv0, 'some-test-value');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

- `process`

##### Description of Changes

When originally created, `writable` was omitted from the definition of `process.argv0` -- presumably because there seemed to be no explicit reason for making it writable. This choice prevents some things Node.js users, specially CLI tool authors (hi) might want to do. In my case, I'm trying to [get npx to replace itself with a Node sub-command](https://github.com/zkat/npx/issues/45) without spawning a new process, and that means I have to do some usually-ill-advised things.

I'd like to get a temperature check from y'all about this change. Holding back on spending a lot of time writing tests, changing docs, etc, until I get a sense of how acceptable it would be. I'll add those to this PR asap if this seems fine. 👌 

I also wonder whether or not something like this would be a breaking change -- I'd argue it's more of a feature, since it would've been an error to assign it, before. I'm also biased 'cause I'd love to get this backported ;)