### PR TITLE
tools: update to ESLint 4.1.1

### DIFF
--- a/tools/eslint/lib/config.js
+++ b/tools/eslint/lib/config.js
@@ -66,13 +66,14 @@ class Config {
         this.parser = options.parser;
         this.parserOptions = options.parserOptions || {};
 
+        this.configCache = new ConfigCache();
+
         this.baseConfig = options.baseConfig
             ? ConfigOps.merge({}, ConfigFile.loadObject(options.baseConfig, this))
             : { rules: {} };
         this.baseConfig.filePath = "";
         this.baseConfig.baseDirectory = this.options.cwd;
 
-        this.configCache = new ConfigCache();
         this.configCache.setConfig(this.baseConfig.filePath, this.baseConfig);
         this.configCache.setMergedVectorConfig(this.baseConfig.filePath, this.baseConfig);
 

--- a/tools/eslint/lib/config/config-cache.js
+++ b/tools/eslint/lib/config/config-cache.js
@@ -24,12 +24,12 @@ function hash(vector) {
 //------------------------------------------------------------------------------
 
 /**
- * Configuration caching class (not exported)
+ * Configuration caching class
  */
-class ConfigCache {
+module.exports = class ConfigCache {
 
     constructor() {
-        this.filePathCache = new Map();
+        this.configFullNameCache = new Map();
         this.localHierarchyCache = new Map();
         this.mergedVectorCache = new Map();
         this.mergedCache = new Map();
@@ -37,23 +37,25 @@ class ConfigCache {
 
     /**
      * Gets a config object from the cache for the specified config file path.
-     * @param {string} configFilePath the absolute path to the config file
+     * @param {string} configFullName the name of the configuration as used in the eslint config(e.g. 'plugin:node/recommended'),
+     * or the absolute path to a config file. This should uniquely identify a config.
      * @returns {Object|null} config object, if found in the cache, otherwise null
      * @private
      */
-    getConfig(configFilePath) {
-        return this.filePathCache.get(configFilePath);
+    getConfig(configFullName) {
+        return this.configFullNameCache.get(configFullName);
     }
 
     /**
      * Sets a config object in the cache for the specified config file path.
-     * @param {string} configFilePath the absolute path to the config file
+     * @param {string} configFullName the name of the configuration as used in the eslint config(e.g. 'plugin:node/recommended'),
+     * or the absolute path to a config file. This should uniquely identify a config.
      * @param {Object} config the config object to add to the cache
      * @returns {void}
      * @private
      */
-    setConfig(configFilePath, config) {
-        this.filePathCache.set(configFilePath, config);
+    setConfig(configFullName, config) {
+        this.configFullNameCache.set(configFullName, config);
     }
 
     /**
@@ -125,6 +127,4 @@ class ConfigCache {
     setMergedConfig(vector, config) {
         this.mergedCache.set(hash(vector), config);
     }
-}
-
-module.exports = ConfigCache;
+};

--- a/tools/eslint/package-lock.json
+++ b/tools/eslint/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -1,27 +1,27 @@
 {
-  "_from": "eslint@4.1.0",
-  "_id": "eslint@4.1.0",
+  "_from": "eslint@latest",
+  "_id": "eslint@4.1.1",
   "_inBundle": false,
-  "_integrity": "sha1-u7VaKCIO4Itp2pVU1FprLr/X2RM=",
+  "_integrity": "sha1-+svfz+Pg+s06i4DcmMTmwTrlgt8=",
   "_location": "/eslint",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
+    "type": "tag",
     "registry": true,
-    "raw": "eslint@4.1.0",
+    "raw": "eslint@latest",
     "name": "eslint",
     "escapedName": "eslint",
-    "rawSpec": "4.1.0",
+    "rawSpec": "latest",
     "saveSpec": null,
-    "fetchSpec": "4.1.0"
+    "fetchSpec": "latest"
   },
   "_requiredBy": [
     "#USER",
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/eslint/-/eslint-4.1.0.tgz",
-  "_shasum": "bbb55a28220ee08b69da9554d45a6b2ebfd7d913",
-  "_spec": "eslint@4.1.0",
+  "_resolved": "https://registry.npmjs.org/eslint/-/eslint-4.1.1.tgz",
+  "_shasum": "facbdfcfe3e0facd3a8b80dc98c4e6c13ae582df",
+  "_spec": "eslint@latest",
   "_where": "/Users/trott/io.js/tools/eslint-tmp",
   "author": {
     "name": "Nicholas C. Zakas",
@@ -152,5 +152,5 @@
     "release": "node Makefile.js release",
     "test": "node Makefile.js test"
   },
-  "version": "4.1.0"
+  "version": "4.1.1"
 }


### PR DESCRIPTION
First ESLint update done with tools/update-eslint.sh. It's a small diff (6 files) because it's a small patch fix release. I don't think the bugs fixed here are likely to affect us, but with new custom rules coming online (such as https://github.com/nodejs/node/pull/13813), I'd rather be up-to-date especially when the diff is small like it is here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools