### PR TITLE
tls: move parseCertString to internal

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -639,7 +639,23 @@ Type: Runtime
 
 Type: Runtime
 
-`tls.parseCertString()` was move to `internal/tls.js`.
+`tls.parseCertString()` is a trivial parsing helper that was made public by
+mistake. This function can usually be replaced with
+
+```js
+const querystring = require('querystring');
+querystring.parse(str, '\n', '=')`;
+```
+
+*Note*: This function is not 100% same as `querystring.parse()`. One difference
+is that `querystring.parse()` does URLDecoding, e.g.:
+
+```js
+> querystring.parse("%E5%A5%BD=1", "\n", "=");
+{ '好': '1' }
+> tls.parseCertString("%E5%A5%BD=1");
+{ '%E5%A5%BD': '1' }
+```
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -634,6 +634,13 @@ Type: Runtime
 
 *Note*: change was made while `async_hooks` was an experimental API.
 
+<a id="DEP0073"></a>
+### DEP0073: tls.parseCertString()
+
+Type: Runtime
+
+`tls.parseCertString()` was move to `internal/tls.js`.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-const tls = require('tls');
+const tls = require('internal/tls');
 
 const SSL_OP_CIPHER_SERVER_PREFERENCE =
     process.binding('constants').crypto.SSL_OP_CIPHER_SERVER_PREFERENCE;

--- a/lib/internal/tls.js
+++ b/lib/internal/tls.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const DEFAULT_CIPHERS = process.binding('constants').crypto.defaultCipherList;
+const DEFAULT_ECDH_CURVE = 'prime256v1';
+
+// Example:
+// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
+function parseCertString(s) {
+  var out = {};
+  var parts = s.split('\n');
+  for (var i = 0, len = parts.length; i < len; i++) {
+    var sepIndex = parts[i].indexOf('=');
+    if (sepIndex > 0) {
+      var key = parts[i].slice(0, sepIndex);
+      var value = parts[i].slice(sepIndex + 1);
+      if (key in out) {
+        if (!Array.isArray(out[key])) {
+          out[key] = [out[key]];
+        }
+        out[key].push(value);
+      } else {
+        out[key] = value;
+      }
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  parseCertString,
+  DEFAULT_CIPHERS,
+  DEFAULT_ECDH_CURVE
+};

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -24,6 +24,7 @@
 const internalUtil = require('internal/util');
 internalUtil.assertCrypto();
 
+const internalTLS = require('internal/tls');
 const net = require('net');
 const url = require('url');
 const binding = process.binding('crypto');
@@ -39,10 +40,12 @@ exports.CLIENT_RENEG_WINDOW = 600;
 
 exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 
-exports.DEFAULT_CIPHERS =
-    process.binding('constants').crypto.defaultCipherList;
-
-exports.DEFAULT_ECDH_CURVE = 'prime256v1';
+[ 'DEFAULT_CIPHERS', 'DEFAULT_ECDH_CURVE' ].forEach((key) => {
+  Object.defineProperty(exports, key, {
+    get: () => { return internalTLS[key]; },
+    set: (c) => { internalTLS[key] = c; }
+  });
+});
 
 exports.getCiphers = internalUtil.cachedResult(
   () => internalUtil.filterDuplicateStrings(binding.getSSLCiphers(), true)
@@ -228,28 +231,10 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   }
 };
 
-// Example:
-// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
-exports.parseCertString = function parseCertString(s) {
-  var out = {};
-  var parts = s.split('\n');
-  for (var i = 0, len = parts.length; i < len; i++) {
-    var sepIndex = parts[i].indexOf('=');
-    if (sepIndex > 0) {
-      var key = parts[i].slice(0, sepIndex);
-      var value = parts[i].slice(sepIndex + 1);
-      if (key in out) {
-        if (!Array.isArray(out[key])) {
-          out[key] = [out[key]];
-        }
-        out[key].push(value);
-      } else {
-        out[key] = value;
-      }
-    }
-  }
-  return out;
-};
+exports.parseCertString = internalUtil.deprecate(
+  internalTLS.parseCertString,
+  'tls.parseCertString is deprecated',
+  'DEP0073');
 
 // Public API
 exports.createSecureContext = require('_tls_common').createSecureContext;

--- a/node.gyp
+++ b/node.gyp
@@ -100,6 +100,7 @@
       'lib/internal/repl.js',
       'lib/internal/socket_list.js',
       'lib/internal/test/unicode.js',
+      'lib/internal/tls.js',
       'lib/internal/url.js',
       'lib/internal/util.js',
       'lib/internal/v8_prof_polyfill.js',

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,10 +1,12 @@
 'use strict';
+
+// Flags: --expose_internals
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const tls = require('tls');
+const tls = require('internal/tls');
 
 {
   const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\n' +
@@ -35,4 +37,18 @@ const tls = require('tls');
   const invalid = 'fhqwhgads';
   const invalidOut = tls.parseCertString(invalid);
   assert.deepStrictEqual(invalidOut, {});
+}
+
+{
+  const regexp = new RegExp('^\\(node:\\d+\\) [DEP0073] DeprecationWarning: ' +
+                            'tls\\.parseCertString is deprecated$');
+
+  // test for deprecate message
+  common.hijackStderr(common.mustCall(function(data) {
+    assert.ok(regexp.test(data));
+    common.restoreStderr();
+  }));
+
+  const ret = require('tls').parseCertString('foo=bar');
+  assert.deepStrictEqual(ret, { foo: 'bar' });
 }


### PR DESCRIPTION
`tls.parseCertString()` exposed by accident. Now move this function to
`internal/tls` and mark the original one as deprecated.

Refs: https://github.com/nodejs/node/issues/14193
Refs: https://github.com/nodejs/node/commit/af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7#diff-cc32376ce1eaf679ec2298cd483f15c7R188

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls