### PR TITLE
src: Node implementation of v8::Platform

### DIFF
--- a/deps/v8/include/libplatform/libplatform.h
+++ b/deps/v8/include/libplatform/libplatform.h
@@ -70,6 +70,8 @@ V8_PLATFORM_EXPORT void RunIdleTasks(v8::Platform* platform,
  * Attempts to set the tracing controller for the given platform.
  *
  * The |platform| has to be created using |CreateDefaultPlatform|.
+ *
+ * DEPRECATED: Will be removed soon.
  */
 V8_PLATFORM_EXPORT void SetTracingController(
     v8::Platform* platform,

--- a/deps/v8/include/libplatform/libplatform.h
+++ b/deps/v8/include/libplatform/libplatform.h
@@ -30,12 +30,15 @@ enum class MessageLoopBehavior : bool {
  * If |idle_task_support| is enabled then the platform will accept idle
  * tasks (IdleTasksEnabled will return true) and will rely on the embedder
  * calling v8::platform::RunIdleTasks to process the idle tasks.
+ * If |tracing_controller| is nullptr, the default platform will create a
+ * v8::platform::TracingController instance and use it.
  */
 V8_PLATFORM_EXPORT v8::Platform* CreateDefaultPlatform(
     int thread_pool_size = 0,
     IdleTaskSupport idle_task_support = IdleTaskSupport::kDisabled,
     InProcessStackDumping in_process_stack_dumping =
-        InProcessStackDumping::kEnabled);
+        InProcessStackDumping::kEnabled,
+    v8::TracingController* tracing_controller = nullptr);
 
 /**
  * Pumps the message loop for the given isolate.

--- a/deps/v8/include/v8-platform.h
+++ b/deps/v8/include/v8-platform.h
@@ -53,6 +53,66 @@ class ConvertableToTraceFormat {
 };
 
 /**
+ * V8 Tracing controller.
+ *
+ * Can be implemented by an embedder to record trace events from V8.
+ */
+class TracingController {
+ public:
+  virtual ~TracingController() = default;
+
+  /**
+   * Called by TRACE_EVENT* macros, don't call this directly.
+   * The name parameter is a category group for example:
+   * TRACE_EVENT0("v8,parse", "V8.Parse")
+   * The pointer returned points to a value with zero or more of the bits
+   * defined in CategoryGroupEnabledFlags.
+   **/
+  virtual const uint8_t* GetCategoryGroupEnabled(const char* name) {
+    static uint8_t no = 0;
+    return &no;
+  }
+
+  /**
+   * Adds a trace event to the platform tracing system. This function call is
+   * usually the result of a TRACE_* macro from trace_event_common.h when
+   * tracing and the category of the particular trace are enabled. It is not
+   * advisable to call this function on its own; it is really only meant to be
+   * used by the trace macros. The returned handle can be used by
+   * UpdateTraceEventDuration to update the duration of COMPLETE events.
+   */
+  virtual uint64_t AddTraceEvent(
+      char phase, const uint8_t* category_enabled_flag, const char* name,
+      const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
+      const char** arg_names, const uint8_t* arg_types,
+      const uint64_t* arg_values,
+      std::unique_ptr<ConvertableToTraceFormat>* arg_convertables,
+      unsigned int flags) {
+    return 0;
+  }
+
+  /**
+   * Sets the duration field of a COMPLETE trace event. It must be called with
+   * the handle returned from AddTraceEvent().
+   **/
+  virtual void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
+                                        const char* name, uint64_t handle) {}
+
+  class TraceStateObserver {
+   public:
+    virtual ~TraceStateObserver() = default;
+    virtual void OnTraceEnabled() = 0;
+    virtual void OnTraceDisabled() = 0;
+  };
+
+  /** Adds tracing state change observer. */
+  virtual void AddTraceStateObserver(TraceStateObserver*) {}
+
+  /** Removes tracing state change observer. */
+  virtual void RemoveTraceStateObserver(TraceStateObserver*) {}
+};
+
+/**
  * V8 Platform abstraction layer.
  *
  * The embedder has to provide an implementation of this interface before
@@ -135,6 +195,20 @@ class Platform {
    * the epoch.
    **/
   virtual double MonotonicallyIncreasingTime() = 0;
+  typedef void (*StackTracePrinter)();
+
+  /**
+   * Returns a function pointer that print a stack trace of the current stack
+   * on invocation. Disables printing of the stack trace if nullptr.
+   */
+  virtual StackTracePrinter GetStackTracePrinter() { return nullptr; }
+
+  /**
+   * Returns an instance of a v8::TracingController. This must be non-nullptr.
+   */
+  virtual TracingController* GetTracingController() { return nullptr; }
+
+  // DEPRECATED methods, use TracingController interface instead.
 
   /**
    * Called by TRACE_EVENT* macros, don't call this directly.
@@ -200,26 +274,13 @@ class Platform {
   virtual void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
                                         const char* name, uint64_t handle) {}
 
-  class TraceStateObserver {
-   public:
-    virtual ~TraceStateObserver() = default;
-    virtual void OnTraceEnabled() = 0;
-    virtual void OnTraceDisabled() = 0;
-  };
+  typedef v8::TracingController::TraceStateObserver TraceStateObserver;
 
   /** Adds tracing state change observer. */
   virtual void AddTraceStateObserver(TraceStateObserver*) {}
 
   /** Removes tracing state change observer. */
   virtual void RemoveTraceStateObserver(TraceStateObserver*) {}
-
-  typedef void (*StackTracePrinter)();
-
-  /**
-   * Returns a function pointer that print a stack trace of the current stack
-   * on invocation. Disables printing of the stack trace if nullptr.
-   */
-  virtual StackTracePrinter GetStackTracePrinter() { return nullptr; }
 };
 
 }  // namespace v8

