### PR TITLE
test: change the regluar express

### DIFF
--- a/test/parallel/test-vm-create-context-arg.js
+++ b/test/parallel/test-vm-create-context-arg.js
@@ -26,7 +26,7 @@ const vm = require('vm');
 
 assert.throws(function() {
   vm.createContext('string is not supported');
-}, TypeError);
+}, /^TypeError: sandbox must be an object$/);
 
 assert.doesNotThrow(function() {
   vm.createContext({ a: 1 });


### PR DESCRIPTION
update the test/parallel/test-vm-create-context-arg.js
in line 27 to change the regluar expression `TypeError`
with the `/^TypeError: sandbox must be an object$/`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test