### PR TITLE
tools: fix tools/addon-verify.js

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1073,7 +1073,6 @@ The following `addon.cc` implements AtExit:
 
 ```cpp
 // addon.cc
-#undef NDEBUG
 #include <assert.h>
 #include <stdlib.h>
 #include <node.h>

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1125,7 +1125,7 @@ Test in JavaScript by running:
 
 ```js
 // test.js
-const addon = require('./build/Release/addon');
+require('./build/Release/addon');
 ```
 
 [Embedder's Guide]: https://github.com/v8/v8/wiki/Embedder's%20Guide

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1109,10 +1109,10 @@ static void sanity_check(void*) {
 }
 
 void init(Local<Object> exports) {
-  AtExit(sanity_check);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb1, exports->GetIsolate());
+  AtExit(sanity_check);
 }
 
 NODE_MODULE(addon, init)


### PR DESCRIPTION
The current implementation of addon-verify.js is including the code
for the "Function arguments" section in test/addons/01_callbacks and
there is no directory generated or the "Function arguments section".
This continues and leads to the last section, "AtExit", code to be
excluded. There is an test/addons/07_atexit_hooks but it contains code
from the "Passing wrapped objects around" section.

This commit modifies addon-verify to associate headers with code and
then iterates over the set and generates the files as a separate step.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, test