### PR TITLE
test: add test to verify ErrnoException path

### DIFF
--- a/test/addons/errno-exception/binding.cc
+++ b/test/addons/errno-exception/binding.cc
@@ -1,0 +1,18 @@
+#include <node.h>
+#include <v8.h>
+
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::HandleScope scope(isolate);
+  args.GetReturnValue().Set(node::ErrnoException(isolate,
+                                                10,
+                                                "syscall",
+                                                "some error msg",
+                                                "päth"));
+}
+
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "errno", Method);
+}
+
+NODE_MODULE(binding, init)

--- a/test/addons/errno-exception/binding.gyp
+++ b/test/addons/errno-exception/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/errno-exception/test.js
+++ b/test/addons/errno-exception/test.js
@@ -1,0 +1,9 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+const err = binding.errno();
+assert.strictEqual(err.syscall, 'syscall');
+assert.strictEqual(err.errno, 10);
+assert.strictEqual(err.path, 'päth');
+assert.ok(/^Error:\s\w+, some error msg 'päth'$/.test(err.toString()));

--- a/test/addons/errno-exception/test.js
+++ b/test/addons/errno-exception/test.js
@@ -1,8 +1,14 @@
 'use strict';
+
 const common = require('../../common');
+
+// Verify that the path argument to node::ErrnoException() can contain UTF-8
+// characters.
+
 const assert = require('assert');
 const binding = require(`./build/${common.buildType}/binding`);
 const err = binding.errno();
+
 assert.strictEqual(err.syscall, 'syscall');
 assert.strictEqual(err.errno, 10);
 assert.strictEqual(err.path, 'päth');


### PR DESCRIPTION
This commit adds a test to verify that the path argument to
ErrnoException can contain UTF-8 characters.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src