### PR TITLE
tools: enable stricter linting in lib directory

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -102,17 +102,17 @@ rules:
   func-name-matching: error
   func-style: [error, declaration, {allowArrowFunctions: true}]
   # indent: [error, 2, {ArrayExpression: first,
-  #                 CallExpression: {arguments: first},
-  #                 FunctionDeclaration: {parameters: first},
-  #                 FunctionExpression: {parameters: first},
-  #                 MemberExpression: off,
-  #                 ObjectExpression: first,
-  #                 SwitchCase: 1}]
+  #                     CallExpression: {arguments: first},
+  #                     FunctionDeclaration: {parameters: first},
+  #                     FunctionExpression: {parameters: first},
+  #                     MemberExpression: off,
+  #                     ObjectExpression: first,
+  #                     SwitchCase: 1}]
   indent-legacy: [error, 2, {ArrayExpression: first,
-                         CallExpression: {arguments: first},
-                         MemberExpression: 1,
-                         ObjectExpression: first,
-                         SwitchCase: 1}]
+                             CallExpression: {arguments: first},
+                             MemberExpression: 1,
+                             ObjectExpression: first,
+                             SwitchCase: 1}]
   key-spacing: [error, {mode: minimum}]
   keyword-spacing: error
   linebreak-style: [error, unix]

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,4 +1,13 @@
 rules:
+  indent: [error, 2, {ArrayExpression: first,
+                      CallExpression: {arguments: first},
+                      FunctionDeclaration: {parameters: first},
+                      FunctionExpression: {parameters: first},
+                      MemberExpression: off,
+                      ObjectExpression: first,
+                      SwitchCase: 1}]
+  indent-legacy: 0
+
   # Custom rules in tools/eslint-rules
   require-buffer: error
   buffer-constructor: error

--- a/lib/net.js
+++ b/lib/net.js
@@ -988,9 +988,9 @@ Socket.prototype.connect = function() {
   if (pipe) {
     if (typeof path !== 'string') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-        'options.path',
-        'string',
-        path);
+                                 'options.path',
+                                 'string',
+                                 path);
     }
     internalConnect(this, path);
   } else {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1058,7 +1058,9 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
     cmd = {action: cmd};
   } else if (typeof cmd.action !== 'function') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-      'action', 'function', cmd.action);
+                               'action',
+                               'function',
+                               cmd.action);
   }
   this.commands[keyword] = cmd;
 };


### PR DESCRIPTION
First commit:

    lib: adjust indentation for impending lint change
    
    ESLint 4.x provides stricter indentation linting than previous versions.
    In preparation for enabling the stricter indentation linting, adjust the
    indentation of four lines in lib/net.js and lib/repl.js.

Second commit:

    tools: enable stricter linting in lib directory
    
    Enable ESLint 4.x linting and disable legacy linting in the lib
    directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools lib net repl