### PR TITLE
test: begin normalizing fixtures use

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -374,6 +374,37 @@ Decrements the `Countdown` counter.
 Specifies the remaining number of times `Countdown.prototype.dec()` must be
 called before the callback is invoked.
 
+## Fixtures Module
+
+The `common/fixtures` module provides convenience methods for working with
+files in the `test/fixtures` directory.
+
+### fixtures.fixturesDir
+
+* [&lt;String>]
+
+The absolute path to the `test/fixtures/` directory.
+
+### fixtures.path(...args)
+
+* `...args` [&lt;String>]
+
+Returns the result of `path.join(fixtures.fixturesDir, ...args)`.
+
+### fixtures.readSync(args[, enc])
+
+* `args` [&lt;String>] | [&lt;Array>]
+
+Returns the result of
+`fs.readFileSync(path.join(fixtures.fixturesDir, ...args), 'enc')`.
+
+### fixtures.readKey(arg[, enc])
+
+* `arg` [&lt;String>]
+
+Returns the result of
+`fs.readFileSync(path.join(fixtures.fixturesDir, 'keys', arg), 'enc')`.
+
 ## WPT Module
 
 The wpt.js module is a port of parts of

--- a/test/common/fixtures.js
+++ b/test/common/fixtures.js
@@ -1,0 +1,28 @@
+/* eslint-disable required-modules */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const fixturesDir = path.join(__dirname, '..', 'fixtures');
+
+function fixturesPath(...args) {
+  return path.join(fixturesDir, ...args);
+}
+
+function readFixtureSync(args, enc) {
+  if (Array.isArray(args))
+    return fs.readFileSync(fixturesPath(...args), enc);
+  return fs.readFileSync(fixturesPath(args), enc);
+}
+
+function readFixtureKey(name, enc) {
+  return fs.readFileSync(fixturesPath('keys', name), enc);
+}
+
+module.exports = {
+  fixturesDir,
+  path: fixturesPath,
+  readSync: readFixtureSync,
+  readKey: readFixtureKey
+};

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -29,13 +29,15 @@ const { exec, execSync, spawn, spawnSync } = require('child_process');
 const stream = require('stream');
 const util = require('util');
 const Timer = process.binding('timer_wrap').Timer;
+const { fixturesDir } = require('./fixtures');
 
 const testRoot = process.env.NODE_TEST_DIR ?
   fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
 
 const noop = () => {};
 
-exports.fixturesDir = path.join(__dirname, '..', 'fixtures');
+exports.fixturesDir = fixturesDir;
+
 exports.tmpDirName = 'tmp';
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;

