### PR TITLE
test: replace string concatenation with template string literals in test-graph.signal.js

### DIFF
--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -16,20 +16,20 @@ hooks.enable();
 process.on('SIGUSR2', common.mustCall(onsigusr2, 2));
 
 let count = 0;
-exec('kill -USR2 ' + process.pid);
+exec(`kill -USR2 ${process.pid}`);
 
 function onsigusr2() {
   count++;
 
   if (count === 1) {
     // trigger same signal handler again
-    exec('kill -USR2 ' + process.pid);
+    exec(`kill -USR2 ${process.pid}`);
   } else {
     // install another signal handler
     process.removeAllListeners('SIGUSR2');
     process.on('SIGUSR2', common.mustCall(onsigusr2Again));
 
-    exec('kill -USR2 ' + process.pid);
+    exec(`kill -USR2 ${process.pid}`);
   }
 }
 


### PR DESCRIPTION
[JSConf CN Code&Learn]
Replace string concatenation in `test/async-hooks/test-graph.signal.js` with template literals.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)