### PR TITLE
fs: two minor optimizations

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -521,7 +521,6 @@ function tryStatSync(fd, isUserFd) {
   } finally {
     if (threw && !isUserFd) fs.closeSync(fd);
   }
-  return !threw;
 }
 
 function tryCreateBuffer(size, fd, isUserFd) {
@@ -553,10 +552,11 @@ fs.readFileSync = function(path, options) {
   var isUserFd = isFd(path); // file descriptor ownership
   var fd = isUserFd ? path : fs.openSync(path, options.flag || 'r', 0o666);
 
+  tryStatSync(fd, isUserFd);
   // Use stats array directly to avoid creating an fs.Stats instance just for
   // our internal use.
   var size;
-  if (tryStatSync(fd, isUserFd) && (statValues[1/*mode*/] & S_IFMT) === S_IFREG)
+  if ((statValues[1/*mode*/] & S_IFMT) === S_IFREG)
     size = statValues[8/*size*/];
   else
     size = 0;
@@ -1085,7 +1085,7 @@ if (constants.O_SYMLINK !== undefined) {
         callback(err);
         return;
       }
-      // prefer to return the chmod error, if one occurs,
+      // Prefer to return the chmod error, if one occurs,
       // but still try to close, and report closing errors if they occur.
       fs.fchmod(fd, mode, function(err) {
         fs.close(fd, function(err2) {
@@ -1098,20 +1098,18 @@ if (constants.O_SYMLINK !== undefined) {
   fs.lchmodSync = function(path, mode) {
     var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
 
-    // prefer to return the chmod error, if one occurs,
+    // Prefer to return the chmod error, if one occurs,
     // but still try to close, and report closing errors if they occur.
-    var err, err2, ret;
+    var ret;
     try {
       ret = fs.fchmodSync(fd, mode);
-    } catch (er) {
-      err = er;
+    } catch (err) {
+      try {
+        fs.closeSync(fd);
+      } catch (ignore) {}
+      throw err;
     }
-    try {
-      fs.closeSync(fd);
-    } catch (er) {
-      err2 = er;
-    }
-    if (err || err2) throw (err || err2);
+    fs.closeSync(fd);
     return ret;
   };
 }


### PR DESCRIPTION
1) If the function in tryStatSync threw, it would never reach that code path to return any value.
2) Only use try catch if necessary. lchmodSync does not need the second try catch in most cases.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs