### PR TITLE
lib: use consistent indentation for ternaries

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -949,9 +949,7 @@ function fromListPartial(n, list, hasStrings) {
     ret = list.shift();
   } else {
     // result spans more than one buffer
-    ret = (hasStrings ?
-           copyFromBufferString(n, list) :
-           copyFromBuffer(n, list));
+    ret = hasStrings ? copyFromBufferString(n, list) : copyFromBuffer(n, list);
   }
   return ret;
 }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -21,6 +21,6 @@
 
 'use strict';
 
-module.exports = ('NODE_UNIQUE_ID' in process.env) ?
-                  require('internal/cluster/child') :
-                  require('internal/cluster/master');
+module.exports = require(`internal/cluster/${
+  'NODE_UNIQUE_ID' in process.env ? 'child' : 'master'
+}`);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -21,6 +21,5 @@
 
 'use strict';
 
-module.exports = require(`internal/cluster/${
-  'NODE_UNIQUE_ID' in process.env ? 'child' : 'master'
-}`);
+const childOrMaster = 'NODE_UNIQUE_ID' in process.env ? 'child' : 'master';
+module.exports = require(`internal/cluster/${childOrMaster}`);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1357,9 +1357,8 @@ function FSWatcher() {
     if (status < 0) {
       self._handle.close();
       const error = !filename ?
-          errnoException(status, 'Error watching file for changes:') :
-          errnoException(status,
-                         `Error watching file ${filename} for changes:`);
+        errnoException(status, 'Error watching file for changes:') :
+        errnoException(status, `Error watching file ${filename} for changes:`);
       error.filename = filename;
       self.emit('error', error);
     } else {

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -276,8 +276,8 @@
       get: function() {
         if (!console) {
           console = originalConsole === undefined ?
-              NativeModule.require('console') :
-              installInspectorConsole(originalConsole);
+            NativeModule.require('console') :
+            installInspectorConsole(originalConsole);
         }
         return console;
       }

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -275,7 +275,7 @@
       enumerable: true,
       get: function() {
         if (!console) {
-          console = originalConsole === undefined ?
+          console = (originalConsole === undefined) ?
             NativeModule.require('console') :
             installInspectorConsole(originalConsole);
         }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -883,8 +883,8 @@ function _validateStdio(stdio, sync) {
     } else if (getHandleWrapType(stdio) || getHandleWrapType(stdio.handle) ||
                getHandleWrapType(stdio._handle)) {
       var handle = getHandleWrapType(stdio) ?
-          stdio :
-          getHandleWrapType(stdio.handle) ? stdio.handle : stdio._handle;
+        stdio :
+        getHandleWrapType(stdio.handle) ? stdio.handle : stdio._handle;
 
       acc.push({
         type: 'wrap',

--- a/lib/url.js
+++ b/lib/url.js
@@ -395,10 +395,10 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     this.query = Object.create(null);
   }
 
-  var firstIdx = (questionIdx !== -1 &&
-                  (hashIdx === -1 || questionIdx < hashIdx) ?
-                  questionIdx :
-                  hashIdx);
+  var firstIdx =
+    questionIdx !== -1 && (hashIdx === -1 || questionIdx < hashIdx) ?
+    questionIdx :
+    hashIdx;
   if (firstIdx === -1) {
     if (rest.length > 0)
       this.pathname = rest;
@@ -586,8 +586,8 @@ Url.prototype.format = function format() {
     host = auth + this.host;
   } else if (this.hostname) {
     host = auth + (this.hostname.indexOf(':') === -1 ?
-        this.hostname :
-        '[' + this.hostname + ']');
+      this.hostname :
+      '[' + this.hostname + ']');
     if (this.port) {
       host += ':' + this.port;
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -395,10 +395,9 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     this.query = Object.create(null);
   }
 
-  var firstIdx =
-    questionIdx !== -1 && (hashIdx === -1 || questionIdx < hashIdx) ?
-    questionIdx :
-    hashIdx;
+  const useQuestionIdx =
+    questionIdx !== -1 && (hashIdx === -1 || questionIdx < hashIdx);
+  const firstIdx = useQuestionIdx ? questionIdx : hashIdx;
   if (firstIdx === -1) {
     if (rest.length > 0)
       this.pathname = rest;

--- a/lib/url.js
+++ b/lib/url.js
@@ -584,9 +584,11 @@ Url.prototype.format = function format() {
   if (this.host) {
     host = auth + this.host;
   } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(':') === -1 ?
-      this.hostname :
-      '[' + this.hostname + ']');
+    host = auth + (
+      this.hostname.indexOf(':') === -1 ?
+        this.hostname :
+        '[' + this.hostname + ']'
+    );
     if (this.port) {
       host += ':' + this.port;
     }


### PR DESCRIPTION
In anticipation of stricter linting for indentation issues, modify
ternary operators in lib that do not conform with the expected ESLint
settings.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib tools