### PR TITLE
zlib: check if the stream is destroyed before push (8.x)

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -431,6 +431,9 @@ Zlib.prototype._processChunk = function _processChunk(chunk, flushFlag, cb) {
     if (self._hadError)
       return;
 
+    if (self.destroyed)
+      return;
+
     var have = availOutBefore - availOutAfter;
     assert(have >= 0, 'have should not go down');
 

--- a/test/parallel/test-zlib-destroy-pipe.js
+++ b/test/parallel/test-zlib-destroy-pipe.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const zlib = require('zlib');
+const { Writable } = require('stream');
+
+// verify that the zlib transform does not error in case
+// it is destroyed with data still in flight
+
+const ts = zlib.createGzip();
+
+const ws = new Writable({
+  write: common.mustCall((chunk, enc, cb) => {
+    setImmediate(cb);
+    ts.destroy();
+  })
+});
+
+const buf = Buffer.allocUnsafe(1024 * 1024 * 20);
+ts.end(buf);
+ts.pipe(ws);


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/14330

 Conflicts:
	lib/zlib.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)


----

Of note, it looks like the line above should also have `buffer = null` but perhaps that should be addressed separately.

I can confirm the test works on 8.x.