### PR TITLE
tools: generate template literal for addon tests

### DIFF
--- a/tools/doc/addon-verify.js
+++ b/tools/doc/addon-verify.js
@@ -66,7 +66,10 @@ function verifyFiles(files, blockName, onprogress, ondone) {
     if (name === 'test.js') {
       files[name] = `'use strict';
 const common = require('../../common');
-${files[name].replace('Release', "' + common.buildType + '")}
+${files[name].replace(
+    "'./build/Release/addon'",
+    // eslint-disable-next-line no-template-curly-in-string
+    '`./build/${common.buildType}/addon`')}
 `;
     }
     return {


### PR DESCRIPTION
Instead of generating string concatenation, generate a template literal.
This is mostly useful as a pre-emptive measure for avoiding problems
when (if?) we enable the prefer-template lint rule in the test
directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test