### PR TITLE
test: replace string concatenation with template literals

### DIFF
--- a/test/parallel/test-require-extensions-same-filename-as-dir.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir.js
@@ -22,9 +22,17 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const path = require('path');
 
-const content = require(common.fixturesDir +
-  '/json-with-directory-name-module/module-stub/one/two/three.js');
+const filePath = path.join(
+  common.fixturesDir,
+  'json-with-directory-name-module',
+  'module-stub',
+  'one',
+  'two',
+  'three.js'
+);
+const content = require(filePath);
 
 assert.notStrictEqual(content.rocko, 'artischocko');
 assert.strictEqual(content, 'hello from module-stub!');


### PR DESCRIPTION
from Workshop Code + Learn
replace string concatenation in _test/parallel/test-require-extensions-same-filename-as-dir.js_ with template literals.