### PR TITLE
build,test: run v8 tests on windows

### DIFF
--- a/tools/test-v8.bat
+++ b/tools/test-v8.bat
@@ -1,0 +1,45 @@
+if not defined DEPOT_TOOLS_PATH goto depot-tools-not-found
+if "%config%"=="Debug" set test_args=%target_arch%.debug
+if "%config%"=="Release" set test_args=%target_arch%.release
+set savedpath=%path%
+set path=%DEPOT_TOOLS_PATH%;%path%
+pushd .
+
+set ERROR_STATUS=0
+echo calling: tools\make-v8.sh
+sh tools\make-v8.sh
+if errorlevel 1 set ERROR_STATUS=1&goto test-v8-exit
+cd %~dp0
+cd deps\v8
+echo running 'python tools\dev\v8gen.py %test_args%'
+call python tools\dev\v8gen.py %test_args%
+if errorlevel 1 set ERROR_STATUS=1&goto test-v8-exit
+echo running 'ninja -C out.gn/%test_args% %v8_build_options%'
+call ninja -C out.gn/%test_args% %v8_build_options%
+if errorlevel 1 set ERROR_STATUS=1&goto test-v8-exit
+set path=%savedpath%
+
+if not defined test_v8 goto test-v8-intl
+echo running 'python tools\run-tests.py %common_v8_test_options% %v8_test_options% --junitout ./v8-tap.xml'
+call python tools\run-tests.py %common_v8_test_options% %v8_test_options% --junitout ./v8-tap.xml
+
+:test-v8-intl
+if not defined test_v8_intl goto test-v8-benchmarks
+echo running 'python tools\run-tests.py %common_v8_test_options% intl --junitout ./v8-intl-tap.xml'
+call python tools\run-tests.py %common_v8_test_options% intl --junitout ./v8-intl-tap.xml
+
+:test-v8-benchmarks
+if not defined test_v8_benchmarks goto test-v8-exit
+echo running 'python tools\run-tests.py %common_v8_test_options% benchmarks --junitout ./v8-benchmarks-tap.xml'
+call python tools\run-tests.py %common_v8_test_options% benchmarks --junitout ./v8-benchmarks-tap.xml
+goto test-v8-exit
+
+:test-v8-exit
+popd
+if defined savedpath set path=%savedpath%
+exit /b %ERROR_STATUS%
+
+:depot-tools-not-found
+echo Failed to find a suitable depot tools to test v8
+exit /b 1
+


### PR DESCRIPTION
This is a port of https://github.com/nodejs/node/pull/4704 for windows. 
Related discussion: https://github.com/nodejs/build/pull/577#issuecomment-306657089

`vcbuild.bat test-v8` : Runs unit test from v8 repo
`vcbuild.bat test-v8-intl` : Runs intl test from v8 repo
`vcbuild.bat test-v8` : Runs benchmarks from v8 repo

The runs needs [depot_tools](https://www.chromium.org/developers/how-tos/install-depot-tools)
installed on the machine expects environment variable `DEPOT_TOOLS_PATH` to be set to the path.

Set environment variable `DISABLE_V8_I18N` to disable i18n.

I verified this on my machine and it works as expected. But would love to setup a CI machine that contains depot_tools installation and try it out.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build