### PR TITLE
test: refactor test-child-process-send-type-error.js

### DIFF
--- a/test/parallel/test-child-process-send-type-error.js
+++ b/test/parallel/test-child-process-send-type-error.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+
 const assert = require('assert');
 const cp = require('child_process');
 
@@ -11,8 +12,13 @@ function fail(proc, args) {
 
 let target = process;
 
-if (process.argv[2] !== 'child')
+if (process.argv[2] !== 'child') {
   target = cp.fork(__filename, ['child']);
+  target.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+}
 
 fail(target, ['msg', null, null]);
 fail(target, ['msg', null, '']);
@@ -20,4 +26,4 @@ fail(target, ['msg', null, 'foo']);
 fail(target, ['msg', null, 0]);
 fail(target, ['msg', null, NaN]);
 fail(target, ['msg', null, 1]);
-fail(target, ['msg', null, null, common.noop]);
+fail(target, ['msg', null, null, common.mustNotCall()]);


### PR DESCRIPTION
* Do not run tests in child process as their failure will not cause the
  test to fail. Only run the tests in the parent process where their
  failure means the test fails.
* Use common.mustNotCall() to guarantee callback is not invoked.
* Insert blank line per test writing guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process