### PR TITLE
test: add comments for whatwg-url tests

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -264,8 +264,8 @@ These imported tests will be wrapped like this:
 
 ```js
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -263,12 +263,12 @@ Some of the tests for the WHATWG URL implementation (named
 These imported tests will be wrapped like this:
 
 ```js
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 
 // Test code
 

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -264,7 +264,8 @@ These imported tests will be wrapped like this:
 
 ```js
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -263,7 +263,7 @@ Some of the tests for the WHATWG URL implementation (named
 These imported tests will be wrapped like this:
 
 ```js
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/fixtures/url-setter-tests.js
+++ b/test/fixtures/url-setter-tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/b30abaecf4/url/setters_tests.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/fixtures/url-setter-tests.js
+++ b/test/fixtures/url-setter-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/b30abaecf4/url/setters_tests.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/fixtures/url-setter-tests.js
+++ b/test/fixtures/url-setter-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/b30abaecf4/url/setters_tests.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -1,7 +1,7 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8df7c9c215/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8df7c9c215/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -1,6 +1,7 @@
 'use strict';
 
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8df7c9c215/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/fixtures/url-toascii.js
+++ b/test/fixtures/url-toascii.js
@@ -1,6 +1,7 @@
 'use strict';
 
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/fixtures/url-toascii.js
+++ b/test/fixtures/url-toascii.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/fixtures/url-toascii.js
+++ b/test/fixtures/url-toascii.js
@@ -1,7 +1,7 @@
 'use strict';
 
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -15,7 +15,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -15,8 +15,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -14,12 +14,12 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-tests'))
 };
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 function runURLConstructorTests() {
   // var setup = async_test("Loading data…")
   // setup.step(function() {

--- a/test/parallel/test-whatwg-url-constructor.js
+++ b/test/parallel/test-whatwg-url-constructor.js
@@ -14,7 +14,7 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-tests'))
 };
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -9,8 +9,8 @@ const URL = require('url').URL;
 const { test, assert_equals, assert_throws } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/historical.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -8,12 +8,12 @@ if (!common.hasIntl) {
 const URL = require('url').URL;
 const { test, assert_equals, assert_throws } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/historical.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 // var objects = [
 //   [function() { return window.location }, "location object"],
 //   [function() { return document.createElement("a") }, "a element"],

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -9,7 +9,8 @@ const URL = require('url').URL;
 const { test, assert_equals, assert_throws } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/historical.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-historical.js
+++ b/test/parallel/test-whatwg-url-historical.js
@@ -8,7 +8,7 @@ if (!common.hasIntl) {
 const URL = require('url').URL;
 const { test, assert_equals, assert_throws } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/historical.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -14,8 +14,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -14,7 +14,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -13,7 +13,7 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-tests'))
 };
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-origin.js
+++ b/test/parallel/test-whatwg-url-origin.js
@@ -13,12 +13,12 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-tests'))
 };
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-origin.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 function runURLOriginTests() {
   // var setup = async_test("Loading data…")
   // setup.step(function() {

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -6,8 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -5,12 +5,12 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams();
     params.append('a', 'b');

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -6,7 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-append.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -8,7 +8,7 @@ const {
   assert_false, assert_throws, assert_array_equals
 } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/54c3502d7b/url/urlsearchparams-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -8,13 +8,13 @@ const {
   assert_false, assert_throws, assert_array_equals
 } = require('../common/wpt');
 
-/* eslint-disable */
-var params;  // Strict mode fix for WPT.
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/54c3502d7b/url/urlsearchparams-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
+var params;  // Strict mode fix for WPT.
 test(function() {
     var params = new URLSearchParams();
     assert_equals(params + '', '');

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -10,7 +10,8 @@ const {
 
 /* eslint-disable */
 var params;  // Strict mode fix for WPT.
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/54c3502d7b/url/urlsearchparams-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-searchparams-constructor.js
@@ -10,8 +10,8 @@ const {
 
 /* eslint-disable */
 var params;  // Strict mode fix for WPT.
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/54c3502d7b/url/urlsearchparams-constructor.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -7,7 +7,8 @@ const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-delete.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -6,12 +6,12 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-delete.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams('a=b&c=d');
     params.delete('a');

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -6,7 +6,7 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-delete.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -7,8 +7,8 @@ const { test, assert_equals, assert_true, assert_false } =
   require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-delete.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -6,13 +6,13 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals, assert_unreached } =
   require('../common/wpt');
 
-/* eslint-disable */
-var i;  // Strict mode fix for WPT.
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/a8b2b1e/url/urlsearchparams-foreach.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
+var i;  // Strict mode fix for WPT.
 test(function() {
     var params = new URLSearchParams('a=1&b=2&c=3');
     var keys = [];

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -8,7 +8,8 @@ const { test, assert_array_equals, assert_unreached } =
 
 /* eslint-disable */
 var i;  // Strict mode fix for WPT.
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/a8b2b1e/url/urlsearchparams-foreach.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -6,7 +6,7 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals, assert_unreached } =
   require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/a8b2b1e/url/urlsearchparams-foreach.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -8,8 +8,8 @@ const { test, assert_array_equals, assert_unreached } =
 
 /* eslint-disable */
 var i;  // Strict mode fix for WPT.
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/a8b2b1e/url/urlsearchparams-foreach.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -6,8 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-get.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -5,12 +5,12 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-get.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams('a=b&c=d');
     assert_equals(params.get('a'), 'b');

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-get.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -6,7 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-get.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -7,8 +7,8 @@ const { test, assert_equals, assert_true, assert_array_equals } =
   require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-getall.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -7,7 +7,8 @@ const { test, assert_equals, assert_true, assert_array_equals } =
   require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-getall.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -6,12 +6,12 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true, assert_array_equals } =
   require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-getall.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams('a=b&c=d');
     assert_array_equals(params.getAll('a'), ['b']);

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -6,7 +6,7 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true, assert_array_equals } =
   require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-getall.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -6,7 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_false, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-has.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -5,12 +5,12 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_false, assert_true } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-has.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams('a=b&c=d');
     assert_true(params.has('a'));

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_false, assert_true } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-has.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -6,8 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_false, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-has.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -6,7 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-set.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -5,12 +5,12 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-set.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams('a=b&c=d');
     params.set('a', 'B');

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -6,8 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-set.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals, assert_true } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-set.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -5,7 +5,8 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/5903e00e77e85f8bcb21c73d1d7819fcd04763bd/url/urlsearchparams-sort.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -4,12 +4,12 @@ require('../common');
 const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/5903e00e77e85f8bcb21c73d1d7819fcd04763bd/url/urlsearchparams-sort.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 [
   {
     "input": "z=b&a=b&z=a&a=a",

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -5,8 +5,8 @@ const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/5903e00e77e85f8bcb21c73d1d7819fcd04763bd/url/urlsearchparams-sort.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-sort.js
+++ b/test/parallel/test-whatwg-url-searchparams-sort.js
@@ -4,7 +4,7 @@ require('../common');
 const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/5903e00e77e85f8bcb21c73d1d7819fcd04763bd/url/urlsearchparams-sort.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -5,12 +5,12 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(function() {
     var params = new URLSearchParams();
     params.append('a', 'b c');

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -6,7 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -6,8 +6,8 @@ const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/urlsearchparams-stringifier.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -18,8 +18,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -17,12 +17,12 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-setter-tests'))
 };
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 function startURLSettersTests() {
 //   var setup = async_test("Loading data…")
 //   setup.step(function() {

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -18,7 +18,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -17,7 +17,7 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-setter-tests'))
 };
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/8791bed/url/url-setters.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -14,7 +14,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -14,8 +14,8 @@ const request = {
 };
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -13,12 +13,12 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-toascii'))
 };
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 // async_test(t => {
 //   const request = new XMLHttpRequest()
 //   request.open("GET", "toascii.json")

--- a/test/parallel/test-whatwg-url-toascii.js
+++ b/test/parallel/test-whatwg-url-toascii.js
@@ -13,7 +13,7 @@ const request = {
   response: require(path.join(common.fixturesDir, 'url-toascii'))
 };
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/4839a0a804/url/toascii.window.js
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -4,12 +4,12 @@ require('../common');
 const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 
-/* eslint-disable */
 /* The following tests are copied from WPT, modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
+/* eslint-disable */
 test(() => {
   const a = new URL("https://example.com/")
   assert_equals(JSON.stringify(a), "\"https://example.com/\"")

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -5,8 +5,8 @@ const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* The following tests are copied from WPT, modifications to them should be upstreamed first.
-   Refs:
+/* The following tests are copied from WPT, modifications to them should be
+   upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -4,7 +4,7 @@ require('../common');
 const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 
-/* The following tests are copied from WPT, modifications to them should be
+/* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/test/parallel/test-whatwg-url-tojson.js
+++ b/test/parallel/test-whatwg-url-tojson.js
@@ -5,7 +5,8 @@ const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 
 /* eslint-disable */
-/* WPT Refs:
+/* The following tests are copied from WPT, modifications to them should be upstreamed first.
+   Refs:
    https://github.com/w3c/web-platform-tests/blob/02585db/url/url-tojson.html
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */


### PR DESCRIPTION
Added comments to whatwg-url tests to document that they should not be modified until modifications are made upstream as per guidelines for [Web Platform Tests](https://github.com/nodejs/node/blob/master/doc/guides/writing-tests.md#web-platform-tests)

Fixes: https://github.com/nodejs/node/issues/12793

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
- [x] _update:_ `make lint`

##### Affected core subsystem(s)
test, url