### PR TITLE
tls: migrate tls.js to use internal/errors.js

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -169,6 +169,8 @@ E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');
+E('ERR_TLS_CERT_ALTNAME_INVALID',
+  'Hostname/IP does not match certificate\'s altnames: %s');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -21,6 +21,7 @@
 
 'use strict';
 
+const errors = require('internal/errors');
 const internalUtil = require('internal/util');
 internalUtil.assertCrypto();
 
@@ -219,8 +220,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   }
 
   if (!valid) {
-    const err = new Error(
-      `Hostname/IP doesn't match certificate's altnames: "${reason}"`);
+    const err = new errors.Error('ERR_TLS_CERT_ALTNAME_INVALID', reason);
     err.reason = reason;
     err.host = host;
     err.cert = cert;

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -170,13 +170,9 @@ function allListening() {
 
   // server1: host 'agent1', signed by ca1
   makeReq('/inv1', port1, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');
-  makeReq('/inv1-ca1', port1,
-          'Hostname/IP doesn\'t match certificate\'s altnames: ' +
-              '"Host: localhost. is not cert\'s CN: agent1"',
+  makeReq('/inv1-ca1', port1, 'ERR_TLS_CERT_ALTNAME_INVALID',
           null, ca1);
-  makeReq('/inv1-ca1ca2', port1,
-          'Hostname/IP doesn\'t match certificate\'s altnames: ' +
-              '"Host: localhost. is not cert\'s CN: agent1"',
+  makeReq('/inv1-ca1ca2', port1, 'ERR_TLS_CERT_ALTNAME_INVALID',
           null, [ca1, ca2]);
   makeReq('/val1-ca1', port1, null, 'agent1', ca1);
   makeReq('/val1-ca1ca2', port1, null, 'agent1', [ca1, ca2]);
@@ -193,13 +189,8 @@ function allListening() {
 
   // server3: host 'agent3', signed by ca2
   makeReq('/inv3', port3, 'UNABLE_TO_VERIFY_LEAF_SIGNATURE');
-  makeReq('/inv3-ca2', port3,
-          'Hostname/IP doesn\'t match certificate\'s altnames: ' +
-              '"Host: localhost. is not cert\'s CN: agent3"',
-          null, ca2);
-  makeReq('/inv3-ca1ca2', port3,
-          'Hostname/IP doesn\'t match certificate\'s altnames: ' +
-              '"Host: localhost. is not cert\'s CN: agent3"',
+  makeReq('/inv3-ca2', port3, 'ERR_TLS_CERT_ALTNAME_INVALID', null, ca2);
+  makeReq('/inv3-ca1ca2', port3, 'ERR_TLS_CERT_ALTNAME_INVALID',
           null, [ca1, ca2]);
   makeReq('/val3-ca2', port3, null, 'agent3', ca2);
   makeReq('/val3-ca1ca2', port3, null, 'agent3', [ca1, ca2]);

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -229,3 +229,9 @@ assert.throws(
     code: 'ERR_ASSERTION',
     message: /^At least one arg needs to be specified$/
   }));
+
+
+// Test ERR_TLS_CERT_ALTNAME_INVALID
+assert.strictEqual(
+    errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
+    'Hostname/IP does not match certificate\'s altnames: altname');

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -29,7 +29,6 @@ const fs = require('fs');
 const path = require('path');
 const tls = require('tls');
 
-const hosterr = /Hostname\/IP doesn't match certificate's altnames/;
 const testCases =
   [{ ca: ['ca1-cert'],
      key: 'agent2-key',
@@ -101,7 +100,7 @@ function testServers(index, servers, clientOptions, cb) {
     clientOptions.port = this.address().port;
     const client = tls.connect(clientOptions, common.mustCall(function() {
       const authorized = client.authorized ||
-                         hosterr.test(client.authorizationError);
+          (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID');
 
       console.error(`expected: ${ok} authed: ${authorized}`);
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -141,7 +141,8 @@ function startTest() {
     options.port = server.address().port;
     const client = tls.connect(options, function() {
       clientResults.push(
-          /Hostname\/IP doesn't/.test(client.authorizationError || ''));
+         client.authorizationError &&
+         (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID'));
       client.destroy();
 
       next();

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -113,7 +113,7 @@ function startTest() {
     const client = tls.connect(options, function() {
       clientResults.push(
         client.authorizationError &&
-        /Hostname\/IP doesn't/.test(client.authorizationError));
+        (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID'));
       client.destroy();
 
       // Continue


### PR DESCRIPTION
Migrate tls.js to use internal/errors.js as per
https://github.com/nodejs/node/issues/11273

The internal code used to set the 'code' as the client.authorizationError, or if no code existed the 'message' as the client.authorizationError.  Since with the new approach there is always a 'code' we end up setting the less descriptive code.  I guess that is consistent though with what was being done for existing errors with a code anyway.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tls