### PR TITLE
[v8.x backport] test: remove common.noop

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -209,7 +209,7 @@ Gets IP of localhost
 Array of IPV6 hosts.
 
 ### mustCall([fn][, exact])
-* `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) default = `common.noop`
+* `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) default = () => {}
 * `exact` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
 * return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 
@@ -217,10 +217,10 @@ Returns a function that calls `fn`. If the returned function has not been called
 exactly `expected` number of times when the test is complete, then the test will
 fail.
 
-If `fn` is not provided, `common.noop` will be used.
+If `fn` is not provided, an empty function will be used.
 
 ### mustCallAtLeast([fn][, minimum])
-* `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) default = `common.noop`
+* `fn` [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function) default = () => {}
 * `minimum` [&lt;Number>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type) default = 1
 * return [&lt;Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
 
@@ -228,7 +228,7 @@ Returns a function that calls `fn`. If the returned function has not been called
 at least `minimum` number of times when the test is complete, then the test will
 fail.
 
-If `fn` is not provided, `common.noop` will be used.
+If `fn` is not provided, an empty function will be used.
 
 ### mustNotCall([msg])
 * `msg` [&lt;String>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type) default = 'function should not have been called'
@@ -242,19 +242,6 @@ Returns a function that triggers an `AssertionError` if it is invoked. `msg` is 
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
 
 Returns `true` if the exit code `exitCode` and/or signal name `signal` represent the exit code and/or signal name of a node process that aborted, `false` otherwise.
-
-### noop
-
-A non-op `Function` that can be used for a variety of scenarios.
-
-For instance,
-
-<!-- eslint-disable strict, no-undef -->
-```js
-const common = require('../common');
-
-someAsyncAPI('foo', common.mustCall(common.noop));
-```
 
 ### opensslCli
 * return [&lt;Boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -37,7 +37,6 @@ const testRoot = process.env.NODE_TEST_DIR ?
 
 const noop = () => {};
 
-exports.noop = noop;
 exports.fixturesDir = path.join(__dirname, '..', 'fixtures');
 exports.tmpDirName = 'tmp';
 // PORT should match the definition in test/testpy/__init__.py.

--- a/test/message/unhandled_promise_trace_warnings.js
+++ b/test/message/unhandled_promise_trace_warnings.js
@@ -1,5 +1,5 @@
 // Flags: --trace-warnings
 'use strict';
-const common = require('../common');
+require('../common');
 const p = Promise.reject(new Error('This was rejected'));
-setImmediate(() => p.catch(common.noop));
+setImmediate(() => p.catch(() => {}));

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -571,29 +571,30 @@ a.throws(makeBlock(a.deepEqual, args, []));
 
 // check messages from assert.throws()
 {
+  const noop = () => {};
   assert.throws(
-    () => { a.throws(common.noop); },
+    () => { a.throws((noop)); },
     common.expectsError({
       code: 'ERR_ASSERTION',
       message: /^Missing expected exception\.$/
     }));
 
   assert.throws(
-    () => { a.throws(common.noop, TypeError); },
+    () => { a.throws(noop, TypeError); },
     common.expectsError({
       code: 'ERR_ASSERTION',
       message: /^Missing expected exception \(TypeError\)\.$/
     }));
 
   assert.throws(
-    () => { a.throws(common.noop, 'fhqwhgads'); },
+    () => { a.throws(noop, 'fhqwhgads'); },
     common.expectsError({
       code: 'ERR_ASSERTION',
       message: /^Missing expected exception: fhqwhgads$/
     }));
 
   assert.throws(
-    () => { a.throws(common.noop, TypeError, 'fhqwhgads'); },
+    () => { a.throws(noop, TypeError, 'fhqwhgads'); },
     common.expectsError({
       code: 'ERR_ASSERTION',
       message: /^Missing expected exception \(TypeError\): fhqwhgads$/

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdef');
@@ -274,7 +274,7 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
 const expectedError =
   /^TypeError: "val" argument must be string, number, Buffer or Uint8Array$/;
 assert.throws(() => {
-  b.includes(common.noop);
+  b.includes(() => {});
 }, expectedError);
 assert.throws(() => {
   b.includes({});

--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
-  setTimeout(common.noop, common.platformTimeout(100));
+  setTimeout(() => {}, common.platformTimeout(100));
   return;
 }
 

--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
-  setInterval(common.noop, 1000);
+  setInterval(() => {}, 1000);
 } else {
   const { SIGKILL } = process.binding('constants').os.signals;
 

--- a/test/parallel/test-cluster-rr-domain-listen.js
+++ b/test/parallel/test-cluster-rr-domain-listen.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const cluster = require('cluster');
 const domain = require('domain');
 
@@ -29,10 +29,10 @@ const domain = require('domain');
 
 if (cluster.isWorker) {
   const d = domain.create();
-  d.run(common.noop);
+  d.run(() => {});
 
   const http = require('http');
-  http.Server(common.noop).listen(0, '127.0.0.1');
+  http.Server(() => {}).listen(0, '127.0.0.1');
 
 } else if (cluster.isMaster) {
 

--- a/test/parallel/test-cluster-worker-wait-server-close.js
+++ b/test/parallel/test-cluster-worker-wait-server-close.js
@@ -11,7 +11,7 @@ if (cluster.isWorker) {
   const server = net.createServer(function(socket) {
     // Wait for any data, then close connection
     socket.write('.');
-    socket.on('data', common.noop);
+    socket.on('data', () => {});
   }).listen(0, common.localhostIPv4);
 
   server.once('close', function() {
@@ -20,7 +20,7 @@ if (cluster.isWorker) {
 
   // Although not typical, the worker process can exit before the disconnect
   // event fires. Use this to keep the process open until the event has fired.
-  const keepOpen = setInterval(common.noop, 9999);
+  const keepOpen = setInterval(() => {}, 9999);
 
   // Check worker events and properties
   process.once('disconnect', function() {

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -101,7 +101,7 @@ const HIJACK_TEST_ARRAY = [ 'foo\n', 'bar\n', 'baz\n' ];
   assert.notStrictEqual(originalWrite, stream.write);
 
   HIJACK_TEST_ARRAY.forEach((val) => {
-    stream.write(val, common.mustCall(common.noop));
+    stream.write(val, common.mustCall());
   });
 
   assert.strictEqual(HIJACK_TEST_ARRAY.length, stream.writeTimes);

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -43,7 +43,7 @@ assert.throws(() => {
 
 // Console constructor should throw if stderr exists but is not writable
 assert.throws(() => {
-  out.write = common.noop;
+  out.write = () => {};
   err.write = undefined;
   new Console(out, err);
 }, /^TypeError: Console expects writable stream instances$/);

--- a/test/parallel/test-event-emitter-get-max-listeners.js
+++ b/test/parallel/test-event-emitter-get-max-listeners.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 
@@ -15,5 +15,5 @@ assert.strictEqual(emitter.getMaxListeners(), 3);
 
 // https://github.com/nodejs/node/issues/523 - second call should not throw.
 const recv = {};
-EventEmitter.prototype.on.call(recv, 'event', common.noop);
-EventEmitter.prototype.on.call(recv, 'event', common.noop);
+EventEmitter.prototype.on.call(recv, 'event', () => {});
+EventEmitter.prototype.on.call(recv, 'event', () => {});

--- a/test/parallel/test-event-emitter-listener-count.js
+++ b/test/parallel/test-event-emitter-listener-count.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const EventEmitter = require('events');
 
 const emitter = new EventEmitter();
-emitter.on('foo', common.noop);
-emitter.on('foo', common.noop);
-emitter.on('baz', common.noop);
+emitter.on('foo', () => {});
+emitter.on('foo', () => {});
+emitter.on('baz', () => {});
 // Allow any type
-emitter.on(123, common.noop);
+emitter.on(123, () => {});
 
 assert.strictEqual(EventEmitter.listenerCount(emitter, 'foo'), 2);
 assert.strictEqual(emitter.listenerCount('foo'), 2);

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-null.js
@@ -18,5 +18,5 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 null listeners added.'));
 }));
 
-e.on(null, common.noop);
-e.on(null, common.noop);
+e.on(null, () => {});
+e.on(null, () => {});

--- a/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning-for-symbol.js
@@ -20,5 +20,5 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 Symbol(symbol) listeners added.'));
 }));
 
-e.on(symbol, common.noop);
-e.on(symbol, common.noop);
+e.on(symbol, () => {});
+e.on(symbol, () => {});

--- a/test/parallel/test-event-emitter-max-listeners-warning.js
+++ b/test/parallel/test-event-emitter-max-listeners-warning.js
@@ -18,6 +18,6 @@ process.on('warning', common.mustCall((warning) => {
   assert.ok(warning.message.includes('2 event-type listeners added.'));
 }));
 
-e.on('event-type', common.noop);
-e.on('event-type', common.noop);  // Trigger warning.
-e.on('event-type', common.noop);  // Verify that warning is emitted only once.
+e.on('event-type', () => {});
+e.on('event-type', () => {});  // Trigger warning.
+e.on('event-type', () => {});  // Verify that warning is emitted only once.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -140,7 +140,7 @@ function listener2() {}
 {
   const ee = new EventEmitter();
 
-  assert.deepStrictEqual(ee, ee.removeListener('foo', common.noop));
+  assert.deepStrictEqual(ee, ee.removeListener('foo', () => {}));
 }
 
 // Verify that the removed listener must be a function
@@ -152,7 +152,7 @@ assert.throws(() => {
 
 {
   const ee = new EventEmitter();
-  const listener = common.noop;
+  const listener = () => {};
   ee._events = undefined;
   const e = ee.removeListener('foo', listener);
   assert.strictEqual(e, ee);

--- a/test/parallel/test-event-emitter-special-event-names.js
+++ b/test/parallel/test-event-emitter-special-event-names.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events');
 const assert = require('assert');
 
 const ee = new EventEmitter();
-const handler = common.noop;
+const handler = () => {};
 
 assert.deepStrictEqual(ee.eventNames(), []);
 

--- a/test/parallel/test-event-emitter-subclass.js
+++ b/test/parallel/test-event-emitter-subclass.js
@@ -62,6 +62,6 @@ MyEE2.prototype = new EventEmitter();
 const ee1 = new MyEE2();
 const ee2 = new MyEE2();
 
-ee1.on('x', common.noop);
+ee1.on('x', () => {});
 
 assert.strictEqual(ee2.listenerCount('x'), 0);

--- a/test/parallel/test-events-list.js
+++ b/test/parallel/test-events-list.js
@@ -5,7 +5,6 @@ const EventEmitter = require('events');
 const assert = require('assert');
 
 const EE = new EventEmitter();
-// Do not use common.noop here, these need to be separate listener functions
 const m = () => {};
 EE.on('foo', () => {});
 assert.deepStrictEqual(['foo'], EE.eventNames());

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const path = require('path');
 
 const filePath = path.join(common.tmpDir, 'test_buffer_type');
-const v = [true, false, 0, 1, Infinity, common.noop, {}, [], undefined, null];
+const v = [true, false, 0, 1, Infinity, () => {}, {}, [], undefined, null];
 
 common.refreshTmpDir();
 

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -77,4 +77,4 @@ common.refreshTmpDir();
 
 // Keep the event loop alive so the async mkdir() requests
 // have a chance to run (since they don't ref the event loop).
-process.nextTick(common.noop);
+process.nextTick(() => {});

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -87,7 +87,7 @@ const strictEqual = require('assert').strictEqual;
 // tcp
 {
   const net = require('net');
-  const server = net.createServer(common.noop).listen(0);
+  const server = net.createServer(() => {}).listen(0);
   strictEqual(Object.getPrototypeOf(server._handle).hasOwnProperty('hasRef'),
               true, 'tcp_wrap: hasRef() missing');
   strictEqual(server._handle.hasRef(),
@@ -112,7 +112,7 @@ const strictEqual = require('assert').strictEqual;
 
 // timers
 {
-  const timer = setTimeout(common.noop, 500);
+  const timer = setTimeout(() => {}, 500);
   timer.unref();
   strictEqual(Object.getPrototypeOf(timer._handle).hasOwnProperty('hasRef'),
               true, 'timer_wrap: hasRef() missing');

--- a/test/parallel/test-http-client-defaults.js
+++ b/test/parallel/test-http-client-defaults.js
@@ -1,23 +1,23 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const ClientRequest = require('http').ClientRequest;
 
 {
-  const req = new ClientRequest({ createConnection: common.noop });
+  const req = new ClientRequest({ createConnection: () => {} });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }
 
 {
-  const req = new ClientRequest({ method: '', createConnection: common.noop });
+  const req = new ClientRequest({ method: '', createConnection: () => {} });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }
 
 {
-  const req = new ClientRequest({ path: '', createConnection: common.noop });
+  const req = new ClientRequest({ path: '', createConnection: () => {} });
   assert.strictEqual(req.path, '/');
   assert.strictEqual(req.method, 'GET');
 }

--- a/test/parallel/test-http-parser-bad-ref.js
+++ b/test/parallel/test-http-parser-bad-ref.js
@@ -4,7 +4,7 @@
 
 // Flags: --expose_gc
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const HTTPParser = process.binding('http_parser').HTTPParser;
 
@@ -39,7 +39,7 @@ function demoBug(part1, part2) {
     console.log('url', info.url);
   };
 
-  parser[kOnBody] = common.noop;
+  parser[kOnBody] = () => {};
 
   parser[kOnMessageComplete] = function() {
     messagesComplete++;

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const util = require('util');
@@ -38,7 +38,7 @@ function createTestServer() {
 }
 
 function testServer() {
-  http.Server.call(this, common.noop);
+  http.Server.call(this, () => {});
 
   this.on('connection', function() {
     requests_recv++;

--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -47,7 +47,7 @@ server.listen(0, function() {
   };
 
   const req = https.request(requestOptions, function(res) {
-    res.on('data', common.noop);
+    res.on('data', () => {});
     setImmediate(shutdown);
   });
   req.end();

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -55,7 +55,7 @@ server_http.listen(0, function() {
   });
   // These methods should exist on the request and get passed down to the socket
   req.setNoDelay(true);
-  req.setTimeout(1000, common.noop);
+  req.setTimeout(1000, () => {});
   req.setSocketKeepAlive(true, 1000);
   req.end();
 });
@@ -79,7 +79,7 @@ server_https.listen(0, function() {
   });
   // These methods should exist on the request and get passed down to the socket
   req.setNoDelay(true);
-  req.setTimeout(1000, common.noop);
+  req.setTimeout(1000, () => {});
   req.setSocketKeepAlive(true, 1000);
   req.end();
 });

--- a/test/parallel/test-instanceof.js
+++ b/test/parallel/test-instanceof.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 
 // Regression test for instanceof, see
 // https://github.com/nodejs/node/issues/7592
-const F = common.noop;
+const F = () => {};
 F.prototype = {};
 assert(Object.create(F.prototype) instanceof F);

--- a/test/parallel/test-net-listen-exclusive-random-ports.js
+++ b/test/parallel/test-net-listen-exclusive-random-ports.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -20,7 +20,7 @@ if (cluster.isMaster) {
     });
   });
 } else {
-  const server = net.createServer(common.noop);
+  const server = net.createServer(() => {});
 
   server.on('error', function(err) {
     process.send(err.code);

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -20,7 +20,7 @@ function connectThrows(input) {
   }, expectedError);
 }
 
-connectDoesNotThrow(common.noop);
+connectDoesNotThrow(() => {});
 
 function connectDoesNotThrow(input) {
   const opts = {

--- a/test/parallel/test-net-socket-timeout.js
+++ b/test/parallel/test-net-socket-timeout.js
@@ -27,7 +27,7 @@ const assert = require('assert');
 // Verify that invalid delays throw
 const s = new net.Socket();
 const nonNumericDelays = [
-  '100', true, false, undefined, null, '', {}, common.noop, []
+  '100', true, false, undefined, null, '', {}, () => {}, []
 ];
 const badRangeDelays = [-0.001, -1, -Infinity, Infinity, NaN];
 const validDelays = [0, 0.001, 1, 1e6];
@@ -35,19 +35,19 @@ const validDelays = [0, 0.001, 1, 1e6];
 
 for (let i = 0; i < nonNumericDelays.length; i++) {
   assert.throws(function() {
-    s.setTimeout(nonNumericDelays[i], common.noop);
+    s.setTimeout(nonNumericDelays[i], () => {});
   }, TypeError);
 }
 
 for (let i = 0; i < badRangeDelays.length; i++) {
   assert.throws(function() {
-    s.setTimeout(badRangeDelays[i], common.noop);
+    s.setTimeout(badRangeDelays[i], () => {});
   }, RangeError);
 }
 
 for (let i = 0; i < validDelays.length; i++) {
   assert.doesNotThrow(function() {
-    s.setTimeout(validDelays[i], common.noop);
+    s.setTimeout(validDelays[i], () => {});
   });
 }
 

--- a/test/parallel/test-net-stream.js
+++ b/test/parallel/test-net-stream.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const net = require('net');
 
@@ -54,7 +54,7 @@ const server = net.createServer(function(socket) {
   });
 
   for (let i = 0; i < N; ++i) {
-    socket.write(buf, common.noop);
+    socket.write(buf, () => {});
   }
   socket.end();
 

--- a/test/parallel/test-no-enter-tickcallback.js
+++ b/test/parallel/test-no-enter-tickcallback.js
@@ -27,6 +27,6 @@ setImmediate(common.mustCall(() => {
   require('domain');
   setImmediate(common.mustCall(() => setImmediate(common.mustCall(() => {
     allsGood = true;
-    process.nextTick(common.noop);
+    process.nextTick(() => {});
   }))));
 }));

--- a/test/parallel/test-process-getactiverequests.js
+++ b/test/parallel/test-process-getactiverequests.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
 for (let i = 0; i < 12; i++)
-  fs.open(__filename, 'r', common.noop);
+  fs.open(__filename, 'r', () => {});
 
 assert.strictEqual(12, process._getActiveRequests().length);

--- a/test/parallel/test-promises-warning-on-unhandled-rejection.js
+++ b/test/parallel/test-promises-warning-on-unhandled-rejection.js
@@ -26,4 +26,4 @@ process.on('warning', common.mustCall((warning) => {
 }, 3));
 
 const p = Promise.reject('This was rejected');
-setImmediate(common.mustCall(() => p.catch(common.noop)));
+setImmediate(common.mustCall(() => p.catch(() => {})));

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -34,10 +34,10 @@ function FakeInput() {
   EventEmitter.call(this);
 }
 inherits(FakeInput, EventEmitter);
-FakeInput.prototype.resume = common.noop;
-FakeInput.prototype.pause = common.noop;
-FakeInput.prototype.write = common.noop;
-FakeInput.prototype.end = common.noop;
+FakeInput.prototype.resume = () => {};
+FakeInput.prototype.pause = () => {};
+FakeInput.prototype.write = () => {};
+FakeInput.prototype.end = () => {};
 
 function isWarned(emitter) {
   for (const name in emitter) {

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -298,7 +298,7 @@ const runKeyIntervalTests = [
     { name: 'escape', sequence: '\x1b', meta: true },
     { name: 'escape', sequence: '\x1b', meta: true }
   ])
-].reverse().reduce((acc, fn) => fn(acc), common.noop);
+].reverse().reduce((acc, fn) => fn(acc), () => {});
 
 // run key interval tests one after another
 runKeyIntervalTests();

--- a/test/parallel/test-regress-GH-4948.js
+++ b/test/parallel/test-regress-GH-4948.js
@@ -1,7 +1,7 @@
 'use strict';
 // https://github.com/joyent/node/issues/4948
 
-const common = require('../common');
+require('../common');
 const http = require('http');
 
 let reqCount = 0;
@@ -22,10 +22,10 @@ const server = http.createServer(function(serverReq, serverRes) {
     serverRes.end();
 
     // required for test to fail
-    res.on('data', common.noop);
+    res.on('data', () => {});
 
   });
-  r.on('error', common.noop);
+  r.on('error', () => {});
   r.end();
 
   serverRes.write('some data');

--- a/test/parallel/test-regress-GH-5051.js
+++ b/test/parallel/test-regress-GH-5051.js
@@ -1,11 +1,11 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const agent = require('http').globalAgent;
 
 // small stub just so we can call addRequest directly
 const req = {
-  getHeader: common.noop
+  getHeader: () => {}
 };
 
 agent.maxSockets = 0;

--- a/test/parallel/test-repl-function-definition-edge-case.js
+++ b/test/parallel/test-repl-function-definition-edge-case.js
@@ -19,7 +19,7 @@ assert.strictEqual(got, expected);
 
 function initRepl() {
   const input = new stream();
-  input.write = input.pause = input.resume = common.noop;
+  input.write = input.pause = input.resume = () => {};
   input.readable = true;
 
   const output = new stream();

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -18,7 +18,7 @@ const Duplex = require('stream').Duplex;
 // and mode 600.
 
 const stream = new Duplex();
-stream.pause = stream.resume = common.noop;
+stream.pause = stream.resume = () => {};
 // ends immediately
 stream._read = function() {
   this.push(null);

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -52,7 +52,7 @@ function testAutoMode() {
 
 function initRepl(mode) {
   const input = new Stream();
-  input.write = input.pause = input.resume = common.noop;
+  input.write = input.pause = input.resume = () => {};
   input.readable = true;
 
   const output = new Stream();

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -98,7 +98,7 @@ putIn.write = function(data) {
   // make sure I get a failed to load message and not some crazy error
   assert.strictEqual(data, `Failed to load:${loadFile}\n`);
   // eat me to avoid work
-  putIn.write = common.noop;
+  putIn.write = () => {};
 };
 putIn.run([`.load ${loadFile}`]);
 
@@ -106,7 +106,7 @@ putIn.run([`.load ${loadFile}`]);
 loadFile = common.tmpDir;
 putIn.write = function(data) {
   assert.strictEqual(data, `Failed to load:${loadFile} is not a valid file\n`);
-  putIn.write = common.noop;
+  putIn.write = () => {};
 };
 putIn.run([`.load ${loadFile}`]);
 
@@ -122,7 +122,7 @@ putIn.write = function(data) {
   // make sure I get a failed to save message and not some other error
   assert.strictEqual(data, `Failed to save:${invalidFileName}\n`);
   // reset to no-op
-  putIn.write = common.noop;
+  putIn.write = () => {};
 };
 
 // save it to a file

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 
-common.ArrayStream.prototype.write = common.noop;
+common.ArrayStream.prototype.write = () => {};
 
 const putIn = new common.ArrayStream();
 const testMe = repl.start('', putIn);

--- a/test/parallel/test-stream-decoder-objectmode.js
+++ b/test/parallel/test-stream-decoder-objectmode.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: common.noop,
+  read: () => {},
   encoding: 'utf16le',
   objectMode: true
 });

--- a/test/parallel/test-stream-duplex.js
+++ b/test/parallel/test-stream-duplex.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const Duplex = require('stream').Duplex;
 
@@ -38,7 +38,7 @@ stream._write = (obj, _, cb) => {
   cb();
 };
 
-stream._read = common.noop;
+stream._read = () => {};
 
 stream.on('data', (obj) => {
   read = obj;

--- a/test/parallel/test-stream-pipe-await-drain.js
+++ b/test/parallel/test-stream-pipe-await-drain.js
@@ -15,7 +15,7 @@ const writer3 = new stream.Writable();
 // See: https://github.com/nodejs/node/issues/5820
 const buffer = Buffer.allocUnsafe(560000);
 
-reader._read = common.noop;
+reader._read = () => {};
 
 writer1._write = common.mustCall(function(chunk, encoding, cb) {
   this.emit('chunk-received');

--- a/test/parallel/test-stream-pipe-cleanup-pause.js
+++ b/test/parallel/test-stream-pipe-cleanup-pause.js
@@ -11,7 +11,7 @@ const writer2 = new stream.Writable();
 // See: https://github.com/nodejs/node/issues/2323
 const buffer = Buffer.allocUnsafe(560000);
 
-reader._read = common.noop;
+reader._read = () => {};
 
 writer1._write = common.mustCall(function(chunk, encoding, cb) {
   this.emit('chunk-received');

--- a/test/parallel/test-stream-pipe-error-handling.js
+++ b/test/parallel/test-stream-pipe-error-handling.js
@@ -101,10 +101,10 @@ const Stream = require('stream').Stream;
   });
 
   w.on('error', common.mustCall());
-  w._write = common.noop;
+  w._write = () => {};
 
   r.pipe(w);
   // Removing some OTHER random listener should not do anything
-  w.removeListener('error', common.noop);
+  w.removeListener('error', () => {});
   removed = true;
 }

--- a/test/parallel/test-stream-pipe-multiple-pipes.js
+++ b/test/parallel/test-stream-pipe-multiple-pipes.js
@@ -4,7 +4,7 @@ const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: common.noop
+  read: () => {}
 });
 
 const writables = [];

--- a/test/parallel/test-stream-pipe-unpipe-streams.js
+++ b/test/parallel/test-stream-pipe-unpipe-streams.js
@@ -4,9 +4,9 @@ const assert = require('assert');
 
 const { Readable, Writable } = require('stream');
 
-const source = Readable({read: common.noop});
-const dest1 = Writable({write: common.noop});
-const dest2 = Writable({write: common.noop});
+const source = Readable({read: () => {}});
+const dest1 = Writable({write: () => {}});
+const dest2 = Writable({write: () => {}});
 
 source.pipe(dest1);
 source.pipe(dest2);

--- a/test/parallel/test-stream-readable-emittedReadable.js
+++ b/test/parallel/test-stream-readable-emittedReadable.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Readable = require('stream').Readable;
 
 const readable = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 // Initialized to false.
@@ -37,7 +37,7 @@ process.nextTick(common.mustCall(() => {
 }));
 
 const noRead = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 noRead.on('readable', common.mustCall(() => {
@@ -52,7 +52,7 @@ noRead.push('foo');
 noRead.push(null);
 
 const flowing = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 flowing.on('data', common.mustCall(() => {

--- a/test/parallel/test-stream-readable-invalid-chunk.js
+++ b/test/parallel/test-stream-readable-invalid-chunk.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const stream = require('stream');
 const assert = require('assert');
 
 const readable = new stream.Readable({
-  read: common.noop
+  read: () => {}
 });
 
 const errMessage = /Invalid non-string\/buffer chunk/;

--- a/test/parallel/test-stream-readable-needReadable.js
+++ b/test/parallel/test-stream-readable-needReadable.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Readable = require('stream').Readable;
 
 const readable = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 // Initialized to false.
@@ -28,7 +28,7 @@ readable.on('end', common.mustCall(() => {
 }));
 
 const asyncReadable = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 asyncReadable.on('readable', common.mustCall(() => {
@@ -51,7 +51,7 @@ process.nextTick(common.mustCall(() => {
 }));
 
 const flowing = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 // Notice this must be above the on('data') call.
@@ -69,7 +69,7 @@ flowing.on('data', common.mustCall(function(data) {
 }, 3));
 
 const slowProducer = new Readable({
-  read: common.noop
+  read: () => {}
 });
 
 slowProducer.on('readable', common.mustCall(() => {

--- a/test/parallel/test-stream-readableListening-state.js
+++ b/test/parallel/test-stream-readableListening-state.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const stream = require('stream');
 
 const r = new stream.Readable({
-  read: common.noop
+  read: () => {}
 });
 
 // readableListening state should start in `false`.
@@ -19,7 +19,7 @@ r.on('readable', common.mustCall(() => {
 r.push(Buffer.from('Testing readableListening state'));
 
 const r2 = new stream.Readable({
-  read: common.noop
+  read: () => {}
 });
 
 // readableListening state should start in `false`.

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const util = require('util');
 const stream = require('stream');
 
@@ -50,7 +50,7 @@ Write.prototype._write = function(buffer, encoding, cb) {
 const read = new Read();
 const write = new Write();
 
-write.once('error', common.noop);
+write.once('error', () => {});
 write.once('alldone', function(err) {
   console.log('ok');
 });

--- a/test/parallel/test-stream2-readable-wrap-empty.js
+++ b/test/parallel/test-stream2-readable-wrap-empty.js
@@ -26,13 +26,13 @@ const Readable = require('_stream_readable');
 const EE = require('events').EventEmitter;
 
 const oldStream = new EE();
-oldStream.pause = common.noop;
-oldStream.resume = common.noop;
+oldStream.pause = () => {};
+oldStream.resume = () => {};
 
 const newStream = new Readable().wrap(oldStream);
 
 newStream
-  .on('readable', common.noop)
+  .on('readable', () => {})
   .on('end', common.mustCall());
 
 oldStream.emit('end');

--- a/test/parallel/test-timers-unref-call.js
+++ b/test/parallel/test-timers-unref-call.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 
 const Timer = process.binding('timer_wrap').Timer;
 Timer.now = function() { return ++Timer.now.ticks; };
 Timer.now.ticks = 0;
 
-const t = setInterval(common.noop, 1);
+const t = setInterval(() => {}, 1);
 const o = { _idleStart: 0, _idleTimeout: 1 };
 t.unref.call(o);
 

--- a/test/parallel/test-timers-unref-remove-other-unref-timers.js
+++ b/test/parallel/test-timers-unref-remove-other-unref-timers.js
@@ -29,4 +29,4 @@ timers.enroll(foo, 50);
 timers._unrefActive(foo);
 
 // Keep the process open.
-setTimeout(common.noop, 100);
+setTimeout(() => {}, 100);

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 let interval_fired = false;
@@ -35,11 +35,11 @@ const LONG_TIME = 10 * 1000;
 const SHORT_TIME = 100;
 
 assert.doesNotThrow(function() {
-  setTimeout(common.noop, 10).unref().ref().unref();
+  setTimeout(() => {}, 10).unref().ref().unref();
 }, 'ref and unref are chainable');
 
 assert.doesNotThrow(function() {
-  setInterval(common.noop, 10).unref().ref().unref();
+  setInterval(() => {}, 10).unref().ref().unref();
 }, 'ref and unref are chainable');
 
 setInterval(function() {
@@ -78,7 +78,7 @@ setInterval(function() {
 
 // Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
 {
-  const t = setInterval(common.noop, 1);
+  const t = setInterval(() => {}, 1);
   process.nextTick(t.unref.bind({}));
   process.nextTick(t.unref.bind(t));
 }

--- a/test/parallel/test-timers-unrefed-in-beforeexit.js
+++ b/test/parallel/test-timers-unrefed-in-beforeexit.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 let once = 0;
@@ -9,7 +9,7 @@ process.on('beforeExit', () => {
   if (once > 1)
     throw new RangeError('beforeExit should only have been called once!');
 
-  setTimeout(common.noop, 1).unref();
+  setTimeout(() => {}, 1).unref();
   once++;
 });
 

--- a/test/parallel/test-timers-zero-timeout.js
+++ b/test/parallel/test-timers-zero-timeout.js
@@ -26,7 +26,7 @@ const assert = require('assert');
 // https://github.com/joyent/node/issues/2079 - zero timeout drops extra args
 {
   setTimeout(common.mustCall(f), 0, 'foo', 'bar', 'baz');
-  setTimeout(common.noop, 0);
+  setTimeout(() => {}, 0);
 
   function f(a, b, c) {
     assert.strictEqual(a, 'foo');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const util = require('util');
 const vm = require('vm');
@@ -785,9 +785,9 @@ if (typeof Symbol !== 'undefined') {
   const rejected = Promise.reject(3);
   assert.strictEqual(util.inspect(rejected), 'Promise { <rejected> 3 }');
   // squelch UnhandledPromiseRejection
-  rejected.catch(common.noop);
+  rejected.catch(() => {});
 
-  const pending = new Promise(common.noop);
+  const pending = new Promise(() => {});
   assert.strictEqual(util.inspect(pending), 'Promise { <pending> }');
 
   const promiseWithProperty = Promise.resolve('foo');
@@ -885,7 +885,7 @@ if (typeof Symbol !== 'undefined') {
                      'SetSubclass { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
                      'MapSubclass { \'foo\' => 42 }');
-  assert.strictEqual(util.inspect(new PromiseSubclass(common.noop)),
+  assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
                      'PromiseSubclass { <pending> }');
 }
 

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -42,7 +42,7 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(onceHandlerCalled, 0);
 
   // Keep the process alive for a while so that the second SIGINT can be caught.
-  const timeout = setTimeout(common.noop, 1000);
+  const timeout = setTimeout(() => {}, 1000);
 
   let afterHandlerCalled = 0;
 

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -22,7 +22,7 @@ const failureTests = tests.filter((test) => test.failure).concat([
   { input: null },
   { input: new Date() },
   { input: new RegExp() },
-  { input: common.noop }
+  { input: () => {} }
 ]);
 
 const expectedError = common.expectsError(

--- a/test/pseudo-tty/ref_keeps_node_running.js
+++ b/test/pseudo-tty/ref_keeps_node_running.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 
 const { TTY, isTTY } = process.binding('tty_wrap');
 const strictEqual = require('assert').strictEqual;
@@ -9,7 +9,7 @@ strictEqual(isTTY(0), true, 'fd 0 is not a TTY');
 
 const handle = new TTY(0);
 handle.readStart();
-handle.onread = common.noop;
+handle.onread = () => {};
 
 function isHandleActive(handle) {
   return process._getActiveHandles().some((active) => active === handle);


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/12822.

This change removes `common.noop` from the Node.js internal testing
common module.

Over the last few weeks, I've grown to dislike the `common.noop`
abstraction.

First, new (and experienced) contributors are unaware of it and so it
results in a large number of low-value nits on PRs. It also increases
the number of things newcomers and infrequent contributors have to be
aware of to be effective on the project.

Second, it is confusing. Is it a singleton/property or a getter? Which
should be expected? This can lead to subtle and hard-to-find bugs. (To
my knowledge, none have landed on master. But I also think it's only a
matter of time.)

Third, the abstraction is low-value in my opinion. What does it really
get us? A case could me made that it is without value at all.

Lastly, and this is minor, but the abstraction is wordier than not using
the abstraction. `common.noop` doesn't save anything over `() => {}`.

So, I propose removing it.

PR-URL: https://github.com/nodejs/node/pull/12822
Reviewed-By: Teddy Katz <teddy.katz@gmail.com>
Reviewed-By: Timothy Gu <timothygu99@gmail.com>
Reviewed-By: Benjamin Gruenbaum <benjamingr@gmail.com>
Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Refael Ackermann <refack@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test