### PR TITLE
test: remove undef NDEBUG from at-exit addons test

### DIFF
--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -1,4 +1,3 @@
-#undef NDEBUG
 #include <assert.h>
 #include <stdlib.h>
 #include <node.h>


### PR DESCRIPTION
The at-exit addons test uses asserts like the other addons tests,
but at-exit is the only one that undefines NDEBUG to make sure
that asserts are enabled. This commit removes the undef for
consistency.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test