### PR TITLE
test: check allowed port argument values

### DIFF
--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -26,3 +26,33 @@ net.Server().listen({ port: '0' }, close);
     net.Server().listen({ port: port }, common.fail);
   }, /invalid listen argument/i);
 });
+
+// Repeat the tests, passing port as an argument, which validates somewhat
+// differently.
+
+net.Server().listen(undefined, close);
+net.Server().listen('0', close);
+
+// 'nan', skip, treated as a path, not a port
+//'+Infinity', skip, treated as a path, not a port
+//'-Infinity' skip, treated as a path, not a port
+
+// The numbers that are out of range are treated as 0
+net.Server().listen(-1, close);
+// Use a float larger than 1024, because EACCESS happens for low ports
+net.Server().listen(1234.56, close);
+net.Server().listen(0x10000, close);
+net.Server().listen(1 / 0, close);
+net.Server().listen(-1 / 0, close);
+
+// null is treated as 0
+net.Server().listen(null, close);
+
+// false/true are converted to 0/1, arguably a bug, but fixing would be
+// semver-major. Note that true fails because ports that low can't be listened
+// on by unprivileged processes.
+net.Server().listen(false, close);
+
+net.Server().listen(true).on('error', common.mustCall(function(err) {
+  assert.strictEqual(err.code, 'EACCES');
+}));


### PR DESCRIPTION
Existing test only covered ports pass as options, add tests for
argument behaviour to avoid regressions.

Ref: https://github.com/nodejs/node/issues/14205

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
