### PR TITLE
test: fix flaky test-net-write-after-close

### DIFF
--- a/test/parallel/test-net-write-after-close.js
+++ b/test/parallel/test-net-write-after-close.js
@@ -21,24 +21,31 @@
 
 'use strict';
 const common = require('../common');
+
 const net = require('net');
 
+let serverSocket;
+
 const server = net.createServer(common.mustCall(function(socket) {
+  serverSocket = socket;
+
   socket.resume();
 
   socket.on('error', common.mustCall(function(error) {
-    console.error('got error, closing server', error);
+    console.error('received error as expected, closing server', error);
     server.close();
   }));
-
-  setTimeout(common.mustCall(function() {
-    console.error('about to try to write');
-    socket.write('test', common.mustCall());
-  }), 250);
 }));
 
 server.listen(0, function() {
   const client = net.connect(this.address().port, function() {
+    // cliend.end() will close both the readable and writable side
+    // of the duplex because allowHalfOpen defaults to false.
+    // Then 'end' will be emitted when it receives a FIN packet from
+    // the other side.
+    client.on('end', common.mustCall(() => {
+      serverSocket.write('test', common.mustCall());
+    }));
     client.end();
   });
 });


### PR DESCRIPTION
Replace 250ms timer with event-based logic to make test robust.

Fixes: https://github.com/nodejs/node/issues/13597

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net