### PR TITLE
test: wrap expectsError in mustCall

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -50,7 +50,7 @@ Platform normalizes the `dd` command
 
 Check if there is more than 1gb of total memory.
 
-### expectsError([fn, ]settings)
+### expectsError([fn, ]settings[, exact])
 * `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 * `settings` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
   with the following optional properties:
@@ -63,9 +63,12 @@ Check if there is more than 1gb of total memory.
     if a string is provided for `message`, expected error must have it for its
     `message` property; if a regular expression is provided for `message`, the
     regular expression must match the `message` property of the expected error
+* `exact` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
 
 * return function suitable for use as a validation function passed as the second
-  argument to `assert.throws()`
+  argument to e.g. `assert.throws()`. If the returned function has not been called
+  exactly `exact` number of times when the test is complete, then the test will
+  fail.
 
 If `fn` is provided, it will be passed to `assert.throws` as first argument.
 
@@ -217,7 +220,7 @@ Array of IPV6 hosts.
 * return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 
 Returns a function that calls `fn`. If the returned function has not been called
-exactly `expected` number of times when the test is complete, then the test will
+exactly `exact` number of times when the test is complete, then the test will
 fail.
 
 If `fn` is not provided, an empty function will be used.

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -488,7 +488,7 @@ exports.mustCallAtLeast = function(fn, minimum) {
   return _mustCallInner(fn, minimum, 'minimum');
 };
 
-function _mustCallInner(fn, criteria, field) {
+function _mustCallInner(fn, criteria = 1, field) {
   if (typeof fn === 'number') {
     criteria = fn;
     fn = noop;
@@ -496,9 +496,7 @@ function _mustCallInner(fn, criteria, field) {
     fn = noop;
   }
 
-  if (criteria === undefined)
-    criteria = 1;
-  else if (typeof criteria !== 'number')
+  if (typeof criteria !== 'number')
     throw new TypeError(`Invalid ${field} value: ${criteria}`);
 
   const context = {
@@ -702,13 +700,14 @@ Object.defineProperty(exports, 'hasSmallICU', {
 });
 
 // Useful for testing expected internal/error objects
-exports.expectsError = function expectsError(fn, options) {
+exports.expectsError = function expectsError(fn, options, exact) {
   if (typeof fn !== 'function') {
+    exact = options;
     options = fn;
     fn = undefined;
   }
   const { code, type, message } = options;
-  function innerFn(error) {
+  const innerFn = exports.mustCall(function(error) {
     assert.strictEqual(error.code, code);
     if (type !== undefined) {
       assert(error instanceof type,
@@ -721,7 +720,7 @@ exports.expectsError = function expectsError(fn, options) {
       assert.strictEqual(error.message, message);
     }
     return true;
-  }
+  }, exact);
   if (fn) {
     assert.throws(fn, innerFn);
     return;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -153,11 +153,7 @@ assert.throws(makeBlock(a.deepEqual, /a/igm, /a/im),
 {
   const re1 = /a/g;
   re1.lastIndex = 3;
-  assert.doesNotThrow(makeBlock(a.deepEqual, re1, /a/g),
-                      common.expectsError({
-                        code: 'ERR_ASSERTION',
-                        message: /^\/a\/g deepEqual \/a\/g$/
-                      }));
+  assert.doesNotThrow(makeBlock(a.deepEqual, re1, /a/g));
 }
 
 assert.doesNotThrow(makeBlock(a.deepEqual, 4, '4'), 'deepEqual(4, \'4\')');

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -57,7 +57,7 @@ assert.strictEqual(1, a.compare(b, Infinity, -Infinity));
 // zero length target because default for targetEnd <= targetSource
 assert.strictEqual(1, a.compare(b, '0xff'));
 
-const oor = common.expectsError({code: 'ERR_INDEX_OUT_OF_RANGE'});
+const oor = common.expectsError({code: 'ERR_INDEX_OUT_OF_RANGE'}, 7);
 
 assert.throws(() => a.compare(b, 0, 100, 0), oor);
 assert.throws(() => a.compare(b, 0, 1, 0, 100), oor);

--- a/test/parallel/test-child-process-send-after-close.js
+++ b/test/parallel/test-child-process-send-after-close.js
@@ -14,9 +14,9 @@ child.on('close', common.mustCall((code, signal) => {
     type: Error,
     message: 'Channel closed',
     code: 'ERR_IPC_CHANNEL_CLOSED'
-  });
+  }, 2);
 
-  child.on('error', common.mustCall(testError));
+  child.on('error', testError);
 
   {
     const result = child.send('ping');
@@ -24,7 +24,7 @@ child.on('close', common.mustCall((code, signal) => {
   }
 
   {
-    const result = child.send('pong', common.mustCall(testError));
+    const result = child.send('pong', testError);
     assert.strictEqual(result, false);
   }
 }));

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -186,7 +186,7 @@ if (!common.isWindows) {
   // Validate the killSignal option
   const typeErr = /^TypeError: "killSignal" must be a string or number$/;
   const unknownSignalErr =
-    common.expectsError({ code: 'ERR_UNKNOWN_SIGNAL', type: TypeError });
+    common.expectsError({ code: 'ERR_UNKNOWN_SIGNAL', type: TypeError }, 17);
 
   pass('killSignal', undefined);
   pass('killSignal', null);

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -6,7 +6,7 @@ const assert = require('assert');
 const _validateStdio = require('internal/child_process')._validateStdio;
 
 const expectedError =
-  common.expectsError({code: 'ERR_INVALID_OPT_VALUE', type: TypeError});
+  common.expectsError({code: 'ERR_INVALID_OPT_VALUE', type: TypeError}, 2);
 
 // should throw if string and not ignore, pipe, or inherit
 assert.throws(() => _validateStdio('foo'), expectedError);

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -28,12 +28,10 @@ fs.readFile(url, common.mustCall((err, data) => {
 
 // Check that using a non file:// URL reports an error
 const httpUrl = new URL('http://example.org');
-fs.readFile(httpUrl, common.mustCall((err) => {
-  common.expectsError({
-    code: 'ERR_INVALID_URL_SCHEME',
-    type: TypeError,
-    message: 'The URL must be of scheme file'
-  })(err);
+fs.readFile(httpUrl, common.expectsError({
+  code: 'ERR_INVALID_URL_SCHEME',
+  type: TypeError,
+  message: 'The URL must be of scheme file'
 }));
 
 // pct-encoded characters in the path will be decoded and checked
@@ -46,31 +44,25 @@ fs.readFile(new URL('file:///c:/tmp/%00test'), common.mustCall((err) => {
 if (common.isWindows) {
   // encoded back and forward slashes are not permitted on windows
   ['%2f', '%2F', '%5c', '%5C'].forEach((i) => {
-    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.mustCall((err) => {
-      common.expectsError({
-        code: 'ERR_INVALID_FILE_URL_PATH',
-        type: TypeError,
-        message: 'File URL path must not include encoded \\ or / characters'
-      })(err);
+    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.expectsError({
+      code: 'ERR_INVALID_FILE_URL_PATH',
+      type: TypeError,
+      message: 'File URL path must not include encoded \\ or / characters'
     }));
   });
 } else {
   // encoded forward slashes are not permitted on other platforms
   ['%2f', '%2F'].forEach((i) => {
-    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.mustCall((err) => {
-      common.expectsError({
-        code: 'ERR_INVALID_FILE_URL_PATH',
-        type: TypeError,
-        message: 'File URL path must not include encoded / characters'
-      })(err);
+    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.expectsError({
+      code: 'ERR_INVALID_FILE_URL_PATH',
+      type: TypeError,
+      message: 'File URL path must not include encoded / characters'
     }));
   });
 
-  fs.readFile(new URL('file://hostname/a/b/c'), common.mustCall((err) => {
-    common.expectsError({
-      code: 'ERR_INVALID_FILE_URL_HOST',
-      type: TypeError,
-      message: `File URL host must be "localhost" or empty on ${os.platform()}`
-    })(err);
+  fs.readFile(new URL('file://hostname/a/b/c'), common.expectsError({
+    code: 'ERR_INVALID_FILE_URL_HOST',
+    type: TypeError,
+    message: `File URL host must be "localhost" or empty on ${os.platform()}`
   }));
 }

--- a/test/parallel/test-internal-util-assertCrypto.js
+++ b/test/parallel/test-internal-util-assertCrypto.js
@@ -4,12 +4,11 @@ const common = require('../common');
 const assert = require('assert');
 const util = require('internal/util');
 
-const expectedError = common.expectsError({
-  code: 'ERR_NO_CRYPTO',
-  type: Error
-});
-
 if (!process.versions.openssl) {
+  const expectedError = common.expectsError({
+    code: 'ERR_NO_CRYPTO',
+    type: Error
+  });
   assert.throws(() => util.assertCrypto(), expectedError);
 } else {
   assert.doesNotThrow(() => util.assertCrypto());

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -91,7 +91,7 @@ const unixSpecialCaseFormatTests = [
 const expectedMessage = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError
-});
+}, 18);
 
 const errors = [
   {method: 'parse', input: [null], message: expectedMessage},

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -35,13 +35,13 @@ const invalidUserArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "preValue.user" property must be of type Number'
-});
+}, 8);
 
 const invalidSystemArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "preValue.system" property must be of type Number'
-});
+}, 2);
 
 
 // Ensure that an invalid shape for the previous value argument throws an error.

--- a/test/parallel/test-process-emitwarning.js
+++ b/test/parallel/test-process-emitwarning.js
@@ -58,7 +58,7 @@ warningThrowToString.toString = function() {
 process.emitWarning(warningThrowToString);
 
 const expectedError =
-  common.expectsError({code: 'ERR_INVALID_ARG_TYPE', type: TypeError});
+  common.expectsError({code: 'ERR_INVALID_ARG_TYPE', type: TypeError}, 11);
 
 // TypeError is thrown on invalid input
 assert.throws(() => process.emitWarning(1), expectedError);

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -42,7 +42,7 @@ const invalidPidArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "pid" argument must be of type Number'
-});
+}, 6);
 
 assert.throws(function() { process.kill('SIGTERM'); },
               invalidPidArgument);

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -25,7 +25,7 @@ assert.strictEqual(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "options" argument must be of type object'
-  });
+  }, 4);
   assert.throws(() => url.format(myURL, true), expectedErr);
   assert.throws(() => url.format(myURL, 1), expectedErr);
   assert.throws(() => url.format(myURL, 'test'), expectedErr);

--- a/test/parallel/test-whatwg-url-domainto.js
+++ b/test/parallel/test-whatwg-url-domainto.js
@@ -13,7 +13,7 @@ const wptToASCIITests = require('../fixtures/url-toascii.js');
 
 {
   const expectedError = common.expectsError(
-      { code: 'ERR_MISSING_ARGS', type: TypeError });
+      { code: 'ERR_MISSING_ARGS', type: TypeError }, 2);
   assert.throws(() => domainToASCII(), expectedError);
   assert.throws(() => domainToUnicode(), expectedError);
   assert.strictEqual(domainToASCII(undefined), 'undefined');

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -26,7 +26,7 @@ const failureTests = tests.filter((test) => test.failure).concat([
 ]);
 
 const expectedError = common.expectsError(
-    { code: 'ERR_INVALID_URL', type: TypeError });
+    { code: 'ERR_INVALID_URL', type: TypeError }, 102);
 
 for (const test of failureTests) {
   assert.throws(

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -209,7 +209,7 @@ function makeIterableFunc(array) {
     code: 'ERR_INVALID_TUPLE',
     type: TypeError,
     message: 'Each query pair must be an iterable [name, value] tuple'
-  });
+  }, 6);
 
   let params;
   params = new URLSearchParams(undefined);

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -76,7 +76,7 @@ sp.forEach(function() {
   const callbackErr = common.expectsError({
     code: 'ERR_INVALID_CALLBACK',
     type: TypeError
-  });
+  }, 2);
   assert.throws(() => sp.forEach(), callbackErr);
   assert.throws(() => sp.forEach(1), callbackErr);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
To make sure that all expectsError calls are indeed called, wrap them in mustCall.
By doing so I found one obsolete expectsError call in the tests.

I think it's nice to have the exact number of calls but having a minimum would also be good if the churn is unwanted.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test