### PR TITLE
http: disable OutgoingMessage pipe method

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -891,7 +891,7 @@ OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
 
 OutgoingMessage.prototype.pipe = function pipe() {
   // OutgoingMessage should be write-only. Piping from it is disabled. 
-  throw new Error('Pipe from a write-only stream');
+  this.emit('error', new Error('Cannot pipe, not readable'));
 };
 
 module.exports = {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -889,6 +889,10 @@ OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
   this.flushHeaders();
 }, 'OutgoingMessage.flush is deprecated. Use flushHeaders instead.', 'DEP0001');
 
+OutgoingMessage.prototype.pipe = function pipe() {
+  // OutgoingMessage should be write-only. Piping from it is disabled. 
+  throw new Error('Pipe from a write-only stream');
+};
 
 module.exports = {
   OutgoingMessage

--- a/test/parallel/test-outgoing-message-pipe.js
+++ b/test/parallel/test-outgoing-message-pipe.js
@@ -1,0 +1,15 @@
+'use strict';
+const assert = require('assert');
+const common = require('../common');
+const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
+
+// Verify that an error is thrown upon a call to `OutgoingMessage.pipe`.
+
+const outgoingMessage = new OutgoingMessage();
+assert.throws(
+  () => { outgoingMessage.pipe(outgoingMessage); },
+  (err) => {
+    return ((err instanceof Error) && /Pipe from a write-only stream/.test(err));
+  },
+  "OutgoingMessage.pipe should throw an error"
+);

--- a/test/parallel/test-outgoing-message-pipe.js
+++ b/test/parallel/test-outgoing-message-pipe.js
@@ -7,9 +7,9 @@ const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
 const outgoingMessage = new OutgoingMessage();
 assert.throws(
-  () => { outgoingMessage.pipe(outgoingMessage); },
+  common.mustCall(() => { outgoingMessage.pipe(outgoingMessage); }),
   (err) => {
-    return ((err instanceof Error) && /Pipe from a write-only stream/.test(err));
+    return ((err instanceof Error) && /Cannot pipe, not readable/.test(err));
   },
-  "OutgoingMessage.pipe should throw an error"
+  'OutgoingMessage.pipe should throw an error'
 );


### PR DESCRIPTION
OutgoingMessage should be a write-only stream, and it shouldn't
be piped. This commit disables the `pipe` method by throwing
an exception (if this method is called).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http

#### Additional data
As was suggested here: https://github.com/nodejs/node/pull/14024, I disabled the use of the method `pipe` in `OutgoingMessage`. `OutgoingMessage` should be write-only, and shouldn't be piped.