### PR TITLE
[code & learn]test: change style in parallel bad options

### DIFF
--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -18,6 +18,8 @@ function requiresArgument(option) {
   assert.strictEqual(r.status, 9);
 
   const msg = r.stderr.split(/\r?\n/)[0];
-  assert.strictEqual(msg, process.execPath + ': ' + option +
-                     ' requires an argument');
+  assert.strictEqual(
+    msg,
+    `${process.execPath}: ${option} requires an argument`
+  );
 }


### PR DESCRIPTION
Replace string concatenation in test/parallel/test-cli-bad-options.js
with template literals.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
