### PR TITLE
(v6.x backport) https: support rejectUnauthorized for unix sockets

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -135,7 +135,8 @@ function ClientRequest(options, cb) {
     self.shouldKeepAlive = false;
     const optionsPath = {
       path: self.socketPath,
-      timeout: self.timeout
+      timeout: self.timeout,
+      rejectUnauthorized: !!options.rejectUnauthorized
     };
     const newSocket = self.agent.createConnection(optionsPath, oncreate);
     if (newSocket && !called) {

--- a/test/parallel/test-https-unix-socket-self-signed.js
+++ b/test/parallel/test-https-unix-socket-self-signed.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+
+common.refreshTmpDir();
+
+const fs = require('fs');
+const https = require('https');
+const options = {
+  cert: fs.readFileSync(common.fixturesDir + '/test_cert.pem'),
+  key: fs.readFileSync(common.fixturesDir + '/test_key.pem')
+};
+
+const server = https.createServer(options, common.mustCall((req, res) => {
+  res.end('bye\n');
+  server.close();
+}));
+
+server.listen(common.PIPE, common.mustCall(() => {
+  https.get({
+    socketPath: common.PIPE,
+    rejectUnauthorized: false
+  });
+}));


### PR DESCRIPTION
This commit allows self signed certificates to work with
unix sockets by forwarding the rejectUnauthorized option.

Fixes: https://github.com/nodejs/node/issues/13470
PR-URL: https://github.com/nodejs/node/pull/13505
Reviewed-By: Refael Ackermann <refack@gmail.com>
Reviewed-By: Sam Roberts <vieuxtech@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Daniel Bevenius <daniel.bevenius@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
