### PR TITLE
timers: remove no longer relevant comment

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -739,7 +739,6 @@ function tryOnImmediate(immediate, oldTail) {
   var threw = true;
   emitBefore(immediate[async_id_symbol], immediate[trigger_id_symbol]);
   try {
-    // make the actual call outside the try/catch to allow it to be optimized
     runCallback(immediate);
     threw = false;
   } finally {

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -739,6 +739,7 @@ function tryOnImmediate(immediate, oldTail) {
   var threw = true;
   emitBefore(immediate[async_id_symbol], immediate[trigger_id_symbol]);
   try {
+    // make the actual call outside the try/finally to allow it to be optimized
     runCallback(immediate);
     threw = false;
   } finally {


### PR DESCRIPTION
This PR resolves #14308 by removing a comment that is no longer relevant.

##### Checklist
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
None. File modified is `timers`, but no code was changed.
