### PR TITLE
path: Fix the error message of path.format

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -960,7 +960,7 @@ const win32 = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
-                                typeof pathObject);
+                                pathObject);
     }
     return _format('\\', pathObject);
   },
@@ -1503,7 +1503,7 @@ const posix = {
   format: function format(pathObject) {
     if (pathObject === null || typeof pathObject !== 'object') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pathObject', 'Object',
-                                typeof pathObject);
+                                pathObject);
     }
     return _format('/', pathObject);
   },

--- a/test/parallel/test-path-format-error.js
+++ b/test/parallel/test-path-format-error.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const assert = require('assert');
+
+const invalidInput = [
+  111,
+  'foo',
+  undefined,
+  () => {}
+];
+invalidInput.forEach((val) => {
+  const err = common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "pathObject" argument must be of type Object. ' +
+             `Received type ${typeof val}`
+  });
+  assert.throws(function() {
+    path.format(val);
+  }, err);
+});


### PR DESCRIPTION
The last argument of `invalidArgType(name, expected, actual)` in internal/errors.js is an actual value, NOT the type of actual value.

This causes:
```js
path.format(123)
//=> TypeError [ERR_INVALID_ARG_TYPE]: The "pathObject" argument must be of type Object. Received type string
```
The last word "string" should be "number".

A parallel test is added for this method.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
path