### PR TITLE
test: adjust indentation for stricter linting

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -6,7 +6,7 @@ rules:
                       MemberExpression: off,
                       ObjectExpression: first,
                       SwitchCase: 1}]
-  indent-legacy: 0
+  indent-legacy: off
 
   # Custom rules in tools/eslint-rules
   require-buffer: error

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,6 +1,16 @@
 ## Test-specific linter rules
 
 rules:
+  # Stylistic Issues
+  # http://eslint.org/docs/rules/#stylistic-issues
+  indent: [error, 2, {ArrayExpression: first,
+                      CallExpression: {arguments: first},
+                      FunctionDeclaration: {parameters: first},
+                      FunctionExpression: {parameters: first},
+                      MemberExpression: off,
+                      ObjectExpression: first,
+                      SwitchCase: 1}]
+  indent-legacy: off
   # ECMAScript 6
   # http://eslint.org/docs/rules/#ecmascript-6
   no-var: error

--- a/test/addons-napi/test_fatal/test.js
+++ b/test/addons-napi/test_fatal/test.js
@@ -12,7 +12,7 @@ if (process.argv[2] === 'child') {
 }
 
 const p = child_process.spawnSync(
-    process.execPath, [ '--napi-modules', __filename, 'child' ]);
+  process.execPath, [ '--napi-modules', __filename, 'child' ]);
 assert.ifError(p.error);
 assert.ok(p.stderr.toString().includes(
-    'FATAL ERROR: test_fatal::Test fatal message'));
+  'FATAL ERROR: test_fatal::Test fatal message'));

