### PR TITLE
errors, url: port url errors to internal/errors

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -26,6 +26,8 @@ const { toASCII } = process.binding('config').hasIntl ?
 
 const { hexTable } = require('internal/querystring');
 
+const errors = require('internal/errors');
+
 // WHATWG URL implementation provided by internal/url
 const {
   URL,
@@ -99,7 +101,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
 
 Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   if (typeof url !== 'string') {
-    throw new TypeError('Parameter "url" must be a string, not ' + typeof url);
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'url', 'string', url);
   }
 
   // Copy chrome, IE, opera backslash-handling behavior.
@@ -556,8 +558,7 @@ function urlFormat(obj, options) {
   if (typeof obj === 'string') {
     obj = urlParse(obj);
   } else if (typeof obj !== 'object' || obj === null) {
-    throw new TypeError('Parameter "urlObj" must be an object, not ' +
-                        (obj === null ? 'null' : typeof obj));
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'urlObj', 'object', obj);
   } else if (!(obj instanceof Url)) {
     var format = obj[formatSymbol];
     return format ?

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const url = require('url');
 
@@ -14,8 +14,12 @@ const throwsObjsAndReportTypes = new Map([
 ]);
 
 for (const [obj, type] of throwsObjsAndReportTypes) {
-  const error = new RegExp(
-    `^TypeError: Parameter "urlObj" must be an object, not ${type}$`);
+  const error = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "urlObj" argument must be of type object. ' +
+             `Received type ${type}`
+  });
   assert.throws(function() { url.format(obj); }, error);
 }
 assert.strictEqual(url.format(''), '');

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -1,23 +1,27 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const url = require('url');
 
 // https://github.com/joyent/node/issues/568
-const errMessage = /^TypeError: Parameter "url" must be a string, not (?:undefined|boolean|number|object|function|symbol)$/;
 [
-  undefined,
-  null,
-  true,
-  false,
-  0.0,
-  0,
-  [],
-  {},
-  () => {},
-  Symbol('foo')
-].forEach((val) => {
-  assert.throws(() => { url.parse(val); }, errMessage);
+  [undefined, 'undefined'],
+  [null, 'null'],
+  [true, 'boolean'],
+  [false, 'boolean'],
+  [0.0, 'number'],
+  [0, 'number'],
+  [[], 'object'],
+  [{}, 'object'],
+  [() => {}, 'function'],
+  [Symbol('foo'), 'symbol']
+].forEach(([val, type]) => {
+  const error = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: `The "url" argument must be of type string. Received type ${type}`
+  });
+  assert.throws(() => { url.parse(val); }, error);
 });
 
 assert.throws(() => { url.parse('http://%E0%A4%A@fail'); },


### PR DESCRIPTION
- Migrate [url.js](https://github.com/nodejs/node/blob/master/lib/url.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js)
- Improve error messages
- Improve test for url module

There is already a PR ([#11360](https://github.com/nodejs/node/pull/11360)) for this migration, but it seems to be out-of-date and deprecated. So I make a new one.

Ref: [#11273](https://github.com/nodejs/node/issues/11273)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
url, test
