### PR TITLE
async_hooks: fix nested hooks mutation

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -335,11 +335,6 @@ function emitInitS(asyncId, type, triggerAsyncId, resource) {
     throw new RangeError('triggerAsyncId must be an unsigned integer');
 
   init(asyncId, type, triggerAsyncId, resource);
-
-  // Isn't null if hooks were added/removed while the hooks were running.
-  if (tmp_active_hooks_array !== null) {
-    restoreTmpHooks();
-  }
 }
 
 function emitHookFactory(symbol, name) {
@@ -442,6 +437,11 @@ function init(asyncId, type, triggerAsyncId, resource) {
     fatalError(e);
   }
   processing_hook = false;
+
+  // Isn't null if hooks were added/removed while the hooks were running.
+  if (tmp_active_hooks_array !== null) {
+    restoreTmpHooks();
+  }
 }
 
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -29,7 +29,7 @@ var active_hooks_array = [];
 // Track whether a hook callback is currently being processed. Used to make
 // sure active_hooks_array isn't altered in mid execution if another hook is
 // added or removed.
-var processing_hook = false;
+var processing_hook = 0;
 // Use to temporarily store and updated active_hooks_array if the user enables
 // or disables a hook while hooks are being processed.
 var tmp_active_hooks_array = null;
@@ -151,7 +151,7 @@ class AsyncHook {
 
 
 function getHookArrays() {
-  if (!processing_hook)
+  if (processing_hook === 0)
     return [active_hooks_array, async_hook_fields];
   // If this hook is being enabled while in the middle of processing the array
   // of currently active hooks then duplicate the current set of active hooks
@@ -342,7 +342,7 @@ function emitHookFactory(symbol, name) {
   // before this is called.
   // eslint-disable-next-line func-style
   const fn = function(asyncId) {
-    processing_hook = true;
+    processing_hook += 1;
     // Use a single try/catch for all hook to avoid setting up one per
     // iteration.
     try {
@@ -354,9 +354,9 @@ function emitHookFactory(symbol, name) {
     } catch (e) {
       fatalError(e);
     }
-    processing_hook = false;
+    processing_hook -= 1;
 
-    if (tmp_active_hooks_array !== null) {
+    if (processing_hook === 0 && tmp_active_hooks_array !== null) {
       restoreTmpHooks();
     }
   };
@@ -422,7 +422,7 @@ function emitDestroyS(asyncId) {
 // slim chance of the application remaining stable after handling one of these
 // exceptions.
 function init(asyncId, type, triggerAsyncId, resource) {
-  processing_hook = true;
+  processing_hook += 1;
   // Use a single try/catch for all hook to avoid setting up one per iteration.
   try {
     for (var i = 0; i < active_hooks_array.length; i++) {
@@ -436,10 +436,16 @@ function init(asyncId, type, triggerAsyncId, resource) {
   } catch (e) {
     fatalError(e);
   }
-  processing_hook = false;
+  processing_hook -= 1;
 
-  // Isn't null if hooks were added/removed while the hooks were running.
-  if (tmp_active_hooks_array !== null) {
+  // * `tmp_active_hooks_array` is null if no hooks were added/removed while
+  //   the hooks were running. In that case no restoration is needed.
+  // * In the case where another hook was added/removed while the hooks were
+  //   running and a handle was created causing the `init` hooks to fire again,
+  //   then `restoreTmpHooks` should not be called for the nested `hooks`.
+  //   Otherwise `active_hooks_array` can change during execution of the
+  //   `hooks`.
+  if (processing_hook === 0 && tmp_active_hooks_array !== null) {
     restoreTmpHooks();
   }
 }

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -353,8 +353,9 @@ function emitHookFactory(symbol, name) {
       }
     } catch (e) {
       fatalError(e);
+    } finally {
+      processing_hook -= 1;
     }
-    processing_hook -= 1;
 
     if (processing_hook === 0 && tmp_active_hooks_array !== null) {
       restoreTmpHooks();
@@ -435,8 +436,9 @@ function init(asyncId, type, triggerAsyncId, resource) {
     }
   } catch (e) {
     fatalError(e);
+  } finally {
+    processing_hook -= 1;
   }
-  processing_hook -= 1;
 
   // * `tmp_active_hooks_array` is null if no hooks were added/removed while
   //   the hooks were running. In that case no restoration is needed.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -26,9 +26,9 @@ const { pushAsyncIds, popAsyncIds } = async_wrap;
 // Using var instead of (preferably const) in order to assign
 // tmp_active_hooks_array if a hook is enabled/disabled during hook execution.
 var active_hooks_array = [];
-// Track whether a hook callback is currently being processed. Used to make
-// sure active_hooks_array isn't altered in mid execution if another hook is
-// added or removed.
+// Use a counter to track whether a hook callback is currently being processed.
+// Used to make sure active_hooks_array isn't altered in mid execution if
+// another hook is added or removed. A counter is used to track nested calls.
 var processing_hook = 0;
 // Use to temporarily store and updated active_hooks_array if the user enables
 // or disables a hook while hooks are being processed.

--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const async_hooks = require('async_hooks');
-const crypto = require('crypto');
+const fs = require('fs');
 
 let nestedCall = false;
 
@@ -11,7 +11,7 @@ async_hooks.createHook({
     nestedHook.disable();
     if (!nestedCall) {
       nestedCall = true;
-      crypto.randomBytes(1, common.mustCall());
+      fs.access(__filename, common.mustCall());
     }
   }, 2)
 }).enable();
@@ -20,4 +20,4 @@ const nestedHook = async_hooks.createHook({
   init: common.mustCall(2)
 }).enable();
 
-crypto.randomBytes(1, common.mustCall());
+fs.access(__filename, common.mustCall());

--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const crypto = require('crypto');
+
+let nestedCall = false;
+
+const rootHook = async_hooks.createHook({
+  init: common.mustCall(function (id, type) {
+    nestedHook.disable();
+    if (!nestedCall) {
+      nestedCall = true;
+      crypto.randomBytes(1, common.mustCall());
+    }
+  }, 2)
+}).enable();
+
+const nestedHook = async_hooks.createHook({
+  init: common.mustCall(2)
+}).enable();
+
+crypto.randomBytes(1, common.mustCall());

--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const async_hooks = require('async_hooks');
 const crypto = require('crypto');
 
 let nestedCall = false;
 
-const rootHook = async_hooks.createHook({
-  init: common.mustCall(function (id, type) {
+async_hooks.createHook({
+  init: common.mustCall(function(id, type) {
     nestedHook.disable();
     if (!nestedCall) {
       nestedCall = true;

--- a/test/async-hooks/test-enable-in-init.js
+++ b/test/async-hooks/test-enable-in-init.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+const crypto = require('crypto');
+
+const nestedHook = async_hooks.createHook({
+  init: common.mustNotCall()
+});
+let nestedCall = false;
+
+const rootHook = async_hooks.createHook({
+  init: common.mustCall(function (id, type) {
+    nestedHook.enable();
+    if (!nestedCall) {
+      nestedCall = true;
+      crypto.randomBytes(1, common.mustCall());
+    }
+  }, 2)
+}).enable();
+
+crypto.randomBytes(1, common.mustCall());

--- a/test/async-hooks/test-enable-in-init.js
+++ b/test/async-hooks/test-enable-in-init.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const async_hooks = require('async_hooks');
 const crypto = require('crypto');
 
@@ -10,8 +9,8 @@ const nestedHook = async_hooks.createHook({
 });
 let nestedCall = false;
 
-const rootHook = async_hooks.createHook({
-  init: common.mustCall(function (id, type) {
+async_hooks.createHook({
+  init: common.mustCall(function(id, type) {
     nestedHook.enable();
     if (!nestedCall) {
       nestedCall = true;

--- a/test/async-hooks/test-enable-in-init.js
+++ b/test/async-hooks/test-enable-in-init.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const async_hooks = require('async_hooks');
-const crypto = require('crypto');
+const fs = require('fs');
 
 const nestedHook = async_hooks.createHook({
   init: common.mustNotCall()
@@ -14,9 +14,9 @@ async_hooks.createHook({
     nestedHook.enable();
     if (!nestedCall) {
       nestedCall = true;
-      crypto.randomBytes(1, common.mustCall());
+      fs.access(__filename, common.mustCall());
     }
   }, 2)
 }).enable();
 
-crypto.randomBytes(1, common.mustCall());
+fs.access(__filename, common.mustCall());

--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+const async_hooks = require('async_hooks');
+const crypto = require('crypto');
+
+const nestedHook = async_hooks.createHook({
+  init: common.mustCall()
+});
+
+async_hooks.createHook({
+  init: common.mustCall((id, type) => {
+    nestedHook.enable();
+  }, 2)
+}).enable();
+
+crypto.randomBytes(1, common.mustCall(() => {
+  crypto.randomBytes(1, common.mustCall());
+}));

--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const async_hooks = require('async_hooks');
-const crypto = require('crypto');
+const fs = require('fs');
 
 const nestedHook = async_hooks.createHook({
   init: common.mustCall()
@@ -14,6 +14,6 @@ async_hooks.createHook({
   }, 2)
 }).enable();
 
-crypto.randomBytes(1, common.mustCall(() => {
-  crypto.randomBytes(1, common.mustCall());
+fs.access(__filename, common.mustCall(() => {
+  fs.access(__filename, common.mustCall());
 }));


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks

In some cases `restoreTmpHooks` is called too early, this causes `active_hooks_array` to change during execution of the init hooks.

This depends on https://github.com/nodejs/node/pull/14054