### PR TITLE
test: replace string concatenation with template string literals in test-fs-watchfile.js

### DIFF
--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -67,7 +67,7 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {
-  const dir = common.tmpDir + '/watch';
+  const dir = `${common.tmpDir}/watch'`;
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -67,7 +67,7 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {
-  const dir = `${common.tmpDir}/watch`;
+  const dir = path.join(common.tmpDir, 'watch');
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);
@@ -79,7 +79,7 @@ if (common.isLinux || common.isOSX || common.isWindows) {
     }));
 
     const interval = setInterval(() => {
-      fs.writeFile(`${dir}/foo.txt`, 'foo', common.mustCall(function(err) {
+      fs.writeFile(path.join(dir, 'foo.txt'), 'foo', common.mustCall(function(err) {
         if (err) assert.fail(err);
       }));
     }, 1);

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -67,7 +67,7 @@ fs.watchFile(enoentFile, {interval: 0}, common.mustCall(function(curr, prev) {
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {
-  const dir = `${common.tmpDir}/watch'`;
+  const dir = `${common.tmpDir}/watch`;
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);


### PR DESCRIPTION
[JSConf CN Code&Learn]
Replace string concatenation in test/parallel/test-fs-watchfile.js with template literals.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

