### PR TITLE
tools: delete an unused argument

### DIFF
--- a/tools/jslint.js
+++ b/tools/jslint.js
@@ -120,7 +120,7 @@ if (cluster.isMaster) {
 
   if (showProgress) {
     // Start the progress display update timer when the first worker is ready
-    cluster.once('online', function(worker) {
+    cluster.once('online', function() {
       startTime = process.hrtime();
       setInterval(printProgress, 1000).unref();
       printProgress();


### PR DESCRIPTION
Delete the argument never being used.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

