### PR TITLE
c-ares NAPTR parser out of bounds access

### DIFF
--- a/deps/cares/src/ares_parse_naptr_reply.c
+++ b/deps/cares/src/ares_parse_naptr_reply.c
@@ -110,6 +110,12 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen,
           status = ARES_EBADRESP;
           break;
         }
+      /* RR must contain at least 7 bytes = 2 x int16 + 3 x name */
+      if (rr_len < 7)
+        {
+          status = ARES_EBADRESP;
+          break;
+        }
 
       /* Check if we are really looking at a NAPTR record */
       if (rr_class == C_IN && rr_type == T_NAPTR)
@@ -185,4 +191,3 @@ ares_parse_naptr_reply (const unsigned char *abuf, int alen,
 
   return ARES_SUCCESS;
 }
-


### PR DESCRIPTION
CVE: CVE-2017-1000381
Upstream bug: https://c-ares.haxx.se/adv_20170620.html
Upstream patch: https://c-ares.haxx.se/CVE-2017-1000381.patch

I haven't seen PR/issue for this CVE, so I created one. It's the same as upstream c-ares patch.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
bundled c-ares