--- a/test/parallel/test-async-wrap-GH13045.js
+++ b/test/parallel/test-async-wrap-GH13045.js
@@ -8,12 +8,12 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const serverOptions = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
-  ca: fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca: fixtures.readKey('ca1-cert.pem')
 };
 
 const server = https.createServer(serverOptions, common.mustCall((req, res) => {

--- a/test/parallel/test-async-wrap-getasyncid.js
+++ b/test/parallel/test-async-wrap-getasyncid.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
+const fixtures = require('../common/fixtures');
 
 // Make sure that all Providers are tested.
 {
@@ -218,9 +219,10 @@ if (common.hasCrypto) {
   const TCP = process.binding('tcp_wrap').TCP;
   const tcp = new TCP();
 
-  const ca = fs.readFileSync(common.fixturesDir + '/test_ca.pem', 'ascii');
-  const cert = fs.readFileSync(common.fixturesDir + '/test_cert.pem', 'ascii');
-  const key = fs.readFileSync(common.fixturesDir + '/test_key.pem', 'ascii');
+  const ca = fixtures.readSync('test_ca.pem', 'ascii');
+  const cert = fixtures.readSync('test_cert.pem', 'ascii');
+  const key = fixtures.readSync('test_key.pem', 'ascii');
+
   const credentials = require('tls').createSecureContext({ ca, cert, key });
 
   // TLSWrap is exposed, but needs to be instantiated via tls_wrap.wrap().

--- a/test/parallel/test-child-process-detached.js
+++ b/test/parallel/test-child-process-detached.js
@@ -20,13 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 const spawn = require('child_process').spawn;
-const childPath = path.join(common.fixturesDir,
-                            'parent-process-nonpersistent.js');
+const childPath = fixtures.path('parent-process-nonpersistent.js');
 let persistentPid = -1;
 
 const child = spawn(process.execPath, [ childPath ]);

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -2,10 +2,10 @@
 const common = require('../common');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const path = require('path');
 const uv = process.binding('uv');
+const fixtures = require('../common/fixtures');
 
-const fixture = path.join(common.fixturesDir, 'exit.js');
+const fixture = fixtures.path('exit.js');
 
 {
   execFile(

--- a/test/parallel/test-child-process-exit-code.js
+++ b/test/parallel/test-child-process-exit-code.js
@@ -23,9 +23,9 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const exitScript = path.join(common.fixturesDir, 'exit.js');
+const exitScript = fixtures.path('exit.js');
 const exitChild = spawn(process.argv[0], [exitScript, 23]);
 exitChild.on('exit', common.mustCall(function(code, signal) {
   assert.strictEqual(code, 23);
@@ -33,8 +33,7 @@ exitChild.on('exit', common.mustCall(function(code, signal) {
 }));
 
 
-const errorScript = path.join(common.fixturesDir,
-                              'child_process_should_emit_error.js');
+const errorScript = fixtures.path('child_process_should_emit_error.js');
 const errorChild = spawn(process.argv[0], [errorScript]);
 errorChild.on('exit', common.mustCall(function(code, signal) {
   assert.ok(code !== 0);

--- a/test/parallel/test-child-process-fork-close.js
+++ b/test/parallel/test-child-process-fork-close.js
@@ -23,8 +23,9 @@
 const common = require('../common');
 const assert = require('assert');
 const fork = require('child_process').fork;
+const fixtures = require('../common/fixtures');
 
-const cp = fork(`${common.fixturesDir}/child-process-message-and-exit.js`);
+const cp = fork(fixtures.path('child-process-message-and-exit.js'));
 
 let gotMessage = false;
 let gotExit = false;

--- a/test/parallel/test-child-process-fork-stdio-string-variant.js
+++ b/test/parallel/test-child-process-fork-stdio-string-variant.js
@@ -7,8 +7,9 @@ const common = require('../common');
 
 const assert = require('assert');
 const fork = require('child_process').fork;
+const fixtures = require('../common/fixtures');
 
-const childScript = `${common.fixturesDir}/child-process-spawn-node`;
+const childScript = fixtures.path('child-process-spawn-node');
 const errorRegexp = /^TypeError: Incorrect value of stdio option:/;
 const malFormedOpts = { stdio: '33' };
 const payload = { hello: 'world' };

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -24,8 +24,9 @@ const common = require('../common');
 const assert = require('assert');
 const fork = require('child_process').fork;
 const args = ['foo', 'bar'];
+const fixtures = require('../common/fixtures');
 
-const n = fork(`${common.fixturesDir}/child-process-spawn-node.js`, args);
+const n = fork(fixtures.path('child-process-spawn-node.js'), args);
 
 assert.strictEqual(n.channel, n._channel);
 assert.deepStrictEqual(args, ['foo', 'bar']);

--- a/test/parallel/test-child-process-fork3.js
+++ b/test/parallel/test-child-process-fork3.js
@@ -20,7 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const child_process = require('child_process');
+const fixtures = require('../common/fixtures');
 
-child_process.fork(`${common.fixturesDir}/empty.js`); // should not hang
+child_process.fork(fixtures.path('empty.js')); // should not hang

--- a/test/parallel/test-child-process-ipc.js
+++ b/test/parallel/test-child-process-ipc.js
@@ -21,14 +21,13 @@
 
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
-const spawn = require('child_process').spawn;
+const { spawn } = require('child_process');
+const fixtures = require('../common/fixtures');
 
-const path = require('path');
-
-const sub = path.join(common.fixturesDir, 'echo.js');
+const sub = fixtures.path('echo.js');
 
 let gotHelloWorld = false;
 let gotEcho = false;

--- a/test/parallel/test-child-process-send-after-close.js
+++ b/test/parallel/test-child-process-send-after-close.js
@@ -2,8 +2,9 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
-const path = require('path');
-const fixture = path.join(common.fixturesDir, 'empty.js');
+const fixtures = require('../common/fixtures');
+
+const fixture = fixtures.path('empty.js');
 const child = cp.fork(fixture);
 
 child.on('close', common.mustCall((code, signal) => {

--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -1,11 +1,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const net = require('net');
 const { fork, spawn } = require('child_process');
+const fixtures = require('../common/fixtures');
 
-const emptyFile = path.join(common.fixturesDir, 'empty.js');
+const emptyFile = fixtures.path('empty.js');
 
 const n = fork(emptyFile);
 

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -22,17 +22,16 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const child_process = require('child_process');
-const spawn = child_process.spawn;
-const fork = child_process.fork;
-const execFile = child_process.execFile;
+const { spawn, fork, execFile } = require('child_process');
+const fixtures = require('../common/fixtures');
 const cmd = common.isWindows ? 'rundll32' : 'ls';
 const invalidcmd = 'hopefully_you_dont_have_this_on_your_machine';
 const invalidArgsMsg = /Incorrect value of args option/;
 const invalidOptionsMsg = /"options" argument must be an object/;
 const invalidFileMsg =
   /^TypeError: "file" argument must be a non-empty string$/;
-const empty = `${common.fixturesDir}/empty.js`;
+
+const empty = fixtures.path('empty.js');
 
 assert.throws(function() {
   const child = spawn(invalidcmd, 'this is not an array');

--- a/test/parallel/test-child-process-stdout-flush.js
+++ b/test/parallel/test-child-process-stdout-flush.js
@@ -22,9 +22,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const spawn = require('child_process').spawn;
-const sub = path.join(common.fixturesDir, 'print-chars.js');
+const fixtures = require('../common/fixtures');
+
+const sub = fixtures.path('print-chars.js');
 
 const n = 500000;
 

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -31,6 +31,7 @@ const common = require('../common');
 const assert = require('assert');
 const child = require('child_process');
 const path = require('path');
+const fixtures = require('../common/fixtures');
 const nodejs = `"${process.execPath}"`;
 
 if (process.argv.length > 2) {
@@ -138,7 +139,7 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
 
 // Regression test for https://github.com/nodejs/node/issues/3574.
 {
-  const emptyFile = path.join(common.fixturesDir, 'empty.js');
+  const emptyFile = fixtures.path('empty.js');
 
   child.exec(`${nodejs} -e 'require("child_process").fork("${emptyFile}")'`,
              common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { exec, spawnSync } = require('child_process');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 const node = process.execPath;
 
@@ -24,7 +24,7 @@ const notFoundRE = /^Error: Cannot find module/m;
   'syntax/good_syntax_shebang',
   'syntax/illegal_if_not_wrapped.js'
 ].forEach(function(file) {
-  file = path.join(common.fixturesDir, file);
+  file = fixtures.path(file);
 
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
@@ -46,7 +46,7 @@ const notFoundRE = /^Error: Cannot find module/m;
   'syntax/bad_syntax_shebang.js',
   'syntax/bad_syntax_shebang'
 ].forEach(function(file) {
-  file = path.join(common.fixturesDir, file);
+  file = fixtures.path(file);
 
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {
@@ -73,7 +73,7 @@ const notFoundRE = /^Error: Cannot find module/m;
   'syntax/file_not_found.js',
   'syntax/file_not_found'
 ].forEach(function(file) {
-  file = path.join(common.fixturesDir, file);
+  file = fixtures.path(file);
 
   // loop each possible option, `-c` or `--check`
   syntaxArgs.forEach(function(args) {

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -32,19 +32,18 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 const DH_NOT_SUITABLE_GENERATOR = crypto.constants.DH_NOT_SUITABLE_GENERATOR;
-const fixtDir = common.fixturesDir;
 
 crypto.DEFAULT_ENCODING = 'latin1';
 
 // Test Certificates
-const certPem = fs.readFileSync(`${fixtDir}/test_cert.pem`, 'ascii');
-const certPfx = fs.readFileSync(`${fixtDir}/test_cert.pfx`);
-const keyPem = fs.readFileSync(`${fixtDir}/test_key.pem`, 'ascii');
-const rsaPubPem = fs.readFileSync(`${fixtDir}/test_rsa_pubkey.pem`, 'ascii');
-const rsaKeyPem = fs.readFileSync(`${fixtDir}/test_rsa_privkey.pem`, 'ascii');
+const certPem = fixtures.readSync('test_cert.pem', 'ascii');
+const certPfx = fixtures.readSync('test_cert.pfx');
+const keyPem = fixtures.readSync('test_key.pem', 'ascii');
+const rsaPubPem = fixtures.readSync('test_rsa_pubkey.pem', 'ascii');
+const rsaKeyPem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
 
 // PFX tests
 assert.doesNotThrow(function() {
@@ -405,7 +404,7 @@ const h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
 assert.strictEqual(h1, h2, 'multipled updates');
 
 // Test hashing for binary files
-const fn = path.join(fixtDir, 'sample.png');
+const fn = fixtures.path('sample.png');
 const sha1Hash = crypto.createHash('sha1');
 const fileStream = fs.createReadStream(fn);
 fileStream.on('data', function(data) {
@@ -614,9 +613,8 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test RSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(`${fixtDir}/test_rsa_privkey_2.pem`);
-
-  const publicKey = fs.readFileSync(`${fixtDir}/test_rsa_pubkey_2.pem`);
+  const privateKey = fixtures.readSync('test_rsa_privkey_2.pem');
+  const publicKey = fixtures.readSync('test_rsa_pubkey_2.pem');
 
   const input = 'I AM THE WALRUS';
 
@@ -644,9 +642,8 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 // Test DSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(`${fixtDir}/test_dsa_privkey.pem`);
-
-  const publicKey = fs.readFileSync(`${fixtDir}/test_dsa_pubkey.pem`);
+  const privateKey = fixtures.readSync('test_dsa_privkey.pem');
+  const publicKey = fixtures.readSync('test_dsa_pubkey.pem');
 
   const input = 'I AM THE WALRUS';
 

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -26,15 +26,14 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
-const fs = require('fs');
-
 // Test Certificates
-const spkacValid = fs.readFileSync(`${common.fixturesDir}/spkac.valid`);
-const spkacFail = fs.readFileSync(`${common.fixturesDir}/spkac.fail`);
-const spkacPem = fs.readFileSync(`${common.fixturesDir}/spkac.pem`);
+const spkacValid = fixtures.readSync('spkac.valid');
+const spkacFail = fixtures.readSync('spkac.fail');
+const spkacPem = fixtures.readSync('spkac.pem');
 
 const certificate = new crypto.Certificate();
 

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -6,13 +6,16 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
+const fixtures = require('../common/fixtures');
 
 const FIPS_ENABLED = 1;
 const FIPS_DISABLED = 0;
 const FIPS_ERROR_STRING = 'Error: Cannot set FIPS mode';
 const OPTION_ERROR_STRING = 'bad option';
-const CNF_FIPS_ON = path.join(common.fixturesDir, 'openssl_fips_enabled.cnf');
-const CNF_FIPS_OFF = path.join(common.fixturesDir, 'openssl_fips_disabled.cnf');
+
+const CNF_FIPS_ON = fixtures.path('openssl_fips_enabled.cnf');
+const CNF_FIPS_OFF = fixtures.path('openssl_fips_disabled.cnf');
+
 let num_children_ok = 0;
 
 function compiledWithFips() {

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -5,8 +5,8 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
 
 // Test hashing
 const a1 = crypto.createHash('sha1').update('Test123').digest('hex');
@@ -74,7 +74,7 @@ const h2 = crypto.createHash('sha1').update('Test').update('123').digest('hex');
 assert.strictEqual(h1, h2, 'multipled updates');
 
 // Test hashing for binary files
-const fn = path.join(common.fixturesDir, 'sample.png');
+const fn = fixtures.path('sample.png');
 const sha1Hash = crypto.createHash('sha1');
 const fileStream = fs.createReadStream(fn);
 fileStream.on('data', function(data) {

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -4,23 +4,23 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const crypto = require('crypto');
 
 const constants = crypto.constants;
-const fixtDir = common.fixturesDir;
+
+const fixtures = require('../common/fixtures');
 
 // Test certificates
-const certPem = fs.readFileSync(`${fixtDir}/test_cert.pem`, 'ascii');
-const keyPem = fs.readFileSync(`${fixtDir}/test_key.pem`, 'ascii');
-const rsaPubPem = fs.readFileSync(`${fixtDir}/test_rsa_pubkey.pem`, 'ascii');
-const rsaKeyPem = fs.readFileSync(`${fixtDir}/test_rsa_privkey.pem`, 'ascii');
-const rsaKeyPemEncrypted = fs.readFileSync(
-  `${fixtDir}/test_rsa_privkey_encrypted.pem`, 'ascii');
-const dsaPubPem = fs.readFileSync(`${fixtDir}/test_dsa_pubkey.pem`, 'ascii');
-const dsaKeyPem = fs.readFileSync(`${fixtDir}/test_dsa_privkey.pem`, 'ascii');
-const dsaKeyPemEncrypted = fs.readFileSync(
-  `${fixtDir}/test_dsa_privkey_encrypted.pem`, 'ascii');
+const certPem = fixtures.readSync('test_cert.pem', 'ascii');
+const keyPem = fixtures.readSync('test_key.pem', 'ascii');
+const rsaPubPem = fixtures.readSync('test_rsa_pubkey.pem', 'ascii');
+const rsaKeyPem = fixtures.readSync('test_rsa_privkey.pem', 'ascii');
+const rsaKeyPemEncrypted = fixtures.readSync('test_rsa_privkey_encrypted.pem',
+                                             'ascii');
+const dsaPubPem = fixtures.readSync('test_dsa_pubkey.pem', 'ascii');
+const dsaKeyPem = fixtures.readSync('test_dsa_privkey.pem', 'ascii');
+const dsaKeyPemEncrypted = fixtures.readSync('test_dsa_privkey_encrypted.pem',
+                                             'ascii');
 
 const decryptError =
   /^Error: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt$/;
@@ -174,9 +174,8 @@ assert.throws(() => {
 // Test RSA signing and verification
 //
 {
-  const privateKey = fs.readFileSync(`${fixtDir}/test_rsa_privkey_2.pem`);
-
-  const publicKey = fs.readFileSync(`${fixtDir}/test_rsa_pubkey_2.pem`);
+  const privateKey = fixtures.readSync('test_rsa_privkey_2.pem');
+  const publicKey = fixtures.readSync('test_rsa_pubkey_2.pem');
 
   const input = 'I AM THE WALRUS';
 

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -8,10 +8,11 @@ const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
 const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
 
 // Test certificates
-const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
-const keyPem = fs.readFileSync(`${common.fixturesDir}/test_key.pem`, 'ascii');
+const certPem = fixtures.readSync('test_cert.pem', 'ascii');
+const keyPem = fixtures.readSync('test_key.pem', 'ascii');
 const modSize = 1024;
 
 // Test signing and verifying
@@ -185,10 +186,7 @@ const modSize = 1024;
     assert.strictEqual(verified, true, 'verify (PSS)');
   }
 
-  const vectorfile = path.join(common.fixturesDir, 'pss-vectors.json');
-  const examples = JSON.parse(fs.readFileSync(vectorfile, {
-    encoding: 'utf8'
-  }));
+  const examples = JSON.parse(fixtures.readSync('pss-vectors.json', 'utf8'));
 
   for (const key in examples) {
     const example = examples[key];
@@ -246,9 +244,8 @@ const modSize = 1024;
   if (!common.opensslCli)
     common.skip('node compiled without OpenSSL CLI.');
 
-  const pubfile = path.join(common.fixturesDir, 'keys/rsa_public_2048.pem');
-  const privfile = path.join(common.fixturesDir, 'keys/rsa_private_2048.pem');
-  const privkey = fs.readFileSync(privfile);
+  const pubfile = fixtures.path('keys', 'rsa_public_2048.pem');
+  const privkey = fixtures.readKey('rsa_private_2048.pem');
 
   const msg = 'Test123';
   const s5 = crypto.createSign('RSA-SHA256')

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -27,16 +27,15 @@ if (!common.hasCrypto)
 
 const crypto = require('crypto');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
-const fs = require('fs');
-
-const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
+const certPem = fixtures.readSync('test_cert.pem', 'ascii');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.Server(options, (socket) => {

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -27,16 +27,16 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const fs = require('fs');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 crypto.DEFAULT_ENCODING = 'buffer';
 
 // Test Certificates
-const caPem = fs.readFileSync(`${common.fixturesDir}/test_ca.pem`, 'ascii');
-const certPem = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`, 'ascii');
-const certPfx = fs.readFileSync(`${common.fixturesDir}/test_cert.pfx`);
-const keyPem = fs.readFileSync(`${common.fixturesDir}/test_key.pem`, 'ascii');
+const caPem = fixtures.readSync('test_ca.pem', 'ascii');
+const certPem = fixtures.readSync('test_cert.pem', 'ascii');
+const certPfx = fixtures.readSync('test_cert.pfx');
+const keyPem = fixtures.readSync('test_key.pem', 'ascii');
 
 // 'this' safety
 // https://github.com/joyent/node/issues/6690
@@ -176,8 +176,8 @@ assert.throws(function() {
   //   $ openssl pkcs8 -topk8 -inform PEM -outform PEM -in mykey.pem \
   //     -out private_key.pem -nocrypt;
   //   Then open private_key.pem and change its header and footer.
-  const sha1_privateKey = fs.readFileSync(
-    `${common.fixturesDir}/test_bad_rsa_privkey.pem`, 'ascii');
+  const sha1_privateKey = fixtures.readSync('test_bad_rsa_privkey.pem',
+                                            'ascii');
   // this would inject errors onto OpenSSL's error stack
   crypto.createSign('sha1').sign(sha1_privateKey);
 }, /asn1 encoding routines:ASN1_CHECK_TLEN:wrong tag/);

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -7,9 +7,10 @@ if (common.isSunOS || common.isWindows || common.isAIX)
 const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
+const fixtures = require('../common/fixtures');
 
 const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
-const abspathFile = require('path').join(common.fixturesDir, 'a.js');
+const abspathFile = fixtures.path('a.js');
 common.refreshTmpDir();
 fs.mkdirSync(dirname);
 process.chdir(dirname);

--- a/test/parallel/test-delayed-require.js
+++ b/test/parallel/test-delayed-require.js
@@ -21,11 +21,11 @@
 
 'use strict';
 const common = require('../common');
-const path = require('path');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
 setTimeout(common.mustCall(function() {
-  const a = require(path.join(common.fixturesDir, 'a'));
+  const a = require(fixtures.path('a'));
   assert.strictEqual(true, 'A' in a);
   assert.strictEqual('A', a.A());
   assert.strictEqual('D', a.D());

--- a/test/parallel/test-fs-empty-readStream.js
+++ b/test/parallel/test-fs-empty-readStream.js
@@ -22,10 +22,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const emptyFile = path.join(common.fixturesDir, 'empty.txt');
+const emptyFile = fixtures.path('empty.txt');
 
 fs.open(emptyFile, 'r', common.mustCall((error, fd) => {
 

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -22,11 +22,11 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
-const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.fixturesDir, 'a.js');
+const file = fixtures.path('a.js');
 
 fs.open(file, 'a', 0o777, common.mustCall(function(err, fd) {
   assert.ifError(err);

--- a/test/parallel/test-fs-read-file-sync.js
+++ b/test/parallel/test-fs-read-file-sync.js
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const fn = path.join(common.fixturesDir, 'elipses.txt');
+const fn = fixtures.path('elipses.txt');
 
 const s = fs.readFileSync(fn, 'utf8');
 for (let i = 0; i < s.length; i++) {

--- a/test/parallel/test-fs-read-stream-encoding.js
+++ b/test/parallel/test-fs-read-stream-encoding.js
@@ -1,12 +1,12 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 const stream = require('stream');
+const fixtures = require('../common/fixtures');
 const encoding = 'base64';
 
-const example = path.join(common.fixturesDir, 'x.txt');
+const example = fixtures.path('x.txt');
 const assertStream = new stream.Writable({
   write: function(chunk, enc, next) {
     const expected = Buffer.from('xyz');

--- a/test/parallel/test-fs-read-stream-fd-leak.js
+++ b/test/parallel/test-fs-read-stream-fd-leak.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 let openCount = 0;
 const _fsopen = fs.open;
@@ -11,7 +11,7 @@ const _fsclose = fs.close;
 
 const loopCount = 50;
 const totalCheck = 50;
-const emptyTxt = path.join(common.fixturesDir, 'empty.txt');
+const emptyTxt = fixtures.path('empty.txt');
 
 fs.open = function() {
   openCount++;

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -24,10 +24,10 @@ const common = require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const fn = path.join(common.fixturesDir, 'elipses.txt');
-const rangeFile = path.join(common.fixturesDir, 'x.txt');
+const fn = fixtures.path('elipses.txt');
+const rangeFile = fixtures.path('x.txt');
 
 {
   let paused = false;

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -1,9 +1,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
-const filepath = path.join(common.fixturesDir, 'x.txt');
+const fixtures = require('../common/fixtures');
+
+const filepath = fixtures.path('x.txt');
 const fd = fs.openSync(filepath, 'r');
 const expected = 'xyz\n';
 

--- a/test/parallel/test-fs-readfile-empty.js
+++ b/test/parallel/test-fs-readfile-empty.js
@@ -20,11 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.fixturesDir, 'empty.txt');
+const fixtures = require('../common/fixtures');
+
+const fn = fixtures.path('empty.txt');
 
 fs.readFile(fn, function(err, data) {
   assert.ok(data);

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -28,10 +28,10 @@ if (common.isFreeBSD)
 
 const assert = require('assert');
 const exec = require('child_process').exec;
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 function test(env, cb) {
-  const filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
+  const filename = fixtures.path('test-fs-readfile-error.js');
   const execPath = `"${process.execPath}" "${filename}"`;
   const options = { env: Object.assign(process.env, env) };
   exec(execPath, options, common.mustCall((err, stdout, stderr) => {

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -20,11 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const dirName = path.resolve(common.fixturesDir, 'test-readfile-unlink');
+const fixtures = require('../common/fixtures');
+
+const dirName = fixtures.path('test-readfile-unlink');
 const fileName = path.resolve(dirName, 'test.bin');
 const buf = Buffer.alloc(512 * 1024, 42);
 

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -1,15 +1,16 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const m = require('module');
+const fixtures = require('../common/fixtures');
 
-const a = require(`${common.fixturesDir}/module-require/relative/dot.js`);
-const b = require(`${common.fixturesDir}/module-require/relative/dot-slash.js`);
+const a = require(fixtures.path('module-require', 'relative', 'dot.js'));
+const b = require(fixtures.path('module-require', 'relative', 'dot-slash.js'));
 
 assert.strictEqual(a.value, 42);
 assert.strictEqual(a, b, 'require(".") should resolve like require("./")');
 
-process.env.NODE_PATH = `${common.fixturesDir}/module-require/relative`;
+process.env.NODE_PATH = fixtures.path('module-require', 'relative');
 m._initPaths();
 
 const c = require('.');

--- a/test/parallel/test-require-extensions-main.js
+++ b/test/parallel/test-require-extensions-main.js
@@ -1,7 +1,10 @@
 'use strict';
+require('../common');
 const assert = require('assert');
-const common = require('../common');
-const fixturesRequire = require(`${common.fixturesDir}/require-bin/bin/req.js`);
+const fixtures = require('../common/fixtures');
+
+const fixturesRequire =
+  require(fixtures.path('require-bin', 'bin', 'req.js'));
 
 assert.strictEqual(
   fixturesRequire,

--- a/test/parallel/test-require-extensions-same-filename-as-dir-trailing-slash.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir-trailing-slash.js
@@ -21,10 +21,16 @@
 
 /* eslint-disable max-len */
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const filePath = '/json-with-directory-name-module/module-stub/one-trailing-slash/two/three.js';
-const content = require(`${common.fixturesDir}${filePath}`);
+const fixtures = require('../common/fixtures');
+
+const content =
+  require(fixtures.path('json-with-directory-name-module',
+                        'module-stub',
+                        'one-trailing-slash',
+                        'two',
+                        'three.js'));
 
 assert.notStrictEqual(content.rocko, 'artischocko');
 assert.strictEqual(content, 'hello from module-stub!');

--- a/test/parallel/test-require-extensions-same-filename-as-dir.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir.js
@@ -20,19 +20,13 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const filePath = path.join(
-  common.fixturesDir,
-  'json-with-directory-name-module',
-  'module-stub',
-  'one',
-  'two',
-  'three.js'
-);
-const content = require(filePath);
+const content = require(fixtures.path('json-with-directory-name-module',
+                                      'module-stub', 'one', 'two',
+                                      'three.js'));
 
 assert.notStrictEqual(content.rocko, 'artischocko');
 assert.strictEqual(content, 'hello from module-stub!');

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -20,12 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
-const path = require('path');
+require('../common');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
 try {
-  require(path.join(common.fixturesDir, 'invalid.json'));
+  require(fixtures.path('invalid.json'));
 } catch (err) {
   assert.ok(
     /test[/\\]fixtures[/\\]invalid\.json: Unexpected string/.test(err.message),

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -6,19 +6,22 @@ const path = require('path');
 const fs = require('fs');
 const { exec, spawn } = require('child_process');
 const util = require('util');
+const fixtures = require('../common/fixtures');
 
 common.refreshTmpDir();
 
-const linkTarget = path.join(common.fixturesDir,
-                             '/module-require-symlink/node_modules/dep2/');
+const linkTarget = fixtures.path('module-require-symlink',
+                                 'node_modules',
+                                 'dep2');
 
-const linkDir = path.join(
-  common.fixturesDir,
-  '/module-require-symlink/node_modules/dep1/node_modules/dep2'
-);
+const linkDir = fixtures.path('module-require-symlink',
+                              'node_modules',
+                              'dep1',
+                              'node_modules',
+                              'dep2');
 
-const linkScriptTarget = path.join(common.fixturesDir,
-                                   '/module-require-symlink/symlinked.js');
+const linkScriptTarget = fixtures.path('module-require-symlink',
+                                       'symlinked.js');
 
 const linkScript = path.join(common.tmpDir, 'module-require-symlink.js');
 
@@ -44,8 +47,7 @@ function test() {
   fs.symlinkSync(linkScriptTarget, linkScript);
 
   // load symlinked-module
-  const fooModule =
-    require(path.join(common.fixturesDir, '/module-require-symlink/foo.js'));
+  const fooModule = require(fixtures.path('/module-require-symlink/foo.js'));
   assert.strictEqual(fooModule.dep1.bar.version, 'CORRECT_VERSION');
   assert.strictEqual(fooModule.dep2.bar.version, 'CORRECT_VERSION');
 

--- a/test/parallel/test-signal-unregister.js
+++ b/test/parallel/test-signal-unregister.js
@@ -2,8 +2,9 @@
 const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
+const fixtures = require('../common/fixtures');
 
-const child = spawn(process.argv[0], [`${common.fixturesDir}/should_exit.js`]);
+const child = spawn(process.argv[0], [fixtures.path('should_exit.js')]);
 child.stdout.once('data', function() {
   child.kill('SIGINT');
 });

--- a/test/parallel/test-stdio-closed.js
+++ b/test/parallel/test-stdio-closed.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 if (common.isWindows) {
   if (process.argv[2] === 'child') {
@@ -13,7 +13,7 @@ if (common.isWindows) {
     return;
   }
   const python = process.env.PYTHON || 'python';
-  const script = path.join(common.fixturesDir, 'spawn_closed_stdio.py');
+  const script = fixtures.path('spawn_closed_stdio.py');
   const proc = spawn(python, [script, process.execPath, __filename, 'child']);
   proc.on('exit', common.mustCall(function(exitCode) {
     assert.strictEqual(exitCode, 0);

--- a/test/parallel/test-stdout-close-catch.js
+++ b/test/parallel/test-stdout-close-catch.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const child_process = require('child_process');
+const fixtures = require('../common/fixtures');
 
-const testScript = path.join(common.fixturesDir, 'catch-stdout-error.js');
+const testScript = fixtures.path('catch-stdout-error.js');
 
 const cmd = `${JSON.stringify(process.execPath)} ` +
             `${JSON.stringify(testScript)} | ` +

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -4,10 +4,10 @@ const assert = require('assert');
 const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const scriptString = path.join(common.fixturesDir, 'print-chars.js');
-const scriptBuffer = path.join(common.fixturesDir,
-                               'print-chars-from-buffer.js');
+const scriptString = fixtures.path('print-chars.js');
+const scriptBuffer = fixtures.path('print-chars-from-buffer.js');
 const tmpFile = path.join(common.tmpDir, 'stdout.txt');
 
 common.refreshTmpDir();

--- a/test/parallel/test-stream-preprocess.js
+++ b/test/parallel/test-stream-preprocess.js
@@ -3,32 +3,26 @@ const common = require('../common');
 const assert = require('assert');
 
 const fs = require('fs');
-const path = require('path');
 const rl = require('readline');
+const fixtures = require('../common/fixtures');
 
 const BOM = '\uFEFF';
 
 // Get the data using a non-stream way to compare with the streamed data.
-const modelData = fs.readFileSync(
-  path.join(common.fixturesDir, 'file-to-read-without-bom.txt'), 'utf8'
-);
+const modelData = fixtures.readSync('file-to-read-without-bom.txt', 'utf8');
 const modelDataFirstCharacter = modelData[0];
 
 // Detect the number of forthcoming 'line' events for mustCall() 'expected' arg.
 const lineCount = modelData.match(/\n/g).length;
 
 // Ensure both without-bom and with-bom test files are textwise equal.
-assert.strictEqual(
-  fs.readFileSync(
-    path.join(common.fixturesDir, 'file-to-read-with-bom.txt'), 'utf8'
-  ),
-  `${BOM}${modelData}`
+assert.strictEqual(fixtures.readSync('file-to-read-with-bom.txt', 'utf8'),
+                   `${BOM}${modelData}`
 );
 
 // An unjustified BOM stripping with a non-BOM character unshifted to a stream.
-const inputWithoutBOM = fs.createReadStream(
-  path.join(common.fixturesDir, 'file-to-read-without-bom.txt'), 'utf8'
-);
+const inputWithoutBOM =
+  fs.createReadStream(fixtures.path('file-to-read-without-bom.txt'), 'utf8');
 
 inputWithoutBOM.once('readable', common.mustCall(() => {
   const maybeBOM = inputWithoutBOM.read(1);
@@ -48,9 +42,8 @@ inputWithoutBOM.once('readable', common.mustCall(() => {
 }));
 
 // A justified BOM stripping.
-const inputWithBOM = fs.createReadStream(
-  path.join(common.fixturesDir, 'file-to-read-with-bom.txt'), 'utf8'
-);
+const inputWithBOM =
+  fs.createReadStream(fixtures.path('file-to-read-with-bom.txt'), 'utf8');
 
 inputWithBOM.once('readable', common.mustCall(() => {
   const maybeBOM = inputWithBOM.read(1);

--- a/test/parallel/test-sync-fileread.js
+++ b/test/parallel/test-sync-fileread.js
@@ -1,9 +1,7 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const fixture = path.join(common.fixturesDir, 'x.txt');
-
-assert.strictEqual(fs.readFileSync(fixture).toString(), 'xyz\n');
+assert.strictEqual(fs.readFileSync(fixtures.path('x.txt')).toString(), 'xyz\n');

--- a/test/parallel/test-tls-0-dns-altname.js
+++ b/test/parallel/test-tls-0-dns-altname.js
@@ -28,11 +28,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const server = tls.createServer({
-  key: fs.readFileSync(`${common.fixturesDir}/0-dns/0-dns-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/0-dns/0-dns-cert.pem`)
+  key: fixtures.readSync(['0-dns', '0-dns-key.pem']),
+  cert: fixtures.readSync(['0-dns', '0-dns-cert.pem'])
 }, function(c) {
   c.once('data', function() {
     c.destroy();

--- a/test/parallel/test-tls-addca.js
+++ b/test/parallel/test-tls-addca.js
@@ -1,14 +1,14 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 
 // Adding a CA certificate to contextWithCert should not also add it to
 // contextWithoutCert. This is tested by trying to connect to a server that
 // depends on that CA using contextWithoutCert.
 
-const join = require('path').join;
 const {
   assert, connect, keys, tls
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 const contextWithoutCert = tls.createSecureContext({});
 const contextWithCert = tls.createSecureContext({});

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -7,17 +7,12 @@ if (!common.hasCrypto)
 if (!common.opensslCli)
   common.skip('node compiled without OpenSSL CLI.');
 
-const fs = require('fs');
 const net = require('net');
-const path = require('path');
 const tls = require('tls');
-
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
+const fixtures = require('../common/fixtures');
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const opts = {

--- a/test/parallel/test-tls-alert.js
+++ b/test/parallel/test-tls-alert.js
@@ -29,18 +29,13 @@ if (!common.opensslCli)
 
 const assert = require('assert');
 const { spawn } = require('child_process');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 let success = false;
 
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
-
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const server = tls.Server({

--- a/test/parallel/test-tls-alpn-server-client.js
+++ b/test/parallel/test-tls-alpn-server-client.js
@@ -10,16 +10,11 @@ if (!process.features.tls_alpn || !process.features.tls_npn) {
 }
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
-
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
+const fixtures = require('../common/fixtures');
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const serverIP = common.localhostIPv4;

--- a/test/parallel/test-tls-ca-concat.js
+++ b/test/parallel/test-tls-ca-concat.js
@@ -1,13 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 
 // Check ca option can contain concatenated certs by prepending an unrelated
 // non-CA cert and showing that agent6's CA root is still found.
 
-const join = require('path').join;
 const {
   assert, connect, keys
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 connect({
   client: {

--- a/test/parallel/test-tls-cert-chains-concat.js
+++ b/test/parallel/test-tls-cert-chains-concat.js
@@ -1,13 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 
 // Check cert chain is received by client, and is completed with the ca cert
 // known to the client.
 
-const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 // agent6-cert.pem includes cert for agent6 and ca3
 connect({

--- a/test/parallel/test-tls-cert-chains-in-ca.js
+++ b/test/parallel/test-tls-cert-chains-in-ca.js
@@ -1,13 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 
 // Check cert chain is received by client, and is completed with the ca cert
 // known to the client.
 
-const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 
 // agent6-cert.pem includes cert for agent6 and ca3, split it apart and

--- a/test/parallel/test-tls-client-abort.js
+++ b/test/parallel/test-tls-client-abort.js
@@ -26,11 +26,10 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
-const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
+const cert = fixtures.readSync('test_cert.pem');
+const key = fixtures.readSync('test_key.pem');
 
 const conn = tls.connect({ cert, key, port: 0 }, common.mustNotCall());
 conn.on('error', function() {

--- a/test/parallel/test-tls-client-destroy-soon.js
+++ b/test/parallel/test-tls-client-destroy-soon.js
@@ -30,11 +30,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem')
 };
 
 const big = Buffer.alloc(2 * 1024 * 1024, 'Y');

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -5,18 +5,19 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
+const key = fixtures.readKey('agent2-key.pem');
+const cert = fixtures.readKey('agent2-cert.pem');
 
 let nsuccess = 0;
 let nerror = 0;
 
 function loadDHParam(n) {
-  let path = common.fixturesDir;
-  if (n !== 'error') path += '/keys';
-  return fs.readFileSync(`${path}/dh${n}.pem`);
+  const params = [`dh${n}.pem`];
+  if (n !== 'error')
+    params.unshift('keys');
+  return fixtures.readSync(params);
 }
 
 function test(size, err, next) {

--- a/test/parallel/test-tls-client-reject.js
+++ b/test/parallel/test-tls-client-reject.js
@@ -26,12 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
-  cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
+  key: fixtures.readSync('test_key.pem'),
+  cert: fixtures.readSync('test_cert.pem')
 };
 
 const server = tls.createServer(options, common.mustCall(function(socket) {
@@ -70,7 +69,7 @@ function rejectUnauthorized() {
 
 function authorized() {
   const socket = tls.connect(server.address().port, {
-    ca: [fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))],
+    ca: [fixtures.readSync('test_cert.pem')],
     servername: 'localhost'
   }, common.mustCall(function() {
     assert(socket.authorized);

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -25,9 +25,8 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 const testCases =
   [{ ca: ['ca1-cert'],
@@ -61,13 +60,9 @@ const testCases =
    }
   ];
 
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
-
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 let successfulTests = 0;

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -6,11 +6,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const server = tls.createServer({
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 }, function(c) {
 }).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, common.mustNotCall());

--- a/test/parallel/test-tls-close-notify.js
+++ b/test/parallel/test-tls-close-notify.js
@@ -26,11 +26,11 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const server = tls.createServer({
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 }, function(c) {
   // Send close-notify without shutting down TCP socket
   if (c._handle.shutdownSSL() !== 1)

--- a/test/parallel/test-tls-cnnic-whitelist.js
+++ b/test/parallel/test-tls-cnnic-whitelist.js
@@ -6,16 +6,11 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
-
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
+const fixtures = require('../common/fixtures');
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const testCases = [

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -26,12 +26,11 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 common.refreshTmpDir();

--- a/test/parallel/test-tls-connect-simple.js
+++ b/test/parallel/test-tls-connect-simple.js
@@ -26,14 +26,13 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 let serverConnected = 0;
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.Server(options, common.mustCall(function(socket) {

--- a/test/parallel/test-tls-connect-stream-writes.js
+++ b/test/parallel/test-tls-connect-stream-writes.js
@@ -4,15 +4,14 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const tls = require('tls');
 const stream = require('stream');
 const net = require('net');
+const fixtures = require('../common/fixtures');
 
-const cert_dir = common.fixturesDir;
-const options = { key: fs.readFileSync(`${cert_dir}/test_key.pem`),
-                  cert: fs.readFileSync(`${cert_dir}/test_cert.pem`),
-                  ca: [ fs.readFileSync(`${cert_dir}/test_ca.pem`) ],
+const options = { key: fixtures.readSync('test_key.pem'),
+                  cert: fixtures.readSync('test_cert.pem'),
+                  ca: [ fixtures.readSync('test_ca.pem') ],
                   ciphers: 'AES256-GCM-SHA384' };
 const content = 'hello world';
 const recv_bufs = [];

--- a/test/parallel/test-tls-delayed-attach-error.js
+++ b/test/parallel/test-tls-delayed-attach-error.js
@@ -5,14 +5,14 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-const fs = require('fs');
 const net = require('net');
+const fixtures = require('../common/fixtures');
 
 const bonkers = Buffer.alloc(1024, 42);
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = net.createServer(common.mustCall(function(c) {

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -31,10 +31,10 @@ if (!common.opensslCli)
 const assert = require('assert');
 const tls = require('tls');
 const spawn = require('child_process').spawn;
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
+const key = fixtures.readKey('agent2-key.pem');
+const cert = fixtures.readKey('agent2-cert.pem');
 let nsuccess = 0;
 let ntests = 0;
 const ciphers = 'DHE-RSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
@@ -44,9 +44,10 @@ common.expectWarning('SecurityWarning',
                      'DH parameter is less than 2048 bits');
 
 function loadDHParam(n) {
-  let path = common.fixturesDir;
-  if (n !== 'error') path += '/keys';
-  return fs.readFileSync(`${path}/dh${n}.pem`);
+  const params = [`dh${n}.pem`];
+  if (n !== 'error')
+    params.unshift('keys');
+  return fixtures.readSync(params);
 }
 
 function test(keylen, expectedCipher, cb) {

--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -7,10 +7,10 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const fork = require('child_process').fork;
+const { fork } = require('child_process');
 
 if (process.env.CHILD) {
   const copts = {
@@ -24,8 +24,8 @@ if (process.env.CHILD) {
 }
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
 };
 
 const server = tls.createServer(options, common.mustCall(function(s) {
@@ -35,7 +35,7 @@ const server = tls.createServer(options, common.mustCall(function(s) {
   const env = {
     CHILD: 'yes',
     PORT: this.address().port,
-    NODE_EXTRA_CA_CERTS: `${common.fixturesDir}/keys/ca1-cert.pem`,
+    NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca1-cert.pem')
   };
 
   fork(__filename, { env: env }).on('exit', common.mustCall(function(status) {

--- a/test/parallel/test-tls-no-rsa-key.js
+++ b/test/parallel/test-tls-no-rsa-key.js
@@ -26,11 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`)
+  key: fixtures.readKey('/ec-key.pem'),
+  cert: fixtures.readKey('ec-cert.pem')
 };
 
 const server = tls.createServer(options, function(conn) {

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -8,11 +8,11 @@ if (common.opensslCli === false)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const spawn = require('child_process').spawn;
+const fixtures = require('../common/fixtures');
 
-const cert = fs.readFileSync(`${common.fixturesDir}/test_cert.pem`);
-const key = fs.readFileSync(`${common.fixturesDir}/test_key.pem`);
+const cert = fixtures.readSync('test_cert.pem');
+const key = fixtures.readSync('test_key.pem');
 const server = tls.createServer({ cert: cert, key: key }, common.mustNotCall());
 const errors = [];
 let stderr = '';

--- a/test/parallel/test-tls-npn-server-client.js
+++ b/test/parallel/test-tls-npn-server-client.js
@@ -28,16 +28,11 @@ if (!process.features.tls_npn)
   common.skip('Skipping because node compiled without NPN feature of OpenSSL.');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
-
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
+const fixtures = require('../common/fixtures');
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const serverOptions = {

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -32,26 +32,22 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
-const fs = require('fs');
-const join = require('path').join;
 
 const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
-const pfx = fs.readFileSync(join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
+const pfx = fixtures.readKey('agent1-pfx.pem');
 
 function test(testOptions, cb) {
 
-  const keyFile = join(common.fixturesDir, 'keys', 'agent1-key.pem');
-  const certFile = join(common.fixturesDir, 'keys', 'agent1-cert.pem');
-  const caFile = join(common.fixturesDir, 'keys', 'ca1-cert.pem');
-  const key = fs.readFileSync(keyFile);
-  const cert = fs.readFileSync(certFile);
-  const ca = fs.readFileSync(caFile);
+  const key = fixtures.readKey('agent1-key.pem');
+  const cert = fixtures.readKey('agent1-cert.pem');
+  const ca = fixtures.readKey('ca1-cert.pem');
   const options = {
-    key: key,
-    cert: cert,
+    key,
+    cert,
     ca: [ca]
   };
   let requestCount = 0;

--- a/test/parallel/test-tls-on-empty-socket.js
+++ b/test/parallel/test-tls-on-empty-socket.js
@@ -6,15 +6,14 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-
-const fs = require('fs');
 const net = require('net');
+const fixtures = require('../common/fixtures');
 
 let out = '';
 
 const server = tls.createServer({
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 }, function(c) {
   c.end('hello');
 }).listen(0, function() {

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -26,14 +26,14 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 const net = require('net');
 const http = require('http');
+const fixtures = require('../common/fixtures');
 
 let gotRequest = false;
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const options = {
   key: key,

--- a/test/parallel/test-tls-passphrase.js
+++ b/test/parallel/test-tls-passphrase.js
@@ -26,12 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const passKey = fs.readFileSync(path.join(common.fixturesDir, 'pass-key.pem'));
-const rawKey = fs.readFileSync(path.join(common.fixturesDir, 'raw-key.pem'));
-const cert = fs.readFileSync(path.join(common.fixturesDir, 'pass-cert.pem'));
+const passKey = fixtures.readSync('pass-key.pem');
+const rawKey = fixtures.readSync('raw-key.pem');
+const cert = fixtures.readSync('pass-cert.pem');
 
 assert(Buffer.isBuffer(passKey));
 assert(Buffer.isBuffer(cert));

--- a/test/parallel/test-tls-pause.js
+++ b/test/parallel/test-tls-pause.js
@@ -26,12 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
-  cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
+  key: fixtures.readSync('test_key.pem'),
+  cert: fixtures.readSync('test_cert.pem')
 };
 
 const bufSize = 1024 * 1024;

--- a/test/parallel/test-tls-peer-certificate-encoding.js
+++ b/test/parallel/test-tls-peer-certificate-encoding.js
@@ -26,14 +26,13 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const util = require('util');
-const join = require('path').join;
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent5-key.pem')),
-  cert: fs.readFileSync(join(common.fixturesDir, 'keys', 'agent5-cert.pem')),
-  ca: [ fs.readFileSync(join(common.fixturesDir, 'keys', 'ca2-cert.pem')) ]
+  key: fixtures.readKey('agent5-key.pem'),
+  cert: fixtures.readKey('agent5-cert.pem'),
+  ca: [ fixtures.readKey('ca2-cert.pem') ]
 };
 
 const server = tls.createServer(options, function(cleartext) {

--- a/test/parallel/test-tls-peer-certificate-multi-keys.js
+++ b/test/parallel/test-tls-peer-certificate-multi-keys.js
@@ -26,13 +26,12 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const util = require('util');
-const join = require('path').join;
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(join(common.fixturesDir, 'agent.key')),
-  cert: fs.readFileSync(join(common.fixturesDir, 'multi-alice.crt'))
+  key: fixtures.readSync('agent.key'),
+  cert: fixtures.readSync('multi-alice.crt')
 };
 
 const server = tls.createServer(options, function(cleartext) {

--- a/test/parallel/test-tls-peer-certificate.js
+++ b/test/parallel/test-tls-peer-certificate.js
@@ -20,14 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 
 // Verify that detailed getPeerCertificate() return value has all certs.
 
-const join = require('path').join;
 const {
   assert, connect, debug, keys
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 connect({
   client: { rejectUnauthorized: false },

--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -7,11 +7,9 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const pfx = fs.readFileSync(
-  path.join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
+const pfx = fixtures.readKey('agent1-pfx.pem');
 
 const server = tls.createServer({
   pfx: pfx,

--- a/test/parallel/test-tls-regr-gh-5108.js
+++ b/test/parallel/test-tls-regr-gh-5108.js
@@ -6,11 +6,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 

--- a/test/parallel/test-tls-request-timeout.js
+++ b/test/parallel/test-tls-request-timeout.js
@@ -26,11 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.Server(options, common.mustCall(function(socket) {

--- a/test/parallel/test-tls-retain-handle-no-abort.js
+++ b/test/parallel/test-tls-retain-handle-no-abort.js
@@ -6,14 +6,14 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const util = require('util');
+const fixtures = require('../common/fixtures');
 
 const sent = 'hello world';
 const serverOptions = {
   isServer: true,
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 let ssl = null;

--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -5,12 +5,12 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 const sslcontext = tls.createSecureContext({
-  cert: fs.readFileSync(`${common.fixturesDir}/test_cert.pem`),
-  key: fs.readFileSync(`${common.fixturesDir}/test_key.pem`)
+  cert: fixtures.readSync('test_cert.pem'),
+  key: fixtures.readSync('test_key.pem')
 });
 
 let catchedServername;
@@ -21,7 +21,7 @@ const pair = tls.createSecurePair(sslcontext, true, false, false, {
 });
 
 // captured traffic from browser's request to https://www.google.com
-const sslHello = fs.readFileSync(`${common.fixturesDir}/google_ssl_hello.bin`);
+const sslHello = fixtures.readSync('google_ssl_hello.bin');
 
 pair.encrypted.write(sslHello);
 

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -29,13 +29,12 @@ if (!common.opensslCli)
 
 const assert = require('assert');
 const tls = require('tls');
-const join = require('path').join;
 const net = require('net');
-const fs = require('fs');
 const spawn = require('child_process').spawn;
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(join(common.fixturesDir, 'agent.key')).toString();
-const cert = fs.readFileSync(join(common.fixturesDir, 'agent.crt')).toString();
+const key = fixtures.readSync('agent.key').toString();
+const cert = fixtures.readSync('agent.crt').toString();
 
 function log(a) {
   console.error(`***server*** ${a}`);

--- a/test/parallel/test-tls-server-connection-server.js
+++ b/test/parallel/test-tls-server-connection-server.js
@@ -6,11 +6,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.createServer(options, function(s) {

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -40,9 +40,8 @@ const assert = require('assert');
 const { spawn } = require('child_process');
 const { SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION } =
   require('crypto').constants;
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 const testCases =
   [{ title: 'Do not request certs. Everyone is unauthorized.',
@@ -128,14 +127,12 @@ const testCases =
    }
   ];
 
-
 function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
+  return fixtures.path('keys', `${n}.pem`);
 }
 
-
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -21,21 +21,16 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const tls = require('tls');
+const { spawn } = require('child_process');
 
 if (!common.opensslCli)
   common.skip('node compiled without OpenSSL CLI.');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
-
-const assert = require('assert');
-const tls = require('tls');
-const fs = require('fs');
-const { join } = require('path');
-const { spawn } = require('child_process');
-
-const keyFile = join(common.fixturesDir, 'agent.key');
-const certFile = join(common.fixturesDir, 'agent.crt');
 
 doTest({ tickets: false }, function() {
   doTest({ tickets: true }, function() {
@@ -46,11 +41,11 @@ doTest({ tickets: false }, function() {
 });
 
 function doTest(testOptions, callback) {
-  const key = fs.readFileSync(keyFile);
-  const cert = fs.readFileSync(certFile);
+  const key = fixtures.readSync('agent.key');
+  const cert = fixtures.readSync('agent.crt');
   const options = {
-    key: key,
-    cert: cert,
+    key,
+    cert,
     ca: [cert],
     requestCert: true,
     rejectUnauthorized: false
@@ -108,8 +103,8 @@ function doTest(testOptions, callback) {
       '-tls1',
       '-connect', `localhost:${this.address().port}`,
       '-servername', 'ohgod',
-      '-key', join(common.fixturesDir, 'agent.key'),
-      '-cert', join(common.fixturesDir, 'agent.crt'),
+      '-key', fixtures.path('agent.key'),
+      '-cert', fixtures.path('agent.crt'),
       '-reconnect'
     ].concat(testOptions.tickets ? [] : '-no_ticket');
 

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -31,11 +31,11 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const exec = require('child_process').exec;
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem'),
   ciphers: 'AES256-SHA'
 };
 

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -26,11 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem')
 };
 
 // Contains a UTF8 only character

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -28,16 +28,11 @@ if (!process.features.tls_sni)
   common.skip('node compiled without OpenSSL or with old OpenSSL version.');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
-
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
+const fixtures = require('../common/fixtures');
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const serverOptions = {

--- a/test/parallel/test-tls-sni-server-client.js
+++ b/test/parallel/test-tls-sni-server-client.js
@@ -28,16 +28,12 @@ if (!process.features.tls_sni)
   common.skip('node compiled without OpenSSL or with old OpenSSL version.');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
 
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const serverOptions = {

--- a/test/parallel/test-tls-socket-close.js
+++ b/test/parallel/test-tls-socket-close.js
@@ -5,11 +5,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const net = require('net');
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`);
+const key = fixtures.readKey('agent2-key.pem');
+const cert = fixtures.readKey('agent2-cert.pem');
 
 let tlsSocket;
 // tls server

--- a/test/parallel/test-tls-socket-default-options.js
+++ b/test/parallel/test-tls-socket-default-options.js
@@ -1,13 +1,13 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 // Test directly created TLS sockets and options.
 
 const assert = require('assert');
-const join = require('path').join;
 const {
   connect, keys, tls
-} = require(join(common.fixturesDir, 'tls-connect'));
+} = require(fixtures.path('tls-connect'));
 
 test(undefined, (err) => {
   assert.strictEqual(err.message, 'unable to verify the first certificate');

--- a/test/parallel/test-tls-socket-destroy.js
+++ b/test/parallel/test-tls-socket-destroy.js
@@ -5,12 +5,13 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+
 const secureContext = tls.createSecureContext({ key, cert });
 
 const server = net.createServer(common.mustCall((conn) => {

--- a/test/parallel/test-tls-startcom-wosign-whitelist.js
+++ b/test/parallel/test-tls-startcom-wosign-whitelist.js
@@ -4,18 +4,13 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
 let finished = 0;
 
-function filenamePEM(n) {
-  return path.join(common.fixturesDir, 'keys', `${n}.pem`);
-}
-
 function loadPEM(n) {
-  return fs.readFileSync(filenamePEM(n));
+  return fixtures.readKey(`${n}.pem`);
 }
 
 const testCases = [

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -9,12 +9,12 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const net = require('net');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const key = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
-const cert = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const server = net.createServer(common.mustCall((s) => {
   const tlsSocket = new tls.TLSSocket(s, {

--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -27,8 +27,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const tls = require('tls');
 const cluster = require('cluster');
-const fs = require('fs');
-const join = require('path').join;
+const fixtures = require('../common/fixtures');
 
 const workerCount = 4;
 const expectedReqCount = 16;
@@ -87,14 +86,10 @@ if (cluster.isMaster) {
   return;
 }
 
-const keyFile = join(common.fixturesDir, 'agent.key');
-const certFile = join(common.fixturesDir, 'agent.crt');
-const key = fs.readFileSync(keyFile);
-const cert = fs.readFileSync(certFile);
-const options = {
-  key: key,
-  cert: cert
-};
+const key = fixtures.readSync('agent.key');
+const cert = fixtures.readSync('agent.crt');
+
+const options = { key, cert };
 
 const server = tls.createServer(options, function(c) {
   if (c.isSessionReused()) {

--- a/test/parallel/test-tls-ticket.js
+++ b/test/parallel/test-tls-ticket.js
@@ -26,9 +26,9 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const net = require('net');
 const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
 
 const keys = crypto.randomBytes(48);
 const serverLog = [];
@@ -42,8 +42,8 @@ function createServer() {
   let previousKey = null;
 
   const server = tls.createServer({
-    key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem'),
     ticketKeys: keys
   }, function(c) {
     serverLog.push(id);

--- a/test/parallel/test-tls-timeout-server-2.js
+++ b/test/parallel/test-tls-timeout-server-2.js
@@ -26,11 +26,11 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.createServer(options, common.mustCall(function(cleartext) {

--- a/test/parallel/test-tls-timeout-server.js
+++ b/test/parallel/test-tls-timeout-server.js
@@ -27,11 +27,11 @@ if (!common.hasCrypto)
 
 const tls = require('tls');
 const net = require('net');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
   handshakeTimeout: 50
 };
 

--- a/test/parallel/test-tls-two-cas-one-string.js
+++ b/test/parallel/test-tls-two-cas-one-string.js
@@ -4,15 +4,13 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const fs = require('fs');
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const keydir = `${common.fixturesDir}/keys`;
-
-const ca1 = fs.readFileSync(`${keydir}/ca1-cert.pem`, 'utf8');
-const ca2 = fs.readFileSync(`${keydir}/ca2-cert.pem`, 'utf8');
-const cert = fs.readFileSync(`${keydir}/agent3-cert.pem`, 'utf8');
-const key = fs.readFileSync(`${keydir}/agent3-key.pem`, 'utf8');
+const ca1 = fixtures.readKey('ca1-cert.pem', 'utf8');
+const ca2 = fixtures.readKey('ca2-cert.pem', 'utf8');
+const cert = fixtures.readKey('agent3-cert.pem', 'utf8');
+const key = fixtures.readKey('agent3-key.pem', 'utf8');
 
 function test(ca, next) {
   const server = tls.createServer({ ca, cert, key }, function(conn) {

--- a/test/parallel/test-tls-wrap-timeout.js
+++ b/test/parallel/test-tls-wrap-timeout.js
@@ -6,13 +6,12 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-
 const net = require('net');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = tls.createServer(options, common.mustCall((c) => {

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -26,12 +26,10 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
+const fixtures = require('../common/fixtures');
 
-const fs = require('fs');
-const path = require('path');
-
-const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
-const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
+const cert = fixtures.readSync('test_cert.pem');
+const key = fixtures.readSync('test_key.pem');
 
 const server = tls.createServer({
   cert: cert,

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -6,9 +6,9 @@ const common = require('../common');
 
 const assert = require('assert');
 const { callbackify } = require('util');
-const { join } = require('path');
 const { execFile } = require('child_process');
-const fixtureDir = join(common.fixturesDir, 'uncaught-exceptions');
+const fixtures = require('../common/fixtures');
+
 const values = [
   'hello world',
   null,
@@ -197,7 +197,7 @@ const values = [
 
 {
   // Test that callback that throws emits an `uncaughtException` event
-  const fixture = join(fixtureDir, 'callbackify1.js');
+  const fixture = fixtures.path('uncaught-exceptions', 'callbackify1.js');
   execFile(
     process.execPath,
     [fixture],
@@ -214,7 +214,7 @@ const values = [
 
 {
   // Test that handled `uncaughtException` works and passes rejection reason
-  const fixture = join(fixtureDir, 'callbackify2.js');
+  const fixture = fixtures.path('uncaught-exceptions', 'callbackify2.js');
   execFile(
     process.execPath,
     [fixture],

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -1,9 +1,9 @@
 'use strict';
 // Flags: --expose_internals
 
-const common = require('../common');
-const path = require('path');
+require('../common');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
 const binding = process.binding('util');
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
@@ -54,7 +54,7 @@ assert.strictEqual(
 let arrowMessage;
 
 try {
-  require(path.join(common.fixturesDir, 'syntax', 'bad_syntax'));
+  require(fixtures.path('syntax', 'bad_syntax'));
 } catch (err) {
   arrowMessage =
       binding.getHiddenValue(err, kArrowMessagePrivateSymbolIndex);

--- a/test/parallel/test-vm-debug-context.js
+++ b/test/parallel/test-vm-debug-context.js
@@ -24,7 +24,8 @@
 const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
-const spawn = require('child_process').spawn;
+const { spawn } = require('child_process');
+const fixtures = require('../common/fixtures');
 
 assert.throws(function() {
   vm.runInDebugContext('*');
@@ -77,7 +78,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 // Can set listeners and breakpoints on a single line file
 {
   const Debug = vm.runInDebugContext('Debug');
-  const fn = require(`${common.fixturesDir}/exports-function-with-param`);
+  const fn = require(fixtures.path('exports-function-with-param'));
   let called = false;
 
   Debug.setListener(function(event, state, data) {
@@ -94,7 +95,7 @@ assert.strictEqual(vm.runInDebugContext(undefined), undefined);
 
 // See https://github.com/nodejs/node/issues/1190, fatal errors should not
 // crash the process.
-const script = `${common.fixturesDir}/vm-run-in-debug-context.js`;
+const script = fixtures.path('vm-run-in-debug-context.js');
 let proc = spawn(process.execPath, [script]);
 const data = [];
 proc.stdout.on('data', common.mustNotCall());

--- a/test/parallel/test-vm-syntax-error-stderr.js
+++ b/test/parallel/test-vm-syntax-error-stderr.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const child_process = require('child_process');
+const fixtures = require('../common/fixtures');
 
-const wrong_script = path.join(common.fixturesDir, 'cert.pem');
+const wrong_script = fixtures.path('cert.pem');
 
 const p = child_process.spawn(process.execPath, [
   '-e',

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -5,13 +5,13 @@ if (!common.hasIntl) {
   common.skip('missing Intl');
 }
 
-const path = require('path');
+const fixtures = require('../common/fixtures');
 const { URL, URLSearchParams } = require('url');
 const { test, assert_equals, assert_true, assert_throws } =
   require('../common/wpt');
 
 const request = {
-  response: require(path.join(common.fixturesDir, 'url-tests'))
+  response: require(fixtures.path('url-tests'))
 };
 
 /* The following tests are copied from WPT. Modifications to them should be

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -5,12 +5,12 @@ if (!common.hasIntl) {
   common.skip('missing Intl');
 }
 
-const path = require('path');
+const fixtures = require('../common/fixtures');
 const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 
 const request = {
-  response: require(path.join(common.fixturesDir, 'url-tests'))
+  response: require(fixtures.path('url-tests'))
 };
 
 /* The following tests are copied from WPT. Modifications to them should be

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -7,11 +7,11 @@ if (!common.hasIntl) {
 }
 
 const URL = require('url').URL;
-const path = require('path');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
 // Tests below are not from WPT.
-const tests = require(path.join(common.fixturesDir, 'url-tests'));
+const tests = require(fixtures.path('url-tests'));
 const failureTests = tests.filter((test) => test.failure).concat([
   { input: '' },
   { input: 'test' },
@@ -44,8 +44,8 @@ for (const test of failureTests) {
     });
 }
 
-const additional_tests = require(
-  path.join(common.fixturesDir, 'url-tests-additional.js'));
+const additional_tests =
+  require(fixtures.path('url-tests-additional.js'));
 
 for (const test of additional_tests) {
   const url = new URL(test.url);

--- a/test/parallel/test-whatwg-url-searchparams.js
+++ b/test/parallel/test-whatwg-url-searchparams.js
@@ -2,8 +2,8 @@
 
 const common = require('../common');
 const assert = require('assert');
-const path = require('path');
 const { URL, URLSearchParams } = require('url');
+const fixtures = require('../common/fixtures');
 
 // Tests below are not from WPT.
 const serialized = 'a=a&a=1&a=true&a=undefined&a=null&a=%EF%BF%BD' +
@@ -84,7 +84,7 @@ sp.forEach(function() {
 m.search = '?a=a&b=b';
 assert.strictEqual(sp.toString(), 'a=a&b=b');
 
-const tests = require(path.join(common.fixturesDir, 'url-searchparams.js'));
+const tests = require(fixtures.path('url-searchparams.js'));
 
 for (const [input, expected, parsed] of tests) {
   if (input[0] !== '?') {

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -7,14 +7,15 @@ if (!common.hasIntl) {
 }
 
 const assert = require('assert');
-const path = require('path');
 const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
-const additionalTestCases = require(
-  path.join(common.fixturesDir, 'url-setter-tests-additional.js'));
+const fixtures = require('../common/fixtures');
+
+const additionalTestCases =
+  require(fixtures.path('url-setter-tests-additional.js'));
 
 const request = {
-  response: require(path.join(common.fixturesDir, 'url-setter-tests'))
+  response: require(fixtures.path('url-setter-tests'))
 };
 
 /* The following tests are copied from WPT. Modifications to them should be

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -5,12 +5,12 @@ if (!common.hasIntl) {
   common.skip('missing Intl');
 }
 
-const path = require('path');
+const fixtures = require('../common/fixtures');
 const { URL } = require('url');
 const { test, assert_equals, assert_throws } = require('../common/wpt');
 
 const request = {
-  response: require(path.join(common.fixturesDir, 'url-toascii'))
+  response: require(fixtures.path('url-toascii'))
 };
 
 /* The following tests are copied from WPT. Modifications to them should be

--- a/test/parallel/test-zlib-flush.js
+++ b/test/parallel/test-zlib-flush.js
@@ -1,11 +1,10 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const file = fs.readFileSync(path.resolve(common.fixturesDir, 'person.jpg'));
+const file = fixtures.readSync('person.jpg');
 const chunkSize = 16;
 const opts = { level: 0 };
 const deflater = zlib.createDeflate(opts);

--- a/test/parallel/test-zlib-from-concatenated-gzip.js
+++ b/test/parallel/test-zlib-from-concatenated-gzip.js
@@ -4,8 +4,8 @@
 const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const abcEncoded = zlib.gzipSync('abc');
 const defEncoded = zlib.gzipSync('def');
@@ -42,8 +42,8 @@ zlib.unzip(Buffer.concat([
 // files that have the "right" magic bytes for starting a new gzip member
 // in the middle of themselves, even if they are part of a single
 // regularly compressed member
-const pmmFileZlib = path.join(common.fixturesDir, 'pseudo-multimember-gzip.z');
-const pmmFileGz = path.join(common.fixturesDir, 'pseudo-multimember-gzip.gz');
+const pmmFileZlib = fixtures.path('pseudo-multimember-gzip.z');
+const pmmFileGz = fixtures.path('pseudo-multimember-gzip.gz');
 
 const pmmExpected = zlib.inflateSync(fs.readFileSync(pmmFileZlib));
 const pmmResultBuffers = [];

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -27,6 +27,7 @@ const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 const path = require('path');
+const fixtures = require('../common/fixtures');
 
 common.refreshTmpDir();
 
@@ -34,8 +35,8 @@ const gunzip = zlib.createGunzip();
 
 const fs = require('fs');
 
-const fixture = path.resolve(common.fixturesDir, 'person.jpg.gz');
-const unzippedFixture = path.resolve(common.fixturesDir, 'person.jpg');
+const fixture = fixtures.path('person.jpg.gz');
+const unzippedFixture = fixtures.path('person.jpg');
 const outputFile = path.resolve(common.tmpDir, 'person.jpg');
 const expect = fs.readFileSync(unzippedFixture);
 const inp = fs.createReadStream(fixture);

--- a/test/parallel/test-zlib-params.js
+++ b/test/parallel/test-zlib-params.js
@@ -1,11 +1,10 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const file = fs.readFileSync(path.resolve(common.fixturesDir, 'person.jpg'));
+const file = fixtures.readSync('person.jpg');
 const chunkSize = 12 * 1024;
 const opts = { level: 9, strategy: zlib.constants.Z_DEFAULT_STRATEGY };
 const deflater = zlib.createDeflate(opts);

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -23,9 +23,8 @@
 const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
-const path = require('path');
-const fs = require('fs');
 const stream = require('stream');
+const fixtures = require('../common/fixtures');
 
 let zlibPairs = [
   [zlib.Deflate, zlib.Inflate],
@@ -69,7 +68,7 @@ if (process.env.FAST) {
 
 const tests = {};
 testFiles.forEach(common.mustCall((file) => {
-  tests[file] = fs.readFileSync(path.resolve(common.fixturesDir, file));
+  tests[file] = fixtures.readSync(file);
 }, testFiles.length));
 
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -248,7 +248,9 @@ try {
   }, {});
 
   assert.deepStrictEqual(children, {
-    'common/index.js': {},
+    'common/index.js': {
+      'common/fixtures.js': {}
+    },
     'fixtures/not-main-module.js': {},
     'fixtures/a.js': {
       'fixtures/b/c.js': {


### PR DESCRIPTION
Adds a new `../common/fixtures' module to begin normalizing
`test/fixtures` use. Our test code is a bit inconsistent with
regards to use of the fixtures directory. Some code uses
`path.join()`, some code uses string concats, some other
code uses template strings, etc. In mnay cases, significant
duplication of code is seen when accessing fixture files, etc.

This updates many (but by no means all) of the tests in the
test suite to use the new consistent API. There are still
many more to update, which would make an excelent Code-n-Learn
exercise.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test