### PR TITLE
doc: fix api docs style

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -334,7 +334,7 @@ added: v6.0.0
 
 Set by calling `.kill()` or `.disconnect()`. Until then, it is `undefined`.
 
-The boolean `worker.exitedAfterDisconnect` allows distinguishing between
+The boolean [`worker.exitedAfterDisconnect`][] allows distinguishing between
 voluntary and accidental exit, the master may choose not to respawn a worker
 based on this value.
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -103,7 +103,7 @@ In an earlier version of the Node.js `cluster`, a boolean property with the name
 `suicide` was added to the `Worker` object. The intent of this property was to
 provide an indication of how and why the `Worker` instance exited. In Node.js
 6.0.0, the old property was deprecated and replaced with a new
-[worker.exitedAfterDisconnect][] property. The old property name did not
+[`worker.exitedAfterDisconnect`][] property. The old property name did not
 precisely describe the actual semantics and was unnecessarily emotion-laden.
 
 <a id="DEP0008"></a>

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -898,7 +898,6 @@ installed.
 [domains]: domain.html
 [event emitter-based]: events.html#events_class_eventemitter
 [file descriptors]: https://en.wikipedia.org/wiki/File_descriptor
-[intl wiki]: https://github.com/nodejs/node/wiki/Intl
 [online]: http://man7.org/linux/man-pages/man3/errno.3.html
 [stream-based]: stream.html
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html


### PR DESCRIPTION
##### Summary

```
doc/api/cluster.md
  L337: Use the definition link

doc/api/deprecations.md
  L106: Fix the definition link name

doc/api/errors.md
  L901: Remove unused definition
```

##### Checklist
- [x] `make -j4 test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc