### PR TITLE
test: run abort tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 CI_NATIVE_SUITES := addons addons-napi
-CI_JS_SUITES := async-hooks doctool inspector known_issues message parallel pseudo-tty sequential
+CI_JS_SUITES := abort async-hooks doctool inspector known_issues message parallel pseudo-tty sequential
 
 # Build and test addons without building anything else
 test-ci-native: LOGLEVEL := info

--- a/test/abort/test-abort-uncaught-exception.js
+++ b/test/abort/test-abort-uncaught-exception.js
@@ -9,7 +9,7 @@ if (process.argv[2] === 'child') {
   throw new Error('child error');
 } else {
   run('', null);
-  run('--abort-on-uncaught-exception', ['SIGABRT', 'SIGILL']);
+  run('--abort-on-uncaught-exception', ['SIGABRT', 'SIGTRAP', 'SIGILL']);
 }
 
 function run(flags, signals) {
@@ -26,7 +26,7 @@ function run(flags, signals) {
         assert.strictEqual(code, 1);
     } else {
       if (signals)
-        assert.strictEqual(signals.includes(sig), true);
+        assert(signals.includes(sig), `Unexpected signal ${sig}`);
       else
         assert.strictEqual(sig, null);
     }

--- a/test/abort/testcfg.py
+++ b/test/abort/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.SimpleTestConfiguration(context, root, 'abort')
+  return testpy.AbortTestConfiguration(context, root, 'abort')

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -180,3 +180,15 @@ class AsyncHooksTestConfiguration(SimpleTestConfiguration):
     for test in result:
       test.parallel = True
     return result
+
+class AbortTestConfiguration(SimpleTestConfiguration):
+  def __init__(self, context, root, section, additional=None):
+    super(AbortTestConfiguration, self).__init__(context, root, section,
+                                                 additional)
+
+  def ListTests(self, current_path, path, arch, mode):
+    result = super(AbortTestConfiguration, self).ListTests(
+         current_path, path, arch, mode)
+    for test in result:
+      test.disable_core_files = True
+    return result


### PR DESCRIPTION
Currently, tests in test/abort do not run in CI.

This change configures the test runner to not write core files, and run
the abort tests.

Fixes: https://github.com/nodejs/node/issues/14012

This should land only after https://github.com/nodejs/node/pull/13985 because that fixes a problem that causes one of the tests to fail. (In other words, had we been running these tests, that bug would have been caught!)

@addaleax @refack @nodejs/build @nodejs/testing 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build test tools