--- a/test/addons-napi/test_general/testInstanceOf.js
+++ b/test/addons-napi/test_general/testInstanceOf.js
@@ -61,8 +61,10 @@ if (typeof Symbol !== 'undefined' && 'hasInstance' in Symbol &&
     typeof Symbol.hasInstance === 'symbol') {
 
   function compareToNative(theObject, theConstructor) {
-    assert.strictEqual(addon.doInstanceOf(theObject, theConstructor),
-      (theObject instanceof theConstructor));
+    assert.strictEqual(
+      addon.doInstanceOf(theObject, theConstructor),
+      (theObject instanceof theConstructor)
+    );
   }
 
   function MyClass() {}

--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -212,13 +212,14 @@ class ActivityCollector {
 }
 
 exports = module.exports = function initHooks({
-    oninit,
-    onbefore,
-    onafter,
-    ondestroy,
-    allowNoInit,
-    logid,
-    logtype } = {}) {
+  oninit,
+  onbefore,
+  onafter,
+  ondestroy,
+  allowNoInit,
+  logid,
+  logtype
+} = {}) {
   return new ActivityCollector(process.hrtime(), {
     oninit,
     onbefore,

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -18,8 +18,8 @@ assert.throws(() => new AsyncResource('invalid_trigger_id', null),
               /^RangeError: triggerAsyncId must be an unsigned integer$/);
 
 assert.strictEqual(
-    new AsyncResource('default_trigger_id').triggerAsyncId(),
-    async_hooks.executionAsyncId()
+  new AsyncResource('default_trigger_id').triggerAsyncId(),
+  async_hooks.executionAsyncId()
 );
 
 // create first custom event 'alcazares' with triggerAsyncId derived

--- a/test/async-hooks/test-internal-nexttick-default-trigger.js
+++ b/test/async-hooks/test-internal-nexttick-default-trigger.js
@@ -41,12 +41,12 @@ process.on('exit', function() {
 
   const as = hooks.activitiesOfTypes('TickObject');
   checkInvocations(as[0], {
-      init: 1, before: 1, after: 1, destroy: 1
+    init: 1, before: 1, after: 1, destroy: 1
   }, 'when process exits');
   checkInvocations(as[1], {
-      init: 1, before: 1, after: 1, destroy: 1
+    init: 1, before: 1, after: 1, destroy: 1
   }, 'when process exits');
   checkInvocations(as[2], {
-      init: 1, before: 1, after: 1, destroy: 1
+    init: 1, before: 1, after: 1, destroy: 1
   }, 'when process exits');
 });

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -100,53 +100,53 @@ function parseDNSPacket(buffer) {
                                .replace(/(.{4}(?!$))/g, '$1:');
             break;
           case types.TXT:
-            {
-              let position = offset;
-              rr.entries = [];
-              while (position < offset + dataLength) {
-                const txtLength = buffer[offset];
-                rr.entries.push(buffer.toString('utf8',
-                                                position + 1,
-                                                position + 1 + txtLength));
-                position += 1 + txtLength;
-              }
-              assert.strictEqual(position, offset + dataLength);
-              break;
+          {
+            let position = offset;
+            rr.entries = [];
+            while (position < offset + dataLength) {
+              const txtLength = buffer[offset];
+              rr.entries.push(buffer.toString('utf8',
+                                              position + 1,
+                                              position + 1 + txtLength));
+              position += 1 + txtLength;
             }
+            assert.strictEqual(position, offset + dataLength);
+            break;
+          }
           case types.MX:
-            {
-              rr.priority = buffer.readInt16BE(buffer, offset);
-              offset += 2;
-              const { nread, domain } = readDomainFromPacket(buffer, offset);
-              rr.exchange = domain;
-              assert.strictEqual(nread, dataLength);
-              break;
-            }
+          {
+            rr.priority = buffer.readInt16BE(buffer, offset);
+            offset += 2;
+            const { nread, domain } = readDomainFromPacket(buffer, offset);
+            rr.exchange = domain;
+            assert.strictEqual(nread, dataLength);
+            break;
+          }
           case types.NS:
           case types.CNAME:
           case types.PTR:
-            {
-              const { nread, domain } = readDomainFromPacket(buffer, offset);
-              rr.value = domain;
-              assert.strictEqual(nread, dataLength);
-              break;
-            }
+          {
+            const { nread, domain } = readDomainFromPacket(buffer, offset);
+            rr.value = domain;
+            assert.strictEqual(nread, dataLength);
+            break;
+          }
           case types.SOA:
-            {
-              const mname = readDomainFromPacket(buffer, offset);
-              const rname = readDomainFromPacket(buffer, offset + mname.nread);
-              rr.nsname = mname.domain;
-              rr.hostmaster = rname.domain;
-              const trailerOffset = offset + mname.nread + rname.nread;
-              rr.serial = buffer.readUInt32BE(trailerOffset);
-              rr.refresh = buffer.readUInt32BE(trailerOffset + 4);
-              rr.retry = buffer.readUInt32BE(trailerOffset + 8);
-              rr.expire = buffer.readUInt32BE(trailerOffset + 12);
-              rr.minttl = buffer.readUInt32BE(trailerOffset + 16);
+          {
+            const mname = readDomainFromPacket(buffer, offset);
+            const rname = readDomainFromPacket(buffer, offset + mname.nread);
+            rr.nsname = mname.domain;
+            rr.hostmaster = rname.domain;
+            const trailerOffset = offset + mname.nread + rname.nread;
+            rr.serial = buffer.readUInt32BE(trailerOffset);
+            rr.refresh = buffer.readUInt32BE(trailerOffset + 4);
+            rr.retry = buffer.readUInt32BE(trailerOffset + 8);
+            rr.expire = buffer.readUInt32BE(trailerOffset + 12);
+            rr.minttl = buffer.readUInt32BE(trailerOffset + 16);
 
-              assert.strictEqual(trailerOffset + 20, dataLength);
-              break;
-            }
+            assert.strictEqual(trailerOffset + 20, dataLength);
+            break;
+          }
           default:
             throw new Error(`Unknown RR type ${rr.type}`);
         }
@@ -253,23 +253,23 @@ function writeDNSPacket(parsed) {
       case 'NS':
       case 'CNAME':
       case 'PTR':
-        {
-          const domain = writeDomainName(rr.exchange || rr.value);
-          rdLengthBuf[0] += domain.length;
-          buffers.push(domain);
-          break;
-        }
+      {
+        const domain = writeDomainName(rr.exchange || rr.value);
+        rdLengthBuf[0] += domain.length;
+        buffers.push(domain);
+        break;
+      }
       case 'SOA':
-        {
-          const mname = writeDomainName(rr.nsname);
-          const rname = writeDomainName(rr.hostmaster);
-          rdLengthBuf[0] = mname.length + rname.length + 20;
-          buffers.push(mname, rname);
-          buffers.push(new Uint32Array([
-            rr.serial, rr.refresh, rr.retry, rr.expire, rr.minttl
-          ]));
-          break;
-        }
+      {
+        const mname = writeDomainName(rr.nsname);
+        const rname = writeDomainName(rr.hostmaster);
+        rdLengthBuf[0] = mname.length + rname.length + 20;
+        buffers.push(mname, rname);
+        buffers.push(new Uint32Array([
+          rr.serial, rr.refresh, rr.retry, rr.expire, rr.minttl
+        ]));
+        break;
+      }
       default:
         throw new Error(`Unknown RR type ${rr.type}`);
     }

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -44,8 +44,8 @@ function send(socket, message, id, callback) {
   for (let i = 0; i < messageBuf.length; i++)
     messageBuf[i] = messageBuf[i] ^ (1 << (i % 4));
   socket.write(
-      Buffer.concat([wsHeaderBuf.slice(0, maskOffset + 4), messageBuf]),
-      callback);
+    Buffer.concat([wsHeaderBuf.slice(0, maskOffset + 4), messageBuf]),
+    callback);
 }
 
 function sendEnd(socket) {
@@ -74,7 +74,7 @@ function parseWSFrame(buffer, handler) {
   if (buffer.length < bodyOffset + dataLen)
     return 0;
   const message = JSON.parse(
-      buffer.slice(bodyOffset, bodyOffset + dataLen).toString('utf8'));
+    buffer.slice(bodyOffset, bodyOffset + dataLen).toString('utf8'));
   if (DEBUG)
     console.log('[received]', JSON.stringify(message));
   handler(message);
@@ -238,7 +238,7 @@ TestSession.prototype.sendInspectorCommands = function(commands) {
     this.sendAll_(commands, () => {
       timeoutId = setTimeout(() => {
         assert.fail(`Messages without response: ${
-                    Object.keys(this.messages_).join(', ')}`);
+          Object.keys(this.messages_).join(', ')}`);
       }, TIMEOUT);
     });
   });
@@ -282,7 +282,7 @@ TestSession.prototype.expectMessages = function(expects) {
   if (!(expects instanceof Array)) expects = [ expects ];
 
   const callback = this.createCallbackWithTimeout_(
-      `Matching response was not received:\n${expects[0]}`);
+    `Matching response was not received:\n${expects[0]}`);
   this.messagefilter_ = (message) => {
     if (expects[0](message))
       expects.shift();
@@ -296,8 +296,8 @@ TestSession.prototype.expectMessages = function(expects) {
 
 TestSession.prototype.expectStderrOutput = function(regexp) {
   this.harness_.addStderrFilter(
-      regexp,
-      this.createCallbackWithTimeout_(`Timed out waiting for ${regexp}`));
+    regexp,
+    this.createCallbackWithTimeout_(`Timed out waiting for ${regexp}`));
   return this;
 };
 
@@ -350,10 +350,10 @@ TestSession.prototype.assertClosed = function() {
 
 TestSession.prototype.testHttpResponse = function(path, check) {
   return this.enqueue((callback) =>
-      checkHttpResponse(null, this.harness_.port, path, (err, response) => {
-        check.call(this, err, response);
-        callback();
-      }));
+    checkHttpResponse(null, this.harness_.port, path, (err, response) => {
+      check.call(this, err, response);
+      callback();
+    }));
 };
 
 
@@ -366,7 +366,7 @@ function Harness(port, childProcess) {
   this.running_ = true;
 
   childProcess.stdout.on('data', makeBufferingDataCallback(
-      (line) => console.log('[out]', line)));
+    (line) => console.log('[out]', line)));
 
 
   childProcess.stderr.on('data', makeBufferingDataCallback((message) => {

--- a/test/inspector/test-inspector.js
+++ b/test/inspector/test-inspector.js
@@ -122,17 +122,17 @@ function testBreakpointOnStart(session) {
 function testSetBreakpointAndResume(session) {
   console.log('[test]', 'Setting a breakpoint and verifying it is hit');
   const commands = [
-      { 'method': 'Debugger.setBreakpointByUrl',
-        'params': { 'lineNumber': 5,
-                    'url': session.mainScriptPath,
-                    'columnNumber': 0,
-                    'condition': ''
-        }
-      },
-      { 'method': 'Debugger.resume' },
-      [ { 'method': 'Debugger.getScriptSource',
-          'params': { 'scriptId': session.mainScriptId } },
-        expectMainScriptSource ],
+    { 'method': 'Debugger.setBreakpointByUrl',
+      'params': { 'lineNumber': 5,
+                  'url': session.mainScriptPath,
+                  'columnNumber': 0,
+                  'condition': ''
+      }
+    },
+    { 'method': 'Debugger.resume' },
+    [ { 'method': 'Debugger.getScriptSource',
+        'params': { 'scriptId': session.mainScriptId } },
+      expectMainScriptSource ],
   ];
   session
     .sendInspectorCommands(commands)

--- a/test/inspector/test-not-blocked-on-idle.js
+++ b/test/inspector/test-not-blocked-on-idle.js
@@ -6,8 +6,8 @@ const helper = require('./inspector-helper.js');
 function shouldShutDown(session) {
   session
     .sendInspectorCommands([
-        { 'method': 'Debugger.enable' },
-        { 'method': 'Debugger.pause' },
+      { 'method': 'Debugger.enable' },
+      { 'method': 'Debugger.pause' },
     ])
     .disconnect(true);
 }

--- a/test/known_issues/test-http-path-contains-unicode.js
+++ b/test/known_issues/test-http-path-contains-unicode.js
@@ -11,9 +11,9 @@ const http = require('http');
 const expected = '/café🐶';
 
 assert.strictEqual(
- expected,
- '/caf\u{e9}\u{1f436}',
- 'Sanity check that string literal produced the expected string'
+  expected,
+  '/caf\u{e9}\u{1f436}',
+  'Sanity check that string literal produced the expected string'
 );
 
 const server = http.createServer(common.mustCall(function(req, res) {

--- a/test/known_issues/test-vm-proxy-failure-CP.js
+++ b/test/known_issues/test-vm-proxy-failure-CP.js
@@ -9,9 +9,9 @@ const assert = require('assert');
 const vm = require('vm');
 
 const handler = {
-    getOwnPropertyDescriptor: (target, prop) => {
-      throw new Error('whoops');
-    }
+  getOwnPropertyDescriptor: (target, prop) => {
+    throw new Error('whoops');
+  }
 };
 const sandbox = new Proxy({ foo: 'bar' }, handler);
 const context = vm.createContext(sandbox);

--- a/test/message/throw_in_line_with_tabs.js
+++ b/test/message/throw_in_line_with_tabs.js
@@ -19,7 +19,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable indent-legacy, no-tabs */
+/* eslint-disable indent, no-tabs */
 'use strict';
 require('../common');
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -501,10 +501,10 @@ assert.throws(() => {
   let threw = false;
   try {
     assert.throws(
-        function() {
-          throw ({}); // eslint-disable-line no-throw-literal
-        },
-        Array
+      function() {
+        throw ({}); // eslint-disable-line no-throw-literal
+      },
+      Array
     );
   } catch (e) {
     threw = true;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -750,7 +750,7 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 
 // Call .fill() first, stops valgrind warning about uninitialized memory reads.
 Buffer.allocUnsafe(3.3).fill().toString();
-  // throws bad argument error in commit 43cb4ec
+// throws bad argument error in commit 43cb4ec
 Buffer.alloc(3.3).fill().toString();
 assert.strictEqual(Buffer.allocUnsafe(NaN).length, 0);
 assert.strictEqual(Buffer.allocUnsafe(3.3).length, 3);

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -67,7 +67,7 @@ assert.throws(() => a.compare(b, 0, Infinity), oor);
 assert.throws(() => a.compare(b, 0, 1, -1), oor);
 assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
 assert.throws(() => a.compare(), common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "target" argument must be one of type buffer or uint8Array'
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "target" argument must be one of type buffer or uint8Array'
 }));

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -29,9 +29,9 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
 assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
 const errMsg = common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "buf1", "buf2" arguments must be one of ' +
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "buf1", "buf2" arguments must be one of ' +
              'type buffer or uint8Array'
 }, 2);
 assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
@@ -39,7 +39,7 @@ assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
 assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), errMsg);
 
 assert.throws(() => Buffer.alloc(1).compare('abc'), common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "target" argument must be one of type buffer or uint8Array'
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "target" argument must be one of type buffer or uint8Array'
 }));

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -81,8 +81,8 @@ assert.deepStrictEqual(Buffer.concat([random10, empty, empty]), random10);
 assert.deepStrictEqual(Buffer.concat([empty], 100), Buffer.alloc(100));
 assert.deepStrictEqual(Buffer.concat([empty], 4096), Buffer.alloc(4096));
 assert.deepStrictEqual(
-    Buffer.concat([random10], 40),
-    Buffer.concat([random10, Buffer.alloc(30)]));
+  Buffer.concat([random10], 40),
+  Buffer.concat([random10, Buffer.alloc(30)]));
 
 assert.deepStrictEqual(Buffer.concat([new Uint8Array([0x41, 0x42]),
                                       new Uint8Array([0x43, 0x44])]),

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -431,36 +431,36 @@ assert.throws(() => {
   { code: undefined, type: RangeError, message: 'Index out of range' }));
 
 assert.deepStrictEqual(
-    Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
-    Buffer.from('61006200610062006100620061006200', 'hex'));
+  Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
+  Buffer.from('61006200610062006100620061006200', 'hex'));
 
 assert.deepStrictEqual(
-    Buffer.allocUnsafeSlow(15).fill('ab', 'utf16le'),
-    Buffer.from('610062006100620061006200610062', 'hex'));
+  Buffer.allocUnsafeSlow(15).fill('ab', 'utf16le'),
+  Buffer.from('610062006100620061006200610062', 'hex'));
 
 assert.deepStrictEqual(
-    Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
-    Buffer.from('61006200610062006100620061006200', 'hex'));
+  Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),
+  Buffer.from('61006200610062006100620061006200', 'hex'));
 assert.deepStrictEqual(
-    Buffer.allocUnsafeSlow(16).fill('a', 'utf16le'),
-    Buffer.from('61006100610061006100610061006100', 'hex'));
+  Buffer.allocUnsafeSlow(16).fill('a', 'utf16le'),
+  Buffer.from('61006100610061006100610061006100', 'hex'));
 
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('a', 'utf16le').toString('utf16le'),
-    'a'.repeat(8));
+  Buffer.allocUnsafeSlow(16).fill('a', 'utf16le').toString('utf16le'),
+  'a'.repeat(8));
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('a', 'latin1').toString('latin1'),
-    'a'.repeat(16));
+  Buffer.allocUnsafeSlow(16).fill('a', 'latin1').toString('latin1'),
+  'a'.repeat(16));
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('a', 'utf8').toString('utf8'),
-    'a'.repeat(16));
+  Buffer.allocUnsafeSlow(16).fill('a', 'utf8').toString('utf8'),
+  'a'.repeat(16));
 
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('Љ', 'utf16le').toString('utf16le'),
-    'Љ'.repeat(8));
+  Buffer.allocUnsafeSlow(16).fill('Љ', 'utf16le').toString('utf16le'),
+  'Љ'.repeat(8));
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('Љ', 'latin1').toString('latin1'),
-    '\t'.repeat(16));
+  Buffer.allocUnsafeSlow(16).fill('Љ', 'latin1').toString('latin1'),
+  '\t'.repeat(16));
 assert.strictEqual(
-    Buffer.allocUnsafeSlow(16).fill('Љ', 'utf8').toString('utf8'),
-    'Љ'.repeat(8));
+  Buffer.allocUnsafeSlow(16).fill('Љ', 'utf8').toString('utf8'),
+  'Љ'.repeat(8));

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -30,9 +30,10 @@ class MyBadPrimitive {
 deepStrictEqual(Buffer.from(new String(checkString)), check);
 deepStrictEqual(Buffer.from(new MyString()), check);
 deepStrictEqual(Buffer.from(new MyPrimitive()), check);
-deepStrictEqual(Buffer.from(
-                  runInNewContext('new String(checkString)', { checkString })),
-                check);
+deepStrictEqual(
+  Buffer.from(runInNewContext('new String(checkString)', { checkString })),
+  check
+);
 
 [
   {},

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -154,11 +154,11 @@ assert(mixedByteStringUcs2.includes('\u03a3', 0, 'ucs2'));
 assert(!mixedByteStringUcs2.includes('\u0396', 0, 'ucs2'));
 
 assert.ok(
-    mixedByteStringUcs2.includes(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
+  mixedByteStringUcs2.includes(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
 assert.ok(
-    mixedByteStringUcs2.includes(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'));
+  mixedByteStringUcs2.includes(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'));
 assert.ok(
-    !mixedByteStringUcs2.includes(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'));
+  !mixedByteStringUcs2.includes(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'));
 
 twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
 
@@ -208,7 +208,7 @@ assert(longBufferString.includes(pattern, 512), 'Long JABACABA..., Second J');
 
 // Search for a non-ASCII string in a pure ASCII string.
 const asciiString = Buffer.from(
-    'arglebargleglopglyfarglebargleglopglyfarglebargleglopglyf');
+  'arglebargleglopglyfarglebargleglopglyfarglebargleglopglyf');
 assert(!asciiString.includes('\x2061'));
 assert(asciiString.includes('leb', 0));
 
@@ -263,11 +263,11 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
     const patternBufferUcs2 =
         allCharsBufferUcs2.slice(index, index + length);
     assert.ok(
-        allCharsBufferUcs2.includes(patternBufferUcs2, 0, 'ucs2'));
+      allCharsBufferUcs2.includes(patternBufferUcs2, 0, 'ucs2'));
 
     const patternStringUcs2 = patternBufferUcs2.toString('ucs2');
     assert.ok(
-        allCharsBufferUcs2.includes(patternStringUcs2, 0, 'ucs2'));
+      allCharsBufferUcs2.includes(patternStringUcs2, 0, 'ucs2'));
   }
 }
 

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -198,11 +198,11 @@ assert.strictEqual(10, mixedByteStringUcs2.indexOf('\u03a3', 0, 'ucs2'));
 assert.strictEqual(-1, mixedByteStringUcs2.indexOf('\u0396', 0, 'ucs2'));
 
 assert.strictEqual(
-    6, mixedByteStringUcs2.indexOf(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
+  6, mixedByteStringUcs2.indexOf(Buffer.from('bc', 'ucs2'), 0, 'ucs2'));
 assert.strictEqual(
-    10, mixedByteStringUcs2.indexOf(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'));
+  10, mixedByteStringUcs2.indexOf(Buffer.from('\u03a3', 'ucs2'), 0, 'ucs2'));
 assert.strictEqual(
-    -1, mixedByteStringUcs2.indexOf(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'));
+  -1, mixedByteStringUcs2.indexOf(Buffer.from('\u0396', 'ucs2'), 0, 'ucs2'));
 
 {
   const twoByteString = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'ucs2');
@@ -222,13 +222,13 @@ assert.strictEqual(
 
   // Test multi-char pattern
   assert.strictEqual(
-      0, twoByteString.indexOf('\u039a\u0391', 0, 'ucs2'), 'Lambda Alpha');
+    0, twoByteString.indexOf('\u039a\u0391', 0, 'ucs2'), 'Lambda Alpha');
   assert.strictEqual(
-      2, twoByteString.indexOf('\u0391\u03a3', 0, 'ucs2'), 'Alpha Sigma');
+    2, twoByteString.indexOf('\u0391\u03a3', 0, 'ucs2'), 'Alpha Sigma');
   assert.strictEqual(
-      4, twoByteString.indexOf('\u03a3\u03a3', 0, 'ucs2'), 'Sigma Sigma');
+    4, twoByteString.indexOf('\u03a3\u03a3', 0, 'ucs2'), 'Sigma Sigma');
   assert.strictEqual(
-      6, twoByteString.indexOf('\u03a3\u0395', 0, 'ucs2'), 'Sigma Epsilon');
+    6, twoByteString.indexOf('\u03a3\u0395', 0, 'ucs2'), 'Sigma Epsilon');
 }
 
 const mixedByteStringUtf8 = Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395');
@@ -258,17 +258,17 @@ for (let i = 0; i < longBufferString.length - pattern.length; i += 7) {
 assert.strictEqual(510, longBufferString.indexOf('AJABACA'),
                    'Long AJABACA, First J');
 assert.strictEqual(
-    1534, longBufferString.indexOf('AJABACA', 511), 'Long AJABACA, Second J');
+  1534, longBufferString.indexOf('AJABACA', 511), 'Long AJABACA, Second J');
 
 pattern = 'JABACABADABACABA';
 assert.strictEqual(
-    511, longBufferString.indexOf(pattern), 'Long JABACABA..., First J');
+  511, longBufferString.indexOf(pattern), 'Long JABACABA..., First J');
 assert.strictEqual(
-    1535, longBufferString.indexOf(pattern, 512), 'Long JABACABA..., Second J');
+  1535, longBufferString.indexOf(pattern, 512), 'Long JABACABA..., Second J');
 
 // Search for a non-ASCII string in a pure ASCII string.
 const asciiString = Buffer.from(
-    'arglebargleglopglyfarglebargleglopglyfarglebargleglopglyf');
+  'arglebargleglopglyfarglebargleglopglyfarglebargleglopglyf');
 assert.strictEqual(-1, asciiString.indexOf('\x2061'));
 assert.strictEqual(3, asciiString.indexOf('leb', 0));
 
@@ -335,11 +335,11 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
       const patternBufferUcs2 =
           allCharsBufferUcs2.slice(index, index + length);
       assert.strictEqual(
-          index, allCharsBufferUcs2.indexOf(patternBufferUcs2, 0, 'ucs2'));
+        index, allCharsBufferUcs2.indexOf(patternBufferUcs2, 0, 'ucs2'));
 
       const patternStringUcs2 = patternBufferUcs2.toString('ucs2');
       assert.strictEqual(
-          index, allCharsBufferUcs2.indexOf(patternStringUcs2, 0, 'ucs2'));
+        index, allCharsBufferUcs2.indexOf(patternStringUcs2, 0, 'ucs2'));
     }
   }
 }

--- a/test/parallel/test-buffer-isencoding.js
+++ b/test/parallel/test-buffer-isencoding.js
@@ -3,7 +3,8 @@
 require('../common');
 const assert = require('assert');
 
-[ 'hex',
+[
+  'hex',
   'utf8',
   'utf-8',
   'ascii',
@@ -13,11 +14,13 @@ const assert = require('assert');
   'ucs2',
   'ucs-2',
   'utf16le',
-  'utf-16le' ].forEach((enc) => {
-    assert.strictEqual(Buffer.isEncoding(enc), true);
-  });
+  'utf-16le'
+].forEach((enc) => {
+  assert.strictEqual(Buffer.isEncoding(enc), true);
+});
 
-[ 'utf9',
+[
+  'utf9',
   'utf-7',
   'Unicode-FTW',
   'new gnu gun',
@@ -28,6 +31,7 @@ const assert = require('assert');
   [],
   1,
   0,
-  -1 ].forEach((enc) => {
-    assert.strictEqual(Buffer.isEncoding(enc), false);
-  });
+  -1
+].forEach((enc) => {
+  assert.strictEqual(Buffer.isEncoding(enc), false);
+});

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -4,8 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 
 assert.throws(() => new Buffer(42, 'utf8'), common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "string" argument must be of type string. ' +
-             'Received type number'
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "string" argument must be of type string. Received type number'
 }));

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -14,9 +14,9 @@ function read(buff, funx, args, expected) {
   );
 
   assert.doesNotThrow(
-  () => assert.strictEqual(buff[funx](...args, true), expected),
-  'noAssert does not change return value for valid ranges'
-);
+    () => assert.strictEqual(buff[funx](...args, true), expected),
+    'noAssert does not change return value for valid ranges'
+  );
 
 }
 

--- a/test/parallel/test-child-process-spawn-argv0.js
+++ b/test/parallel/test-child-process-spawn-argv0.js
@@ -14,5 +14,5 @@ const noArgv0 = cp.spawnSync(process.execPath, [__filename, 'child']);
 assert.strictEqual(noArgv0.stdout.toString().trim(), process.execPath);
 
 const withArgv0 = cp.spawnSync(process.execPath, [__filename, 'child'],
-    { argv0: 'withArgv0' });
+                               { argv0: 'withArgv0' });
 assert.strictEqual(withArgv0.stdout.toString().trim(), 'withArgv0');

--- a/test/parallel/test-child-process-spawnsync-timeout.js
+++ b/test/parallel/test-child-process-spawnsync-timeout.js
@@ -38,7 +38,7 @@ switch (process.argv[2]) {
   default:
     const start = Date.now();
     const ret = spawnSync(process.execPath, [__filename, 'child'],
-                        { timeout: TIMER });
+                          { timeout: TIMER });
     assert.strictEqual(ret.error.errno, 'ETIMEDOUT');
     const end = Date.now() - start;
     assert(end < SLEEP);

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -69,9 +69,9 @@ const errMessage = /Invalid IV length/;
 // But non-empty IVs should be rejected.
 for (let n = 1; n < 256; n += 1) {
   assert.throws(
-      () => crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16),
-                                  Buffer.alloc(n)),
-      errMessage);
+    () => crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16),
+                                Buffer.alloc(n)),
+    errMessage);
 }
 
 // Correctly sized IV should be accepted in CBC mode.
@@ -81,16 +81,16 @@ crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16), Buffer.alloc(16));
 for (let n = 0; n < 256; n += 1) {
   if (n === 16) continue;
   assert.throws(
-      () => crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16),
-                                  Buffer.alloc(n)),
-      errMessage);
+    () => crypto.createCipheriv('aes-128-cbc', Buffer.alloc(16),
+                                Buffer.alloc(n)),
+    errMessage);
 }
 
 // Zero-sized IV should be rejected in GCM mode.
 assert.throws(
-    () => crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16),
-                                Buffer.alloc(0)),
-    errMessage);
+  () => crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16),
+                              Buffer.alloc(0)),
+  errMessage);
 
 // But all other IV lengths should be accepted.
 for (let n = 1; n < 256; n += 1) {

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -41,7 +41,7 @@ function testHelper(stream, args, expectedOutput, cmd, env) {
 
   console.error(
     `Spawned child [pid:${child.pid}] with cmd '${cmd}' expect %j with args '${
-    args}' OPENSSL_CONF=%j`, expectedOutput, env.OPENSSL_CONF);
+      args}' OPENSSL_CONF=%j`, expectedOutput, env.OPENSSL_CONF);
 
   function childOk(child) {
     console.error(`Child #${++num_children_ok} [pid:${child.pid}] OK.`);

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -94,13 +94,13 @@ assert.throws(function() {
 // Default UTF-8 encoding
 const hutf8 = crypto.createHash('sha512').update('УТФ-8 text').digest('hex');
 assert.strictEqual(
-    hutf8,
-    '4b21bbd1a68e690a730ddcb5a8bc94ead9879ffe82580767ad7ec6fa8ba2dea6' +
+  hutf8,
+  '4b21bbd1a68e690a730ddcb5a8bc94ead9879ffe82580767ad7ec6fa8ba2dea6' +
         '43a821af66afa9a45b6a78c712fecf0e56dc7f43aef4bcfc8eb5b4d8dca6ea5b');
 
 assert.notStrictEqual(
-    hutf8,
-    crypto.createHash('sha512').update('УТФ-8 text', 'latin1').digest('hex'));
+  hutf8,
+  crypto.createHash('sha512').update('УТФ-8 text', 'latin1').digest('hex'));
 
 const h3 = crypto.createHash('sha256');
 h3.digest();

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -267,8 +267,8 @@ const modSize = 1024;
 
   const cmd =
     `"${common.opensslCli}" dgst -sha256 -verify "${pubfile}" -signature "${
-    sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${
-    msgfile}"`;
+      sigfile}" -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-2 "${
+      msgfile}"`;
 
   exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert(stdout.includes('Verified OK'));

--- a/test/parallel/test-dns-resolveany.js
+++ b/test/parallel/test-dns-resolveany.js
@@ -46,8 +46,8 @@ server.bind(0, common.mustCall(() => {
     assert.ifError(err);
     // Compare copies with ttl removed, c-ares fiddles with that value.
     assert.deepStrictEqual(
-        res.map((r) => Object.assign({}, r, { ttl: null })),
-        answers.map((r) => Object.assign({}, r, { ttl: null })));
+      res.map((r) => Object.assign({}, r, { ttl: null })),
+      answers.map((r) => Object.assign({}, r, { ttl: null })));
     server.close();
   }));
 }));

--- a/test/parallel/test-domain-nested.js
+++ b/test/parallel/test-domain-nested.js
@@ -34,7 +34,7 @@ domain.create().run(function() {
   domain.create().run(function() {
     domain.create().run(function() {
       domain.create().on('error', function(e) {
-          // Don't need to do anything here
+        // Don't need to do anything here
       }).run(function() {
         throw new Error('died');
       });

--- a/test/parallel/test-domain-uncaught-exception.js
+++ b/test/parallel/test-domain-uncaught-exception.js
@@ -185,7 +185,7 @@ if (process.argv[2] === 'child') {
         const msgs = test.messagesReceived;
         if (msgs === undefined || !msgs.includes(expectedMessage)) {
           assert.fail(`test ${test.fn.name} should have sent message: ${
-                      expectedMessage} but didn't`);
+            expectedMessage} but didn't`);
         }
       });
 
@@ -193,7 +193,7 @@ if (process.argv[2] === 'child') {
         test.messagesReceived.forEach(function(receivedMessage) {
           if (!test.expectedMessages.includes(receivedMessage)) {
             assert.fail(`test ${test.fn.name} should not have sent message: ${
-                        receivedMessage} but did`);
+              receivedMessage} but did`);
           }
         });
       }

--- a/test/parallel/test-domain.js
+++ b/test/parallel/test-domain.js
@@ -81,7 +81,7 @@ d.on('error', function(er) {
       break;
 
     case
-    "ENOENT: no such file or directory, open 'stream for nonexistent file'":
+      "ENOENT: no such file or directory, open 'stream for nonexistent file'":
       assert.strictEqual(typeof er.errno, 'number');
       assert.strictEqual(er.code, 'ENOENT');
       assert.strictEqual(er_path, 'stream for nonexistent file');

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -177,10 +177,10 @@ function run_test_3() {
 const run_test_4 = common.mustCall(function() {
   //  Error: start must be >= zero
   assert.throws(
-      function() {
-        fs.createWriteStream(filepath, { start: -5, flags: 'r+' });
-      },
-      /"start" must be/
+    function() {
+      fs.createWriteStream(filepath, { start: -5, flags: 'r+' });
+    },
+    /"start" must be/
   );
 });
 

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -20,20 +20,20 @@ assert.throws(function() {
 
 const enoentFile = path.join(common.tmpDir, 'non-existent-file');
 const expectedStatObject = new fs.Stats(
-    0,                                        // dev
-    0,                                        // mode
-    0,                                        // nlink
-    0,                                        // uid
-    0,                                        // gid
-    0,                                        // rdev
-    common.isWindows ? undefined : 0,         // blksize
-    0,                                        // ino
-    0,                                        // size
-    common.isWindows ? undefined : 0,         // blocks
-    Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
-    Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
-    Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
-    Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
+  0,                                        // dev
+  0,                                        // mode
+  0,                                        // nlink
+  0,                                        // uid
+  0,                                        // gid
+  0,                                        // rdev
+  common.isWindows ? undefined : 0,         // blksize
+  0,                                        // ino
+  0,                                        // size
+  common.isWindows ? undefined : 0,         // blocks
+  Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
+  Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
+  Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
+  Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
 );
 
 common.refreshTmpDir();

--- a/test/parallel/test-handle-wrap-isrefed.js
+++ b/test/parallel/test-handle-wrap-isrefed.js
@@ -19,8 +19,8 @@ const strictEqual = require('assert').strictEqual;
   strictEqual(cp._handle.hasRef(),
               true, 'process_wrap: ref() ineffective');
   cp._handle.close(common.mustCall(() =>
-      strictEqual(cp._handle.hasRef(),
-                  false, 'process_wrap: not unrefed on close')));
+    strictEqual(cp._handle.hasRef(),
+                false, 'process_wrap: not unrefed on close')));
 }
 
 
@@ -40,8 +40,8 @@ const dgram = require('dgram');
   strictEqual(sock4._handle.hasRef(),
               true, 'udp_wrap: ipv4: ref() ineffective');
   sock4._handle.close(common.mustCall(() =>
-      strictEqual(sock4._handle.hasRef(),
-                  false, 'udp_wrap: ipv4: not unrefed on close')));
+    strictEqual(sock4._handle.hasRef(),
+                false, 'udp_wrap: ipv4: not unrefed on close')));
 }
 
 
@@ -59,8 +59,8 @@ const dgram = require('dgram');
   strictEqual(sock6._handle.hasRef(),
               true, 'udp_wrap: ipv6: ref() ineffective');
   sock6._handle.close(common.mustCall(() =>
-      strictEqual(sock6._handle.hasRef(),
-                  false, 'udp_wrap: ipv6: not unrefed on close')));
+    strictEqual(sock6._handle.hasRef(),
+                false, 'udp_wrap: ipv6: not unrefed on close')));
 }
 
 
@@ -79,8 +79,8 @@ const dgram = require('dgram');
   strictEqual(handle.hasRef(),
               true, 'pipe_wrap: ref() ineffective');
   handle.close(common.mustCall(() =>
-      strictEqual(handle.hasRef(),
-                  false, 'pipe_wrap: not unrefed on close')));
+    strictEqual(handle.hasRef(),
+                false, 'pipe_wrap: not unrefed on close')));
 }
 
 
@@ -105,8 +105,8 @@ const dgram = require('dgram');
   strictEqual(server._unref,
               false, 'tcp_wrap: _unref not updated on ref()');
   server._handle.close(common.mustCall(() =>
-      strictEqual(server._handle.hasRef(),
-                  false, 'tcp_wrap: not unrefed on close')));
+    strictEqual(server._handle.hasRef(),
+                false, 'tcp_wrap: not unrefed on close')));
 }
 
 
@@ -122,8 +122,8 @@ const dgram = require('dgram');
   strictEqual(timer._handle.hasRef(),
               true, 'timer_wrap: ref() ineffective');
   timer._handle.close(common.mustCall(() =>
-      strictEqual(timer._handle.hasRef(),
-                  false, 'timer_wrap: not unrefed on close')));
+    strictEqual(timer._handle.hasRef(),
+                false, 'timer_wrap: not unrefed on close')));
 }
 
 

--- a/test/parallel/test-http-agent.js
+++ b/test/parallel/test-http-agent.js
@@ -81,4 +81,4 @@ test1
     console.error(e);
     process.exit(1);
   }
-);
+  );

--- a/test/parallel/test-http-header-read.js
+++ b/test/parallel/test-http-header-read.js
@@ -38,9 +38,9 @@ const s = http.createServer(function(req, res) {
   // This checks that after the headers have been sent, getHeader works
   // and does not throw an exception (Issue 752)
   assert.doesNotThrow(
-      function() {
-        assert.strictEqual(plain, res.getHeader(contentType));
-      }
+    function() {
+      assert.strictEqual(plain, res.getHeader(contentType));
+    }
   );
 });
 

--- a/test/parallel/test-http-parser.js
+++ b/test/parallel/test-http-parser.js
@@ -27,7 +27,6 @@ const binding = process.binding('http_parser');
 const methods = binding.methods;
 const HTTPParser = binding.HTTPParser;
 
-const CRLF = '\r\n';
 const REQUEST = HTTPParser.REQUEST;
 const RESPONSE = HTTPParser.RESPONSE;
 
@@ -92,7 +91,7 @@ function expectBody(expected) {
 // Simple request test.
 //
 {
-  const request = Buffer.from(`GET /hello HTTP/1.1${CRLF}${CRLF}`);
+  const request = Buffer.from('GET /hello HTTP/1.1\r\n\r\n');
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -129,11 +128,12 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'HTTP/1.1 200 OK' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Content-Length: 4' + CRLF +
-      CRLF +
-      'pong');
+    'HTTP/1.1 200 OK\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Content-Length: 4\r\n' +
+    '\r\n' +
+    'pong'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -162,7 +162,7 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-    `HTTP/1.0 200 Connection established${CRLF}${CRLF}`);
+    'HTTP/1.0 200 Connection established\r\n\r\n');
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -186,15 +186,16 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'POST /it HTTP/1.1' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '4' + CRLF +
-      'ping' + CRLF +
-      '0' + CRLF +
-      'Vary: *' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      CRLF);
+    'POST /it HTTP/1.1\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '4\r\n' +
+    'ping\r\n' +
+    '0\r\n' +
+    'Vary: *\r\n' +
+    'Content-Type: text/plain\r\n' +
+    '\r\n'
+  );
 
   let seen_body = false;
 
@@ -233,11 +234,12 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'GET / HTTP/1.0' + CRLF +
-      'X-Filler: 1337' + CRLF +
-      'X-Filler:   42' + CRLF +
-      'X-Filler2:  42' + CRLF +
-      CRLF);
+    'GET / HTTP/1.0\r\n' +
+    'X-Filler: 1337\r\n' +
+    'X-Filler:   42\r\n' +
+    'X-Filler2:  42\r\n' +
+    '\r\n'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -246,8 +248,8 @@ function expectBody(expected) {
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 0);
     assert.deepStrictEqual(
-        headers || parser.headers,
-        ['X-Filler', '1337', 'X-Filler', '42', 'X-Filler2', '42']);
+      headers || parser.headers,
+      ['X-Filler', '1337', 'X-Filler', '42', 'X-Filler2', '42']);
   };
 
   const parser = newParser(REQUEST);
@@ -261,12 +263,13 @@ function expectBody(expected) {
 //
 {
   // 256 X-Filler headers
-  const lots_of_headers = `X-Filler: 42${CRLF}`.repeat(256);
+  const lots_of_headers = 'X-Filler: 42\r\n'.repeat(256);
 
   const request = Buffer.from(
-      'GET /foo/bar/baz?quux=42#1337 HTTP/1.0' + CRLF +
-      lots_of_headers +
-      CRLF);
+    'GET /foo/bar/baz?quux=42#1337 HTTP/1.0\r\n' +
+    lots_of_headers +
+    '\r\n'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -296,11 +299,12 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'POST /it HTTP/1.1' + CRLF +
-      'Content-Type: application/x-www-form-urlencoded' + CRLF +
-      'Content-Length: 15' + CRLF +
-      CRLF +
-      'foo=42&bar=1337');
+    'POST /it HTTP/1.1\r\n' +
+    'Content-Type: application/x-www-form-urlencoded\r\n' +
+    'Content-Length: 15\r\n' +
+    '\r\n' +
+    'foo=42&bar=1337'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -328,17 +332,18 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'POST /it HTTP/1.1' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '3' + CRLF +
-      '123' + CRLF +
-      '6' + CRLF +
-      '123456' + CRLF +
-      'A' + CRLF +
-      '1234567890' + CRLF +
-      '0' + CRLF);
+    'POST /it HTTP/1.1\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '3\r\n' +
+    '123\r\n' +
+    '6\r\n' +
+    '123456\r\n' +
+    'A\r\n' +
+    '1234567890\r\n' +
+    '0\r\n'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -369,14 +374,15 @@ function expectBody(expected) {
 //
 {
   let request = Buffer.from(
-      'POST /it HTTP/1.1' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '3' + CRLF +
-      '123' + CRLF +
-      '6' + CRLF +
-      '123456' + CRLF);
+    'POST /it HTTP/1.1\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '3\r\n' +
+    '123\r\n' +
+    '6\r\n' +
+    '123456\r\n'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -402,13 +408,14 @@ function expectBody(expected) {
   parser.execute(request, 0, request.length);
 
   request = Buffer.from(
-      '9' + CRLF +
-      '123456789' + CRLF +
-      'C' + CRLF +
-      '123456789ABC' + CRLF +
-      'F' + CRLF +
-      '123456789ABCDEF' + CRLF +
-      '0' + CRLF);
+    '9\r\n' +
+    '123456789\r\n' +
+    'C\r\n' +
+    '123456789ABC\r\n' +
+    'F\r\n' +
+    '123456789ABCDEF\r\n' +
+    '0\r\n'
+  );
 
   parser.execute(request, 0, request.length);
 }
@@ -419,21 +426,22 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'POST /helpme HTTP/1.1' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '3' + CRLF +
-      '123' + CRLF +
-      '6' + CRLF +
-      '123456' + CRLF +
-      '9' + CRLF +
-      '123456789' + CRLF +
-      'C' + CRLF +
-      '123456789ABC' + CRLF +
-      'F' + CRLF +
-      '123456789ABCDEF' + CRLF +
-      '0' + CRLF);
+    'POST /helpme HTTP/1.1\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '3\r\n' +
+    '123\r\n' +
+    '6\r\n' +
+    '123456\r\n' +
+    '9\r\n' +
+    '123456789\r\n' +
+    'C\r\n' +
+    '123456789ABC\r\n' +
+    'F\r\n' +
+    '123456789ABCDEF\r\n' +
+    '0\r\n'
+  );
 
   function test(a, b) {
     const onHeadersComplete = (versionMajor, versionMinor, headers,
@@ -477,21 +485,22 @@ function expectBody(expected) {
 //
 {
   const request = Buffer.from(
-      'POST /it HTTP/1.1' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '3' + CRLF +
-      '123' + CRLF +
-      '6' + CRLF +
-      '123456' + CRLF +
-      '9' + CRLF +
-      '123456789' + CRLF +
-      'C' + CRLF +
-      '123456789ABC' + CRLF +
-      'F' + CRLF +
-      '123456789ABCDEF' + CRLF +
-      '0' + CRLF);
+    'POST /it HTTP/1.1\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '3\r\n' +
+    '123\r\n' +
+    '6\r\n' +
+    '123456\r\n' +
+    '9\r\n' +
+    '123456789\r\n' +
+    'C\r\n' +
+    '123456789ABC\r\n' +
+    'F\r\n' +
+    '123456789ABCDEF\r\n' +
+    '0\r\n'
+  );
 
   const onHeadersComplete = (versionMajor, versionMinor, headers,
                              method, url, statusCode, statusMessage,
@@ -501,8 +510,8 @@ function expectBody(expected) {
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 1);
     assert.deepStrictEqual(
-        headers || parser.headers,
-        ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
+      headers || parser.headers,
+      ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
   };
 
   let expected_body = '123123456123456789123456789ABC123456789ABCDEF';
@@ -530,20 +539,22 @@ function expectBody(expected) {
 //
 {
   const req1 = Buffer.from(
-      'PUT /this HTTP/1.1' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Transfer-Encoding: chunked' + CRLF +
-      CRLF +
-      '4' + CRLF +
-      'ping' + CRLF +
-      '0' + CRLF);
+    'PUT /this HTTP/1.1\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '4\r\n' +
+    'ping\r\n' +
+    '0\r\n'
+  );
 
   const req2 = Buffer.from(
-      'POST /that HTTP/1.0' + CRLF +
-      'Content-Type: text/plain' + CRLF +
-      'Content-Length: 4' + CRLF +
-      CRLF +
-      'pong');
+    'POST /that HTTP/1.0\r\n' +
+    'Content-Type: text/plain\r\n' +
+    'Content-Length: 4\r\n' +
+    '\r\n' +
+    'pong'
+  );
 
   const onHeadersComplete1 = (versionMajor, versionMinor, headers,
                               method, url, statusCode, statusMessage,
@@ -553,8 +564,8 @@ function expectBody(expected) {
     assert.strictEqual(versionMajor, 1);
     assert.strictEqual(versionMinor, 1);
     assert.deepStrictEqual(
-        headers,
-        ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
+      headers,
+      ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked']);
   };
 
   const onHeadersComplete2 = (versionMajor, versionMinor, headers,
@@ -584,7 +595,7 @@ function expectBody(expected) {
 // Test parser 'this' safety
 // https://github.com/joyent/node/issues/6690
 assert.throws(function() {
-  const request = Buffer.from(`GET /hello HTTP/1.1${CRLF}${CRLF}`);
+  const request = Buffer.from('GET /hello HTTP/1.1\r\n\r\n');
 
   const parser = newParser(REQUEST);
   const notparser = { execute: parser.execute };

--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -84,8 +84,8 @@ server.on('listening', function() {
       outstanding_reqs--;
       clearTimeout(tid);
       assert.ok(
-          /0\r\nx-foo: bar\r\n\r\n$/.test(res_buffer),
-          'No trailer in HTTP/1.1 response.'
+        /0\r\nx-foo: bar\r\n\r\n$/.test(res_buffer),
+        'No trailer in HTTP/1.1 response.'
       );
       if (outstanding_reqs === 0) {
         server.close();

--- a/test/parallel/test-http-should-keep-alive.js
+++ b/test/parallel/test-http-should-keep-alive.js
@@ -54,7 +54,7 @@ const server = net.createServer(function(socket) {
       assert.strictEqual(
         req.shouldKeepAlive, SHOULD_KEEP_ALIVE[responses],
         `${SERVER_RESPONSES[responses]} should ${
-        SHOULD_KEEP_ALIVE[responses] ? '' : 'not '}Keep-Alive`);
+          SHOULD_KEEP_ALIVE[responses] ? '' : 'not '}Keep-Alive`);
       ++responses;
       if (responses < SHOULD_KEEP_ALIVE.length) {
         makeRequest();

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -57,9 +57,9 @@ const s = http.createServer(common.mustCall((req, res) => {
   assert.throws(() => {
     res.writeHead(100, {});
   }, common.expectsError({
-       code: 'ERR_HTTP_HEADERS_SENT',
-       type: Error,
-       message: 'Cannot render headers after they are sent to the client'
+    code: 'ERR_HTTP_HEADERS_SENT',
+    type: Error,
+    message: 'Cannot render headers after they are sent to the client'
   })
   );
 

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -143,9 +143,9 @@ function makeReq(path, port, error, host, ca) {
   }
   const req = https.get(options);
   const server = port === server1.address().port ? server1 :
-      port === server2.address().port ? server2 :
+    port === server2.address().port ? server2 :
       port === server3.address().port ? server3 :
-      null;
+        null;
   if (!server) throw new Error(`invalid port: ${port}`);
   server.expectCount++;
 

--- a/test/parallel/test-icu-stringwidth.js
+++ b/test/parallel/test-icu-stringwidth.js
@@ -55,7 +55,7 @@ assert.strictEqual(readline.getStringWidth(0x20DD), 0);
 // individually.
 assert.strictEqual(readline.getStringWidth('👩‍👩‍👧‍👧'), 2);
 assert.strictEqual(
-    readline.getStringWidth('👩‍👩‍👧‍👧', { expandEmojiSequence: true }), 8);
+  readline.getStringWidth('👩‍👩‍👧‍👧', { expandEmojiSequence: true }), 8);
 
 // By default, unicode characters whose width is considered ambiguous will
 // be considered half-width. For these characters, getStringWidth will return
@@ -65,7 +65,7 @@ assert.strictEqual(
 // as 2 columns.
 assert.strictEqual(readline.getStringWidth('\u01d4'), 1);
 assert.strictEqual(
-    readline.getStringWidth('\u01d4', { ambiguousAsFullWidth: true }), 2);
+  readline.getStringWidth('\u01d4', { ambiguousAsFullWidth: true }), 2);
 
 // Control chars and combining chars are zero
 assert.strictEqual(readline.getStringWidth('\u200E\n\u220A\u20D2'), 1);

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -57,21 +57,21 @@ assert.throws(
 );
 
 assert.deepStrictEqual(
-    buffer.transcode(Buffer.from('hi', 'ascii'), 'ascii', 'utf16le'),
-    Buffer.from('hi', 'utf16le'));
+  buffer.transcode(Buffer.from('hi', 'ascii'), 'ascii', 'utf16le'),
+  Buffer.from('hi', 'utf16le'));
 assert.deepStrictEqual(
-    buffer.transcode(Buffer.from('hi', 'latin1'), 'latin1', 'utf16le'),
-    Buffer.from('hi', 'utf16le'));
+  buffer.transcode(Buffer.from('hi', 'latin1'), 'latin1', 'utf16le'),
+  Buffer.from('hi', 'utf16le'));
 assert.deepStrictEqual(
-    buffer.transcode(Buffer.from('hä', 'latin1'), 'latin1', 'utf16le'),
-    Buffer.from('hä', 'utf16le'));
+  buffer.transcode(Buffer.from('hä', 'latin1'), 'latin1', 'utf16le'),
+  Buffer.from('hä', 'utf16le'));
 
 // Test that Uint8Array arguments are okay.
 {
   const uint8array = new Uint8Array([...Buffer.from('hä', 'latin1')]);
   assert.deepStrictEqual(
-      buffer.transcode(uint8array, 'latin1', 'utf16le'),
-      Buffer.from('hä', 'utf16le'));
+    buffer.transcode(uint8array, 'latin1', 'utf16le'),
+    Buffer.from('hä', 'utf16le'));
 }
 
 {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -233,5 +233,5 @@ assert.throws(
 
 // Test ERR_TLS_CERT_ALTNAME_INVALID
 assert.strictEqual(
-    errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
-    'Hostname/IP does not match certificate\'s altnames: altname');
+  errors.message('ERR_TLS_CERT_ALTNAME_INVALID', ['altname']),
+  'Hostname/IP does not match certificate\'s altnames: altname');

--- a/test/parallel/test-intl.js
+++ b/test/parallel/test-intl.js
@@ -55,7 +55,7 @@ if (!common.hasIntl) {
 } else {
   const erMsg =
     `"Intl" object is present but v8_enable_i18n_support is ${
-    enablei18n}. Is this test out of date?`;
+      enablei18n}. Is this test out of date?`;
   assert.strictEqual(enablei18n, 1, erMsg);
 
   // Construct a new date at the beginning of Unix time

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -47,11 +47,11 @@ if (process.argv[2] === 'child') {
   fs.mkdirSync(noPkgHomeDir);
   env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
   assert.throws(
-      () => {
-        child_process.execFileSync(testExecPath, [ __filename, 'child' ],
-                                   { encoding: 'utf8', env: env });
-      },
-      new RegExp(`Cannot find module '${pkgName}'`));
+    () => {
+      child_process.execFileSync(testExecPath, [ __filename, 'child' ],
+                                 { encoding: 'utf8', env: env });
+    },
+    new RegExp(`Cannot find module '${pkgName}'`));
 
   // Test module in $HOME/.node_modules.
   const modHomeDir = path.join(testFixturesDir, 'home-pkg-in-node_modules');

--- a/test/parallel/test-openssl-ca-options.js
+++ b/test/parallel/test-openssl-ca-options.js
@@ -8,23 +8,23 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const os = require('os');
 const childProcess = require('child_process');
-const result = childProcess.spawnSync(process.execPath, [
-                                      '--use-bundled-ca',
-                                      '--use-openssl-ca',
-                                      '-p', 'process.version'],
-                                      { encoding: 'utf8' });
+const result = childProcess.spawnSync(
+  process.execPath,
+  [ '--use-bundled-ca', '--use-openssl-ca', '-p', 'process.version' ],
+  { encoding: 'utf8' }
+);
 
 assert.strictEqual(result.stderr, `${process.execPath
-  }: either --use-openssl-ca or --use-bundled-ca can be used, not both${os.EOL}`
+}: either --use-openssl-ca or --use-bundled-ca can be used, not both${os.EOL}`
 );
 assert.strictEqual(result.status, 9);
 
 const useBundledCA = childProcess.spawnSync(process.execPath, [
-                                            '--use-bundled-ca',
-                                            '-p', 'process.version']);
+  '--use-bundled-ca',
+  '-p', 'process.version']);
 assert.strictEqual(useBundledCA.status, 0);
 
 const useOpenSSLCA = childProcess.spawnSync(process.execPath, [
-                                            '--use-openssl-ca',
-                                            '-p', 'process.version']);
+  '--use-openssl-ca',
+  '-p', 'process.version']);
 assert.strictEqual(useOpenSSLCA.status, 0);

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -115,25 +115,25 @@ if (!common.isSunOS) {
 const interfaces = os.networkInterfaces();
 switch (platform) {
   case 'linux':
-    {
-      const filter = (e) => e.address === '127.0.0.1';
-      const actual = interfaces.lo.filter(filter);
-      const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                          mac: '00:00:00:00:00:00', family: 'IPv4',
-                          internal: true }];
-      assert.deepStrictEqual(actual, expected);
-      break;
-    }
+  {
+    const filter = (e) => e.address === '127.0.0.1';
+    const actual = interfaces.lo.filter(filter);
+    const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
+                        mac: '00:00:00:00:00:00', family: 'IPv4',
+                        internal: true }];
+    assert.deepStrictEqual(actual, expected);
+    break;
+  }
   case 'win32':
-    {
-      const filter = (e) => e.address === '127.0.0.1';
-      const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
-      const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
-                          mac: '00:00:00:00:00:00', family: 'IPv4',
-                          internal: true }];
-      assert.deepStrictEqual(actual, expected);
-      break;
-    }
+  {
+    const filter = (e) => e.address === '127.0.0.1';
+    const actual = interfaces['Loopback Pseudo-Interface 1'].filter(filter);
+    const expected = [{ address: '127.0.0.1', netmask: '255.0.0.0',
+                        mac: '00:00:00:00:00:00', family: 'IPv4',
+                        internal: true }];
+    assert.deepStrictEqual(actual, expected);
+    break;
+  }
 }
 
 const EOL = os.EOL;

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -287,51 +287,51 @@ joinTests.push([
   path.win32.join,
   joinTests[0][1].slice(0).concat(
     [// arguments                     result
-     // UNC path expected
-     [['//foo/bar'], '\\\\foo\\bar\\'],
-     [['\\/foo/bar'], '\\\\foo\\bar\\'],
-     [['\\\\foo/bar'], '\\\\foo\\bar\\'],
-     // UNC path expected - server and share separate
-     [['//foo', 'bar'], '\\\\foo\\bar\\'],
-     [['//foo/', 'bar'], '\\\\foo\\bar\\'],
-     [['//foo', '/bar'], '\\\\foo\\bar\\'],
-     // UNC path expected - questionable
-     [['//foo', '', 'bar'], '\\\\foo\\bar\\'],
-     [['//foo/', '', 'bar'], '\\\\foo\\bar\\'],
-     [['//foo/', '', '/bar'], '\\\\foo\\bar\\'],
-     // UNC path expected - even more questionable
-     [['', '//foo', 'bar'], '\\\\foo\\bar\\'],
-     [['', '//foo/', 'bar'], '\\\\foo\\bar\\'],
-     [['', '//foo/', '/bar'], '\\\\foo\\bar\\'],
-     // No UNC path expected (no double slash in first component)
-     [['\\', 'foo/bar'], '\\foo\\bar'],
-     [['\\', '/foo/bar'], '\\foo\\bar'],
-     [['', '/', '/foo/bar'], '\\foo\\bar'],
-     // No UNC path expected (no non-slashes in first component -
-     // questionable)
-     [['//', 'foo/bar'], '\\foo\\bar'],
-     [['//', '/foo/bar'], '\\foo\\bar'],
-     [['\\\\', '/', '/foo/bar'], '\\foo\\bar'],
-     [['//'], '/'],
-     // No UNC path expected (share name missing - questionable).
-     [['//foo'], '\\foo'],
-     [['//foo/'], '\\foo\\'],
-     [['//foo', '/'], '\\foo\\'],
-     [['//foo', '', '/'], '\\foo\\'],
-     // No UNC path expected (too many leading slashes - questionable)
-     [['///foo/bar'], '\\foo\\bar'],
-     [['////foo', 'bar'], '\\foo\\bar'],
-     [['\\\\\\/foo/bar'], '\\foo\\bar'],
-     // Drive-relative vs drive-absolute paths. This merely describes the
-     // status quo, rather than being obviously right
-     [['c:'], 'c:.'],
-     [['c:.'], 'c:.'],
-     [['c:', ''], 'c:.'],
-     [['', 'c:'], 'c:.'],
-     [['c:.', '/'], 'c:.\\'],
-     [['c:.', 'file'], 'c:file'],
-     [['c:', '/'], 'c:\\'],
-     [['c:', 'file'], 'c:\\file']
+      // UNC path expected
+      [['//foo/bar'], '\\\\foo\\bar\\'],
+      [['\\/foo/bar'], '\\\\foo\\bar\\'],
+      [['\\\\foo/bar'], '\\\\foo\\bar\\'],
+      // UNC path expected - server and share separate
+      [['//foo', 'bar'], '\\\\foo\\bar\\'],
+      [['//foo/', 'bar'], '\\\\foo\\bar\\'],
+      [['//foo', '/bar'], '\\\\foo\\bar\\'],
+      // UNC path expected - questionable
+      [['//foo', '', 'bar'], '\\\\foo\\bar\\'],
+      [['//foo/', '', 'bar'], '\\\\foo\\bar\\'],
+      [['//foo/', '', '/bar'], '\\\\foo\\bar\\'],
+      // UNC path expected - even more questionable
+      [['', '//foo', 'bar'], '\\\\foo\\bar\\'],
+      [['', '//foo/', 'bar'], '\\\\foo\\bar\\'],
+      [['', '//foo/', '/bar'], '\\\\foo\\bar\\'],
+      // No UNC path expected (no double slash in first component)
+      [['\\', 'foo/bar'], '\\foo\\bar'],
+      [['\\', '/foo/bar'], '\\foo\\bar'],
+      [['', '/', '/foo/bar'], '\\foo\\bar'],
+      // No UNC path expected (no non-slashes in first component -
+      // questionable)
+      [['//', 'foo/bar'], '\\foo\\bar'],
+      [['//', '/foo/bar'], '\\foo\\bar'],
+      [['\\\\', '/', '/foo/bar'], '\\foo\\bar'],
+      [['//'], '/'],
+      // No UNC path expected (share name missing - questionable).
+      [['//foo'], '\\foo'],
+      [['//foo/'], '\\foo\\'],
+      [['//foo', '/'], '\\foo\\'],
+      [['//foo', '', '/'], '\\foo\\'],
+      // No UNC path expected (too many leading slashes - questionable)
+      [['///foo/bar'], '\\foo\\bar'],
+      [['////foo', 'bar'], '\\foo\\bar'],
+      [['\\\\\\/foo/bar'], '\\foo\\bar'],
+      // Drive-relative vs drive-absolute paths. This merely describes the
+      // status quo, rather than being obviously right
+      [['c:'], 'c:.'],
+      [['c:.'], 'c:.'],
+      [['c:', ''], 'c:.'],
+      [['', 'c:'], 'c:.'],
+      [['c:.', '/'], 'c:.\\'],
+      [['c:.', 'file'], 'c:file'],
+      [['c:', '/'], 'c:\\'],
+      [['c:', 'file'], 'c:\\file']
     ]
   )
 ]);
@@ -461,7 +461,7 @@ resolveTests.forEach((test) => {
     const expected = test[1];
     const message =
       `path.${os}.resolve(${test[0].map(JSON.stringify).join(',')})\n  expect=${
-      JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
+        JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
     if (actual !== expected && actualAlt !== expected)
       failures.push(`\n${message}`);
   });

--- a/test/parallel/test-preload.js
+++ b/test/parallel/test-preload.js
@@ -104,7 +104,7 @@ replProc.on('close', function(code) {
 // also test that duplicated preload only gets loaded once
 childProcess.exec(
   `"${nodeBinary}" ${preloadOption([fixtureA])}-e "console.log('hello');" ${
-  preloadOption([fixtureA, fixtureB])}`,
+    preloadOption([fixtureA, fixtureB])}`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.strictEqual(stdout, 'A\nB\nhello\n');
@@ -125,7 +125,7 @@ interactive.stdin.write('process.exit()\n');
 
 childProcess.exec(
   `"${nodeBinary}" --require "${fixture('cluster-preload.js')}" "${
-  fixture('cluster-preload-test.js')}"`,
+    fixture('cluster-preload-test.js')}"`,
   function(err, stdout, stderr) {
     assert.ifError(err);
     assert.ok(/worker terminated with code 43/.test(stdout));

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -6,16 +6,16 @@ assert.strictEqual(process.assert(1, 'error'), undefined);
 assert.throws(() => {
   process.assert(undefined, 'errorMessage');
 }, common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: Error,
-    message: 'errorMessage'
+  code: 'ERR_ASSERTION',
+  type: Error,
+  message: 'errorMessage'
 })
 );
 assert.throws(() => {
   process.assert(false);
 }, common.expectsError({
-    code: 'ERR_ASSERTION',
-    type: Error,
-    message: 'assertion error'
+  code: 'ERR_ASSERTION',
+  type: Error,
+  message: 'assertion error'
 })
 );

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -328,13 +328,13 @@ check(qs.parse('a', null, []), { '': 'a' });
 
 // Test limiting
 assert.strictEqual(
-    Object.keys(qs.parse('a=1&b=1&c=1', null, null, { maxKeys: 1 })).length,
-    1);
+  Object.keys(qs.parse('a=1&b=1&c=1', null, null, { maxKeys: 1 })).length,
+  1);
 
 // Test limiting with a case that starts from `&`
 assert.strictEqual(
-    Object.keys(qs.parse('&a', null, null, { maxKeys: 1 })).length,
-    0);
+  Object.keys(qs.parse('&a', null, null, { maxKeys: 1 })).length,
+  0);
 
 // Test removing limit
 {
@@ -356,7 +356,7 @@ assert.strictEqual(
 {
   const b = qs.unescapeBuffer('%d3%f2Ug%1f6v%24%5e%98%cb' +
     '%0d%ac%a2%2f%9d%eb%d8%a2%e6');
-// <Buffer d3 f2 55 67 1f 36 76 24 5e 98 cb 0d ac a2 2f 9d eb d8 a2 e6>
+  // <Buffer d3 f2 55 67 1f 36 76 24 5e 98 cb 0d ac a2 2f 9d eb d8 a2 e6>
   assert.strictEqual(0xd3, b[0]);
   assert.strictEqual(0xf2, b[1]);
   assert.strictEqual(0x55, b[2]);
@@ -411,7 +411,7 @@ check(qs.parse('%\u0100=%\u0101'), { '%Ā': '%ā' });
   }
 
   check(qs.parse('a=a', null, null, { decodeURIComponent: errDecode }),
-    { a: 'a' });
+        { a: 'a' });
 }
 
 // Test custom encode

