### PR TITLE
build: run test-hash-seed at the end of test-v8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,13 +433,15 @@ test-async-hooks:
 
 
 ifneq ("","$(wildcard deps/v8/tools/run-tests.py)")
-test-v8: v8 test-hash-seed
+test-v8: v8
 #	note: performs full test unless QUICKCHECK is specified
 	deps/v8/tools/run-tests.py --arch=$(V8_ARCH) \
         --mode=$(BUILDTYPE_LOWER) $(V8_TEST_OPTIONS) $(QUICKCHECK_ARG) \
         --no-presubmit \
         --shell-dir=$(PWD)/deps/v8/out/$(V8_ARCH).$(BUILDTYPE_LOWER) \
 	 $(TAP_V8)
+	@echo Testing hash seed
+	$(MAKE) test-hash-seed
 
 test-v8-intl: v8
 #	note: performs full test unless QUICKCHECK is specified


### PR DESCRIPTION
The v8 and test-hash-seed targets cannot be run in parallel because they
need different copies of the deps/v8 directory.

Ref: https://github.com/nodejs/node/pull/14004#issuecomment-314774773

I'm open to a better solution but I don't think `test-hash-seed` shoud be run here, even if we make it sequential (V8 has to be built twice).

@ofrobots @nodejs/v8 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
