### PR TITLE
test: fix flaky http(s)-set-timeout-server tests

### DIFF
--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -183,8 +183,7 @@ test(function fastTimeout(cb) {
 
   const server = http.createServer(common.mustCall((req, res) => {
     req.on('timeout', common.mustNotCall());
-    res.on('timeout', common.mustNotCall());
-    res.end();
+    res.end(() => { res.on('timeout', common.mustNotCall()); });
     connectionHandlerInvoked = true;
     invokeCallbackIfDone();
   }));

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -152,6 +152,7 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
+  // Test that the an idle connection invokes the timeout callback.
   const server = http.createServer();
   const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
@@ -165,6 +166,7 @@ test(function idleTimeout(cb) {
       allowHalfOpen: true,
     };
     const c = net.connect(options, () => {
+      // ECONNRESET could happen on a heavily-loaded server.
       c.on('error', (e) => {
         if (e.message !== 'read ECONNRESET')
           throw e;

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -122,11 +122,14 @@ test(function serverResponseTimeoutWithPipeline(cb) {
   const server = http.createServer((req, res) => {
     if (req.url === '/2')
       secReceived = true;
+    if (req.url === '/1') {
+      res.end();
+      return;
+    }
     const s = res.setTimeout(50, () => {
       caughtTimeout += req.url;
     });
     assert.ok(s instanceof http.OutgoingMessage);
-    if (req.url === '/1') res.end();
   });
   server.on('timeout', common.mustCall((socket) => {
     if (secReceived) {

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -162,6 +162,10 @@ test(function idleTimeout(cb) {
       allowHalfOpen: true,
     };
     const c = net.connect(options, () => {
+      c.on('error', (e) => {
+        if (e.message !== 'read ECONNRESET')
+          throw e;
+      });
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       // Keep-Alive
     });

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -183,7 +183,7 @@ test(function fastTimeout(cb) {
 
   const server = http.createServer(common.mustCall((req, res) => {
     req.on('timeout', common.mustNotCall());
-    res.end(() => { res.on('timeout', common.mustNotCall()); });
+    res.end();
     connectionHandlerInvoked = true;
     invokeCallbackIfDone();
   }));

--- a/test/parallel/test-http-set-timeout-server.js
+++ b/test/parallel/test-http-set-timeout-server.js
@@ -42,10 +42,7 @@ function run() {
 }
 
 test(function serverTimeout(cb) {
-  const server = http.createServer((req, res) => {
-    // Do nothing. We should get a timeout event.
-    // Might not be invoked. Do not wrap in common.mustCall().
-  });
+  const server = http.createServer();
   server.listen(common.mustCall(() => {
     const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
@@ -152,12 +149,7 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
-  // Do not wrap the callback in common.mustCall(). It might not be invoked.
-  const server = http.createServer((req, res) => {
-    req.on('timeout', common.mustNotCall());
-    res.on('timeout', common.mustNotCall());
-    res.end();
-  });
+  const server = http.createServer();
   const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
     server.close();

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -184,6 +184,10 @@ test(function idleTimeout(cb) {
       rejectUnauthorized: false
     };
     const c = tls.connect(options, () => {
+      c.on('error', (e) => {
+        if (e.message !== 'read ECONNRESET')
+          throw e;
+      });
       c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
       // Keep-Alive
     });

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -175,17 +175,57 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
-  const server = https.createServer(
-    serverOptions,
-    common.mustCall((req, res) => {
-      req.on('timeout', common.mustNotCall());
-      res.on('timeout', common.mustNotCall());
-      res.end();
-    }));
+  // Do not wrap the callback in common.mustCall(). It might not be invoked.
+  const server = https.createServer(serverOptions, (req, res) => {
+    req.on('timeout', common.mustNotCall());
+    res.on('timeout', common.mustNotCall());
+    res.end();
+  });
   const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
     server.close();
     cb();
+  }));
+  assert.ok(s instanceof https.Server);
+  server.listen(common.mustCall(() => {
+    const options = {
+      port: server.address().port,
+      allowHalfOpen: true,
+      rejectUnauthorized: false
+    };
+    const c = tls.connect(options, () => {
+      c.write('GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n');
+      // Keep-Alive
+    });
+  }));
+});
+
+test(function fastTimeout(cb) {
+  let connectionHandlerInvoked = false;
+  let timeoutHandlerInvoked = false;
+  let connectionSocket;
+
+  function invokeCallbackIfDone() {
+    if (connectionHandlerInvoked && timeoutHandlerInvoked) {
+      connectionSocket.destroy();
+      server.close();
+      cb();
+    }
+  }
+
+  const server = https.createServer(serverOptions, common.mustCall(
+    (req, res) => {
+      req.on('timeout', common.mustNotCall());
+      res.on('timeout', common.mustNotCall());
+      res.end();
+      connectionHandlerInvoked = true;
+      invokeCallbackIfDone();
+    }
+  ));
+  const s = server.setTimeout(1, common.mustCall((socket) => {
+    connectionSocket = socket;
+    timeoutHandlerInvoked = true;
+    invokeCallbackIfDone();
   }));
   assert.ok(s instanceof https.Server);
   server.listen(common.mustCall(() => {

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -173,6 +173,7 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
+  // Test that the an idle connection invokes the timeout callback.
   const server = https.createServer(serverOptions);
   const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
@@ -187,6 +188,7 @@ test(function idleTimeout(cb) {
       rejectUnauthorized: false
     };
     const c = tls.connect(options, () => {
+      // ECONNRESET could happen on a heavily-loaded server.
       c.on('error', (e) => {
         if (e.message !== 'read ECONNRESET')
           throw e;
@@ -198,6 +200,7 @@ test(function idleTimeout(cb) {
 });
 
 test(function fastTimeout(cb) {
+  // Test that the socket timeout fires but no timeout fires for the request.
   let connectionHandlerInvoked = false;
   let timeoutHandlerInvoked = false;
   let connectionSocket;

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -142,11 +142,14 @@ test(function serverResponseTimeoutWithPipeline(cb) {
   const server = https.createServer(serverOptions, (req, res) => {
     if (req.url === '/2')
       secReceived = true;
+    if (req.url === '/1') {
+      res.end();
+      return;
+    }
     const s = res.setTimeout(50, () => {
       caughtTimeout += req.url;
     });
     assert.ok(s instanceof http.OutgoingMessage);
-    if (req.url === '/1') res.end();
   });
   server.on('timeout', common.mustCall((socket) => {
     if (secReceived) {

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -206,8 +206,7 @@ test(function fastTimeout(cb) {
   const server = https.createServer(serverOptions, common.mustCall(
     (req, res) => {
       req.on('timeout', common.mustNotCall());
-      res.on('timeout', common.mustNotCall());
-      res.end();
+      res.end(() => { res.on('timeout', common.mustNotCall()); });
       connectionHandlerInvoked = true;
       invokeCallbackIfDone();
     }

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -52,12 +52,7 @@ function run() {
 }
 
 test(function serverTimeout(cb) {
-  const server = https.createServer(
-    serverOptions,
-    (req, res) => {
-      // Do nothing. We should get a timeout event.
-      // Might not be invoked. Do not wrap in common.mustCall().
-    });
+  const server = https.createServer(serverOptions);
   server.listen(common.mustCall(() => {
     const s = server.setTimeout(50, common.mustCall((socket) => {
       socket.destroy();
@@ -175,12 +170,7 @@ test(function serverResponseTimeoutWithPipeline(cb) {
 });
 
 test(function idleTimeout(cb) {
-  // Do not wrap the callback in common.mustCall(). It might not be invoked.
-  const server = https.createServer(serverOptions, (req, res) => {
-    req.on('timeout', common.mustNotCall());
-    res.on('timeout', common.mustNotCall());
-    res.end();
-  });
+  const server = https.createServer(serverOptions);
   const s = server.setTimeout(50, common.mustCall((socket) => {
     socket.destroy();
     server.close();

--- a/test/parallel/test-https-set-timeout-server.js
+++ b/test/parallel/test-https-set-timeout-server.js
@@ -206,7 +206,7 @@ test(function fastTimeout(cb) {
   const server = https.createServer(serverOptions, common.mustCall(
     (req, res) => {
       req.on('timeout', common.mustNotCall());
-      res.end(() => { res.on('timeout', common.mustNotCall()); });
+      res.end();
       connectionHandlerInvoked = true;
       invokeCallbackIfDone();
     }


### PR DESCRIPTION
The tests include a callback that might not be invoked but is wrapped in
common.mustCall(). Remove the common.mustCall() wrapper and add a
comment explaining that it should not be added.

Fixes: https://github.com/nodejs/node/issues/11768

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http https