### PR TITLE
test: improve error message for stream writable change default encoding test

### DIFF
--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -61,7 +61,7 @@ assert.throws(function changeDefaultEncodingToInvalidValue() {
   m.setDefaultEncoding({});
   m.write('bar');
   m.end();
-}, TypeError);
+}, /^TypeError: Unknown encoding: \[object Object\]$/);
 
 (function checkVairableCaseEncoding() {
   const m = new MyWritable(function(isBuffer, type, enc) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test