### PR TITLE
util: remove redundant declaration

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -202,10 +202,8 @@ const kCustomPromisifiedSymbol = Symbol('util.promisify.custom');
 const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
 function promisify(orig) {
-  if (typeof orig !== 'function') {
-    const errors = require('internal/errors');
+  if (typeof orig !== 'function')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'function');
-  }
 
   if (orig[kCustomPromisifiedSymbol]) {
     const fn = orig[kCustomPromisifiedSymbol];


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util

This module is already required in the top scope ([Line 3](https://github.com/vsemozhetbyt/node/blob/9dfa2ef9e8b8779345dd96baa3d7d5a8bb5de492/lib/internal/util.js#L3)). So if I do not miss any intended side effects this declaration can be deleted.
