### PR TITLE
test: fix flaky test-https-set-timeout-server

### DIFF
--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -42,9 +42,10 @@ function run() {
 }
 
 test(function serverTimeout(cb) {
-  const server = http.createServer(common.mustCall((req, res) => {
-    // just do nothing, we should get a timeout event.
-  }));
+  const server = http.createServer((req, res) => {
+    // Do nothing. We should get a timeout event.
+    // Might not be invoked. Do not wrap in common.mustCall().
+  });
   server.listen(common.mustCall(() => {
     const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -54,9 +54,10 @@ function run() {
 test(function serverTimeout(cb) {
   const server = https.createServer(
     serverOptions,
-    common.mustCall((req, res) => {
-      // just do nothing, we should get a timeout event.
-    }));
+    (req, res) => {
+      // Do nothing. We should get a timeout event.
+      // Might not be invoked. Do not wrap in common.mustCall().
+    });
   server.listen(common.mustCall(() => {
     const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();


### PR DESCRIPTION
Because of a race condition, connection listener may not be invoked if
test is run under load. Remove `common.mustCall()` wrapper from the
listener. Move the test to `parallel` because it now works under load.
Make similar change to http test to keep them in synch even though it is
much harder to trigger the race in http.

Fixes: https://github.com/nodejs/node/issues/14133

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http https