### PR TITLE
n-api: implement promise

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -218,6 +218,14 @@ V8EscapableHandleScopeFromJsEscapableHandleScope(
 static_assert(sizeof(v8::Local<v8::Value>) == sizeof(napi_value),
   "Cannot convert between v8::Local<v8::Value> and napi_value");
 
+napi_deferred JsDeferredFromV8Persistent(v8::Persistent<v8::Value>* local) {
+  return reinterpret_cast<napi_deferred>(local);
+}
+
+v8::Persistent<v8::Value>* V8PersistentFromJsDeferred(napi_deferred local) {
+  return reinterpret_cast<v8::Persistent<v8::Value>*>(local);
+}
+
 napi_value JsValueFromV8LocalValue(v8::Local<v8::Value> local) {
   return reinterpret_cast<napi_value>(*local);
 }
@@ -772,6 +780,33 @@ napi_status Unwrap(napi_env env,
   *result = unwrappedValue.As<v8::External>()->Value();
 
   return napi_ok;
+}
+
+napi_status ConcludeDeferred(napi_env env,
+                             napi_deferred deferred,
+                             napi_value result,
+                             bool is_resolved) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Context> context = env->isolate->GetCurrentContext();
+  v8::Persistent<v8::Value>* deferred_ref =
+      V8PersistentFromJsDeferred(deferred);
+  v8::Local<v8::Value> v8_deferred =
+      v8::Local<v8::Value>::New(env->isolate, *deferred_ref);
+
+  auto v8_resolver = v8::Local<v8::Promise::Resolver>::Cast(v8_deferred);
+
+  v8::Maybe<bool> success = is_resolved ?
+      v8_resolver->Resolve(context, v8impl::V8LocalValueFromJsValue(result)) :
+      v8_resolver->Reject(context, v8impl::V8LocalValueFromJsValue(result));
+
+  deferred_ref->Reset();
+  delete deferred_ref;
+
+  RETURN_STATUS_IF_FALSE(env, success.FromMaybe(false), napi_generic_failure);
+
+  return GET_RETURN_STATUS(env);
 }
 
 }  // end of namespace v8impl
@@ -3329,6 +3364,49 @@ napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
   uvimpl::Work* w = reinterpret_cast<uvimpl::Work*>(work);
 
   CALL_UV(env, uv_cancel(reinterpret_cast<uv_req_t*>(w->Request())));
+
+  return napi_clear_last_error(env);
+}
+
+NAPI_EXTERN napi_status napi_create_promise(napi_env env,
+                                            napi_deferred* deferred,
+                                            napi_value* promise) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, deferred);
+  CHECK_ARG(env, promise);
+
+  auto maybe = v8::Promise::Resolver::New(env->isolate->GetCurrentContext());
+  CHECK_MAYBE_EMPTY(env, maybe, napi_generic_failure);
+
+  auto v8_resolver = maybe.ToLocalChecked();
+  auto v8_deferred = new v8::Persistent<v8::Value>();
+  v8_deferred->Reset(env->isolate, v8_resolver);
+
+  *deferred = v8impl::JsDeferredFromV8Persistent(v8_deferred);
+  *promise = v8impl::JsValueFromV8LocalValue(v8_resolver->GetPromise());
+  return GET_RETURN_STATUS(env);
+}
+
+NAPI_EXTERN napi_status napi_resolve_deferred(napi_env env,
+                                              napi_deferred deferred,
+                                              napi_value resolution) {
+  return v8impl::ConcludeDeferred(env, deferred, resolution, true);
+}
+
+NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
+                                             napi_deferred deferred,
+                                             napi_value resolution) {
+  return v8impl::ConcludeDeferred(env, deferred, resolution, false);
+}
+
+NAPI_EXTERN napi_status napi_is_promise(napi_env env,
+                                        napi_value promise,
+                                        bool* is_promise) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, promise);
+  CHECK_ARG(env, is_promise);
+
+  *is_promise = v8impl::V8LocalValueFromJsValue(promise)->IsPromise();
 
   return napi_clear_last_error(env);
 }

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -543,6 +543,20 @@ NAPI_EXTERN
 napi_status napi_get_node_version(napi_env env,
                                   const napi_node_version** version);
 
+// Promises
+NAPI_EXTERN napi_status napi_create_promise(napi_env env,
+                                            napi_deferred* deferred,
+                                            napi_value* promise);
+NAPI_EXTERN napi_status napi_resolve_deferred(napi_env env,
+                                              napi_deferred deferred,
+                                              napi_value resolution);
+NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
+                                             napi_deferred deferred,
+                                             napi_value rejection);
+NAPI_EXTERN napi_status napi_is_promise(napi_env env,
+                                        napi_value promise,
+                                        bool* is_promise);
+
 EXTERN_C_END
 
 #endif  // SRC_NODE_API_H_

