### PR TITLE
[v6.x] addons: remove semicolons from after module definition

### DIFF
--- a/benchmark/misc/function_call/binding.cc
+++ b/benchmark/misc/function_call/binding.cc
@@ -14,4 +14,4 @@ extern "C" void init (Local<Object> target) {
   NODE_SET_METHOD(target, "hello", Hello);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1096,7 +1096,7 @@ void init(Local<Object> exports) {
   AtExit(at_exit_cb1, exports->GetIsolate());
 }
 
-NODE_MODULE(addon, init);
+NODE_MODULE(addon, init)
 
 }  // namespace demo
 ```

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -915,4 +915,4 @@ void InitContextify(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(contextify, node::InitContextify);
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(contextify, node::InitContextify)

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -77,4 +77,4 @@ void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -40,4 +40,4 @@ void init(Local<Object> exports) {
   atexit(sanity_check);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -41,4 +41,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "check", Check);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -11,4 +11,4 @@ void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -11,4 +11,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -38,4 +38,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "run", Run);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -35,4 +35,4 @@ void Initialize(v8::Local<v8::Object> exports) {
 
 }  // anonymous namespace
 
-NODE_MODULE(binding, Initialize);
+NODE_MODULE(binding, Initialize)

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -23,4 +23,4 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "method", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -21,4 +21,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "ensureAllocation", EnsureAllocation);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)

--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init);
+NODE_MODULE(binding, init)


### PR DESCRIPTION
Having semicolons there runs counter to our documentation and illicits
warnings in pedantic mode. This removes semicolons from after uses of
NODE_MODULE and NODE_MODULE_CONTEXT_AWARE_BUILTIN.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
