### PR TITLE
zlib: check if the stream is destroyed before push

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -472,6 +472,11 @@ function processCallback() {
     return;
   }
 
+  if (self.destroyed) {
+    this.buffer = null;
+    return;
+  }
+
   var availOutAfter = state[0];
   var availInAfter = state[1];
 

--- a/test/parallel/test-zlib-destroy-pipe.js
+++ b/test/parallel/test-zlib-destroy-pipe.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const zlib = require('zlib');
+const { Writable } = require('stream');
+
+// verify that the zlib transform does not error in case
+// it is destroyed with data still in flight
+
+const ts = zlib.createGzip();
+
+const ws = new Writable({
+  write: common.mustCall((chunk, enc, cb) => {
+    setImmediate(cb);
+    ts.destroy();
+  })
+});
+
+const buf = Buffer.allocUnsafe(1024 * 1024 * 20);
+ts.end(buf);
+ts.pipe(ws);


### PR DESCRIPTION
If the stream is destroyed while the transform is still being
applied, push() should not be called, and the internal state
should be cleared.

See: https://github.com/koajs/compress/issues/60

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

zlib, stream