### PR TITLE
Ignore template literals

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -109,17 +109,18 @@ rules:
   #                 ObjectExpression: first,
   #                 SwitchCase: 1}]
   indent-legacy: [error, 2, {ArrayExpression: first,
-                         CallExpression: {arguments: first},
-                         MemberExpression: 1,
-                         ObjectExpression: first,
-                         SwitchCase: 1}]
+                             CallExpression: {arguments: first},
+                             MemberExpression: 1,
+                             ObjectExpression: first,
+                             SwitchCase: 1}]
   key-spacing: [error, {mode: minimum}]
   keyword-spacing: error
   linebreak-style: [error, unix]
   max-len: [error, {code: 80,
-                ignoreRegExpLiterals: true,
-                ignoreUrls: true,
-                tabWidth: 2}]
+                    ignoreRegExpLiterals: true,
+                    ignoreTemplateLiterals: true,
+                    ignoreUrls: true,
+                    tabWidth: 2}]
   new-parens: error
   no-mixed-spaces-and-tabs: error
   no-multiple-empty-lines: [error, {max: 2, maxEOF: 0, maxBOF: 0}]

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -124,8 +124,7 @@ E('ERR_INVALID_ARRAY_LENGTH',
   (name, length, actual) => {
     const assert = lazyAssert();
     assert.strictEqual(typeof actual, 'number');
-    return `The "${name}" array must have a length of ${
-           length}. Received length ${actual}`;
+    return `The "${name}" array must have a length of ${length}. Received length ${actual}`;
   });
 E('ERR_INVALID_CALLBACK', 'Callback must be a function');
 E('ERR_INVALID_CHAR', 'Invalid character in %s');

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -237,8 +237,7 @@ TestSession.prototype.sendInspectorCommands = function(commands) {
     };
     this.sendAll_(commands, () => {
       timeoutId = setTimeout(() => {
-        assert.fail(`Messages without response: ${
-                    Object.keys(this.messages_).join(', ')}`);
+        assert.fail(`Messages without response: ${Object.keys(this.messages_).join(', ')}`);
       }, TIMEOUT);
     });
   });

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -40,8 +40,10 @@ function testHelper(stream, args, expectedOutput, cmd, env) {
   });
 
   console.error(
-    `Spawned child [pid:${child.pid}] with cmd '${cmd}' expect %j with args '${
-    args}' OPENSSL_CONF=%j`, expectedOutput, env.OPENSSL_CONF);
+    `Spawned child [pid:${child.pid}] with cmd '${cmd}' expect %j with args '${args}' OPENSSL_CONF=%j`,
+    expectedOutput,
+    env.OPENSSL_CONF
+  );
 
   function childOk(child) {
     console.error(`Child #${++num_children_ok} [pid:${child.pid}] OK.`);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -266,9 +266,7 @@ const modSize = 1024;
   fs.writeFileSync(msgfile, msg);
 
   const cmd =
-    `"${common.opensslCli}" dgst -sha256 -verify "${pubfile}" -signature "${
-    sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${
-    msgfile}"`;
+    `"${common.opensslCli}" dgst -sha256 -verify "${pubfile}" -signature "${sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${msgfile}"`;
 
   exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert(stdout.includes('Verified OK'));

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -184,16 +184,18 @@ if (process.argv[2] === 'child') {
       test.expectedMessages.forEach(function(expectedMessage) {
         const msgs = test.messagesReceived;
         if (msgs === undefined || !msgs.includes(expectedMessage)) {
-          assert.fail(`test ${test.fn.name} should have sent message: ${
-                      expectedMessage} but didn't`);
+          assert.fail(
+            `test ${test.fn.name} should have sent message: ${expectedMessage} but didn't`
+          );
         }
       });
 
       if (test.messagesReceived) {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (!test.expectedMessages.includes(receivedMessage)) {
-            assert.fail(`test ${test.fn.name} should not have sent message: ${
-                        receivedMessage} but did`);
+            assert.fail(
+              `test ${test.fn.name} should not have sent message: ${receivedMessage} but did`
+            );
           }
         });
       }

--- a/test/parallel/test-domain-with-abort-on-uncaught-exception.js
+++ b/test/parallel/test-domain-with-abort-on-uncaught-exception.js
@@ -103,8 +103,8 @@ if (process.argv[2] === 'child') {
     if (options.useTryCatch)
       useTryCatchOpt = 'useTryCatch';
 
-    cmdToExec += `"${process.argv[0]}" ${cmdLineOption ? cmdLineOption : ''} "${
-      process.argv[1]}" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
+    cmdToExec +=
+      `"${process.argv[0]}" ${cmdLineOption ? cmdLineOption : ''} "${process.argv[1]}" child ${throwInDomainErrHandlerOpt} ${useTryCatchOpt}`;
 
     const child = exec(cmdToExec);
 

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -52,9 +52,10 @@ const server = net.createServer(function(socket) {
   function makeRequest() {
     const req = http.get({port: server.address().port}, function(res) {
       assert.strictEqual(
-        req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
-        `${SERVER_RESPONSES[responses]} should ${
-        SHOULD_KEEP_ALIVE[responses] ? '' : 'not '}Keep-Alive`);
+        req.shouldKeepAlive,
+        SHOULD_KEEP_ALIVE[responses],
+        `${SERVER_RESPONSES[responses]} should ${SHOULD_KEEP_ALIVE[responses] ? '' : 'not '}Keep-Alive`
+      );
       ++responses;
       if (responses < SHOULD_KEEP_ALIVE.length) {
         makeRequest();

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -54,8 +54,7 @@ if (!common.hasIntl) {
   common.skip('Intl tests because Intl object not present.');
 } else {
   const erMsg =
-    `"Intl" object is present but v8_enable_i18n_support is ${
-    enablei18n}. Is this test out of date?`;
+    `"Intl" object is present but v8_enable_i18n_support is ${enablei18n}. Is this test out of date?`;
   assert.strictEqual(enablei18n, 1, erMsg);
 
   // Construct a new date at the beginning of Unix time

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -149,8 +149,10 @@ trailingTests.forEach(function(test) {
   test[1].forEach(function(test) {
     const actual = parse(test[0]);
     const expected = test[1];
-    const message = `path.${os}.parse(${JSON.stringify(test[0])})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+    const message =
+      `path.${os}.parse(${JSON.stringify(test[0])})\n` +
+      `  expect=${JSON.stringify(expected)}\n` +
+      `  actual=${JSON.stringify(actual)}`;
     const actualKeys = Object.keys(actual);
     const expectedKeys = Object.keys(expected);
     let failed = (actualKeys.length !== expectedKeys.length);

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -198,8 +198,10 @@ assert.strictEqual(path.win32.dirname('foo'), '.');
     }
     const actual = extname(input);
     const expected = test[1];
-    const message = `path.${os}.extname(${JSON.stringify(input)})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+    const message =
+      `path.${os}.extname(${JSON.stringify(input)})\n` +
+      `  expect=${JSON.stringify(expected)}\n` +
+      `  actual=${JSON.stringify(actual)}`;
     if (actual !== expected)
       failures.push(`\n${message}`);
   });
@@ -354,8 +356,9 @@ joinTests.forEach((test) => {
         os = 'posix';
       }
       const message =
-        `path.${os}.join(${test[0].map(JSON.stringify).join(',')})\n  expect=${
-          JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        `path.${os}.join(${test[0].map(JSON.stringify).join(',')})\n` +
+        `  expect=${JSON.stringify(expected)}\n` +
+        `  actual=${JSON.stringify(actual)}`;
       if (actual !== expected && actualAlt !== expected)
         failures.push(`\n${message}`);
     });
