### PR TITLE
(v8.x backport) benchmark,lib,test: use braces for multiline block

### DIFF
--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -29,9 +29,11 @@ function main(conf) {
 function benchFor(buffer, n) {
   bench.start();
 
-  for (var k = 0; k < n; k++)
-    for (var i = 0; i < buffer.length; i++)
+  for (var k = 0; k < n; k++) {
+    for (var i = 0; i < buffer.length; i++) {
       assert(buffer[i] === 0);
+    }
+  }
 
   bench.end(n);
 }
@@ -39,10 +41,11 @@ function benchFor(buffer, n) {
 function benchForOf(buffer, n) {
   bench.start();
 
-  for (var k = 0; k < n; k++)
-    for (var b of buffer)
+  for (var k = 0; k < n; k++) {
+    for (var b of buffer) {
       assert(b === 0);
-
+    }
+  }
   bench.end(n);
 }
 

--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -46,17 +46,19 @@ function server() {
   var onsend = type === 'concat' ? onsendConcat : onsendMulti;
 
   function onsendConcat() {
-    if (sent++ % num === 0)
+    if (sent++ % num === 0) {
       for (var i = 0; i < num; i++) {
         socket.send(Buffer.concat(chunk), PORT, '127.0.0.1', onsend);
       }
+    }
   }
 
   function onsendMulti() {
-    if (sent++ % num === 0)
+    if (sent++ % num === 0) {
       for (var i = 0; i < num; i++) {
         socket.send(chunk, PORT, '127.0.0.1', onsend);
       }
+    }
   }
 
   socket.on('listening', function() {

--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -45,9 +45,11 @@ function server() {
   var socket = dgram.createSocket('udp4');
 
   function onsend() {
-    if (sent++ % num === 0)
-      for (var i = 0; i < num; i++)
+    if (sent++ % num === 0) {
+      for (var i = 0; i < num; i++) {
         socket.send(chunk, PORT, '127.0.0.1', onsend);
+      }
+    }
   }
 
   socket.on('listening', function() {

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -37,9 +37,11 @@ function server() {
   var socket = dgram.createSocket('udp4');
 
   function onsend() {
-    if (sent++ % num === 0)
-      for (var i = 0; i < num; i++)
+    if (sent++ % num === 0) {
+      for (var i = 0; i < num; i++) {
         socket.send(chunk, 0, chunk.length, PORT, '127.0.0.1', onsend);
+      }
+    }
   }
 
   socket.on('listening', function() {

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -37,9 +37,11 @@ function server() {
   var socket = dgram.createSocket('udp4');
 
   function onsend() {
-    if (sent++ % num === 0)
-      for (var i = 0; i < num; i++)
+    if (sent++ % num === 0) {
+      for (var i = 0; i < num; i++) {
         socket.send(chunk, PORT, '127.0.0.1', onsend);
+      }
+    }
   }
 
   socket.on('listening', function() {

--- a/benchmark/url/url-searchparams-iteration.js
+++ b/benchmark/url/url-searchparams-iteration.js
@@ -32,11 +32,12 @@ function iterator(n) {
   const noDead = [];
 
   bench.start();
-  for (var i = 0; i < n; i += 1)
+  for (var i = 0; i < n; i += 1) {
     for (var pair of params) {
       noDead[0] = pair[0];
       noDead[1] = pair[1];
     }
+  }
   bench.end(n);
 
   assert.strictEqual(noDead[0], 'three');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -319,12 +319,13 @@ ClientRequest.prototype.abort = function abort() {
   this.aborted = Date.now();
 
   // If we're aborting, we don't care about any more response data.
-  if (this.res)
+  if (this.res) {
     this.res._dump();
-  else
+  } else {
     this.once('response', function(res) {
       res._dump();
     });
+  }
 
   // In the event that we don't have a socket, we will pop out of
   // the request queue through handling in onSocket.

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -218,12 +218,13 @@ OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
 OutgoingMessage.prototype.destroy = function destroy(error) {
-  if (this.socket)
+  if (this.socket) {
     this.socket.destroy(error);
-  else
+  } else {
     this.once('socket', function(socket) {
       socket.destroy(error);
     });
+  }
 };
 
 
@@ -496,8 +497,7 @@ function matchHeader(self, state, field, value) {
 
 function validateHeader(msg, name, value) {
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name))
-    throw new TypeError(
-      'Header name must be a valid HTTP Token ["' + name + '"]');
+    throw new TypeError(`Header name must be a valid HTTP Token ["${name}"]`);
   if (value === undefined)
     throw new Error('"value" required in setHeader("' + name + '", value)');
   if (msg._header)

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -206,13 +206,14 @@ Object.setPrototypeOf(Buffer, Uint8Array);
 function assertSize(size) {
   let err = null;
 
-  if (typeof size !== 'number')
+  if (typeof size !== 'number') {
     err = new TypeError('"size" argument must be a number');
-  else if (size < 0)
+  } else if (size < 0) {
     err = new RangeError('"size" argument must not be negative');
-  else if (size > binding.kMaxLength)
+  } else if (size > binding.kMaxLength) {
     err = new RangeError('"size" argument must not be larger ' +
                          'than ' + binding.kMaxLength);
+  }
 
   if (err) {
     Error.captureStackTrace(err, assertSize);

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -537,15 +537,16 @@ function spawnSync(/*file, args, options*/) {
     var input = options.stdio[i] && options.stdio[i].input;
     if (input != null) {
       var pipe = options.stdio[i] = util._extend({}, options.stdio[i]);
-      if (isUint8Array(input))
+      if (isUint8Array(input)) {
         pipe.input = input;
-      else if (typeof input === 'string')
+      } else if (typeof input === 'string') {
         pipe.input = Buffer.from(input, options.encoding);
-      else
+      } else {
         throw new TypeError(util.format(
             'stdio[%d] should be Buffer, Uint8Array or string not %s',
             i,
             typeof input));
+      }
     }
   }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1951,10 +1951,11 @@ ReadStream.prototype.open = function() {
 };
 
 ReadStream.prototype._read = function(n) {
-  if (typeof this.fd !== 'number')
+  if (typeof this.fd !== 'number') {
     return this.once('open', function() {
       this._read(n);
     });
+  }
 
   if (this.destroyed)
     return;
@@ -2116,10 +2117,11 @@ WriteStream.prototype._write = function(data, encoding, cb) {
   if (!(data instanceof Buffer))
     return this.emit('error', new Error('Invalid data'));
 
-  if (typeof this.fd !== 'number')
+  if (typeof this.fd !== 'number') {
     return this.once('open', function() {
       this._write(data, encoding, cb);
     });
+  }
 
   var self = this;
   fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
@@ -2151,10 +2153,11 @@ function writev(fd, chunks, position, callback) {
 
 
 WriteStream.prototype._writev = function(data, cb) {
-  if (typeof this.fd !== 'number')
+  if (typeof this.fd !== 'number') {
     return this.once('open', function() {
       this._writev(data, cb);
     });
+  }
 
   const self = this;
   const len = data.length;

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -41,22 +41,26 @@ class Session extends EventEmitter {
   }
 
   post(method, params, callback) {
-    if (typeof method !== 'string')
+    if (typeof method !== 'string') {
       throw new TypeError(
           `"method" must be a string, got ${typeof method} instead`);
+    }
     if (!callback && util.isFunction(params)) {
       callback = params;
       params = null;
     }
-    if (params && typeof params !== 'object')
+    if (params && typeof params !== 'object') {
       throw new TypeError(
           `"params" must be an object, got ${typeof params} instead`);
-    if (callback && typeof callback !== 'function')
+    }
+    if (callback && typeof callback !== 'function') {
       throw new TypeError(
           `"callback" must be a function, got ${typeof callback} instead`);
+    }
 
-    if (!this[connectionSymbol])
+    if (!this[connectionSymbol]) {
       throw new Error('Session is not connected');
+    }
     const id = this[nextIdSymbol]++;
     const message = {id, method};
     if (params) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -43,10 +43,12 @@ function setup_cpuUsage() {
     }
 
     // If a previous value was passed in, return diff of current from previous.
-    if (prevValue) return {
-      user: cpuValues[0] - prevValue.user,
-      system: cpuValues[1] - prevValue.system
-    };
+    if (prevValue) {
+      return {
+        user: cpuValues[0] - prevValue.user,
+        system: cpuValues[1] - prevValue.system
+      };
+    }
 
     // If no previous value passed in, return current value.
     return {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1005,19 +1005,23 @@ function lookupAndConnect(self, options) {
   var localAddress = options.localAddress;
   var localPort = options.localPort;
 
-  if (localAddress && !cares.isIP(localAddress))
+  if (localAddress && !cares.isIP(localAddress)) {
     throw new TypeError('"localAddress" option must be a valid IP: ' +
                         localAddress);
+  }
 
-  if (localPort && typeof localPort !== 'number')
+  if (localPort && typeof localPort !== 'number') {
     throw new TypeError('"localPort" option should be a number: ' + localPort);
+  }
 
   if (typeof port !== 'undefined') {
-    if (typeof port !== 'number' && typeof port !== 'string')
+    if (typeof port !== 'number' && typeof port !== 'string') {
       throw new TypeError('"port" option should be a number or string: ' +
                           port);
-    if (!isLegalPort(port))
+    }
+    if (!isLegalPort(port)) {
       throw new RangeError('"port" option should be >= 0 and < 65536: ' + port);
+    }
   }
   port |= 0;
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -283,8 +283,9 @@ Interface.prototype._writeToOutput = function _writeToOutput(stringToWrite) {
   if (typeof stringToWrite !== 'string')
     throw new TypeError('"stringToWrite" argument must be a string');
 
-  if (this.output !== null && this.output !== undefined)
+  if (this.output !== null && this.output !== undefined) {
     this.output.write(stringToWrite);
+  }
 };
 
 Interface.prototype._addHistory = function() {

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -122,9 +122,10 @@ function check(hostParts, pattern, wildcards) {
     return false;
 
   // Check host parts from right to left first.
-  for (var i = hostParts.length - 1; i > 0; i -= 1)
+  for (var i = hostParts.length - 1; i > 0; i -= 1) {
     if (hostParts[i] !== patternParts[i])
       return false;
+  }
 
   const hostSubdomain = hostParts[0];
   const patternSubdomain = patternParts[0];

--- a/lib/util.js
+++ b/lib/util.js
@@ -962,9 +962,10 @@ exports.inherits = function(ctor, superCtor) {
     throw new TypeError('The super constructor to "inherits" must not ' +
                         'be null or undefined');
 
-  if (superCtor.prototype === undefined)
+  if (superCtor.prototype === undefined) {
     throw new TypeError('The super constructor to "inherits" must ' +
                         'have a prototype');
+  }
 
   ctor.super_ = superCtor;
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -429,9 +429,11 @@ function leakedGlobals() {
   const leaked = [];
 
   // eslint-disable-next-line no-var
-  for (var val in global)
-    if (!knownGlobals.includes(global[val]))
+  for (var val in global) {
+    if (!knownGlobals.includes(global[val])) {
       leaked.push(val);
+    }
+  }
 
   if (global.__coverage__) {
     return leaked.filter((varname) => !/^(?:cov_|__cov)/.test(varname));
@@ -700,9 +702,10 @@ Object.defineProperty(exports, 'hasSmallICU', {
 exports.expectsError = function expectsError({code, type, message}) {
   return function(error) {
     assert.strictEqual(error.code, code);
-    if (type !== undefined)
+    if (type !== undefined) {
       assert(error instanceof type,
              `${error} is not the expected type ${type}`);
+    }
     if (message instanceof RegExp) {
       assert(message.test(error.message),
              `${error.message} does not match ${message}`);
@@ -758,11 +761,13 @@ exports.getTTYfd = function getTTYfd() {
   if (!tty.isatty(tty_fd)) tty_fd++;
   else if (!tty.isatty(tty_fd)) tty_fd++;
   else if (!tty.isatty(tty_fd)) tty_fd++;
-  else try {
-    tty_fd = require('fs').openSync('/dev/tty');
-  } catch (e) {
-    // There aren't any tty fd's available to use.
-    return -1;
+  else {
+    try {
+      tty_fd = require('fs').openSync('/dev/tty');
+    } catch (e) {
+      // There aren't any tty fd's available to use.
+      return -1;
+    }
   }
   return tty_fd;
 };

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -182,10 +182,11 @@ if (process.argv[2] === 'child') {
       // Make sure that all expected messages were sent from the
       // child process
       test.expectedMessages.forEach(function(expectedMessage) {
-        if (test.messagesReceived === undefined ||
-          test.messagesReceived.indexOf(expectedMessage) === -1)
+        const msgs = test.messagesReceived;
+        if (msgs === undefined || !msgs.includes(expectedMessage)) {
           assert.fail(`test ${test.fn.name} should have sent message: ${
                       expectedMessage} but didn't`);
+        }
       });
 
       if (test.messagesReceived) {

--- a/test/parallel/test-fs-null-bytes.js
+++ b/test/parallel/test-fs-null-bytes.js
@@ -33,13 +33,15 @@ function check(async, sync) {
     assert.strictEqual(er.code, 'ENOENT');
   });
 
-  if (sync)
+  if (sync) {
     assert.throws(() => {
       sync.apply(null, argsSync);
     }, expected);
+  }
 
-  if (async)
+  if (async) {
     async.apply(null, argsAsync);
+  }
 }
 
 check(fs.access, fs.accessSync, 'foo\u0000bar');

--- a/test/pummel/test-net-write-callbacks.js
+++ b/test/pummel/test-net-write-callbacks.js
@@ -46,9 +46,10 @@ function makeCallback(c) {
     if (called)
       throw new Error(`called callback #${c} more than once`);
     called = true;
-    if (c < lastCalled)
+    if (c < lastCalled) {
       throw new Error(
         `callbacks out of order. last=${lastCalled} current=${c}`);
+    }
     lastCalled = c;
     cbcount++;
   };


### PR DESCRIPTION
For if/else and loops where the bodies span more than one line, use
curly braces.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
bookmark lib test