### PR TITLE
readline: fix character width calculation

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -682,13 +682,14 @@ Interface.prototype._getDisplayPos = function(str) {
       row += 1;
       continue;
     }
-    if (isFullWidthCodePoint(code)) {
+    const width = getStringWidth(code);
+    if (width === 0 || width === 1) {
+      offset += width;
+    } else { // width === 2
       if ((offset + 1) % col === 0) {
         offset++;
       }
       offset += 2;
-    } else {
-      offset++;
     }
   }
   var cols = offset % col;

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -11,13 +11,43 @@ const assert = require('assert');
 const readline = require('internal/readline');
 
 // Test column width
+
+// Ll (Lowercase Letter): LATIN SMALL LETTER A
 assert.strictEqual(readline.getStringWidth('a'), 1);
+assert.strictEqual(readline.getStringWidth(0x0061), 1);
+// Lo (Other Letter)
 assert.strictEqual(readline.getStringWidth('丁'), 2);
+assert.strictEqual(readline.getStringWidth(0x4E01), 2);
+// Surrogate pairs
 assert.strictEqual(readline.getStringWidth('\ud83d\udc78\ud83c\udfff'), 2);
 assert.strictEqual(readline.getStringWidth('👅'), 2);
+// Cs (Surrogate): High Surrogate
+assert.strictEqual(readline.getStringWidth('\ud83d'), 1);
+// Cs (Surrogate): Low Surrogate
+assert.strictEqual(readline.getStringWidth('\udc78'), 1);
+// Cc (Control): NULL
+assert.strictEqual(readline.getStringWidth(0), 0);
+// Cc (Control): BELL
+assert.strictEqual(readline.getStringWidth(0x0007), 0);
+// Cc (Control): LINE FEED
 assert.strictEqual(readline.getStringWidth('\n'), 0);
+// Cf (Format): SOFT HYPHEN
+assert.strictEqual(readline.getStringWidth(0x00AD), 1);
+// Cf (Format): LEFT-TO-RIGHT MARK
+// Cf (Format): RIGHT-TO-LEFT MARK
 assert.strictEqual(readline.getStringWidth('\u200Ef\u200F'), 1);
-assert.strictEqual(readline.getStringWidth(97), 1);
+// Cn (Unassigned): Not a character
+assert.strictEqual(readline.getStringWidth(0x10FFEF), 1);
+// Cn (Unassigned): Not a character (but in a CJK range)
+assert.strictEqual(readline.getStringWidth(0x3FFEF), 2);
+// Mn (Nonspacing Mark): COMBINING ACUTE ACCENT
+assert.strictEqual(readline.getStringWidth(0x0301), 0);
+// Mc (Spacing Mark): BALINESE ADEG ADEG
+// Chosen as its Canonical_Combining_Class is not 0, but is not a 0-width
+// character.
+assert.strictEqual(readline.getStringWidth(0x1B44), 1);
+// Me (Enclosing Mark): COMBINING ENCLOSING CIRCLE
+assert.strictEqual(readline.getStringWidth(0x20DD), 0);
 
 // The following is an emoji sequence. In some implementations, it is
 // represented as a single glyph, in other implementations as a sequence

--- a/test/parallel/test-readline-position.js
+++ b/test/parallel/test-readline-position.js
@@ -1,0 +1,31 @@
+'use strict';
+require('../common');
+const { PassThrough } = require('stream');
+const readline = require('readline');
+const assert = require('assert');
+
+const ctrlU = { ctrl: true, name: 'u' };
+
+{
+  const input = new PassThrough();
+  const rl = readline.createInterface({
+    terminal: true,
+    input: input,
+    prompt: ''
+  });
+
+  for (const [cursor, string] of [
+    [1, 'a'],
+    [2, 'ab'],
+    [2, '丁'],
+    [0, '\u0301'],   // COMBINING ACUTE ACCENT
+    [1, 'a\u0301'],  // á
+    [0, '\u20DD'],   // COMBINING ENCLOSING CIRCLE
+    [2, 'a\u20DDb'], // a⃝b
+    [0, '\u200E']    // LEFT-TO-RIGHT MARK
+  ]) {
+    rl.write(string);
+    assert.strictEqual(rl._getCursorPos().cols, cursor);
+    rl.write(null, ctrlU);
+  }
+}


### PR DESCRIPTION
Fixes width calculation of non-spacing marks, commonly seen in Unicode Normalization Form D. Example: `'a\u0301'` (`'á'.normalize('NFD')`), `'ру́сский язы́к'` (Unicode doesn't have many precomposed accented Cyrillic letters).

<details><summary>Outdated information</summary>

Not sure where to add tests for this feature though. `readline` has the following tests:

- test-readline-csi.js
- test-readline-emit-keypress-events.js
- test-readline-interface.js
- test-readline.js
- test-readline-keys.js
- test-readline-reopen.js
- test-readline-set-raw-mode.js
- test-readline-undefined-columns.js
- test-icu-stringwidth.js

None of them seem to fit this bug, which is the glue between `getStringWidth` and readline, Hence the WIP.
</details>

----

The second commit changes how widths of certain characters are determined:

- Categorize all nonspacing marks (Mn) and enclosing marks (Me) as    0-width
- Categorize all spacing marks (Mc) as non-0-width.
- Do not treat all unassigned code points as 0-width; instead, let ICU      select the [default for that block](http://unicode.org/reports/tr11/#Unassigned).

These decisions are made, partially by following the behavior of GNOME Terminal. Testing on other terminals is of course welcome.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline