### PR TITLE
doc: fix some links

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -191,7 +191,7 @@ added: v0.1.27
 - `rrtype` {string} Resource record type. Default: `'A'`.
 - `callback` {Function}
   - `err` {Error}
-  - `records` {string[] | Object[] | string[][] | Object}
+  - `records` {string[] | Object[] | Object}
 
 Uses the DNS protocol to resolve a hostname (e.g. `'nodejs.org'`) into an array
 of the resource records. The `callback` function has arguments
@@ -422,7 +422,7 @@ added: v0.1.27
 - `hostname` {string}
 - `callback` {Function}
   - `err` {Error}
-  - `addresses` {string[][]}
+  - `addresses` {string[]}
 
 Uses the DNS protocol to resolve text queries (`TXT` records) for the
 `hostname`. The `addresses` argument passed to the `callback` function is
@@ -436,7 +436,7 @@ treated separately.
 - `hostname` {string}
 - `callback` {Function}
   - `err` {Error}
-  - `ret` {Object[][]}
+  - `ret` {Object[]}
 
 Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
 The `ret` argument passed to the `callback` function will be an array containing

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3203,6 +3203,7 @@ support it:
 [`napi_queue_async_work`]: #n_api_napi_queue_async_work
 [`napi_reference_ref`]: #n_api_napi_reference_ref
 [`napi_reference_unref`]: #n_api_napi_reference_unref
+[`napi_throw`]: #n_api_napi_throw
 [`napi_throw_error`]: #n_api_napi_throw_error
 [`napi_throw_range_error`]: #n_api_napi_throw_range_error
 [`napi_throw_type_error`]: #n_api_napi_throw_type_error

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -289,7 +289,7 @@ by subclasses.
 * `flag` {boolean}
 
 Indicate whether to treat `TypedArray` and `DataView` objects as
-host objects, i.e. pass them to [`serializer._writeHostObject`][].
+host objects, i.e. pass them to [`serializer._writeHostObject()`][].
 
 The default is not to treat those objects as host objects.
 

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -92,7 +92,7 @@ The test checks functionality in the `http` module.
 Most tests use the `assert` module to confirm expectations of the test.
 
 The require statements are sorted in
-[ASCII](http://man7.org/linux/man-pages/man7/ascii.7.html) order (digits, upper
+[ASCII][] order (digits, upper
 case, `_`, lower case).
 
 ### **Lines 10-21**
@@ -231,9 +231,9 @@ assert.throws(
 For performance considerations, we only use a selected subset of ES.Next
 features in JavaScript code in the `lib` directory. However, when writing
 tests, for the ease of backporting, it is encouraged to use those ES.Next
-features that can be used directly without a flag in [all maintained branches]
-(https://github.com/nodejs/lts). [node.green](http://node.green/) lists
-available features in each release.
+features that can be used directly without a flag in
+[all maintained branches][]. [node.green][] lists available features
+in each release.
 
 For example:
 
@@ -258,8 +258,7 @@ functions worked correctly with the `beforeExit` event, then it might be named
 ### Web Platform Tests
 
 Some of the tests for the WHATWG URL implementation (named
-`test-whatwg-url-*.js`) are imported from the
-[Web Platform Tests Project](https://github.com/w3c/web-platform-tests/tree/master/url).
+`test-whatwg-url-*.js`) are imported from the [Web Platform Tests Project][].
 These imported tests will be wrapped like this:
 
 ```js
@@ -331,13 +330,17 @@ $ make cctest
 ```
 
 ### Node test fixture
-There is a [test fixture] named `node_test_fixture.h` which can be included by
+There is a [test fixture][] named `node_test_fixture.h` which can be included by
 unit tests. The fixture takes care of setting up the Node.js environment
 and tearing it down after the tests have finished.
 
 It also contains a helper to create arguments to be passed into Node.js. It
 will depend on what is being tested if this is required or not.
 
+[ASCII]: http://man7.org/linux/man-pages/man7/ascii.7.html
 [Google Test]: https://github.com/google/googletest
-[Test fixture]: https://github.com/google/googletest/blob/master/googletest/docs/Primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests
+[Web Platform Tests Project]: https://github.com/w3c/web-platform-tests/tree/master/url
 [`common` module]: https://github.com/nodejs/node/blob/master/test/common/README.md
+[all maintained branches]: https://github.com/nodejs/lts
+[node.green]: http://node.green/
+[test fixture]: https://github.com/google/googletest/blob/master/googletest/docs/Primer.md#test-fixtures-using-the-same-data-configuration-for-multiple-tests


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

I am not sure about `[][]` type links in the DNS doc. Do they mean two-dimensional array, as stated in the `dns.resolveTxt()` description? If so, let me know to revert (and they should be fixed in doc tools as now they are not rendered as links).
