### PR TITLE
n-api: fix warning in test_general

### DIFF
--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -98,7 +98,7 @@ napi_value testNapiTypeof(napi_env env, napi_callback_info info) {
   napi_valuetype argument_type;
   NAPI_CALL(env, napi_typeof(env, args[0], &argument_type));
 
-  napi_value result;
+  napi_value result = NULL;
   if (argument_type == napi_number) {
     NAPI_CALL(env, napi_create_string_utf8(env, "number", -1, &result));
   } else if (argument_type == napi_string) {


### PR DESCRIPTION
Currently the following warning is issued when buildning:
```console
Building addon
/work/nodejs/node/test/addons-napi/test_general/
  CC(target) Debug/obj.target/test_general/test_general.o
../test_general.c:116:14: warning: variable 'result' is used
uninitialized whenever 'if' condition is false
[-Wsometimes-uninitialized]
  } else if (argument_type == napi_null) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
../test_general.c:119:10: note: uninitialized use occurs here
  return result;
         ^~~~~~
../test_general.c:116:10: note: remove the 'if' if its condition is
always true
  } else if (argument_type == napi_null) {
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../test_general.c:101:20: note: initialize the variable 'result' to
silence this warning
  napi_value result;
                   ^
                    = NULL
```
This commit simply initializes result to NULL to avoid this warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
n-api, test
##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
