### PR TITLE
util: delete unused argument 'depth' in lib/util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1053,7 +1053,7 @@ exports._exceptionWithHostPort = function(err,
 
 // process.versions needs a custom function as some values are lazy-evaluated.
 process.versions[exports.inspect.custom] =
-  (depth) => exports.format(JSON.parse(JSON.stringify(process.versions)));
+  () => exports.format(JSON.parse(JSON.stringify(process.versions)));
 
 exports.promisify = internalUtil.promisify;
 


### PR DESCRIPTION
In `lib/util.js`, Line `1056`, there is a `depth` argument that is unused for `process.versions[exports.inspect.custom]`, so delete it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util