### PR TITLE
test: restore no-op function in test

### DIFF
--- a/test/parallel/test-http-hostname-typechecking.js
+++ b/test/parallel/test-http-hostname-typechecking.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const http = require('http');
@@ -21,7 +21,7 @@ vals.forEach((v) => {
 // These values are OK and should not throw synchronously
 ['', undefined, null].forEach((v) => {
   assert.doesNotThrow(() => {
-    http.request({hostname: v}).on('error', common.mustCall()).end();
-    http.request({host: v}).on('error', common.mustCall()).end();
+    http.request({hostname: v}).on('error', () => {}).end();
+    http.request({host: v}).on('error', () => {}).end();
   });
 });


### PR DESCRIPTION
Remove common.mustCall() in test that might connect to a server already
running on the local host.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http