### PR TITLE
src: move crypto_bio/clienthello to crypto ns

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -27,6 +27,7 @@
 #include <string.h>
 
 namespace node {
+namespace crypto {
 
 const BIO_METHOD NodeBIO::method = {
   BIO_TYPE_MEM,
@@ -488,4 +489,5 @@ NodeBIO::~NodeBIO() {
   write_head_ = nullptr;
 }
 
+}  // namespace crypto
 }  // namespace node

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -32,6 +32,7 @@
 #include "v8.h"
 
 namespace node {
+namespace crypto {
 
 class NodeBIO {
  public:
@@ -156,6 +157,7 @@ class NodeBIO {
   Buffer* write_head_;
 };
 
+}  // namespace crypto
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -28,6 +28,7 @@
 #include "util-inl.h"
 
 namespace node {
+namespace crypto {
 
 inline void ClientHelloParser::Reset() {
   frame_len_ = 0;
@@ -74,6 +75,7 @@ inline bool ClientHelloParser::IsPaused() const {
   return state_ == kPaused;
 }
 
+}  // namespace crypto
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -23,6 +23,7 @@
 #include "node_crypto_clienthello-inl.h"
 
 namespace node {
+namespace crypto {
 
 void ClientHelloParser::Parse(const uint8_t* data, size_t avail) {
   switch (state_) {
@@ -244,4 +245,5 @@ bool ClientHelloParser::ParseTLSClientHello(const uint8_t* data, size_t avail) {
   return true;
 }
 
+}  // namespace crypto
 }  // namespace node

--- a/src/node_crypto_clienthello.h
+++ b/src/node_crypto_clienthello.h
@@ -30,6 +30,7 @@
 #include <stdlib.h>  // nullptr
 
 namespace node {
+namespace crypto {
 
 class ClientHelloParser {
  public:
@@ -133,6 +134,7 @@ class ClientHelloParser {
   const uint8_t* tls_ticket_;
 };
 
+}  // namespace crypto
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -38,10 +38,10 @@
 namespace node {
 
 // Forward-declarations
-class NodeBIO;
 class WriteWrap;
 namespace crypto {
 class SecureContext;
+class NodeBIO;
 }
 
 class TLSWrap : public AsyncWrap,
@@ -172,7 +172,7 @@ class TLSWrap : public AsyncWrap,
   StreamBase* stream_;
   BIO* enc_in_;
   BIO* enc_out_;
-  NodeBIO* clear_in_;
+  crypto::NodeBIO* clear_in_;
   size_t write_size_;
   typedef ListHead<WriteItem, &WriteItem::member_> WriteItemList;
   WriteItemList write_item_queue_;


### PR DESCRIPTION
Currently, node_crypto_bio and node_crypto_clienthello are not in the
crypto namespace but simply in the node namespace. Not sure if this was
intentional or not, but I think it would make sense to move them to be
consistent.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, crypto