### PR TITLE
crypto: fix memory leak, reduce heap allocations, clean up

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2373,10 +2373,9 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     if (resp == nullptr) {
       arg = Null(env->isolate());
     } else {
-      arg = Buffer::Copy(
-          env,
-          reinterpret_cast<char*>(const_cast<unsigned char*>(resp)),
-          len).ToLocalChecked();
+      arg =
+          Buffer::Copy(env, reinterpret_cast<const char*>(resp), len)
+          .ToLocalChecked();
     }
 
     w->MakeCallback(env->onocspresponse_string(), 1, &arg);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3648,7 +3648,6 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
 
   unsigned char* out_value = nullptr;
   int out_len = -1;
-  Local<Value> outString;
 
   // Check IsAuthenticatedMode() first, Final() destroys the EVP_CIPHER_CTX.
   const bool is_auth_mode = cipher->IsAuthenticatedMode();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5355,8 +5355,9 @@ void PBKDF2Request::Work(uv_work_t* work_req) {
 void PBKDF2Request::After(Local<Value> (*argv)[2]) {
   if (error()) {
     (*argv)[0] = Undefined(env()->isolate());
-    (*argv)[1] = Encode(env()->isolate(), key(), keylen(), BUFFER);
-    OPENSSL_cleanse(key(), keylen());
+    (*argv)[1] = Buffer::New(env(), key(), keylen()).ToLocalChecked();
+    key_ = nullptr;
+    keylen_ = 0;
   } else {
     (*argv)[0] = Exception::Error(env()->pbkdf2_error_string());
     (*argv)[1] = Undefined(env()->isolate());

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1804,11 +1804,10 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
   int slen = i2d_SSL_SESSION(sess, nullptr);
   CHECK_GT(slen, 0);
 
-  char* sbuf = new char[slen];
+  char* sbuf = Malloc(slen);
   unsigned char* p = reinterpret_cast<unsigned char*>(sbuf);
   i2d_SSL_SESSION(sess, &p);
-  args.GetReturnValue().Set(Encode(env->isolate(), sbuf, slen, BUFFER));
-  delete[] sbuf;
+  args.GetReturnValue().Set(Buffer::New(env, sbuf, slen).ToLocalChecked());
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5498,6 +5498,7 @@ class RandomBytesRequest : public AsyncWrap {
     size_ = 0;
     if (free_mode_ == FREE_DATA) {
       free(data_);
+      data_ = nullptr;
     }
   }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5245,7 +5245,18 @@ class PBKDF2Request : public AsyncWrap {
   }
 
   ~PBKDF2Request() override {
-    release();
+    free(pass_);
+    pass_ = nullptr;
+    passlen_ = 0;
+
+    free(salt_);
+    salt_ = nullptr;
+    saltlen_ = 0;
+
+    free(key_);
+    key_ = nullptr;
+    keylen_ = 0;
+
     ClearWrap(object());
     persistent().Reset();
   }
@@ -5284,20 +5295,6 @@ class PBKDF2Request : public AsyncWrap {
 
   inline int iter() const {
     return iter_;
-  }
-
-  inline void release() {
-    free(pass_);
-    pass_ = nullptr;
-    passlen_ = 0;
-
-    free(salt_);
-    salt_ = nullptr;
-    saltlen_ = 0;
-
-    free(key_);
-    key_ = nullptr;
-    keylen_ = 0;
   }
 
   inline int error() const {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -587,7 +587,7 @@ class Sign : public SignBase {
   Error SignFinal(const char* key_pem,
                   int key_pem_len,
                   const char* passphrase,
-                  unsigned char** sig,
+                  unsigned char* sig,
                   unsigned int *sig_len,
                   int padding,
                   int saltlen);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -467,7 +467,6 @@ class CipherBase : public BaseObject {
              v8::Local<v8::Object> wrap,
              CipherKind kind)
       : BaseObject(env, wrap),
-        cipher_(nullptr),
         initialised_(false),
         kind_(kind),
         auth_tag_len_(0) {
@@ -476,7 +475,6 @@ class CipherBase : public BaseObject {
 
  private:
   EVP_CIPHER_CTX ctx_; /* coverity[member_decl] */
-  const EVP_CIPHER* cipher_; /* coverity[member_decl] */
   bool initialised_;
   CipherKind kind_;
   unsigned int auth_tag_len_;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -494,7 +494,6 @@ class Hmac : public BaseObject {
  protected:
   void HmacInit(const char* hash_type, const char* key, int key_len);
   bool HmacUpdate(const char* data, int len);
-  bool HmacDigest(unsigned char** md_value, unsigned int* md_len);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HmacInit(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -690,6 +690,8 @@ class DiffieHellman : public BaseObject {
   }
 
  private:
+  static void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
+                       BIGNUM* (DH::*field), const char* err_if_null);
   bool VerifyContext();
 
   bool initialised_;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -692,6 +692,8 @@ class DiffieHellman : public BaseObject {
  private:
   static void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
                        BIGNUM* (DH::*field), const char* err_if_null);
+  static void SetKey(const v8::FunctionCallbackInfo<v8::Value>& args,
+                     BIGNUM* (DH::*field), const char* what);
   bool VerifyContext();
 
   bool initialised_;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -428,7 +428,6 @@ class CipherBase : public BaseObject {
   ~CipherBase() override {
     if (!initialised_)
       return;
-    delete[] auth_tag_;
     EVP_CIPHER_CTX_cleanup(&ctx_);
   }
 
@@ -451,8 +450,6 @@ class CipherBase : public BaseObject {
   bool SetAutoPadding(bool auto_padding);
 
   bool IsAuthenticatedMode() const;
-  bool GetAuthTag(char** out, unsigned int* out_len) const;
-  bool SetAuthTag(const char* data, unsigned int len);
   bool SetAAD(const char* data, unsigned int len);
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -473,7 +470,6 @@ class CipherBase : public BaseObject {
         cipher_(nullptr),
         initialised_(false),
         kind_(kind),
-        auth_tag_(nullptr),
         auth_tag_len_(0) {
     MakeWeak<CipherBase>(this);
   }
@@ -483,8 +479,8 @@ class CipherBase : public BaseObject {
   const EVP_CIPHER* cipher_; /* coverity[member_decl] */
   bool initialised_;
   CipherKind kind_;
-  char* auth_tag_;
   unsigned int auth_tag_len_;
+  char auth_tag_[EVP_GCM_TLS_TAG_LEN];
 };
 
 class Hmac : public BaseObject {

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -476,7 +476,7 @@ class CipherBase : public BaseObject {
  private:
   EVP_CIPHER_CTX ctx_; /* coverity[member_decl] */
   bool initialised_;
-  CipherKind kind_;
+  const CipherKind kind_;
   unsigned int auth_tag_len_;
   char auth_tag_[EVP_GCM_TLS_TAG_LEN];
 };

--- a/test/parallel/test-crypto-dh-leak.js
+++ b/test/parallel/test-crypto-dh-leak.js
@@ -1,0 +1,26 @@
+// Flags: --expose-gc
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const before = process.memoryUsage().rss;
+{
+  const dh = crypto.createDiffieHellman(common.hasFipsCrypto ? 1024 : 256);
+  const publicKey = dh.generateKeys();
+  const privateKey = dh.getPrivateKey();
+  for (let i = 0; i < 5e4; i += 1) {
+    dh.setPublicKey(publicKey);
+    dh.setPrivateKey(privateKey);
+  }
+}
+global.gc();
+const after = process.memoryUsage().rss;
+
+// RSS should stay the same, ceteris paribus, but allow for
+// some slop because V8 mallocs memory during execution.
+assert(after - before < 5 << 20);

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -379,3 +379,38 @@ for (let i = 0, l = rfc2202_sha1.length; i < l; i++) {
 assert.throws(function() {
   crypto.createHmac('sha256', 'w00t').digest('ucs2');
 }, /^Error: hmac\.digest\(\) does not support UTF-16$/);
+
+// Check initialized -> uninitialized state transition after calling digest().
+{
+  const expected =
+      '\u0010\u0041\u0052\u00c5\u00bf\u00dc\u00a0\u007b\u00c6\u0033' +
+      '\u00ee\u00bd\u0046\u0019\u009f\u0002\u0055\u00c9\u00f4\u009d';
+  {
+    const h = crypto.createHmac('sha1', 'key').update('data');
+    assert.deepStrictEqual(h.digest('buffer'), Buffer.from(expected, 'latin1'));
+    assert.deepStrictEqual(h.digest('buffer'), Buffer.from(''));
+  }
+  {
+    const h = crypto.createHmac('sha1', 'key').update('data');
+    assert.deepStrictEqual(h.digest('latin1'), expected);
+    assert.deepStrictEqual(h.digest('latin1'), '');
+  }
+}
+
+// Check initialized -> uninitialized state transition after calling digest().
+// Calls to update() omitted intentionally.
+{
+  const expected =
+      '\u00f4\u002b\u00b0\u00ee\u00b0\u0018\u00eb\u00bd\u0045\u0097' +
+      '\u00ae\u0072\u0013\u0071\u001e\u00c6\u0007\u0060\u0084\u003f';
+  {
+    const h = crypto.createHmac('sha1', 'key');
+    assert.deepStrictEqual(h.digest('buffer'), Buffer.from(expected, 'latin1'));
+    assert.deepStrictEqual(h.digest('buffer'), Buffer.from(''));
+  }
+  {
+    const h = crypto.createHmac('sha1', 'key');
+    assert.deepStrictEqual(h.digest('latin1'), expected);
+    assert.deepStrictEqual(h.digest('latin1'), '');
+  }
+}


### PR DESCRIPTION
Fixes: nodejs#13917

Also of note:

> The EVP_CIPHER can be reconstructed from the EVP_CIPHER_CTX instance,
no need to store it separately.
>
>This brought to light the somewhat dubious practice of accessing the
EVP_CIPHER after the EVP_CIPHER_CTX instance had been destroyed.
>
> It's mostly harmless due to the static nature of built-in EVP_CIPHER
instances but it segfaults when the cipher is provided by an ENGINE
and the ENGINE is unloaded because its reference count drops to zero.

I'll clean up the commit logs some more before landing.

CI: https://ci.nodejs.org/job/node-test-pull-request/9027/