### PR TITLE
tools: update outdated package.json `engine` field

### DIFF
--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -4,7 +4,7 @@
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
   "engines": {
-    "node": ">=0.6.10"
+    "node": ">=6"
   },
   "dependencies": {
     "marked": "^0.3.5",

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -3,9 +3,6 @@
   "name": "node-doc-generator",
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
-  "engines": {
-    "node": ">=0.6.10"
-  },
   "dependencies": {
     "marked": "^0.3.5",
     "js-yaml": "^3.5.2"

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -3,6 +3,9 @@
   "name": "node-doc-generator",
   "description": "Internal tool for generating Node.js API docs",
   "version": "0.0.0",
+  "engines": {
+    "node": ">=0.6.10"
+  },
   "dependencies": {
     "marked": "^0.3.5",
     "js-yaml": "^3.5.2"


### PR DESCRIPTION
This `engines` field clearly hasn't been true for a long time and is just useless. So get rid of it.

##### Checklist

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tools