### PR TITLE
async_hooks: move statement

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -335,11 +335,6 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
     throw new RangeError('triggerAsyncId must be an unsigned integer');
 
   init(asyncId, type, triggerAsyncId, resource);
-
-  // Isn't null if hooks were added/removed while the hooks were running.
-  if (tmp_active_hooks_array !== null) {
-    restoreTmpHooks();
-  }
 }
 
 function emitHookFactory(symbol, name) {
@@ -442,6 +437,11 @@ function init(asyncId, type, triggerAsyncId, resource) {
     fatalError(e);
   }
   processing_hook = false;
+
+  // Isn't null if hooks were added/removed while the hooks were running.
+  if (tmp_active_hooks_array !== null) {
+    restoreTmpHooks();
+  }
 }
 
 

--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+const async_hooks = require('async_hooks');
+const crypto = require('crypto');
+
+const nestedHook = async_hooks.createHook({
+  init: common.mustCall()
+});
+
+async_hooks.createHook({
+  init: common.mustCall((id, type) => {
+    nestedHook.enable();
+  }, 2)
+}).enable();
+
+crypto.randomBytes(1, common.mustCall(() => {
+  crypto.randomBytes(1, common.mustCall());
+}));

--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const async_hooks = require('async_hooks');
-const crypto = require('crypto');
+const fs = require('fs');
 
 const nestedHook = async_hooks.createHook({
   init: common.mustCall()
@@ -14,6 +14,6 @@ async_hooks.createHook({
   }, 2)
 }).enable();
 
-crypto.randomBytes(1, common.mustCall(() => {
-  crypto.randomBytes(1, common.mustCall());
+fs.access(__filename, common.mustCall(() => {
+  fs.access(__filename, common.mustCall());
 }));


### PR DESCRIPTION
<s>The fatalError function is overloaded to receive either an error or a string. Instead, it would be simpler to just always provide a error.</s> Removed due to a conflict.

I <s>also</s> moved the `restoreTmpHooks` call. It seemed to be more appropriate in the init function. Ref https://github.com/nodejs/node/pull/13755#issuecomment-312616004

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks
