### PR TITLE
doc: fix mistake in http.md

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -519,7 +519,7 @@ unsent, it will flush them to the stream. If the request is
 chunked, this will send the terminating `'0\r\n\r\n'`.
 
 If `data` is specified, it is equivalent to calling
-[`response.write(data, encoding)`][] followed by `request.end(callback)`.
+[`request.write(data, encoding)`][] followed by `request.end(callback)`.
 
 If `callback` is specified, it will be called when the request stream
 is finished.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1900,6 +1900,7 @@ const req = http.request(options, (res) => {
 [`net.createConnection()`]: net.html#net_net_createconnection_options_connectlistener
 [`request.socket`]: #http_request_socket
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
+[`request.write(data, encoding)`]: #http_request_write_chunk_encoding_callback
 [`response.end()`]: #http_response_end_data_encoding_callback
 [`response.setHeader()`]: #http_response_setheader_name_value
 [`response.socket`]: #http_response_socket


### PR DESCRIPTION
If the first parameter of `request.end` `data` is specified, it should
be equivalent to calling `request.write(data, encoding)` (not
`response.write(data, encoding)`) followed by `request.end(callback)`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- [x] doc
