### PR TITLE
n-api: directly create Local from Persistent

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -56,7 +56,8 @@ struct napi_env__ {
       (destination)->SetInternalFieldCount((field_count));         \
       (env)->prefix ## _template.Reset(isolate, (destination));    \
     } else {                                                       \
-      (destination) = env->prefix ## _template.Get(isolate);       \
+      (destination) = v8::Local<v8::ObjectTemplate>::New(          \
+          isolate, env->prefix ## _template);                      \
     }                                                              \
   } while (0)
 


### PR DESCRIPTION
The `v8::PersistentBase<T>.Get` method didn't exist in node 4 and it's
just a helper which creates a new `v8::Local` from the given object.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api