### PR TITLE
dns, errors: Migrate to use internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -596,6 +596,10 @@ Used when `Console` is instantiated without `stdout` stream or when `stdout` or
 
 Used when the native call from `process.cpuUsage` cannot be processed properly.
 
+<a id="ERR_DNS_SET_SERVERS_FAILED"></a>
+
+Used when `c-ares` failed to set the DNS server.
+
 <a id="ERR_FALSY_VALUE_REJECTION"></a>
 ### ERR_FALSY_VALUE_REJECTION
 
@@ -684,6 +688,10 @@ platform-dependent.
 Used when an attempt is made to send an unsupported "handle" over an IPC
 communication channel to a child process. See [`child.send()`] and
 [`process.send()`] for more information.
+
+<a id="ERR_INVALID_IP_ADDRESS"></a>
+
+Used when an IP address is not valid. 
 
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### ERR_INVALID_OPT_VALUE

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -27,6 +27,7 @@ const cares = process.binding('cares_wrap');
 const uv = process.binding('uv');
 const internalNet = require('internal/net');
 const { customPromisifyArgs } = require('internal/util');
+const errors = require('internal/errors');
 
 const GetAddrInfoReqWrap = cares.GetAddrInfoReqWrap;
 const GetNameInfoReqWrap = cares.GetNameInfoReqWrap;
@@ -126,13 +127,13 @@ function lookup(hostname, options, callback) {
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
-    throw new TypeError('Invalid arguments: ' +
-                        'hostname must be a string or falsey');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'hostname',
+                               ['string', 'falsey'], hostname);
   } else if (typeof options === 'function') {
     callback = options;
     family = 0;
   } else if (typeof callback !== 'function') {
-    throw new TypeError('Invalid arguments: callback must be passed');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   } else if (options !== null && typeof options === 'object') {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
@@ -142,14 +143,14 @@ function lookup(hostname, options, callback) {
         hints !== cares.AI_ADDRCONFIG &&
         hints !== cares.AI_V4MAPPED &&
         hints !== (cares.AI_ADDRCONFIG | cares.AI_V4MAPPED)) {
-      throw new TypeError('Invalid argument: hints must use valid flags');
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'hints', hints);
     }
   } else {
     family = options >>> 0;
   }
 
   if (family !== 0 && family !== 4 && family !== 6)
-    throw new TypeError('Invalid argument: family must be 4 or 6');
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'family', family);
 
   if (!hostname) {
     if (all) {
@@ -200,16 +201,16 @@ function onlookupservice(err, host, service) {
 // lookupService(address, port, callback)
 function lookupService(host, port, callback) {
   if (arguments.length !== 3)
-    throw new Error('Invalid arguments');
+    throw new errors.TypeError('ERR_MISSING_ARGS', 'host', 'port', 'callback');
 
   if (isIP(host) === 0)
-    throw new TypeError('"host" argument needs to be a valid IP address');
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'host', host);
 
   if (!isLegalPort(port))
-    throw new TypeError(`"port" should be >= 0 and < 65536, got "${port}"`);
+    throw new errors.RangeError('ERR_SOCKET_BAD_PORT');
 
   if (typeof callback !== 'function')
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
   port = +port;
 
@@ -250,9 +251,10 @@ function resolver(bindingName) {
     }
 
     if (typeof name !== 'string') {
-      throw new Error('"name" argument must be a string');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'name',
+                                 'string', name);
     } else if (typeof callback !== 'function') {
-      throw new Error('"callback" argument must be a function');
+      throw new errors.TypeError('ERR_INVALID_CALLBACK');
     }
 
     var req = new QueryReqWrap();
@@ -290,13 +292,14 @@ function resolve(hostname, rrtype, callback) {
     resolver = resolveMap.A;
     callback = rrtype;
   } else {
-    throw new TypeError('"rrtype" argument must be a string');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'rrtype',
+                               'string', rrtype);
   }
 
   if (typeof resolver === 'function') {
     return resolver(hostname, callback);
   } else {
-    throw new Error(`Unknown type "${rrtype}"`);
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'rrtype', rrtype);
   }
 }
 
@@ -344,7 +347,7 @@ function setServers(servers) {
       return newSet.push([ipVersion, s, parseInt(p)]);
     }
 
-    throw new Error(`IP address is not properly formatted: ${serv}`);
+    throw new errors.Error('ERR_INVALID_IP_ADDRESS', serv);
   });
 
   const errorNumber = cares.setServers(newSet);
@@ -354,7 +357,7 @@ function setServers(servers) {
     cares.setServers(orig.join(','));
 
     var err = cares.strerror(errorNumber);
-    throw new Error(`c-ares failed to set servers: "${err}" [${servers}]`);
+    throw new errors.Error('ERR_DNS_SET_SERVERS_FAILED', err, servers);
   }
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -106,6 +106,8 @@ E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
+  `c-ares failed to set servers: "${err}" [${servers}]`);
 E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot render headers after they are sent to the client');
