### PR TITLE
test: verify isNativeError() accepts internal errors

### DIFF
--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -20,9 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+// Flags: --expose-internals
 const common = require('../common');
 const assert = require('assert');
 const util = require('util');
+const errors = require('internal/errors');
 const binding = process.binding('util');
 const context = require('vm').runInNewContext;
 
@@ -167,4 +169,8 @@ util.error('test');
   assert.strictEqual(binding.isNativeError([]), false);
   assert.strictEqual(binding.isNativeError(Object.create(Error.prototype)),
                      false);
+  assert.strictEqual(
+    binding.isNativeError(new errors.Error('ERR_IPC_CHANNEL_CLOSED')),
+    true
+  );
 }


### PR DESCRIPTION
This commit verifies that Node's internal errors are recognized by V8's `IsNativeError()`, which is exposed in Node as `process.binding('util').isNativeError()`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
