### PR TITLE
src: --abort-on-uncaught-exception in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -457,6 +457,7 @@ Node options that are allowed are:
 - `--zero-fill-buffers`
 
 V8 options that are allowed are:
+- `--abort-on-uncaught-exception`
 - `--max_old_space_size`
 
 ### `NODE_PENDING_DEPRECATION=1`

--- a/src/node.cc
+++ b/src/node.cc
@@ -3766,6 +3766,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--icu-data-dir",
 
     // V8 options
+    "--abort-on-uncaught-exception",
     "--max_old_space_size",
   };
 

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -40,6 +40,7 @@ function disallow(opt) {
 
 const printA = require.resolve('../fixtures/printA.js');
 
+expect('--abort-on-uncaught-exception', 'B\n');
 expect(`-r ${printA}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');
 expect('--no-warnings', 'B\n');


### PR DESCRIPTION
Allow --abort-on-uncaught-exception in NODE_OPTIONS, its useful to
enable for post-mortem debugging.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
