### PR TITLE
lib: fix urlObject parameter name in url.format

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -550,22 +550,23 @@ function autoEscapeStr(rest) {
 }
 
 // format a parsed object into a url string
-function urlFormat(obj, options) {
+function urlFormat(urlObject, options) {
   // ensure it's an object, and not a string url.
-  // If it's an obj, this is a no-op.
-  // this way, you can call url_format() on strings
+  // If it's an object, this is a no-op.
+  // this way, you can call urlParse() on strings
   // to clean up potentially wonky urls.
-  if (typeof obj === 'string') {
-    obj = urlParse(obj);
-  } else if (typeof obj !== 'object' || obj === null) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'urlObj', 'object', obj);
-  } else if (!(obj instanceof Url)) {
-    var format = obj[formatSymbol];
+  if (typeof urlObject === 'string') {
+    urlObject = urlParse(urlObject);
+  } else if (typeof urlObject !== 'object' || urlObject === null) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'urlObject',
+                               ['object', 'string'], urlObject);
+  } else if (!(urlObject instanceof Url)) {
+    var format = urlObject[formatSymbol];
     return format ?
-      format.call(obj, options) :
-      Url.prototype.format.call(obj);
+      format.call(urlObject, options) :
+      Url.prototype.format.call(urlObject);
   }
-  return obj.format();
+  return urlObject.format();
 }
 
 Url.prototype.format = function format() {

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -13,14 +13,14 @@ const throwsObjsAndReportTypes = new Map([
   [Symbol('foo'), 'symbol']
 ]);
 
-for (const [obj, type] of throwsObjsAndReportTypes) {
+for (const [urlObject, type] of throwsObjsAndReportTypes) {
   const error = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "urlObj" argument must be of type object. ' +
+    message: 'The "urlObject" argument must be one of type object or string. ' +
              `Received type ${type}`
   });
-  assert.throws(function() { url.format(obj); }, error);
+  assert.throws(function() { url.format(urlObject); }, error);
 }
 assert.strictEqual(url.format(''), '');
 assert.strictEqual(url.format({}), '');


### PR DESCRIPTION
Fixed typo in error message to output the right parameter name `url` instead of `objUrl`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
lib