### PR TITLE
[v6.x backport] cluster, dns, repl, tls, util: fix RegExp nits

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -954,7 +954,7 @@ function SNICallback(servername, callback) {
   var ctx;
 
   this.server._contexts.some(function(elem) {
-    if (servername.match(elem[0]) !== null) {
+    if (elem[0].test(servername)) {
       ctx = elem[1];
       return true;
     }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -298,14 +298,13 @@ function masterInit() {
     var workerEnv = util._extend({}, process.env);
     var execArgv = cluster.settings.execArgv.slice();
     var debugPort = 0;
+    var debugArgvRE = /^(--inspect|--debug|--debug-(brk|port))(=\d+)?$/;
 
     workerEnv = util._extend(workerEnv, env);
     workerEnv.NODE_UNIQUE_ID = '' + id;
 
     for (var i = 0; i < execArgv.length; i++) {
-      var match = execArgv[i].match(
-        /^(--inspect|--debug|--debug-(brk|port))(=\d+)?$/
-      );
+      var match = execArgv[i].match(debugArgvRE);
 
       if (match) {
         if (debugPort === 0) {

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -297,13 +297,15 @@ exports.setServers = function(servers) {
   // servers cares won't have any servers available for resolution
   const orig = cares.getServers();
   const newSet = [];
+  const IPv6RE = /\[(.*)\]/;
+  const addrSplitRE = /:\d+$/;
 
   servers.forEach((serv) => {
     var ipVersion = isIP(serv);
     if (ipVersion !== 0)
       return newSet.push([ipVersion, serv]);
 
-    const match = serv.match(/\[(.*)\](?::\d+)?/);
+    const match = serv.match(IPv6RE);
     // we have an IPv6 in brackets
     if (match) {
       ipVersion = isIP(match[1]);
@@ -311,7 +313,7 @@ exports.setServers = function(servers) {
         return newSet.push([ipVersion, match[1]]);
     }
 
-    const s = serv.split(/:\d+$/)[0];
+    const s = serv.split(addrSplitRE)[0];
     ipVersion = isIP(s);
 
     if (ipVersion !== 0)

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -861,6 +861,7 @@ function complete(line, callback) {
     const exts = Object.keys(this.context.require.extensions);
     var indexRe = new RegExp('^index(' + exts.map(regexpEscape).join('|') +
                              ')$');
+    var versionedFileNamesRe = /-\d+\.\d+/;
 
     completeOn = match[1];
     var subdir = match[2] || '';
@@ -879,7 +880,7 @@ function complete(line, callback) {
         name = files[f];
         ext = path.extname(name);
         base = name.slice(0, -ext.length);
-        if (base.match(/-\d+\.\d+(\.\d+)?/) || name === '.npm') {
+        if (versionedFileNamesRe.test(base) || name === '.npm') {
           // Exclude versioned names that 'npm' installs.
           continue;
         }
@@ -923,7 +924,7 @@ function complete(line, callback) {
   //   spam.eggs.<|>  # completions for 'spam.eggs' with filter ''
   //   foo<|>         # all scope vars with filter 'foo'
   //   foo.<|>        # completions for 'foo' with filter ''
-  } else if (line.length === 0 || line[line.length - 1].match(/\w|\.|\$/)) {
+  } else if (line.length === 0 || /\w|\.|\$/.test(line[line.length - 1])) {
     match = simpleExpressionRE.exec(line);
     if (line.length === 0 || match) {
       var expr;
@@ -1175,7 +1176,7 @@ REPLServer.prototype.memory = function memory(cmd) {
           self.lines.level.push({
             line: self.lines.length - 1,
             depth: depth,
-            isFunction: /\s*function\s*/.test(cmd)
+            isFunction: /\bfunction\b/.test(cmd)
           });
         } else if (depth < 0) {
           // going... up.

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,8 @@ const inspectDefaultOptions = Object.seal({
   breakLength: 60
 });
 
+const numbersOnlyRE = /^\d+$/;
+
 var Debug;
 var simdFormatters;
 
@@ -668,7 +670,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }
   keys.forEach(function(key) {
-    if (typeof key === 'symbol' || !key.match(/^\d+$/)) {
+    if (typeof key === 'symbol' || !numbersOnlyRE.test(key)) {
       output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                  key, true));
     }
@@ -687,7 +689,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
     output.push(`... ${remaining} more item${remaining > 1 ? 's' : ''}`);
   }
   for (const key of keys) {
-    if (typeof key === 'symbol' || !key.match(/^\d+$/)) {
+    if (typeof key === 'symbol' || !numbersOnlyRE.test(key)) {
       output.push(
           formatProperty(ctx, value, recurseTimes, visibleKeys, key, true));
     }
@@ -801,11 +803,11 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (name === undefined) {
-    if (array && key.match(/^\d+$/)) {
+    if (array && numbersOnlyRE.test(key)) {
       return str;
     }
     name = JSON.stringify('' + key);
-    if (name.match(/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/)) {
+    if (/^"([a-zA-Z_][a-zA-Z_0-9]*)"$/.test(name)) {
       name = name.substr(1, name.length - 2);
       name = ctx.stylize(name, 'name');
     } else {


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
cluster, dns, repl, tls, util

Backport of #13536

* Take RegExp creation out of cycles.
* Use test(), not match() in boolean context.
* Remove redundant RegExp parts.
