### PR TITLE
errors, buffer: Migrate buffer errors to use internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -575,6 +575,11 @@ Used as special type of error that can be triggered whenever Node.js detects an
 exceptional logic violation that should never occur. These are raised typically
 by the `assert` module.
 
+<a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
+### ERR_BUFFER_OUT_OF_BOUNDS
+
+Used when attempting to perform an operation outside the bounds of a `Buffer`.
+
 <a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
 ### ERR_CONSOLE_WRITABLE_STREAM
 
@@ -624,6 +629,11 @@ to a Node.js API.
 ### ERR_INVALID_ARRAY_LENGTH
 
 Used when an Array is not of the expected length or in a valid range.
+
+<a id="ERR_INVALID_BUFFER_SIZE"></a>
+### ERR_INVALID_BUFFER_SIZE
+
+Used when performing a swap on a `Buffer` but it's size is not compatible with the operation.
 
 <a id="ERR_INVALID_CALLBACK"></a>
 ### ERR_INVALID_CALLBACK
@@ -781,6 +791,13 @@ would be possible by calling a callback more then once.
 Used when an attempt is made to use crypto features while Node.js is not
 compiled with OpenSSL crypto support.
 
+<a id="ERR_NO_LONGER_SUPPORTED"></a>
+### ERR_NO_LONGER_SUPPORTED
+
+Used when a Node.js API is called in an unsupported manner.
+
+For example: `Buffer.write(string, encoding, offset[, length])`
+
 <a id="ERR_PARSE_HISTORY_DATA"></a>
 ### ERR_PARSE_HISTORY_DATA
 
@@ -843,6 +860,11 @@ instance.setEncoding('utf-8');
 Used to identify a specific kind of internal Node.js error that should not
 typically be triggered by user code. Instances of this error point to an
 internal bug within the Node.js binary itself.
+
+<a id="ERR_UNKNOWN_ENCODING"></a>
+### ERR_UNKNOWN_ENCODING
+
+Used when an invalid or unknown encoding option is passed to an API.
 
 <a id="ERR_UNKNOWN_SIGNAL"></a>
 ### ERR_UNKNOWN_SIGNAL

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -67,9 +67,6 @@ Object.defineProperty(exports, 'constants', {
 
 exports.kStringMaxLength = binding.kStringMaxLength;
 
-const kFromErrorMsg = 'First argument must be a string, Buffer, ' +
-                      'ArrayBuffer, Array, or array-like object.';
-
 Buffer.poolSize = 8 * 1024;
 var poolSize, poolOffset, allocPool;
 
@@ -146,9 +143,8 @@ function Buffer(arg, encodingOrOffset, length) {
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {
-      throw new Error(
-        'If encoding is specified then the first argument must be a string'
-      );
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'string',
+        'string', arg);
     }
     return Buffer.alloc(arg);
   }
@@ -177,10 +173,12 @@ Buffer.from = function(value, encodingOrOffset, length) {
     return fromArrayBuffer(value, encodingOrOffset, length);
 
   if (value == null)
-    throw new TypeError(kFromErrorMsg);
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
+      ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object'], value);
 
   if (typeof value === 'number')
-    throw new TypeError('"value" argument must not be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'value', 'not number',
+      value);
 
   const valueOf = value.valueOf && value.valueOf();
   if (valueOf != null && valueOf !== value)
@@ -196,7 +194,8 @@ Buffer.from = function(value, encodingOrOffset, length) {
                        length);
   }
 
-  throw new TypeError(kFromErrorMsg);
+  throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
+      ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object']);
 };
 
 Object.setPrototypeOf(Buffer, Uint8Array);
@@ -208,12 +207,11 @@ function assertSize(size) {
   let err = null;
 
   if (typeof size !== 'number') {
-    err = new TypeError('"size" argument must be a number');
+    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number', size);
   } else if (size < 0) {
-    err = new RangeError('"size" argument must not be negative');
+    err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
   } else if (size > binding.kMaxLength) {
-    err = new RangeError('"size" argument must not be larger ' +
-                         'than ' + binding.kMaxLength);
+    err = new errors.RangeError('ERR_INVALID_OPT_VALUE', 'size', size);
   }
 
   if (err) {
@@ -300,7 +298,7 @@ function fromString(string, encoding) {
   } else {
     length = byteLength(string, encoding, true);
     if (length === -1)
-      throw new TypeError('"encoding" must be a valid string encoding');
+      throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
     if (string.length === 0)
       return new FastBuffer();
   }
@@ -343,7 +341,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
   const maxLength = obj.byteLength - byteOffset;
 
   if (maxLength < 0)
-    throw new RangeError("'offset' is out of bounds");
+    throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'offset');
 
   if (length === undefined) {
     length = maxLength;
@@ -355,7 +353,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
       length = 0;
     } else if (length > 0) {
       if (length > maxLength)
-        throw new RangeError("'length' is out of bounds");
+        throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'length');
     } else {
       length = 0;
     }
@@ -399,7 +397,8 @@ Buffer.isBuffer = function isBuffer(b) {
 
 Buffer.compare = function compare(a, b) {
   if (!isUint8Array(a) || !isUint8Array(b)) {
-    throw new TypeError('Arguments must be Buffers or Uint8Arrays');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', ['buf1', 'buf2'],
+      ['buffer', 'uint8Array']);
   }
 
   if (a === b) {
@@ -416,13 +415,13 @@ Buffer.isEncoding = function(encoding) {
 };
 Buffer[internalUtil.kIsEncodingSymbol] = Buffer.isEncoding;
 
-const kConcatErrMsg = '"list" argument must be an Array ' +
-                      'of Buffer or Uint8Array instances';
+const kConcatErr = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'list',
+      ['array', 'buffer', 'uint8Array']);
 
 Buffer.concat = function(list, length) {
   var i;
   if (!Array.isArray(list))
-    throw new TypeError(kConcatErrMsg);
+    throw kConcatErr;
 
   if (list.length === 0)
     return new FastBuffer();
@@ -440,7 +439,7 @@ Buffer.concat = function(list, length) {
   for (i = 0; i < list.length; i++) {
     var buf = list[i];
     if (!isUint8Array(buf))
-      throw new TypeError(kConcatErrMsg);
+      throw kConcatErr;
     binding.copy(buf, buffer, pos);
     pos += buf.length;
   }
@@ -475,7 +474,8 @@ function byteLength(string, encoding) {
       return string.byteLength;
     }
 
-    throw new TypeError('"string" must be a string, Buffer, or ArrayBuffer');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'string',
+      ['string', 'buffer', 'arrayBuffer']);
   }
 
   const len = string.length;
@@ -591,7 +591,7 @@ function stringSlice(buf, encoding, start, end) {
         return buf.ucs2Slice(start, end);
       break;
   }
-  throw new TypeError('Unknown encoding: ' + encoding);
+  throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
 }
 
 
@@ -633,8 +633,8 @@ Buffer.prototype.toString = function(encoding, start, end) {
 
 Buffer.prototype.equals = function equals(b) {
   if (!isUint8Array(b))
-    throw new TypeError('Argument must be a Buffer or Uint8Array');
-
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'otherBuffer',
+      ['buffer', 'uint8Array']);
   if (this === b)
     return true;
 
@@ -659,7 +659,8 @@ Buffer.prototype.compare = function compare(target,
                                             thisStart,
                                             thisEnd) {
   if (!isUint8Array(target))
-    throw new TypeError('Argument must be a Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
+     ['buffer', 'uint8Array']);
   if (arguments.length === 1)
     return compare_(this, target);
 
@@ -738,8 +739,8 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
     return binding.indexOfNumber(buffer, val, byteOffset, dir);
   }
 
-  throw new TypeError('"val" argument must be string, number, Buffer ' +
-                      'or Uint8Array');
+  throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'val',
+    ['string', 'buffer', 'uint8Array']);
 }
 
 
@@ -765,7 +766,7 @@ function slowIndexOf(buffer, val, byteOffset, encoding, dir) {
 
       default:
         if (loweredCase) {
-          throw new TypeError('Unknown encoding: ' + encoding);
+          throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
         }
 
         encoding = ('' + encoding).toLowerCase();
@@ -807,11 +808,11 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
     }
 
     if (encoding !== undefined && typeof encoding !== 'string') {
-      throw new TypeError('encoding must be a string');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'encoding', 'string');
     }
     var normalizedEncoding = internalUtil.normalizeEncoding(encoding);
     if (normalizedEncoding === undefined) {
-      throw new TypeError('Unknown encoding: ' + encoding);
+      throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
     }
 
     if (val.length === 0) {
@@ -872,13 +873,13 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
       length = remaining;
 
     if (string.length > 0 && (length < 0 || offset < 0))
-      throw new RangeError('Attempt to write outside buffer bounds');
+      throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'length', true);
   } else {
     // if someone is still calling the obsolete form of write(), tell them.
     // we don't want eg buf.write("foo", "utf8", 10) to silently turn into
     // buf.write("foo", "utf8"), so we can't ignore extra args
-    throw new Error('Buffer.write(string, encoding, offset[, length]) ' +
-                    'is no longer supported');
+    throw new errors.Error('ERR_NO_LONGER_SUPPORTED',
+      'Buffer.write(string, encoding, offset[, length])');
   }
 
   if (!encoding) return this.utf8Write(string, offset, length);
@@ -925,7 +926,7 @@ Buffer.prototype.write = function(string, offset, length, encoding) {
         return this.hexWrite(string, offset, length);
       break;
   }
-  throw new TypeError('Unknown encoding: ' + encoding);
+  throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
 };
 
 
@@ -1176,7 +1177,7 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
 
 function checkInt(buffer, value, offset, ext, max, min) {
   if (value > max || value < min)
-    throw new TypeError('"value" argument is out of bounds');
+    throw new errors.RangeError('ERR_INVALID_OPT_VALUE', 'value', value);
   if (offset + ext > buffer.length)
     throw new errors.RangeError('ERR_INDEX_OUT_OF_RANGE');
 }
@@ -1448,7 +1449,7 @@ Buffer.prototype.swap16 = function swap16() {
   // dropping down to the native code is faster.
   const len = this.length;
   if (len % 2 !== 0)
-    throw new RangeError('Buffer size must be a multiple of 16-bits');
+    throw new errors.RangeError('ERR_INVALID_BUFFER_SIZE', '16-bits');
   if (len < 128) {
     for (var i = 0; i < len; i += 2)
       swap(this, i, i + 1);
@@ -1464,7 +1465,7 @@ Buffer.prototype.swap32 = function swap32() {
   // dropping down to the native code is faster.
   const len = this.length;
   if (len % 4 !== 0)
-    throw new RangeError('Buffer size must be a multiple of 32-bits');
+    throw new errors.RangeError('ERR_INVALID_BUFFER_SIZE', '32-bits');
   if (len < 192) {
     for (var i = 0; i < len; i += 4) {
       swap(this, i, i + 3);
@@ -1482,7 +1483,7 @@ Buffer.prototype.swap64 = function swap64() {
   // dropping down to the native code is faster.
   const len = this.length;
   if (len % 8 !== 0)
-    throw new RangeError('Buffer size must be a multiple of 64-bits');
+    throw new errors.RangeError('ERR_INVALID_BUFFER_SIZE', '64-bits');
   if (len < 192) {
     for (var i = 0; i < len; i += 8) {
       swap(this, i, i + 7);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -109,9 +109,11 @@ module.exports = exports = {
 // Note: Please try to keep these in alphabetical order
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', '%s');
+E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
 E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot render headers after they are sent to the client');
@@ -127,6 +129,7 @@ E('ERR_INVALID_ARRAY_LENGTH',
     return `The "${name}" array must have a length of ${
            length}. Received length ${actual}`;
   });
+E('ERR_INVALID_BUFFER_SIZE', 'Buffer size must be a multiple of %s');
 E('ERR_INVALID_CALLBACK', 'Callback must be a function');
 E('ERR_INVALID_CHAR', 'Invalid character in %s');
 E('ERR_INVALID_CURSOR_POS',
@@ -173,6 +176,7 @@ E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',
   'Calling transform done when writableState.length != 0');
+E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s');
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s');
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
@@ -183,8 +187,29 @@ E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
 function invalidArgType(name, expected, actual) {
   const assert = lazyAssert();
   assert(name, 'name is required');
-  const type = name.includes('.') ? 'property' : 'argument';
-  var msg = `The "${name}" ${type} must be ${oneOf(expected, 'type')}`;
+
+  // determiner: 'must be' or 'must not be'
+  let determiner;
+  if (expected.includes('not ')) {
+    determiner = 'must not be';
+    expected = expected.split('not ')[1];
+  } else {
+    determiner = 'must be';
+  }
+
+  let msg;
+  if (Array.isArray(name)) {
+    var names = name.map((val) => `"${val}"`).join(', ');
+    msg = `The ${names} arguments ${determiner} ${oneOf(expected, 'type')}`;
+  } else if (name.includes(' argument')) {
+    // for the case like 'first argument'
+    msg = `The ${name} ${determiner} ${oneOf(expected, 'type')}`;
+  } else {
+    const type = name.includes('.') ? 'property' : 'argument';
+    msg = `The "${name}" ${type} ${determiner} ${oneOf(expected, 'type')}`;
+  }
+
+  // if actual value received, output it
   if (arguments.length >= 3) {
     msg += `. Received type ${actual !== null ? typeof actual : 'null'}`;
   }
@@ -229,5 +254,13 @@ function oneOf(expected, thing) {
     }
   } else {
     return `of ${thing} ${String(expected)}`;
+  }
+}
+
+function bufferOutOfBounds(name, isWriting) {
+  if (isWriting) {
+    return 'Attempt to write outside buffer bounds';
+  } else {
+    return `"${name}" is outside of buffer bounds`;
   }
 }

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -27,7 +27,6 @@ const assert = require('assert');
 const os = require('os');
 const child_process = require('child_process');
 const stream = require('stream');
-const buffer = require('buffer');
 const util = require('util');
 const Timer = process.binding('timer_wrap').Timer;
 const execSync = require('child_process').execSync;
@@ -54,8 +53,6 @@ exports.isLinux = process.platform === 'linux';
 exports.isOSX = process.platform === 'darwin';
 
 exports.enoughTestMem = os.totalmem() > 0x40000000; /* 1 Gb */
-exports.bufferMaxSizeMsg = new RegExp(
-  `^RangeError: "size" argument must not be larger than ${buffer.kMaxLength}$`);
 const cpus = os.cpus();
 exports.enoughTestCpu = Array.isArray(cpus) &&
                         (cpus.length > 1 || cpus[0].speed > 999);

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const LENGTH = 16;
@@ -65,16 +65,16 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer.from(ab.buffer, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'offset' is out of bounds/.test(err.message));
-    return true;
-  });
-  assert.throws(() => Buffer.from(ab.buffer, 3, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'length' is out of bounds/.test(err.message));
-    return true;
-  });
+  assert.throws(() => Buffer.from(ab.buffer, 6), common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
+  }));
+  assert.throws(() => Buffer.from(ab.buffer, 3, 6), common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"length" is outside of buffer bounds'
+  }));
 }
 
 // Test the deprecated Buffer() version also
