### PR TITLE
test: http outgoing _renderHeaders

### DIFF
--- a/test/parallel/test-http-outgoing-renderHeaders.js
+++ b/test/parallel/test-http-outgoing-renderHeaders.js
@@ -1,0 +1,46 @@
+'use strict';
+// Flags: --expose-internals
+
+require('../common');
+const assert = require('assert');
+
+const outHeadersKey = require('internal/http').outHeadersKey;
+const http = require('http');
+const OutgoingMessage = http.OutgoingMessage;
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage._header = {};
+  assert.throws(
+    outgoingMessage._renderHeaders.bind(outgoingMessage),
+    /^Error: Can't render headers after they are sent to the client$/
+  );
+}
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[outHeadersKey] = null;
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {});
+}
+
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[outHeadersKey] = {};
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {});
+}
+
+{
+  const outgoingMessage = new OutgoingMessage();
+  outgoingMessage[outHeadersKey] = {
+    host: ['host', 'nodejs.org'],
+    origin: ['Origin', 'localhost']
+  };
+  const result = outgoingMessage._renderHeaders();
+  assert.deepStrictEqual(result, {
+    host: 'nodejs.org',
+    Origin: 'localhost'
+  });
+}


### PR DESCRIPTION
Improve http outgoing test coverage

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http-outgoing
