### PR TITLE
test: fix flaky test-net-can-reset-timeout

### DIFF
--- a/test/parallel/test-net-can-reset-timeout.js
+++ b/test/parallel/test-net-can-reset-timeout.js
@@ -21,6 +21,9 @@
 
 'use strict';
 const common = require('../common');
+
+// Ref: https://github.com/nodejs/node-v0.x-archive/issues/481
+
 const net = require('net');
 
 const server = net.createServer(common.mustCall(function(stream) {
@@ -28,7 +31,7 @@ const server = net.createServer(common.mustCall(function(stream) {
 
   stream.resume();
 
-  stream.on('timeout', common.mustCall(function() {
+  stream.once('timeout', common.mustCall(function() {
     console.log('timeout');
     // try to reset the timeout.
     stream.write('WHAT.');


### PR DESCRIPTION
`timeout` can fire more than once, so remove the listener after the first time. The test still checks for issue that the test was originally written for (nodejs/node-v0.x-archive#481).

Fixes: https://github.com/nodejs/node/issues/14241

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net