@@ -93,16 +93,16 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer(ab.buffer, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'offset' is out of bounds/.test(err.message));
-    return true;
-  });
-  assert.throws(() => Buffer(ab.buffer, 3, 6), (err) => {
-    assert(err instanceof RangeError);
-    assert(/'length' is out of bounds/.test(err.message));
-    return true;
-  });
+  assert.throws(() => Buffer(ab.buffer, 6), common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
+  }));
+  assert.throws(() => Buffer(ab.buffer, 3, 6), common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"length" is outside of buffer bounds'
+  }));
 }
 
 {
@@ -118,10 +118,13 @@ b.writeDoubleBE(11.11, 0, true);
   assert.deepStrictEqual(Buffer.from(ab, [1]), Buffer.from(ab, 1));
 
   // If byteOffset is Infinity, throw.
-  assert.throws(
-    () => { Buffer.from(ab, Infinity); },
-    /^RangeError: 'offset' is out of bounds$/
-  );
+  assert.throws(() => {
+    Buffer.from(ab, Infinity);
+  }, common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"offset" is outside of buffer bounds'
+  }));
 }
 
 {
@@ -137,8 +140,11 @@ b.writeDoubleBE(11.11, 0, true);
   assert.deepStrictEqual(Buffer.from(ab, 0, [1]), Buffer.from(ab, 0, 1));
 
   //If length is Infinity, throw.
-  assert.throws(
-    () => { Buffer.from(ab, 0, Infinity); },
-    /^RangeError: 'length' is out of bounds$/
-  );
+  assert.throws(() => {
+    Buffer.from(ab, 0, Infinity);
+  }, common.expectsError({
+    code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+    type: RangeError,
+    message: '"length" is outside of buffer bounds'
+  }));
 }

--- a/test/parallel/test-buffer-bad-overload.js
+++ b/test/parallel/test-buffer-bad-overload.js
@@ -1,14 +1,20 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 assert.doesNotThrow(function() {
   Buffer.allocUnsafe(10);
 });
 
+const err = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "value" argument must not be of type number. ' +
+           'Received type number'
+});
 assert.throws(function() {
   Buffer.from(10, 'hex');
-}, /^TypeError: "value" argument must not be a number$/);
+}, err);
 
 assert.doesNotThrow(function() {
   Buffer.from('deadbeaf', 'hex');

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -1,16 +1,21 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const SlowBuffer = require('buffer').SlowBuffer;
 const vm = require('vm');
 
 // coerce values to string
-const re = /"string" must be a string, Buffer, or ArrayBuffer/;
-assert.throws(() => { Buffer.byteLength(32, 'latin1'); }, re);
-assert.throws(() => { Buffer.byteLength(NaN, 'utf8'); }, re);
-assert.throws(() => { Buffer.byteLength({}, 'latin1'); }, re);
-assert.throws(() => { Buffer.byteLength(); }, re);
+const errMsg = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "string" argument must be one of type string, ' +
+           'buffer, or arrayBuffer'
+}, 4);
+assert.throws(() => { Buffer.byteLength(32, 'latin1'); }, errMsg);
+assert.throws(() => { Buffer.byteLength(NaN, 'utf8'); }, errMsg);
+assert.throws(() => { Buffer.byteLength({}, 'latin1'); }, errMsg);
+assert.throws(() => { Buffer.byteLength(); }, errMsg);
 
 assert.strictEqual(Buffer.byteLength('', undefined, true), -1);
 

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -66,4 +66,8 @@ assert.throws(() => a.compare(b, 0, '0xff'), oor);
 assert.throws(() => a.compare(b, 0, Infinity), oor);
 assert.throws(() => a.compare(b, 0, 1, -1), oor);
 assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
-assert.throws(() => a.compare(), /Argument must be a Buffer/);
+assert.throws(() => a.compare(), common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "target" argument must be one of type buffer or uint8Array'
+}));

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const b = Buffer.alloc(1, 'a');
@@ -28,11 +28,18 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
 assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'),
-              /^TypeError: Arguments must be Buffers or Uint8Arrays$/);
+const errMsg = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "buf1", "buf2" arguments must be one of ' +
+             'type buffer or uint8Array'
+}, 2);
+assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
 
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)),
-              /^TypeError: Arguments must be Buffers or Uint8Arrays$/);
+assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), errMsg);
 
