### PR TITLE
tools: remove comment in eslint rule

### DIFF
--- a/tools/eslint-rules/align-multiline-assignment.js
+++ b/tools/eslint-rules/align-multiline-assignment.js
@@ -54,7 +54,6 @@ function testAssignment(context, node) {
 function testDeclaration(context, node) {
   node.declarations.forEach((declaration) => {
     const msg = checkExpressionAlignment(declaration.init);
-    // const start = declaration.init.loc.start;
     if (msg)
       context.report(node, msg);
   });


### PR DESCRIPTION
I noticed this comment while working on a different task and could not
find any reason for it being there. Just bringing this up in case it was
overlooked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools