### PR TITLE
test: reduce test-benchmark-net run duration

### DIFF
--- a/test/sequential/test-benchmark-net.js
+++ b/test/sequential/test-benchmark-net.js
@@ -15,7 +15,10 @@ const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
-const child = fork(runjs, ['--set', 'dur=0', 'net'],
+const child = fork(runjs,
+                   ['--set', 'dur=0',
+                    '--set', 'type=buf',
+                    'net'],
                    {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});
 child.on('exit', (code, signal) => {
   assert.strictEqual(code, 0);

--- a/test/sequential/test-benchmark-net.js
+++ b/test/sequential/test-benchmark-net.js
@@ -17,6 +17,7 @@ const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
 
 const child = fork(runjs,
                    ['--set', 'dur=0',
+                    '--set', 'len=1024',
                     '--set', 'type=buf',
                     'net'],
                    {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});


### PR DESCRIPTION
Set configuration option to reduce combinations of benchmark settings
tried in test, reducing execution time by about 50%.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test