### PR TITLE
test: refactor expectsError

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -51,28 +51,41 @@ Platform normalizes the `dd` command
 Check if there is more than 1gb of total memory.
 
 ### expectsError([fn, ]settings[, exact])
-* `fn` [&lt;Function>]
+* `fn` [&lt;Function>] a function that should throw.
 * `settings` [&lt;Object>]
-  with the following optional properties:
+  that must contain the `code` property plus any of the other following
+  properties (some properties only apply for `AssertionError`):
   * `code` [&lt;String>]
-    expected error must have this value for its `code` property
+    expected error must have this value for its `code` property.
   * `type` [&lt;Function>]
-    expected error must be an instance of `type`
-  * `message` [&lt;String>]
-    or [&lt;RegExp>]
+    expected error must be an instance of `type` and must be an Error subclass.
+  * `message` [&lt;String>] or [&lt;RegExp>]
     if a string is provided for `message`, expected error must have it for its
     `message` property; if a regular expression is provided for `message`, the
-    regular expression must match the `message` property of the expected error
+    regular expression must match the `message` property of the expected error.
+  * `name` [&lt;String>]
+    expected error must have this value for its `name` property.
+  * `generatedMessage` [&lt;String>]
+    (`AssertionError` only) expected error must have this value for its
+    `generatedMessage` property.
+  * `actual` &lt;any>
+    (`AssertionError` only) expected error must have this value for its
+    `actual` property.
+  * `expected` &lt;any>
+    (`AssertionError` only) expected error must have this value for its
+    `expected` property.
+  * `operator` &lt;any>
+    (`AssertionError` only) expected error must have this value for its
+    `operator` property.
 * `exact` [&lt;Number>] default = 1
+* return [&lt;Function>]
 
-* return function suitable for use as a validation function passed as the second
-  argument to e.g. `assert.throws()`. If the returned function has not been
-  called exactly `exact` number of times when the test is complete, then the
-  test will fail.
-
-If `fn` is provided, it will be passed to `assert.throws` as first argument.
-
-The expected error should be [subclassed by the `internal/errors` module](https://github.com/nodejs/node/blob/master/doc/guides/using-internal-errors.md#api).
+  If `fn` is provided, it will be passed to `assert.throws` as first argument
+  and `undefined` will be returned.
+  Otherwise a function suitable as callback or for use as a validation function
+  passed as the second argument to `assert.throws()` will be returned. If the
+  returned function has not been called exactly `exact` number of times when the
+  test is complete, then the test will fail.
 
 ### expectWarning(name, expected)
 * `name` [&lt;String>]

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -166,7 +166,7 @@ assert.throws(() => {
   }, common.expectsError({ code: 'TEST_ERROR_1', type: RangeError }));
 }, common.expectsError({
   code: 'ERR_ASSERTION',
-  message: /^.+ is not the expected type \S/
+  message: /^.+ is not instance of \S/
 }));
 
 assert.throws(() => {


### PR DESCRIPTION
So far common.expectsError only tested `type`, `message` and `code` instead of all properties.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
