### PR TITLE
test: add get/set effective uid/gid tests

### DIFF
--- a/test/parallel/test-process-geteuid-getegid.js
+++ b/test/parallel/test-process-geteuid-getegid.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (common.isWindows) {
+  assert.strictEqual(process.geteuid, undefined);
+  assert.strictEqual(process.getegid, undefined);
+  assert.strictEqual(process.seteuid, undefined);
+  assert.strictEqual(process.setegid, undefined);
+  return;
+}
+
+assert.throws(() => {
+  process.seteuid({});
+}, /^TypeError: seteuid argument must be a number or string$/);
+
+assert.throws(() => {
+  process.seteuid('fhqwhgadshgnsdhjsdbkhsdabkfabkveybvf');
+}, /^Error: seteuid user id does not exist$/);
+
+// If we're not running as super user...
+if (process.getuid() !== 0) {
+  assert.doesNotThrow(() => {
+    process.getegid();
+    process.geteuid();
+  });
+
+  assert.throws(() => {
+    process.setegid('nobody');
+  }, /^Error: (?:EPERM, .+|setegid group id does not exist)$/);
+
+  assert.throws(() => {
+    process.seteuid('nobody');
+  }, /^Error: (?:EPERM, .+|seteuid user id does not exist)$/);
+
+  return;
+}
+
+// If we are running as super user...
+const oldgid = process.getegid();
+process.setegid('nobody');
+const newgid = process.getegid();
+assert.notStrictEqual(newgid, oldgid);
+
+const olduid = process.geteuid();
+process.seteuid('nobody');
+const newuid = process.geteuid();
+assert.notStrictEqual(newuid, olduid);


### PR DESCRIPTION
3c92ca2b5c1aea283efebd50b27e2a256adf5f7f should have had tests to go along with it.
This adds tests for the following functions:

* `process.geteuid()`
* `process.seteuid()`
* `process.getegid()`
* `process.setegid()`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test