### PR TITLE
net: fix bytesWritten during writev

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -835,10 +835,12 @@ protoGetter('bytesWritten', function bytesWritten() {
       else
         bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
     }
-  } else if (data instanceof Buffer) {
-    bytes += data.length;
   } else if (data) {
-    bytes += Buffer.byteLength(data, encoding);
+    // Writes are either a string or a Buffer.
+    if (typeof data !== 'string')
+      bytes += data.length;
+    else
+      bytes += Buffer.byteLength(data, encoding);
   }
 
   return bytes;

--- a/lib/net.js
+++ b/lib/net.js
@@ -835,11 +835,10 @@ protoGetter('bytesWritten', function bytesWritten() {
       else
         bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
     }
+  } else if (data instanceof Buffer) {
+    bytes += data.length;
   } else if (data) {
-    if (data instanceof Buffer)
-      bytes += data.length;
-    else
-      bytes += Buffer.byteLength(data, encoding);
+    bytes += Buffer.byteLength(data, encoding);
   }
 
   return bytes;

--- a/lib/net.js
+++ b/lib/net.js
@@ -825,7 +825,17 @@ protoGetter('bytesWritten', function bytesWritten() {
       bytes += Buffer.byteLength(el.chunk, el.encoding);
   });
 
-  if (data) {
+  if (Array.isArray(data)) {
+    // was a writev, iterate over chunks to get total length
+    for (var i = 0; i < data.length; i++) {
+      const chunk = data[i];
+
+      if (chunk instanceof Buffer)
+        bytes += chunk.length;
+      else
+        bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);
+    }
+  } else if (data) {
     if (data instanceof Buffer)
       bytes += data.length;
     else

--- a/lib/net.js
+++ b/lib/net.js
@@ -830,7 +830,7 @@ protoGetter('bytesWritten', function bytesWritten() {
     for (var i = 0; i < data.length; i++) {
       const chunk = data[i];
 
-      if (chunk instanceof Buffer)
+      if (data.allBuffers || chunk instanceof Buffer)
         bytes += chunk.length;
       else
         bytes += Buffer.byteLength(chunk.chunk, chunk.encoding);

--- a/test/parallel/test-net-socket-byteswritten.js
+++ b/test/parallel/test-net-socket-byteswritten.js
@@ -3,14 +3,13 @@
 const common = require('../common');
 const assert = require('assert');
 const net = require('net');
-const Buffer = require('buffer').Buffer;
 
 const server = net.createServer(function(socket) {
   socket.end();
 });
 
-server.listen(common.PORT, common.mustCall(function() {
-  const socket = net.connect(common.PORT);
+server.listen(0, common.mustCall(function() {
+  const socket = net.connect(server.address().port);
 
   // Cork the socket, then write twice; this should cause a writev, which
   // previously caused an err in the bytesWritten count.

--- a/test/parallel/test-net-socket-byteswritten.js
+++ b/test/parallel/test-net-socket-byteswritten.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const Buffer = require('buffer').Buffer;
+
+const server = net.createServer(function(socket) {
+  socket.end();
+});
+
+server.listen(common.PORT, common.mustCall(function() {
+  const socket = net.connect(common.PORT);
+
+  // Cork the socket, then write twice; this should cause a writev, which
+  // previously caused an err in the bytesWritten count.
+  socket.cork();
+
+  socket.write('one');
+  socket.write(new Buffer('twø', 'utf8'));
+
+  socket.uncork();
+
+  // one = 3 bytes, twø = 4 bytes
+  assert.strictEqual(socket.bytesWritten, 3 + 4);
+
+  socket.on('connect', common.mustCall(function() {
+    assert.strictEqual(socket.bytesWritten, 3 + 4);
+  }));
+
+  socket.on('end', common.mustCall(function() {
+    assert.strictEqual(socket.bytesWritten, 3 + 4);
+
+    server.close();
+  }));
+}));


### PR DESCRIPTION
When a `writev` is caused on a socket (sometimes through corking and
uncorking), previously net would call `Buffer.byteLength` on the array of
buffers and chunks. This throws a `TypeError`, because `Buffer.byteLength`
throws when passed a non-string.

In dbfe8c4e, behavior changed to throw when passed a non-string. This is
correct behavior. Previously, it would cast the argument to a string, so
before this commit, `bytesWritten` would give an erroneous value. This
commit corrects the behavior equally both before and after dbfe8c4e.

This commit fixes this bug by iterating over each chunk in the pending
stack and calculating the length individually. Also adds a regression
test.

Refs: https://github.com/nodejs/node/pull/2960

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net