--- a/src/node_api_types.h
+++ b/src/node_api_types.h
@@ -17,6 +17,7 @@ typedef struct napi_handle_scope__ *napi_handle_scope;
 typedef struct napi_escapable_handle_scope__ *napi_escapable_handle_scope;
 typedef struct napi_callback_info__ *napi_callback_info;
 typedef struct napi_async_work__ *napi_async_work;
+typedef struct napi_deferred__ *napi_deferred;
 
 typedef enum {
   napi_default = 0,

--- a/test/addons-napi/test_promise/binding.gyp
+++ b/test/addons-napi/test_promise/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_promise",
+      "sources": [ "test_promise.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../../common');
+const test_promise = require(`./build/${common.buildType}/test_promise`);
+const assert = require('assert');
+
+let expected_result, promise;
+
+// A resolution
+expected_result = 42;
+promise = test_promise.createPromise();
+promise.then(
+  common.mustCall(function(result) {
+    assert.strictEqual(result, expected_result,
+                       'promise resolved as expected');
+  }),
+  common.mustNotCall());
+test_promise.concludeCurrentPromise(expected_result, true);
+
+// A rejection
+expected_result = 'It\'s not you, it\'s me.';
+promise = test_promise.createPromise();
+promise.then(
+  common.mustNotCall(),
+  common.mustCall(function(result) {
+    assert.strictEqual(result, expected_result,
+                       'promise rejected as expected');
+  }));
+test_promise.concludeCurrentPromise(expected_result, false);
+
+// Chaining
+promise = test_promise.createPromise();
+promise.then(
+  common.mustCall(function(result) {
+    assert.strictEqual(result, 'chained answer',
+                       'resolving with a promise chains properly');
+  }),
+  common.mustNotCall());
+test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
+
+assert.strictEqual(test_promise.isPromise(promise), true,
+                   'natively created promise is recognized as a promise');
+
+assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true,
+                   'Promise created with JS is recognized as a promise');
+
+assert.strictEqual(test_promise.isPromise(2.4), false,
+                   'Number is recognized as not a promise');
+
+assert.strictEqual(test_promise.isPromise('I promise!'), false,
+                   'String is recognized as not a promise');
+
+assert.strictEqual(test_promise.isPromise(undefined), false,
+                   'undefined is recognized as not a promise');
+
+assert.strictEqual(test_promise.isPromise(null), false,
+                   'null is recognized as not a promise');
+
+assert.strictEqual(test_promise.isPromise({}), false,
+                   'an object is recognized as not a promise');

--- a/test/addons-napi/test_promise/test_promise.c
+++ b/test/addons-napi/test_promise/test_promise.c
@@ -1,0 +1,60 @@
+#include <node_api.h>
+#include "../common.h"
+
+napi_deferred deferred = NULL;
+
+napi_value createPromise(napi_env env, napi_callback_info info) {
+  napi_value promise;
+
+  // We do not overwrite an existing deferred.
+  if (deferred != NULL) {
+    return NULL;
+  }
+
+  NAPI_CALL(env, napi_create_promise(env, &deferred, &promise));
+
+  return promise;
+}
+
+napi_value concludeCurrentPromise(napi_env env, napi_callback_info info) {
+  napi_value argv[2];
+  size_t argc = 2;
+  bool resolution;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &resolution));
+  if (resolution) {
+    NAPI_CALL(env, napi_resolve_deferred(env, deferred, argv[0]));
+  } else {
+    NAPI_CALL(env, napi_reject_deferred(env, deferred, argv[0]));
+  }
+
+  deferred = NULL;
+
+  return NULL;
+}
+
+napi_value isPromise(napi_env env, napi_callback_info info) {
+  napi_value promise, result;
+  size_t argc = 1;
+  bool is_promise;
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &promise, NULL, NULL));
+  NAPI_CALL(env, napi_is_promise(env, promise, &is_promise));
+  NAPI_CALL(env, napi_get_boolean(env, is_promise, &result));
+
+  return result;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("createPromise", createPromise),
+    DECLARE_NAPI_PROPERTY("concludeCurrentPromise", concludeCurrentPromise),
+    DECLARE_NAPI_PROPERTY("isPromise", isPromise),
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
Promise is implemented as a pair of objects. `napi_create_promise()`
returns both a JavaScript promise and a "deferred" in its out-params.
The deferred is linked to the promise such that the deferred can be
passed to `napi_conclude_deferred()` to rejct/resolve the promise. The
deferred is a valid JavaScript value, but it is a shell object offering
no useful JavaScript functionality. In contrast, the promise returned
by `napi_create_promise()` is a full-fledged native JavaScript Promise
which can be used for chaining in JavaScript.

`napi_is_promise()` can be used to check if a `napi_value` is a native
promise - that is, a promise created by the underlying engine, rather
than a pure JS implementation of a promise.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api