### PR TITLE
assert: fix assert.fail with zero arguments

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -256,19 +256,20 @@ If the values are not equal, an `AssertionError` is thrown with a `message`
 property set equal to the value of the `message` parameter. If the `message`
 parameter is undefined, a default error message is assigned.
 
-## assert.fail(message)
+## assert.fail([message])
 ## assert.fail(actual, expected, message, operator)
 <!-- YAML
 added: v0.1.21
 -->
 * `actual` {any}
 * `expected` {any}
-* `message` {any}
+* `message` {any} (default: 'Failed')
 * `operator` {string} (default: '!=')
 
 Throws an `AssertionError`. If `message` is falsy, the error message is set as
 the values of `actual` and `expected` separated by the provided `operator`.
 Otherwise, the error message is the value of `message`.
+If no arguments are provided at all, a default message will be used instead.
 
 ```js
 const assert = require('assert');
@@ -284,6 +285,9 @@ assert.fail('boom');
 
 assert.fail('a', 'b');
 // AssertionError: 'a' != 'b'
+
+assert.fail();
+// AssertionError: Failed
 ```
 
 ## assert.ifError(value)

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -52,8 +52,13 @@ const assert = module.exports = ok;
 // display purposes.
 
 function fail(actual, expected, message, operator, stackStartFunction) {
-  if (arguments.length === 1)
+  if (arguments.length === 0) {
+    message = 'Failed';
+  }
+  if (arguments.length === 1) {
     message = actual;
+    actual = undefined;
+  }
   if (arguments.length === 2)
     operator = '!=';
   const errors = lazyErrors();

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -8,7 +8,7 @@ assert.throws(
   common.expectsError({
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: 'undefined undefined undefined'
+    message: 'Failed'
   })
 );
 


### PR DESCRIPTION
Use a default message in case there is no argument and set `actual` to undefined (it will show up as a property of the thrown error object). Currently the message would be `undefined undefined undefined` instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
