### PR TITLE
test: add check on an addon that doesn't register

### DIFF
--- a/test/addons/not-a-binding/binding.gyp
+++ b/test/addons/not-a-binding/binding.gyp
@@ -1,0 +1,8 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'not_a_binding.c' ]
+    }
+  ]
+}

--- a/test/addons/not-a-binding/not_a_binding.c
+++ b/test/addons/not-a-binding/not_a_binding.c
@@ -1,0 +1,3 @@
+int foo(void) {
+  return 0;
+}

--- a/test/addons/not-a-binding/test.js
+++ b/test/addons/not-a-binding/test.js
@@ -1,0 +1,6 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+const re = /^Error: Module did not self-register\.$/;
+assert.throws(() => require(`./build/${common.buildType}/binding`), re);


### PR DESCRIPTION
This test `require()`s a shared library that won't register as a node module.

Other tests would be possible such as loading a file that is not a shared library, or loading a path that doesn't exist. However, these two tests produce platform-dependent error messages, and so I haven't included them.

##### Checklist
- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test