### PR TITLE
Fix incorrect use of ERR_INVALID_ARG_TYPE

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -536,7 +536,7 @@ function _throws(shouldThrow, block, expected, message) {
   if (typeof block !== 'function') {
     const errors = lazyErrors();
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'function',
-                               typeof block);
+                               block);
   }
 
   if (typeof expected === 'string') {

--- a/lib/path.js
+++ b/lib/path.js
@@ -960,7 +960,7 @@ const win32 = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
-                                typeof pathObject);
+                                 pathObject);
     }
     return _format('\\', pathObject);
   },
@@ -1503,7 +1503,7 @@ const posix = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
-                                typeof pathObject);
+                                 pathObject);
     }
     return _format('/', pathObject);
   },

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -669,10 +669,9 @@ try {
 
 {
   // Verify that throws() and doesNotThrow() throw on non-function block
-  const validationFunction = common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
+  function typeName(value) {
+    return value === null ? 'null' : typeof value;
+  }
 
   const testBlockTypeError = (method, block) => {
     let threw = true;
@@ -681,7 +680,12 @@ try {
       method(block);
       threw = false;
     } catch (e) {
-      validationFunction(e);
+      common.expectsError({
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "block" argument must be of type function. Received ' +
+                 'type ' + typeName(block)
+      })(e);
     }
 
     assert.ok(threw);

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -207,4 +207,19 @@ function checkFormat(path, testCases) {
   testCases.forEach(function(testCase) {
     assert.strictEqual(path.format(testCase[0]), testCase[1]);
   });
+
+  function typeName(value) {
+    return value === null ? 'null' : typeof value;
+  }
+
+  [null, undefined, 1, true, false, 'string'].forEach((pathObject) => {
+    assert.throws(() => {
+      path.format(pathObject);
+    }, common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "pathObject" argument must be of type Object. Received ' +
+               'type ' + typeName(pathObject)
+    }));
+  });
 }


### PR DESCRIPTION
These lines effectively printed `typeof typeof value`, which is always `string`, instead of `typeof value`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
path, assert