### PR TITLE
test: check and fail inspector-cluster-port-clash

### DIFF
--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -11,6 +11,8 @@ const assert = require('assert');
 //
 // Refs: https://github.com/nodejs/node/issues/13343
 
+// This following check should be replaced by common.skipIfInspectorDisabled()
+// if moved out of the known_issues directory.
 if (process.config.variables.v8_enable_inspector === 0) {
   // When the V8 inspector is disabled, using either --without-inspector or
   // --without-ssl, this test will not fail which it is expected to do.

--- a/test/known_issues/test-inspector-cluster-port-clash.js
+++ b/test/known_issues/test-inspector-cluster-port-clash.js
@@ -1,6 +1,7 @@
 // Flags: --inspect=0
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 
 // With the current behavior of Node.js (at least as late as 8.1.0), this
 // test fails with the following error:
@@ -10,9 +11,13 @@ const common = require('../common');
 //
 // Refs: https://github.com/nodejs/node/issues/13343
 
-common.skipIfInspectorDisabled();
+if (process.config.variables.v8_enable_inspector === 0) {
+  // When the V8 inspector is disabled, using either --without-inspector or
+  // --without-ssl, this test will not fail which it is expected to do.
+  // The following fail will allow this test to be skipped by failing it.
+  assert.fail('skipping as V8 inspector is disabled');
+}
 
-const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
 


### PR DESCRIPTION
Currently this test fail when configured --without-inspector or
--without-ssl as it is expected to fail but the skipIfInspectorDisabled
check will exit as if the test was successful.

This commit checks if inspector support is available and fails the test
allowing the test to be skipped.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, tools