### PR TITLE
test: replace string concatenation in async-hooks/test-tlswrap.js with template literals

### DIFF
--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -4,13 +4,14 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const path = require('path');
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const tls = require('tls');
+
 const tick = require('./tick');
 const initHooks = require('./init-hooks');
-const fs = require('fs');
 const { checkInvocations } = require('./hook-checks');
-const tls = require('tls');
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -19,8 +19,8 @@ hooks.enable();
 //
 const server = tls
   .createServer({
-    cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
-    key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+    cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
+    key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
   })
   .on('listening', common.mustCall(onlistening))
   .on('secureConnection', common.mustCall(onsecureConnection))

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -4,6 +4,7 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const path = require('path');
 const assert = require('assert');
 const tick = require('./tick');
 const initHooks = require('./init-hooks');
@@ -19,8 +20,8 @@ hooks.enable();
 //
 const server = tls
   .createServer({
-    cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
-    key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
+    cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem')),
+    key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'))
   })
   .on('listening', common.mustCall(onlistening))
   .on('secureConnection', common.mustCall(onsecureConnection))


### PR DESCRIPTION
[JSConf CN Code&Learn] Replace string concatenation in `async-hooks/test-tlswrap.js` with template literals

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
no.
Just update tests.