### PR TITLE
doc: fix document of Error.captureStackTrace

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -222,7 +222,8 @@ myObject.stack;  // similar to `new Error().stack`
 ```
 
 The first line of the trace, instead of being prefixed with `ErrorType:
-message`, will be the result of calling `targetObject.toString()`.
+message`, will be formatted as `Error: <targetObject message>` when
+`targetObject.message` isn't `undefined`, or else just be `Error`.
 
 The optional `constructorOpt` argument accepts a function. If given, all frames
 above `constructorOpt`, including `constructorOpt`, will be omitted from the


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
After executing the below code, the first line of output is `Error: myObject.message`.
```
const myObject = {};
myObject.message = 'myObject.message';
myObject.toString = () => 'myObject.toString';
Error.captureStackTrace(myObject);
console.log(myObject.stack);
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, errors