### PR TITLE
test: skip whether TTY is availble

### DIFF
--- a/test/async-hooks/test-ttywrap.readstream.js
+++ b/test/async-hooks/test-ttywrap.readstream.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 
@@ -10,31 +11,33 @@ const { checkInvocations } = require('./hook-checks');
 const hooks = initHooks();
 hooks.enable();
 
+if (!process.stdin.isTTY)
+  return common.skip('no valid readable TTY available');
+
 // test specific setup
-const { ReadStream } = require('tty');
 const checkInitOpts = { init: 1 };
 const checkEndedOpts = { init: 1, before: 1, after: 1, destroy: 1 };
 
 // test code
 //
 // listen to stdin except on Windows
-const targetFD = common.isWindows ? 1 : 0;
-const ttyStream = new ReadStream(targetFD);
 const activities = hooks.activitiesOfTypes('TTYWRAP');
 assert.strictEqual(activities.length, 1);
+
 const tty = activities[0];
 assert.strictEqual(tty.type, 'TTYWRAP');
 assert.strictEqual(typeof tty.uid, 'number');
 assert.strictEqual(typeof tty.triggerAsyncId, 'number');
 checkInvocations(tty, checkInitOpts, 'when tty created');
+
 const delayedOnCloseHandler = common.mustCall(() => {
   checkInvocations(tty, checkEndedOpts, 'when tty ended');
 });
-ttyStream.on('error', (err) => assert.fail(err));
-ttyStream.on('close', common.mustCall(() =>
+process.stdin.on('error', (err) => assert.fail(err));
+process.stdin.on('close', common.mustCall(() =>
   tick(2, delayedOnCloseHandler)
 ));
-ttyStream.destroy();
+process.stdin.destroy();
 checkInvocations(tty, checkInitOpts, 'when tty.end() was invoked');
 
 process.on('exit', () => {

--- a/test/async-hooks/test-ttywrap.writestream.js
+++ b/test/async-hooks/test-ttywrap.writestream.js
@@ -1,64 +1,47 @@
 'use strict';
 
 const common = require('../common');
-
-const tty_fd = common.getTTYfd();
-if (tty_fd < 0)
-  common.skip('no valid TTY fd available');
-
 const assert = require('assert');
+
+// general hook test setup
 const tick = require('./tick');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');
 
-const ttyStream = (() => {
-  try {
-    return new (require('tty').WriteStream)(tty_fd);
-  } catch (e) {
-    return null;
-  }
-})();
-if (ttyStream === null)
-  common.skip('no valid TTY fd available');
-
 const hooks = initHooks();
 hooks.enable();
 
-const as = hooks.activitiesOfTypes('TTYWRAP');
-assert.strictEqual(as.length, 1);
-const tty = as[0];
+if (!process.stdout.isTTY)
+  return common.skip('no valid writable TTY available');
+
+// test specific setup
+const checkInitOpts = { init: 1 };
+const checkEndedOpts = { init: 1, before: 1, after: 1, destroy: 1 };
+
+// test code
+//
+// listen to stdin except on Windows
+const activities = hooks.activitiesOfTypes('TTYWRAP');
+assert.strictEqual(activities.length, 1);
+
+const tty = activities[0];
 assert.strictEqual(tty.type, 'TTYWRAP');
 assert.strictEqual(typeof tty.uid, 'number');
 assert.strictEqual(typeof tty.triggerAsyncId, 'number');
-checkInvocations(tty, { init: 1 }, 'when tty created');
+checkInvocations(tty, checkInitOpts, 'when tty created');
 
-ttyStream
-  .on('finish', common.mustCall(onfinish))
-  .end(common.mustCall(onend));
+const delayedOnCloseHandler = common.mustCall(() => {
+  checkInvocations(tty, checkEndedOpts, 'when tty ended');
+});
+process.stdout.on('error', (err) => assert.fail(err));
+process.stdout.on('close', common.mustCall(() =>
+  tick(2, delayedOnCloseHandler)
+));
+process.stdout.destroy();
+checkInvocations(tty, checkInitOpts, 'when tty.end() was invoked');
 
-checkInvocations(tty, { init: 1 }, 'when tty.end() was invoked ');
-
-function onend() {
-  tick(2, common.mustCall(() =>
-    checkInvocations(
-      tty, { init: 1, before: 1, after: 1, destroy: 1 },
-      'when tty ended ')
-  ));
-}
-
-function onfinish() {
-  tick(2, common.mustCall(() =>
-    checkInvocations(
-      tty, { init: 1, before: 1, after: 1, destroy: 1 },
-      'when tty ended ')
-  ));
-}
-
-process.on('exit', onexit);
-
-function onexit() {
+process.on('exit', () => {
   hooks.disable();
   hooks.sanityCheck('TTYWRAP');
-  checkInvocations(tty, { init: 1, before: 1, after: 1, destroy: 1 },
-                   'when process exits');
-}
+  checkInvocations(tty, checkEndedOpts, 'when process exits');
+});


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

##### Description

If TTY isn't available then the test will always fail.

Fixes: https://github.com/nodejs/node/issues/13984

CI: https://ci.nodejs.org/job/node-test-pull-request/8879/