### PR TITLE
lib: fix off-by-one indentation

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -187,7 +187,7 @@ function writeHead(statusCode, reason, obj) {
   statusCode |= 0;
   if (statusCode < 100 || statusCode > 999) {
     throw new errors.RangeError('ERR_HTTP_INVALID_STATUS_CODE',
-                                 originalStatusCode);
+                                originalStatusCode);
   }
 
 


### PR DESCRIPTION
In preparation for more robust indentation linting, fix an off-by-one
indentation in lib/http_server.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib