### PR TITLE
doc: add guidance on testing new errors

### DIFF
--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -69,6 +69,54 @@ for the error code should be added to the `doc/api/errors.md` file. This will
 give users a place to go to easily look up the meaning of individual error
 codes.
 
+## Testing new errors
+
+When adding a new error, corresponding test(s) for the error message
+formatting may also be required. If the messasge for the error is a
+constant string then no test is required for the error message formatting
+as we can trust the error helper implementation. An example of this kind of
+error would be:
+
+```
+E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
+```
+
+If the error message is not a constant string then test(s) to validate
+the formatting of the message based on the parameters used when
+creating the error should be added to
+`.../test/parallel/test-internal-errors.js`.  These tests should validate
+all of the different ways parameters can be used to generate the final
+message string. As simple example would be:
+
+```
+// Test ERR_TLS_CERT_ALTNAME_INVALID
+assert.strictEqual(
+    errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
+    'Hostname/IP does not match certificate\'s altnames: altname');
+```
+
+In addition, there should also be tests which validate the use of the
+error based on where it is used in the codebase.  For these tests, except in
+special cases, they should only validate that the expected code is received
+and NOT validate the massage.  This will reduce the amount of test change
+required when the message for an error changes.
+
+For example:
+
+```
+ assert.throws(() => {
+    socket.bind();
+  }, common.expectsError({
+    code: 'ERR_SOCKET_ALREADY_BOUND',
+    type: Error
+  }));
+
+```
+
+One final note is that it is bad practice to change the format of the message
+after the error has been created and should avoided.  If it does make sense
+to do this for some reason, then additional tests validating the formatting of
+the error message for those cases will likely be required.
 
 ## API
 

--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -98,7 +98,7 @@ assert.strictEqual(
 In addition, there should also be tests which validate the use of the
 error based on where it is used in the codebase.  For these tests, except in
 special cases, they should only validate that the expected code is received
-and NOT validate the massage.  This will reduce the amount of test change
+and NOT validate the message.  This will reduce the amount of test change
 required when the message for an error changes.
 
 For example:

--- a/doc/guides/using-internal-errors.md
+++ b/doc/guides/using-internal-errors.md
@@ -77,22 +77,22 @@ constant string then no test is required for the error message formatting
 as we can trust the error helper implementation. An example of this kind of
 error would be:
 
-```
+```js
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
 ```
 
-If the error message is not a constant string then test(s) to validate
+If the error message is not a constant string then tests to validate
 the formatting of the message based on the parameters used when
 creating the error should be added to
-`.../test/parallel/test-internal-errors.js`.  These tests should validate
+`test/parallel/test-internal-errors.js`.  These tests should validate
 all of the different ways parameters can be used to generate the final
-message string. As simple example would be:
+message string. A simple example is:
 
-```
+```js
 // Test ERR_TLS_CERT_ALTNAME_INVALID
 assert.strictEqual(
-    errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
-    'Hostname/IP does not match certificate\'s altnames: altname');
+  errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
+  'Hostname/IP does not match certificate\'s altnames: altname');
 ```
 
 In addition, there should also be tests which validate the use of the
@@ -103,20 +103,19 @@ required when the message for an error changes.
 
 For example:
 
+```js
+assert.throws(() => {
+  socket.bind();
+}, common.expectsError({
+  code: 'ERR_SOCKET_ALREADY_BOUND',
+  type: Error
+}));
 ```
- assert.throws(() => {
-    socket.bind();
-  }, common.expectsError({
-    code: 'ERR_SOCKET_ALREADY_BOUND',
-    type: Error
-  }));
 
-```
-
-One final note is that it is bad practice to change the format of the message
-after the error has been created and should avoided.  If it does make sense
-to do this for some reason, then additional tests validating the formatting of
-the error message for those cases will likely be required.
+Avoid changing the format of the message after the error has been created.
+If it does make sense to do this for some reason, then additional tests
+validating the formatting of the error message for those cases will
+likely be required.
 
 ## API
 


### PR DESCRIPTION
##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, errors