### PR TITLE
test: favor regex over TypeError in assert.throws

### DIFF
--- a/test/addons-napi/test_conversions/test.js
+++ b/test/addons-napi/test_conversions/test.js
@@ -106,7 +106,10 @@ assert.strictEqual(0, test.toNumber(''));
 assert.ok(Number.isNaN(test.toNumber(Number.NaN)));
 assert.ok(Number.isNaN(test.toNumber({})));
 assert.ok(Number.isNaN(test.toNumber(undefined)));
-assert.throws(() => test.toNumber(testSym), TypeError);
+assert.throws(
+  () => test.toNumber(testSym),
+  /^TypeError: Cannot convert a Symbol value to a number$/
+);
 
 assert.deepStrictEqual({}, test.toObject({}));
 assert.deepStrictEqual({ 'test': 1 }, test.toObject({ 'test': 1 }));
@@ -137,4 +140,7 @@ assert.strictEqual('[object Object]', test.toString({}));
 assert.strictEqual('test', test.toString({ toString: () => 'test' }));
 assert.strictEqual('', test.toString([]));
 assert.strictEqual('1,2,3', test.toString([ 1, 2, 3 ]));
-assert.throws(() => test.toString(testSym), TypeError);
+assert.throws(
+  () => test.toString(testSym),
+  /^TypeError: Cannot convert a Symbol value to a string$/
+);


### PR DESCRIPTION
There are 2 `assert.throws()` that test type-conversions that
intentionally fail. These failing type-conversions throw `TypeError`
values.

Previously, the 2 `assert.throws()` checked if the invalid
type-conversions threw `TypeError` values. This was accomplished
by passing the `TypeError` constructor as the 2nd argument to
`assert.throws()`.

Now, the 2 `assert.throws()` check the thrown errors' messages
specifically. This is accomplished by passing a regex as the
2nd argument to `assert.throws()`.

This modification conforms to the prescribed format of assertions
detailed in `doc/guides/writing-tests.md`.

Refs: https://github.com/nodejs/node/blob/master/doc/guides/writing-tests.md#assertions

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
`test/`
