### PR TITLE
buffer: remove MAX_SAFE_INTEGER check on length

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -354,8 +354,6 @@ function fromArrayBuffer(obj, byteOffset, length) {
     if (length !== length) {
       length = 0;
     } else if (length > 0) {
-      length = (length < Number.MAX_SAFE_INTEGER ?
-                length : Number.MAX_SAFE_INTEGER);
       if (length > maxLength)
         throw new RangeError("'length' is out of bounds");
     } else {


### PR DESCRIPTION
MAX_SAFE_INTEGER is millions of times larger than the largest buffer
allowed in Node.js. There is no need to squash the length down to
MAX_SAFE_INTEGER. Removing that check results in a small but
statistically significant increase for Buffer.from() operating on
ArrayBuffers in some situations.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer