### PR TITLE
[v6.x backport] test: change deprecated method to recommended

### DIFF
--- a/test/parallel/test-stream-pipe-await-drain-push-while-write.js
+++ b/test/parallel/test-stream-pipe-await-drain-push-while-write.js
@@ -17,7 +17,7 @@ const writable = new stream.Writable({
   write: common.mustCall(function(chunk, encoding, cb) {
     if (chunk.length === 32 * 1024) { // first chunk
       const beforePush = readable._readableState.awaitDrain;
-      readable.push(new Buffer(34 * 1024)); // above hwm
+      readable.push(Buffer.alloc(34 * 1024)); // above hwm
       // We should check if awaitDrain counter is increased.
       const afterPush = readable._readableState.awaitDrain;
       assert.strictEqual(afterPush - beforePush, 1,
@@ -34,7 +34,7 @@ const writable = new stream.Writable({
 });
 
 // A readable stream which produces two buffers.
-const bufs = [new Buffer(32 * 1024), new Buffer(33 * 1024)]; // above hwm
+const bufs = [Buffer.alloc(32 * 1024), Buffer.alloc(33 * 1024)]; // above hwm
 const readable = new stream.Readable({
   read: function() {
     while (bufs.length > 0) {

--- a/test/parallel/test-stream2-decode-partial.js
+++ b/test/parallel/test-stream2-decode-partial.js
@@ -4,8 +4,8 @@ const Readable = require('_stream_readable');
 const assert = require('assert');
 
 let buf = '';
-const euro = new Buffer([0xE2, 0x82, 0xAC]);
-const cent = new Buffer([0xC2, 0xA2]);
+const euro = Buffer.from([0xE2, 0x82, 0xAC]);
+const cent = Buffer.from([0xC2, 0xA2]);
 const source = Buffer.concat([euro, cent]);
 
 const readable = Readable({ encoding: 'utf8' });

--- a/test/parallel/test-stream3-cork-end.js
+++ b/test/parallel/test-stream3-cork-end.js
@@ -79,7 +79,7 @@ writeChunks(inputChunks, () => {
     // there was a chunk
     assert.ok(seen);
 
-    const expected = new Buffer(expectedChunks[i]);
+    const expected = Buffer.from(expectedChunks[i]);
     // it was what we expected
     assert.ok(seen.equals(expected));
   }

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -74,7 +74,7 @@ writeChunks(inputChunks, () => {
     // there was a chunk
     assert.ok(seen);
 
-    const expected = new Buffer(expectedChunks[i]);
+    const expected = Buffer.from(expectedChunks[i]);
     // it was what we expected
     assert.ok(seen.equals(expected));
   }

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -28,7 +28,7 @@ assert.throws(() => tls.createServer({sessionTimeout: 'abcd'}),
 assert.throws(() => tls.createServer({ticketKeys: 'abcd'}),
               /TypeError: Ticket keys must be a buffer/);
 
-assert.throws(() => tls.createServer({ticketKeys: new Buffer(0)}),
+assert.throws(() => tls.createServer({ticketKeys: Buffer.alloc(0)}),
               /TypeError: Ticket keys length must be 48 bytes/);
 
 assert.throws(() => tls.createSecurePair({}),

--- a/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+++ b/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
@@ -9,7 +9,7 @@ const zlib = require('zlib');
 let data = Buffer.concat([
   zlib.gzipSync('abc'),
   zlib.gzipSync('def'),
-  Buffer(10).fill(0)
+  Buffer.alloc(10)
 ]);
 
 assert.strictEqual(zlib.gunzipSync(data).toString(), 'abcdef');
@@ -28,8 +28,8 @@ zlib.gunzip(data, common.mustCall((err, result) => {
 data = Buffer.concat([
   zlib.gzipSync('abc'),
   zlib.gzipSync('def'),
-  Buffer([0x1f, 0x8b, 0xff, 0xff]),
-  Buffer(10).fill(0)
+  Buffer.from([0x1f, 0x8b, 0xff, 0xff]),
+  Buffer.alloc(10)
 ]);
 
 assert.throws(
@@ -49,7 +49,7 @@ zlib.gunzip(data, common.mustCall((err, result) => {
 data = Buffer.concat([
   zlib.gzipSync('abc'),
   zlib.gzipSync('def'),
-  Buffer([0x1f, 0x8b, 0xff, 0xff])
+  Buffer.from([0x1f, 0x8b, 0xff, 0xff])
 ]);
 
 assert.throws(

--- a/test/parallel/test-zlib-sync-no-event.js
+++ b/test/parallel/test-zlib-sync-no-event.js
@@ -10,7 +10,7 @@ const message = 'Come on, Fhqwhgads.';
 const zipper = new zlib.Gzip();
 zipper.on('close', shouldNotBeCalled);
 
-const buffer = new Buffer(message);
+const buffer = Buffer.from(message);
 const zipped = zipper._processChunk(buffer, zlib.Z_FINISH);
 
 const unzipper = new zlib.Gunzip();


### PR DESCRIPTION
In non-buffer tests, change usage of the Buffer constructor to one of
the recommended alternatives.

PR-URL: https://github.com/nodejs/node/pull/13649
Reviewed-By: Refael Ackermann <refack@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Tobias Nießen <tniessen@tnie.de>
Reviewed-By: Brian White <mscdex@mscdex.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
