### PR TITLE
doc: fix minor typo in cluster.md

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -191,7 +191,7 @@ added: v0.7.0
 
 Similar to the `cluster.on('message')` event, but specific to this worker.
 
-Within a worker, `process.on('message)` may also be used.
+Within a worker, `process.on('message')` may also be used.
 
 See [`process` event: `'message'`][].
 


### PR DESCRIPTION
Add a missing `'` to example code.

Fixes: https://github.com/nodejs/node/issues/14352

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
