### PR TITLE
V6.x backport 13531 docs

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -89,12 +89,16 @@ Don't call `server.address()` until the `'listening'` event has been emitted.
 added: v0.1.90
 -->
 
+* Returns: {net.Server}
+
 Stops the server from accepting new connections and keeps existing
 connections. This function is asynchronous, the server is finally
 closed when all connections are ended and the server emits a [`'close'`][] event.
 The optional `callback` will be called once the `'close'` event occurs. Unlike
 that event, it will be called with an Error as its only argument if the server
 was not open when it was closed.
+
+Returns `server`.
 
 ### server.connections
 <!-- YAML
@@ -128,6 +132,7 @@ added: v0.5.10
 * `handle` {Object}
 * `backlog` {number}
 * `callback` {Function}
+* Returns: {net.Server}
 
 The `handle` object can be set to either a server or socket (anything
 with an underlying `_handle` member), or a `{fd: <n>}` object.
@@ -158,6 +163,7 @@ added: v0.11.14
   * `path` {string} - Optional.
   * `exclusive` {boolean} - Optional.
 * `callback` {Function} - Optional.
+* Returns: {net.Server}
 
 The `port`, `host`, and `backlog` properties of `options`, as well as the
 optional callback function, behave as they do on a call to
@@ -189,6 +195,7 @@ added: v0.1.90
 * `path` {string}
 * `backlog` {number}
 * `callback` {Function}
+* Returns: {net.Server}
 
 Start a local socket server listening for connections on the given `path`.
 
@@ -227,6 +234,7 @@ subsequent call will *re-open* the server using the provided options.
 <!-- YAML
 added: v0.1.90
 -->
+* Returns: {net.Server}
 
 Begin accepting connections on the specified `port` and `hostname`. If the
 `hostname` is omitted, the server will accept connections on any IPv6 address
@@ -289,22 +297,22 @@ with [`child_process.fork()`][].
 added: v0.9.1
 -->
 
+* Returns: {net.Server}
+
 Opposite of `unref`, calling `ref` on a previously `unref`d server will *not*
 let the program exit if it's the only server left (the default behavior). If
 the server is `ref`d calling `ref` again will have no effect.
-
-Returns `server`.
 
 ### server.unref()
 <!-- YAML
 added: v0.9.1
 -->
 
+* Returns: {net.Server}
+
 Calling `unref` on a server will allow the program to exit if this is the only
 active server in the event system. If the server is already `unref`d calling
 `unref` again will have no effect.
-
-Returns `server`.
 
 ## Class: net.Socket
 <!-- YAML
@@ -501,6 +509,10 @@ specifies:
 
   - `path`: Path the client should connect to (Required).
 
+For either case:
+
+* Returns: {net.Socket} The socket itself.
+
 Normally this method is not needed, as `net.createConnection` opens the
 socket. Use this only if you are implementing a custom Socket.
 
@@ -519,6 +531,8 @@ added: v0.1.90
 
 As [`socket.connect(options[, connectListener])`][`socket.connect(options, connectListener)`],
 with options as either `{port: port, host: host}` or `{path: path}`.
+
+* Returns: {net.Socket} The socket itself.
 
 ### socket.connecting
 <!-- YAML
@@ -550,6 +564,8 @@ connection is destroyed no further data can be transferred using it.
 added: v0.1.90
 -->
 
+* Returns: {net.Socket} The socket itself.
+
 Half-closes the socket. i.e., it sends a FIN packet. It is possible the
 server will still send some data.
 
@@ -575,6 +591,8 @@ The numeric representation of the local port. For example,
 
 ### socket.pause()
 
+* Returns: {net.Socket} The socket itself.
+
 Pauses the reading of data. That is, [`'data'`][] events will not be emitted.
 Useful to throttle back an upload.
 
@@ -583,11 +601,11 @@ Useful to throttle back an upload.
 added: v0.9.1
 -->
 
+* Returns: {net.Socket} The socket itself.
+
 Opposite of `unref`, calling `ref` on a previously `unref`d socket will *not*
 let the program exit if it's the only socket left (the default behavior). If
 the socket is `ref`d calling `ref` again will have no effect.
-
-Returns `socket`.
 
 ### socket.remoteAddress
 <!-- YAML
@@ -615,12 +633,16 @@ The numeric representation of the remote port. For example,
 
 ### socket.resume()
 
+* Returns: {net.Socket} The socket itself.
+
 Resumes reading after a call to [`pause()`][].
 
 ### socket.setEncoding([encoding])
 <!-- YAML
 added: v0.1.90
 -->
+
+* Returns: {net.Socket} The socket itself.
 
 Set the encoding for the socket as a [Readable Stream][]. See
 [`stream.setEncoding()`][] for more information.
@@ -629,6 +651,8 @@ Set the encoding for the socket as a [Readable Stream][]. See
 <!-- YAML
 added: v0.1.92
 -->
+
+* Returns: {net.Socket} The socket itself.
 
 Enable/disable keep-alive functionality, and optionally set the initial
 delay before the first keepalive probe is sent on an idle socket.
@@ -639,24 +663,24 @@ data packet received and the first keepalive probe. Setting 0 for
 initialDelay will leave the value unchanged from the default
 (or previous) setting. Defaults to `0`.
 
-Returns `socket`.
-
 ### socket.setNoDelay([noDelay])
 <!-- YAML
 added: v0.1.90
 -->
+
+* Returns: {net.Socket} The socket itself.
 
 Disables the Nagle algorithm. By default TCP connections use the Nagle
 algorithm, they buffer data before sending it off. Setting `true` for
 `noDelay` will immediately fire off data each time `socket.write()` is called.
 `noDelay` defaults to `true`.
 
-Returns `socket`.
-
 ### socket.setTimeout(timeout[, callback])
 <!-- YAML
 added: v0.1.90
 -->
+
+* Returns: {net.Socket} The socket itself.
 
 Sets the socket to timeout after `timeout` milliseconds of inactivity on
 the socket. By default `net.Socket` do not have a timeout.
@@ -670,18 +694,16 @@ If `timeout` is 0, then the existing idle timeout is disabled.
 The optional `callback` parameter will be added as a one time listener for the
 [`'timeout'`][] event.
 
-Returns `socket`.
-
 ### socket.unref()
 <!-- YAML
 added: v0.9.1
 -->
 
+* Returns: {net.Socket} The socket itself.
+
 Calling `unref` on a socket will allow the program to exit if this is the only
 active socket in the event system. If the socket is already `unref`d calling
 `unref` again will have no effect.
-
-Returns `socket`.
 
 ### socket.write(data[, encoding][, callback])
 <!-- YAML
@@ -843,6 +865,8 @@ automatically set as a listener for the [`'connection'`][] event.
   pauseOnConnect: false
 }
 ```
+
+* Returns: {net.Server}
 
 If `allowHalfOpen` is `true`, then the socket won't automatically send a FIN
 packet when the other end of the socket sends a FIN packet. The socket becomes


### PR DESCRIPTION

backport of docs from https://github.com/nodejs/node/pull/13531

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
