### PR TITLE
N-API: Reuse ObjectTemplate used for napi_wrap()

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -34,13 +34,31 @@ struct napi_env__ {
   ~napi_env__() {
     last_exception.Reset();
     has_instance.Reset();
+    wrap_template.Reset();
+    function_data_template.Reset();
+    accessor_data_template.Reset();
   }
   v8::Isolate* isolate;
   v8::Persistent<v8::Value> last_exception;
   v8::Persistent<v8::Value> has_instance;
+  v8::Persistent<v8::ObjectTemplate> wrap_template;
+  v8::Persistent<v8::ObjectTemplate> function_data_template;
+  v8::Persistent<v8::ObjectTemplate> accessor_data_template;
   bool has_instance_available;
   napi_extended_error_info last_error;
 };
+
+#define ENV_OBJECT_TEMPLATE(env, prefix, destination, field_count) \
+  do {                                                             \
+    if ((env)->prefix ## _template.IsEmpty()) {                    \
+      (destination) = v8::ObjectTemplate::New(isolate);            \
+      (destination)->SetInternalFieldCount((field_count));         \
+      (env)->prefix ## _template.Reset(isolate, (destination));    \
+    } else {                                                       \
+      (destination) = env->prefix ## _template.Get(isolate);       \
+    }                                                              \
+  } while (0)
+
 
 #define RETURN_STATUS_IF_FALSE(env, condition, status)                  \
   do {                                                                  \
@@ -603,8 +621,8 @@ v8::Local<v8::Object> CreateFunctionCallbackData(napi_env env,
   v8::Isolate* isolate = env->isolate;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  v8::Local<v8::ObjectTemplate> otpl = v8::ObjectTemplate::New(isolate);
-  otpl->SetInternalFieldCount(v8impl::kFunctionFieldCount);
+  v8::Local<v8::ObjectTemplate> otpl;
+  ENV_OBJECT_TEMPLATE(env, function_data, otpl, v8impl::kFunctionFieldCount);
   v8::Local<v8::Object> cbdata = otpl->NewInstance(context).ToLocalChecked();
 
   cbdata->SetInternalField(
@@ -629,8 +647,8 @@ v8::Local<v8::Object> CreateAccessorCallbackData(napi_env env,
   v8::Isolate* isolate = env->isolate;
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-  v8::Local<v8::ObjectTemplate> otpl = v8::ObjectTemplate::New(isolate);
-  otpl->SetInternalFieldCount(v8impl::kAccessorFieldCount);
+  v8::Local<v8::ObjectTemplate> otpl;
+  ENV_OBJECT_TEMPLATE(env, accessor_data, otpl, v8impl::kAccessorFieldCount);
   v8::Local<v8::Object> cbdata = otpl->NewInstance(context).ToLocalChecked();
 
   cbdata->SetInternalField(
@@ -1966,11 +1984,10 @@ napi_status napi_wrap(napi_env env,
   v8::Local<v8::Object> obj = value.As<v8::Object>();
 
   // Create a wrapper object with an internal field to hold the wrapped pointer.
-  v8::Local<v8::ObjectTemplate> wrapperTemplate =
-    v8::ObjectTemplate::New(isolate);
-  wrapperTemplate->SetInternalFieldCount(1);
+  v8::Local<v8::ObjectTemplate> wrapper_template;
+  ENV_OBJECT_TEMPLATE(env, wrap, wrapper_template, 1);
   v8::Local<v8::Object> wrapper =
-    wrapperTemplate->NewInstance(context).ToLocalChecked();
+      wrapper_template->NewInstance(context).ToLocalChecked();
   wrapper->SetInternalField(0, v8::External::New(isolate, native_object));
 
   // Insert the wrapper into the object's prototype chain.


### PR DESCRIPTION
V8 caches and does not subsequently release `ObjectTemplate` instances.
Thus, we need to store the `ObjectTemplate` from which we derive object
instances we use for `napi_wrap()` in a persistent in the `napi_env`.

Re https://github.com/nodejs/node-addon-api/pull/70#discussion_r124998408

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
N-API