### PR TITLE
test: allow inspector to reopen with same port

### DIFF
--- a/test/parallel/test-inspector-open.js
+++ b/test/parallel/test-inspector-open.js
@@ -68,7 +68,6 @@ function tryToCloseWhenClosed(msg) {
 function reopenAfterClose(msg) {
   assert.strictEqual(msg.cmd, 'url');
   const port = url.parse(msg.url).port;
-  assert.notStrictEqual(port, firstPort);
   ping(port, (err) => {
     assert.ifError(err);
     process.exit();


### PR DESCRIPTION
Test checks that if you open the inspector with '0' (pick a random free
port), close it, then reopen it, you get a different port. However this
isn't necessarily true.

Fixes: https://github.com/nodejs/node/issues/14316

Refs: https://github.com/nodejs/node/issues/14316#issuecomment-315680755

>So [this assertion checks](https://github.com/nodejs/node/blob/master/test/parallel/test-inspector-open.js#L71) that when you close and reopen you don't get the same port. However AIUI node just picks a free port, so there is a (very small) chance you'll get the same port.
>
>cc/ @sam-github as you wrote the original test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, inspector