@@ -460,8 +463,9 @@ resolveTests.forEach((test) => {
 
     const expected = test[1];
     const message =
-      `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+      `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})\n` +
+      `  expect=${JSON.stringify(expected)}\n` +
+      `  actual=${JSON.stringify(actual)}`;
     if (actual !== expected && actualAlt !== expected)
       failures.push(`\n${message}`);
   });
@@ -559,9 +563,10 @@ relativeTests.forEach((test) => {
     const actual = relative(test[0], test[1]);
     const expected = test[2];
     const os = relative === path.win32.relative ? 'win32' : 'posix';
-    const message = `path.${os}.relative(${
-      test.slice(0, 2).map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+    const message =
+      `path.${os}.relative(${test.slice(0, 2).map(JSON.stringify).join(',')})\n` +
+      `  expect=${JSON.stringify(expected)}\n` +
+      `  actual=${JSON.stringify(actual)}`;
     if (actual !== expected)
       failures.push(`\n${message}`);
   });

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -103,8 +103,7 @@ replProc.on('close', function(code) {
 // test that preload placement at other points in the cmdline
 // also test that duplicated preload only gets loaded once
 childProcess.exec(
-  `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');" ${
-  preloadOption([fixtureA, fixtureB])}`,
+  `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');" ${preloadOption([fixtureA, fixtureB])}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\nhello\n');
@@ -124,8 +123,7 @@ interactive.stdin.write('a\n');
 interactive.stdin.write('process.exit()\n');
 
 childProcess.exec(
-  `"${nodeBinary}" --require "${fixture('cluster-preload.js')}" "${
-  fixture('cluster-preload-test.js')}"`,
+  `"${nodeBinary}" --require "${fixture('cluster-preload.js')}" "${fixture('cluster-preload-test.js')}"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));
@@ -135,8 +133,7 @@ childProcess.exec(
 // https://github.com/nodejs/node/issues/1691
 process.chdir(common.fixturesDir);
 childProcess.exec(
-  `"${nodeBinary}" --expose_natives_as=v8natives --require ` +
-     `"${fixture('cluster-preload.js')}" cluster-preload-test.js`,
+  `"${nodeBinary}" --expose_natives_as=v8natives --require "${fixture('cluster-preload.js')}" cluster-preload-test.js`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -83,11 +83,12 @@ function error_test() {
 
   client_unix.on('data', function(data) {
     read_buffer += data.toString('ascii', 0, data.length);
-    console.error(
-      `Unix data: ${JSON.stringify(read_buffer)}, expecting ${
-      client_unix.expect.exec ?
+    const expected = client_unix.expect.exec ?
       client_unix.expect :
-      JSON.stringify(client_unix.expect)}`);
+      JSON.stringify(client_unix.expect);
+    console.error(
+      `Unix data: ${JSON.stringify(read_buffer)}, expecting ${expected}`
+    );
 
     if (read_buffer.includes(prompt_unix)) {
       // if it's an exact match, then don't do the regexp
@@ -267,8 +268,8 @@ function error_test() {
       expect: /\bSyntaxError: Invalid or unexpected token/ },
     // do not fail when a String is created with line continuation
     { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
-      expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n` +
+              `${prompt_unix}` },
     // Don't fail when a partial String is created and line continuation is used
     // with whitespace characters at the end of the string. We are to ignore it.
     // This test is to make sure that we properly remove the whitespace
@@ -277,12 +278,12 @@ function error_test() {
       expect: prompt_unix },
     // multiline strings preserve whitespace characters in them
     { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
-      expect: `${prompt_multiline}${
-              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}'the    fourth\\t\\t  eye  '\n` +
+              `${prompt_unix}` },
     // more than one multiline strings also should preserve whitespace chars
     { client: client_unix, send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
-      expect: `${prompt_multiline}${
-              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}'the    fourth\\t\\t  eye  '\n` +
+              `${prompt_unix}` },
     // using REPL commands within a string literal should still work
     { client: client_unix, send: '\'\\\n.break',
       expect: prompt_unix },
@@ -294,8 +295,8 @@ function error_test() {
       expect: prompt_unix + prompt_unix + prompt_unix },
     // empty lines in the string literals should not affect the string
     { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
-      expect: `${prompt_multiline}${
-              prompt_multiline}'thefourtheye'\n${prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n` +
+              `${prompt_unix}` },
     // Regression test for https://github.com/nodejs/node/issues/597
     { client: client_unix,
       send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
@@ -308,25 +309,25 @@ function error_test() {
                '\'7\'\n', '\'8\'\n', '\'9\'\n'].join(`${prompt_unix}`) },
     // regression tests for https://github.com/nodejs/node/issues/2749
     { client: client_unix, send: 'function x() {\nreturn \'\\n\';\n }',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n` +
+              `${prompt_unix}` },
     { client: client_unix, send: 'function x() {\nreturn \'\\\\\';\n }',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n` +
+              `${prompt_unix}` },
     // regression tests for https://github.com/nodejs/node/issues/3421
     { client: client_unix, send: 'function x() {\n//\'\n }',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n` +
+              `${prompt_unix}` },
     { client: client_unix, send: 'function x() {\n//"\n }',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n` +
+              `${prompt_unix}` },
     { client: client_unix, send: 'function x() {//\'\n }',
       expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {//"\n }',
       expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {\nvar i = "\'";\n }',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+      expect: `${prompt_multiline}${prompt_multiline}undefined\n` +
+              `${prompt_unix}` },
     { client: client_unix, send: 'function x(/*optional*/) {}',
       expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x(/* // 5 */) {}',
@@ -453,8 +454,6 @@ function tcp_test() {
 
     client_tcp.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
-      console.error(`TCP data: ${JSON.stringify(read_buffer)}, expecting ${
-                    JSON.stringify(client_tcp.expect)}`);
       if (read_buffer.includes(prompt_tcp)) {
         assert.strictEqual(client_tcp.expect, read_buffer);
         console.error('match');
@@ -523,8 +522,6 @@ function unix_test() {
 
     client_unix.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
-      console.error(`Unix data: ${JSON.stringify(read_buffer)}, expecting ${
-                    JSON.stringify(client_unix.expect)}`);
       if (read_buffer.includes(prompt_unix)) {
         assert.strictEqual(client_unix.expect, read_buffer);
         console.error('match');

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -13,8 +13,7 @@ const tmpFile = path.join(common.tmpDir, 'stdout.txt');
 common.refreshTmpDir();
 
 function test(size, useBuffer, cb) {
-  const cmd = `"${process.argv[0]}" "${
-              useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
+  const cmd = `"${process.argv[0]}" "${useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
 
   try {
     fs.unlinkSync(tmpFile);

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -42,8 +42,8 @@ const options = {
 const server = tls.createServer(options, common.mustNotCall());
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
-  let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+  let cmd =
+    `"${common.opensslCli}" s_client -cipher ${options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -48,8 +48,8 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 }));
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
-  let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+  let cmd =
+    `"${common.opensslCli}" s_client -cipher ${options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -246,8 +246,8 @@ function runClient(prefix, port, options, cb) {
         `${prefix}${options.name} rejected, but should NOT have been`);
       assert.strictEqual(
         options.shouldAuth, authed,
-        `${prefix}${options.name} authed is ${authed} but should have been ${
-        options.shouldAuth}`);
+        `${prefix}${options.name} authed is ${authed} but should have been ${options.shouldAuth}`
+      );
     }
 
     cb();
@@ -312,8 +312,6 @@ function runTest(port, testIndex) {
     }
 
     if (c.authorized) {
-      console.error(`${prefix}- authed connection: ${
-                    c.getPeerCertificate().subject.CN}`);
       c.write('\n_authed\n');
     } else {
       console.error(`${prefix}- unauthed connection: %s`, c.authorizationError);

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -51,8 +51,8 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 }));
 
 server.listen(0, '127.0.0.1', function() {
-  let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+  let cmd =
+    `"${common.opensslCli}" s_client -cipher ${options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -253,6 +253,5 @@ for (const u in formatTests) {
   assert.strictEqual(actual, expect,
                      `wonky format(${u}) == ${expect}\nactual:${actual}`);
   assert.strictEqual(actualObj, expect,
-                     `wonky format(${JSON.stringify(formatTests[u])}) == ${
-                     expect}\nactual: ${actualObj}`);
+                     `wonky format(${JSON.stringify(formatTests[u])}) == ${expect}\nactual: ${actualObj}`);
 }

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -184,8 +184,8 @@ Object.keys(tests).forEach(function(file) {
 
                 // verify that the same exact buffer comes out the other end.
                 buf.on('data', function(c) {
-                  const msg = `${file} ${chunkSize} ${
-                              JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;
+                  const msg =
+                    `${file} ${chunkSize} ${JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;
                   let ok = true;
                   const testNum = ++done;
                   let i;

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -57,8 +57,12 @@ const spawn = require('child_process').spawn;
  * when we call getloadavg() -- with the implicit assumption that our
  * deepest function is the only caller of os.loadavg().
  */
-const dtrace = spawn('dtrace', [ '-qwn', `syscall::getloadavg:entry/pid == ${
-                                process.pid}/{ustack(100, 8192); exit(0); }` ]);
+const dtrace = spawn(
+  'dtrace',
+  [ '-qwn',
+    `syscall::getloadavg:entry/pid == ${process.pid}/{ustack(100, 8192); exit(0); }`
+  ]
+);
 
 let output = '';
 

--- a/test/sequential/test-regress-GH-877.js
+++ b/test/sequential/test-regress-GH-877.js
@@ -54,11 +54,6 @@ server.listen(common.PORT, '127.0.0.1', function() {
 
     assert.strictEqual(req.agent, agent);
 
-    console.log(
-      `Socket: ${agent.sockets[addrString].length}/${
-      agent.maxSockets} queued: ${
-      agent.requests[addrString] ? agent.requests[addrString].length : 0}`);
-
     const agentRequests = agent.requests[addrString] ?
         agent.requests[addrString].length : 0;
 

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -56,8 +56,8 @@ function test(environ, shouldWrite, section) {
 
   if (shouldWrite) {
     expectErr =
-      `${section.toUpperCase()} ${child.pid}: this { is: 'a' } /debugging/\n${
-         section.toUpperCase()} ${child.pid}: num=1 str=a obj={"foo":"bar"}\n`;
+      `${section.toUpperCase()} ${child.pid}: this { is: 'a' } /debugging/\n` +
+      `${section.toUpperCase()} ${child.pid}: num=1 str=a obj={"foo":"bar"}\n`;
   }
 
   let err = '';


### PR DESCRIPTION
First commit:

    tools: ignore template literals for line length
    
    The line length limitation applied by linting is intended to improve
    readability. Unfortunately with template literals, practices used to get
    around it can inhibit readability. For example:
    
        return `The "${name}" array must have a length of ${
               length}. Received length ${actual}`;
    
    Configure the linter to ignore line length limitations for template
    literals.

Second commit:

    lib,test: remove linebreaks from template literals
    
    Improve readability of template literals by removing some creative use
    of line breaks.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools test lib