### PR TITLE
doc, tls: mark parseCertString() as deprecated

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -674,12 +674,12 @@ querystring.parse(str, '\n', '=');
 ```
 
 *Note*: This function is not completely equivalent to `querystring.parse()`. One
-difference is that `querystring.parse()` does URLDecoding:
+difference is that `querystring.parse()` does url encoding:
 
 ```sh
-> querystring.parse("%E5%A5%BD=1", "\n", "=");
+> querystring.parse('%E5%A5%BD=1', '\n', '=');
 { '好': '1' }
-> tls.parseCertString("%E5%A5%BD=1");
+> tls.parseCertString('%E5%A5%BD=1');
 { '%E5%A5%BD': '1' }
 ```
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -660,6 +660,28 @@ Type: Runtime
 
 `REPLServer.parseREPLKeyword()` was removed from userland visibility.
 
+<a id="DEP00XX"></a>
+### DEP00XX: tls.parseCertString()
+
+Type: Documentation-only
+
+`tls.parseCertString()` is a trivial parsing helper that was made public by
+mistake. This function can usually be replaced with:
+
+```js
+const querystring = require('querystring');
+querystring.parse(str, '\n', '=');
+```
+
+*Note*: This function is not completely equivalent to `querystring.parse()`. One
+difference is that `querystring.parse()` does URLDecoding:
+
+```sh
+> querystring.parse("%E5%A5%BD=1", "\n", "=");
+{ '好': '1' }
+> tls.parseCertString("%E5%A5%BD=1");
+{ '%E5%A5%BD': '1' }
+```
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array


### PR DESCRIPTION
`tls.parseCertString()` was made public by mistack. So mark it as
deprecated.

Refs: https://github.com/nodejs/node/issues/14193
Refs: https://github.com/nodejs/node/commit/af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7#diff-cc32376ce1eaf679ec2298cd483f15c7R188

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls, doc