### PR TITLE
stream: avoid possible slow paths w UInt8Array

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -248,7 +248,7 @@ function validChunk(stream, state, chunk, cb) {
 Writable.prototype.write = function(chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
-  var isBuf = Stream._isUint8Array(chunk) && !state.objectMode;
+  var isBuf = !state.objectMode && Stream._isUint8Array(chunk);
 
   if (isBuf && Object.getPrototypeOf(chunk) !== Buffer.prototype) {
     chunk = Stream._uint8ArrayToBuffer(chunk);


### PR DESCRIPTION
A chunk validity checks verifie if a chunk is a UInt8Array.
We should defer it as it might be very expensive in older Node.js
platforms.

It avoid the UInt8Array checks if the streams are in `objectMode: true`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

stream