### PR TITLE
tls: deprecate parseCertString & move to internal

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -663,7 +663,7 @@ Type: Runtime
 <a id="DEP00XX"></a>
 ### DEP00XX: tls.parseCertString()
 
-Type: Documentation-only
+Type: Runtime
 
 `tls.parseCertString()` is a trivial parsing helper that was made public by
 mistake. This function can usually be replaced with:

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -21,6 +21,7 @@
 
 'use strict';
 
+const { parseCertString } = require('internal/tls');
 const tls = require('tls');
 const errors = require('internal/errors');
 
@@ -202,11 +203,11 @@ exports.translatePeerCertificate = function translatePeerCertificate(c) {
   if (!c)
     return null;
 
-  if (c.issuer != null) c.issuer = tls.parseCertString(c.issuer);
+  if (c.issuer != null) c.issuer = parseCertString(c.issuer);
   if (c.issuerCertificate != null && c.issuerCertificate !== c) {
     c.issuerCertificate = translatePeerCertificate(c.issuerCertificate);
   }
-  if (c.subject != null) c.subject = tls.parseCertString(c.subject);
+  if (c.subject != null) c.subject = parseCertString(c.subject);
   if (c.infoAccess != null) {
     var info = c.infoAccess;
     c.infoAccess = Object.create(null);

--- a/lib/internal/tls.js
+++ b/lib/internal/tls.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Example:
+// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
+function parseCertString(s) {
+  var out = Object.create(null);
+  var parts = s.split('\n');
+  for (var i = 0, len = parts.length; i < len; i++) {
+    var sepIndex = parts[i].indexOf('=');
+    if (sepIndex > 0) {
+      var key = parts[i].slice(0, sepIndex);
+      var value = parts[i].slice(sepIndex + 1);
+      if (key in out) {
+        if (!Array.isArray(out[key])) {
+          out[key] = [out[key]];
+        }
+        out[key].push(value);
+      } else {
+        out[key] = value;
+      }
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  parseCertString
+};

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -23,6 +23,7 @@
 
 const errors = require('internal/errors');
 const internalUtil = require('internal/util');
+const internalTLS = require('internal/tls');
 internalUtil.assertCrypto();
 
 const net = require('net');
@@ -228,28 +229,11 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
   }
 };
 
-// Example:
-// C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
-exports.parseCertString = function parseCertString(s) {
-  var out = Object.create(null);
-  var parts = s.split('\n');
-  for (var i = 0, len = parts.length; i < len; i++) {
-    var sepIndex = parts[i].indexOf('=');
-    if (sepIndex > 0) {
-      var key = parts[i].slice(0, sepIndex);
-      var value = parts[i].slice(sepIndex + 1);
-      if (key in out) {
-        if (!Array.isArray(out[key])) {
-          out[key] = [out[key]];
-        }
-        out[key].push(value);
-      } else {
-        out[key] = value;
-      }
-    }
-  }
-  return out;
-};
+exports.parseCertString = internalUtil.deprecate(
+  internalTLS.parseCertString,
+  'tls.parseCertString() is deprecated. ' +
+  'Please use querystring.parse() instead.',
+  'DEP00XX');
 
 // Public API
 exports.createSecureContext = require('_tls_common').createSecureContext;

--- a/node.gyp
+++ b/node.gyp
@@ -112,6 +112,7 @@
       'lib/internal/repl.js',
       'lib/internal/socket_list.js',
       'lib/internal/test/unicode.js',
+      'lib/internal/tls.js',
       'lib/internal/url.js',
       'lib/internal/util.js',
       'lib/internal/http2/core.js',

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,16 +1,22 @@
 /* eslint-disable no-proto */
 'use strict';
+
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
+// Flags: --expose_internals
+const internalTLS = require('internal/tls');
 const tls = require('tls');
+
+const noOutput = common.mustNotCall();
+common.hijackStderr(noOutput);
 
 {
   const singles = 'C=US\nST=CA\nL=SF\nO=Node.js Foundation\nOU=Node.js\n' +
                   'CN=ca1\nemailAddress=ry@clouds.org';
-  const singlesOut = tls.parseCertString(singles);
+  const singlesOut = internalTLS.parseCertString(singles);
   assert.deepStrictEqual(singlesOut, {
     __proto__: null,
     C: 'US',
@@ -26,7 +32,7 @@ const tls = require('tls');
 {
   const doubles = 'OU=Domain Control Validated\nOU=PositiveSSL Wildcard\n' +
                   'CN=*.nodejs.org';
-  const doublesOut = tls.parseCertString(doubles);
+  const doublesOut = internalTLS.parseCertString(doubles);
   assert.deepStrictEqual(doublesOut, {
     __proto__: null,
     OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
@@ -36,7 +42,7 @@ const tls = require('tls');
 
 {
   const invalid = 'fhqwhgads';
-  const invalidOut = tls.parseCertString(invalid);
+  const invalidOut = internalTLS.parseCertString(invalid);
   assert.deepStrictEqual(invalidOut, { __proto__: null });
 }
 
@@ -45,5 +51,16 @@ const tls = require('tls');
   const expected = Object.create(null);
   expected.__proto__ = 'mostly harmless';
   expected.hasOwnProperty = 'not a function';
-  assert.deepStrictEqual(tls.parseCertString(input), expected);
+  assert.deepStrictEqual(internalTLS.parseCertString(input), expected);
+}
+
+common.restoreStderr();
+
+{
+  common.expectWarning('DeprecationWarning',
+                       'tls.parseCertString() is deprecated. ' +
+                       'Please use querystring.parse() instead.');
+
+  const ret = tls.parseCertString('foo=bar');
+  assert.deepStrictEqual(ret, { __proto__: null, foo: 'bar' });
 }


### PR DESCRIPTION
`tls.parseCertString()` exposed by accident. Now move this function to
`internal/tls` and mark the original one as deprecated.

Refs: https://github.com/nodejs/node/issues/14193
Refs: https://github.com/nodejs/node/commit/af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7#diff-cc32376ce1eaf679ec2298cd483f15c7R188

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls, doc