### PR TITLE
doc: fix padding mode of crypto.publicDecrypt

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1643,8 +1643,8 @@ added: v1.1.0
   - `key` {string} A PEM encoded private key.
   - `passphrase` {string} An optional passphrase for the private key.
   - `padding` {crypto.constants} An optional padding value defined in
-    `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING`,
-    `RSA_PKCS1_PADDING`, or `crypto.constants.RSA_PKCS1_OAEP_PADDING`.
+    `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING` or
+    `RSA_PKCS1_PADDING`.
 - `buffer` {Buffer | TypedArray | DataView}
 
 Decrypts `buffer` with `publicKey`.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
fix padding mode of crypto.publicDecrypt.
crypto.publicDecrypt does not support `RSA_PKCS1_OAEP_PADDING` padding mode.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, crypto