### PR TITLE
events: remove internal spliceOne()

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -392,7 +392,7 @@ EventEmitter.prototype.removeListener =
         if (position === 0)
           list.shift();
         else
-          spliceOne(list, position);
+          list.splice(position, 1);
 
         if (list.length === 1)
           events[type] = list[0];
@@ -503,13 +503,6 @@ function listenerCount(type) {
 EventEmitter.prototype.eventNames = function eventNames() {
   return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
 };
-
-// About 1.5x faster than the two-arg version of Array#splice().
-function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
-}
 
 function arrayClone(arr, n) {
   var copy = new Array(n);


### PR DESCRIPTION
spliceOne() was added as a faster alternative to Array#splice in the
particular use case in events.js. However, current master shows no
difference in performance with or without spliceOne():

```console
                                  improvement confidence   p.value
 events/ee-add-remove.js n=250000      0.14 %            0.7573913
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
events