### PR TITLE
test: skip test-fs-readdir-ucs2 if no support

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -13,7 +13,6 @@ prefix parallel
 [$system==macos]
 
 [$arch==arm || $arch==arm64]
-test-fs-readdir-ucs2 : PASS,FLAKY
 test-npm-install:      PASS,FLAKY
 
 [$system==solaris] # Also applies to SmartOS

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -16,16 +16,20 @@ const root = Buffer.from(`${common.tmpDir}${path.sep}`);
 const filebuff = Buffer.from(filename, 'ucs2');
 const fullpath = Buffer.concat([root, filebuff]);
 
-fs.closeSync(fs.openSync(fullpath, 'w+'));
+try {
+  fs.closeSync(fs.openSync(fullpath, 'w+'));
+} catch (e) {
+  if (e.code === 'EINVAL') {
+    common.skip('test requires filesystem that supports UCS2');
+    return;
+  }
+  throw e;
+}
 
-fs.readdir(common.tmpDir, 'ucs2', (err, list) => {
+fs.readdir(common.tmpDir, 'ucs2', common.mustCall((err, list) => {
   assert.ifError(err);
   assert.strictEqual(1, list.length);
   const fn = list[0];
   assert.deepStrictEqual(filebuff, Buffer.from(fn, 'ucs2'));
   assert.strictEqual(fn, filename);
-});
-
-process.on('exit', () => {
-  fs.unlinkSync(fullpath);
-});
+}));


### PR DESCRIPTION
If the filesystem does not support UCS2, do not run the test.

Fixes: https://github.com/nodejs/node/issues/14028

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs