### PR TITLE
http: don't double-fire the req error event

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -374,8 +374,8 @@ function socketCloseListener() {
     // This socket error fired before we started to
     // receive a response. The error needs to
     // fire on the request.
-    req.emit('error', createHangUpError());
     req.socket._hadError = true;
+    req.emit('error', createHangUpError());
   }
 
   // Too bad.  That output wasn't getting written.
@@ -398,10 +398,10 @@ function socketErrorListener(err) {
   debug('SOCKET ERROR:', err.message, err.stack);
 
   if (req) {
-    req.emit('error', err);
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;
+    req.emit('error', err);
   }
 
   // Handle any pending data
@@ -434,8 +434,8 @@ function socketOnEnd() {
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
-    req.emit('error', createHangUpError());
     req.socket._hadError = true;
+    req.emit('error', createHangUpError());
   }
   if (parser) {
     parser.finish();
@@ -456,8 +456,8 @@ function socketOnData(d) {
     debug('parse error', ret);
     freeParser(parser, req, socket);
     socket.destroy();
-    req.emit('error', ret);
     req.socket._hadError = true;
+    req.emit('error', ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade or CONNECT
     var bytesParsed = ret;

--- a/test/parallel/test-http-client-req-error-dont-double-fire.js
+++ b/test/parallel/test-http-client-req-error-dont-double-fire.js
@@ -1,0 +1,16 @@
+'use strict';
+const assert = require('assert');
+const http = require('http');
+const common = require('../common');
+
+// not exists host
+const host = '*'.repeat(256);
+const req = http.get({ host });
+const err = new Error('mock unexpected code error');
+req.on('error', common.mustCall(() => {
+  throw err;
+}));
+
+process.on('uncaughtException', common.mustCall((e) => {
+  assert.strictEqual(e, err);
+}));


### PR DESCRIPTION
Should set req.socket._hadError to true before emit the error event.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http