### PR TITLE
N-API: Remove reference to node internals

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -17,7 +17,9 @@
 #include <vector>
 #include "uv.h"
 #include "node_api.h"
-#include "node_internals.h"
+
+// We must avoid making use of node internals because this file must compile
+// outside of node as well.
 
 #define NAPI_VERSION  1
 
@@ -759,7 +761,8 @@ napi_status napi_get_last_error_info(napi_env env,
   // We don't have a napi_status_last as this would result in an ABI
   // change each time a message was added.
   static_assert(
-      node::arraysize(error_messages) == napi_escape_called_twice + 1,
+      (sizeof (error_messages) / sizeof (*error_messages)) ==
+          napi_escape_called_twice + 1,
       "Count of error messages must match count of error values");
   assert(env->last_error.error_code <= napi_escape_called_twice);
 


### PR DESCRIPTION
We must keep src/node_api.cc free of node internals because it must
build cleanly outside of node as well - for example in node_addon_api.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
