### PR TITLE
module: deprecate Module._debug

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -683,6 +683,15 @@ difference is that `querystring.parse()` does url encoding:
 { '%E5%A5%BD': '1' }
 ```
 
+<a id="DEP00XX"></a>
+### DEP00XX: Module.\_debug()
+
+Type: Runtime
+
+`Module._debug()` has been deprecated.
+
+*Note*: `Module._debug()` was never documented as an officially supported API.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/lib/module.js
+++ b/lib/module.js
@@ -80,11 +80,11 @@ Module.globalPaths = [];
 
 Module.wrapper = NativeModule.wrapper;
 Module.wrap = NativeModule.wrap;
-Module._debug = util.debuglog('module');
 
-// We use this alias for the preprocessor that filters it out
-const debug = Module._debug;
+const debug = util.debuglog('module');
 
+Module._debug = util.deprecate(debug, 'Module._debug is deprecated.',
+                               'DEP00XX');
 
 // given a module name, and a list of paths to test, returns the first
 // matching file in the following precedence.


### PR DESCRIPTION
The _debug of Module is undocumented and it useless here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
module