### PR TITLE
test: add optional throw fn to expectsError

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -50,7 +50,8 @@ Platform normalizes the `dd` command
 
 Check if there is more than 1gb of total memory.
 
-### expectsError(settings)
+### expectsError([fn, ]settings)
+* `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 * `settings` [&lt;Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
   with the following optional properties:
   * `code` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)
@@ -65,6 +66,8 @@ Check if there is more than 1gb of total memory.
 
 * return function suitable for use as a validation function passed as the second
   argument to `assert.throws()`
+
+If `fn` is provided, it will be passed to `assert.throws` as first argument.
 
 The expected error should be [subclassed by the `internal/errors` module](https://github.com/nodejs/node/blob/master/doc/guides/using-internal-errors.md#api).
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -702,8 +702,13 @@ Object.defineProperty(exports, 'hasSmallICU', {
 });
 
 // Useful for testing expected internal/error objects
-exports.expectsError = function expectsError({code, type, message}) {
-  return function(error) {
+exports.expectsError = function expectsError(fn, options) {
+  if (typeof fn !== 'function') {
+    options = fn;
+    fn = undefined;
+  }
+  const { code, type, message } = options;
+  function innerFn(error) {
     assert.strictEqual(error.code, code);
     if (type !== undefined) {
       assert(error instanceof type,
@@ -716,7 +721,12 @@ exports.expectsError = function expectsError({code, type, message}) {
       assert.strictEqual(error.message, message);
     }
     return true;
-  };
+  }
+  if (fn) {
+    assert.throws(fn, innerFn);
+    return;
+  }
+  return innerFn;
 };
 
 exports.skipIfInspectorDisabled = function skipIfInspectorDisabled() {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -114,12 +114,12 @@ for (const a of similar) {
   }
 }
 
-assert.throws(
-  () => { assert.deepEqual(new Set([{a: 0}]), new Set([{a: 1}])); },
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    message: /^Set { { a: 0 } } deepEqual Set { { a: 1 } }$/
-  }));
+common.expectsError(() => {
+  assert.deepEqual(new Set([{a: 0}]), new Set([{a: 1}]));
+}, {
+  code: 'ERR_ASSERTION',
+  message: /^Set { { a: 0 } } deepEqual Set { { a: 1 } }$/
+});
 
 function assertDeepAndStrictEqual(a, b) {
   assert.deepEqual(a, b);

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -17,57 +17,52 @@ assert.throws(
 );
 
 // One arg = message
-assert.throws(
-  () => { assert.fail('custom message'); },
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'custom message',
-    operator: undefined,
-    actual: undefined,
-    expected: undefined
-  })
-);
+common.expectsError(() => {
+  assert.fail('custom message');
+}, {
+  code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
+  message: 'custom message',
+  operator: undefined,
+  actual: undefined,
+  expected: undefined
+});
 
 // Two args only, operator defaults to '!='
-assert.throws(
-  () => { assert.fail('first', 'second'); },
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: '\'first\' != \'second\'',
-    operator: '!=',
-    actual: 'first',
-    expected: 'second'
-
-  })
-);
+common.expectsError(() => {
+  assert.fail('first', 'second');
+}, {
+  code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
+  message: '\'first\' != \'second\'',
+  operator: '!=',
+  actual: 'first',
+  expected: 'second'
+});
 
 // Three args
-assert.throws(
-  () => { assert.fail('ignored', 'ignored', 'another custom message'); },
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: 'another custom message',
-    operator: undefined,
-    actual: 'ignored',
-    expected: 'ignored'
-  })
-);
+common.expectsError(() => {
+  assert.fail('ignored', 'ignored', 'another custom message');
+}, {
+  code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
+  message: 'another custom message',
+  operator: undefined,
+  actual: 'ignored',
+  expected: 'ignored'
+});
 
 // No third arg (but a fourth arg)
-assert.throws(
-  () => { assert.fail('first', 'second', undefined, 'operator'); },
-  common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: assert.AssertionError,
-    message: '\'first\' operator \'second\'',
-    operator: 'operator',
-    actual: 'first',
-    expected: 'second'
-  })
-);
+common.expectsError(() => {
+  assert.fail('first', 'second', undefined, 'operator');
+}, {
+  code: 'ERR_ASSERTION',
+  type: assert.AssertionError,
+  message: '\'first\' operator \'second\'',
+  operator: 'operator',
+  actual: 'first',
+  expected: 'second'
+});
 
 // The stackFrameFunction should exclude the foo frame
 assert.throws(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
This is mainly a style thing but I think it's pretty nice to add the throwing function directly to `common.expectsError` instead of wrapping that into the throw function as it's done most of the time.

I thought I just create this as a example and I only changed a few tests accordingly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test