### PR TITLE
test: refactor test-vm-sigint

### DIFF
--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+
 const assert = require('assert');
 const vm = require('vm');
 
@@ -15,7 +16,7 @@ if (process.argv[2] === 'child') {
   const method = process.argv[3];
   const listeners = +process.argv[4];
   assert.ok(method);
-  assert.ok(typeof listeners, 'number');
+  assert.ok(Number.isInteger(listeners));
 
   const script = `process.send('${method}'); while(true) {}`;
   const args = method === 'runInContext' ?
@@ -24,7 +25,7 @@ if (process.argv[2] === 'child') {
   const options = { breakOnSigint: true };
 
   for (let i = 0; i < listeners; i++)
-    process.on('SIGINT', common.noop);
+    process.on('SIGINT', common.mustNotCall());
 
   assert.throws(() => { vm[method](script, ...args, options); },
                 /^Error: Script execution interrupted\.$/);


### PR DESCRIPTION
* Use common.mustNotCall() to confirm SIGINT listeners are not being
  invoked.
* Improve assertion check on integer child argument.
* Add blank line per test writing guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test vm