### PR TITLE
test: increase test coverage for os.js

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,3 +19,5 @@ test-npm-install:      PASS,FLAKY
 
 [$system==freebsd]
 
+[$system==aix]
+test-os:               PASS,FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -18,6 +18,3 @@ test-npm-install:      PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
-
-[$system==aix]
-test-os:               PASS,FLAKY

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -36,6 +36,10 @@ const is = {
   }
 };
 
+const flatten = (arr) =>
+  arr.reduce((acc, c) =>
+    acc.concat(Array.isArray(c) ? flatten(c) : c), []);
+
 process.env.TMPDIR = '/tmpdir';
 process.env.TMP = '/tmp';
 process.env.TEMP = '/temp';
@@ -114,82 +118,40 @@ if (!common.isSunOS) {
 }
 
 const interfaces = os.networkInterfaces();
-const local = (e) => e.address === '127.0.0.1';
 switch (platform) {
-  case 'linux':
-<<<<<<< HEAD
-  {
-    const filter =
-      (e) => e.address === '127.0.0.1' && e.netmask === '255.0.0.0';
+  case 'linux': {
+    const filter = (e) =>
+      e.address === '127.0.0.1' &&
+      e.netmask === '255.0.0.0';
+
     const actual = interfaces.lo.filter(filter);
-    const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                        mac: '00:00:00:00:00:00', family: 'IPv4',
-                        internal: true, cidr: '127.0.0.1/8' }];
+    const expected = [{
+      address: '127.0.0.1',
+      netmask: '255.0.0.0',
+      mac: '00:00:00:00:00:00',
+      family: 'IPv4',
+      internal: true,
+      cidr: '127.0.0.1/8'
+    }];
     assert.deepStrictEqual(actual, expected);
     break;
   }
-  case 'win32':
-  {
-    const filter = (e) => e.address === '127.0.0.1';
+  case 'win32': {
+    const filter = (e) =>
+      e.address === '127.0.0.1';
+
     const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
-    const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                        mac: '00:00:00:00:00:00', family: 'IPv4',
-                        internal: true, cidr: '127.0.0.1/8' }];
+    const expected = [{
+      address: '127.0.0.1',
+      netmask: '255.0.0.0',
+      mac: '00:00:00:00:00:00',
+      family: 'IPv4',
+      internal: true,
+      cidr: '127.0.0.1/8'
+    }];
     assert.deepStrictEqual(actual, expected);
     break;
   }
-}
-function flatten(arr) {
-  return arr.reduce(
-    (acc, c) => acc.concat(Array.isArray(c) ? flatten(c) : c),
-    []
-  );
-=======
-    {
-      const actual = interfaces.lo.filter(local);
-      const expected = [{
-        address: '127.0.0.1',
-        netmask: '255.0.0.0',
-        mac: '00:00:00:00:00:00',
-        family: 'IPv4',
-        internal: true
-      }];
-      assert.deepStrictEqual(actual, expected);
-      break;
-    }
-  case 'win32':
-    {
-      const actual = interfaces['Loopback Pseudo-Interface 1'].filter(local);
-      const expected = [{
-        address: '127.0.0.1',
-        netmask: '255.0.0.0',
-        mac: '00:00:00:00:00:00',
-        family: 'IPv4',
-        internal: true
-      }];
-      assert.deepStrictEqual(actual, expected);
-      break;
-    }
-  case 'aix':
-    {
-      // This test will fail on aix by default
-      // Issue: https://github.com/nodejs/node/issues/14119
-      const lo0 = interfaces.lo0;
-      // There might not be a lo0 entry configured
-      if (!lo0) break;
-      const actual = lo0.filter(local);
-      // We cannot test mac field because it is non-zero
-      delete actual[0].mac;
-      const expected = [{
-        address: '127.0.0.1',
-        netmask: '0.0.0.1',
-        family: 'IPv4',
-        internal: true
-      }];
-      assert.deepStrictEqual(actual, expected);
-      break;
-    }
->>>>>>> test: add os.networkInterfaces test case for aix
 }
 const netmaskToCIDRSuffixMap = new Map(Object.entries({
   '255.0.0.0': 8,
@@ -197,6 +159,7 @@ const netmaskToCIDRSuffixMap = new Map(Object.entries({
   'ffff:ffff:ffff:ffff::': 64,
   'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff': 128
 }));
+
 flatten(Object.values(interfaces))
   .map((v) => ({ v, mask: netmaskToCIDRSuffixMap.get(v.netmask) }))
   .forEach(({ v, mask }) => {

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -27,8 +27,11 @@ const path = require('path');
 const { inspect } = require('util');
 
 const is = {
+  number: (value, key) => {
+    assert(!isNaN(value), `${key} should not be NaN`);
+    assert.strictEqual(typeof value, 'number');
+  },
   string: (value) => { assert.strictEqual(typeof value, 'string'); },
-  number: (value) => { assert.strictEqual(typeof value, 'number'); },
   array: (value) => { assert.ok(Array.isArray(value)); },
   object: (value) => {
     assert.strictEqual(typeof value, 'object');
@@ -217,17 +220,20 @@ assert.ok(pwd.homedir.includes(path.sep));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
 
-// Test Symbol.toPrimitive on these functions
-[
-  [+os.freemem, os.freemem()],
-  [+os.totalmem, os.totalmem()],
-  [+os.uptime, os.uptime()],
-  [`${os.hostname}`, os.hostname()],
-  [`${os.homedir}`, os.homedir()],
-  [`${os.release}`, os.release()],
-  [`${os.type}`, os.type()],
-  [`${os.endianness}`, os.endianness()],
-  [`${os.tmpdir}`, os.tmpdir()],
-  [`${os.arch}`, os.arch()],
-  [`${os.platform}`, os.platform()]
-].forEach(([expected, actual]) => assert.strictEqual(expected, actual));
+assert.strictEqual(String(os.hostname), os.hostname());
+assert.strictEqual(String(os.homedir), os.homedir());
+assert.strictEqual(String(os.release), os.release());
+assert.strictEqual(String(os.type), os.type());
+assert.strictEqual(String(os.endianness), os.endianness());
+assert.strictEqual(String(os.tmpdir), os.tmpdir());
+assert.strictEqual(String(os.arch), os.arch());
+assert.strictEqual(String(os.platform), os.platform());
+
+assert.strictEqual(Number(os.totalmem), os.totalmem());
+
+// At least we can check that these values are numbers
+is.number(Number(os.uptime), 'uptime');
+is.number(os.uptime(), 'uptime');
+
+is.number(Number(os.freemem), 'freemem');
+is.number(os.freemem(), 'freemem');

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -172,6 +172,8 @@ function flatten(arr) {
     }
   case 'aix':
     {
+      // This test will fail on aix by default
+      // Issue: https://github.com/nodejs/node/issues/14119
       const lo0 = interfaces.lo0;
       // There might not be a lo0 entry configured
       if (!lo0) break;
@@ -205,8 +207,6 @@ flatten(Object.values(interfaces))
   });
 
 const EOL = os.EOL;
-assert.ok(EOL.length > 0);
-
 if (common.isWindows) {
   assert.strictEqual(EOL, '\r\n');
 } else {
@@ -267,4 +267,4 @@ assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
   [`${os.tmpdir}`, os.tmpdir()],
   [`${os.arch}`, os.arch()],
   [`${os.platform}`, os.platform()]
-].forEach((set) => assert.strictEqual(set[0], set[1]));
+].forEach(([expected, actual]) => assert.strictEqual(expected, actual));

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+
 const common = require('../common');
 const assert = require('assert');
 const os = require('os');
@@ -27,9 +28,9 @@ const path = require('path');
 const { inspect } = require('util');
 
 const is = {
-  string: (value) => { assert.strictEqual(typeof value, 'string'); },
-  number: (value) => { assert.strictEqual(typeof value, 'number'); },
-  array: (value) => { assert.ok(Array.isArray(value)); },
+  string: (value) => assert.strictEqual(typeof value, 'string'),
+  number: (value) => assert.strictEqual(typeof value, 'number'),
+  array: (value) => assert.ok(Array.isArray(value)),
   object: (value) => {
     assert.strictEqual(typeof value, 'object');
     assert.notStrictEqual(value, null);
@@ -96,6 +97,7 @@ assert.ok(release.length > 0);
 //TODO: Check format on more than just AIX
 if (common.isAIX)
   assert.ok(/^\d+\.\d+$/.test(release));
+}
 
 const platform = os.platform();
 is.string(platform);
@@ -111,7 +113,6 @@ if (!common.isSunOS) {
   assert.ok(os.freemem() > 0);
   assert.ok(os.totalmem() > 0);
 }
-
 
 const interfaces = os.networkInterfaces();
 switch (platform) {
@@ -161,9 +162,13 @@ flatten(Object.values(interfaces))
 const EOL = os.EOL;
 assert.ok(EOL.length > 0);
 
+if (common.isWindows) {
+  assert.strictEqual(EOL, '\r\n');
+} else {
+  assert.strictEqual(EOL, '\n');
+}
 
 const home = os.homedir();
-
 is.string(home);
 assert.ok(home.includes(path.sep));
 
@@ -206,9 +211,15 @@ assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
 
 // Test that the Symbol.toPrimitive functions work correctly
 [
+  [+os.freemem, os.freemem()],
+  [+os.totalmem, os.totalmem()],
+  [+os.uptime, os.uptime()],
   [`${os.hostname}`, os.hostname()],
   [`${os.homedir}`, os.homedir()],
   [`${os.release}`, os.release()],
   [`${os.type}`, os.type()],
-  [`${os.endianness}`, os.endianness()]
+  [`${os.endianness}`, os.endianness()],
+  [`${os.tmpdir}`, os.tmpdir()],
+  [`${os.arch}`, os.arch()],
+  [`${os.platform}`, os.platform()]
 ].forEach((set) => assert.strictEqual(set[0], set[1]));

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -20,7 +20,6 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-
 const common = require('../common');
 const assert = require('assert');
 const os = require('os');
@@ -28,9 +27,9 @@ const path = require('path');
 const { inspect } = require('util');
 
 const is = {
-  string: (value) => assert.strictEqual(typeof value, 'string'),
-  number: (value) => assert.strictEqual(typeof value, 'number'),
-  array: (value) => assert.ok(Array.isArray(value)),
+  string: (value) => { assert.strictEqual(typeof value, 'string'); },
+  number: (value) => { assert.strictEqual(typeof value, 'number'); },
+  array: (value) => { assert.ok(Array.isArray(value)); },
   object: (value) => {
     assert.strictEqual(typeof value, 'object');
     assert.notStrictEqual(value, null);
@@ -95,7 +94,7 @@ const release = os.release();
 is.string(release);
 assert.ok(release.length > 0);
 //TODO: Check format on more than just AIX
-if (common.isAIX)
+if (common.isAIX) {
   assert.ok(/^\d+\.\d+$/.test(release));
 }
 
@@ -115,8 +114,10 @@ if (!common.isSunOS) {
 }
 
 const interfaces = os.networkInterfaces();
+const local = (e) => e.address === '127.0.0.1';
 switch (platform) {
   case 'linux':
+<<<<<<< HEAD
   {
     const filter =
       (e) => e.address === '127.0.0.1' && e.netmask === '255.0.0.0';
@@ -143,6 +144,50 @@ function flatten(arr) {
     (acc, c) => acc.concat(Array.isArray(c) ? flatten(c) : c),
     []
   );
+=======
+    {
+      const actual = interfaces.lo.filter(local);
+      const expected = [{
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        mac: '00:00:00:00:00:00',
+        family: 'IPv4',
+        internal: true
+      }];
+      assert.deepStrictEqual(actual, expected);
+      break;
+    }
+  case 'win32':
+    {
+      const actual = interfaces['Loopback Pseudo-Interface 1'].filter(local);
+      const expected = [{
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        mac: '00:00:00:00:00:00',
+        family: 'IPv4',
+        internal: true
+      }];
+      assert.deepStrictEqual(actual, expected);
+      break;
+    }
+  case 'aix':
+    {
+      const lo0 = interfaces.lo0;
+      // There might not be a lo0 entry configured
+      if (!lo0) break;
+      const actual = lo0.filter(local);
+      // We cannot test mac field because it is non-zero
+      delete actual[0].mac;
+      const expected = [{
+        address: '127.0.0.1',
+        netmask: '0.0.0.1',
+        family: 'IPv4',
+        internal: true
+      }];
+      assert.deepStrictEqual(actual, expected);
+      break;
+    }
+>>>>>>> test: add os.networkInterfaces test case for aix
 }
 const netmaskToCIDRSuffixMap = new Map(Object.entries({
   '255.0.0.0': 8,
@@ -209,7 +254,7 @@ assert.ok(pwd.homedir.includes(path.sep));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
 
-// Test that the Symbol.toPrimitive functions work correctly
+// Test Symbol.toPrimitive on these functions
 [
   [+os.freemem, os.freemem()],
   [+os.totalmem, os.totalmem()],

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -220,20 +220,20 @@ assert.ok(pwd.homedir.includes(path.sep));
 assert.strictEqual(pwd.username, pwdBuf.username.toString('utf8'));
 assert.strictEqual(pwd.homedir, pwdBuf.homedir.toString('utf8'));
 
-assert.strictEqual(String(os.hostname), os.hostname());
-assert.strictEqual(String(os.homedir), os.homedir());
-assert.strictEqual(String(os.release), os.release());
-assert.strictEqual(String(os.type), os.type());
-assert.strictEqual(String(os.endianness), os.endianness());
-assert.strictEqual(String(os.tmpdir), os.tmpdir());
-assert.strictEqual(String(os.arch), os.arch());
-assert.strictEqual(String(os.platform), os.platform());
+assert.strictEqual(`${os.hostname}`, os.hostname());
+assert.strictEqual(`${os.homedir}`, os.homedir());
+assert.strictEqual(`${os.release}`, os.release());
+assert.strictEqual(`${os.type}`, os.type());
+assert.strictEqual(`${os.endianness}`, os.endianness());
+assert.strictEqual(`${os.tmpdir}`, os.tmpdir());
+assert.strictEqual(`${os.arch}`, os.arch());
+assert.strictEqual(`${os.platform}`, os.platform());
 
-assert.strictEqual(Number(os.totalmem), os.totalmem());
+assert.strictEqual(+os.totalmem, os.totalmem());
 
 // At least we can check that these values are numbers
-is.number(Number(os.uptime), 'uptime');
+is.number(+os.uptime, 'uptime');
 is.number(os.uptime(), 'uptime');
 
-is.number(Number(os.freemem), 'freemem');
+is.number(+os.freemem, 'freemem');
 is.number(os.freemem(), 'freemem');


### PR DESCRIPTION
Basically added tests for `Symbol.toPrimitive` cases

- Statements from **82%** to **94.12%**
  I think it is actually a 100% because some statements/branches are `platform` dependent
- Functions from **66.67%** to **100%**

**NB** Obviously I ran tests, but seems like `master` branch has some tests failing in other modules. `os` module not failing though

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

- `test`