### PR TITLE
async_hooks: C++ Embedder API overhaul

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -770,8 +770,8 @@ async_context EmitAsyncInit(Isolate* isolate,
     trigger_async_id = env->get_init_trigger_id();
 
   async_context context = {
-    env->new_async_id(), // async_id_
-    trigger_async_id // trigger_async_id_
+    env->new_async_id(),  // async_id_
+    trigger_async_id  // trigger_async_id_
   };
 
   // Run init hooks

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -751,7 +751,7 @@ async_uid AsyncHooksGetCurrentId(Isolate* isolate) {
 
 
 async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
-  return Environment::GetCurrent(isolate)->get_init_trigger_id();
+  return Environment::GetCurrent(isolate)->trigger_id();
 }
 
 async_uid AsyncHooksGetTriggerId(Isolate* isolate) {

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -778,14 +778,14 @@ async_context EmitAsyncInit(Isolate* isolate,
   Local<String> type =
       String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized)
           .ToLocalChecked();
-  AsyncWrap::EmitAsyncInit(env, resource, type, context.async_id_,
-                           context.trigger_async_id_);
+  AsyncWrap::EmitAsyncInit(env, resource, type, context.async_id,
+                           context.trigger_async_id);
 
   return context;
 }
 
 void EmitAsyncDestroy(Isolate* isolate, async_context asyncContext) {
-  PushBackDestroyId(Environment::GetCurrent(isolate), asyncContext.async_id_);
+  PushBackDestroyId(Environment::GetCurrent(isolate), asyncContext.async_id);
 }
 
 }  // namespace node

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -741,20 +741,20 @@ Local<Value> AsyncWrap::MakeCallback(const Local<Function> cb,
 /* Public C++ embedder API */
 
 
-async_uid AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
+async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->current_async_id();
 }
 
-async_uid AsyncHooksGetCurrentId(Isolate* isolate) {
+async_id AsyncHooksGetCurrentId(Isolate* isolate) {
   return AsyncHooksGetExecutionAsyncId(isolate);
 }
 
 
-async_uid AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
+async_id AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->trigger_id();
 }
 
-async_uid AsyncHooksGetTriggerId(Isolate* isolate) {
+async_id AsyncHooksGetTriggerId(Isolate* isolate) {
   return AsyncHooksGetTriggerAsyncId(isolate);
 }
 
@@ -762,31 +762,31 @@ async_uid AsyncHooksGetTriggerId(Isolate* isolate) {
 async_context EmitAsyncInit(Isolate* isolate,
                             Local<Object> resource,
                             const char* name,
-                            async_uid trigger_async_id) {
+                            async_id trigger_async_id) {
   Environment* env = Environment::GetCurrent(isolate);
 
   // Initialize async context struct
   async_context context = {};
-  context.async_id = env->new_async_id();
+  context.async_id_ = env->new_async_id();
 
   if (trigger_async_id == -1) {
-    context.trigger_async_id = env->get_init_trigger_id();
+    context.trigger_async_id_ = env->get_init_trigger_id();
   } else {
-    context.trigger_async_id = trigger_async_id;
+    context.trigger_async_id_ = trigger_async_id;
   }
 
   // Run init hooks
   Local<String> type =
       String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized)
           .ToLocalChecked();
-  AsyncWrap::EmitAsyncInit(env, resource, type, context.async_id,
-                           context.trigger_async_id);
+  AsyncWrap::EmitAsyncInit(env, resource, type, context.async_id_,
+                           context.trigger_async_id_);
 
   return context;
 }
 
 void EmitAsyncDestroy(Isolate* isolate, async_context asyncContext) {
-  PushBackDestroyId(Environment::GetCurrent(isolate), asyncContext.async_id);
+  PushBackDestroyId(Environment::GetCurrent(isolate), asyncContext.async_id_);
 }
 
 }  // namespace node

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -766,14 +766,13 @@ async_context EmitAsyncInit(Isolate* isolate,
   Environment* env = Environment::GetCurrent(isolate);
 
   // Initialize async context struct
-  async_context context = {};
-  context.async_id_ = env->new_async_id();
+  if (trigger_async_id == -1)
+    trigger_async_id = env->get_init_trigger_id();
 
-  if (trigger_async_id == -1) {
-    context.trigger_async_id_ = env->get_init_trigger_id();
-  } else {
-    context.trigger_async_id_ = trigger_async_id;
-  }
+  async_context context = {
+    env->new_async_id(), // async_id_
+    trigger_async_id // trigger_async_id_
+  };
 
   // Run init hooks
   Local<String> type =

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -604,7 +604,7 @@ bool Agent::StartIoThread(bool wait_for_connect) {
     message
   };
   MakeCallback(parent_env_->isolate(), process_object, emit_fn.As<Function>(),
-               arraysize(argv), argv, 0, 0);
+               arraysize(argv), argv, {0, 0});
 
   return true;
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -363,7 +363,7 @@ static void CheckImmediate(uv_check_t* handle) {
                env->immediate_callback_string(),
                0,
                nullptr,
-               0, 0).ToLocalChecked();
+               {0, 0}).ToLocalChecked();
 }
 
 
