### PR TITLE
doc: replace dead link in v8 module

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -407,4 +407,4 @@ A subclass of [`Deserializer`][] corresponding to the format written by
 [V8]: https://developers.google.com/v8/
 [`vm.Script`]: vm.html#vm_new_vm_script_code_options
 [here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md
-[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-5.0/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4
+[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-6.10/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -407,4 +407,4 @@ A subclass of [`Deserializer`][] corresponding to the format written by
 [V8]: https://developers.google.com/v8/
 [`vm.Script`]: vm.html#vm_new_vm_script_code_options
 [here]: https://github.com/thlorenz/v8-flags/blob/master/flags-0.11.md
-[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-6.10/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4
+[`GetHeapSpaceStatistics`]: https://v8docs.nodesource.com/node-8.0/d5/dda/classv8_1_1_isolate.html#ac673576f24fdc7a33378f8f57e1d13a4


### PR DESCRIPTION
Identified a dead link to the V8 `GetHeapSpaceStatistics()` function on the v8 module documentation page. I updated the link to the version from the `6.10` version of the V8 docs, but could easily update it to the `8.0` version if desired, for some reason.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
**doc**
