### PR TITLE
test: refactor test-tls-two-cas-one-string

### DIFF
--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -1,22 +1,20 @@
 'use strict';
-
 const common = require('../common');
+
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
 
-const tls = require('tls');
 const fs = require('fs');
+const tls = require('tls');
 
-const ca1 =
-    fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`, 'utf8');
-const ca2 =
-    fs.readFileSync(`${common.fixturesDir}/keys/ca2-cert.pem`, 'utf8');
-const cert =
-    fs.readFileSync(`${common.fixturesDir}/keys/agent3-cert.pem`, 'utf8');
-const key =
-    fs.readFileSync(`${common.fixturesDir}/keys/agent3-key.pem`, 'utf8');
+const keydir = `${common.fixturesDir}/keys`;
+
+const ca1 = fs.readFileSync(`${keydir}/ca1-cert.pem`, 'utf8');
+const ca2 = fs.readFileSync(`${keydir}/ca2-cert.pem`, 'utf8');
+const cert = fs.readFileSync(`${keydir}/agent3-cert.pem`, 'utf8');
+const key = fs.readFileSync(`${keydir}/agent3-key.pem`, 'utf8');
 
 function test(ca, next) {
   const server = tls.createServer({ ca, cert, key }, function(conn) {
@@ -31,9 +29,11 @@ function test(ca, next) {
     tls.connect({ servername: 'agent3', host, port: this.address().port, ca });
   });
 
-  server.once('close', next);
+  if (next) {
+    server.once('close', next);
+  }
 }
 
 const array = [ca1, ca2];
 const string = `${ca1}\n${ca2}`;
-test(array, () => test(string, common.noop));
+test(array, common.mustCall(() => test(string)));


### PR DESCRIPTION
* order require() statements per test writing guide
* add keydir variable to make readFileSync() calls more readable
* make `next` argument to test() optional
* use common.mustCall() to guarantee second test runs

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tls