### PR TITLE
async_hooks: remove deprecated APIs

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -607,7 +607,7 @@ The DebugContext will be removed in V8 soon and will not be available in Node
 <a id="DEP0070"></a>
 ### DEP0070: async_hooks.currentId()
 
-Type: Runtime
+Type: End-of-Life
 
 `async_hooks.currentId()` was renamed to `async_hooks.executionAsyncId()` for
 clarity.
@@ -617,7 +617,7 @@ clarity.
 <a id="DEP0071"></a>
 ### DEP0071: async_hooks.triggerId()
 
-Type: Runtime
+Type: End-of-Life
 
 `async_hooks.triggerId()` was renamed to `async_hooks.triggerAsyncId()` for
 clarity.
@@ -627,7 +627,7 @@ clarity.
 <a id="DEP0072"></a>
 ### DEP0072: async_hooks.AsyncResource.triggerId()
 
-Type: Runtime
+Type: End-of-Life
 
 `async_hooks.AsyncResource.triggerId()` was renamed to
 `async_hooks.AsyncResource.triggerAsyncId()` for clarity.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const internalUtil = require('internal/util');
 const async_wrap = process.binding('async_wrap');
 /* Both these arrays are used to communicate between JS and C++ with as little
  * overhead as possible.
@@ -244,17 +243,6 @@ class AsyncResource {
 }
 
 
-// triggerId was renamed to triggerAsyncId. This was in 8.2.0 during the
-// experimental stage so the alias can be removed at any time, we are just
-// being nice :)
-Object.defineProperty(AsyncResource.prototype, 'triggerId', {
-  get: internalUtil.deprecate(function() {
-    return AsyncResource.prototype.triggerAsyncId;
-  }, 'AsyncResource.triggerId is deprecated. ' +
-     'Use AsyncResource.triggerAsyncId instead.', 'DEP0072')
-});
-
-
 function runInAsyncIdScope(asyncId, cb) {
   // Store the async id now to make sure the stack is still good when the ids
   // are popped off the stack.
@@ -461,23 +449,3 @@ module.exports = {
   emitAfter: emitAfterScript,
   emitDestroy: emitDestroyScript,
 };
-
-// currentId was renamed to executionAsyncId. This was in 8.2.0 during the
-// experimental stage so the alias can be removed at any time, we are just
-// being nice :)
-Object.defineProperty(module.exports, 'currentId', {
-  get: internalUtil.deprecate(function() {
-    return executionAsyncId;
-  }, 'async_hooks.currentId is deprecated. ' +
-     'Use async_hooks.executionAsyncId instead.', 'DEP0070')
-});
-
-// triggerId was renamed to triggerAsyncId. This was in 8.2.0 during the
-// experimental stage so the alias can be removed at any time, we are just
-// being nice :)
-Object.defineProperty(module.exports, 'triggerId', {
-  get: internalUtil.deprecate(function() {
-    return triggerAsyncId;
-  }, 'async_hooks.triggerId is deprecated. ' +
-     'Use async_hooks.triggerAsyncId instead.', 'DEP0071')
-});

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -745,17 +745,9 @@ async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->current_async_id();
 }
 
-async_id AsyncHooksGetCurrentId(Isolate* isolate) {
-  return AsyncHooksGetExecutionAsyncId(isolate);
-}
-
 
 async_id AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   return Environment::GetCurrent(isolate)->trigger_id();
-}
-
-async_id AsyncHooksGetTriggerId(Isolate* isolate) {
-  return AsyncHooksGetTriggerAsyncId(isolate);
 }
 
 

--- a/src/node.h
+++ b/src/node.h
@@ -533,17 +533,9 @@ NODE_EXTERN void AddPromiseHook(v8::Isolate* isolate,
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
 NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
-/* legacy alias */
-NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetExecutionAsyncId(isolate)",
-                async_id AsyncHooksGetCurrentId(v8::Isolate* isolate));
-
 
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_id AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
-/* legacy alias */
-NODE_EXTERN NODE_DEPRECATED("Use AsyncHooksGetTriggerAsyncId(isolate)",
-                async_id AsyncHooksGetTriggerId(v8::Isolate* isolate));
-
 
 /* If the native API doesn't inherit from the helper class then the callbacks
  * must be triggered manually. This triggers the init() callback. The return
@@ -642,12 +634,6 @@ class AsyncResource {
     v8::Local<v8::Object> get_resource() {
       return resource_.Get(isolate_);
     }
-
-    NODE_DEPRECATED("Use AsyncResource::get_async_id()",
-      async_id get_uid() const {
-        return get_async_id();
-      }
-    )
 
     async_id get_async_id() const {
       return async_context_.async_id;


### PR DESCRIPTION
These APIs were introduced during the lifetime of Node 8 in an experimental API and should safely be removable in Node 9+.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks

/cc @nodejs/async_hooks 