### PR TITLE
deps: cherry-pick 6cb999b97b from V8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 9
 #define V8_BUILD_NUMBER 211
-#define V8_PATCH_LEVEL 37
+#define V8_PATCH_LEVEL 38
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/ic/handler-configuration-inl.h
+++ b/deps/v8/src/ic/handler-configuration-inl.h
@@ -13,6 +13,11 @@
 namespace v8 {
 namespace internal {
 
+// Decodes kind from Smi-handler.
+LoadHandler::Kind LoadHandler::GetHandlerKind(Smi* smi_handler) {
+  return KindBits::decode(smi_handler->value());
+}
+
 Handle<Smi> LoadHandler::LoadNormal(Isolate* isolate) {
   int config = KindBits::encode(kNormal);
   return handle(Smi::FromInt(config), isolate);

--- a/deps/v8/src/ic/handler-configuration.h
+++ b/deps/v8/src/ic/handler-configuration.h
@@ -90,6 +90,9 @@ class LoadHandler {
   static const int kHolderCellIndex = 2;
   static const int kFirstPrototypeIndex = 3;
 
+  // Decodes kind from Smi-handler.
+  static inline Kind GetHandlerKind(Smi* smi_handler);
+
   // Creates a Smi-handler for loading a property from a slow object.
   static inline Handle<Smi> LoadNormal(Isolate* isolate);
 

--- a/deps/v8/test/cctest/test-api-interceptors.cc
+++ b/deps/v8/test/cctest/test-api-interceptors.cc
@@ -1383,6 +1383,41 @@ THREADED_TEST(InterceptorLoadGlobalICGlobalWithInterceptor) {
   CHECK(value->BooleanValue(context.local()).FromJust());
 }
 
+// Test load of a non-existing global through prototype chain when a global
+// object has an interceptor.
+THREADED_TEST(InterceptorLoadICGlobalWithInterceptor) {
+  i::FLAG_allow_natives_syntax = true;
+  v8::Isolate* isolate = CcTest::isolate();
+  v8::HandleScope scope(isolate);
+  v8::Local<v8::ObjectTemplate> templ_global = v8::ObjectTemplate::New(isolate);
+  templ_global->SetHandler(v8::NamedPropertyHandlerConfiguration(
+      GenericInterceptorGetter, GenericInterceptorSetter));
+
+  LocalContext context(nullptr, templ_global);
+  i::Handle<i::JSReceiver> global_proxy =
+      v8::Utils::OpenHandle<Object, i::JSReceiver>(context->Global());
+  CHECK(global_proxy->IsJSGlobalProxy());
+  i::Handle<i::JSGlobalObject> global(
+      i::JSGlobalObject::cast(global_proxy->map()->prototype()));
+  CHECK(global->map()->has_named_interceptor());
+
+  ExpectInt32(
+      "(function() {"
+      "  var f = function(obj) { "
+      "    return obj.foo;"
+      "  };"
+      "  var obj = { __proto__: this, _str_foo: 42 };"
+      "  for (var i = 0; i < 1500; i++) obj['p' + i] = 0;"
+      "  /* Ensure that |obj| is in dictionary mode. */"
+      "  if (%HasFastProperties(obj)) return -1;"
+      "  for (var i = 0; i < 3; i++) {"
+      "    f(obj);"
+      "  };"
+      "  return f(obj);"
+      "})();",
+      42);
+}
+
 static void InterceptorLoadICGetter0(
     Local<Name> name, const v8::PropertyCallbackInfo<v8::Value>& info) {
   ApiTestFuzzer::Fuzz();


### PR DESCRIPTION
“This will not be merged to 5.9.” → I’m opening this cherry-pick.

Original commit message:

    Properly handle loads from global interceptor via prototype chain.

    ... when receiver is in dictionary mode.

    Bug: v8:6490
    Change-Id: Ic5a8d214adcc4efd4cb163cbc6b351c4e6b596af
    Reviewed-on: https://chromium-review.googlesource.com/559548
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Igor Sheludko <ishell@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#46428}

Ref: https://chromium.googlesource.com/v8/v8.git/+/6cb999b97b7953ebfd4aabf2e1f62bf405f21c69
Fixes: https://github.com/nodejs/node/issues/13804

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

deps/v8