### PR TITLE
benchmark: use much smaller values for n in some http tests

### DIFF
--- a/benchmark/http/check_invalid_header_char.js
+++ b/benchmark/http/check_invalid_header_char.js
@@ -27,7 +27,7 @@ const bench = common.createBenchmark(main, {
     'foo\nbar',
     '\x7F'
   ],
-  n: [5e8],
+  n: [1e6],
 });
 
 function main(conf) {

--- a/benchmark/http/check_is_http_token.js
+++ b/benchmark/http/check_is_http_token.js
@@ -37,7 +37,7 @@ const bench = common.createBenchmark(main, {
     ':alternate-protocol', // fast bailout
     'alternate-protocol:' // slow bailout
   ],
-  n: [5e8],
+  n: [1e6],
 });
 
 function main(conf) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark

The n values here are really, really high right now, and we can still get high confidence (3 stars) with this much lower n value. This makes the benchmarks run a lot faster without sacrificing accuracy.