### PR TITLE
test: fix test-process-kill-null.js for Windows

### DIFF
--- a/test/parallel/test-process-kill-null.js
+++ b/test/parallel/test-process-kill-null.js
@@ -20,29 +20,23 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-const cat = spawn('cat');
-let called;
+const child = common.isWindows ? spawn('cmd.exe') : spawn('cat');
 
-assert.ok(process.kill(cat.pid, 0));
+assert.ok(process.kill(child.pid, 0));
 
-cat.on('exit', function() {
+child.on('exit', common.mustCall(function() {
   assert.throws(function() {
-    process.kill(cat.pid, 0);
+    process.kill(child.pid, 0);
   }, Error);
-});
+}));
 
-cat.stdout.on('data', function() {
-  called = true;
-  process.kill(cat.pid, 'SIGKILL');
-});
+child.stdout.on('data', common.mustCall(function() {
+  process.kill(child.pid, 'SIGKILL');
+}));
 
 // EPIPE when null sig fails
-cat.stdin.write('test');
-
-process.on('exit', function() {
-  assert.ok(called);
-});
+child.stdin.write('test');


### PR DESCRIPTION
The [test-process-kill-null.js](https://github.com/nodejs/node/blob/master/test/parallel/test-process-kill-null.js) failed in Windows because `cat` command is invalid for Windows cmd.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
