### PR TITLE
repl: deprecate REPLServer.parseREPLKeyword

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -653,6 +653,14 @@ Type: Runtime
 The `REPLServer.bufferedCommand` property was deprecated in favor of
 [`REPLServer.clearBufferedCommand()`][].
 
+<a id="DEP00XX"></a>
+### DEP00XX: REPLServer.parseREPLKeyword()
+
+Type: Runtime
+
+`REPLServer.parseREPLKeyword()` was removed from userland visibility.
+
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -388,7 +388,7 @@ called from within the action function for commands registered using the
 ### replServer.parseREPLKeyword(keyword, [rest])
 <!-- YAML
 added: v0.8.9
-deprecated: XXXX
+deprecated: REPLACEME
 -->
 
 * `keyword` {string} the potential keyword to parse and execute

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -385,6 +385,20 @@ buffered but not yet executed. This method is primarily intended to be
 called from within the action function for commands registered using the
 `replServer.defineCommand()` method.
 
+### replServer.parseREPLKeyword(keyword, [rest])
+<!-- YAML
+added: v0.8.9
+deprecated: XXXX
+-->
+
+* `keyword` {string} the potential keyword to parse and execute
+* `rest` {any} any parameters to the keyword command
+
+> Stability: 0 - Deprecated.
+
+An internal method used to parse and execute `REPLServer` keywords.
+Returns `true` if `keyword` is a valid keyword, otherwise `false`.
+
 ## repl.start([options])
 <!-- YAML
 added: v0.1.91

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -434,7 +434,7 @@ function REPLServer(prompt,
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];
-        if (self.parseREPLKeyword(keyword, rest) === true) {
+        if (_parseREPLKeyword(self, keyword, rest) === true) {
           return;
         }
         if (!self[kBufferedCommandSymbol]) {
@@ -1064,21 +1064,10 @@ REPLServer.prototype.completeOnEditorMode = (callback) => (err, results) => {
   callback(null, [[`${completeOn}${longestCommonPrefix(data)}`], completeOn]);
 };
 
-/**
- * Used to parse and execute the Node REPL commands.
- *
- * @param {keyword} keyword The command entered to check.
- * @return {Boolean} If true it means don't continue parsing the command.
- */
-REPLServer.prototype.parseREPLKeyword = function(keyword, rest) {
-  var cmd = this.commands[keyword];
-  if (cmd) {
-    cmd.action.call(this, rest);
-    return true;
-  }
-  return false;
-};
-
+REPLServer.prototype.parseREPLKeyword = util.deprecate(
+  function(keyword, rest) {
+    return _parseREPLKeyword(this, keyword, rest);
+  }, 'REPLServer.parseREPLKeyword() is deprecated', 'DEP00XX');
 
 REPLServer.prototype.defineCommand = function(keyword, cmd) {
   if (typeof cmd === 'function') {
@@ -1378,6 +1367,15 @@ function isCodeRecoverable(code) {
   }
 
   return stringLiteral ? lastChar === '\\' : isBlockComment;
+}
+
+function _parseREPLKeyword(repl, keyword, rest) {
+  var cmd = repl.commands[keyword];
+  if (cmd) {
+    cmd.action.call(repl, rest);
+    return true;
+  }
+  return false;
 }
 
 function Recoverable(err) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -374,6 +374,20 @@ function REPLServer(prompt,
     };
   }
 
+  function _parseREPLKeyword(keyword, rest) {
+    var cmd = this.commands[keyword];
+    if (cmd) {
+      cmd.action.call(this, rest);
+      return true;
+    }
+    return false;
+  }
+
+  self.parseREPLKeyword = util.deprecate(
+    _parseREPLKeyword,
+    'REPLServer.parseREPLKeyword() is deprecated',
+    'DEP00XX');
+
   self.on('close', function emitExit() {
     self.emit('exit');
   });
@@ -434,7 +448,7 @@ function REPLServer(prompt,
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];
-        if (_parseREPLKeyword(self, keyword, rest) === true) {
+        if (_parseREPLKeyword.call(self, keyword, rest) === true) {
           return;
         }
         if (!self[kBufferedCommandSymbol]) {
@@ -1064,11 +1078,6 @@ REPLServer.prototype.completeOnEditorMode = (callback) => (err, results) => {
   callback(null, [[`${completeOn}${longestCommonPrefix(data)}`], completeOn]);
 };
 
-REPLServer.prototype.parseREPLKeyword = util.deprecate(
-  function(keyword, rest) {
-    return _parseREPLKeyword(this, keyword, rest);
-  }, 'REPLServer.parseREPLKeyword() is deprecated', 'DEP00XX');
-
 REPLServer.prototype.defineCommand = function(keyword, cmd) {
   if (typeof cmd === 'function') {
     cmd = { action: cmd };
@@ -1367,15 +1376,6 @@ function isCodeRecoverable(code) {
   }
 
   return stringLiteral ? lastChar === '\\' : isBlockComment;
-}
-
-function _parseREPLKeyword(repl, keyword, rest) {
-  var cmd = repl.commands[keyword];
-  if (cmd) {
-    cmd.action.call(repl, rest);
-    return true;
-  }
-  return false;
 }
 
 function Recoverable(err) {

--- a/test/parallel/test-repl-deprecations.js
+++ b/test/parallel/test-repl-deprecations.js
@@ -19,4 +19,3 @@ function testParseREPLKeyword() {
   assert.ok(!server.parseREPLKeyword('tacos'));
   server.close();
 }
-

--- a/test/parallel/test-repl-deprecations.js
+++ b/test/parallel/test-repl-deprecations.js
@@ -3,11 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 
-test();
-
-function test() {
-  testParseREPLKeyword();
-}
+testParseREPLKeyword();
 
 function testParseREPLKeyword() {
   const server = repl.start({ prompt: '> ' });

--- a/test/parallel/test-repl-deprecations.js
+++ b/test/parallel/test-repl-deprecations.js
@@ -15,7 +15,6 @@ function testParseREPLKeyword() {
 
   common.expectWarning('DeprecationWarning', warn);
   assert.ok(server.parseREPLKeyword('clear'));
-  common.expectWarning('DeprecationWarning', warn);
   assert.ok(!server.parseREPLKeyword('tacos'));
   server.close();
 }

--- a/test/parallel/test-repl-deprecations.js
+++ b/test/parallel/test-repl-deprecations.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+test();
+
+function test() {
+  testParseREPLKeyword();
+}
+
+function testParseREPLKeyword() {
+  const server = repl.start({ prompt: '> ' });
+  const warn = 'REPLServer.parseREPLKeyword() is deprecated';
+
+  common.expectWarning('DeprecationWarning', warn);
+  assert.ok(server.parseREPLKeyword('clear'));
+  common.expectWarning('DeprecationWarning', warn);
+  assert.ok(!server.parseREPLKeyword('tacos'));
+  server.close();
+}
+


### PR DESCRIPTION
This method does not need to be visible to user code. It has been
undocumented since it was introduced which was perhaps v0.8.9, as
far as I can tell. 

The motivation for this change is that the method is simply an
implementation detail of the `REPLServer` behavior, and does
not need to be exposed to user code.

This change adds documentation of the method with a deprecation
warning as recommended by @jasnell in
https://github.com/nodejs/node/issues/7619#issuecomment-236608809.

Refs: https://github.com/nodejs/node/issues/7619

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl, doc
