### PR TITLE
net: support passing null to listen()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1451,11 +1451,12 @@ Server.prototype.listen = function(...args) {
   }
 
   // ([port][, host][, backlog][, cb]) where port is omitted,
-  // that is, listen() or listen(cb),
-  // or (options[, cb]) where options.port is explicitly set as undefined,
-  // bind to an arbitrary unused port
+  // that is, listen(), listen(null), listen(cb), or listen(null, cb)
+  // or (options[, cb]) where options.port is explicitly set as undefined or
+  // null, bind to an arbitrary unused port
   if (args.length === 0 || typeof args[0] === 'function' ||
-    (typeof options.port === 'undefined' && 'port' in options)) {
+      (typeof options.port === 'undefined' && 'port' in options) ||
+      options.port === null) {
     options.port = 0;
   }
   // ([port][, host][, backlog][, cb]) where port is specified

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -42,6 +42,7 @@ const listenOnPort = [
     listen('0', common.mustCall(close));
     listen(0, common.mustCall(close));
     listen(undefined, common.mustCall(close));
+    listen(null, common.mustCall(close));
     // Test invalid ports
     assert.throws(() => listen(-1, common.mustNotCall()), portError);
     assert.throws(() => listen(NaN, common.mustNotCall()), portError);
@@ -71,8 +72,6 @@ const listenOnPort = [
                   `expect listen(${util.inspect(options)}) to throw`);
   }
 
-  shouldFailToListen(null, { port: null });
-  shouldFailToListen({ port: null });
   shouldFailToListen(false, { port: false });
   shouldFailToListen({ port: false });
   shouldFailToListen(true, { port: true });


### PR DESCRIPTION
This commit fixes a regression around the handling of `null` as the port passed to `Server#listen()`. With this commit, `null`, `undefined`, and 0 have the same behavior, which was the case in Node 4.

Fixes: https://github.com/nodejs/node/issues/14205

R= @sam-github @evanlucas 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
net