### PR TITLE
module: addBuiltinLibsToObject refactoring

### DIFF
--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -83,43 +83,50 @@ const builtinLibs = [
   'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ];
 
+// Make built-in modules available directly (loaded lazily).
 function addBuiltinLibsToObject(object) {
-  // Make built-in modules available directly (loaded lazily).
-  builtinLibs.forEach((name) => {
+  const configurable = true;
+  const enumerable = false;
+
+  // Setter function that will be bound to some lib name
+  function setReal(libname, value) {
+    // Deleting the property before re-assigning it disables the
+    // getter/setter mechanism.
+    delete object[libname];
+    object[libname] = value;
+  }
+
+  for (var n = 0, len = builtinLibs.length; n < len; n++) {
     // Goals of this mechanism are:
     // - Lazy loading of built-in modules
     // - Having all built-in modules available as non-enumerable properties
     // - Allowing the user to re-assign these variables as if there were no
     //   pre-existing globals with the same name.
+    const libname = builtinLibs[n];
+    const set = setReal.bind(null, libname);
 
-    const setReal = (val) => {
-      // Deleting the property before re-assigning it disables the
-      // getter/setter mechanism.
-      delete object[name];
-      object[name] = val;
-    };
-
-    Object.defineProperty(object, name, {
+    Object.defineProperty(object, libname, {
       get: () => {
-        const lib = require(name);
+        const lib = require(libname);
 
-        // Disable the current getter/setter and set up a new
-        // non-enumerable property.
-        delete object[name];
-        Object.defineProperty(object, name, {
+        // Disable the current getter/setter
+        delete object[libname];
+
+        // Set up a new non-emumerable propery
+        Object.defineProperty(object, libname, {
           get: () => lib,
-          set: setReal,
-          configurable: true,
-          enumerable: false
+          set,
+          configurable,
+          enumerable
         });
 
         return lib;
       },
-      set: setReal,
-      configurable: true,
-      enumerable: false
+      set,
+      configurable,
+      enumerable
     });
-  });
+  }
 }
 
 module.exports = exports = {


### PR DESCRIPTION
- Replace `forEach` loop by `for` loop for several reasons. One of them
being performance. Loop over a small array is fast anyway, but this will
make code more consistent across the project. Feels like Node.js is
trying to be as fast as possible 

- Move `setReal` function definition out of the loop and make
it *bindable*. Defining a function inside loop is considered bad
practice in general.

- Predefine `configurable` and `enumerable` as these are staying consistent
across the function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- `internal/module`