### PR TITLE
test: reduce run time for test-benchmark-crypto

### DIFF
--- a/test/parallel/test-benchmark-crypto.js
+++ b/test/parallel/test-benchmark-crypto.js
@@ -16,13 +16,15 @@ const fork = require('child_process').fork;
 const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
-const argv = ['--set', 'n=1',
-              '--set', 'writes=1',
-              '--set', 'len=1',
+const argv = ['--set', 'algo=sha256',
               '--set', 'api=stream',
-              '--set', 'out=buffer',
               '--set', 'keylen=1024',
+              '--set', 'len=1',
+              '--set', 'n=1',
+              '--set', 'out=buffer',
               '--set', 'type=buf',
+              '--set', 'v=crypto',
+              '--set', 'writes=1',
               'crypto'];
 
 const child = fork(runjs, argv, {env: {NODEJS_BENCHMARK_ZERO_ALLOWED: 1}});


### PR DESCRIPTION
Specify options to reduce combinations of benchmarks run during testing.
This reduces the run time by approximately 30% and will hopefully allow
Raspberry Pi 1 devices in CI to finish the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark crypto