### PR TITLE
test,fs: delay unlink in test-regress-GH-4027.js

### DIFF
--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -36,4 +36,4 @@ fs.watchFile(filename, { interval: 50 }, common.mustCall(function(curr, prev) {
   fs.unwatchFile(filename);
 }));
 
-setTimeout(fs.unlinkSync, 300, filename);
+setTimeout(fs.unlinkSync, common.platformTimeout(300), filename);

--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -29,10 +29,11 @@ common.refreshTmpDir();
 
 const filename = path.join(common.tmpDir, 'watched');
 fs.writeFileSync(filename, 'quis custodiet ipsos custodes');
-setTimeout(fs.unlinkSync, 100, filename);
 
 fs.watchFile(filename, { interval: 50 }, common.mustCall(function(curr, prev) {
   assert.strictEqual(prev.nlink, 1);
   assert.strictEqual(curr.nlink, 0);
   fs.unwatchFile(filename);
 }));
+
+setTimeout(fs.unlinkSync, 300, filename);


### PR DESCRIPTION
The [sequential/test-regress-GH-4027](https://github.com/nodejs/node/blob/c9cf7c2780e4f5ae8ad6583c8b179b59d676c1f1/test/sequential/test-regress-GH-4027.js) test is [flaky on Windows CI](https://github.com/nodejs/node/issues/13800) with an increased system load, failing when the watched file is unlinked before the first state of the watched file is retrieved.

After increasing the delay before unlinking and calling `setTimeout` after `watchFile`, the flakiness stopped reproducing.

Fixes: https://github.com/nodejs/node/issues/13800

/cc @nodejs/testing

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test