### PR TITLE
fs,doc,test: open reserved characters under win32

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1587,22 +1587,10 @@ fs.open('<directory>', 'a+', (err, fd) => {
 });
 ```
 
-Some characters are reserved under Windows as documented by
-[Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains a
-colon, Node.js will open a file system stream, as described by
+Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
+by [Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
+a colon, Node.js will open a file system stream, as described by
 [this MSDN page][MSDN-Using-Streams].
-
-The reserved characters are list below.
-
-+ `<` (less than)
-+ `>` (greater than)
-+ `:` (colon)
-+ `"` (double quote)
-+ `/` (forward slash)
-+ `\` (backslash)
-+ `|` (vertical bar or pipe)
-+ `?` (question mark)
-+ `*` (asterisk)
 
 Functions based on `fs.open()` exhibit this behavior as well. eg.
 `fs.writeFile()`, `fs.readFile()`, etc.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1587,6 +1587,29 @@ fs.open('<directory>', 'a+', (err, fd) => {
 });
 ```
 
+Some characters are reserved under Windows which documented by
+[Naming Files, Paths, and Namespaces][].
+
++ `<` (less than)
++ `>` (greater than)
++ `:` (colon)
++ `"` (double quote)
++ `/` (forward slash)
++ `\` (backslash)
++ `|` (vertical bar or pipe)
++ `?` (question mark)
++ `*` (asterisk)
+
+Node.js would get an error while opening any file path containes characters
+above except colon (`:`).
+
+If file path contains colon which not indicates a disk drive and you're
+under NTFS, Node.js will lead to a NTFS file system stream. This is
+documented by [this MSDN page][MSDN-Using-Streams].
+
+Functions based on `fs.open` contain this behavior too. eg. `fs.writeFile()`,
+`fs.readFile()`, etc.
+
 ## fs.openSync(path, flags[, mode])
 <!-- YAML
 added: v0.1.21
@@ -2864,3 +2887,5 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [Readable Stream]: stream.html#stream_class_stream_readable
 [Writable Stream]: stream.html#stream_class_stream_writable
 [inode]: https://en.wikipedia.org/wiki/Inode
+[Naming Files, Paths, and Namespaces]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+[MSDN-Using-Streams]: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1588,7 +1588,7 @@ fs.open('<directory>', 'a+', (err, fd) => {
 ```
 
 Some characters are reserved under Windows as documented by
-[Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
+[Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains a
 colon, Node.js will open a file system stream, as described by
 [this MSDN page][MSDN-Using-Streams].
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1587,8 +1587,12 @@ fs.open('<directory>', 'a+', (err, fd) => {
 });
 ```
 
-Some characters are reserved under Windows which documented by
-[Naming Files, Paths, and Namespaces][].
+Some characters are reserved under Windows as documented by
+[Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
+colon, Node.js will open a file system stream, as described by
+[this MSDN page][MSDN-Using-Streams].
+
+The reserved characters are list below.
 
 + `<` (less than)
 + `>` (greater than)
@@ -1600,15 +1604,8 @@ Some characters are reserved under Windows which documented by
 + `?` (question mark)
 + `*` (asterisk)
 
-Node.js would get an error while opening any file path containes characters
-above except colon (`:`).
-
-If file path contains colon which not indicates a disk drive and you're
-under NTFS, Node.js will lead to a NTFS file system stream. This is
-documented by [this MSDN page][MSDN-Using-Streams].
-
-Functions based on `fs.open` contain this behavior too. eg. `fs.writeFile()`,
-`fs.readFile()`, etc.
+Functions based on `fs.open()` exhibit this behavior as well. eg.
+`fs.writeFile()`, `fs.readFile()`, etc.
 
 ## fs.openSync(path, flags[, mode])
 <!-- YAML

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -5,10 +5,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-if (!common.isWindows) {
+if (!common.isWindows)
   common.skip('This test is for Windows only.');
-  return;
-}
 
 common.refreshTmpDir();
 
@@ -32,9 +30,16 @@ Array.prototype.forEach.call(REVERSED_CHARACTERS, (ch) => {
 // Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx
 const pathname = path.join(common.tmpDir, 'foo:bar');
 fs.writeFileSync(pathname, DATA_VALUE);
+
+let content = '';
 const fileDataStream = fs.createReadStream(pathname, {
   encoding: 'utf8'
 });
-fileDataStream.on('data', common.mustCall((data) => {
-  assert.strictEqual(data.toString(), DATA_VALUE);
+
+fileDataStream.on('data', (data) => {
+  content += data.toString();
+});
+
+fileDataStream.on('end', common.mustCall(() => {
+  assert.strictEqual(content, DATA_VALUE);
 }));

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+if (!common.isWindows) {
+  common.skip('This test is for Windows only.');
+  return;
+}
+
+common.refreshTmpDir();
+
+const DATA_VALUE = 'hello';
+
+// Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+// Ignore '/', '\\' and ':'
+const REVERSED_CHARACTERS = '<>"|?*';
+
+Array.prototype.forEach.call(REVERSED_CHARACTERS, (ch) => {
+  const pathname = path.join(common.tmpDir, `somefile_${ch}`);
+  assert.throws(
+    () => {
+      fs.writeFileSync(pathname, DATA_VALUE);
+    },
+    /^Error: ENOENT: no such file or directory, open '.*'$/,
+    `failed with '${ch}'`);
+});
+
+// Test for ':' (NTFS data streams).
+// Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx
+const pathname = path.join(common.tmpDir, 'foo:bar');
+fs.writeFileSync(pathname, DATA_VALUE);
+const fileDataStream = fs.createReadStream(pathname, {
+  encoding: 'utf8'
+});
+fileDataStream.on('data', common.mustCall((data) => {
+  assert.strictEqual(data.toString(), DATA_VALUE);
+}));

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -14,9 +14,9 @@ const DATA_VALUE = 'hello';
 
 // Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
 // Ignore '/', '\\' and ':'
-const REVERSED_CHARACTERS = '<>"|?*';
+const RESERVED_CHARACTERS = '<>"|?*';
 
-[...REVERSED_CHARACTERS].forEach((ch) => {
+[...RESERVED_CHARACTERS].forEach((ch) => {
   const pathname = path.join(common.tmpDir, `somefile_${ch}`);
   assert.throws(
     () => {

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -16,7 +16,7 @@ const DATA_VALUE = 'hello';
 // Ignore '/', '\\' and ':'
 const REVERSED_CHARACTERS = '<>"|?*';
 
-Array.prototype.forEach.call(REVERSED_CHARACTERS, (ch) => {
+[...REVERSED_CHARACTERS].forEach((ch) => {
   const pathname = path.join(common.tmpDir, `somefile_${ch}`);
   assert.throws(
     () => {
@@ -37,7 +37,7 @@ const fileDataStream = fs.createReadStream(pathname, {
 });
 
 fileDataStream.on('data', (data) => {
-  content += data.toString();
+  content += data;
 });
 
 fileDataStream.on('end', common.mustCall(() => {


### PR DESCRIPTION
Explain the behavior of `fs.open()` under win32 that file path contains
some characters and add some test cases for them.

+ \< (less than)
+ \> (greater than)
+ : (colon)
+ " (double quote)
+ / (forward slash)
+ \ (backslash)
+ | (vertical bar or pipe)
+ ? (question mark)
+ \* (asterisk)

Refs: https://github.com/nodejs/node/issues/13868
Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs, doc, test