@@ -1298,8 +1298,7 @@ MaybeLocal<Value> MakeCallback(Environment* env,
                                const Local<Function> callback,
                                int argc,
                                Local<Value> argv[],
-                               double async_id,
-                               double trigger_id) {
+                               async_context asyncContext) {
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
@@ -1321,10 +1320,12 @@ MaybeLocal<Value> MakeCallback(Environment* env,
   MaybeLocal<Value> ret;
 
   {
-    AsyncHooks::ExecScope exec_scope(env, async_id, trigger_id);
+    AsyncHooks::ExecScope exec_scope(env, asyncContext.async_id,
+                                     asyncContext.trigger_async_id);
 
-    if (async_id != 0) {
-      if (!AsyncWrap::EmitBefore(env, async_id)) return Local<Value>();
+    if (asyncContext.async_id != 0) {
+      if (!AsyncWrap::EmitBefore(env, asyncContext.async_id))
+        return Local<Value>();
     }
 
     ret = callback->Call(env->context(), recv, argc, argv);
@@ -1336,8 +1337,9 @@ MaybeLocal<Value> MakeCallback(Environment* env,
           ret : Undefined(env->isolate());
     }
 
-    if (async_id != 0) {
-      if (!AsyncWrap::EmitAfter(env, async_id)) return Local<Value>();
+    if (asyncContext.async_id != 0) {
+      if (!AsyncWrap::EmitAfter(env, asyncContext.async_id))
+        return Local<Value>();
     }
   }
 
@@ -1358,8 +1360,8 @@ MaybeLocal<Value> MakeCallback(Environment* env,
 
   // Make sure the stack unwound properly. If there are nested MakeCallback's
   // then it should return early and not reach this code.
-  CHECK_EQ(env->current_async_id(), async_id);
-  CHECK_EQ(env->trigger_id(), trigger_id);
+  CHECK_EQ(env->current_async_id(), asyncContext.async_id);
+  CHECK_EQ(env->trigger_id(), asyncContext.trigger_async_id);
 
   Local<Object> process = env->process_object();
 
@@ -1384,13 +1386,11 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
                                const char* method,
                                int argc,
                                Local<Value> argv[],
-                               async_uid async_id,
-                               async_uid trigger_id) {
+                               async_context asyncContext) {
   Local<String> method_string =
       String::NewFromUtf8(isolate, method, v8::NewStringType::kNormal)
           .ToLocalChecked();
-  return MakeCallback(isolate, recv, method_string, argc, argv,
-                      async_id, trigger_id);
+  return MakeCallback(isolate, recv, method_string, argc, argv, asyncContext);
 }
 
 
@@ -1399,14 +1399,12 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
                                Local<String> symbol,
                                int argc,
                                Local<Value> argv[],
-                               async_uid async_id,
-                               async_uid trigger_id) {
+                               async_context asyncContext) {
   Local<Value> callback_v = recv->Get(symbol);
   if (callback_v.IsEmpty()) return Local<Value>();
   if (!callback_v->IsFunction()) return Local<Value>();
   Local<Function> callback = callback_v.As<Function>();
-  return MakeCallback(isolate, recv, callback, argc, argv,
-                      async_id, trigger_id);
+  return MakeCallback(isolate, recv, callback, argc, argv, asyncContext);
 }
 
 
@@ -1415,8 +1413,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
                                Local<Function> callback,
                                int argc,
                                Local<Value> argv[],
-                               async_uid async_id,
-                               async_uid trigger_id) {
+                               async_context asyncContext) {
   // Observe the following two subtleties:
   //
   // 1. The environment is retrieved from the callback function's context.
@@ -1427,7 +1424,7 @@ MaybeLocal<Value> MakeCallback(Isolate* isolate,
   Environment* env = Environment::GetCurrent(callback->CreationContext());
   Context::Scope context_scope(env->context());
   return MakeCallback(env, recv.As<Value>(), callback, argc, argv,
-                      async_id, trigger_id);
+                      asyncContext);
 }
 
 
@@ -1440,7 +1437,7 @@ Local<Value> MakeCallback(Isolate* isolate,
                           Local<Value>* argv) {
   EscapableHandleScope handle_scope(isolate);
   return handle_scope.Escape(
-      MakeCallback(isolate, recv, method, argc, argv, 0, 0)
+      MakeCallback(isolate, recv, method, argc, argv, {0, 0})
           .FromMaybe(Local<Value>()));
 }
 
@@ -1452,7 +1449,7 @@ Local<Value> MakeCallback(Isolate* isolate,
     Local<Value>* argv) {
   EscapableHandleScope handle_scope(isolate);
   return handle_scope.Escape(
-      MakeCallback(isolate, recv, symbol, argc, argv, 0, 0)
+      MakeCallback(isolate, recv, symbol, argc, argv, {0, 0})
           .FromMaybe(Local<Value>()));
 }
 
@@ -1464,7 +1461,7 @@ Local<Value> MakeCallback(Isolate* isolate,
     Local<Value>* argv) {
   EscapableHandleScope handle_scope(isolate);
   return handle_scope.Escape(
-      MakeCallback(isolate, recv, callback, argc, argv, 0, 0)
+      MakeCallback(isolate, recv, callback, argc, argv, {0, 0})
           .FromMaybe(Local<Value>()));
 }
 
@@ -4425,7 +4422,7 @@ void EmitBeforeExit(Environment* env) {
   };
   MakeCallback(env->isolate(),
                process_object, "emit", arraysize(args), args,
-               0, 0).ToLocalChecked();
+               {0, 0}).ToLocalChecked();
 }
 
 
@@ -4446,7 +4443,7 @@ int EmitExit(Environment* env) {
 
   MakeCallback(env->isolate(),
                process_object, "emit", arraysize(args), args,
-               0, 0).ToLocalChecked();
+               {0, 0}).ToLocalChecked();
 
   // Reload exit code, it may be changed by `emit('exit')`
   return process_object->Get(exitCode)->Int32Value();

--- a/src/node.cc
+++ b/src/node.cc
@@ -1320,11 +1320,11 @@ MaybeLocal<Value> MakeCallback(Environment* env,
   MaybeLocal<Value> ret;
 
   {
-    AsyncHooks::ExecScope exec_scope(env, asyncContext.async_id_,
-                                     asyncContext.trigger_async_id_);
+    AsyncHooks::ExecScope exec_scope(env, asyncContext.async_id,
+                                     asyncContext.trigger_async_id);
 
-    if (asyncContext.async_id_ != 0) {
-      if (!AsyncWrap::EmitBefore(env, asyncContext.async_id_))
+    if (asyncContext.async_id != 0) {
+      if (!AsyncWrap::EmitBefore(env, asyncContext.async_id))
         return Local<Value>();
     }
 
@@ -1337,8 +1337,8 @@ MaybeLocal<Value> MakeCallback(Environment* env,
           ret : Undefined(env->isolate());
     }
 
-    if (asyncContext.async_id_ != 0) {
-      if (!AsyncWrap::EmitAfter(env, asyncContext.async_id_))
+    if (asyncContext.async_id != 0) {
+      if (!AsyncWrap::EmitAfter(env, asyncContext.async_id))
         return Local<Value>();
     }
   }
@@ -1360,8 +1360,8 @@ MaybeLocal<Value> MakeCallback(Environment* env,
 
   // Make sure the stack unwound properly. If there are nested MakeCallback's
   // then it should return early and not reach this code.
-  CHECK_EQ(env->current_async_id(), asyncContext.async_id_);
-  CHECK_EQ(env->trigger_id(), asyncContext.trigger_async_id_);
+  CHECK_EQ(env->current_async_id(), asyncContext.async_id);
+  CHECK_EQ(env->trigger_id(), asyncContext.trigger_async_id);
 
   Local<Object> process = env->process_object();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -1320,11 +1320,11 @@ MaybeLocal<Value> MakeCallback(Environment* env,
   MaybeLocal<Value> ret;
 
   {
-    AsyncHooks::ExecScope exec_scope(env, asyncContext.async_id,
-                                     asyncContext.trigger_async_id);
+    AsyncHooks::ExecScope exec_scope(env, asyncContext.async_id_,
+                                     asyncContext.trigger_async_id_);
 
-    if (asyncContext.async_id != 0) {
-      if (!AsyncWrap::EmitBefore(env, asyncContext.async_id))
+    if (asyncContext.async_id_ != 0) {
+      if (!AsyncWrap::EmitBefore(env, asyncContext.async_id_))
         return Local<Value>();
     }
 
@@ -1337,8 +1337,8 @@ MaybeLocal<Value> MakeCallback(Environment* env,
           ret : Undefined(env->isolate());
     }
 
-    if (asyncContext.async_id != 0) {
-      if (!AsyncWrap::EmitAfter(env, asyncContext.async_id))
+    if (asyncContext.async_id_ != 0) {
+      if (!AsyncWrap::EmitAfter(env, asyncContext.async_id_))
         return Local<Value>();
     }
   }
@@ -1360,8 +1360,8 @@ MaybeLocal<Value> MakeCallback(Environment* env,
 
   // Make sure the stack unwound properly. If there are nested MakeCallback's
   // then it should return early and not reach this code.
-  CHECK_EQ(env->current_async_id(), asyncContext.async_id);
-  CHECK_EQ(env->trigger_id(), asyncContext.trigger_async_id);
+  CHECK_EQ(env->current_async_id(), asyncContext.async_id_);
+  CHECK_EQ(env->trigger_id(), asyncContext.trigger_async_id_);
 
   Local<Object> process = env->process_object();
 

--- a/src/node.h
+++ b/src/node.h
@@ -518,10 +518,10 @@ typedef void (*promise_hook_func) (v8::PromiseHookType type,
                                    void* arg);
 
 typedef double async_id;
-typedef struct async_context {
+struct async_context {
   async_id async_id_;
   async_id trigger_async_id_;
-} async_context;
+};
 
 /* Registers an additional v8::PromiseHook wrapper. This API exists because V8
  * itself supports only a single PromiseHook. */

--- a/src/node.h
+++ b/src/node.h
@@ -652,6 +652,10 @@ class AsyncResource {
     async_id get_async_id() const {
       return async_context_.async_id;
     }
+
+    async_id get_trigger_async_id() const {
+      return async_context_.trigger_async_id;
+    }
   private:
     v8::Isolate* isolate_;
     v8::Persistent<v8::Object> resource_;

--- a/src/node.h
+++ b/src/node.h
@@ -519,8 +519,8 @@ typedef void (*promise_hook_func) (v8::PromiseHookType type,
 
 typedef double async_id;
 struct async_context {
-  async_id async_id_;
-  async_id trigger_async_id_;
+  ::node::async_id async_id;
+  ::node::async_id trigger_async_id;
 };
 
 /* Registers an additional v8::PromiseHook wrapper. This API exists because V8
@@ -644,7 +644,7 @@ class AsyncResource {
     }
 
     async_id get_uid() const {
-      return async_context_.async_id_;
+      return async_context_.async_id;
     }
   private:
     v8::Isolate* isolate_;

--- a/src/node.h
+++ b/src/node.h
@@ -604,7 +604,7 @@ class AsyncResource {
           resource_(isolate, resource),
           trigger_async_id_(trigger_async_id) {
       if (trigger_async_id_ == -1)
-        trigger_async_id_ = AsyncHooksGetTriggerAsyncId(isolate);
+        trigger_async_id_ = Environment::GetCurrent(isolate)->get_init_trigger_id();
 
       uid_ = EmitAsyncInit(isolate, resource, name, trigger_async_id_);
     }

--- a/src/node.h
+++ b/src/node.h
@@ -145,7 +145,7 @@ inline v8::Local<v8::Value> UVException(int errorno,
  * These methods need to be called in a HandleScope.
  *
  * It is preferred that you use the `MakeCallback` overloads taking
- * `async_uid` arguments.
+ * `async_id` arguments.
  */
 
 NODE_EXTERN v8::Local<v8::Value> MakeCallback(
@@ -517,10 +517,10 @@ typedef void (*promise_hook_func) (v8::PromiseHookType type,
                                    v8::Local<v8::Value> parent,
                                    void* arg);
 
-typedef double async_uid;
+typedef double async_id;
 typedef struct async_context {
-  async_uid async_id;
-  async_uid trigger_async_id;
+  async_id async_id_;
+  async_id trigger_async_id_;
 } async_context;
 
 /* Registers an additional v8::PromiseHook wrapper. This API exists because V8
@@ -532,17 +532,17 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
 /* Returns the id of the current execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
-NODE_EXTERN async_uid AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
+NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 /* legacy alias */
 NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetExecutionAsyncId(isolate)",
-                async_uid AsyncHooksGetCurrentId(v8::Isolate* isolate));
+                async_id AsyncHooksGetCurrentId(v8::Isolate* isolate));
 
 
 /* Return same value as async_hooks.triggerAsyncId(); */
-NODE_EXTERN async_uid AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
+NODE_EXTERN async_id AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
 /* legacy alias */
 NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
-                async_uid AsyncHooksGetTriggerId(v8::Isolate* isolate));
+                async_id AsyncHooksGetTriggerId(v8::Isolate* isolate));
 
 
 /* If the native API doesn't inherit from the helper class then the callbacks
@@ -555,7 +555,7 @@ NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
 NODE_EXTERN async_context EmitAsyncInit(v8::Isolate* isolate,
                                         v8::Local<v8::Object> resource,
                                         const char* name,
-                                        async_uid trigger_async_id = -1);
+                                        async_id trigger_async_id = -1);
 
 /* Emit the destroy() callback. */
 NODE_EXTERN void EmitAsyncDestroy(v8::Isolate* isolate,
@@ -601,7 +601,7 @@ class AsyncResource {
     AsyncResource(v8::Isolate* isolate,
                   v8::Local<v8::Object> resource,
                   const char* name,
-                  async_uid trigger_async_id = -1)
+                  async_id trigger_async_id = -1)
         : isolate_(isolate),
           resource_(isolate, resource) {
       async_context_ = EmitAsyncInit(isolate, resource, name,
@@ -643,8 +643,8 @@ class AsyncResource {
       return resource_.Get(isolate_);
     }
 
-    async_uid get_uid() const {
-      return async_context_.async_id;
+    async_id get_uid() const {
+      return async_context_.async_id_;
     }
   private:
     v8::Isolate* isolate_;

--- a/src/node.h
+++ b/src/node.h
@@ -643,7 +643,13 @@ class AsyncResource {
       return resource_.Get(isolate_);
     }
 
-    async_id get_uid() const {
+    NODE_DEPRECATED("Use AsyncResource::get_async_id()",
+      async_id get_uid() const {
+        return get_async_id();
+      }
+    )
+
+    async_id get_async_id() const {
       return async_context_.async_id;
     }
   private:

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1237,7 +1237,7 @@ int SecureContext::TicketKeyCallback(SSL* ssl,
                                         env->ticketkeycallback_string(),
                                         arraysize(argv),
                                         argv,
-                                        0, 0).ToLocalChecked();
+                                        {0, 0}).ToLocalChecked();
   Local<Array> arr = ret.As<Array>();
 
   int r = arr->Get(kTicketKeyReturnIndex)->Int32Value();

--- a/test/addons/async-hooks-id/binding.cc
+++ b/test/addons/async-hooks-id/binding.cc
@@ -1,0 +1,27 @@
+#include "node.h"
+
+namespace {
+
+using v8::FunctionCallbackInfo;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+void GetExecutionAsyncId(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(
+    node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
+}
+
+void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(
+    node::AsyncHooksGetTriggerAsyncId(args.GetIsolate()));
+}
+
+void Initialize(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "getExecutionAsyncId", GetExecutionAsyncId);
+  NODE_SET_METHOD(exports, "getTriggerAsyncId", GetTriggerAsyncId);
+}
+
+}  // namespace
+
+NODE_MODULE(binding, Initialize)

--- a/test/addons/async-hooks-id/binding.gyp
+++ b/test/addons/async-hooks-id/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/async-hooks-id/test.js
+++ b/test/addons/async-hooks-id/test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const binding = require(`./build/${common.buildType}/binding`);
+const async_hooks = require('async_hooks');
+
+assert.strictEqual(
+  binding.getExecutionAsyncId(),
+  async_hooks.executionAsyncId()
+);
+assert.strictEqual(
+  binding.getTriggerAsyncId(),
+  async_hooks.triggerAsyncId()
+);
+
+process.nextTick(common.mustCall(function() {
+  assert.strictEqual(
+    binding.getExecutionAsyncId(),
+    async_hooks.executionAsyncId()
+  );
+  assert.strictEqual(
+    binding.getTriggerAsyncId(),
+    async_hooks.triggerAsyncId()
+  );
+}));

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -92,11 +92,6 @@ void GetResource(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(r->get_resource());
 }
 
-void GetCurrentId(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(
-    node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
-}
-
 void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "createAsyncResource", CreateAsyncResource);
   NODE_SET_METHOD(exports, "destroyAsyncResource", DestroyAsyncResource);
@@ -105,7 +100,6 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "callViaUtf8Name", CallViaUtf8Name);
   NODE_SET_METHOD(exports, "getUid", GetUid);
   NODE_SET_METHOD(exports, "getResource", GetResource);
-  NODE_SET_METHOD(exports, "getCurrentId", GetCurrentId);
 }
 
 }  // namespace

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -80,10 +80,10 @@ void CallViaUtf8Name(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret.FromMaybe(Local<Value>()));
 }
 
-void GetUid(const FunctionCallbackInfo<Value>& args) {
+void GetAsyncId(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
   auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
-  args.GetReturnValue().Set(r->get_uid());
+  args.GetReturnValue().Set(r->get_async_id());
 }
 
 void GetResource(const FunctionCallbackInfo<Value>& args) {
@@ -98,7 +98,7 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "callViaFunction", CallViaFunction);
   NODE_SET_METHOD(exports, "callViaString", CallViaString);
   NODE_SET_METHOD(exports, "callViaUtf8Name", CallViaUtf8Name);
-  NODE_SET_METHOD(exports, "getUid", GetUid);
+  NODE_SET_METHOD(exports, "getAsyncId", GetAsyncId);
   NODE_SET_METHOD(exports, "getResource", GetResource);
 }
 

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -86,6 +86,12 @@ void GetAsyncId(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(r->get_async_id());
 }
 
+void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
+  assert(args[0]->IsExternal());
+  auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
+  args.GetReturnValue().Set(r->get_trigger_async_id());
+}
+
 void GetResource(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsExternal());
   auto r = static_cast<AsyncResource*>(args[0].As<External>()->Value());
@@ -99,6 +105,7 @@ void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "callViaString", CallViaString);
   NODE_SET_METHOD(exports, "callViaUtf8Name", CallViaUtf8Name);
   NODE_SET_METHOD(exports, "getAsyncId", GetAsyncId);
+  NODE_SET_METHOD(exports, "getTriggerAsyncId", GetTriggerAsyncId);
   NODE_SET_METHOD(exports, "getResource", GetResource);
 }
 

--- a/test/addons/async-resource/test.js
+++ b/test/addons/async-resource/test.js
@@ -65,7 +65,7 @@ for (const call of [binding.callViaFunction,
     const ret = call(resource);
     assert.strictEqual(ret, 'baz');
     assert.strictEqual(binding.getResource(resource), object);
-    assert.strictEqual(binding.getUid(resource), uid);
+    assert.strictEqual(binding.getAsyncId(resource), uid);
 
     binding.destroyAsyncResource(resource);
   }

--- a/test/addons/async-resource/test.js
+++ b/test/addons/async-resource/test.js
@@ -6,6 +6,7 @@ const binding = require(`./build/${common.buildType}/binding`);
 const async_hooks = require('async_hooks');
 
 const kObjectTag = Symbol('kObjectTag');
+const rootAsyncId = async_hooks.executionAsyncId();
 
 const bindingUids = [];
 let expectedTriggerId;
@@ -38,8 +39,6 @@ async_hooks.createHook({
   }
 }).enable();
 
-assert.strictEqual(binding.getCurrentId(), 1);
-
 for (const call of [binding.callViaFunction,
                     binding.callViaString,
                     binding.callViaUtf8Name]) {
@@ -49,14 +48,14 @@ for (const call of [binding.callViaFunction,
       methöd(arg) {
         assert.strictEqual(this, object);
         assert.strictEqual(arg, 42);
-        assert.strictEqual(binding.getCurrentId(), uid);
+        assert.strictEqual(async_hooks.executionAsyncId(), uid);
         return 'baz';
       },
       kObjectTag
     };
 
     if (passedTriggerId === undefined)
-      expectedTriggerId = 1;
+      expectedTriggerId = rootAsyncId;
     else
       expectedTriggerId = passedTriggerId;
 

--- a/test/addons/async-resource/test.js
+++ b/test/addons/async-resource/test.js
@@ -66,6 +66,7 @@ for (const call of [binding.callViaFunction,
     assert.strictEqual(ret, 'baz');
     assert.strictEqual(binding.getResource(resource), object);
     assert.strictEqual(binding.getAsyncId(resource), uid);
+    assert.strictEqual(binding.getTriggerAsyncId(resource), expectedTriggerId);
 
     binding.destroyAsyncResource(resource);
   }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks

I'm not sure how to split up the `AsyncHooksGetTriggerAsyncId` and the `async_context` commit. If someone has a specific suggestion I would be happy to do it.

* Fix `AsyncHooksGetTriggerAsyncId` such it corresponds to `async_hooks.triggerAsyncId` and not `async_hooks.initTriggerId`.
* Use an `async_context` struct instead of two `async_uid` values. This change was necessary since the fixing `AsyncHooksGetTriggerAsyncId` otherwise makes it impossible to get the correct default trigger id. It also prevents an invalid `triggerAsyncId` in `MakeCallback`.
* Rename `async_uid` to `async_id` for consistency.

/cc @nodejs/async_hooks 