### PR TITLE
[v8.x backport] build: allow enabling the --trace-maps flag in V8

### DIFF
--- a/configure
+++ b/configure
@@ -288,6 +288,11 @@ parser.add_option('--enable-d8',
     dest='enable_d8',
     help=optparse.SUPPRESS_HELP)  # Unsupported, undocumented.
 
+parser.add_option('--enable-trace-maps',
+    action='store_true',
+    dest='trace_maps',
+    help='Enable the --trace-maps flag in V8 (use at your own risk)')
+
 parser.add_option('--v8-options',
     action='store',
     dest='v8_options',
@@ -956,6 +961,7 @@ def configure_v8(o):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_snapshot'] = b(options.with_snapshot)
+  o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
   o['variables']['force_dynamic_crt'] = 1 if options.shared else 0

--- a/node.gyp
+++ b/node.gyp
@@ -1,6 +1,7 @@
 {
   'variables': {
     'v8_use_snapshot%': 'false',
+    'v8_trace_maps%': 0,
     'node_use_dtrace%': 'false',
     'node_use_lttng%': 'false',
     'node_use_etw%': 'false',


### PR DESCRIPTION
Backport of #14018 to v8.x

This can be useful for tracing map creation.

PR-URL: https://github.com/nodejs/node/pull/14018
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Refael Ackermann <refack@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
