### PR TITLE
process: improve hrtime() error message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -114,10 +114,9 @@ E('ERR_HTTP_TRAILER_INVALID',
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_ARRAY_LENGTH',
-  (name, length, actual) => {
+  (name, len, actual) => {
     assert.strictEqual(typeof actual, 'number');
-    return `The "${name}" array must have a length of ${
-           length}. Received length ${actual}`;
+    return `The array "${name}" (length ${actual}) must be of length ${len}.`;
   });
 E('ERR_INVALID_BUFFER_SIZE', 'Buffer size must be a multiple of %s');
 E('ERR_INVALID_CALLBACK', 'Callback must be a function');

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -45,21 +45,21 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" array must have a length of 2. Received length 0'
+  message: 'The array "time" (length 0) must be of length 2.'
 }));
 assert.throws(() => {
   process.hrtime([1]);
 }, common.expectsError({
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" array must have a length of 2. Received length 1'
+  message: 'The array "time" (length 1) must be of length 2.'
 }));
 assert.throws(() => {
   process.hrtime([1, 2, 3]);
 }, common.expectsError({
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
-  message: 'The "time" array must have a length of 2. Received length 3'
+  message: 'The array "time" (length 3) must be of length 2.'
 }));
 
 function validateTuple(tuple) {


### PR DESCRIPTION
Change error message from the form this format:

    The "time" array must have a length of 2. Received length 0

...to this format:

    The array "time" (length 0) must be length 2.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process errors test