### PR TITLE
assert: move AssertionError to prevent lazy loading

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -27,6 +27,27 @@ const { objectToString } = require('internal/util');
 const { Buffer } = require('buffer');
 const errors = require('internal/errors');
 
+class AssertionError extends Error {
+  constructor(options) {
+    if (typeof options !== 'object' || options === null) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+    }
+    const message = options.message ||
+                    `${util.inspect(options.actual).slice(0, 128)} ` +
+                    `${options.operator} ` +
+                    util.inspect(options.expected).slice(0, 128);
+
+    super(message);
+    this.generatedMessage = !options.message;
+    this.name = 'AssertionError [ERR_ASSERTION]';
+    this.code = 'ERR_ASSERTION';
+    this.actual = options.actual;
+    this.expected = options.expected;
+    this.operator = options.operator;
+    Error.captureStackTrace(this, options.stackStartFunction);
+  }
+}
+
 // The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
@@ -45,7 +66,7 @@ const assert = module.exports = ok;
 // display purposes.
 
 function innerFail(actual, expected, message, operator, stackStartFunction) {
-  throw new errors.AssertionError({
+  throw new AssertionError({
     message,
     actual,
     expected,
@@ -75,7 +96,7 @@ assert.fail = fail;
 // new assert.AssertionError({ message: message,
 //                             actual: actual,
 //                             expected: expected });
-assert.AssertionError = errors.AssertionError;
+assert.AssertionError = AssertionError;
 
 
 // Pure assertion tests whether a value is truthy, as determined

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -40,28 +40,6 @@ function makeNodeError(Base) {
   };
 }
 
-class AssertionError extends Error {
-  constructor(options) {
-    if (typeof options !== 'object' || options === null) {
-      throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
-    }
-    const util = lazyUtil();
-    const message = options.message ||
-                    `${util.inspect(options.actual).slice(0, 128)} ` +
-                    `${options.operator} ` +
-                    util.inspect(options.expected).slice(0, 128);
-
-    super(message);
-    this.generatedMessage = !options.message;
-    this.name = 'AssertionError [ERR_ASSERTION]';
-    this.code = 'ERR_ASSERTION';
-    this.actual = options.actual;
-    this.expected = options.expected;
-    this.operator = options.operator;
-    Error.captureStackTrace(this, options.stackStartFunction);
-  }
-}
-
 function message(key, args) {
   const assert = lazyAssert();
   assert.strictEqual(typeof key, 'string');
@@ -90,7 +68,6 @@ module.exports = exports = {
   Error: makeNodeError(Error),
   TypeError: makeNodeError(TypeError),
   RangeError: makeNodeError(RangeError),
-  AssertionError,
   E // This is exported only to facilitate testing.
 };
 

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -1,6 +1,6 @@
 Exiting with code=1
 assert.js:*
-  throw new errors.AssertionError({
+  throw new AssertionError({
   ^
 
 AssertionError [ERR_ASSERTION]: 1 === 2


### PR DESCRIPTION
This prevents lazy loading util.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
assert
