### PR TITLE
process: add one-shot signal handler support

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -332,6 +332,7 @@ function _onceWrap(target, type, listener) {
   var state = { fired: false, wrapFn: undefined, target, type, listener };
   var wrapped = onceWrapper.bind(state);
   wrapped.listener = listener;
+  listener.oneshot = true;
   state.wrapFn = wrapped;
   return wrapped;
 }

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -197,38 +197,68 @@ function setupSignalHandlers() {
   // Load events module in order to access prototype elements on process like
   // process.addListener.
   const signalWraps = {};
+  const oneshots = {};
 
   function isSignal(event) {
     return typeof event === 'string' && lazyConstants()[event] !== undefined;
   }
 
+  function startSignalWrap(type, isOneShot) {
+    if (signalWraps[type]) {
+      signalWraps[type].close();
+      delete signalWraps[type];
+    }
+
+    const Signal = process.binding('signal_wrap').Signal;
+    const wrap = new Signal();
+    wrap.unref();
+
+    wrap.onsignal = function() { process.emit(type); };
+
+    const signum = lazyConstants()[type];
+    const err = wrap.start(signum, isOneShot);
+    if (err) {
+      wrap.close();
+      const errnoException = require('util')._errnoException;
+      throw errnoException(err, 'uv_signal_start');
+    }
+
+    signalWraps[type] = wrap;
+  }
+
   // Detect presence of a listener for the special signal types
   process.on('newListener', function(type, listener) {
-    if (isSignal(type) &&
-        !signalWraps.hasOwnProperty(type)) {
-      const Signal = process.binding('signal_wrap').Signal;
-      const wrap = new Signal();
-
-      wrap.unref();
-
-      wrap.onsignal = function() { process.emit(type); };
-
-      const signum = lazyConstants()[type];
-      const err = wrap.start(signum);
-      if (err) {
-        wrap.close();
-        const errnoException = require('util')._errnoException;
-        throw errnoException(err, 'uv_signal_start');
+    if (isSignal(type)) {
+      if (listener.oneshot) {
+        if (oneshots[type])
+          ++oneshots[type];
+        else
+          oneshots[type] = 1;
       }
 
-      signalWraps[type] = wrap;
+      if (!signalWraps.hasOwnProperty(type)) {
+        startSignalWrap(type, listener.oneshot);
+      } else {
+        if (!listener.oneshot && this.listenerCount(type) === oneshots[type]) {
+          startSignalWrap(type, false);
+        }
+      }
     }
   });
 
   process.on('removeListener', function(type, listener) {
-    if (signalWraps.hasOwnProperty(type) && this.listenerCount(type) === 0) {
-      signalWraps[type].close();
-      delete signalWraps[type];
+    if (listener.oneshot)
+      --oneshots[type];
+
+    if (signalWraps.hasOwnProperty(type)) {
+      const count = this.listenerCount(type);
+      if (count === 0) {
+        signalWraps[type].close();
+        delete signalWraps[type];
+        delete oneshots[type];
+      } else if ((count === oneshots[type]) && !listener.oneshot) {
+        startSignalWrap(type, true);
+      }
     }
   });
 }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -88,6 +88,7 @@ class SignalWrap : public HandleWrap {
     SignalWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
     int signum = args[0]->Int32Value();
+    bool oneshot = args[1]->BooleanValue();
 #if defined(__POSIX__) && HAVE_INSPECTOR
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);
@@ -98,7 +99,9 @@ class SignalWrap : public HandleWrap {
       }
     }
 #endif
-    int err = uv_signal_start(&wrap->handle_, OnSignal, signum);
+    int err = oneshot ?
+              uv_signal_start_oneshot(&wrap->handle_, OnSignal, signum) :
+              uv_signal_start(&wrap->handle_, OnSignal, signum);
     args.GetReturnValue().Set(err);
   }
 

--- a/test/parallel/test-signal-oneshot.js
+++ b/test/parallel/test-signal-oneshot.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+
+if (process.argv[2] === 'child') {
+  if (process.argv[3] === 'once') {
+    const on_sigint = common.mustCall(() => {
+      process.removeListener('SIGINT', on_sigint);
+    });
+
+    process.on('SIGINT', on_sigint);
+    process.once('SIGINT', common.mustCall(() => {
+      process.send('signal');
+      while (true) {};
+    }));
+  } else if (process.argv[3] === 'on') {
+    let signals = 0;
+    process.once('SIGINT', common.mustCall(() => {
+      process.send('signal');
+    }));
+
+    process.on('SIGINT', common.mustCall(() => {
+      if (++ signals === 2)
+        process.exit(0);
+    }, 2));
+  }
+
+  process.send('signal');
+  setTimeout(() => {}, 100000);
+
+  return;
+}
+
+{
+  const child = spawn(process.execPath, [__filename, 'child', 'once'], {
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, null);
+    assert.strictEqual(signal, 'SIGINT');
+  }));
+
+  child.on('message', (msg) => {
+    assert.strictEqual(msg, 'signal');
+    child.kill('SIGINT');
+  });
+}
+
+{
+  const child = spawn(process.execPath, [__filename, 'child', 'on'], {
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+
+  child.on('message', (msg) => {
+    assert.strictEqual(msg, 'signal');
+    child.kill('SIGINT');
+  });
+}


### PR DESCRIPTION
`one-shot` signal handlers reset the handler once the signal is received
and not when the signal notification reaches the main loop. This commit
adds support for this functionality when *only* there are `once`
listeners on a specific signal.

Refs: https://github.com/nodejs/node/issues/9050
Refs: https://github.com/libuv/libuv/issues/1104
Refs: https://github.com/libuv/libuv/pull/1106

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process

/cc @bnoordhuis 