### PR TITLE
test: fix error handling in test-http-full-response

### DIFF
--- a/test/parallel/test-http-full-response.js
+++ b/test/parallel/test-http-full-response.js
@@ -46,8 +46,7 @@ function runAb(opts, callback) {
         common.printSkipMessage(`problem spawning \`ab\`.\n${stderr}`);
         process.reallyExit(0);
       }
-      process.exit();
-      return;
+      throw err;
     }
 
     let m = /Document Length:\s*(\d+) bytes/i.exec(stdout);


### PR DESCRIPTION
The way it is currently written, test-http-full-response will fail if
there is a problem with spawning that doesn't include `ab` or `api` in
`stderr`, but it will fail with a misleading mismatched-calls
`common.mustCall()` error.

Alter the error handling so that it rethrows the actual error, providing
better information.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http