### PR TITLE
repl, url, tools: use no-use-before-define ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -78,6 +78,9 @@ rules:
   no-delete-var: 2
   no-undef: 2
   no-unused-vars: [2, {args: none}]
+  no-use-before-define: [2, {classes: true,
+                             functions: false,
+                             variables: false}]
 
   # Node.js and CommonJS
   # http://eslint.org/docs/rules/#nodejs-and-commonjs

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -90,6 +90,112 @@ class URLContext {
   }
 }
 
+class URLSearchParams {
+  // URL Standard says the default value is '', but as undefined and '' have
+  // the same result, undefined is used to prevent unnecessary parsing.
+  // Default parameter is necessary to keep URLSearchParams.length === 0 in
+  // accordance with Web IDL spec.
+  constructor(init = undefined) {
+    if (init === null || init === undefined) {
+      this[searchParams] = [];
+    } else if ((typeof init === 'object' && init !== null) ||
+               typeof init === 'function') {
+      const method = init[Symbol.iterator];
+      if (method === this[Symbol.iterator]) {
+        // While the spec does not have this branch, we can use it as a
+        // shortcut to avoid having to go through the costly generic iterator.
+        const childParams = init[searchParams];
+        this[searchParams] = childParams.slice();
+      } else if (method !== null && method !== undefined) {
+        if (typeof method !== 'function') {
+          throw new errors.TypeError('ERR_ARG_NOT_ITERABLE', 'Query pairs');
+        }
+
+        // sequence<sequence<USVString>>
+        // Note: per spec we have to first exhaust the lists then process them
+        const pairs = [];
+        for (const pair of init) {
+          if ((typeof pair !== 'object' && typeof pair !== 'function') ||
+              pair === null ||
+              typeof pair[Symbol.iterator] !== 'function') {
+            throw new errors.TypeError('ERR_INVALID_TUPLE', 'Each query pair',
+                                       '[name, value]');
+          }
+          const convertedPair = [];
+          for (const element of pair)
+            convertedPair.push(toUSVString(element));
+          pairs.push(convertedPair);
+        }
+
+        this[searchParams] = [];
+        for (const pair of pairs) {
+          if (pair.length !== 2) {
+            throw new errors.TypeError('ERR_INVALID_TUPLE', 'Each query pair',
+                                       '[name, value]');
+          }
+          this[searchParams].push(pair[0], pair[1]);
+        }
+      } else {
+        // record<USVString, USVString>
+        // Need to use reflection APIs for full spec compliance.
+        this[searchParams] = [];
+        const keys = Reflect.ownKeys(init);
+        for (var i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          const desc = Reflect.getOwnPropertyDescriptor(init, key);
+          if (desc !== undefined && desc.enumerable) {
+            const typedKey = toUSVString(key);
+            const typedValue = toUSVString(init[key]);
+            this[searchParams].push(typedKey, typedValue);
+          }
+        }
+      }
+    } else {
+      // USVString
+      init = toUSVString(init);
+      if (init[0] === '?') init = init.slice(1);
+      initSearchParams(this, init);
+    }
+
+    // "associated url object"
+    this[context] = null;
+  }
+
+  [util.inspect.custom](recurseTimes, ctx) {
+    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
+      throw new errors.TypeError('ERR_INVALID_THIS', 'URLSearchParams');
+    }
+
+    if (typeof recurseTimes === 'number' && recurseTimes < 0)
+      return ctx.stylize('[Object]', 'special');
+
+    var separator = ', ';
+    var innerOpts = Object.assign({}, ctx);
+    if (recurseTimes !== null) {
+      innerOpts.depth = recurseTimes - 1;
+    }
+    var innerInspect = (v) => util.inspect(v, innerOpts);
+
+    var list = this[searchParams];
+    var output = [];
+    for (var i = 0; i < list.length; i += 2)
+      output.push(`${innerInspect(list[i])} => ${innerInspect(list[i + 1])}`);
+
+    var colorRe = /\u001b\[\d\d?m/g;
+    var length = output.reduce(
+      (prev, cur) => prev + cur.replace(colorRe, '').length + separator.length,
+      -separator.length
+    );
+    if (length > ctx.breakLength) {
+      return `${this.constructor.name} {\n  ${output.join(',\n  ')} }`;
+    } else if (output.length) {
+      return `${this.constructor.name} { ${output.join(separator)} }`;
+    } else {
+      return `${this.constructor.name} {}`;
+    }
+  }
+}
+
 function onParseComplete(flags, protocol, username, password,
                          host, port, path, query, fragment) {
   var ctx = this[context];
@@ -803,112 +909,6 @@ function defineIDLClass(proto, classStr, obj) {
       configurable: true,
       value: obj[key]
     });