--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -32,7 +32,7 @@ function testStrictMode() {
 
   cli.input.emit('data', 'x = 3\n');
   assert.ok(/ReferenceError: x is not defined/.test(
-      cli.output.accumulator.join('')));
+    cli.output.accumulator.join('')));
   cli.output.accumulator.length = 0;
 
   cli.input.emit('data', 'let y = 3\n');

--- a/test/parallel/test-repl-tab.js
+++ b/test/parallel/test-repl-tab.js
@@ -7,7 +7,7 @@ const zlib = require('zlib');
 // just use builtin stream inherited from Duplex
 const putIn = zlib.createGzip();
 const testMe = repl.start('', putIn, function(cmd, context, filename,
-      callback) {
+                                              callback) {
   callback(null, cmd);
 });
 

--- a/test/parallel/test-repl-use-global.js
+++ b/test/parallel/test-repl-use-global.js
@@ -80,7 +80,7 @@ function runRepl(useGlobal, testFunc, cb) {
   };
 
   repl.createInternalRepl(
-      process.env,
-      opts,
-      testFunc(useGlobal, cb, opts.output));
+    process.env,
+    opts,
+    testFunc(useGlobal, cb, opts.output));
 }

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -85,9 +85,9 @@ function error_test() {
     read_buffer += data.toString('ascii', 0, data.length);
     console.error(
       `Unix data: ${JSON.stringify(read_buffer)}, expecting ${
-      client_unix.expect.exec ?
-      client_unix.expect :
-      JSON.stringify(client_unix.expect)}`);
+        client_unix.expect.exec ?
+          client_unix.expect :
+          JSON.stringify(client_unix.expect)}`);
 
     if (read_buffer.includes(prompt_unix)) {
       // if it's an exact match, then don't do the regexp
@@ -268,7 +268,7 @@ function error_test() {
     // do not fail when a String is created with line continuation
     { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
       expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n${
-              prompt_unix}` },
+        prompt_unix}` },
     // Don't fail when a partial String is created and line continuation is used
     // with whitespace characters at the end of the string. We are to ignore it.
     // This test is to make sure that we properly remove the whitespace
@@ -278,11 +278,11 @@ function error_test() {
     // multiline strings preserve whitespace characters in them
     { client: client_unix, send: '\'the \\\n   fourth\t\t\\\n  eye  \'',
       expect: `${prompt_multiline}${
-              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
+        prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
     // more than one multiline strings also should preserve whitespace chars
     { client: client_unix, send: '\'the \\\n   fourth\' +  \'\t\t\\\n  eye  \'',
       expect: `${prompt_multiline}${
-              prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
+        prompt_multiline}'the    fourth\\t\\t  eye  '\n${prompt_unix}` },
     // using REPL commands within a string literal should still work
     { client: client_unix, send: '\'\\\n.break',
       expect: prompt_unix },
@@ -295,7 +295,7 @@ function error_test() {
     // empty lines in the string literals should not affect the string
     { client: client_unix, send: '\'the\\\n\\\nfourtheye\'\n',
       expect: `${prompt_multiline}${
-              prompt_multiline}'thefourtheye'\n${prompt_unix}` },
+        prompt_multiline}'thefourtheye'\n${prompt_unix}` },
     // Regression test for https://github.com/nodejs/node/issues/597
     { client: client_unix,
       send: '/(.)(.)(.)(.)(.)(.)(.)(.)(.)/.test(\'123456789\')\n',
@@ -309,24 +309,24 @@ function error_test() {
     // regression tests for https://github.com/nodejs/node/issues/2749
     { client: client_unix, send: 'function x() {\nreturn \'\\n\';\n }',
       expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+        prompt_unix}` },
     { client: client_unix, send: 'function x() {\nreturn \'\\\\\';\n }',
       expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+        prompt_unix}` },
     // regression tests for https://github.com/nodejs/node/issues/3421
     { client: client_unix, send: 'function x() {\n//\'\n }',
       expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+        prompt_unix}` },
     { client: client_unix, send: 'function x() {\n//"\n }',
       expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+        prompt_unix}` },
     { client: client_unix, send: 'function x() {//\'\n }',
       expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {//"\n }',
       expect: `${prompt_multiline}undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x() {\nvar i = "\'";\n }',
       expect: `${prompt_multiline}${prompt_multiline}undefined\n${
-              prompt_unix}` },
+        prompt_unix}` },
     { client: client_unix, send: 'function x(/*optional*/) {}',
       expect: `undefined\n${prompt_unix}` },
     { client: client_unix, send: 'function x(/* // 5 */) {}',
@@ -454,7 +454,7 @@ function tcp_test() {
     client_tcp.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
       console.error(`TCP data: ${JSON.stringify(read_buffer)}, expecting ${
-                    JSON.stringify(client_tcp.expect)}`);
+        JSON.stringify(client_tcp.expect)}`);
       if (read_buffer.includes(prompt_tcp)) {
         assert.strictEqual(client_tcp.expect, read_buffer);
         console.error('match');
@@ -524,7 +524,7 @@ function unix_test() {
     client_unix.on('data', function(data) {
       read_buffer += data.toString('ascii', 0, data.length);
       console.error(`Unix data: ${JSON.stringify(read_buffer)}, expecting ${
-                    JSON.stringify(client_unix.expect)}`);
+        JSON.stringify(client_unix.expect)}`);
       if (read_buffer.includes(prompt_unix)) {
         assert.strictEqual(client_unix.expect, read_buffer);
         console.error('match');

--- a/test/parallel/test-require-extensions-main.js
+++ b/test/parallel/test-require-extensions-main.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const fixturesRequire = require(`${common.fixturesDir}/require-bin/bin/req.js`);
 
 assert.strictEqual(
-    fixturesRequire,
-    '',
-    'test-require-extensions-main failed to import fixture requirements'
+  fixturesRequire,
+  '',
+  'test-require-extensions-main failed to import fixture requirements'
 );

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -26,14 +26,14 @@ const assert = require('assert');
 const path = require('path');
 
 assert.strictEqual(
-    path.join(__dirname, '../fixtures/a.js').toLowerCase(),
-    require.resolve('../fixtures/a').toLowerCase());
+  path.join(__dirname, '../fixtures/a.js').toLowerCase(),
+  require.resolve('../fixtures/a').toLowerCase());
 assert.strictEqual(
-    path.join(fixturesDir, 'a.js').toLowerCase(),
-    require.resolve(path.join(fixturesDir, 'a')).toLowerCase());
+  path.join(fixturesDir, 'a.js').toLowerCase(),
+  require.resolve(path.join(fixturesDir, 'a')).toLowerCase());
 assert.strictEqual(
-    path.join(fixturesDir, 'nested-index', 'one', 'index.js').toLowerCase(),
-    require.resolve('../fixtures/nested-index/one').toLowerCase());
+  path.join(fixturesDir, 'nested-index', 'one', 'index.js').toLowerCase(),
+  require.resolve('../fixtures/nested-index/one').toLowerCase());
 assert.strictEqual('path', require.resolve('path'));
 
 console.log('ok');

--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -26,8 +26,8 @@ if (common.isWindows)
 // To pass this test on alpine, since Busybox `ps` does not
 // support `-p` switch, use `ps -o` and `grep` instead.
 const cmd = common.isLinux ?
-            `ps -o pid,args | grep '${process.pid} ${title}' | grep -v grep` :
-            `ps -p ${process.pid} -o args=`;
+  `ps -o pid,args | grep '${process.pid} ${title}' | grep -v grep` :
+  `ps -p ${process.pid} -o args=`;
 
 exec(cmd, common.mustCall((error, stdout, stderr) => {
   assert.ifError(error);

--- a/test/parallel/test-stdin-child-proc.js
+++ b/test/parallel/test-stdin-child-proc.js
@@ -5,8 +5,10 @@ const common = require('../common');
 const assert = require('assert');
 const child_process = require('child_process');
 const path = require('path');
-const cp = child_process.spawn(process.execPath,
-                    [path.resolve(__dirname, 'test-stdin-pause-resume.js')]);
+const cp = child_process.spawn(
+  process.execPath,
+  [path.resolve(__dirname, 'test-stdin-pause-resume.js')]
+);
 
 cp.on('exit', common.mustCall((code) => {
   assert.strictEqual(code, 0);

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -14,7 +14,7 @@ common.refreshTmpDir();
 
 function test(size, useBuffer, cb) {
   const cmd = `"${process.argv[0]}" "${
-              useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
+    useBuffer ? scriptBuffer : scriptString}" ${size} > "${tmpFile}"`;
 
   try {
     fs.unlinkSync(tmpFile);

--- a/test/parallel/test-stream-writev.js
+++ b/test/parallel/test-stream-writev.js
@@ -86,7 +86,7 @@ function test(decode, uncork, multi, next) {
       return {
         encoding: chunk.encoding,
         chunk: Buffer.isBuffer(chunk.chunk) ?
-            Array.prototype.slice.call(chunk.chunk) : chunk.chunk
+          Array.prototype.slice.call(chunk.chunk) : chunk.chunk
       };
     });
     cb();

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -28,7 +28,7 @@ assert.throws(() => tls.createServer({ handshakeTimeout: 'abcd' }),
                 type: TypeError,
                 message: 'The "timeout" argument must be of type number'
               })
-            );
+);
 
 assert.throws(() => tls.createServer({ sessionTimeout: 'abcd' }),
               /TypeError: Session timeout must be a 32-bit integer/);

