### PR TITLE
test: replace with template literals

### DIFF
--- a/test/parallel/test-http-extra-response.js
+++ b/test/parallel/test-http-extra-response.js
@@ -32,7 +32,7 @@ const net = require('net');
 const body = 'hello world\r\n';
 const fullResponse =
     'HTTP/1.1 500 Internal Server Error\r\n' +
-    'Content-Length: ' + body.length + '\r\n' +
+    `Content-Length: ${body.length}\r\n` +
     'Content-Type: text/plain\r\n' +
     'Date: Fri + 18 Feb 2011 06:22:45 GMT\r\n' +
     'Host: 10.20.149.2\r\n' +


### PR DESCRIPTION
use template literals instead of string concatenation in test/parallel/test-http-extra-response.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test-http