### PR TITLE
test: fix require nits in some test-tls-* tests

### DIFF
--- a/test/internet/test-tls-add-ca-cert.js
+++ b/test/internet/test-tls-add-ca-cert.js
@@ -10,10 +10,11 @@ if (!common.hasCrypto) {
 
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -11,12 +11,13 @@ if (!common.hasCrypto) {
   return;
 }
 
-const tls = require('tls');
-const net = require('net');
 const fs = require('fs');
+const net = require('net');
+const path = require('path');
+const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -21,7 +21,6 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.opensslCli) {
   common.skip('node compiled without OpenSSL CLI.');
@@ -32,15 +31,17 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-const tls = require('tls');
 
+const assert = require('assert');
+const { spawn } = require('child_process');
 const fs = require('fs');
-const spawn = require('child_process').spawn;
+const path = require('path');
+const tls = require('tls');
 
 let success = false;
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -14,10 +14,11 @@ if (!process.features.tls_alpn || !process.features.tls_npn) {
 
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -21,15 +21,16 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
-const tls = require('tls');
 
+const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
+const tls = require('tls');
 
 const hosterr = /Hostname\/IP doesn't match certificate's altnames/;
 const testCases =
@@ -65,7 +66,7 @@ const testCases =
   ];
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -8,9 +8,9 @@ if (!common.hasCrypto) {
 }
 
 const assert = require('assert');
-const tls = require('tls');
 const fs = require('fs');
 const path = require('path');
+const tls = require('tls');
 
 function filenamePEM(n) {
   return path.join(common.fixturesDir, 'keys', `${n}.pem`);

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -26,18 +26,18 @@ if (!process.features.tls_npn) {
   return;
 }
 
-const assert = require('assert');
-const fs = require('fs');
-
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const tls = require('tls');
 
-
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -27,6 +27,11 @@ if (!common.opensslCli) {
   return;
 }
 
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
 // This is a rather complex test which sets up various TLS servers with node
 // and connects to them using the 'openssl s_client' command line utility
 // with various keys. Depending on the certificate authority and other
@@ -34,6 +39,14 @@ if (!common.opensslCli) {
 // - rejected,
 // - accepted and "unauthorized", or
 // - accepted and "authorized".
+
+const assert = require('assert');
+const { spawn } = require('child_process');
+const { SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION } =
+  require('crypto').constants;
+const fs = require('fs');
+const path = require('path');
+const tls = require('tls');
 
 const testCases =
   [{ title: 'Do not request certs. Everyone is unauthorized.',
@@ -119,22 +132,9 @@ const testCases =
   }
   ];
 
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
-  return;
-}
-const tls = require('tls');
-
-const SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION =
-  require('crypto').constants.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
-
-const assert = require('assert');
-const fs = require('fs');
-const spawn = require('child_process').spawn;
-
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -26,17 +26,18 @@ if (!process.features.tls_sni) {
   return;
 }
 
-const assert = require('assert');
-const fs = require('fs');
-
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -26,17 +26,18 @@ if (!process.features.tls_sni) {
   return;
 }
 
-const assert = require('assert');
-const fs = require('fs');
-
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const tls = require('tls');
 
 function filenamePEM(n) {
-  return require('path').join(common.fixturesDir, 'keys', `${n}.pem`);
+  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
 }
 
 function loadPEM(n) {

--- a/test/parallel/test-tls-startcom-wosign-whitelist.js
+++ b/test/parallel/test-tls-startcom-wosign-whitelist.js
@@ -1,15 +1,16 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 
 if (!common.hasCrypto) {
   common.skip('missing crypto');
   return;
 }
 
-const tls = require('tls');
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const tls = require('tls');
+
 let finished = 0;
 
 function filenamePEM(n) {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

* Do not `require` if test is skipped.
* Do not re-`require` without need.
* Sort requiring by module names.

I've just stumble upon these nits in these connected tests by chance. Maybe I shall try to fix this class of nits in tests more thoroughly later if this makes any sense.