### PR TITLE
lib: normalize indentation in parentheses

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -741,11 +741,12 @@ function SecurePair(context, isServer, requestCert, rejectUnauthorized,
   this._rejectUnauthorized = rejectUnauthorized ? true : false;
   this._requestCert = requestCert ? true : false;
 
-  this.ssl = new Connection(this.credentials.context,
-                            this._isServer ? true : false,
-                            this._isServer ? this._requestCert :
-                                             options.servername,
-                            this._rejectUnauthorized);
+  this.ssl = new Connection(
+    this.credentials.context,
+    this._isServer ? true : false,
+    this._isServer ? this._requestCert : options.servername,
+    this._rejectUnauthorized
+  );
 
   if (this._isServer) {
     this.ssl.onhandshakestart = () => onhandshakestart.call(this);

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -522,8 +522,7 @@ function handleGroup(self, group, width, maxColumns) {
       var item = group[idx];
       self._writeToOutput(item);
       if (col < maxColumns - 1) {
-        for (var s = 0, itemLen = item.length; s < width - itemLen;
-             s++) {
+        for (var s = 0, itemLen = item.length; s < width - itemLen; s++) {
           self._writeToOutput(' ');
         }
       }


### PR DESCRIPTION
In anticipation of stricter indentation linting, normalize indentation
of code in parentheses.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib tools