### PR TITLE
doc: fix Error:captureStackTrace description

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -221,7 +221,7 @@ Error.captureStackTrace(myObject);
 myObject.stack;  // similar to `new Error().stack`
 ```
 
-The first line of the trace will be prefixed with `ErrorType.name: message`.
+The first line of the trace will be prefixed with `${myObject.name}: ${myObject.message}`.
 
 The optional `constructorOpt` argument accepts a function. If given, all frames
 above `constructorOpt`, including `constructorOpt`, will be omitted from the

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -221,8 +221,7 @@ Error.captureStackTrace(myObject);
 myObject.stack;  // similar to `new Error().stack`
 ```
 
-The first line of the trace, instead of being prefixed with `ErrorType:
-message`, will be the result of calling `targetObject.toString()`.
+The first line of the trace will be prefixed with `ErrorType.name: message`.
 
 The optional `constructorOpt` argument accepts a function. If given, all frames
 above `constructorOpt`, including `constructorOpt`, will be omitted from the


### PR DESCRIPTION
Hi everyone!

I fixed the wrong sentence in the `Error.captureStackTrace(targetObject[, constructorOpt])` part of  [api/errors doc](https://github.com/romanshoryn/node/blob/master/doc/api/errors.md#errorcapturestacktracetargetobject-constructoropt).

Fixes: https://github.com/nodejs/node/issues/5675

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
