### PR TITLE
tools: fix error in eslintrc comment

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -101,7 +101,7 @@ rules:
   func-call-spacing: error
   func-name-matching: error
   func-style: [error, declaration, {allowArrowFunctions: true}]
-  # indent: [error, error, {ArrayExpression: first,
+  # indent: [error, 2, {ArrayExpression: first,
   #                 CallExpression: {arguments: first},
   #                 FunctionDeclaration: {parameters: first},
   #                 FunctionExpression: {parameters: first},


### PR DESCRIPTION
46d7cb88c7f8b416e667c52de80e6766115b3781 introduced an error in a
comment in `.eslintrc.yaml`. The second option needs to be an integer
specifying the number of spaces per level of indentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools