### PR TITLE
readline: remove the caching variable

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -483,7 +483,7 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
           maxColumns = 1;
         }
         var group = [];
-        for (var i = 0, compLen = completions.length; i < compLen; i++) {
+        for (var i = 0; i < completions.length; i++) {
           var c = completions[i];
           if (c === '') {
             handleGroup(self, group, width, maxColumns);
@@ -522,7 +522,7 @@ function handleGroup(self, group, width, maxColumns) {
       var item = group[idx];
       self._writeToOutput(item);
       if (col < maxColumns - 1) {
-        for (var s = 0, itemLen = item.length; s < width - itemLen; s++) {
+        for (var s = 0; s < width - item.length; s++) {
           self._writeToOutput(' ');
         }
       }


### PR DESCRIPTION
line 486 and 525 contain for loops where a length property
is cached in a variable (for example, itemLen). This used
to be a performance optimization, but current V8 handles
the optimization internally.

these caching variables are removed, and using the length
property directly instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