-  }
-}
-
-class URLSearchParams {
-  // URL Standard says the default value is '', but as undefined and '' have
-  // the same result, undefined is used to prevent unnecessary parsing.
-  // Default parameter is necessary to keep URLSearchParams.length === 0 in
-  // accordance with Web IDL spec.
-  constructor(init = undefined) {
-    if (init === null || init === undefined) {
-      this[searchParams] = [];
-    } else if ((typeof init === 'object' && init !== null) ||
-               typeof init === 'function') {
-      const method = init[Symbol.iterator];
-      if (method === this[Symbol.iterator]) {
-        // While the spec does not have this branch, we can use it as a
-        // shortcut to avoid having to go through the costly generic iterator.
-        const childParams = init[searchParams];
-        this[searchParams] = childParams.slice();
-      } else if (method !== null && method !== undefined) {
-        if (typeof method !== 'function') {
-          throw new errors.TypeError('ERR_ARG_NOT_ITERABLE', 'Query pairs');
-        }
-
-        // sequence<sequence<USVString>>
-        // Note: per spec we have to first exhaust the lists then process them
-        const pairs = [];
-        for (const pair of init) {
-          if ((typeof pair !== 'object' && typeof pair !== 'function') ||
-              pair === null ||
-              typeof pair[Symbol.iterator] !== 'function') {
-            throw new errors.TypeError('ERR_INVALID_TUPLE', 'Each query pair',
-                                       '[name, value]');
-          }
-          const convertedPair = [];
-          for (const element of pair)
-            convertedPair.push(toUSVString(element));
-          pairs.push(convertedPair);
-        }
-
-        this[searchParams] = [];
-        for (const pair of pairs) {
-          if (pair.length !== 2) {
-            throw new errors.TypeError('ERR_INVALID_TUPLE', 'Each query pair',
-                                       '[name, value]');
-          }
-          this[searchParams].push(pair[0], pair[1]);
-        }
-      } else {
-        // record<USVString, USVString>
-        // Need to use reflection APIs for full spec compliance.
-        this[searchParams] = [];
-        const keys = Reflect.ownKeys(init);
-        for (var i = 0; i < keys.length; i++) {
-          const key = keys[i];
-          const desc = Reflect.getOwnPropertyDescriptor(init, key);
-          if (desc !== undefined && desc.enumerable) {
-            const typedKey = toUSVString(key);
-            const typedValue = toUSVString(init[key]);
-            this[searchParams].push(typedKey, typedValue);
-          }
-        }
-      }
-    } else {
-      // USVString
-      init = toUSVString(init);
-      if (init[0] === '?') init = init.slice(1);
-      initSearchParams(this, init);
-    }
-
-    // "associated url object"
-    this[context] = null;
-  }
-
-  [util.inspect.custom](recurseTimes, ctx) {
-    if (!this || !this[searchParams] || this[searchParams][searchParams]) {
-      throw new errors.TypeError('ERR_INVALID_THIS', 'URLSearchParams');
-    }
-
-    if (typeof recurseTimes === 'number' && recurseTimes < 0)
-      return ctx.stylize('[Object]', 'special');
-
-    var separator = ', ';
-    var innerOpts = Object.assign({}, ctx);
-    if (recurseTimes !== null) {
-      innerOpts.depth = recurseTimes - 1;
-    }
-    var innerInspect = (v) => util.inspect(v, innerOpts);
-
-    var list = this[searchParams];
-    var output = [];
-    for (var i = 0; i < list.length; i += 2)
-      output.push(`${innerInspect(list[i])} => ${innerInspect(list[i + 1])}`);
-
-    var colorRe = /\u001b\[\d\d?m/g;
-    var length = output.reduce(
-      (prev, cur) => prev + cur.replace(colorRe, '').length + separator.length,
-      -separator.length
-    );
-    if (length > ctx.breakLength) {
-      return `${this.constructor.name} {\n  ${output.join(',\n  ')} }`;
-    } else if (output.length) {
-      return `${this.constructor.name} { ${output.join(separator)} }`;
-    } else {
-      return `${this.constructor.name} {}`;
-    }
   }
 }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -740,6 +740,7 @@ function complete(line, callback) {
   var completeOn, i, group, c;
 
   // REPL commands (e.g. ".break").
+  var filter;
   var match = null;
   match = line.match(/^\s*\.(\w*)$/);
   if (match) {
@@ -759,7 +760,7 @@ function complete(line, callback) {
 
     completeOn = match[1];
     var subdir = match[2] || '';
-    var filter = match[1];
+    filter = match[1];
     var dir, files, f, name, base, ext, abs, subfiles, s;
     group = [];
     var paths = module.paths.concat(require('module').globalPaths);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl, url, tools

**Prehistory**

In https://github.com/nodejs/node/pull/14021, I've committed something like this by an oversight:
```js
const assert = require('assert');
if (!common.hasCrypto)
  common.skip('missing crypto');

const common = require('../common');
```
`assert` and `common` lines was erroneously swapped. [All tests have failed except linter.](https://ci.nodejs.org/job/node-test-commit/10865/)

ESLint has a rule for these cases: http://eslint.org/docs/rules/no-use-before-define

It has 3 options for classes, functions, and variables. I've left the class function on (defaults) as its violation is noted to be potentially dangerous. I've set the function option off as this is considered safe due to hoisting. And I've set the variable option off as we have many cases with cross-references from callbacks which are rather difficult to refactor. But with this option off, the rule will still check cases inside the same scope, like my above-mentioned error.

The first commit fixes 2 fragments in libs, the second one applies the rule.