### PR TITLE
benchmark: Improve event performance tests.

### DIFF
--- a/benchmark/events/ee-add-remove.js
+++ b/benchmark/events/ee-add-remove.js
@@ -16,10 +16,13 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    for (k = listeners.length; --k >= 0; /* empty */)
-      ee.on('dummy', listeners[k]);
-    for (k = listeners.length; --k >= 0; /* empty */)
-      ee.removeListener('dummy', listeners[k]);
+    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    for (k = listeners.length; --k >= 0; /* empty */) {
+      ee.on(dummy, listeners[k]);
+    }
+    for (k = listeners.length; --k >= 0; /* empty */) {
+      ee.removeListener(dummy, listeners[k]);
+    }
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-listener-count-on-prototype.js
+++ b/benchmark/events/ee-listener-count-on-prototype.js
@@ -9,12 +9,15 @@ function main(conf) {
 
   var ee = new EventEmitter();
 
-  for (var k = 0; k < 10; k += 1)
-    ee.on('dummy', function() {});
+  for (var k = 0; k < 5; k += 1) {
+    ee.on('dummy0', function() {});
+    ee.on('dummy1', function() {});
+  }
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    ee.listenerCount('dummy');
+    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    ee.listenerCount(dummy);
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-listeners-many.js
+++ b/benchmark/events/ee-listeners-many.js
@@ -10,12 +10,15 @@ function main(conf) {
   var ee = new EventEmitter();
   ee.setMaxListeners(101);
 
-  for (var k = 0; k < 100; k += 1)
-    ee.on('dummy', function() {});
+  for (var k = 0; k < 50; k += 1) {
+    ee.on('dummy0', function() {});
+    ee.on('dummy1', function() {});
+  }
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    ee.listeners('dummy');
+    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    ee.listeners(dummy);
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-listeners.js
+++ b/benchmark/events/ee-listeners.js
@@ -9,12 +9,15 @@ function main(conf) {
 
   var ee = new EventEmitter();
 
-  for (var k = 0; k < 10; k += 1)
-    ee.on('dummy', function() {});
+  for (var k = 0; k < 5; k += 1) {
+    ee.on('dummy0', function() {});
+    ee.on('dummy1', function() {});
+  }
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    ee.listeners('dummy');
+    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    ee.listeners(dummy);
   }
   bench.end(n);
 }

--- a/benchmark/events/ee-once.js
+++ b/benchmark/events/ee-once.js
@@ -13,8 +13,9 @@ function main(conf) {
 
   bench.start();
   for (var i = 0; i < n; i += 1) {
-    ee.once('dummy', listener);
-    ee.emit('dummy');
+    var dummy = (i % 2 === 0) ? 'dummy0' : 'dummy1';
+    ee.once(dummy, listener);
+    ee.emit(dummy);
   }
   bench.end(n);
 }


### PR DESCRIPTION
Currently most of the event tests only test a single event type,
which might let those benchmark take fast-paths (in V8) that aren't
taken in realistic use cases, and thus the benchmarks are not good
proxies of real world uses.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

benchmark