### PR TITLE
test: refactor test-http(s)-set-timeout-server

### DIFF
--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -42,11 +42,11 @@ function run() {
 }
 
 test(function serverTimeout(cb) {
-  const server = http.createServer(common.mustCall(function(req, res) {
+  const server = http.createServer(common.mustCall((req, res) => {
     // just do nothing, we should get a timeout event.
   }));
-  server.listen(common.mustCall(function() {
-    const s = server.setTimeout(50, common.mustCall(function(socket) {
+  server.listen(common.mustCall(() => {
+    const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
       server.close();
       cb();
@@ -59,16 +59,16 @@ test(function serverTimeout(cb) {
 });
 
 test(function serverRequestTimeout(cb) {
-  const server = http.createServer(common.mustCall(function(req, res) {
+  const server = http.createServer(common.mustCall((req, res) => {
     // just do nothing, we should get a timeout event.
-    const s = req.setTimeout(50, common.mustCall(function(socket) {
+    const s = req.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
       server.close();
       cb();
     }));
     assert.ok(s instanceof http.IncomingMessage);
   }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     const req = http.request({
       port: server.address().port,
       method: 'POST'
@@ -80,16 +80,16 @@ test(function serverRequestTimeout(cb) {
 });
 
 test(function serverResponseTimeout(cb) {
-  const server = http.createServer(common.mustCall(function(req, res) {
+  const server = http.createServer(common.mustCall((req, res) => {
     // just do nothing, we should get a timeout event.
-    const s = res.setTimeout(50, common.mustCall(function(socket) {
+    const s = res.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
       server.close();
       cb();
     }));
     assert.ok(s instanceof http.OutgoingMessage);
   }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     http.get({
       port: server.address().port
     }).on('error', common.mustCall());
@@ -97,18 +97,18 @@ test(function serverResponseTimeout(cb) {
 });
 
 test(function serverRequestNotTimeoutAfterEnd(cb) {
-  const server = http.createServer(common.mustCall(function(req, res) {
+  const server = http.createServer(common.mustCall((req, res) => {
     // just do nothing, we should get a timeout event.
     const s = req.setTimeout(50, common.mustNotCall());
     assert.ok(s instanceof http.IncomingMessage);
     res.on('timeout', common.mustCall());
   }));
-  server.on('timeout', common.mustCall(function(socket) {
+  server.on('timeout', common.mustCall((socket) => {
     socket.destroy();
     server.close();
     cb();
   }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     http.get({
       port: server.address().port
     }).on('error', common.mustCall());
@@ -118,31 +118,31 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
 test(function serverResponseTimeoutWithPipeline(cb) {
   let caughtTimeout = '';
   let secReceived = false;
-  process.on('exit', function() {
+  process.on('exit', () => {
     assert.strictEqual(caughtTimeout, '/2');
   });
-  const server = http.createServer(function(req, res) {
+  const server = http.createServer((req, res) => {
     if (req.url === '/2')
       secReceived = true;
-    const s = res.setTimeout(50, function() {
+    const s = res.setTimeout(50, () => {
       caughtTimeout += req.url;
     });
     assert.ok(s instanceof http.OutgoingMessage);
     if (req.url === '/1') res.end();
   });
-  server.on('timeout', common.mustCall(function(socket) {
+  server.on('timeout', common.mustCall((socket) => {
     if (secReceived) {
       socket.destroy();
       server.close();
       cb();
     }
   }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
     };
-    const c = net.connect(options, function() {
+    const c = net.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
@@ -151,23 +151,23 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
-  const server = http.createServer(common.mustCall(function(req, res) {
+  const server = http.createServer(common.mustCall((req, res) => {
     req.on('timeout', common.mustNotCall());
     res.on('timeout', common.mustNotCall());
     res.end();
   }));
-  const s = server.setTimeout(50, common.mustCall(function(socket) {
+  const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
     server.close();
     cb();
   }));
   assert.ok(s instanceof http.Server);
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
     };
-    const c = net.connect(options, function() {
+    const c = net.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       // Keep-Alive
     });

--- a/test/sequential/test-https-set-timeout-server.js
+++ b/test/sequential/test-https-set-timeout-server.js
@@ -43,28 +43,24 @@ const serverOptions = {
 function test(fn) {
   if (!tests.length)
     process.nextTick(run);
-  tests.push(fn);
+  tests.push(common.mustCall(fn));
 }
 
 function run() {
   const fn = tests.shift();
   if (fn) {
-    console.log('# %s', fn.name);
     fn(run);
-  } else {
-    console.log('ok');
   }
 }
 
 test(function serverTimeout(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall(function(req, res) {
-      // just do nothing, we should get a
-      // timeout event.
+    common.mustCall((req, res) => {
+      // just do nothing, we should get a timeout event.
     }));
-  server.listen(common.mustCall(function() {
-    const s = server.setTimeout(50, common.mustCall(function(socket) {
+  server.listen(common.mustCall(() => {
+    const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
       server.close();
       cb();
@@ -80,19 +76,16 @@ test(function serverTimeout(cb) {
 test(function serverRequestTimeout(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall(function(req, res) {
-      // just do nothing, we should get a
-      // timeout event.
-      const s = req.setTimeout(
-        50,
-        common.mustCall(function(socket) {
-          socket.destroy();
-          server.close();
-          cb();
-        }));
+    common.mustCall((req, res) => {
+      // just do nothing, we should get a timeout event.
+      const s = req.setTimeout(50, common.mustCall((socket) => {
+        socket.destroy();
+        server.close();
+        cb();
+      }));
       assert.ok(s instanceof http.IncomingMessage);
     }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     const req = https.request({
       port: server.address().port,
       method: 'POST',
@@ -107,16 +100,16 @@ test(function serverRequestTimeout(cb) {
 test(function serverResponseTimeout(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall(function(req, res) {
+    common.mustCall((req, res) => {
       // just do nothing, we should get a timeout event.
-      const s = res.setTimeout(50, common.mustCall(function(socket) {
+      const s = res.setTimeout(50, common.mustCall((socket) => {
         socket.destroy();
         server.close();
         cb();
       }));
       assert.ok(s instanceof http.OutgoingMessage);
     }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     https.get({
       port: server.address().port,
       rejectUnauthorized: false
@@ -127,18 +120,18 @@ test(function serverResponseTimeout(cb) {
 test(function serverRequestNotTimeoutAfterEnd(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall(function(req, res) {
+    common.mustCall((req, res) => {
       // just do nothing, we should get a timeout event.
       const s = req.setTimeout(50, common.mustNotCall());
       assert.ok(s instanceof http.IncomingMessage);
       res.on('timeout', common.mustCall());
     }));
-  server.on('timeout', common.mustCall(function(socket) {
+  server.on('timeout', common.mustCall((socket) => {
     socket.destroy();
     server.close();
     cb();
   }));
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     https.get({
       port: server.address().port,
       rejectUnauthorized: false
@@ -149,32 +142,32 @@ test(function serverRequestNotTimeoutAfterEnd(cb) {
 test(function serverResponseTimeoutWithPipeline(cb) {
   let caughtTimeout = '';
   let secReceived = false;
-  process.on('exit', function() {
+  process.on('exit', () => {
     assert.strictEqual(caughtTimeout, '/2');
   });
-  const server = https.createServer(serverOptions, function(req, res) {
+  const server = https.createServer(serverOptions, (req, res) => {
     if (req.url === '/2')
       secReceived = true;
-    const s = res.setTimeout(50, function() {
+    const s = res.setTimeout(50, () => {
       caughtTimeout += req.url;
     });
     assert.ok(s instanceof http.OutgoingMessage);
     if (req.url === '/1') res.end();
   });
-  server.on('timeout', function(socket) {
+  server.on('timeout', common.mustCall((socket) => {
     if (secReceived) {
       socket.destroy();
       server.close();
       cb();
     }
-  });
-  server.listen(common.mustCall(function() {
+  }));
+  server.listen(common.mustCall(() => {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
       rejectUnauthorized: false
     };
-    const c = tls.connect(options, function() {
+    const c = tls.connect(options, () => {
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       c.write('GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       c.write('GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n');
@@ -185,25 +178,25 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 test(function idleTimeout(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall(function(req, res) {
+    common.mustCall((req, res) => {
       req.on('timeout', common.mustNotCall());
       res.on('timeout', common.mustNotCall());
       res.end();
     }));
-  const s = server.setTimeout(50, common.mustCall(function(socket) {
+  const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
     server.close();
     cb();
   }));
   assert.ok(s instanceof https.Server);
-  server.listen(common.mustCall(function() {
+  server.listen(common.mustCall(() => {
     const options = {
       port: server.address().port,
       allowHalfOpen: true,
       rejectUnauthorized: false
     };
-    tls.connect(options, function() {
-      this.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+    const c = tls.connect(options, () => {
+      c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       // Keep-Alive
     });
   }));


### PR DESCRIPTION
* Make changes to `test-https-set-timeout-server` to resolve
  inconsistencies with its http counterpart:

  - Apply the changes analogous to those in GH-13802 to the https test.
  - Add a missing `common.mustCall()` wrapper.
  - Make small stylistic changes (e.g., remove unnecessary line breaks
    in comments) to make it visually consistent with the http test.

* Use arrow functions.

Refs: https://github.com/nodejs/node/pull/13802
Refs: https://github.com/nodejs/node/pull/13625
Refs: https://github.com/nodejs/node/pull/13822
Fixes: https://github.com/nodejs/node/issues/13588

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test