### PR TITLE
util: use magenta;bold

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -224,7 +224,7 @@ inspect.colors = Object.assign(Object.create(null), {
   'blue': [34, 39],
   'cyan': [36, 39],
   'green': [32, 39],
-  'magenta': [35, 39],
+  'magenta': ['35;1', '39;22'],
   'red': [31, 39],
   'yellow': [33, 39]
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -224,9 +224,10 @@ inspect.colors = Object.assign(Object.create(null), {
   'blue': [34, 39],
   'cyan': [36, 39],
   'green': [32, 39],
-  'magenta': ['35;1', '39;22'],
+  'magenta': [35, 39],
   'red': [31, 39],
-  'yellow': [33, 39]
+  'yellow': [33, 39],
+  'magenta;bold': ['35;1', '39;22']
 });
 
 // Don't use 'blue' not visible on cmd.exe
@@ -242,6 +243,10 @@ inspect.styles = Object.assign(Object.create(null), {
   // "name": intentionally not styling
   'regexp': 'red'
 });
+// Magenta has problems with the deafult configuration of Powershell
+// Ref: https://github.com/nodejs/node/issues/14243
+if (process.platform === 'win32')
+  inspect.styles.date = 'magenta;bold';
 
 const customInspectSymbol = internalUtil.customInspectSymbol;
 


### PR DESCRIPTION
* Default Powershell on Windows setting remap
  ANSI magenta to the color of the background

Microsoft will not/can not change the palette remapping on all installed instances of Windows, but we can use magenta;bold instead of regular magenta 🤷‍♂️ 

Fixes: #14243

![image](https://user-images.githubusercontent.com/96947/28349904-8463cb84-6c13-11e7-85d8-3838443f034a.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl,util
