### PR TITLE
os: add CIDR support

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -253,6 +253,9 @@ The properties available on the assigned network address object include:
   similar interface that is not remotely accessible; otherwise `false`
 * `scopeid` {number} The numeric IPv6 scope ID (only specified when `family`
   is `IPv6`)
+* `cidr` {string} The assigned IPv4 or IPv6 address with the routing prefix
+  in CIDR notation. If the `netmask` is invalid, this property is set
+  to `null`
 
 <!-- eslint-skip -->
 ```js
@@ -263,14 +266,16 @@ The properties available on the assigned network address object include:
       netmask: '255.0.0.0',
       family: 'IPv4',
       mac: '00:00:00:00:00:00',
-      internal: true
+      internal: true,
+      cidr: '127.0.0.1/8'
     },
     {
       address: '::1',
       netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
       family: 'IPv6',
       mac: '00:00:00:00:00:00',
-      internal: true
+      internal: true,
+      cidr: '::1/128'
     }
   ],
   eth0: [
@@ -279,14 +284,16 @@ The properties available on the assigned network address object include:
       netmask: '255.255.255.0',
       family: 'IPv4',
       mac: '01:02:03:0a:0b:0c',
-      internal: false
+      internal: false,
+      cidr: '192.168.1.108/24'
     },
     {
       address: 'fe80::a00:27ff:fe4e:66a1',
       netmask: 'ffff:ffff:ffff:ffff::',
       family: 'IPv6',
       mac: '01:02:03:0a:0b:0c',
-      internal: false
+      internal: false,
+      cidr: 'fe80::a00:27ff:fe4e:66a1/64'
     }
   ]
 }

--- a/lib/internal/os.js
+++ b/lib/internal/os.js
@@ -1,0 +1,41 @@
+'use strict';
+
+function getCIDRSuffix(mask, protocol = 'ipv4') {
+  const isV6 = protocol === 'ipv6';
+  const bitsString = mask
+        .split(isV6 ? ':' : '.')
+        .filter((v) => !!v)
+        .map((v) => pad(parseInt(v, isV6 ? 16 : 10).toString(2), isV6))
+        .join('');
+
+  if (isValidMask(bitsString)) {
+    return countOnes(bitsString);
+  } else {
+    return null;
+  }
+}
+
+function pad(binaryString, isV6) {
+  const groupLength = isV6 ? 16 : 8;
+  const binLen = binaryString.length;
+
+  return binLen < groupLength ?
+    `${'0'.repeat(groupLength - binLen)}${binaryString}` : binaryString;
+}
+
+function isValidMask(bitsString) {
+  const firstIndexOfZero = bitsString.indexOf(0);
+  const lastIndexOfOne = bitsString.lastIndexOf(1);
+
+  return firstIndexOfZero < 0 || firstIndexOfZero > lastIndexOfOne;
+}
+
+function countOnes(bitsString) {
+  return bitsString
+    .split('')
+    .reduce((acc, bit) => acc += parseInt(bit, 10), 0);
+}
+
+module.exports = {
+  getCIDRSuffix
+};

--- a/lib/os.js
+++ b/lib/os.js
@@ -24,6 +24,7 @@
 const pushValToArrayMax = process.binding('util').pushValToArrayMax;
 const constants = process.binding('constants').os;
 const deprecate = require('internal/util').deprecate;
+const getCIDRSuffix = require('internal/os').getCIDRSuffix;
 const isWindows = process.platform === 'win32';
 
 const {
@@ -121,6 +122,21 @@ function endianness() {
 }
 endianness[Symbol.toPrimitive] = () => kEndianness;
 
+function networkInterfaces() {
+  const interfaceAddresses = getInterfaceAddresses();
+
+  return Object.entries(interfaceAddresses).reduce((acc, [key, val]) => {
+    acc[key] = val.map((v) => {
+      const protocol = v.family.toLowerCase();
+      const suffix = getCIDRSuffix(v.netmask, protocol);
+      const cidr = suffix ? `${v.address}/${suffix}` : null;
+
+      return Object.assign({}, v, { cidr });
+    });
+    return acc;
+  }, {});
+}
+
 module.exports = exports = {
   arch,
   cpus,
@@ -130,7 +146,7 @@ module.exports = exports = {
   homedir: getHomeDirectory,
   hostname: getHostname,
   loadavg,
-  networkInterfaces: getInterfaceAddresses,
+  networkInterfaces,
   platform,
   release: getOSRelease,
   tmpdir,

--- a/node.gyp
+++ b/node.gyp
@@ -91,6 +91,7 @@
       'lib/internal/linkedlist.js',
       'lib/internal/net.js',
       'lib/internal/module.js',
+      'lib/internal/os.js',
       'lib/internal/process/next_tick.js',
       'lib/internal/process/promises.js',
       'lib/internal/process/stdio.js',

--- a/test/parallel/test-internal-os.js
+++ b/test/parallel/test-internal-os.js
@@ -1,0 +1,32 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const getCIDRSuffix = require('internal/os').getCIDRSuffix;
+
+const specs = [
+  // valid
+  ['128.0.0.0', 'ipv4', 1],
+  ['255.0.0.0', 'ipv4', 8],
+  ['255.255.255.128', 'ipv4', 25],
+  ['255.255.255.255', 'ipv4', 32],
+  ['ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'ipv6', 128],
+  ['ffff:ffff:ffff:ffff::', 'ipv6', 64],
+  ['ffff:ffff:ffff:ff80::', 'ipv6', 57],
+  // invalid
+  ['255.0.0.1', 'ipv4', null],
+  ['255.255.9.0', 'ipv4', null],
+  ['255.255.1.0', 'ipv4', null],
+  ['ffff:ffff:43::', 'ipv6', null],
+  ['ffff:ffff:ffff:1::', 'ipv6', null]
+];
+
+specs.forEach(([mask, protocol, expectedSuffix]) => {
+  const actualSuffix = getCIDRSuffix(mask, protocol);
+
+  assert.strictEqual(
+    actualSuffix, expectedSuffix,
+    `Mask: ${mask}, expected: ${expectedSuffix}, actual: ${actualSuffix}`
+  );
+});


### PR DESCRIPTION
This patch adds support for CIDR notation to the output of the
`networkInterfaces()` method

Fixes: https://github.com/nodejs/node/issues/14006

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
os
