### PR TITLE
[JSConf CN Code&Learn] Replace the string concatenation with template literals 

### DIFF
--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -27,9 +27,11 @@ const CRLF = '\r\n';
 
 const server = http.createServer();
 server.on('upgrade', function(req, socket, head) {
-  socket.write('HTTP/1.1 101 Ok' + CRLF +
-               'Connection: Upgrade' + CRLF +
-               'Upgrade: Test' + CRLF + CRLF + 'head');
+  socket.write(`HTTP/1.1 101 Ok
+    Connection: Upgrade
+    Upgrade: Test
+
+    head`);
   socket.on('end', function() {
     socket.end();
   });

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -27,11 +27,10 @@ const CRLF = '\r\n';
 
 const server = http.createServer();
 server.on('upgrade', function(req, socket, head) {
-  socket.write(`HTTP/1.1 101 Ok
-    Connection: Upgrade
-    Upgrade: Test
-
-    head`);
+  socket.write(`HTTP/1.1 101 Ok${CRLF}` +
+               `Connection: Upgrade${CRLF}` +
+               `Upgrade: Test${CRLF}${CRLF}` +
+               'head');
   socket.on('end', function() {
     socket.end();
   });


### PR DESCRIPTION
##### [JSConf CN Code&Learn]
Replace string concatenation in test /parallel/test-http-upgrade-client2.js with template literals.

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
no.
Just update tests.
