### PR TITLE
test: add coverage for napi_typeof

### DIFF
--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -44,9 +44,9 @@ assert.strictEqual(test_general.testGetVersion(), 1);
   undefined,
   Symbol()
 ].forEach((val) => {
-  assert.strictEqual(typeof val, test_general.testNapiTypeof(val));
+  assert.strictEqual(test_general.testNapiTypeof(val), typeof val);
 });
 
 // since typeof in js return object need to validate specific case
 // for null
-assert.strictEqual('null', test_general.testNapiTypeof(null));
+assert.strictEqual(test_general.testNapiTypeof(null), 'null');

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -34,3 +34,12 @@ assert.ok(test_general.testGetPrototype(baseObject) !==
 // test version management functions
 // expected version is currently 1
 assert.strictEqual(test_general.testGetVersion(), 1);
+
+[123, 'test string', function() {}, new Object(), true,
+ undefined, Symbol()].forEach((val) => {
+   assert.strictEqual(typeof val, typeof (test_general.testNapiTypeof(val)));
+ });
+
+// since typeof in js return object need to validate specific case
+// for null
+assert.strictEqual(null, test_general.testNapiTypeof(null));

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -35,11 +35,18 @@ assert.ok(test_general.testGetPrototype(baseObject) !==
 // expected version is currently 1
 assert.strictEqual(test_general.testGetVersion(), 1);
 
-[123, 'test string', function() {}, new Object(), true,
- undefined, Symbol()].forEach((val) => {
-   assert.strictEqual(typeof val, typeof (test_general.testNapiTypeof(val)));
- });
+[
+  123,
+  'test string',
+  function() {},
+  new Object(),
+  true,
+  undefined,
+  Symbol()
+].forEach((val) => {
+  assert.strictEqual(typeof val, test_general.testNapiTypeof(val));
+});
 
 // since typeof in js return object need to validate specific case
 // for null
-assert.strictEqual(null, test_general.testNapiTypeof(null));
+assert.strictEqual('null', test_general.testNapiTypeof(null));

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -29,7 +29,7 @@ napi_value testGetVersion(napi_env env, napi_callback_info info) {
   uint32_t version;
   napi_value result;
   NAPI_CALL(env, napi_get_version(env, &version));
-  NAPI_CALL(env ,napi_create_number(env, version, &result));
+  NAPI_CALL(env,napi_create_number(env, version, &result));
   return result;
 }
 
@@ -95,32 +95,26 @@ napi_value testNapiTypeof(napi_env env, napi_callback_info info) {
   napi_value args[1];
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
-  napi_valuetype object_type;
-  NAPI_CALL(env, napi_typeof(env, args[0], &object_type));  
+  napi_valuetype argument_type;
+  NAPI_CALL(env, napi_typeof(env, args[0], &argument_type));  
 
   napi_value result;
-  if (object_type == napi_number) {
-    NAPI_CALL(env ,napi_create_number(env, 42, &result));
-  } else if (object_type == napi_string) {
-    NAPI_CALL(env, napi_create_string_utf8(env, "42", -1, &result));
-  } else if (object_type == napi_function) {
-    NAPI_CALL(env, napi_create_function(env,
-                                        NULL,
-                                        testNapiTypeof,
-                                        NULL,
-                                        &result));
-  } else if (object_type == napi_object) {
-    NAPI_CALL(env, napi_create_object(env, &result));
-  } else if (object_type == napi_boolean) {
-    NAPI_CALL(env, napi_get_boolean(env, true, &result));
-  } else if (object_type == napi_undefined) {
-    NAPI_CALL(env, napi_get_undefined(env, &result));
-  } else if (object_type == napi_symbol) {
-    napi_value symbol_description;
-    NAPI_CALL(env, napi_create_string_utf8(env, "NameKeySymbol", -1, &symbol_description));
-    NAPI_CALL(env, napi_create_symbol(env, symbol_description, &result));
-  } else if (object_type == napi_null) {
-    NAPI_CALL(env, napi_get_null(env, &result));
+  if (argument_type == napi_number) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "number", -1, &result));
+  } else if (argument_type == napi_string) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "string", -1, &result));
+  } else if (argument_type == napi_function) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "function", -1, &result));
+  } else if (argument_type == napi_object) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "object", -1, &result));
+  } else if (argument_type == napi_boolean) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "boolean", -1, &result));
+  } else if (argument_type == napi_undefined) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "undefined", -1, &result));
+  } else if (argument_type == napi_symbol) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "symbol", -1, &result));
+  } else if (argument_type == napi_null) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "null", -1, &result));
   }
   return result;
 }

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -29,7 +29,7 @@ napi_value testGetVersion(napi_env env, napi_callback_info info) {
   uint32_t version;
   napi_value result;
   NAPI_CALL(env, napi_get_version(env, &version));
-  NAPI_CALL(env,napi_create_number(env, version, &result));
+  NAPI_CALL(env, napi_create_number(env, version, &result));
   return result;
 }
 

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -90,6 +90,41 @@ napi_value testNapiErrorCleanup(napi_env env, napi_callback_info info) {
   return result;
 }
 
+napi_value testNapiTypeof(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_valuetype object_type;
+  NAPI_CALL(env, napi_typeof(env, args[0], &object_type));  
+
+  napi_value result;
+  if (object_type == napi_number) {
+    NAPI_CALL(env ,napi_create_number(env, 42, &result));
+  } else if (object_type == napi_string) {
+    NAPI_CALL(env, napi_create_string_utf8(env, "42", -1, &result));
+  } else if (object_type == napi_function) {
+    NAPI_CALL(env, napi_create_function(env,
+                                        NULL,
+                                        testNapiTypeof,
+                                        NULL,
+                                        &result));
+  } else if (object_type == napi_object) {
+    NAPI_CALL(env, napi_create_object(env, &result));
+  } else if (object_type == napi_boolean) {
+    NAPI_CALL(env, napi_get_boolean(env, true, &result));
+  } else if (object_type == napi_undefined) {
+    NAPI_CALL(env, napi_get_undefined(env, &result));
+  } else if (object_type == napi_symbol) {
+    napi_value symbol_description;
+    NAPI_CALL(env, napi_create_string_utf8(env, "NameKeySymbol", -1, &symbol_description));
+    NAPI_CALL(env, napi_create_symbol(env, symbol_description, &result));
+  } else if (object_type == napi_null) {
+    NAPI_CALL(env, napi_get_null(env, &result));
+  }
+  return result;
+}
+
 void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("testStrictEquals", testStrictEquals),
@@ -100,6 +135,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("getNull", getNull),
     DECLARE_NAPI_PROPERTY("createNapiError", createNapiError),
     DECLARE_NAPI_PROPERTY("testNapiErrorCleanup", testNapiErrorCleanup),
+    DECLARE_NAPI_PROPERTY("testNapiTypeof", testNapiTypeof),
   };
 
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(


### PR DESCRIPTION
We had some, but not complete coverage indirectly through
other tests.  Add test to validate it specifically and
covers cases that were not being covered.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, n-api