### PR TITLE
test: move test-fs-largefile to pummel

### DIFF
--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -35,9 +35,9 @@ const message = 'Large File';
 
 fs.truncateSync(fd, offset);
 assert.strictEqual(fs.statSync(filepath).size, offset);
-var writeBuf = Buffer.from(message);
+const writeBuf = Buffer.from(message);
 fs.writeSync(fd, writeBuf, 0, writeBuf.length, offset);
-var readBuf = Buffer.allocUnsafe(writeBuf.length);
+const readBuf = Buffer.allocUnsafe(writeBuf.length);
 fs.readSync(fd, readBuf, 0, readBuf.length, offset);
 assert.strictEqual(readBuf.toString(), message);
 fs.readSync(fd, readBuf, 0, 1, 0);


### PR DESCRIPTION
test-fs-largefile was disabled. It was fixed in bbf74fb but left in
disabled because it generates a 5Gb file. However, gibfahn had the
sensible suggestion of moving it to the pummel directory. Which is what
this change does.

In pummel, lint rules are applied, so this does necessitate changing a
pair of `var` declarations to `const`.

Refs: https://github.com/nodejs/node/commit/bbf74fb87b2f8273e1d93e949f9c840b12ce4805

h/t @gibfahn 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs