### PR TITLE
doc: doc lifetime of n-api last error info

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -269,6 +269,9 @@ Returns `napi_ok` if the API succeeded.
 This API retrieves a `napi_extended_error_info` structure with information
 about the last error that occurred.
 
+*Note*: The content of the 'napi_extended_error_info` returned is only
+valid up until an n-api function is called on the same `env`.
+
 *Note*: Do not rely on the content or format of any of the extended
 information as it is not subject to SemVer and may change at any time.
 It is intended only for logging purposes.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -269,7 +269,7 @@ Returns `napi_ok` if the API succeeded.
 This API retrieves a `napi_extended_error_info` structure with information
 about the last error that occurred.
 
-*Note*: The content of the 'napi_extended_error_info` returned is only
+*Note*: The content of the `napi_extended_error_info` returned is only
 valid up until an n-api function is called on the same `env`.
 
 *Note*: Do not rely on the content or format of any of the extended


### PR DESCRIPTION
Document the lifetime of the structure returned
by napi_get_last_error_info

Fixes: https://github.com/nodejs/abi-stable-node/issues/251

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api