### PR TITLE
net: support passing undefined to listen()

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1338,7 +1338,7 @@ Server.prototype.listen = function() {
     self.once('listening', lastArg);
   }
 
-  var port = toNumber(arguments[0]);
+  var port = typeof arguments[0] === 'undefined' ? 0 : toNumber(arguments[0]);
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -26,3 +26,47 @@ net.Server().listen({ port: '' + common.PORT }, close);
     net.Server().listen({ port: port }, common.fail);
   }, /invalid listen argument/i);
 });
+
+// Repeat the tests, passing port as an argument, which validates somewhat
+// differently.
+
+net.Server().listen(undefined, close);
+net.Server().listen('0', close);
+
+// 'nan', skip, treated as a path, not a port
+//'+Infinity', skip, treated as a path, not a port
+//'-Infinity' skip, treated as a path, not a port
+
+// 4.x treats these as 0, but 6.x treats them as invalid numbers.
+[
+  -1,
+  123.456,
+  0x10000,
+  1 / 0,
+  -1 / 0,
+].forEach(function(port) {
+  assert.throws(function() {
+    net.Server().listen(port, common.fail);
+  }, /"port" argument must be >= 0 and < 65536/i);
+});
+
+// null is treated as 0
+net.Server().listen(null, close);
+
+// false/true are converted to 0/1, arguably a bug, but fixing would be
+// semver-major. Note that true fails when port 1 low can't be listened on by
+// unprivileged processes (Linux) but the listen does succeed on some Windows
+// versions.
+net.Server().listen(false, close);
+
+(function() {
+  const done = common.mustCall(function(err) {
+    if (err)
+      return assert.strictEqual(err.code, 'EACCES');
+
+    assert.strictEqual(this.address().port, 1);
+    this.close();
+  });
+
+  net.Server().listen(true).on('error', done).on('listening', done);
+})();


### PR DESCRIPTION
For consistency with 4.x and 8.x.

This commit also contains a forward port of
https://github.com/nodejs/node/pull/14232 to confirm that 4.x and 6.x
behave identically with respect to the port argument.

Ref: https://github.com/nodejs/node/issues/14205

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