@@ -129,6 +131,7 @@ E('ERR_INVALID_FILE_URL_HOST',
   'File URL host must be "localhost" or empty on %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
+E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s');
 E('ERR_INVALID_OPT_VALUE',
   (name, value) => {
     return `The value "${String(value)}" is invalid for option "${name}"`;

--- a/test/parallel/test-c-ares.js
+++ b/test/parallel/test-c-ares.js
@@ -46,11 +46,21 @@ dns.lookup('::1', common.mustCall((error, result, addressType) => {
   assert.strictEqual(6, addressType);
 }));
 
-// Try calling resolve with an unsupported type.
-assert.throws(() => dns.resolve('www.google.com', 'HI'), /Unknown type/);
-
-// Try calling resolve with an unsupported type that's an object key
-assert.throws(() => dns.resolve('www.google.com', 'toString'), /Unknown type/);
+[
+  // Try calling resolve with an unsupported type.
+  'HI',
+  // Try calling resolve with an unsupported type that's an object key
+  'toString'
+].forEach((val) => {
+  common.expectsError(
+    () => dns.resolve('www.google.com', val),
+    {
+      code: 'ERR_INVALID_OPT_VALUE',
+      type: TypeError,
+      message: `The value "${val}" is invalid for option "rrtype"`
+    }
+  );
+});
 
 // Windows doesn't usually have an entry for localhost 127.0.0.1 in
 // C:\Windows\System32\drivers\etc\hosts

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -9,15 +9,25 @@ cares.getaddrinfo = () => process.binding('uv').UV_ENOENT;
 
 assert.throws(() => {
   dns.lookup(1, {});
-}, /^TypeError: Invalid arguments: hostname must be a string or falsey$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: /^The "hostname" argument must be one of type string or falsey/
+}));
 
 assert.throws(() => {
   dns.lookup(false, 'cb');
-}, /^TypeError: Invalid arguments: callback must be passed$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_CALLBACK',
+  type: TypeError
+}));
 
 assert.throws(() => {
   dns.lookup(false, 'options', 'cb');
-}, /^TypeError: Invalid arguments: callback must be passed$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_CALLBACK',
+  type: TypeError
+}));
 
 assert.throws(() => {
   dns.lookup(false, {
@@ -25,7 +35,11 @@ assert.throws(() => {
     family: 0,
     all: false
   }, common.mustNotCall());
-}, /^TypeError: Invalid argument: hints must use valid flags$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: TypeError,
+  message: 'The value "100" is invalid for option "hints"'
+}));
 
 assert.throws(() => {
   dns.lookup(false, {
@@ -33,7 +47,11 @@ assert.throws(() => {
     family: 20,
     all: false
   }, common.mustNotCall());
-}, /^TypeError: Invalid argument: family must be 4 or 6$/);
+}, common.expectsError({
+  code: 'ERR_INVALID_OPT_VALUE',
+  type: TypeError,
+  message: 'The value "20" is invalid for option "family"'
+}));
 
 assert.doesNotThrow(() => {
   dns.lookup(false, {

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -20,12 +20,19 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const dns = require('dns');
 
 // Should not raise assertion error. Issue #7070
 assert.throws(() => dns.resolveNs([]), // bad name
-              /^Error: "name" argument must be a string$/);
+              common.expectsError({
+                code: 'ERR_INVALID_ARG_TYPE',
+                type: TypeError,
+                message: /^The "name" argument must be of type string/
+              }));
 assert.throws(() => dns.resolveNs(''), // bad callback
-              /^Error: "callback" argument must be a function$/);
+              common.expectsError({
+                code: 'ERR_INVALID_CALLBACK',
+                type: TypeError
+              }));

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -60,14 +60,16 @@ const net = require('net');
 
 // Test invalid hints
 {
-  const regexp = /^TypeError: Invalid argument: hints must use valid flags$/;
   // connect({hint}, cb) and connect({hint})
   const hints = (dns.ADDRCONFIG | dns.V4MAPPED) + 42;
   const hintOptBlocks = doConnect([{ hints: hints }],
                                   () => common.mustNotCall());
   for (const block of hintOptBlocks) {
-    assert.throws(block, regexp,
-                  `${block.name}({hints: ${hints})`);
+    assert.throws(block, common.expectsError({
+      code: 'ERR_INVALID_OPT_VALUE',
+      type: TypeError,
+      message: /The value "\d+" is invalid for option "hints"/
+    }));
   }
 }
 


### PR DESCRIPTION
Migrate dns errors to use internal/errors.

Ref: #11273 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dns, errors
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