-assert.throws(() => Buffer.alloc(1).compare('abc'),
-              /^TypeError: Argument must be a Buffer or Uint8Array$/);
+assert.throws(() => Buffer.alloc(1).compare('abc'), common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "target" argument must be one of type buffer or uint8Array'
+}));

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -54,11 +54,12 @@ assertWrongList(['hello', Buffer.from('world')]);
 function assertWrongList(value) {
   assert.throws(() => {
     Buffer.concat(value);
-  }, function(err) {
-    return err instanceof TypeError &&
-           err.message === '"list" argument must be an Array of Buffer ' +
-                           'or Uint8Array instances';
-  });
+  }, common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "list" argument must be one of type ' +
+             'array, buffer, or uint8Array'
+  }));
 }
 
 const random10 = common.hasCrypto ?

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdf');
@@ -15,4 +15,9 @@ assert.ok(d.equals(d));
 assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
 assert.throws(() => Buffer.alloc(1).equals('abc'),
-              /^TypeError: Argument must be a Buffer or Uint8Array$/);
+              common.expectsError({
+                code: 'ERR_INVALID_ARG_TYPE',
+                type: TypeError,
+                message: 'The "otherBuffer" argument must be one of type ' +
+                         'buffer or uint8Array'
+              }));

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -206,16 +206,30 @@ assert.throws(
   common.expectsError({code: 'ERR_INDEX_OUT_OF_RANGE'}));
 assert.throws(
   () => buf1.fill('a', 0, buf1.length, 'node rocks!'),
-  /^TypeError: Unknown encoding: node rocks!$/);
+  common.expectsError({
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: node rocks!'
+  }));
 assert.throws(
   () => buf1.fill('a', 0, 0, NaN),
-  /^TypeError: encoding must be a string$/);
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "encoding" argument must be of type string'
+  }));
 assert.throws(
   () => buf1.fill('a', 0, 0, null),
-  /^TypeError: encoding must be a string$/);
+  common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "encoding" argument must be of type string'
+  }));
 assert.throws(
   () => buf1.fill('a', 0, 0, 'foo'),
-  /^TypeError: Unknown encoding: foo$/);
+  common.expectsError({
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: foo'
+  }));
 
 
 function genBuffer(size, args) {

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const { deepStrictEqual, throws } = require('assert');
 const { Buffer } = require('buffer');
 const { runInNewContext } = require('vm');
@@ -34,9 +34,6 @@ deepStrictEqual(Buffer.from(
                   runInNewContext('new String(checkString)', {checkString})),
                 check);
 
-const err = new RegExp('^TypeError: First argument must be a string, Buffer, ' +
-                       'ArrayBuffer, Array, or array-like object\\.$');
-
 [
   {},
   new Boolean(true),
@@ -45,6 +42,12 @@ const err = new RegExp('^TypeError: First argument must be a string, Buffer, ' +
   { valueOf: null },
   Object.create(null)
 ].forEach((input) => {
+  const err = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The first argument must be one of type string, buffer, ' +
+    'arrayBuffer, array, or array-like object'
+  });
   throws(() => Buffer.from(input), err);
 });
 
@@ -52,6 +55,11 @@ const err = new RegExp('^TypeError: First argument must be a string, Buffer, ' +
   new Number(true),
   new MyBadPrimitive()
 ].forEach((input) => {
-  throws(() => Buffer.from(input),
-         /^TypeError: "value" argument must not be a number$/);
+  const errMsg = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "value" argument must not be of type number. ' +
+             'Received type number'
+  });
+  throws(() => Buffer.from(input), errMsg);
 });

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -1,6 +1,6 @@
 'use strict';
-require('../common');
 const assert = require('assert');
+const common = require('../common');
 
 const b = Buffer.from('abcdef');
 const buf_a = Buffer.from('a');
