### PR TITLE
http: reset stream to unconsumed in `unconsume()`

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -527,6 +527,7 @@ class Parser : public AsyncWrap {
 
       stream->set_alloc_cb(parser->prev_alloc_cb_);
       stream->set_read_cb(parser->prev_read_cb_);
+      stream->Unconsume();
     }
 
     parser->prev_alloc_cb_.clear();

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -234,6 +234,11 @@ class StreamBase : public StreamResource {
     consumed_ = true;
   }
 
+  inline void Unconsume() {
+    CHECK_EQ(consumed_, true);
+    consumed_ = false;
+  }
+
   template <class Outer>
   inline Outer* Cast() { return static_cast<Outer*>(Cast()); }
 

--- a/test/parallel/test-http-upgrade-reconsume-stream.js
+++ b/test/parallel/test-http-upgrade-reconsume-stream.js
@@ -19,11 +19,11 @@ server.on('upgrade', common.mustCall((request, socket, head) => {
 }));
 
 server.listen(0, common.mustCall(() => {
-  http.request({
+  http.get({
     port: server.address().port,
     headers: {
       'Connection': 'Upgrade',
       'Upgrade': 'websocket'
     }
-  }).on('error', () => {}).end();
+  }).on('error', () => {});
 }));

--- a/test/parallel/test-http-upgrade-reconsume-stream.js
+++ b/test/parallel/test-http-upgrade-reconsume-stream.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+const http = require('http');
+
+// Tests that, after the HTTP parser stopped owning a socket that emits an
+// 'upgrade' event, another C++ stream can start owning it (e.g. a TLSSocket).
+
+const server = http.createServer(common.mustNotCall());
+
+server.on('upgrade', common.mustCall((request, socket, head) => {
+  // This should not crash.
+  new tls.TLSSocket(socket);
+  server.close();
+  socket.destroy();
+}));
+
+server.listen(0, common.mustCall(() => {
+  http.request({
+    port: server.address().port,
+    headers: {
+      'Connection': 'Upgrade',
+      'Upgrade': 'websocket'
+    }
+  }).on('error', () => {}).end();
+}));


### PR DESCRIPTION
Reset the underlying socket of an HTTP stream to be marked as
unconsume after the HTTP parser no longer owns it.

Fixes: https://github.com/nodejs/node/issues/14407

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

http