### PR TITLE
http: OutgoingMessage change writable after end

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -793,6 +793,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this.connection.uncork();
 
   this.finished = true;
+  this.writable = false;
 
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -18,9 +18,15 @@ const server = http.createServer(common.mustCall(function(req, res) {
 server.listen(0);
 
 server.on('listening', common.mustCall(function() {
-  http.request({
+  const clientRequest = http.request({
     port: server.address().port,
     method: 'GET',
     path: '/'
-  }).end();
+  });
+
+  assert(clientRequest.writable, 'ClientRequest should be writable when \
+                            it is created.');
+  clientRequest.end();
+  assert(!clientRequest.writable, 'ClientRequest shouldn\'t be writable \
+                            after it was closed.');
 }));

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  assert(res.writable, 'Res should be writable when it is received \
+                          and opened.');
+  assert(!res.finished, 'Res shouldn\'t be finished when it is received \
+                          and opened.');
+  res.end();
+  assert(!res.writable, 'Res shouldn\'t be writable after it was closed.');
+  assert(res.finished, 'Res should be finished after it was closed.');
+
+  server.close();
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  http.request({
+    port: server.address().port,
+    method: 'GET',
+    path: '/'
+  }).end();
+}));

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -3,14 +3,15 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
+// Verify that after calling end() on an `OutgoingMessage` (or a type that
+// inherits from `OutgoingMessage`), its `writable` property is set to false.
+
 const server = http.createServer(common.mustCall(function(req, res) {
-  assert(res.writable, 'Res should be writable when it is received \
-                          and opened.');
-  assert(!res.finished, 'Res shouldn\'t be finished when it is received \
-                          and opened.');
+  assert.strictEqual(res.writable, true);
+  assert.strictEqual(res.finished, false);
   res.end();
-  assert(!res.writable, 'Res shouldn\'t be writable after it was closed.');
-  assert(res.finished, 'Res should be finished after it was closed.');
+  assert.strictEqual(res.writable, false);
+  assert.strictEqual(res.finished, true);
 
   server.close();
 }));
@@ -24,9 +25,7 @@ server.on('listening', common.mustCall(function() {
     path: '/'
   });
 
-  assert(clientRequest.writable, 'ClientRequest should be writable when \
-                            it is created.');
+  assert.strictEqual(clientRequest.writable, true);
   clientRequest.end();
-  assert(!clientRequest.writable, 'ClientRequest shouldn\'t be writable \
-                            after it was closed.');
+  assert.strictEqual(clientRequest.writable, false);
 }));

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -1,27 +1,27 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
+const util = require('util');
+const stream = require('stream');
+
+function MyStream() {
+  stream.call(this);
+}
+util.inherits(MyStream, stream);
 
 const server = http.createServer(common.mustCall(function(req, res) {
-  console.log('Got a request, piping an OutgoingMessage to it.');
-  const outgointMessage = new OutgoingMessage();
-  outgointMessage.pipe(res);
+  console.log('Got a request, piping a stream to it.');
+  const myStream = new MyStream();
+  myStream.pipe(res);
 
-  setTimeout(() => {
+  process.nextTick(() => {
     console.log('Closing response.');
     res.end();
-    outgointMessage.emit('data', 'some data');
+    myStream.emit('data', 'some data');
 
     // If we got here - 'write after end' wasn't raised and the test passed.
-    setTimeout(() => server.close(), 10);
-  }, 10);
-
-  setInterval(() => {
-    console.log('Emitting some data to outgointMessage');
-    outgointMessage.emit('data', 'some data');
-  }, 1).unref();
-
+    process.nextTick(() => server.close());
+  });
 }));
 
 server.listen(0);

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -10,18 +10,16 @@ function MyStream() {
 util.inherits(MyStream, stream);
 
 const server = http.createServer(common.mustCall(function(req, res) {
-  console.log('Got a request, piping a stream to it.');
   const myStream = new MyStream();
   myStream.pipe(res);
 
-  process.nextTick(() => {
-    console.log('Closing response.');
+  process.nextTick(common.mustCall(() => {
     res.end();
     myStream.emit('data', 'some data');
 
     // If we got here - 'write after end' wasn't raised and the test passed.
-    process.nextTick(() => server.close());
-  });
+    process.nextTick(common.mustCall(() => server.close()));
+  }));
 }));
 
 server.listen(0);

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  console.log('Got a request, piping an OutgoingMessage to it.');
+  const outgointMessage = new OutgoingMessage();
+  outgointMessage.pipe(res);
+
+  setTimeout(() => {
+    console.log('Closing response.');
+    res.end();
+    outgointMessage.emit('data', 'some data');
+
+    // If we got here - 'write after end' wasn't raised and the test passed.
+    setTimeout(() => server.close(), 10);
+  }, 10);
+
+  setInterval(() => {
+    console.log('Emitting some data to outgointMessage');
+    outgointMessage.emit('data', 'some data');
+  }, 1).unref();
+
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  http.request({
+    port: server.address().port,
+    method: 'GET',
+    path: '/'
+  }).end();
+}));

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -4,6 +4,12 @@ const http = require('http');
 const util = require('util');
 const stream = require('stream');
 
+// Verify that when piping a stream to an `OutgoingMessage` (or a type that
+// inherits from `OutgoingMessage`), if data is emitted after the
+// `OutgoingMessage` was closed - no `write after end` error is raised (this
+// should be the case when piping - when writing data directly to the
+// `OutgoingMessage` this error should be raised).
+
 function MyStream() {
   stream.call(this);
 }


### PR DESCRIPTION
When an OutgoingMessage is closed (for example, using the `end`
method), its 'writable' property should be changed to false - since it
is not writable anymore. The 'writable' property should have the
opposite value of the 'finished' property.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http

Issue: #14023