@@ -271,8 +271,12 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
   }
 }
 
-const expectedError =
-  /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
+const expectedError = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "val" argument must be one of type ' +
+           'string, buffer, or uint8Array'
+}, 3);
 assert.throws(() => {
   b.includes(() => {});
 }, expectedError);

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdef');
@@ -344,8 +344,12 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
   }
 }
 
-const argumentExpected =
-    /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
+const argumentExpected = common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "val" argument must be one of type ' +
+           'string, buffer, or uint8Array'
+}, 3);
 
 assert.throws(() => {
   b.indexOf(() => { });

--- a/test/parallel/test-buffer-negative-length.js
+++ b/test/parallel/test-buffer-negative-length.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const SlowBuffer = require('buffer').SlowBuffer;
+
+const bufferNegativeMsg = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "size"$/
+}, 5);
+assert.throws(() => Buffer(-1).toString('utf8'), bufferNegativeMsg);
+assert.throws(() => SlowBuffer(-1).toString('utf8'), bufferNegativeMsg);
+assert.throws(() => Buffer.alloc(-1).toString('utf8'), bufferNegativeMsg);
+assert.throws(() => Buffer.allocUnsafe(-1).toString('utf8'), bufferNegativeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(-1).toString('utf8'),
+              bufferNegativeMsg);

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -1,6 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
-assert.throws(() => new Buffer(42, 'utf8'), /first argument must be a string/);
+assert.throws(() => new Buffer(42, 'utf8'), common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "string" argument must be of type string. ' +
+             'Received type number'
+}));

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -1,9 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
-const msg = /"size" argument must not be negative/;
+const msg = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "size"$/
+}, 12);
 
 // Test that negative Buffer length inputs throw errors.
 

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -7,7 +7,11 @@ const Buffer = buffer.Buffer;
 const SlowBuffer = buffer.SlowBuffer;
 
 const kMaxLength = buffer.kMaxLength;
-const bufferMaxSizeMsg = common.bufferMaxSizeMsg;
+const bufferMaxSizeMsg = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "size"$/
+}, 12);
 
 assert.throws(() => Buffer((-1 >>> 0) + 1), bufferMaxSizeMsg);
 assert.throws(() => SlowBuffer((-1 >>> 0) + 1), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-regression-649.js
+++ b/test/parallel/test-buffer-regression-649.js
@@ -6,7 +6,11 @@ const SlowBuffer = require('buffer').SlowBuffer;
 
 // Regression test for https://github.com/nodejs/node/issues/649.
 const len = 1422561062959;
-const message = common.bufferMaxSizeMsg;
+const message = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "size"$/
+}, 5);
 assert.throws(() => Buffer(len).toString('utf8'), message);
 assert.throws(() => SlowBuffer(len).toString('utf8'), message);
 assert.throws(() => Buffer.alloc(len).toString('utf8'), message);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -48,12 +48,22 @@ assert.strictEqual(SlowBuffer({}).length, 0);
 assert.strictEqual(SlowBuffer('string').length, 0);
 
 // should throw with invalid length
+const bufferMaxSizeMsg = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "size"$/
+}, 2);
 assert.throws(function() {
   SlowBuffer(Infinity);
-}, common.bufferMaxSizeMsg);
+}, bufferMaxSizeMsg);
 assert.throws(function() {
   SlowBuffer(-1);
-}, /^RangeError: "size" argument must not be negative$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: 'The value "-1" is invalid for option "size"'
+}));
+
 assert.throws(function() {
   SlowBuffer(buffer.kMaxLength + 1);
-}, common.bufferMaxSizeMsg);
+}, bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const rangeBuffer = Buffer.from('abc');
@@ -86,7 +86,15 @@ assert.strictEqual(rangeBuffer.toString({toString: function() {
 // try toString() with 0 and null as the encoding
 assert.throws(() => {
   rangeBuffer.toString(0, 1, 2);
-}, /^TypeError: Unknown encoding: 0$/);
+}, common.expectsError({
+  code: 'ERR_UNKNOWN_ENCODING',
+  type: TypeError,
+  message: 'Unknown encoding: 0'
+}));
 assert.throws(() => {
   rangeBuffer.toString(null, 1, 2);
-}, /^TypeError: Unknown encoding: null$/);
+}, common.expectsError({
+  code: 'ERR_UNKNOWN_ENCODING',
+  type: TypeError,
+  message: 'Unknown encoding: null'
+}));

