### PR TITLE
tools: add download testing

### DIFF
--- a/tools/download-test.sh
+++ b/tools/download-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -z ${NODE_VERSION} ]; then
+  echo "NODE_VERSION is undefined! Please declare NODE_VERSION"
+  exit 1
+fi
+# Remove old files
+rm -r nodejs.org || true
+
+# Scrape the download server
+wget -r --no-parent http://nodejs.org/dist/v${NODE_VERSION}/
+
+cat nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt | while read line
+do
+   sha=$(echo "${line}" | awk '{print $1}')
+   file=$(echo "${line}" | awk '{print $2}')
+   echo "Checking shasum for $file"
+   remoteSHA=$(shasum -a 256 "nodejs.org/dist/v${NODE_VERSION}/${file}" | awk '{print $1}')
+   if [ ${remoteSHA} != ${sha} ]; then
+     echo "Error - SHASUMS256 does not match for ${file}"
+     echo "Expected - ${sha}"
+     echo "Found - ${remoteSHA}"
+     return 1
+   else
+     echo "Pass - SHASUMS256 for ${file} is correct"
+   fi
+done


### PR DESCRIPTION
This script will take an environment variable (NODE_VERSION) and
download all of the files from `http://nodejs.org/dist/v<NODE_VERSION>/`
It will then loop through the `SHASUMS256.txt` file to check if the
SHA256SUMS match up. Initial issue here:
https://github.com/nodejs/build/issues/513

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools