### PR TITLE
doc, util, console: clarify ambiguous docs

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -246,9 +246,7 @@ console.log('count:', count);
 // Prints: count: 5, to stdout
 ```
 
-If formatting elements (e.g. `%d`) are not found in the first string then
-[`util.inspect()`][] is called on each argument and the resulting string
-values are concatenated. See [`util.format()`][] for more information.
+See [`util.format()`][] for more information.
 
 ### console.time(label)
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -177,20 +177,14 @@ util.format('%s:%s', 'foo');
 // Returns: 'foo:%s'
 ```
 
-If there are more arguments passed to the `util.format()` method than the
-number of placeholders, the extra arguments are coerced into strings (for
-objects and symbols, `util.inspect()` is used) then concatenated to the
-returned string, each delimited by a space.
+If there are more arguments passed to the `util.format()` method than the number
+of placeholders, the extra arguments are coerced into strings then concatenated
+to the returned string, each delimited by a space. Excessive arguments whose
+`typeof` is `'object'` or `'symbol'` (except `null`) will be transformed by
+`util.inspect()`.
 
 ```js
 util.format('%s:%s', 'foo', 'bar', 'baz'); // 'foo:bar baz'
-```
-
-Any non-object and non-symbol excessive argument will **not** have
-`util.inspect()` called on them.
-
-```js
-util.format('%s', 'foo', () => true); // 'foo () => true'
 ```
 
 If the first argument is not a string then `util.format()` returns

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -186,7 +186,14 @@ returned string, each delimited by a space.
 util.format('%s:%s', 'foo', 'bar', 'baz'); // 'foo:bar baz'
 ```
 
-If the first argument is not a format string then `util.format()` returns
+Any non-object and non-symbol excessive argument will **not** have
+`util.inspect()` called on them.
+
+```js
+util.format('%s', 'foo', () => true); // 'foo () => true'
+```
+
+If the first argument is not a string then `util.format()` returns
 a string that is the concatenation of all arguments separated by spaces.
 Each argument is converted to a string using `util.inspect()`.
 


### PR DESCRIPTION
Add clarification to the documentation on util.format() and console.log()
regarding how excessive arguments are treated when the first argument is
a non-format string compared to when it is not a string at all.

Fixes: https://github.com/nodejs/node/issues/13908

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, util, console