--- a/test/parallel/test-buffer-tostring.js
+++ b/test/parallel/test-buffer-tostring.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 // utf8, ucs2, ascii, latin1, utf16le
@@ -27,8 +27,11 @@ encodings
 // Invalid encodings
 for (let i = 1; i < 10; i++) {
   const encoding = String(i).repeat(i);
-  const error = new RegExp(`^TypeError: Unknown encoding: ${encoding}$`);
-
+  const error = common.expectsError({
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: `Unknown encoding: ${encoding}`
+  });
   assert.ok(!Buffer.isEncoding(encoding));
   assert.throws(() => Buffer.from('foo').toString(encoding), error);
 }

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -1,9 +1,13 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
-const outsideBounds = /^RangeError: Attempt to write outside buffer bounds$/;
+const outsideBounds = common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+  type: RangeError,
+  message: 'Attempt to write outside buffer bounds'
+}, 2);
 
 assert.throws(() => Buffer.alloc(9).write('foo', -1), outsideBounds);
 assert.throws(() => Buffer.alloc(9).write('foo', 10), outsideBounds);
@@ -57,7 +61,11 @@ encodings
 // Invalid encodings
 for (let i = 1; i < 10; i++) {
   const encoding = String(i).repeat(i);
-  const error = new RegExp(`^TypeError: Unknown encoding: ${encoding}$`);
+  const error = common.expectsError({
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: `Unknown encoding: ${encoding}`
+  });
 
   assert.ok(!Buffer.isEncoding(encoding));
   assert.throws(() => Buffer.alloc(9).write('foo', encoding), error);

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -255,7 +255,7 @@ const values = [
     }, common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "last argument" argument must be of type function'
+      message: 'The last argument must be of type function'
     }));
   });
 }

--- a/test/parallel/test-writeint.js
+++ b/test/parallel/test-writeint.js
@@ -23,9 +23,13 @@
 /*
  * Tests to verify we're writing signed integers correctly
  */
-require('../common');
+const common = require('../common');
 const assert = require('assert');
-const errorOutOfBounds = /^TypeError: "value" argument is out of bounds$/;
+const errorOutOfBounds = common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: RangeError,
+  message: /^The value "[^"]*" is invalid for option "value"$/
+}, 12);
 
 function test8(clazz) {
   const buffer = new clazz(2);

--- a/test/parallel/test-writeuint.js
+++ b/test/parallel/test-writeuint.js
@@ -23,7 +23,7 @@
 /*
  * A battery of tests to help us read a series of uints
  */
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 /*
@@ -149,13 +149,17 @@ function testUint(clazz) {
 
   // Test 0 to 5 bytes.
   for (let i = 0; i <= 5; i++) {
-    const errmsg = `byteLength: ${i}`;
+    const errMsg = common.expectsError({
+      code: 'ERR_INVALID_OPT_VALUE',
+      type: RangeError,
+      message: /^The value "[^"]*" is invalid for option "value"$/
+    }, 2);
     assert.throws(function() {
       data.writeUIntBE(val, 0, i);
-    }, /"value" argument is out of bounds/, errmsg);
+    }, errMsg);
     assert.throws(function() {
       data.writeUIntLE(val, 0, i);
-    }, /"value" argument is out of bounds/, errmsg);
+    }, errMsg);
     val *= 0x100;
   }
 }


### PR DESCRIPTION
Migrate buffer errors to use internal/errors.

Ref: [#11273](https://github.com/nodejs/node/issues/11273)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer, errors