--- a/test/parallel/test-tls-client-verify.js
+++ b/test/parallel/test-tls-client-verify.js
@@ -34,31 +34,31 @@ const testCases =
      key: 'agent2-key',
      cert: 'agent2-cert',
      servers: [
-         { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
-         { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
-         { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
+      { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
+      { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
+      { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
+    ]
+  },
+
+   { ca: [],
+     key: 'agent2-key',
+     cert: 'agent2-cert',
+     servers: [
+       { ok: false, key: 'agent1-key', cert: 'agent1-cert' },
+       { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
+       { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
      ]
-  },
+   },
 
-  { ca: [],
-    key: 'agent2-key',
-    cert: 'agent2-cert',
-    servers: [
-         { ok: false, key: 'agent1-key', cert: 'agent1-cert' },
-         { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
-         { ok: false, key: 'agent3-key', cert: 'agent3-cert' }
-    ]
-  },
-
-  { ca: ['ca1-cert', 'ca2-cert'],
-    key: 'agent2-key',
-    cert: 'agent2-cert',
-    servers: [
-         { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
-         { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
-         { ok: true, key: 'agent3-key', cert: 'agent3-cert' }
-    ]
-  }
+   { ca: ['ca1-cert', 'ca2-cert'],
+     key: 'agent2-key',
+     cert: 'agent2-cert',
+     servers: [
+       { ok: true, key: 'agent1-key', cert: 'agent1-cert' },
+       { ok: false, key: 'agent2-key', cert: 'agent2-cert' },
+       { ok: true, key: 'agent3-key', cert: 'agent3-cert' }
+     ]
+   }
   ];
 
 function filenamePEM(n) {

--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -43,7 +43,7 @@ const server = tls.createServer(options, common.mustNotCall());
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
   let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+    options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -49,7 +49,7 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 
 server.listen(0, '127.0.0.1', common.mustCall(function() {
   let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+    options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -93,7 +93,7 @@ function test(testOptions, cb) {
       port: this.address().port,
       requestOCSP: testOptions.ocsp !== false,
       secureOptions: testOptions.ocsp === false ?
-          SSL_OP_NO_TICKET : 0,
+        SSL_OP_NO_TICKET : 0,
       rejectUnauthorized: false
     }, function() {
       clientSecure++;

--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 
 const pfx = fs.readFileSync(
-    path.join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
+  path.join(common.fixturesDir, 'keys', 'agent1-pfx.pem'));
 
 const server = tls.createServer({
   pfx: pfx,

--- a/test/parallel/test-tls-server-verify.js
+++ b/test/parallel/test-tls-server-verify.js
@@ -52,80 +52,80 @@ const testCases =
      CAs: ['ca1-cert'],
      clients:
      [{ name: 'agent1', shouldReject: false, shouldAuth: false },
-        { name: 'agent2', shouldReject: false, shouldAuth: false },
-        { name: 'agent3', shouldReject: false, shouldAuth: false },
-        { name: 'nocert', shouldReject: false, shouldAuth: false }
+      { name: 'agent2', shouldReject: false, shouldAuth: false },
+      { name: 'agent3', shouldReject: false, shouldAuth: false },
+      { name: 'nocert', shouldReject: false, shouldAuth: false }
      ]
   },
 
-  { title: 'Allow both authed and unauthed connections with CA1',
-    requestCert: true,
-    rejectUnauthorized: false,
-    renegotiate: false,
-    CAs: ['ca1-cert'],
-    clients:
+   { title: 'Allow both authed and unauthed connections with CA1',
+     requestCert: true,
+     rejectUnauthorized: false,
+     renegotiate: false,
+     CAs: ['ca1-cert'],
+     clients:
     [{ name: 'agent1', shouldReject: false, shouldAuth: true },
-        { name: 'agent2', shouldReject: false, shouldAuth: false },
-        { name: 'agent3', shouldReject: false, shouldAuth: false },
-        { name: 'nocert', shouldReject: false, shouldAuth: false }
+     { name: 'agent2', shouldReject: false, shouldAuth: false },
+     { name: 'agent3', shouldReject: false, shouldAuth: false },
+     { name: 'nocert', shouldReject: false, shouldAuth: false }
     ]
-  },
+   },
 
-  { title: 'Do not request certs at connection. Do that later',
-    requestCert: false,
-    rejectUnauthorized: false,
-    renegotiate: true,
-    CAs: ['ca1-cert'],
-    clients:
+   { title: 'Do not request certs at connection. Do that later',
+     requestCert: false,
+     rejectUnauthorized: false,
+     renegotiate: true,
+     CAs: ['ca1-cert'],
+     clients:
     [{ name: 'agent1', shouldReject: false, shouldAuth: true },
-        { name: 'agent2', shouldReject: false, shouldAuth: false },
-        { name: 'agent3', shouldReject: false, shouldAuth: false },
-        { name: 'nocert', shouldReject: false, shouldAuth: false }
+     { name: 'agent2', shouldReject: false, shouldAuth: false },
+     { name: 'agent3', shouldReject: false, shouldAuth: false },
+     { name: 'nocert', shouldReject: false, shouldAuth: false }
     ]
-  },
+   },
 
-  { title: 'Allow only authed connections with CA1',
-    requestCert: true,
-    rejectUnauthorized: true,
-    renegotiate: false,
-    CAs: ['ca1-cert'],
-    clients:
+   { title: 'Allow only authed connections with CA1',
+     requestCert: true,
+     rejectUnauthorized: true,
+     renegotiate: false,
+     CAs: ['ca1-cert'],
+     clients:
     [{ name: 'agent1', shouldReject: false, shouldAuth: true },
-        { name: 'agent2', shouldReject: true },
-        { name: 'agent3', shouldReject: true },
-        { name: 'nocert', shouldReject: true }
+     { name: 'agent2', shouldReject: true },
+     { name: 'agent3', shouldReject: true },
+     { name: 'nocert', shouldReject: true }
     ]
-  },
+   },
 
-  { title: 'Allow only authed connections with CA1 and CA2',
-    requestCert: true,
-    rejectUnauthorized: true,
-    renegotiate: false,
-    CAs: ['ca1-cert', 'ca2-cert'],
-    clients:
+   { title: 'Allow only authed connections with CA1 and CA2',
+     requestCert: true,
+     rejectUnauthorized: true,
+     renegotiate: false,
+     CAs: ['ca1-cert', 'ca2-cert'],
+     clients:
     [{ name: 'agent1', shouldReject: false, shouldAuth: true },
-        { name: 'agent2', shouldReject: true },
-        { name: 'agent3', shouldReject: false, shouldAuth: true },
-        { name: 'nocert', shouldReject: true }
+     { name: 'agent2', shouldReject: true },
+     { name: 'agent3', shouldReject: false, shouldAuth: true },
+     { name: 'nocert', shouldReject: true }
     ]
-  },
+   },
 
 
-  { title: 'Allow only certs signed by CA2 but not in the CRL',
-    requestCert: true,
-    rejectUnauthorized: true,
-    renegotiate: false,
-    CAs: ['ca2-cert'],
-    crl: 'ca2-crl',
-    clients: [
-        { name: 'agent1', shouldReject: true, shouldAuth: false },
-        { name: 'agent2', shouldReject: true, shouldAuth: false },
-        { name: 'agent3', shouldReject: false, shouldAuth: true },
-        // Agent4 has a cert in the CRL.
-        { name: 'agent4', shouldReject: true, shouldAuth: false },
-        { name: 'nocert', shouldReject: true }
-    ]
-  }
+   { title: 'Allow only certs signed by CA2 but not in the CRL',
+     requestCert: true,
+     rejectUnauthorized: true,
+     renegotiate: false,
+     CAs: ['ca2-cert'],
+     crl: 'ca2-crl',
+     clients: [
+       { name: 'agent1', shouldReject: true, shouldAuth: false },
+       { name: 'agent2', shouldReject: true, shouldAuth: false },
+       { name: 'agent3', shouldReject: false, shouldAuth: true },
+       // Agent4 has a cert in the CRL.
+       { name: 'agent4', shouldReject: true, shouldAuth: false },
+       { name: 'nocert', shouldReject: true }
+     ]
+   }
   ];
 
 
@@ -247,7 +247,7 @@ function runClient(prefix, port, options, cb) {
       assert.strictEqual(
         options.shouldAuth, authed,
         `${prefix}${options.name} authed is ${authed} but should have been ${
-        options.shouldAuth}`);
+          options.shouldAuth}`);
     }
 
     cb();
@@ -313,7 +313,7 @@ function runTest(port, testIndex) {
 
     if (c.authorized) {
       console.error(`${prefix}- authed connection: ${
-                    c.getPeerCertificate().subject.CN}`);
+        c.getPeerCertificate().subject.CN}`);
       c.write('\n_authed\n');
     } else {
       console.error(`${prefix}- unauthed connection: %s`, c.authorizationError);

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -52,7 +52,7 @@ const server = tls.createServer(options, common.mustCall(function(conn) {
 
 server.listen(0, '127.0.0.1', function() {
   let cmd = `"${common.opensslCli}" s_client -cipher ${
-            options.ciphers} -connect 127.0.0.1:${this.address().port}`;
+    options.ciphers} -connect 127.0.0.1:${this.address().port}`;
 
   // for the performance and stability issue in s_client on Windows
   if (common.isWindows)

--- a/test/parallel/test-tls-sni-option.js
+++ b/test/parallel/test-tls-sni-option.js
@@ -141,7 +141,7 @@ function startTest() {
     options.port = server.address().port;
     const client = tls.connect(options, function() {
       clientResults.push(
-         client.authorizationError &&
+        client.authorizationError &&
          (client.authorizationError === 'ERR_TLS_CERT_ALTNAME_INVALID'));
       client.destroy();
 

--- a/test/parallel/test-trace-event.js
+++ b/test/parallel/test-trace-event.js
@@ -10,14 +10,16 @@ const FILE_NAME = 'node_trace.1.log';
 common.refreshTmpDir();
 process.chdir(common.tmpDir);
 
-const proc_no_categories = cp.spawn(process.execPath,
-  [ '--trace-events-enabled', '--trace-event-categories', '""', '-e', CODE ]);
+const proc_no_categories = cp.spawn(
+  process.execPath,
+  [ '--trace-events-enabled', '--trace-event-categories', '""', '-e', CODE ]
+);
 
 proc_no_categories.once('exit', common.mustCall(() => {
   assert(!common.fileExists(FILE_NAME));
 
   const proc = cp.spawn(process.execPath,
-  [ '--trace-events-enabled', '-e', CODE ]);
+                        [ '--trace-events-enabled', '-e', CODE ]);
 
   proc.once('exit', common.mustCall(() => {
     assert(common.fileExists(FILE_NAME));

--- a/test/parallel/test-ttywrap-invalid-fd.js
+++ b/test/parallel/test-ttywrap-invalid-fd.js
@@ -7,15 +7,15 @@ const tty = require('tty');
 assert.throws(() => {
   new tty.WriteStream(-1);
 }, common.expectsError({
-    code: 'ERR_INVALID_FD',
-    type: RangeError,
-    message: '"fd" must be a positive integer: -1'
+  code: 'ERR_INVALID_FD',
+  type: RangeError,
+  message: '"fd" must be a positive integer: -1'
 })
 );
 
 const err_regex = common.isWindows ?
-                    /^Error: EBADF: bad file descriptor, uv_tty_init$/ :
-                    /^Error: EINVAL: invalid argument, uv_tty_init$/;
+  /^Error: EBADF: bad file descriptor, uv_tty_init$/ :
+  /^Error: EINVAL: invalid argument, uv_tty_init$/;
 assert.throws(() => {
   let fd = 2;
   // Get first known bad file descriptor.
@@ -28,9 +28,9 @@ assert.throws(() => {
 assert.throws(() => {
   new tty.ReadStream(-1);
 }, common.expectsError({
-    code: 'ERR_INVALID_FD',
-    type: RangeError,
-    message: '"fd" must be a positive integer: -1'
+  code: 'ERR_INVALID_FD',
+  type: RangeError,
+  message: '"fd" must be a positive integer: -1'
 })
 );
 

--- a/test/parallel/test-url-format.js
+++ b/test/parallel/test-url-format.js
@@ -217,7 +217,7 @@ const formatTests = {
     path: '/node'
   },
 
-   // greater than or equal to 63 characters after `.` in hostname
+  // greater than or equal to 63 characters after `.` in hostname
   [`http://www.${'z'.repeat(63)}example.com/node`]: {
     href: `http://www.${'z'.repeat(63)}example.com/node`,
     protocol: 'http:',
@@ -254,5 +254,5 @@ for (const u in formatTests) {
                      `wonky format(${u}) == ${expect}\nactual:${actual}`);
   assert.strictEqual(actualObj, expect,
                      `wonky format(${JSON.stringify(formatTests[u])}) == ${
-                     expect}\nactual: ${actualObj}`);
+                       expect}\nactual: ${actualObj}`);
 }

--- a/test/parallel/test-url-relative.js
+++ b/test/parallel/test-url-relative.js
@@ -372,8 +372,8 @@ const relativeTests2 = [
    'https://user:password@example.com',
    'https://user:password@example.com/foo'],
 
-   // No path at all
-   ['#hash1', '#hash2', '#hash1']
+  // No path at all
+  ['#hash1', '#hash2', '#hash1']
 ];
 relativeTests2.forEach(function(relativeTest) {
   const a = url.resolve(relativeTest[1], relativeTest[0]);

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -30,7 +30,7 @@ assert.strictEqual(b.a(), 'a');
 assert.strictEqual(b.b(), 'b');
 assert.strictEqual(b.constructor, B);
 
- // two levels of inheritance
+// two levels of inheritance
 function C() {
   B.call(this, 'b');
   this._c = 'c';
@@ -83,9 +83,9 @@ assert.strictEqual(e.constructor, E);
 assert.throws(function() {
   inherits(A, {});
 }, common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "superCtor.prototype" property must be of type function'
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "superCtor.prototype" property must be of type function'
 })
 );
 assert.throws(function() {
@@ -94,8 +94,8 @@ assert.throws(function() {
 assert.throws(function() {
   inherits(null, A);
 }, common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError,
-    message: 'The "ctor" argument must be of type function'
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "ctor" argument must be of type function'
 })
 );

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -76,13 +76,22 @@ assert.strictEqual(util.inspect({ 'a': { 'b': { 'c': 2 } } }, false, 1),
                    '{ a: { b: [Object] } }');
 assert.strictEqual(util.inspect({ 'a': { 'b': ['c'] } }, false, 1),
                    '{ a: { b: [Array] } }');
-assert.strictEqual(util.inspect(Object.create({},
-  { visible: { value: 1, enumerable: true }, hidden: { value: 2 } })),
-                   '{ visible: 1 }'
+assert.strictEqual(
+  util.inspect(
+    Object.create(
+      {},
+      { visible: { value: 1, enumerable: true }, hidden: { value: 2 } }
+    )
+  ),
+  '{ visible: 1 }'
 );
-assert.strictEqual(util.inspect(Object.assign(new String('hello'),
-                   { [Symbol('foo')]: 123 }), { showHidden: true }),
-                   '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }');
+assert.strictEqual(
+  util.inspect(
+    Object.assign(new String('hello'), { [Symbol('foo')]: 123 }),
+    { showHidden: true }
+  ),
+  '{ [String: \'hello\'] [length]: 5, [Symbol(foo)]: 123 }'
+);
 
 assert.strictEqual(util.inspect((new JSStream())._externalStream),
                    '[External]');
@@ -177,14 +186,14 @@ for (const showHidden of [true, false]) {
   Uint32Array,
   Uint8Array,
   Uint8ClampedArray ].forEach((constructor) => {
-    const length = 2;
-    const byteLength = length * constructor.BYTES_PER_ELEMENT;
-    const array = new constructor(new ArrayBuffer(byteLength), 0, length);
-    array[0] = 65;
-    array[1] = 97;
-    assert.strictEqual(
-      util.inspect(array, true),
-      `${constructor.name} [\n` +
+  const length = 2;
+  const byteLength = length * constructor.BYTES_PER_ELEMENT;
+  const array = new constructor(new ArrayBuffer(byteLength), 0, length);
+  array[0] = 65;
+  array[1] = 97;
+  assert.strictEqual(
+    util.inspect(array, true),
+    `${constructor.name} [\n` +
       '  65,\n' +
       '  97,\n' +
       `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
@@ -192,11 +201,11 @@ for (const showHidden of [true, false]) {
       `  [byteLength]: ${byteLength},\n` +
       '  [byteOffset]: 0,\n' +
       `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
-    assert.strictEqual(
-      util.inspect(array, false),
-      `${constructor.name} [ 65, 97 ]`
-    );
-  });
+  assert.strictEqual(
+    util.inspect(array, false),
+    `${constructor.name} [ 65, 97 ]`
+  );
+});
 
 // Now check that declaring a TypedArray in a different context works the same
 [ Float32Array,
@@ -208,17 +217,17 @@ for (const showHidden of [true, false]) {
   Uint32Array,
   Uint8Array,
   Uint8ClampedArray ].forEach((constructor) => {
-    const length = 2;
-    const byteLength = length * constructor.BYTES_PER_ELEMENT;
-    const array = vm.runInNewContext(
-      'new constructor(new ArrayBuffer(byteLength), 0, length)',
-      { constructor, byteLength, length }
-    );
-    array[0] = 65;
-    array[1] = 97;
-    assert.strictEqual(
-      util.inspect(array, true),
-      `${constructor.name} [\n` +
+  const length = 2;
+  const byteLength = length * constructor.BYTES_PER_ELEMENT;
+  const array = vm.runInNewContext(
+    'new constructor(new ArrayBuffer(byteLength), 0, length)',
+    { constructor, byteLength, length }
+  );
+  array[0] = 65;
+  array[1] = 97;
+  assert.strictEqual(
+    util.inspect(array, true),
+    `${constructor.name} [\n` +
       '  65,\n' +
       '  97,\n' +
       `  [BYTES_PER_ELEMENT]: ${constructor.BYTES_PER_ELEMENT},\n` +
@@ -226,11 +235,11 @@ for (const showHidden of [true, false]) {
       `  [byteLength]: ${byteLength},\n` +
       '  [byteOffset]: 0,\n' +
       `  [buffer]: ArrayBuffer { byteLength: ${byteLength} } ]`);
-    assert.strictEqual(
-      util.inspect(array, false),
-      `${constructor.name} [ 65, 97 ]`
-    );
-  });
+  assert.strictEqual(
+    util.inspect(array, false),
+    `${constructor.name} [ 65, 97 ]`
+  );
+});
 
 // Due to the hash seed randomization it's not deterministic the order that
 // the following ways this hash is displayed.
@@ -443,9 +452,9 @@ assert.strictEqual(util.inspect(-0), '-0');
   function BadCustomError(msg) {
     Error.call(this);
     Object.defineProperty(this, 'message',
-      { value: msg, enumerable: false });
+                          { value: msg, enumerable: false });
     Object.defineProperty(this, 'name',
-      { value: 'BadCustomError', enumerable: false });
+                          { value: 'BadCustomError', enumerable: false });
   }
   util.inherits(BadCustomError, Error);
   assert.strictEqual(
@@ -1039,18 +1048,18 @@ if (typeof Symbol !== 'undefined') {
   assert.throws(() => {
     util.inspect.defaultOptions = null;
   }, common.expectsError({
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "options" argument must be of type object'
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "options" argument must be of type object'
   })
   );
 
   assert.throws(() => {
     util.inspect.defaultOptions = 'bad';
   }, common.expectsError({
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: TypeError,
-      message: 'The "options" argument must be of type object'
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "options" argument must be of type object'
   })
   );
 }

--- a/test/parallel/test-util-internal.js
+++ b/test/parallel/test-util-internal.js
@@ -32,8 +32,8 @@ assert.throws(getHiddenValue({}), errMessageIndex);
 assert.throws(getHiddenValue({}, null), errMessageIndex);
 assert.throws(getHiddenValue({}, []), errMessageIndex);
 assert.deepStrictEqual(
-    binding.getHiddenValue({}, kArrowMessagePrivateSymbolIndex),
-    undefined);
+  binding.getHiddenValue({}, kArrowMessagePrivateSymbolIndex),
+  undefined);
 
 assert.throws(setHiddenValue(), errMessageObj);
 assert.throws(setHiddenValue(null, 'foo'), errMessageObj);
@@ -45,11 +45,11 @@ assert.throws(setHiddenValue({}, null), errMessageIndex);
 assert.throws(setHiddenValue({}, []), errMessageIndex);
 const obj = {};
 assert.strictEqual(
-    binding.setHiddenValue(obj, kArrowMessagePrivateSymbolIndex, 'bar'),
-    true);
+  binding.setHiddenValue(obj, kArrowMessagePrivateSymbolIndex, 'bar'),
+  true);
 assert.strictEqual(
-    binding.getHiddenValue(obj, kArrowMessagePrivateSymbolIndex),
-    'bar');
+  binding.getHiddenValue(obj, kArrowMessagePrivateSymbolIndex),
+  'bar');
 
 let arrowMessage;
 

--- a/test/parallel/test-util-sigint-watchdog.js
+++ b/test/parallel/test-util-sigint-watchdog.js
@@ -16,7 +16,7 @@ const binding = process.binding('util');
   next();
 },
  (next) => {
-  // Test with one call to the watchdog, one signal.
+   // Test with one call to the watchdog, one signal.
    binding.startSigintWatchdog();
    process.kill(process.pid, 'SIGINT');
    waitForPendingSignal(common.mustCall(() => {
@@ -26,7 +26,7 @@ const binding = process.binding('util');
    }));
  },
  (next) => {
-  // Nested calls are okay.
+   // Nested calls are okay.
    binding.startSigintWatchdog();
    binding.startSigintWatchdog();
    process.kill(process.pid, 'SIGINT');
@@ -39,7 +39,7 @@ const binding = process.binding('util');
    }));
  },
  () => {
-  // Signal comes in after first call to stop.
+   // Signal comes in after first call to stop.
    binding.startSigintWatchdog();
    binding.startSigintWatchdog();
    const hadPendingSignals1 = binding.stopSigintWatchdog();

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -127,7 +127,7 @@ const objects = [
   buf = buf.slice(32);
 
   const expectedResult = os.endianness() === 'LE' ?
-      new Uint16Array([0xdead, 0xbeef]) : new Uint16Array([0xadde, 0xefbe]);
+    new Uint16Array([0xdead, 0xbeef]) : new Uint16Array([0xadde, 0xefbe]);
 
   assert.deepStrictEqual(v8.deserialize(buf), expectedResult);
 }

--- a/test/parallel/test-vm-sigint-existing-handler.js
+++ b/test/parallel/test-vm-sigint-existing-handler.js
@@ -32,8 +32,8 @@ if (process.argv[2] === 'child') {
 
   const script = `process.send('${method}'); while(true) {}`;
   const args = method === 'runInContext' ?
-                          [vm.createContext({ process })] :
-                          [];
+    [vm.createContext({ process })] :
+    [];
   const options = { breakOnSigint: true };
 
   assert.throws(() => { vm[method](script, ...args, options); },

--- a/test/parallel/test-vm-sigint.js
+++ b/test/parallel/test-vm-sigint.js
@@ -17,8 +17,8 @@ if (process.argv[2] === 'child') {
 
   const script = `process.send('${method}'); while(true) {}`;
   const args = method === 'runInContext' ?
-                          [vm.createContext({ process })] :
-                          [];
+    [vm.createContext({ process })] :
+    [];
   const options = { breakOnSigint: true };
 
   for (let i = 0; i < listeners; i++)

--- a/test/parallel/test-whatwg-url-domainto.js
+++ b/test/parallel/test-whatwg-url-domainto.js
@@ -13,7 +13,7 @@ const wptToASCIITests = require('../fixtures/url-toascii.js');
 
 {
   const expectedError = common.expectsError(
-      { code: 'ERR_MISSING_ARGS', type: TypeError }, 2);
+    { code: 'ERR_MISSING_ARGS', type: TypeError }, 2);
   assert.throws(() => domainToASCII(), expectedError);
   assert.throws(() => domainToUnicode(), expectedError);
   assert.strictEqual(domainToASCII(undefined), 'undefined');

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -26,7 +26,7 @@ const failureTests = tests.filter((test) => test.failure).concat([
 ]);
 
 const expectedError = common.expectsError(
-    { code: 'ERR_INVALID_URL', type: TypeError }, 102);
+  { code: 'ERR_INVALID_URL', type: TypeError }, 102);
 
 for (const test of failureTests) {
   assert.throws(

--- a/test/parallel/test-whatwg-url-setters.js
+++ b/test/parallel/test-whatwg-url-setters.js
@@ -11,7 +11,7 @@ const path = require('path');
 const URL = require('url').URL;
 const { test, assert_equals } = require('../common/wpt');
 const additionalTestCases = require(
-    path.join(common.fixturesDir, 'url-setter-tests-additional.js'));
+  path.join(common.fixturesDir, 'url-setter-tests-additional.js'));
 
 const request = {
   response: require(path.join(common.fixturesDir, 'url-setter-tests'))

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -185,7 +185,7 @@ Object.keys(tests).forEach(function(file) {
                 // verify that the same exact buffer comes out the other end.
                 buf.on('data', function(c) {
                   const msg = `${file} ${chunkSize} ${
-                              JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;
+                    JSON.stringify(opts)} ${Def.name} -> ${Inf.name}`;
                   let ok = true;
                   const testNum = ++done;
                   let i;

--- a/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
+++ b/test/pseudo-tty/test-handle-wrap-isrefed-tty.js
@@ -19,5 +19,5 @@ tty.ref();
 strictEqual(tty._handle.hasRef(),
             true, 'tty_wrap: ref() ineffective');
 tty._handle.close(common.mustCall(() =>
-    strictEqual(tty._handle.hasRef(),
-                false, 'tty_wrap: not unrefed on close')));
+  strictEqual(tty._handle.hasRef(),
+              false, 'tty_wrap: not unrefed on close')));

--- a/test/pummel/test-dtrace-jsstack.js
+++ b/test/pummel/test-dtrace-jsstack.js
@@ -58,7 +58,7 @@ const spawn = require('child_process').spawn;
  * deepest function is the only caller of os.loadavg().
  */
 const dtrace = spawn('dtrace', [ '-qwn', `syscall::getloadavg:entry/pid == ${
-                                process.pid}/{ustack(100, 8192); exit(0); }` ]);
+  process.pid}/{ustack(100, 8192); exit(0); }` ]);
 
 let output = '';
 

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -58,21 +58,21 @@ process.on('exit', function() {
 fs.writeFileSync(filepathOne, 'hello');
 
 assert.throws(
-    function() {
-      fs.watchFile(filepathOne);
-    },
-    function(e) {
-      return e.message === '"watchFile()" requires a listener function';
-    }
+  function() {
+    fs.watchFile(filepathOne);
+  },
+  function(e) {
+    return e.message === '"watchFile()" requires a listener function';
+  }
 );
 
 assert.doesNotThrow(
-    function() {
-      fs.watchFile(filepathOne, function() {
-        fs.unwatchFile(filepathOne);
-        ++watchSeenOne;
-      });
-    }
+  function() {
+    fs.watchFile(filepathOne, function() {
+      fs.unwatchFile(filepathOne);
+      ++watchSeenOne;
+    });
+  }
 );
 
 setTimeout(function() {
@@ -85,27 +85,27 @@ process.chdir(testDir);
 fs.writeFileSync(filepathTwoAbs, 'howdy');
 
 assert.throws(
-    function() {
-      fs.watchFile(filepathTwo);
-    },
-    function(e) {
-      return e.message === '"watchFile()" requires a listener function';
-    }
+  function() {
+    fs.watchFile(filepathTwo);
+  },
+  function(e) {
+    return e.message === '"watchFile()" requires a listener function';
+  }
 );
 
 assert.doesNotThrow(
-    function() {
-      function a() {
-        fs.unwatchFile(filepathTwo, a);
-        ++watchSeenTwo;
-      }
-      function b() {
-        fs.unwatchFile(filepathTwo, b);
-        ++watchSeenTwo;
-      }
-      fs.watchFile(filepathTwo, a);
-      fs.watchFile(filepathTwo, b);
+  function() {
+    function a() {
+      fs.unwatchFile(filepathTwo, a);
+      ++watchSeenTwo;
     }
+    function b() {
+      fs.unwatchFile(filepathTwo, b);
+      ++watchSeenTwo;
+    }
+    fs.watchFile(filepathTwo, a);
+    fs.watchFile(filepathTwo, b);
+  }
 );
 
 setTimeout(function() {
@@ -113,15 +113,15 @@ setTimeout(function() {
 }, 1000);
 
 assert.doesNotThrow(
-    function() {
-      function b() {
-        fs.unwatchFile(filenameThree, b);
-        ++watchSeenThree;
-      }
-      fs.watchFile(filenameThree, common.mustNotCall());
-      fs.watchFile(filenameThree, b);
-      fs.unwatchFile(filenameThree, common.mustNotCall());
+  function() {
+    function b() {
+      fs.unwatchFile(filenameThree, b);
+      ++watchSeenThree;
     }
+    fs.watchFile(filenameThree, common.mustNotCall());
+    fs.watchFile(filenameThree, b);
+    fs.unwatchFile(filenameThree, common.mustNotCall());
+  }
 );
 
 setTimeout(function() {
@@ -137,12 +137,12 @@ setTimeout(function() {
 }, 500);
 
 assert.doesNotThrow(
-    function() {
-      function a() {
-        ++watchSeenFour;
-        assert.strictEqual(1, watchSeenFour);
-        fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
-      }
-      fs.watchFile(filenameFour, a);
+  function() {
+    function a() {
+      ++watchSeenFour;
+      assert.strictEqual(1, watchSeenFour);
+      fs.unwatchFile(`.${path.sep}${filenameFour}`, a);
     }
+    fs.watchFile(filenameFour, a);
+  }
 );

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -11,7 +11,7 @@ const seeds = [];
 
 for (let i = 0; i < REPETITIONS; ++i) {
   const seed = cp.spawnSync(process.execPath, [targetScript],
-    { encoding: 'utf8' }).stdout.trim();
+                            { encoding: 'utf8' }).stdout.trim();
   seeds.push(seed);
 }
 

--- a/test/sequential/test-dgram-bind-shared-ports.js
+++ b/test/sequential/test-dgram-bind-shared-ports.js
@@ -83,19 +83,19 @@ if (cluster.isMaster) {
   // First worker should bind, second should err
   const socket3OnBind =
     isSecondWorker ?
-    common.mustNotCall() :
-    common.mustCall(() => {
-      const port3 = socket3.address().port;
-      assert.strictEqual(typeof port3, 'number');
-      process.send('success');
-    });
+      common.mustNotCall() :
+      common.mustCall(() => {
+        const port3 = socket3.address().port;
+        assert.strictEqual(typeof port3, 'number');
+        process.send('success');
+      });
   // an error is expected only in the second worker
   const socket3OnError =
     !isSecondWorker ?
-    common.mustNotCall() :
-    common.mustCall((err) => {
-      process.send(`socket3:${err.code}`);
-    });
+      common.mustNotCall() :
+      common.mustCall((err) => {
+        process.send(`socket3:${err.code}`);
+      });
   const address = common.localhostIPv4;
   const opt1 = { address, port: 0, exclusive: false };
   const opt2 = { address, port: common.PORT, exclusive: false };

--- a/test/sequential/test-domain-abort-on-uncaught.js
+++ b/test/sequential/test-domain-abort-on-uncaught.js
@@ -248,7 +248,7 @@ if (process.argv[2] === 'child') {
       assert.strictEqual(
         code, 0, `Test at index ${testIndex
         } should have exited with exit code 0 but instead exited with code ${
-        code} and signal ${signal}`);
+          code} and signal ${signal}`);
     });
   });
 }

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -54,18 +54,18 @@ common.refreshTmpDir();
 fs.writeFileSync(filepathOne, 'hello');
 
 assert.doesNotThrow(
-    function() {
-      const watcher = fs.watch(filepathOne);
-      watcher.on('change', function(event, filename) {
-        assert.strictEqual(event, 'change');
+  function() {
+    const watcher = fs.watch(filepathOne);
+    watcher.on('change', function(event, filename) {
+      assert.strictEqual(event, 'change');
 
-        if (expectFilePath) {
-          assert.strictEqual(filename, 'watch.txt');
-        }
-        watcher.close();
-        ++watchSeenOne;
-      });
-    }
+      if (expectFilePath) {
+        assert.strictEqual(filename, 'watch.txt');
+      }
+      watcher.close();
+      ++watchSeenOne;
+    });
+  }
 );
 
 setImmediate(function() {
@@ -78,17 +78,17 @@ process.chdir(testDir);
 fs.writeFileSync(filepathTwoAbs, 'howdy');
 
 assert.doesNotThrow(
-    function() {
-      const watcher = fs.watch(filepathTwo, function(event, filename) {
-        assert.strictEqual(event, 'change');
+  function() {
+    const watcher = fs.watch(filepathTwo, function(event, filename) {
+      assert.strictEqual(event, 'change');
 
-        if (expectFilePath) {
-          assert.strictEqual(filename, 'hasOwnProperty');
-        }
-        watcher.close();
-        ++watchSeenTwo;
-      });
-    }
+      if (expectFilePath) {
+        assert.strictEqual(filename, 'hasOwnProperty');
+      }
+      watcher.close();
+      ++watchSeenTwo;
+    });
+  }
 );
 
 setImmediate(function() {
@@ -100,19 +100,19 @@ const testsubdir = fs.mkdtempSync(testDir + path.sep);
 const filepathThree = path.join(testsubdir, filenameThree);
 
 assert.doesNotThrow(
-    function() {
-      const watcher = fs.watch(testsubdir, function(event, filename) {
-        const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
-        assert.strictEqual(event, renameEv);
-        if (expectFilePath) {
-          assert.strictEqual(filename, 'newfile.txt');
-        } else {
-          assert.strictEqual(filename, null);
-        }
-        watcher.close();
-        ++watchSeenThree;
-      });
-    }
+  function() {
+    const watcher = fs.watch(testsubdir, function(event, filename) {
+      const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
+      assert.strictEqual(event, renameEv);
+      if (expectFilePath) {
+        assert.strictEqual(filename, 'newfile.txt');
+      } else {
+        assert.strictEqual(filename, null);
+      }
+      watcher.close();
+      ++watchSeenThree;
+    });
+  }
 );
 
 setImmediate(function() {

--- a/test/sequential/test-regress-GH-877.js
+++ b/test/sequential/test-regress-GH-877.js
@@ -56,11 +56,11 @@ server.listen(common.PORT, '127.0.0.1', function() {
 
     console.log(
       `Socket: ${agent.sockets[addrString].length}/${
-      agent.maxSockets} queued: ${
-      agent.requests[addrString] ? agent.requests[addrString].length : 0}`);
+        agent.maxSockets} queued: ${
+        agent.requests[addrString] ? agent.requests[addrString].length : 0}`);
 
     const agentRequests = agent.requests[addrString] ?
-        agent.requests[addrString].length : 0;
+      agent.requests[addrString].length : 0;
 
     if (maxQueued < agentRequests) {
       maxQueued = agentRequests;

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -57,7 +57,7 @@ function test(environ, shouldWrite, section) {
   if (shouldWrite) {
     expectErr =
       `${section.toUpperCase()} ${child.pid}: this { is: 'a' } /debugging/\n${
-         section.toUpperCase()} ${child.pid}: num=1 str=a obj={"foo":"bar"}\n`;
+        section.toUpperCase()} ${child.pid}: num=1 str=a obj={"foo":"bar"}\n`;
   }
 
   let err = '';

--- a/test/timers/test-timers-reliability.js
+++ b/test/timers/test-timers-reliability.js
@@ -33,7 +33,7 @@ let intervalFired = false;
 
 const monoTimer = new Timer();
 monoTimer[Timer.kOnTimeout] = function() {
-    /*
+  /*
      * Make sure that setTimeout's and setInterval's callbacks have
      * already fired, otherwise it means that they are vulnerable to
      * time drifting or inconsistent time changes.


### PR DESCRIPTION
ESLint 4.x has stricter linting than previous versions. We are currently
using the legacy indentation rules in the test directory. This commit
changes the indentation of files to comply with the stricter 4.x
linting and enable stricter linting in the test directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tools