### PR TITLE
cctest: Fix cctest failure on windows

### DIFF
--- a/test/cctest/test_inspector_socket_server.cc
+++ b/test/cctest/test_inspector_socket_server.cc
@@ -621,7 +621,7 @@ TEST_F(InspectorSocketServerTest, BindsToIpV6) {
   ASSERT_TRUE(server->Start());
 
   SocketWrapper socket1(&loop);
-  socket1.Connect("::", server.port(), true);
+  socket1.Connect("::1", server.port(), true);
   socket1.Write(WsHandshakeRequest(MAIN_TARGET_ID));
   socket1.Expect(WS_HANDSHAKE_RESPONSE);
   server->Stop(ServerHolder::CloseCallback);


### PR DESCRIPTION
Linux converts the ipv6 address "::" to "::1", while windows does not.
By explicitly using "::1" in the test we allow it to succeed on windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

cctest