### PR TITLE
build,windows: Implement python detection

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -1,0 +1,51 @@
+@IF NOT DEFINED DEBUG_HELPER @ECHO OFF
+SETLOCAL
+:: If python.exe is in %Path%, just validate
+FOR /F "delims=" %%a IN ('where python 2^> NUL') DO (
+  SET need_path=0
+  SET p=%%~dpa
+  IF NOT ERRORLEVEL 1 GOTO :validate
+)
+
+:: Query the 3 locations mentioned in PEP 514 for a python2 InstallPath
+FOR %%K IN ( "HKCU\Software", "HKLM\SOFTWARE", "HKLM\Software\Wow6432Node") DO (
+  SET need_path=1
+  CALL :find-main-branch %%K
+  :: If validate returns 0 just jump to the end
+  IF NOT ERRORLEVEL 1 GOTO :validate
+)
+EXIT /B 1
+
+:: Helper subroutine to handle quotes in %1
+:find-main-branch
+SET main_key="%~1\Python\PythonCore"
+REG QUERY %main_key% /s | findstr "2." | findstr InstallPath > NUL 2> NUL
+IF NOT ERRORLEVEL 1 CALL :find-key %main_key%
+EXIT /B
+
+:: Query registry sub-tree for InstallPath
+:find-key
+FOR /F "delims=" %%a IN ('REG QUERY %1 /s  ^| findstr "2." ^| findstr InstallPath') DO IF NOT ERRORLEVEL 1 CALL :find-path %%a
+EXIT /B
+
+:: Parse the value of %1 as the path for python.exe
+:find-path
+FOR /F "tokens=3*" %%a IN ('REG QUERY %1 /ve') DO (
+  SET pt=%%a
+  IF NOT ERRORLEVEL 1 SET p=%pt%
+  EXIT /B 0
+)
+EXIT /B 1
+
+:: Check if %p% holds a path to a real python2 executable
+:validate
+IF NOT EXIST "%p%python.exe" EXIT /B 1
+:: Check if %p% is python2
+%p%python.exe -V 2>&1 | findstr /R "^Python.2.*" > NUL
+IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
+:: We can wrap it up
+ENDLOCAL & SET pt=%p%& SET need_path_ext=%need_path%
+SET VCBUILD_PYTHON_LOCATION=%pt%python.exe
+IF %need_path_ext%==1 SET Path=%Path%;%pt%
+SET need_path_ext=
+EXIT /B %ERRORLEVEL%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -222,8 +222,7 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-echo configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
-python configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
+call :run-python configure %configure_flags% --dest-cpu=%target_arch% --tag=%TAG%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -408,7 +407,7 @@ if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
 :node-check-deopts
-python tools\test.py --mode=release --check-deopts parallel sequential -J
+call :run-python tools\test.py --mode=release --check-deopts parallel sequential -J
 if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
@@ -423,8 +422,7 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-echo running 'python tools\test.py %test_args%'
-python tools\test.py %test_args%
+call :run-python tools\test.py %test_args%
 goto cpplint
 
 :cpplint
@@ -442,8 +440,8 @@ test\gc\binding.cc tools\icu\*.cc tools\icu\*.h') do (
 ( endlocal
   set cppfilelist=%localcppfilelist%
 )
-python tools/cpplint.py %cppfilelist%
-python tools/check-imports.py
+call :run-python tools/cpplint.py %cppfilelist%
+call :run-python tools/check-imports.py
 goto jslint
 
 :add-to-list
@@ -502,6 +500,14 @@ echo   vcbuild.bat build-release  : builds the release distribution as used by n
 echo   vcbuild.bat enable-vtune   : builds nodejs with Intel VTune profiling support to profile JavaScript
 goto exit
 
+:run-python
+call tools\msvs\find_python.cmd
+if errorlevel 1 echo Could not find python2 & goto :exit
+set cmd1=%VCBUILD_PYTHON_LOCATION% %*
+echo %cmd1%
+%cmd1%
+exit /b %ERRORLEVEL%
+
 :exit
 goto :EOF
 
@@ -513,8 +519,9 @@ rem ***************
 set NODE_VERSION=
 set TAG=
 set FULLVERSION=
-
-for /F "usebackq tokens=*" %%i in (`python "%~dp0tools\getnodeversion.py"`) do set NODE_VERSION=%%i
+:: Call as subroutine for validation of python
+call :run-python tools\getnodeversion.py > nul
+for /F "tokens=*" %%i in ('%VCBUILD_PYTHON_LOCATION% tools\getnodeversion.py') do set NODE_VERSION=%%i
 if not defined NODE_VERSION (
   echo Cannot determine current version of Node.js
   exit /b 1
@@ -523,7 +530,7 @@ if not defined NODE_VERSION (
 if not defined DISTTYPE set DISTTYPE=release
 if "%DISTTYPE%"=="release" (
   set FULLVERSION=%NODE_VERSION%
-  goto exit
+  exit /b 0
 )
 if "%DISTTYPE%"=="custom" (
   if not defined CUSTOMTAG (
@@ -550,7 +557,4 @@ if not "%DISTTYPE%"=="custom" (
   set TAG=%DISTTYPE%%DATESTRING%%COMMIT%
 )
 set FULLVERSION=%NODE_VERSION%-%TAG%
-
-:exit
-if not defined DISTTYPEDIR set DISTTYPEDIR=%DISTTYPE%
-goto :EOF
+exit /b 0


### PR DESCRIPTION
According to [PEP 514](https://www.python.org/dev/peps/pep-0514/)

Fixes: https://github.com/nodejs/node/issues/13882

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build,tools,windows