--- a/deps/v8/include/v8-platform.h
+++ b/deps/v8/include/v8-platform.h
@@ -206,7 +206,7 @@ class Platform {
   /**
    * Returns an instance of a v8::TracingController. This must be non-nullptr.
    */
-  virtual TracingController* GetTracingController() { return nullptr; }
+  virtual TracingController* GetTracingController() = 0;
 
   // DEPRECATED methods, use TracingController interface instead.
 

--- a/deps/v8/src/cancelable-task.cc
+++ b/deps/v8/src/cancelable-task.cc
@@ -29,18 +29,17 @@ Cancelable::~Cancelable() {
 CancelableTaskManager::CancelableTaskManager()
     : task_id_counter_(0), canceled_(false) {}
 
-uint32_t CancelableTaskManager::Register(Cancelable* task) {
+CancelableTaskManager::Id CancelableTaskManager::Register(Cancelable* task) {
   base::LockGuard<base::Mutex> guard(&mutex_);
-  uint32_t id = ++task_id_counter_;
-  // The loop below is just used when task_id_counter_ overflows.
-  while (cancelable_tasks_.count(id) > 0) ++id;
+  CancelableTaskManager::Id id = ++task_id_counter_;
+  // Id overflows are not supported.
+  CHECK_NE(0, id);
   CHECK(!canceled_);
   cancelable_tasks_[id] = task;
   return id;
 }
 
-
-void CancelableTaskManager::RemoveFinishedTask(uint32_t id) {
+void CancelableTaskManager::RemoveFinishedTask(CancelableTaskManager::Id id) {
   base::LockGuard<base::Mutex> guard(&mutex_);
   size_t removed = cancelable_tasks_.erase(id);
   USE(removed);
@@ -49,7 +48,7 @@ void CancelableTaskManager::RemoveFinishedTask(uint32_t id) {
 }
 
 CancelableTaskManager::TryAbortResult CancelableTaskManager::TryAbort(
-    uint32_t id) {
+    CancelableTaskManager::Id id) {
   base::LockGuard<base::Mutex> guard(&mutex_);
   auto entry = cancelable_tasks_.find(id);
   if (entry != cancelable_tasks_.end()) {

--- a/deps/v8/src/cancelable-task.h
+++ b/deps/v8/src/cancelable-task.h
@@ -5,7 +5,7 @@
 #ifndef V8_CANCELABLE_TASK_H_
 #define V8_CANCELABLE_TASK_H_
 
-#include <map>
+#include <unordered_map>
 
 #include "include/v8-platform.h"
 #include "src/base/atomic-utils.h"
@@ -24,12 +24,14 @@ class Isolate;
 // from any fore- and background task/thread.
 class V8_EXPORT_PRIVATE CancelableTaskManager {
  public:
+  using Id = uint64_t;
+
   CancelableTaskManager();
 
   // Registers a new cancelable {task}. Returns the unique {id} of the task that
   // can be used to try to abort a task by calling {Abort}.
   // Must not be called after CancelAndWait.
-  uint32_t Register(Cancelable* task);
+  Id Register(Cancelable* task);
 
   // Try to abort running a task identified by {id}. The possible outcomes are:
   // (1) The task is already finished running or was canceled before and
@@ -39,7 +41,7 @@ class V8_EXPORT_PRIVATE CancelableTaskManager {
   //     removed.
   //
   enum TryAbortResult { kTaskRemoved, kTaskRunning, kTaskAborted };
-  TryAbortResult TryAbort(uint32_t id);
+  TryAbortResult TryAbort(Id id);
 
   // Cancels all remaining registered tasks and waits for tasks that are
   // already running. This disallows subsequent Register calls.
@@ -59,13 +61,13 @@ class V8_EXPORT_PRIVATE CancelableTaskManager {
  private:
   // Only called by {Cancelable} destructor. The task is done with executing,
   // but needs to be removed.
-  void RemoveFinishedTask(uint32_t id);
+  void RemoveFinishedTask(Id id);
 
   // To mitigate the ABA problem, the api refers to tasks through an id.
-  uint32_t task_id_counter_;
+  Id task_id_counter_;
 
   // A set of cancelable tasks that are currently registered.
-  std::map<uint32_t, Cancelable*> cancelable_tasks_;
+  std::unordered_map<Id, Cancelable*> cancelable_tasks_;
 
   // Mutex and condition variable enabling concurrent register and removing, as
   // well as waiting for background tasks on {CancelAndWait}.
@@ -89,7 +91,7 @@ class V8_EXPORT_PRIVATE Cancelable {
   // a platform. This step transfers ownership to the platform, which destroys
   // the task after running it. Since the exact time is not known, we cannot
   // access the object after handing it to a platform.
-  uint32_t id() { return id_; }
+  CancelableTaskManager::Id id() { return id_; }
 
  protected:
   bool TryRun() { return status_.TrySetValue(kWaiting, kRunning); }
@@ -120,7 +122,7 @@ class V8_EXPORT_PRIVATE Cancelable {
 
   CancelableTaskManager* parent_;
   base::AtomicValue<Status> status_;
-  uint32_t id_;
+  CancelableTaskManager::Id id_;
 
   // The counter is incremented for failing tries to cancel a task. This can be
   // used by the task itself as an indication how often external entities tried

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -161,6 +161,7 @@ Heap::Heap()
       heap_iterator_depth_(0),
       local_embedder_heap_tracer_(nullptr),
       fast_promotion_mode_(false),
+      use_tasks_(true),
       force_oom_(false),
       delay_sweeper_tasks_for_testing_(false),
       pending_layout_change_object_(nullptr) {
@@ -5823,6 +5824,7 @@ void Heap::RegisterExternallyReferencedObject(Object** object) {
 }
 
 void Heap::TearDown() {
+  use_tasks_ = false;
 #ifdef VERIFY_HEAP
   if (FLAG_verify_heap) {
     Verify();

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1016,6 +1016,8 @@ class Heap {
   // Returns whether SetUp has been called.
   bool HasBeenSetUp();
 
+  bool use_tasks() const { return use_tasks_; }
+
   // ===========================================================================
   // Getters for spaces. =======================================================
   // ===========================================================================
@@ -2374,6 +2376,8 @@ class Heap {
   LocalEmbedderHeapTracer* local_embedder_heap_tracer_;
 
   bool fast_promotion_mode_;
+
+  bool use_tasks_;
 
   // Used for testing purposes.
   bool force_oom_;

--- a/deps/v8/src/heap/item-parallel-job.h
+++ b/deps/v8/src/heap/item-parallel-job.h
@@ -133,7 +133,8 @@ class ItemParallelJob {
     const size_t num_tasks = tasks_.size();
     const size_t num_items = items_.size();
     const size_t items_per_task = (num_items + num_tasks - 1) / num_tasks;
-    uint32_t* task_ids = new uint32_t[num_tasks];
+    CancelableTaskManager::Id* task_ids =
+        new CancelableTaskManager::Id[num_tasks];
     size_t start_index = 0;
     Task* main_task = nullptr;
     Task* task = nullptr;

--- a/deps/v8/src/heap/mark-compact.h
+++ b/deps/v8/src/heap/mark-compact.h
@@ -471,7 +471,7 @@ class MarkCompactCollector final : public MarkCompactCollectorBase {
 
     Heap* const heap_;
     int num_tasks_;
-    uint32_t task_ids_[kMaxSweeperTasks];
+    CancelableTaskManager::Id task_ids_[kMaxSweeperTasks];
     base::Semaphore pending_sweeper_tasks_semaphore_;
     base::Mutex mutex_;
     SweptList swept_list_[kAllocationSpaces];

--- a/deps/v8/src/heap/mark-compact.h
+++ b/deps/v8/src/heap/mark-compact.h
@@ -408,8 +408,6 @@ class MarkCompactCollector final : public MarkCompactCollectorBase {
 
   class Sweeper {
    public:
-    class SweeperTask;
-
     enum FreeListRebuildingMode { REBUILD_FREE_LIST, IGNORE_FREE_LIST };
     enum ClearOldToNewSlotsMode {
       DO_NOT_CLEAR,
@@ -425,8 +423,8 @@ class MarkCompactCollector final : public MarkCompactCollectorBase {
 
     explicit Sweeper(Heap* heap)
         : heap_(heap),
+          num_tasks_(0),
           pending_sweeper_tasks_semaphore_(0),
-          semaphore_counter_(0),
           sweeping_in_progress_(false),
           num_sweeping_tasks_(0) {}
 
@@ -452,7 +450,10 @@ class MarkCompactCollector final : public MarkCompactCollectorBase {
     Page* GetSweptPageSafe(PagedSpace* space);
 
    private:
+    class SweeperTask;
+
     static const int kAllocationSpaces = LAST_PAGED_SPACE + 1;
+    static const int kMaxSweeperTasks = kAllocationSpaces;
 
     static ClearOldToNewSlotsMode GetClearOldToNewSlotsMode(Page* p);
 
@@ -468,10 +469,10 @@ class MarkCompactCollector final : public MarkCompactCollectorBase {
 
     void PrepareToBeSweptPage(AllocationSpace space, Page* page);
 
-    Heap* heap_;
+    Heap* const heap_;
+    int num_tasks_;
+    uint32_t task_ids_[kMaxSweeperTasks];
     base::Semaphore pending_sweeper_tasks_semaphore_;
-    // Counter is only used for waiting on the semaphore.
-    intptr_t semaphore_counter_;
     base::Mutex mutex_;
     SweptList swept_list_[kAllocationSpaces];
     SweepingList sweeping_list_[kAllocationSpaces];

--- a/deps/v8/src/isolate.cc
+++ b/deps/v8/src/isolate.cc
@@ -2455,6 +2455,7 @@ void Isolate::Deinit() {
   }
 
   heap_.mark_compact_collector()->EnsureSweepingCompleted();
+  heap_.memory_allocator()->unmapper()->WaitUntilCompleted();
 
   DumpAndResetStats();
 

--- a/deps/v8/src/libplatform/default-platform.cc
+++ b/deps/v8/src/libplatform/default-platform.cc
@@ -13,6 +13,8 @@
 #include "src/base/platform/platform.h"
 #include "src/base/platform/time.h"
 #include "src/base/sys-info.h"
+#include "src/libplatform/tracing/trace-buffer.h"
+#include "src/libplatform/tracing/trace-writer.h"
 #include "src/libplatform/worker-thread.h"
 
 namespace v8 {
@@ -36,11 +38,10 @@ v8::Platform* CreateDefaultPlatform(int thread_pool_size,
   if (in_process_stack_dumping == InProcessStackDumping::kEnabled) {
     v8::base::debug::EnableInProcessStackDumping();
   }
-  DefaultPlatform* platform = new DefaultPlatform(idle_task_support);
+  DefaultPlatform* platform =
+    new DefaultPlatform(idle_task_support, tracing_controller);
   platform->SetThreadPoolSize(thread_pool_size);
   platform->EnsureInitialized();
-  if (tracing_controller != nullptr)
-    platform->SetTracingController(tracing_controller);
   return platform;
 }
 
@@ -70,10 +71,22 @@ void SetTracingController(
 
 const int DefaultPlatform::kMaxThreadPoolSize = 8;
 
-DefaultPlatform::DefaultPlatform(IdleTaskSupport idle_task_support)
+DefaultPlatform::DefaultPlatform(IdleTaskSupport idle_task_support,
+                                 v8::TracingController* tracing_controller)
     : initialized_(false),
       thread_pool_size_(0),
-      idle_task_support_(idle_task_support) {}
+      idle_task_support_(idle_task_support) {
+  if (tracing_controller) {
+    tracing_controller_.reset(tracing_controller);
+  } else {
+    tracing::TraceWriter* writer = new tracing::NullTraceWriter();
+    tracing::TraceBuffer* ring_buffer =
+        new tracing::TraceBufferRingBuffer(1, writer);
+    tracing::TracingController* controller = new tracing::TracingController();
+    controller->Initialize(ring_buffer);
+    tracing_controller_.reset(controller);
+  }
+}
 
 DefaultPlatform::~DefaultPlatform() {
   base::LockGuard<base::Mutex> guard(&lock_);
@@ -274,62 +287,14 @@ TracingController* DefaultPlatform::GetTracingController() {
   return tracing_controller_.get();
 }
 
-uint64_t DefaultPlatform::AddTraceEvent(
-    char phase, const uint8_t* category_enabled_flag, const char* name,
-    const char* scope, uint64_t id, uint64_t bind_id, int num_args,
-    const char** arg_names, const uint8_t* arg_types,
-    const uint64_t* arg_values,
-    std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
-    unsigned int flags) {
-  if (tracing_controller_) {
-    return tracing_controller_->AddTraceEvent(
-        phase, category_enabled_flag, name, scope, id, bind_id, num_args,
-        arg_names, arg_types, arg_values, arg_convertables, flags);
-  }
-
-  return 0;
-}
-
-void DefaultPlatform::UpdateTraceEventDuration(
-    const uint8_t* category_enabled_flag, const char* name, uint64_t handle) {
-  if (tracing_controller_) {
-    tracing_controller_->UpdateTraceEventDuration(category_enabled_flag, name,
-                                                  handle);
-  }
-}
-
-const uint8_t* DefaultPlatform::GetCategoryGroupEnabled(const char* name) {
-  if (tracing_controller_) {
-    return tracing_controller_->GetCategoryGroupEnabled(name);
-  }
-  static uint8_t no = 0;
-  return &no;
-}
-
-
-const char* DefaultPlatform::GetCategoryGroupName(
-    const uint8_t* category_enabled_flag) {
-  static const char dummy[] = "dummy";
-  return dummy;
-}
-
 void DefaultPlatform::SetTracingController(
-    TracingController* tracing_controller) {
+    v8::TracingController* tracing_controller) {
+  DCHECK_NOT_NULL(tracing_controller);
   tracing_controller_.reset(tracing_controller);
 }
 
 size_t DefaultPlatform::NumberOfAvailableBackgroundThreads() {
   return static_cast<size_t>(thread_pool_size_);
-}
-
-void DefaultPlatform::AddTraceStateObserver(TraceStateObserver* observer) {
-  if (!tracing_controller_) return;
-  tracing_controller_->AddTraceStateObserver(observer);
-}
-
-void DefaultPlatform::RemoveTraceStateObserver(TraceStateObserver* observer) {
-  if (!tracing_controller_) return;
-  tracing_controller_->RemoveTraceStateObserver(observer);
 }
 
 Platform::StackTracePrinter DefaultPlatform::GetStackTracePrinter() {

--- a/deps/v8/src/libplatform/default-platform.cc
+++ b/deps/v8/src/libplatform/default-platform.cc
@@ -272,6 +272,10 @@ double DefaultPlatform::MonotonicallyIncreasingTime() {
          static_cast<double>(base::Time::kMicrosecondsPerSecond);
 }
 
+TracingController* DefaultPlatform::GetTracingController() {
+  return tracing_controller_.get();
+}
+
 uint64_t DefaultPlatform::AddTraceEvent(
     char phase, const uint8_t* category_enabled_flag, const char* name,
     const char* scope, uint64_t id, uint64_t bind_id, int num_args,

--- a/deps/v8/src/libplatform/default-platform.h
+++ b/deps/v8/src/libplatform/default-platform.h
@@ -58,6 +58,7 @@ class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
   void CallIdleOnForegroundThread(Isolate* isolate, IdleTask* task) override;
   bool IdleTasksEnabled(Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
+  TracingController* GetTracingController() override;
   const uint8_t* GetCategoryGroupEnabled(const char* name) override;
   const char* GetCategoryGroupName(
       const uint8_t* category_enabled_flag) override;

--- a/deps/v8/src/libplatform/default-platform.h
+++ b/deps/v8/src/libplatform/default-platform.h
@@ -30,7 +30,8 @@ class WorkerThread;
 class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
  public:
   explicit DefaultPlatform(
-      IdleTaskSupport idle_task_support = IdleTaskSupport::kDisabled);
+      IdleTaskSupport idle_task_support = IdleTaskSupport::kDisabled,
+      v8::TracingController* tracing_controller = nullptr);
   virtual ~DefaultPlatform();
 
   void SetThreadPoolSize(int thread_pool_size);
@@ -44,6 +45,8 @@ class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
 
   void RunIdleTasks(v8::Isolate* isolate, double idle_time_in_seconds);
 
+  void SetTracingController(v8::TracingController* tracing_controller);
+
   // v8::Platform implementation.
   size_t NumberOfAvailableBackgroundThreads() override;
   void CallOnBackgroundThread(Task* task,
@@ -54,24 +57,7 @@ class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
   void CallIdleOnForegroundThread(Isolate* isolate, IdleTask* task) override;
   bool IdleTasksEnabled(Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
-  TracingController* GetTracingController() override;
-  const uint8_t* GetCategoryGroupEnabled(const char* name) override;
-  const char* GetCategoryGroupName(
-      const uint8_t* category_enabled_flag) override;
-  using Platform::AddTraceEvent;
-  uint64_t AddTraceEvent(
-      char phase, const uint8_t* category_enabled_flag, const char* name,
-      const char* scope, uint64_t id, uint64_t bind_id, int32_t num_args,
-      const char** arg_names, const uint8_t* arg_types,
-      const uint64_t* arg_values,
-      std::unique_ptr<v8::ConvertableToTraceFormat>* arg_convertables,
-      unsigned int flags) override;
-  void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
-                                const char* name, uint64_t handle) override;
-  void SetTracingController(TracingController* tracing_controller);
-
-  void AddTraceStateObserver(TraceStateObserver* observer) override;
-  void RemoveTraceStateObserver(TraceStateObserver* observer) override;
+  v8::TracingController* GetTracingController() override;
   StackTracePrinter GetStackTracePrinter() override;
 
  private:

--- a/deps/v8/src/libplatform/default-platform.h
+++ b/deps/v8/src/libplatform/default-platform.h
@@ -27,10 +27,6 @@ class TaskQueue;
 class Thread;
 class WorkerThread;
 
-namespace tracing {
-class TracingController;
-}
-
 class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
  public:
   explicit DefaultPlatform(
@@ -72,7 +68,7 @@ class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
       unsigned int flags) override;
   void UpdateTraceEventDuration(const uint8_t* category_enabled_flag,
                                 const char* name, uint64_t handle) override;
-  void SetTracingController(tracing::TracingController* tracing_controller);
+  void SetTracingController(TracingController* tracing_controller);
 
   void AddTraceStateObserver(TraceStateObserver* observer) override;
   void RemoveTraceStateObserver(TraceStateObserver* observer) override;
@@ -103,7 +99,7 @@ class V8_PLATFORM_EXPORT DefaultPlatform : public NON_EXPORTED_BASE(Platform) {
            std::priority_queue<DelayedEntry, std::vector<DelayedEntry>,
                                std::greater<DelayedEntry> > >
       main_thread_delayed_queue_;
-  std::unique_ptr<tracing::TracingController> tracing_controller_;
+  std::unique_ptr<TracingController> tracing_controller_;
 
   DISALLOW_COPY_AND_ASSIGN(DefaultPlatform);
 };

--- a/deps/v8/src/libplatform/tracing/trace-writer.h
+++ b/deps/v8/src/libplatform/tracing/trace-writer.h
@@ -26,6 +26,14 @@ class JSONTraceWriter : public TraceWriter {
   bool append_comma_ = false;
 };
 
+class NullTraceWriter : public TraceWriter {
+ public:
+  NullTraceWriter() = default;
+  ~NullTraceWriter() = default;
+  void AppendTraceEvent(TraceObject*) override {}
+  void Flush() override {}
+};
+
 }  // namespace tracing
 }  // namespace platform
 }  // namespace v8

--- a/deps/v8/src/libplatform/tracing/tracing-controller.cc
+++ b/deps/v8/src/libplatform/tracing/tracing-controller.cc
@@ -40,7 +40,7 @@ v8::base::AtomicWord g_category_index = g_num_builtin_categories;
 
 TracingController::TracingController() {}
 
-TracingController::~TracingController() {}
+TracingController::~TracingController() { StopTracing(); }
 
 void TracingController::Initialize(TraceBuffer* trace_buffer) {
   trace_buffer_.reset(trace_buffer);
@@ -111,6 +111,10 @@ void TracingController::StartTracing(TraceConfig* trace_config) {
 }
 
 void TracingController::StopTracing() {
+  if (mode_ == DISABLED) {
+    return;
+  }
+  DCHECK(trace_buffer_);
   mode_ = DISABLED;
   UpdateCategoryGroupEnabledFlags();
   std::unordered_set<v8::TracingController::TraceStateObserver*> observers_copy;

--- a/deps/v8/src/libplatform/tracing/tracing-controller.cc
+++ b/deps/v8/src/libplatform/tracing/tracing-controller.cc
@@ -98,7 +98,7 @@ const char* TracingController::GetCategoryGroupName(
 
 void TracingController::StartTracing(TraceConfig* trace_config) {
   trace_config_.reset(trace_config);
-  std::unordered_set<Platform::TraceStateObserver*> observers_copy;
+  std::unordered_set<v8::TracingController::TraceStateObserver*> observers_copy;
   {
     base::LockGuard<base::Mutex> lock(mutex_.get());
     mode_ = RECORDING_MODE;
@@ -113,7 +113,7 @@ void TracingController::StartTracing(TraceConfig* trace_config) {
 void TracingController::StopTracing() {
   mode_ = DISABLED;
   UpdateCategoryGroupEnabledFlags();
-  std::unordered_set<Platform::TraceStateObserver*> observers_copy;
+  std::unordered_set<v8::TracingController::TraceStateObserver*> observers_copy;
   {
     base::LockGuard<base::Mutex> lock(mutex_.get());
     observers_copy = observers_;
@@ -196,7 +196,7 @@ const uint8_t* TracingController::GetCategoryGroupEnabledInternal(
 }
 
 void TracingController::AddTraceStateObserver(
-    Platform::TraceStateObserver* observer) {
+    v8::TracingController::TraceStateObserver* observer) {
   {
     base::LockGuard<base::Mutex> lock(mutex_.get());
     observers_.insert(observer);
@@ -207,7 +207,7 @@ void TracingController::AddTraceStateObserver(
 }
 
 void TracingController::RemoveTraceStateObserver(
-    Platform::TraceStateObserver* observer) {
+    v8::TracingController::TraceStateObserver* observer) {
   base::LockGuard<base::Mutex> lock(mutex_.get());
   DCHECK(observers_.find(observer) != observers_.end());
   observers_.erase(observer);

--- a/deps/v8/src/profiler/tracing-cpu-profiler.cc
+++ b/deps/v8/src/profiler/tracing-cpu-profiler.cc
@@ -25,12 +25,13 @@ TracingCpuProfilerImpl::TracingCpuProfilerImpl(Isolate* isolate)
   TRACE_EVENT_WARMUP_CATEGORY(TRACE_DISABLED_BY_DEFAULT("v8.cpu_profiler"));
   TRACE_EVENT_WARMUP_CATEGORY(
       TRACE_DISABLED_BY_DEFAULT("v8.cpu_profiler.hires"));
-  V8::GetCurrentPlatform()->AddTraceStateObserver(this);
+  V8::GetCurrentPlatform()->GetTracingController()->AddTraceStateObserver(this);
 }
 
 TracingCpuProfilerImpl::~TracingCpuProfilerImpl() {
   StopProfiling();
-  V8::GetCurrentPlatform()->RemoveTraceStateObserver(this);
+  V8::GetCurrentPlatform()->GetTracingController()->RemoveTraceStateObserver(
+      this);
 }
 
 void TracingCpuProfilerImpl::OnTraceEnabled() {

--- a/deps/v8/src/profiler/tracing-cpu-profiler.h
+++ b/deps/v8/src/profiler/tracing-cpu-profiler.h
@@ -17,13 +17,14 @@ namespace internal {
 class CpuProfiler;
 class Isolate;
 
-class TracingCpuProfilerImpl final : public TracingCpuProfiler,
-                                     private v8::Platform::TraceStateObserver {
+class TracingCpuProfilerImpl final
+    : public TracingCpuProfiler,
+      private v8::TracingController::TraceStateObserver {
  public:
   explicit TracingCpuProfilerImpl(Isolate*);
   ~TracingCpuProfilerImpl();
 
-  // v8::Platform::TraceStateObserver
+  // v8::TracingController::TraceStateObserver
   void OnTraceEnabled() final;
   void OnTraceDisabled() final;
 

--- a/deps/v8/src/tracing/trace-event.cc
+++ b/deps/v8/src/tracing/trace-event.cc
@@ -15,8 +15,8 @@ namespace v8 {
 namespace internal {
 namespace tracing {
 
-v8::Platform* TraceEventHelper::GetCurrentPlatform() {
-  return v8::internal::V8::GetCurrentPlatform();
+v8::TracingController* TraceEventHelper::GetTracingController() {
+  return v8::internal::V8::GetCurrentPlatform()->GetTracingController();
 }
 
 void CallStatsScopedTracer::AddEndTraceEvent() {

--- a/deps/v8/src/tracing/trace-event.h
+++ b/deps/v8/src/tracing/trace-event.h
@@ -72,8 +72,8 @@ enum CategoryGroupEnabledFlags {
 // for best performance when tracing is disabled.
 // const uint8_t*
 //     TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(const char* category_group)
-#define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED              \
-  v8::internal::tracing::TraceEventHelper::GetCurrentPlatform() \
+#define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED                \
+  v8::internal::tracing::TraceEventHelper::GetTracingController() \
       ->GetCategoryGroupEnabled
 
 // Get the number of times traces have been recorded. This is used to implement
@@ -101,8 +101,8 @@ enum CategoryGroupEnabledFlags {
 //     const uint8_t* category_group_enabled,
 //     const char* name,
 //     uint64_t id)
-#define TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION             \
-  v8::internal::tracing::TraceEventHelper::GetCurrentPlatform() \
+#define TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION               \
+  v8::internal::tracing::TraceEventHelper::GetTracingController() \
       ->UpdateTraceEventDuration
 
 // Defines atomic operations used internally by the tracing system.
@@ -277,7 +277,7 @@ const uint64_t kNoId = 0;
 
 class TraceEventHelper {
  public:
-  static v8::Platform* GetCurrentPlatform();
+  static v8::TracingController* GetTracingController();
 };
 
 // TraceID encapsulates an ID that can either be an integer or pointer. Pointers
@@ -424,11 +424,11 @@ static V8_INLINE uint64_t AddTraceEventImpl(
         static_cast<intptr_t>(arg_values[1])));
   }
   DCHECK(num_args <= 2);
-  v8::Platform* platform =
-      v8::internal::tracing::TraceEventHelper::GetCurrentPlatform();
-  return platform->AddTraceEvent(phase, category_group_enabled, name, scope, id,
-                                 bind_id, num_args, arg_names, arg_types,
-                                 arg_values, arg_convertables, flags);
+  v8::TracingController* controller =
+      v8::internal::tracing::TraceEventHelper::GetTracingController();
+  return controller->AddTraceEvent(phase, category_group_enabled, name, scope,
+                                   id, bind_id, num_args, arg_names, arg_types,
+                                   arg_values, arg_convertables, flags);
 }
 
 // Define SetTraceValue for each allowed type. It stores the type and

--- a/deps/v8/src/tracing/tracing-category-observer.cc
+++ b/deps/v8/src/tracing/tracing-category-observer.cc
@@ -15,8 +15,9 @@ TracingCategoryObserver* TracingCategoryObserver::instance_ = nullptr;
 
 void TracingCategoryObserver::SetUp() {
   TracingCategoryObserver::instance_ = new TracingCategoryObserver();
-  v8::internal::V8::GetCurrentPlatform()->AddTraceStateObserver(
-      TracingCategoryObserver::instance_);
+  v8::internal::V8::GetCurrentPlatform()
+      ->GetTracingController()
+      ->AddTraceStateObserver(TracingCategoryObserver::instance_);
   TRACE_EVENT_WARMUP_CATEGORY(TRACE_DISABLED_BY_DEFAULT("v8.runtime_stats"));
   TRACE_EVENT_WARMUP_CATEGORY(
       TRACE_DISABLED_BY_DEFAULT("v8.runtime_stats_sampling"));
@@ -25,8 +26,9 @@ void TracingCategoryObserver::SetUp() {
 }
 
 void TracingCategoryObserver::TearDown() {
-  v8::internal::V8::GetCurrentPlatform()->RemoveTraceStateObserver(
-      TracingCategoryObserver::instance_);
+  v8::internal::V8::GetCurrentPlatform()
+      ->GetTracingController()
+      ->RemoveTraceStateObserver(TracingCategoryObserver::instance_);
   delete TracingCategoryObserver::instance_;
 }
 

--- a/deps/v8/src/tracing/tracing-category-observer.h
+++ b/deps/v8/src/tracing/tracing-category-observer.h
@@ -10,7 +10,7 @@
 namespace v8 {
 namespace tracing {
 
-class TracingCategoryObserver : public Platform::TraceStateObserver {
+class TracingCategoryObserver : public TracingController::TraceStateObserver {
  public:
   enum Mode {
     ENABLED_BY_NATIVE = 1 << 0,
@@ -21,7 +21,7 @@ class TracingCategoryObserver : public Platform::TraceStateObserver {
   static void SetUp();
   static void TearDown();
 
-  // v8::Platform::TraceStateObserver
+  // v8::TracingController::TraceStateObserver
   void OnTraceEnabled() final;
   void OnTraceDisabled() final;
 

--- a/deps/v8/test/cctest/heap/test-incremental-marking.cc
+++ b/deps/v8/test/cctest/heap/test-incremental-marking.cc
@@ -71,29 +71,6 @@ class MockPlatform : public v8::Platform {
     delete task;
   }
 
-  using Platform::AddTraceEvent;
-  uint64_t AddTraceEvent(char phase, const uint8_t* categoryEnabledFlag,
-                         const char* name, const char* scope, uint64_t id,
-                         uint64_t bind_id, int numArgs, const char** argNames,
-                         const uint8_t* argTypes, const uint64_t* argValues,
-                         unsigned int flags) override {
-    return 0;
-  }
-
-  void UpdateTraceEventDuration(const uint8_t* categoryEnabledFlag,
-                                const char* name, uint64_t handle) override {}
-
-  const uint8_t* GetCategoryGroupEnabled(const char* name) override {
-    static uint8_t no = 0;
-    return &no;
-  }
-
-  const char* GetCategoryGroupName(
-      const uint8_t* categoryEnabledFlag) override {
-    static const char* dummy = "dummy";
-    return dummy;
-  }
-
  private:
   v8::Platform* platform_;
   Task* task_;

--- a/deps/v8/test/cctest/heap/test-incremental-marking.cc
+++ b/deps/v8/test/cctest/heap/test-incremental-marking.cc
@@ -62,6 +62,10 @@ class MockPlatform : public v8::Platform {
 
   bool IdleTasksEnabled(v8::Isolate* isolate) override { return false; }
 
+  v8::TracingController* GetTracingController() override {
+    return platform_->GetTracingController();
+  }
+
   bool PendingTask() { return task_ != nullptr; }
 
   void PerformTask() {

--- a/deps/v8/test/cctest/heap/test-spaces.cc
+++ b/deps/v8/test/cctest/heap/test-spaces.cc
@@ -370,6 +370,7 @@ TEST(NewSpace) {
   }
 
   new_space.TearDown();
+  memory_allocator->unmapper()->WaitUntilCompleted();
   memory_allocator->TearDown();
   delete memory_allocator;
 }

--- a/deps/v8/test/cctest/test-cpu-profiler.cc
+++ b/deps/v8/test/cctest/test-cpu-profiler.cc
@@ -33,6 +33,7 @@
 #include "src/api.h"
 #include "src/base/platform/platform.h"
 #include "src/deoptimizer.h"
+#include "src/libplatform/default-platform.h"
 #include "src/objects-inl.h"
 #include "src/profiler/cpu-profiler-inl.h"
 #include "src/profiler/profiler-listener.h"
@@ -2152,7 +2153,8 @@ TEST(TracingCpuProfiler) {
   i::V8::SetPlatformForTesting(default_platform);
 
   v8::platform::tracing::TracingController tracing_controller;
-  v8::platform::SetTracingController(default_platform, &tracing_controller);
+  static_cast<v8::platform::DefaultPlatform*>(default_platform)
+      ->SetTracingController(&tracing_controller);
 
   CpuProfileEventChecker* event_checker = new CpuProfileEventChecker();
   TraceBuffer* ring_buffer =

--- a/deps/v8/test/unittests/cancelable-tasks-unittest.cc
+++ b/deps/v8/test/unittests/cancelable-tasks-unittest.cc
@@ -180,7 +180,7 @@ TEST(CancelableTask, RemoveBeforeCancelAndWait) {
   ResultType result1 = 0;
   TestTask* task1 = new TestTask(&manager, &result1, TestTask::kCheckNotRun);
   ThreadedRunner runner1(task1);
-  uint32_t id = task1->id();
+  CancelableTaskManager::Id id = task1->id();
   EXPECT_EQ(id, 1u);
   EXPECT_TRUE(manager.TryAbort(id));
   runner1.Start();
@@ -195,7 +195,7 @@ TEST(CancelableTask, RemoveAfterCancelAndWait) {
   ResultType result1 = 0;
   TestTask* task1 = new TestTask(&manager, &result1);
   ThreadedRunner runner1(task1);
-  uint32_t id = task1->id();
+  CancelableTaskManager::Id id = task1->id();
   EXPECT_EQ(id, 1u);
   runner1.Start();
   runner1.Join();

--- a/node.gyp
+++ b/node.gyp
@@ -190,6 +190,7 @@
         'src/node_http_parser.cc',
         'src/node_main.cc',
         'src/node_os.cc',
+        'src/node_platform.cc',
         'src/node_revert.cc',
         'src/node_serdes.cc',
         'src/node_url.cc',
@@ -238,6 +239,7 @@
         'src/node_internals.h',
         'src/node_javascript.h',
         'src/node_mutex.h',
+        'src/node_platform.h',
         'src/node_root_certs.h',
         'src/node_version.h',
         'src/node_watchdog.h',
@@ -656,6 +658,8 @@
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
 
       'sources': [
+        'src/node_platform.cc',
+        'src/node_platform.h',
         'test/cctest/test_base64.cc',
         'test/cctest/test_environment.cc',
         'test/cctest/test_util.cc',

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -502,11 +502,9 @@ class InspectorTimerHandle {
 
 class NodeInspectorClient : public V8InspectorClient {
  public:
-  NodeInspectorClient(node::Environment* env,
-                      v8::Platform* platform) : env_(env),
-                                                platform_(platform),
-                                                terminated_(false),
-                                                running_nested_loop_(false) {
+  NodeInspectorClient(node::Environment* env, node::NodePlatform* platform)
+      : env_(env), platform_(platform), terminated_(false),
+        running_nested_loop_(false) {
     client_ = V8Inspector::create(env->isolate(), this);
     contextCreated(env->context(), "Node.js Main Context");
   }
@@ -518,8 +516,7 @@ class NodeInspectorClient : public V8InspectorClient {
     terminated_ = false;
     running_nested_loop_ = true;
     while (!terminated_ && channel_->waitForFrontendMessage()) {
-      while (v8::platform::PumpMessageLoop(platform_, env_->isolate()))
-        {}
+      platform_->FlushForegroundTasksInternal();
     }
     terminated_ = false;
     running_nested_loop_ = false;
@@ -647,7 +644,7 @@ class NodeInspectorClient : public V8InspectorClient {
 
  private:
   node::Environment* env_;
-  v8::Platform* platform_;
+  node::NodePlatform* platform_;
   bool terminated_;
   bool running_nested_loop_;
   std::unique_ptr<V8Inspector> client_;
@@ -666,7 +663,7 @@ Agent::Agent(Environment* env) : parent_env_(env),
 Agent::~Agent() {
 }
 
-bool Agent::Start(v8::Platform* platform, const char* path,
+bool Agent::Start(node::NodePlatform* platform, const char* path,
                   const DebugOptions& options) {
   path_ = path == nullptr ? "" : path;
   debug_options_ = options;

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -14,6 +14,7 @@
 // Forward declaration to break recursive dependency chain with src/env.h.
 namespace node {
 class Environment;
+class NodePlatform;
 }  // namespace node
 
 #include "v8.h"
@@ -42,7 +43,7 @@ class Agent {
   ~Agent();
 
   // Create client_, may create io_ if option enabled
-  bool Start(v8::Platform* platform, const char* path,
+  bool Start(node::NodePlatform* platform, const char* path,
              const DebugOptions& options);
   // Stop and destroy io_
   void Stop();

--- a/src/node.cc
+++ b/src/node.cc
@@ -23,6 +23,7 @@
 #include "node_buffer.h"
 #include "node_constants.h"
 #include "node_javascript.h"
+#include "node_platform.h"
 #include "node_version.h"
 #include "node_internals.h"
 #include "node_revert.h"
@@ -250,25 +251,26 @@ node::DebugOptions debug_options;
 
 static struct {
 #if NODE_USE_V8_PLATFORM
-  void Initialize(int thread_pool_size) {
+  void Initialize(int thread_pool_size, uv_loop_t* loop) {
     tracing_agent_ =
-      trace_enabled ? new tracing::Agent() : nullptr;
-    platform_ = v8::platform::CreateDefaultPlatform(
-      thread_pool_size, v8::platform::IdleTaskSupport::kDisabled,
-      v8::platform::InProcessStackDumping::kDisabled,
-      trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
+        trace_enabled ? new tracing::Agent() : nullptr;
+    platform_ = new NodePlatform(thread_pool_size, loop,
+        trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
     V8::InitializePlatform(platform_);
     tracing::TraceEventHelper::SetTracingController(
-      trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
-  }
-
-  void PumpMessageLoop(Isolate* isolate) {
-    v8::platform::PumpMessageLoop(platform_, isolate);
+        trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
   }
 
   void Dispose() {
+    platform_->Shutdown();
     delete platform_;
     platform_ = nullptr;
+    delete tracing_agent_;
+    tracing_agent_ = nullptr;
+  }
+
+  void DrainVMTasks() {
+    platform_->DrainBackgroundTasks();
   }
 
 #if HAVE_INSPECTOR
@@ -293,12 +295,12 @@ static struct {
     tracing_agent_->Stop();
   }
 
-  v8::Platform* platform_;
   tracing::Agent* tracing_agent_;
+  NodePlatform* platform_;
 #else  // !NODE_USE_V8_PLATFORM
-  void Initialize(int thread_pool_size) {}
-  void PumpMessageLoop(Isolate* isolate) {}
+  void Initialize(int thread_pool_size, uv_loop_t* loop) {}
   void Dispose() {}
+  void DrainVMTasks() {}
   bool StartInspector(Environment *env, const char* script_path,
                       const node::DebugOptions& options) {
     env->ThrowError("Node compiled with NODE_USE_V8_PLATFORM=0");
@@ -4555,19 +4557,14 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
     SealHandleScope seal(isolate);
     bool more;
     do {
-      v8_platform.PumpMessageLoop(isolate);
-      more = uv_run(env.event_loop(), UV_RUN_ONCE);
+      uv_run(env.event_loop(), UV_RUN_DEFAULT);
 
-      if (more == false) {
-        v8_platform.PumpMessageLoop(isolate);
-        EmitBeforeExit(&env);
+      EmitBeforeExit(&env);
 
-        // Emit `beforeExit` if the loop became alive either after emitting
-        // event, or after running some callbacks.
-        more = uv_loop_alive(env.event_loop());
-        if (uv_run(env.event_loop(), UV_RUN_NOWAIT) != 0)
-          more = true;
-      }
+      v8_platform.DrainVMTasks();
+      // Emit `beforeExit` if the loop became alive either after emitting
+      // event, or after running some callbacks.
+      more = uv_loop_alive(env.event_loop());
     } while (more == true);
   }
 
@@ -4577,6 +4574,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   RunAtExit(&env);
   uv_key_delete(&thread_local_env);
 
+  v8_platform.DrainVMTasks();
   WaitForInspectorDisconnect(&env);
 #if defined(LEAK_SANITIZER)
   __lsan_do_leak_check();
@@ -4665,7 +4663,7 @@ int Start(int argc, char** argv) {
   V8::SetEntropySource(crypto::EntropySource);
 #endif  // HAVE_OPENSSL
 
-  v8_platform.Initialize(v8_thread_pool_size);
+  v8_platform.Initialize(v8_thread_pool_size, uv_default_loop());
   // Enable tracing when argv has --trace-events-enabled.
   if (trace_enabled) {
     fprintf(stderr, "Warning: Trace event is an experimental feature "
@@ -4682,6 +4680,12 @@ int Start(int argc, char** argv) {
   v8_initialized = false;
   V8::Dispose();
 
+  // uv_run cannot be called from the time before the beforeExit callback
+  // runs until the program exits unless the event loop has any referenced
+  // handles after beforeExit terminates. This prevents unrefed timers
+  // that happen to terminate during shutdown from being run unsafely.
+  // Since uv_run cannot be called, uv_async handles held by the platform
+  // will never be fully cleaned up.
   v8_platform.Dispose();
 
   delete[] exec_argv;

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -1,0 +1,189 @@
+#include "node_platform.h"
+
+#include "util.h"
+
+namespace node {
+
+using v8::Isolate;
+using v8::Platform;
+using v8::Task;
+using v8::TracingController;
+
+static void FlushTasks(uv_async_t* handle) {
+  NodePlatform* platform = static_cast<NodePlatform*>(handle->data);
+  platform->FlushForegroundTasksInternal();
+}
+
+static void BackgroundRunner(void* data) {
+  TaskQueue<Task>* background_tasks = static_cast<TaskQueue<Task>*>(data);
+  while (Task* task = background_tasks->BlockingPop()) {
+    task->Run();
+    delete task;
+    background_tasks->NotifyOfCompletion();
+  }
+}
+
+NodePlatform::NodePlatform(int thread_pool_size, uv_loop_t* loop,
+                           TracingController* tracing_controller)
+    : loop_(loop) {
+  CHECK_EQ(0, uv_async_init(loop, &flush_tasks_, FlushTasks));
+  flush_tasks_.data = static_cast<void*>(this);
+  uv_unref(reinterpret_cast<uv_handle_t*>(&flush_tasks_));
+  if (tracing_controller) {
+    tracing_controller_.reset(tracing_controller);
+  } else {
+    TracingController* controller = new TracingController();
+    tracing_controller_.reset(controller);
+  }
+  for (int i = 0; i < thread_pool_size; i++) {
+    uv_thread_t* t = new uv_thread_t();
+    if (uv_thread_create(t, BackgroundRunner, &background_tasks_) != 0) {
+      delete t;
+      break;
+    }
+    threads_.push_back(std::unique_ptr<uv_thread_t>(t));
+  }
+}
+
+void NodePlatform::Shutdown() {
+  background_tasks_.Stop();
+  for (size_t i = 0; i < threads_.size(); i++) {
+    CHECK_EQ(0, uv_thread_join(threads_[i].get()));
+  }
+  // uv_run cannot be called from the time before the beforeExit callback
+  // runs until the program exits unless the event loop has any referenced
+  // handles after beforeExit terminates. This prevents unrefed timers
+  // that happen to terminate during shutdown from being run unsafely.
+  // Since uv_run cannot be called, this handle will never be fully cleaned
+  // up.
+  uv_close(reinterpret_cast<uv_handle_t*>(&flush_tasks_), nullptr);
+}
+
+size_t NodePlatform::NumberOfAvailableBackgroundThreads() {
+  return threads_.size();
+}
+
+static void RunForegroundTask(uv_timer_t* handle) {
+  Task* task = static_cast<Task*>(handle->data);
+  task->Run();
+  delete task;
+  uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* handle) {
+    delete reinterpret_cast<uv_timer_t*>(handle);
+  });
+}
+
+void NodePlatform::DrainBackgroundTasks() {
+  FlushForegroundTasksInternal();
+  background_tasks_.BlockingDrain();
+}
+
+void NodePlatform::FlushForegroundTasksInternal() {
+  while (auto delayed = foreground_delayed_tasks_.Pop()) {
+    uint64_t delay_millis =
+        static_cast<uint64_t>(delayed->second + 0.5) * 1000;
+    uv_timer_t* handle = new uv_timer_t();
+    handle->data = static_cast<void*>(delayed->first);
+    uv_timer_init(loop_, handle);
+    // Timers may not guarantee queue ordering of events with the same delay if
+    // the delay is non-zero. This should not be a problem in practice.
+    uv_timer_start(handle, RunForegroundTask, delay_millis, 0);
+    uv_unref(reinterpret_cast<uv_handle_t*>(handle));
+    delete delayed;
+  }
+  while (Task* task = foreground_tasks_.Pop()) {
+    task->Run();
+    delete task;
+  }
+}
+
+void NodePlatform::CallOnBackgroundThread(Task* task,
+                                          ExpectedRuntime expected_runtime) {
+  background_tasks_.Push(task);
+}
+
+void NodePlatform::CallOnForegroundThread(Isolate* isolate, Task* task) {
+  foreground_tasks_.Push(task);
+  uv_async_send(&flush_tasks_);
+}
+
+void NodePlatform::CallDelayedOnForegroundThread(Isolate* isolate,
+                                                 Task* task,
+                                                 double delay_in_seconds) {
+  auto pair = new std::pair<Task*, double>(task, delay_in_seconds);
+  foreground_delayed_tasks_.Push(pair);
+  uv_async_send(&flush_tasks_);
+}
+
+bool NodePlatform::IdleTasksEnabled(Isolate* isolate) { return false; }
+
+double NodePlatform::MonotonicallyIncreasingTime() {
+  // Convert nanos to seconds.
+  return uv_hrtime() / 1e9;
+}
+
+TracingController* NodePlatform::GetTracingController() {
+  return tracing_controller_.get();
+}
+
+template <class T>
+TaskQueue<T>::TaskQueue()
+    : lock_(), tasks_available_(), tasks_drained_(),
+      outstanding_tasks_(0), stopped_(false), task_queue_() { }
+
+template <class T>
+void TaskQueue<T>::Push(T* task) {
+  Mutex::ScopedLock scoped_lock(lock_);
+  outstanding_tasks_++;
+  task_queue_.push(task);
+  tasks_available_.Signal(scoped_lock);
+}
+
+template <class T>
+T* TaskQueue<T>::Pop() {
+  Mutex::ScopedLock scoped_lock(lock_);
+  T* result = nullptr;
+  if (!task_queue_.empty()) {
+    result = task_queue_.front();
+    task_queue_.pop();
+  }
+  return result;
+}
+
+template <class T>
+T* TaskQueue<T>::BlockingPop() {
+  Mutex::ScopedLock scoped_lock(lock_);
+  while (task_queue_.empty() && !stopped_) {
+    tasks_available_.Wait(scoped_lock);
+  }
+  if (stopped_) {
+    return nullptr;
+  }
+  T* result = task_queue_.front();
+  task_queue_.pop();
+  return result;
+}
+
+template <class T>
+void TaskQueue<T>::NotifyOfCompletion() {
+  Mutex::ScopedLock scoped_lock(lock_);
+  if (--outstanding_tasks_ == 0) {
+    tasks_drained_.Broadcast(scoped_lock);
+  }
+}
+
+template <class T>
+void TaskQueue<T>::BlockingDrain() {
+  Mutex::ScopedLock scoped_lock(lock_);
+  while (outstanding_tasks_ > 0) {
+    tasks_drained_.Wait(scoped_lock);
+  }
+}
+
+template <class T>
+void TaskQueue<T>::Stop() {
+  Mutex::ScopedLock scoped_lock(lock_);
+  stopped_ = true;
+  tasks_available_.Broadcast(scoped_lock);
+}
+
+}  // namespace node

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -1,0 +1,69 @@
+#ifndef SRC_NODE_PLATFORM_H_
+#define SRC_NODE_PLATFORM_H_
+
+#include <queue>
+#include <vector>
+
+#include "libplatform/libplatform.h"
+#include "node_mutex.h"
+#include "uv.h"
+
+namespace node {
+
+template <class T>
+class TaskQueue {
+ public:
+  TaskQueue();
+  ~TaskQueue() {}
+
+  void Push(T* task);
+  T* Pop();
+  T* BlockingPop();
+  void NotifyOfCompletion();
+  void BlockingDrain();
+  void Stop();
+
+ private:
+  Mutex lock_;
+  ConditionVariable tasks_available_;
+  ConditionVariable tasks_drained_;
+  int outstanding_tasks_;
+  bool stopped_;
+  std::queue<T*> task_queue_;
+};
+
+class NodePlatform : public v8::Platform {
+ public:
+  NodePlatform(int thread_pool_size, uv_loop_t* loop,
+               v8::TracingController* tracing_controller);
+  virtual ~NodePlatform() {}
+
+  void DrainBackgroundTasks();
+  void FlushForegroundTasksInternal();
+  void Shutdown();
+
+  // v8::Platform implementation.
+  size_t NumberOfAvailableBackgroundThreads() override;
+  void CallOnBackgroundThread(v8::Task* task,
+                              ExpectedRuntime expected_runtime) override;
+  void CallOnForegroundThread(v8::Isolate* isolate, v8::Task* task) override;
+  void CallDelayedOnForegroundThread(v8::Isolate* isolate, v8::Task* task,
+                                     double delay_in_seconds) override;
+  bool IdleTasksEnabled(v8::Isolate* isolate) override;
+  double MonotonicallyIncreasingTime() override;
+  v8::TracingController* GetTracingController() override;
+
+ private:
+  uv_loop_t* const loop_;
+  uv_async_t flush_tasks_;
+  TaskQueue<v8::Task> foreground_tasks_;
+  TaskQueue<std::pair<v8::Task*, double>> foreground_delayed_tasks_;
+  TaskQueue<v8::Task> background_tasks_;
+  std::vector<std::unique_ptr<uv_thread_t>> threads_;
+
+  std::unique_ptr<v8::TracingController> tracing_controller_;
+};
+
+}  // namespace node
+
+#endif  // SRC_NODE_PLATFORM_H_

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "env-inl.h"
-#include "libplatform/libplatform.h"
 
 namespace node {
 namespace tracing {

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -12,20 +12,18 @@ namespace tracing {
 using v8::platform::tracing::TraceConfig;
 using std::string;
 
-Agent::Agent() {}
-
-void Agent::Start(v8::Platform* platform, const string& enabled_categories) {
-  platform_ = platform;
-
+Agent::Agent() {
   int err = uv_loop_init(&tracing_loop_);
   CHECK_EQ(err, 0);
 
   NodeTraceWriter* trace_writer = new NodeTraceWriter(&tracing_loop_);
   TraceBuffer* trace_buffer = new NodeTraceBuffer(
       NodeTraceBuffer::kBufferChunks, trace_writer, &tracing_loop_);
-
   tracing_controller_ = new TracingController();
+  tracing_controller_->Initialize(trace_buffer);
+}
 
+void Agent::Start(const string& enabled_categories) {
   TraceConfig* trace_config = new TraceConfig();
   if (!enabled_categories.empty()) {
     std::stringstream category_list(enabled_categories);
@@ -42,27 +40,25 @@ void Agent::Start(v8::Platform* platform, const string& enabled_categories) {
   // This thread should be created *after* async handles are created
   // (within NodeTraceWriter and NodeTraceBuffer constructors).
   // Otherwise the thread could shut down prematurely.
-  err = uv_thread_create(&thread_, ThreadCb, this);
+  int err = uv_thread_create(&thread_, ThreadCb, this);
   CHECK_EQ(err, 0);
 
-  tracing_controller_->Initialize(trace_buffer);
   tracing_controller_->StartTracing(trace_config);
-  v8::platform::SetTracingController(platform, tracing_controller_);
+  started_ = true;
 }
 
 void Agent::Stop() {
-  if (!IsStarted()) {
+  if (!started_) {
     return;
   }
   // Perform final Flush on TraceBuffer. We don't want the tracing controller
   // to flush the buffer again on destruction of the V8::Platform.
   tracing_controller_->StopTracing();
   tracing_controller_->Initialize(nullptr);
-  tracing_controller_ = nullptr;
+  started_ = false;
 
   // Thread should finish when the tracing loop is stopped.
   uv_thread_join(&thread_);
-  v8::platform::SetTracingController(platform_, nullptr);
 }
 
 // static

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -1,6 +1,7 @@
 #ifndef SRC_TRACING_AGENT_H_
 #define SRC_TRACING_AGENT_H_
 
+#include "node_platform.h"
 #include "tracing/node_trace_buffer.h"
 #include "tracing/node_trace_writer.h"
 #include "uv.h"

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -12,16 +12,17 @@ namespace tracing {
 class Agent {
  public:
   Agent();
-  void Start(v8::Platform* platform, const std::string& enabled_categories);
+  void Start(const std::string& enabled_categories);
   void Stop();
 
+  TracingController* GetTracingController() { return tracing_controller_; }
+
  private:
-  bool IsStarted() { return platform_ != nullptr; }
   static void ThreadCb(void* arg);
 
   uv_thread_t thread_;
   uv_loop_t tracing_loop_;
-  v8::Platform* platform_ = nullptr;
+  bool started_ = false;
   TracingController* tracing_controller_ = nullptr;
 };
 

--- a/src/tracing/trace_event.cc
+++ b/src/tracing/trace_event.cc
@@ -3,14 +3,14 @@
 namespace node {
 namespace tracing {
 
-v8::Platform* platform_ = nullptr;
+v8::TracingController* controller_ = nullptr;
 
-void TraceEventHelper::SetCurrentPlatform(v8::Platform* platform) {
-  platform_ = platform;
+void TraceEventHelper::SetTracingController(v8::TracingController* controller) {
+  controller_ = controller;
 }
 
-v8::Platform* TraceEventHelper::GetCurrentPlatform() {
-  return platform_;
+v8::TracingController* TraceEventHelper::GetTracingController() {
+  return controller_;
 }
 
 }  // namespace tracing

--- a/src/tracing/trace_event.cc
+++ b/src/tracing/trace_event.cc
@@ -3,14 +3,14 @@
 namespace node {
 namespace tracing {
 
-v8::TracingController* controller_ = nullptr;
+v8::TracingController* g_controller = nullptr;
 
 void TraceEventHelper::SetTracingController(v8::TracingController* controller) {
-  controller_ = controller;
+  g_controller = controller;
 }
 
 v8::TracingController* TraceEventHelper::GetTracingController() {
-  return controller_;
+  return g_controller;
 }
 
 }  // namespace tracing

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 
+#include "node_platform.h"
 #include "v8-platform.h"
 #include "trace_event_common.h"
 

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -70,7 +70,7 @@ enum CategoryGroupEnabledFlags {
 // const uint8_t*
 //     TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(const char* category_group)
 #define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED              \
-  node::tracing::TraceEventHelper::GetCurrentPlatform() \
+  node::tracing::TraceEventHelper::GetTracingController() \
       ->GetCategoryGroupEnabled
 
 // Get the number of times traces have been recorded. This is used to implement
@@ -99,7 +99,7 @@ enum CategoryGroupEnabledFlags {
 //     const char* name,
 //     uint64_t id)
 #define TRACE_EVENT_API_UPDATE_TRACE_EVENT_DURATION             \
-  node::tracing::TraceEventHelper::GetCurrentPlatform() \
+  node::tracing::TraceEventHelper::GetTracingController() \
       ->UpdateTraceEventDuration
 
 // Defines atomic operations used internally by the tracing system.
@@ -258,8 +258,8 @@ extern intptr_t kRuntimeCallStatsTracingEnabled;
 
 class TraceEventHelper {
  public:
-  static v8::Platform* GetCurrentPlatform();
-  static void SetCurrentPlatform(v8::Platform* platform);
+  static v8::TracingController* GetTracingController();
+  static void SetTracingController(v8::TracingController* controller);
 };
 
 // TraceID encapsulates an ID that can either be an integer or pointer. Pointers
@@ -406,11 +406,11 @@ static inline uint64_t AddTraceEventImpl(
         static_cast<intptr_t>(arg_values[1])));
   }
   // DCHECK(num_args <= 2);
-  v8::Platform* platform =
-      node::tracing::TraceEventHelper::GetCurrentPlatform();
-  return platform->AddTraceEvent(phase, category_group_enabled, name, scope, id,
-                                 bind_id, num_args, arg_names, arg_types,
-                                 arg_values, arg_convertibles, flags);
+  v8::TracingController* controller =
+      node::tracing::TraceEventHelper::GetTracingController();
+  return controller->AddTraceEvent(phase, category_group_enabled, name, scope, id,
+                                   bind_id, num_args, arg_names, arg_types,
+                                   arg_values, arg_convertibles, flags);
 }
 
 // Define SetTraceValue for each allowed type. It stores the type and

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -66,7 +66,12 @@ struct Argv {
   int nr_args_;
 };
 
+uv_loop_t current_loop;
+
 class NodeTestFixture : public ::testing::Test {
+ public:
+  static uv_loop_t* CurrentLoop() { return &current_loop; }
+
  protected:
   v8::Isolate::CreateParams params_;
   ArrayBufferAllocator allocator_;
@@ -77,7 +82,8 @@ class NodeTestFixture : public ::testing::Test {
   }
 
   virtual void SetUp() {
-    platform_ = v8::platform::CreateDefaultPlatform();
+    CHECK_EQ(0, uv_loop_init(&current_loop));
+    platform_ = new node::NodePlatform(8, &current_loop, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
     params_.array_buffer_allocator = &allocator_;
@@ -86,13 +92,18 @@ class NodeTestFixture : public ::testing::Test {
 
   virtual void TearDown() {
     if (platform_ == nullptr) return;
+    platform_->Shutdown();
+    while (uv_loop_alive(&current_loop)) {
+      uv_run(&current_loop, UV_RUN_ONCE);
+    }
     v8::V8::ShutdownPlatform();
     delete platform_;
     platform_ = nullptr;
+    CHECK_EQ(0, uv_loop_close(&current_loop));
   }
 
  private:
-  v8::Platform* platform_ = nullptr;
+  node::NodePlatform* platform_ = nullptr;
 };
 
 #endif  // TEST_CCTEST_NODE_TEST_FIXTURE_H_

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -31,7 +31,8 @@ class EnvironmentTest : public NodeTestFixture {
         const Argv& argv) {
       context_ = v8::Context::New(isolate);
       CHECK(!context_.IsEmpty());
-      isolate_data_ = CreateIsolateData(isolate, uv_default_loop());
+      isolate_data_ = CreateIsolateData(isolate,
+                                        NodeTestFixture::CurrentLoop());
       CHECK_NE(nullptr, isolate_data_);
       environment_ = CreateEnvironment(isolate_data_,
                                        context_,


### PR DESCRIPTION
Node.js currently uses the V8 implementation of the DefaultPlatform
which schedules VM tasks on a V8 managed thread pool. Since the Node.js
event loop is not aware of these tasks, the Node.js process may exit
while there are outstanding VM tasks. This will become problematic once
asynchronous wasm compilation lands in V8.

This PR introduces a Node.js specific implementation of the v8::Platform
on top of libuv so that the event loop is aware of outstanding VM tasks.

Fixes: nodejs#12980

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, tracing
