### PR TITLE
doc,stream: _transform cannot be called in parallel

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2033,6 +2033,10 @@ The `transform._transform()` method is prefixed with an underscore because it
 is internal to the class that defines it, and should never be called directly by
 user programs.
 
+`transform._transform()` is never called in  parallel; streams implement a
+queue mechanism, and to receive the next chunk, `callback` must be
+called, either synchronously or asychronously.
+
 #### Class: stream.PassThrough
 
 The `stream.PassThrough` class is a trivial implementation of a [Transform][]


### PR DESCRIPTION
Add a note to the stream docs specifying that at most a single
call to _transform can happen, and the provided callback()
should be used to process another chunk.

Fixes: https://github.com/nodejs/node/issues/3208

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, stream