### PR TITLE
test: handle missing V8 tests in n-api test

### DIFF
--- a/test/addons-napi/test_general/testInstanceOf.js
+++ b/test/addons-napi/test_general/testInstanceOf.js
@@ -9,6 +9,11 @@ const assert = require('assert');
 const addon = require(`./build/${common.buildType}/test_general`);
 const path = require('path');
 
+// This test depends on a number of V8 tests.
+const v8TestsDir = path.resolve(__dirname, '..', '..', '..', 'deps', 'v8',
+                                'test', 'mjsunit');
+const v8TestsDirExists = fs.existsSync(v8TestsDir);
+
 // The following assert functions are referenced by v8's unit tests
 // See for instance deps/v8/test/mjsunit/instanceof.js
 // eslint-disable-next-line no-unused-vars
@@ -34,19 +39,22 @@ function assertThrows(statement) {
 }
 
 function testFile(fileName) {
-  const contents = fs.readFileSync(fileName, { encoding: 'utf8' });
-  eval(contents.replace(/[(]([^\s(]+)\s+instanceof\s+([^)]+)[)]/g,
-                        '(addon.doInstanceOf($1, $2))'));
+  try {
+    const contents = fs.readFileSync(fileName, { encoding: 'utf8' });
+    eval(contents.replace(/[(]([^\s(]+)\s+instanceof\s+([^)]+)[)]/g,
+                          '(addon.doInstanceOf($1, $2))'));
+  } catch (err) {
+    // This test depends on V8 test files, which may not exist in downloaded
+    // archives. Emit a warning if the tests cannot be found instead of failing.
+    if (err.code === 'ENOENT' && !v8TestsDirExists)
+      process.emitWarning(`test file ${fileName} does not exist.`);
+    else
+      throw err;
+  }
 }
 
-testFile(
-    path.join(path.resolve(__dirname, '..', '..', '..',
-                           'deps', 'v8', 'test', 'mjsunit'),
-              'instanceof.js'));
-testFile(
-    path.join(path.resolve(__dirname, '..', '..', '..',
-                           'deps', 'v8', 'test', 'mjsunit'),
-              'instanceof-2.js'));
+testFile(path.join(v8TestsDir, 'instanceof.js'));
+testFile(path.join(v8TestsDir, 'instanceof-2.js'));
 
 // We can only perform this test if we have a working Symbol.hasInstance
 if (typeof Symbol !== 'undefined' && 'hasInstance' in Symbol &&


### PR DESCRIPTION
The N-API test `testInstanceOf.js` relies on several V8 test files which may not exist in downloadable archives. If the files are missing, this commit causes a warning to be emitted rather than failing the test.

Refs: https://github.com/nodejs/node/issues/14113
Fixes: https://github.com/nodejs/node/issues/13344

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test