### PR TITLE
async-hooks: add trace events to AsyncWrap

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -218,6 +218,16 @@ bool DomainExit(Environment* env, v8::Local<v8::Object> object) {
 
 
 static bool PreCallbackExecution(AsyncWrap* wrap, bool run_domain_cbs) {
+  switch (wrap->provider_type()) {
+#define V(PROVIDER)                                                           \
+    case AsyncWrap::PROVIDER_ ## PROVIDER:                                    \
+      TRACE_EVENT_NESTABLE_ASYNC_BEGIN0("node", #PROVIDER " cb",              \
+        static_cast<int64_t>(wrap->get_id()));                                \
+      break;
+    NODE_ASYNC_PROVIDER_TYPES(V)
+#undef V
+  }
+
   if (wrap->env()->using_domains() && run_domain_cbs) {
     bool is_disposed = DomainEnter(wrap->env(), wrap->object());
     if (is_disposed)
@@ -249,6 +259,16 @@ bool AsyncWrap::EmitBefore(Environment* env, double async_id) {
 
 
 static bool PostCallbackExecution(AsyncWrap* wrap, bool run_domain_cbs) {
+  switch (wrap->provider_type()) {
+#define V(PROVIDER)                                                           \
+    case AsyncWrap::PROVIDER_ ## PROVIDER:                                    \
+      TRACE_EVENT_NESTABLE_ASYNC_END0("node", #PROVIDER " cb",                \
+        static_cast<int64_t>(wrap->get_id()));                                \
+      break;
+    NODE_ASYNC_PROVIDER_TYPES(V)
+#undef V
+  }
+
   if (!AsyncWrap::EmitAfter(wrap->env(), wrap->get_id()))
     return false;
 
@@ -617,10 +637,29 @@ AsyncWrap::AsyncWrap(Environment* env,
 
   // Use AsyncReset() call to execute the init() callbacks.
   AsyncReset(silent);
+
+  switch (provider_type()) {
+#define V(PROVIDER)                                                           \
+    case PROVIDER_ ## PROVIDER:                                               \
+      TRACE_EVENT_NESTABLE_ASYNC_BEGIN0("node", #PROVIDER,                    \
+        static_cast<int64_t>(get_id()));                                      \
+      break;
+    NODE_ASYNC_PROVIDER_TYPES(V)
+#undef V
+  }
 }
 
 
 AsyncWrap::~AsyncWrap() {
+  switch (provider_type()) {
+#define V(PROVIDER)                                                           \
+    case PROVIDER_ ## PROVIDER:                                               \
+      TRACE_EVENT_NESTABLE_ASYNC_END0("node", #PROVIDER,                      \
+        static_cast<int64_t>(get_id()));                                      \
+      break;
+    NODE_ASYNC_PROVIDER_TYPES(V)
+#undef V
+  }
   PushBackDestroyId(env(), get_id());
 }
 
@@ -774,6 +813,9 @@ async_context EmitAsyncInit(Isolate* isolate,
     trigger_async_id  // trigger_async_id_
   };
 
+  TRACE_EVENT_NESTABLE_ASYNC_BEGIN0("node", "custom_event",
+    static_cast<int64_t>(context.async_id));
+
   // Run init hooks
   Local<String> type =
       String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized)
@@ -785,6 +827,8 @@ async_context EmitAsyncInit(Isolate* isolate,
 }
 
 void EmitAsyncDestroy(Isolate* isolate, async_context asyncContext) {
+  TRACE_EVENT_NESTABLE_ASYNC_END0("node", "custom_event",
+    static_cast<int64_t>(asyncContext.async_id));
   PushBackDestroyId(Environment::GetCurrent(isolate), asyncContext.async_id);
 }
 


### PR DESCRIPTION
This will allow trace event to record timing information for all
asynchronous operations that are observed by AsyncWrap.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async-hooks, tracing