### PR TITLE
N api dataview

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1339,7 +1339,7 @@ added: REPLACEME
 
 ```C
 napi_status napi_create_dataview(napi_env env,
-                                 size_t length,
+                                 size_t byte_length,
                                  napi_value arraybuffer,
                                  size_t byte_offset,
                                  napi_value* result)
@@ -1359,6 +1359,9 @@ This API creates a JavaScript DataView object over an existing ArrayBuffer.
 Dataview objects provide an array-like view over an underlying data buffer,
 but one which allows items of different size and type in the ArrayBuffer.
 
+It's required that (byte_length * size_of_element) + byte_offset
+should be <= the size in bytes of the array passed in. If not, a RangeError
+exception is raised.
 
 JavaScript DataView Objects are described in
 [Section 24.3][] of the ECMAScript Language Specification.
@@ -1594,7 +1597,7 @@ added: REPLACEME
 ```C
 napi_status napi_get_dataview_info(napi_env env,
                                    napi_value dataview,
-                                   size_t* bytelength,
+                                   size_t* byte_length,
                                    void** data,
                                    napi_value* arraybuffer,
                                    size_t* byte_offset)
@@ -1603,7 +1606,7 @@ napi_status napi_get_dataview_info(napi_env env,
 - `[in] env`: The environment that the API is invoked under.
 - `[in] dataview`: `napi_value` representing the DataView whose
   properties to query.
-- `[out] bytelength`: Number of bytes in the DataView.
+- `[out] byte_length`: Number of bytes in the DataView.
 - `[out] data`: The data buffer underlying the DataView.
 - `[out] arraybuffer`: ArrayBuffer underlying the DataView.
 - `[out] byte_offset`: The byte offset within the data buffer from which

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1331,6 +1331,41 @@ JavaScript TypedArray Objects are described in
 [Section 22.2](https://tc39.github.io/ecma262/#sec-typedarray-objects)
 of the ECMAScript Language Specification.
 
+
+#### *napi_create_typedarray*
+<!-- YAML
+added: v8.0.0
+-->
+```C
+napi_status napi_create_dataview(napi_env env,
+                                   size_t length,
+                                   napi_value arraybuffer,
+                                   size_t byte_offset,
+                                   napi_value* result) {
+
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] length`: Number of elements in the DataView.
+- `[in] arraybuffer`: ArrayBuffer underlying the DataView.
+- `[in] byte_offset`: The byte offset within the ArrayBuffer from which to
+start projecting the DataVIew.
+- `[out] result`: A `napi_value` representing a JavaScript DataView.
+
+Returns `napi_ok` if the API succeeded.
+
+This API creates a JavaScript DataView object over an existing ArrayBuffer.
+Dataview objects provide an array-like view over an underlying data buffer,
+but one which allows items of different size and type in the ArrayBuffer.
+
+It's required that (length * size_of_element) + byte_offset should
+be <= the size in bytes of the array passed in. If not, a RangeError exception is
+raised.
+
+JavaScript DataView Objects are described in
+[Section 22.2](https://tc39.github.io/ecma262/#sec-dataview-objects)
+of the ECMAScript Language Specification.
+
 ### Functions to convert from C types to N-API
 #### *napi_create_number*
 <!-- YAML
@@ -1548,6 +1583,37 @@ to start projecting the TypedArray.
 Returns `napi_ok` if the API succeeded.
 
 This API returns various properties of a typed array.
+
+*Warning*: Use caution while using this API since the underlying data buffer
+is managed by the VM
+
+
+
+#### *napi_get_typedarray_info*
+<!-- YAML
+added: v8.0.0
+-->
+napi_status napi_get_dataview_info(napi_env env,
+                                     napi_value dataview,
+                                     size_t* bytelength,
+                                     void** data,
+                                     napi_value* arraybuffer,
+                                     size_t* byte_offset)
+```C
+
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] dataview`: `napi_value` representing the DataView whose
+properties to query.
+- `[out] length`: Number of elements in the DataView.
+- `[out] data`: The data buffer underlying the DataView.
+- `[out] byte_offset`: The byte offset within the data buffer from which
+to start projecting the DataView.
+
+Returns `napi_ok` if the API succeeded.
+
+This API returns various properties of a DataView.
 
 *Warning*: Use caution while using this API since the underlying data buffer
 is managed by the VM
@@ -2018,6 +2084,24 @@ napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 Returns `napi_ok` if the API succeeded.
 
 This API checks if the Object passsed in is a typed array.
+
+
+
+### *napi_is_dataview*
+<!-- YAML
+added: v8.0.0
+-->
+```C
+napi_status napi_is_dataview(napi_env env, napi_value value, bool* result)
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] value`: The JavaScript value to check.
+- `[out] result`: Whether the given `napi_value` represents a DataView.
+
+Returns `napi_ok` if the API succeeded.
+
+This API checks if the Object passsed in is a dataview.
 
 ### *napi_strict_equals*
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1586,18 +1586,17 @@ is managed by the VM
 
 
 
-#### *napi_get_typedarray_info*
+#### *napi_get_dataview_info*
 <!-- YAML
 added: v8.0.0
 -->
+```C
 napi_status napi_get_dataview_info(napi_env env,
                                      napi_value dataview,
                                      size_t* bytelength,
                                      void** data,
                                      napi_value* arraybuffer,
                                      size_t* byte_offset)
-```C
-
 ```
 
 - `[in] env`: The environment that the API is invoked under.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2086,7 +2086,7 @@ This API checks if the Object passsed in is a typed array.
 
 ### *napi_is_dataview*
 <!-- YAML
-added: v8.0.0
+added: REPLACEME
 -->
 
 ```C

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1334,14 +1334,15 @@ of the ECMAScript Language Specification.
 
 #### *napi_create_dataview*
 <!-- YAML
-added: v8.0.0
+added: REPLACEME
 -->
+
 ```C
 napi_status napi_create_dataview(napi_env env,
-                                   size_t length,
-                                   napi_value arraybuffer,
-                                   size_t byte_offset,
-                                   napi_value* result)
+                                 size_t length,
+                                 napi_value arraybuffer,
+                                 size_t byte_offset,
+                                 napi_value* result)
 
 ```
 
@@ -1349,7 +1350,7 @@ napi_status napi_create_dataview(napi_env env,
 - `[in] length`: Number of elements in the DataView.
 - `[in] arraybuffer`: ArrayBuffer underlying the DataView.
 - `[in] byte_offset`: The byte offset within the ArrayBuffer from which to
-start projecting the DataVIew.
+  start projecting the DataView.
 - `[out] result`: A `napi_value` representing a JavaScript DataView.
 
 Returns `napi_ok` if the API succeeded.
@@ -1588,31 +1589,31 @@ is managed by the VM
 
 #### *napi_get_dataview_info*
 <!-- YAML
-added: v8.0.0
+added: REPLACEME
 -->
+
 ```C
 napi_status napi_get_dataview_info(napi_env env,
-                                     napi_value dataview,
-                                     size_t* bytelength,
-                                     void** data,
-                                     napi_value* arraybuffer,
-                                     size_t* byte_offset)
+                                   napi_value dataview,
+                                   size_t* bytelength,
+                                   void** data,
+                                   napi_value* arraybuffer,
+                                   size_t* byte_offset)
 ```
 
 - `[in] env`: The environment that the API is invoked under.
 - `[in] dataview`: `napi_value` representing the DataView whose
-properties to query.
-- `[out] length`: Number of elements in the DataView.
+  properties to query.
+- `[out] bytelength`: Number of bytes in the DataView.
 - `[out] data`: The data buffer underlying the DataView.
+- `[out] arraybuffer`: ArrayBuffer underlying the DataView.
 - `[out] byte_offset`: The byte offset within the data buffer from which
-to start projecting the DataView.
+  to start projecting the DataView.
 
 Returns `napi_ok` if the API succeeded.
 
 This API returns various properties of a DataView.
 
-*Warning*: Use caution while using this API since the underlying data buffer
-is managed by the VM
 
 #### *napi_get_value_bool*
 <!-- YAML
@@ -2087,6 +2088,7 @@ This API checks if the Object passsed in is a typed array.
 <!-- YAML
 added: v8.0.0
 -->
+
 ```C
 napi_status napi_is_dataview(napi_env env, napi_value value, bool* result)
 ```
@@ -2097,7 +2099,7 @@ napi_status napi_is_dataview(napi_env env, napi_value value, bool* result)
 
 Returns `napi_ok` if the API succeeded.
 
-This API checks if the Object passsed in is a dataview.
+This API checks if the Object passsed in is a DataView.
 
 ### *napi_strict_equals*
 <!-- YAML

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1332,7 +1332,7 @@ JavaScript TypedArray Objects are described in
 of the ECMAScript Language Specification.
 
 
-#### *napi_create_typedarray*
+#### *napi_create_dataview*
 <!-- YAML
 added: v8.0.0
 -->
@@ -1341,7 +1341,7 @@ napi_status napi_create_dataview(napi_env env,
                                    size_t length,
                                    napi_value arraybuffer,
                                    size_t byte_offset,
-                                   napi_value* result) {
+                                   napi_value* result)
 
 ```
 
@@ -1358,12 +1358,9 @@ This API creates a JavaScript DataView object over an existing ArrayBuffer.
 Dataview objects provide an array-like view over an underlying data buffer,
 but one which allows items of different size and type in the ArrayBuffer.
 
-It's required that (length * size_of_element) + byte_offset should
-be <= the size in bytes of the array passed in. If not, a RangeError exception is
-raised.
 
 JavaScript DataView Objects are described in
-[Section 22.2](https://tc39.github.io/ecma262/#sec-dataview-objects)
+[Section 24.3](https://tc39.github.io/ecma262/#sec-dataview-objects)
 of the ECMAScript Language Specification.
 
 ### Functions to convert from C types to N-API

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3251,6 +3251,7 @@ support it:
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties
 [Working with JavaScript Values]: #n_api_working_with_javascript_values
 [Working with JavaScript Values - Abstract Operations]: #n_api_working_with_javascript_values_abstract_operations
+[Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 
 [`napi_cancel_async_work`]: #n_api_napi_cancel_async_work
 [`napi_close_escapable_handle_scope`]: #n_api_napi_close_escapable_handle_scope

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1361,8 +1361,7 @@ but one which allows items of different size and type in the ArrayBuffer.
 
 
 JavaScript DataView Objects are described in
-[Section 24.3](https://tc39.github.io/ecma262/#sec-dataview-objects)
-of the ECMAScript Language Specification.
+[Section 24.3][] of the ECMAScript Language Specification.
 
 ### Functions to convert from C types to N-API
 #### *napi_create_number*
@@ -3247,11 +3246,11 @@ support it:
 [Object Wrap]: #n_api_object_wrap
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
 [Section 12.5.5]: https://tc39.github.io/ecma262/#sec-typeof-operator
+[Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 [Working with JavaScript Functions]: #n_api_working_with_javascript_functions
 [Working with JavaScript Properties]: #n_api_working_with_javascript_properties
 [Working with JavaScript Values]: #n_api_working_with_javascript_values
 [Working with JavaScript Values - Abstract Operations]: #n_api_working_with_javascript_values_abstract_operations
-[Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects
 
 [`napi_cancel_async_work`]: #n_api_napi_cancel_async_work
 [`napi_close_escapable_handle_scope`]: #n_api_napi_close_escapable_handle_scope

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1359,7 +1359,7 @@ This API creates a JavaScript DataView object over an existing ArrayBuffer.
 Dataview objects provide an array-like view over an underlying data buffer,
 but one which allows items of different size and type in the ArrayBuffer.
 
-It's required that (byte_length * size_of_element) + byte_offset
+It's required that byte_length + byte_offset
 should be <= the size in bytes of the array passed in. If not, a RangeError
 exception is raised.
 

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2958,7 +2958,7 @@ napi_status napi_get_typedarray_info(napi_env env,
 }
 
 napi_status napi_create_dataview(napi_env env,
-                                 size_t length,
+                                 size_t byte_length,
                                  napi_value arraybuffer,
                                  size_t byte_offset,
                                  napi_value* result) {
@@ -2971,7 +2971,7 @@ napi_status napi_create_dataview(napi_env env,
 
   v8::Local<v8::ArrayBuffer> buffer = value.As<v8::ArrayBuffer>();
   v8::Local<v8::DataView> DataView = v8::DataView::New(buffer, byte_offset,
-                                                       length);
+                                                       byte_length);
 
   *result = v8impl::JsValueFromV8LocalValue(DataView);
   return GET_RETURN_STATUS(env);
@@ -2990,7 +2990,7 @@ napi_status napi_is_dataview(napi_env env, napi_value value, bool* result) {
 
 napi_status napi_get_dataview_info(napi_env env,
                                    napi_value dataview,
-                                   size_t* bytelength,
+                                   size_t* byte_length,
                                    void** data,
                                    napi_value* arraybuffer,
                                    size_t* byte_offset) {
@@ -3003,8 +3003,8 @@ napi_status napi_get_dataview_info(napi_env env,
   v8::Local<v8::DataView> array = value.As<v8::DataView>();
 
 
-  if (bytelength != nullptr) {
-    *bytelength = array->ByteLength();
+  if (byte_length != nullptr) {
+    *byte_length = array->ByteLength();
   }
 
   v8::Local<v8::ArrayBuffer> buffer = array->Buffer();

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2957,6 +2957,73 @@ napi_status napi_get_typedarray_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
+napi_status napi_create_dataview(napi_env env,
+                                   size_t length,
+                                   napi_value arraybuffer,
+                                   size_t byte_offset,
+                                   napi_value* result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, arraybuffer);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(arraybuffer);
+  RETURN_STATUS_IF_FALSE(env, value->IsArrayBuffer(), napi_invalid_arg);
+
+  v8::Local<v8::ArrayBuffer> buffer = value.As<v8::ArrayBuffer>();
+  v8::Local<v8::DataView> DataView = v8::DataView::New(buffer, byte_offset,
+                                                       length);
+
+  *result = v8impl::JsValueFromV8LocalValue(DataView);
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status napi_is_dataview(napi_env env, napi_value value, bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, value);
+  CHECK_ARG(env, result);
+
+  v8::Local<v8::Value> val = v8impl::V8LocalValueFromJsValue(value);
+  *result = val->IsDataView();
+
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_get_dataview_info(napi_env env,
+                                     napi_value dataview,
+                                     size_t* bytelength,
+                                     void** data,
+                                     napi_value* arraybuffer,
+                                     size_t* byte_offset) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, dataview);
+
+  v8::Local<v8::Value> value = v8impl::V8LocalValueFromJsValue(dataview);
+  RETURN_STATUS_IF_FALSE(env, value->IsDataView(), napi_invalid_arg);
+
+  v8::Local<v8::DataView> array = value.As<v8::DataView>();
+
+
+  if (bytelength != nullptr) {
+    *bytelength = array->ByteLength();
+  }
+
+  v8::Local<v8::ArrayBuffer> buffer = array->Buffer();
+  if (data != nullptr) {
+    *data = static_cast<uint8_t*>(buffer->GetContents().Data()) +
+            array->ByteOffset();
+  }
+
+  if (arraybuffer != nullptr) {
+    *arraybuffer = v8impl::JsValueFromV8LocalValue(buffer);
+  }
+
+  if (byte_offset != nullptr) {
+    *byte_offset = array->ByteOffset();
+  }
+
+  return napi_clear_last_error(env);
+}
+
 napi_status napi_get_version(napi_env env, uint32_t* result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2958,10 +2958,10 @@ napi_status napi_get_typedarray_info(napi_env env,
 }
 
 napi_status napi_create_dataview(napi_env env,
-                                   size_t length,
-                                   napi_value arraybuffer,
-                                   size_t byte_offset,
-                                   napi_value* result) {
+                                 size_t length,
+                                 napi_value arraybuffer,
+                                 size_t byte_offset,
+                                 napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, arraybuffer);
   CHECK_ARG(env, result);
@@ -2989,11 +2989,11 @@ napi_status napi_is_dataview(napi_env env, napi_value value, bool* result) {
 }
 
 napi_status napi_get_dataview_info(napi_env env,
-                                     napi_value dataview,
-                                     size_t* bytelength,
-                                     void** data,
-                                     napi_value* arraybuffer,
-                                     size_t* byte_offset) {
+                                   napi_value dataview,
+                                   size_t* bytelength,
+                                   void** data,
+                                   napi_value* arraybuffer,
+                                   size_t* byte_offset) {
   CHECK_ENV(env);
   CHECK_ARG(env, dataview);
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -495,10 +495,10 @@ NAPI_EXTERN napi_status napi_get_typedarray_info(napi_env env,
                                                  size_t* byte_offset);
 
 NAPI_EXTERN napi_status napi_create_dataview(napi_env env,
-                                 size_t length,
-                                 napi_value arraybuffer,
-                                 size_t byte_offset,
-                                 napi_value* result);
+                                             size_t length,
+                                             napi_value arraybuffer,
+                                             size_t byte_offset,
+                                             napi_value* result);
 NAPI_EXTERN napi_status napi_is_dataview(napi_env env,
                                          napi_value value,
                                          bool* result);

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -494,6 +494,21 @@ NAPI_EXTERN napi_status napi_get_typedarray_info(napi_env env,
                                                  napi_value* arraybuffer,
                                                  size_t* byte_offset);
 
+NAPI_EXTERN napi_status napi_create_dataview(napi_env env,
+                                 size_t length,
+                                 napi_value arraybuffer,
+                                 size_t byte_offset,
+                                 napi_value* result);
+NAPI_EXTERN napi_status napi_is_dataview(napi_env env,
+                                         napi_value value,
+                                         bool* result);
+NAPI_EXTERN napi_status napi_get_dataview_info(napi_env env,
+                                               napi_value dataview,
+                                               size_t* bytelength,
+                                               void** data,
+                                               napi_value* arraybuffer,
+                                               size_t* byte_offset);
+
 // Methods to manage simple async operations
 NAPI_EXTERN
 napi_status napi_create_async_work(napi_env env,

--- a/test/addons-napi/test_dataview/binding.gyp
+++ b/test/addons-napi/test_dataview/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_dataview",
+      "sources": [ "test_dataview.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -6,11 +6,8 @@ const assert = require('assert');
 const test_dataview = require(`./build/${common.buildType}/test_dataview`);
 
 //create dataview
-const buffer3 = new ArrayBuffer(128);
-console.log(buffer3 instanceof ArrayBuffer);
-const template = Reflect.construct(DataView, [buffer3]);
-console.log(template);
-console.log(template instanceof DataView);
+const buffer = new ArrayBuffer(128);
+const template = Reflect.construct(DataView, [buffer]);
 
 const theDataview = test_dataview.CreateDataView(template);
 assert.ok(theDataview instanceof DataView,

--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+
+// Testing api calls for arrays
+const test_dataview = require(`./build/${common.buildType}/test_dataview`);
+
+//create dataview
+const buffer3 = new ArrayBuffer(128);
+console.log(buffer3 instanceof ArrayBuffer);
+const template = Reflect.construct(DataView, [buffer3]);
+console.log(template);
+console.log(template instanceof DataView);
+
+const theDataview = test_dataview.CreateDataView(template);
+assert.ok(theDataview instanceof DataView,
+          'The new variable should be of type Dataview');

--- a/test/addons-napi/test_dataview/test_dataview.c
+++ b/test/addons-napi/test_dataview/test_dataview.c
@@ -14,21 +14,24 @@ napi_value CreateDataView(napi_env env, napi_callback_info info) {
 
   NAPI_CALL(env, napi_typeof(env, input_dataview, &valuetype));
   NAPI_ASSERT(env, valuetype == napi_object,
-   "Wrong type of argments. Expects a dataview  as the first argument.");
+              "Wrong type of argments. Expects a dataview  as the first"
+               "argument.");
 
   bool is_dataview;
   NAPI_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));
   NAPI_ASSERT(env,is_dataview,
-    "Wrong type of arugments. Expects a dataview as first argument.");
+              "Wrong type of arugments. Expects a dataview as first argument.");
   size_t byte_offset = 0;
   size_t length = 0;
   napi_value buffer;
-  NAPI_CALL(env, napi_get_dataview_info(
-              env, input_dataview, &length, NULL, &buffer, &byte_offset));
+  NAPI_CALL(env,
+            napi_get_dataview_info(env, input_dataview, &length, NULL,
+                                   &buffer, &byte_offset));
 
   napi_value output_dataview;
-  NAPI_CALL(env, napi_create_dataview(
-      env, length, buffer, byte_offset, &output_dataview));
+  NAPI_CALL(env,
+            napi_create_dataview(env, length, buffer,
+                                 byte_offset, &output_dataview));
 
   return output_dataview;
 }
@@ -38,8 +41,8 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("CreateDataView", CreateDataView)
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL_RETURN_VOID(env,napi_define_properties(
+      env, exports,sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
 NAPI_MODULE(addon, Init)

--- a/test/addons-napi/test_dataview/test_dataview.c
+++ b/test/addons-napi/test_dataview/test_dataview.c
@@ -1,0 +1,45 @@
+#include <node_api.h>
+#include <string.h>
+#include "../common.h"
+
+napi_value CreateDataView(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args [1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype;
+  napi_value input_dataview = args[0];
+
+  NAPI_CALL(env, napi_typeof(env, input_dataview, &valuetype));
+  NAPI_ASSERT(env, valuetype == napi_object,
+   "Wrong type of argments. Expects a dataview  as the first argument.");
+
+  bool is_dataview;
+  NAPI_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));
+  NAPI_ASSERT(env,is_dataview,
+    "Wrong type of arugments. Expects a dataview as first argument.");
+  size_t byte_offset = 0;
+  size_t length = 0;
+  napi_value buffer;
+  NAPI_CALL(env, napi_get_dataview_info(
+              env, input_dataview, &length, NULL, &buffer, &byte_offset));
+
+  napi_value output_dataview;
+  NAPI_CALL(env, napi_create_dataview(
+      env, length, buffer, byte_offset, &output_dataview));
+
+  return output_dataview;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("CreateDataView", CreateDataView)
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+}
+
+NAPI_MODULE(addon, Init)

--- a/test/addons-napi/test_dataview/test_dataview.c
+++ b/test/addons-napi/test_dataview/test_dataview.c
@@ -15,7 +15,7 @@ napi_value CreateDataView(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, input_dataview, &valuetype));
   NAPI_ASSERT(env, valuetype == napi_object,
               "Wrong type of argments. Expects a dataview  as the first"
-               "argument.");
+              "argument.");
 
   bool is_dataview;
   NAPI_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api

n-api: Add support for DataView …Basic support for Dataview is added by this commit. This is achieved by using three functions, `napi_create_dataview()`, `napi_is_dataview()` and `napi_get_dataview_info()`.

Fixes: #13926


<sub>_(edited by @vsemozhetbyt: fix formatting_</sub>