### PR TITLE
assert: replace many if's with if-else statement

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -62,14 +62,14 @@ function innerFail(actual, expected, message, operator, stackStartFunction) {
 }
 
 function fail(actual, expected, message, operator, stackStartFunction) {
-  const args = arguments.length;
+  const argsLen = arguments.length;
 
-  if (args === 0) {
+  if (argsLen === 0) {
     message = 'Failed';
-  } else if (args === 1) {
+  } else if (argsLen === 1) {
     message = actual;
     actual = undefined;
-  } else if (args === 2) {
+  } else if (argsLen === 2) {
     operator = '!=';
   }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -62,18 +62,20 @@ function innerFail(actual, expected, message, operator, stackStartFunction) {
 }
 
 function fail(actual, expected, message, operator, stackStartFunction) {
-  if (arguments.length === 0) {
+  const args = arguments.length;
+
+  if (args === 0) {
     message = 'Failed';
-  }
-  if (arguments.length === 1) {
+  } else if (args === 1) {
     message = actual;
     actual = undefined;
-  }
-  if (arguments.length === 2) {
+  } else if (args === 2) {
     operator = '!=';
   }
+
   innerFail(actual, expected, message, operator, stackStartFunction || fail);
 }
+
 assert.fail = fail;
 
 // The AssertionError is defined in internal/error.


### PR DESCRIPTION
If assert.fail has less than 3 arguments then some conditions will
be applied. However after applying one of them there is no need to
check for others.

Tests are passing

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- `assert`
