### PR TITLE
url: do not use HandleScope in ToObject

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2085,7 +2085,6 @@ static void DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
 const Local<Value> URL::ToObject(Environment* env) const {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
-  HandleScope handle_scope(isolate);
   Context::Scope context_scope(context);
 
   const Local<Value> undef = Undefined(isolate);


### PR DESCRIPTION
It is not needed / invalidates the returned value unlike EscapableHandleScope

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

url
