### PR TITLE
test: use a different external object in test-util-inspect

### DIFF
--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const JSStream = process.binding('js_stream').JSStream;
 const util = require('util');
 const vm = require('vm');
 
@@ -82,7 +83,7 @@ assert.strictEqual(util.inspect(Object.assign(new String('hello'),
                    { [Symbol('foo')]: 123 }), { showHidden: true }),
                    '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }');
 
-assert.strictEqual(util.inspect(process.stdin._handle._externalStream),
+assert.strictEqual(util.inspect((new JSStream())._externalStream),
                    '[External]');
 
 {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

This test can fail if process.stdin._handle doesn't exist, which can happen in some environments. The test just wants to check that external objects are represented properly, so we can pass in a JSStream external object instead.