### PR TITLE
(v6.x backport) dns: fix `resolve` failed starts without network

### DIFF
--- a/configure
+++ b/configure
@@ -419,12 +419,12 @@ parser.add_option('--without-perfctr',
 # Dummy option for backwards compatibility
 parser.add_option('--with-snapshot',
     action='store_true',
-    dest='with_snapshot',
+    dest='unused_with_snapshot',
     help=optparse.SUPPRESS_HELP)
 
 parser.add_option('--without-snapshot',
     action='store_true',
-    dest='unused_without_snapshot',
+    dest='without_snapshot',
     help=optparse.SUPPRESS_HELP)
 
 parser.add_option('--without-ssl',
@@ -802,7 +802,7 @@ def configure_node(o):
   cross_compiling = (options.cross_compiling
                      if options.cross_compiling is not None
                      else target_arch != host_arch)
-  want_snapshots = 1 if options.with_snapshot else 0
+  want_snapshots = not options.without_snapshot
   o['variables']['want_separate_host_toolset'] = int(
       cross_compiling and want_snapshots)
 
@@ -946,7 +946,7 @@ def configure_v8(o):
   o['variables']['v8_no_strict_aliasing'] = 1  # Work around compiler bugs.
   o['variables']['v8_optimized_debug'] = 0  # Compile with -O0 in debug builds.
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
-  o['variables']['v8_use_snapshot'] = b(options.with_snapshot)
+  o['variables']['v8_use_snapshot'] = 'false' if options.without_snapshot else 'true'
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
   o['variables']['force_dynamic_crt'] = 1 if options.shared else 0

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 103
+#define V8_PATCH_LEVEL 104
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -391,6 +391,9 @@ StartupData SerializeIsolateAndContext(
 
   i::Isolate* internal_isolate = reinterpret_cast<i::Isolate*>(isolate);
 
+  // We might rehash strings and re-sort descriptors. Clear the lookup cache.
+  internal_isolate->descriptor_lookup_cache()->Clear();
+
   // If we don't do this then we end up with a stray root pointing at the
   // context even after we have disposed of the context.
   internal_isolate->heap()->CollectAllAvailableGarbage("mksnapshot");
@@ -427,6 +430,9 @@ StartupData SerializeIsolateAndContext(
   i::PartialSerializer context_ser(internal_isolate, &ser, &context_sink);
   context_ser.Serialize(&raw_context);
   ser.SerializeWeakReferencesAndDeferred();
+
+  metadata.set_can_rehash(ser.can_be_rehashed() &&
+                          context_ser.can_be_rehashed());
 
   return i::Snapshot::CreateSnapshotBlob(ser, context_ser, metadata);
 }

--- a/deps/v8/src/bootstrapper.cc
+++ b/deps/v8/src/bootstrapper.cc
@@ -655,6 +655,8 @@ Handle<JSFunction> Genesis::GetThrowTypeErrorIntrinsic(
     DCHECK(false);
   }
 
+  JSObject::MigrateSlowToFast(function, 0, "Bootstrapping");
+
   return function;
 }
 
@@ -1133,6 +1135,8 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
 
     sloppy_function_map_writable_prototype_->SetConstructor(*function_fun);
     strict_function_map_writable_prototype_->SetConstructor(*function_fun);
+
+    JSObject::MigrateSlowToFast(function_fun, 0, "Bootstrapping");
   }
 
   {  // --- A r r a y ---

--- a/deps/v8/src/flag-definitions.h
+++ b/deps/v8/src/flag-definitions.h
@@ -830,6 +830,8 @@ DEFINE_BOOL(abort_on_uncaught_exception, false,
 DEFINE_BOOL(randomize_hashes, true,
             "randomize hashes to avoid predictable hash collisions "
             "(with snapshots this option cannot override the baked-in seed)")
+DEFINE_BOOL(rehash_snapshot, true,
+            "rehash strings from the snapshot to override the baked-in seed")
 DEFINE_INT(hash_seed, 0,
            "Fixed seed to use to hash property keys (0 means random)"
            "(with snapshots this option cannot override the baked-in seed)")

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -5348,14 +5348,7 @@ bool Heap::SetUp() {
 
   // Set up the seed that is used to randomize the string hash function.
   DCHECK(hash_seed() == 0);
-  if (FLAG_randomize_hashes) {
-    if (FLAG_hash_seed == 0) {
-      int rnd = isolate()->random_number_generator()->NextInt();
-      set_hash_seed(Smi::FromInt(rnd & Name::kHashBitMask));
-    } else {
-      set_hash_seed(Smi::FromInt(FLAG_hash_seed));
-    }
-  }
+  if (FLAG_randomize_hashes) InitializeHashSeed();
 
   for (int i = 0; i < static_cast<int>(v8::Isolate::kUseCounterFeatureCount);
        i++) {
@@ -5393,6 +5386,14 @@ bool Heap::SetUp() {
   return true;
 }
 
+void Heap::InitializeHashSeed() {
+  if (FLAG_hash_seed == 0) {
+    int rnd = isolate()->random_number_generator()->NextInt();
+    set_hash_seed(Smi::FromInt(rnd & Name::kHashBitMask));
+  } else {
+    set_hash_seed(Smi::FromInt(FLAG_hash_seed));
+  }
+}
 
 bool Heap::CreateHeapObjects() {
   // Create initial maps.

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -864,6 +864,9 @@ class Heap {
   // without actually creating any objects.
   bool SetUp();
 
+  // (Re-)Initialize hash seed from flag or RNG.
+  void InitializeHashSeed();
+
   // Bootstraps the object heap with the core set of objects required to run.
   // Returns whether it succeeded.
   bool CreateHeapObjects();

--- a/deps/v8/src/js/array.js
+++ b/deps/v8/src/js/array.js
@@ -1831,6 +1831,8 @@ var unscopables = {
   keys: true,
 };
 
+%ToFastProperties(unscopables);
+
 %AddNamedProperty(GlobalArray.prototype, unscopablesSymbol, unscopables,
                   DONT_ENUM | READ_ONLY);
 

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -9469,6 +9469,12 @@ void Map::TraceAllTransitions(Map* map) {
 
 void Map::ConnectTransition(Handle<Map> parent, Handle<Map> child,
                             Handle<Name> name, SimpleTransitionFlag flag) {
+  // Do not track transitions during bootstrap except for element transitions.
+  Isolate* isolate = parent->GetIsolate();
+  if (isolate->bootstrapper()->IsActive() &&
+      !name.is_identical_to(isolate->factory()->elements_transition_symbol())) {
+    return;
+  }
   if (!parent->GetBackPointer()->IsUndefined()) {
     parent->set_owns_descriptors(false);
   } else {
@@ -17519,6 +17525,12 @@ template class Dictionary<SeededNumberDictionary,
 template class Dictionary<UnseededNumberDictionary,
                           UnseededNumberDictionaryShape,
                           uint32_t>;
+
+template void
+HashTable<GlobalDictionary, GlobalDictionaryShape, Handle<Name> >::Rehash(Handle<Name> key);
+
+template void
+HashTable<NameDictionary, NameDictionaryShape, Handle<Name> >::Rehash(Handle<Name> key);
 
 template Handle<SeededNumberDictionary>
 Dictionary<SeededNumberDictionary, SeededNumberDictionaryShape, uint32_t>::

--- a/deps/v8/src/snapshot/deserializer.cc
+++ b/deps/v8/src/snapshot/deserializer.cc
@@ -109,6 +109,8 @@ void Deserializer::Deserialize(Isolate* isolate) {
   LOG_CODE_EVENT(isolate_, LogCodeObjects());
   LOG_CODE_EVENT(isolate_, LogBytecodeHandlers());
   LOG_CODE_EVENT(isolate_, LogCompiledFunctions());
+
+  if (FLAG_rehash_snapshot && can_rehash_) Rehash();
 }
 
 MaybeHandle<Object> Deserializer::DeserializePartial(
@@ -138,6 +140,9 @@ MaybeHandle<Object> Deserializer::DeserializePartial(
   // changed and logging should be added to notify the profiler et al of the
   // new code, which also has to be flushed from instruction cache.
   CHECK_EQ(start_address, code_space->top());
+
+  if (FLAG_rehash_snapshot && can_rehash_) RehashContext(Context::cast(root));
+
   return Handle<Object>(root, isolate);
 }
 
@@ -161,6 +166,64 @@ MaybeHandle<SharedFunctionInfo> Deserializer::DeserializeCode(
     }
     CommitPostProcessedObjects(isolate);
     return scope.CloseAndEscape(result);
+  }
+}
+
+// We only really just need HashForObject here.
+class StringRehashKey : public HashTableKey {
+ public:
+  uint32_t HashForObject(Object* other) override {
+    return String::cast(other)->Hash();
+  }
+
+  static uint32_t StringHash(Object* obj) {
+    UNREACHABLE();
+    return String::cast(obj)->Hash();
+  }
+
+  bool IsMatch(Object* string) override {
+    UNREACHABLE();
+    return false;
+  }
+
+  uint32_t Hash() override {
+    UNREACHABLE();
+    return 0;
+  }
+
+  Handle<Object> AsHandle(Isolate* isolate) override {
+    UNREACHABLE();
+    return isolate->factory()->empty_string();
+  }
+};
+
+void Deserializer::Rehash() {
+  DCHECK(can_rehash_);
+  isolate_->heap()->InitializeHashSeed();
+  if (FLAG_profile_deserialization) {
+    PrintF("Re-initializing hash seed to %x\n",
+           isolate_->heap()->hash_seed()->value());
+  }
+  StringRehashKey string_rehash_key;
+  isolate_->heap()->string_table()->Rehash(&string_rehash_key);
+  isolate_->heap()->intrinsic_function_names()->Rehash(
+      isolate_->factory()->empty_string());
+  SortMapDescriptors();
+}
+
+void Deserializer::RehashContext(Context* context) {
+  DCHECK(can_rehash_);
+  for (const auto& array : transition_arrays_) array->Sort();
+  Handle<Name> dummy = isolate_->factory()->empty_string();
+  context->global_object()->global_dictionary()->Rehash(dummy);
+  SortMapDescriptors();
+}
+
+void Deserializer::SortMapDescriptors() {
+  for (const auto& map : maps_) {
+    if (map->instance_descriptors()->number_of_descriptors() > 1) {
+      map->instance_descriptors()->Sort();
+    }
   }
 }
 
@@ -286,6 +349,18 @@ HeapObject* Deserializer::PostProcessNewObject(HeapObject* obj, int space) {
     // When deserializing user code, remember each individual code object.
     if (deserializing_user_code() || space == LO_SPACE) {
       new_code_objects_.Add(Code::cast(obj));
+    }
+  }
+  if (FLAG_rehash_snapshot && can_rehash_ && !deserializing_user_code()) {
+    if (obj->IsString()) {
+      // Uninitialize hash field as we are going to reinitialize the hash seed.
+      String* string = String::cast(obj);
+      string->set_hash_field(String::kEmptyHashField);
+    } else if (obj->IsTransitionArray() &&
+               TransitionArray::cast(obj)->number_of_entries() > 1) {
+      transition_arrays_.Add(TransitionArray::cast(obj));
+    } else if (obj->IsMap()) {
+      maps_.Add(Map::cast(obj));
     }
   }
   // Check alignment.

--- a/deps/v8/src/snapshot/partial-serializer.h
+++ b/deps/v8/src/snapshot/partial-serializer.h
@@ -21,6 +21,8 @@ class PartialSerializer : public Serializer {
   // Serialize the objects reachable from a single object pointer.
   void Serialize(Object** o);
 
+  bool can_be_rehashed() const { return can_be_rehashed_; }
+
  private:
   class PartialCacheIndexMap : public AddressMapBase {
    public:
@@ -49,10 +51,16 @@ class PartialSerializer : public Serializer {
   int PartialSnapshotCacheIndex(HeapObject* o);
   bool ShouldBeInThePartialSnapshotCache(HeapObject* o);
 
+  void CheckRehashability(HeapObject* table);
+
   Serializer* startup_serializer_;
   Object* global_object_;
   PartialCacheIndexMap partial_cache_index_map_;
   int next_partial_cache_index_;
+  Context* rehashable_context_;
+  // Indicates whether we only serialized hash tables that we can rehash.
+  // TODO(yangguo): generalize rehashing, and remove this flag.
+  bool can_be_rehashed_;
   DISALLOW_COPY_AND_ASSIGN(PartialSerializer);
 };
 

--- a/deps/v8/src/snapshot/snapshot-common.cc
+++ b/deps/v8/src/snapshot/snapshot-common.cc
@@ -58,6 +58,7 @@ bool Snapshot::Initialize(Isolate* isolate) {
   Vector<const byte> startup_data = ExtractStartupData(blob);
   SnapshotData snapshot_data(startup_data);
   Deserializer deserializer(&snapshot_data);
+  deserializer.SetRehashability(ExtractMetadata(blob).can_rehash());
   bool success = isolate->Init(&deserializer);
   if (FLAG_profile_deserialization) {
     double ms = timer.Elapsed().InMillisecondsF();
@@ -78,6 +79,7 @@ MaybeHandle<Context> Snapshot::NewContextFromSnapshot(
   Vector<const byte> context_data = ExtractContextData(blob);
   SnapshotData snapshot_data(context_data);
   Deserializer deserializer(&snapshot_data);
+  deserializer.SetRehashability(ExtractMetadata(blob).can_rehash());
 
   MaybeHandle<Object> maybe_context =
       deserializer.DeserializePartial(isolate, global_proxy);

--- a/deps/v8/src/snapshot/snapshot.h
+++ b/deps/v8/src/snapshot/snapshot.h
@@ -26,10 +26,16 @@ class Snapshot : public AllStatic {
       data_ = EmbedsScriptBits::update(data_, v);
     }
 
+    bool can_rehash() { return RehashabilityBits::decode(data_); }
+    void set_can_rehash(bool v) {
+      data_ = RehashabilityBits::update(data_, v);
+    }
+
     uint32_t& RawValue() { return data_; }
 
    private:
     class EmbedsScriptBits : public BitField<bool, 0, 1> {};
+    class RehashabilityBits : public BitField<bool, 1, 1> {};
     uint32_t data_;
   };
 

--- a/deps/v8/src/snapshot/startup-serializer.h
+++ b/deps/v8/src/snapshot/startup-serializer.h
@@ -28,6 +28,8 @@ class StartupSerializer : public Serializer {
   void SerializeStrongReferences();
   void SerializeWeakReferencesAndDeferred();
 
+  bool can_be_rehashed() const { return can_be_rehashed_; }
+
  private:
   // The StartupSerializer has to serialize the root array, which is slightly
   // different.
@@ -42,10 +44,17 @@ class StartupSerializer : public Serializer {
   // roots. In the second pass, we serialize the rest.
   bool RootShouldBeSkipped(int root_index);
 
+  void CheckRehashability(HeapObject* hashtable);
+
   FunctionCodeHandling function_code_handling_;
   bool serializing_builtins_;
   bool serializing_immortal_immovables_roots_;
   std::bitset<Heap::kStrongRootListLength> root_has_been_serialized_;
+
+  // Indicates whether we only serialized hash tables that we can rehash.
+  // TODO(yangguo): generalize rehashing, and remove this flag.
+  bool can_be_rehashed_;
+
   DISALLOW_COPY_AND_ASSIGN(StartupSerializer);
 };
 

--- a/deps/v8/src/transitions-inl.h
+++ b/deps/v8/src/transitions-inl.h
@@ -106,7 +106,6 @@ int TransitionArray::SearchName(Name* name, int* out_insertion_index) {
 }
 
 
-#ifdef DEBUG
 bool TransitionArray::IsSpecialTransition(Name* name) {
   if (!name->IsSymbol()) return false;
   Heap* heap = name->GetHeap();
@@ -116,7 +115,6 @@ bool TransitionArray::IsSpecialTransition(Name* name) {
          name == heap->strict_function_transition_symbol() ||
          name == heap->observed_symbol();
 }
-#endif
 
 
 int TransitionArray::CompareKeys(Name* key1, uint32_t hash1, PropertyKind kind1,

--- a/deps/v8/src/transitions.cc
+++ b/deps/v8/src/transitions.cc
@@ -549,5 +549,47 @@ int TransitionArray::Search(PropertyKind kind, Name* name,
   if (transition == kNotFound) return kNotFound;
   return SearchDetails(transition, kind, attributes, out_insertion_index);
 }
+
+void TransitionArray::Sort() {
+  DisallowHeapAllocation no_gc;
+  // In-place insertion sort.
+  int length = number_of_transitions();
+  for (int i = 1; i < length; i++) {
+    Name* key = GetKey(i);
+    Map* target = GetTarget(i);
+    PropertyKind kind = kData;
+    PropertyAttributes attributes = NONE;
+    if (!IsSpecialTransition(key)) {
+      PropertyDetails details = GetTargetDetails(key, target);
+      kind = details.kind();
+      attributes = details.attributes();
+    }
+    int j;
+    for (j = i - 1; j >= 0; j--) {
+      Name* temp_key = GetKey(j);
+      Map* temp_target = GetTarget(j);
+      PropertyKind temp_kind = kData;
+      PropertyAttributes temp_attributes = NONE;
+      if (!IsSpecialTransition(temp_key)) {
+        PropertyDetails details = GetTargetDetails(temp_key, temp_target);
+        temp_kind = details.kind();
+        temp_attributes = details.attributes();
+      }
+      int cmp =
+          CompareKeys(temp_key, temp_key->Hash(), temp_kind, temp_attributes,
+                      key, key->Hash(), kind, attributes);
+      if (cmp > 0) {
+        SetKey(j + 1, temp_key);
+        SetTarget(j + 1, temp_target);
+      } else {
+        break;
+      }
+    }
+    SetKey(j + 1, key);
+    SetTarget(j + 1, target);
+  }
+  DCHECK(IsSortedNoDuplicates());
+}
+
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/transitions.h
+++ b/deps/v8/src/transitions.h
@@ -189,15 +189,17 @@ class TransitionArray: public FixedArray {
   void TransitionArrayVerify();
 #endif
 
+  void Sort();
+
 #ifdef DEBUG
   bool IsSortedNoDuplicates(int valid_entries = -1);
   static bool IsSortedNoDuplicates(Map* map);
   static bool IsConsistentWithBackPointers(Map* map);
+#endif
 
   // Returns true for a non-property transitions like elements kind, observed
   // or frozen transitions.
   static inline bool IsSpecialTransition(Name* name);
-#endif
 
   // Constant for denoting key was not found.
   static const int kNotFound = -1;

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -1834,6 +1834,36 @@ TEST(Regress503552) {
 }
 
 
+UNINITIALIZED_TEST(ReinitializeStringHashSeedNotRehashable) {
+  DisableTurbofan();
+  i::FLAG_rehash_snapshot = true;
+  i::FLAG_hash_seed = 42;
+  i::FLAG_allow_natives_syntax = true;
+
+  v8::StartupData blob = v8::V8::CreateSnapshotDataBlob("var a = {};"
+          "a.b = 1;"
+          "a.c = 2;"
+          "delete a.b;");
+
+  i::FLAG_hash_seed = 1337;
+  v8::Isolate::CreateParams create_params;
+  create_params.array_buffer_allocator = CcTest::array_buffer_allocator();
+  create_params.snapshot_blob = &blob;
+  v8::Isolate* isolate = v8::Isolate::New(create_params);
+  {
+    // Check that no rehashing has been performed.
+    CHECK_EQ(42, reinterpret_cast<i::Isolate*>(isolate)->heap()->HashSeed());
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Local<v8::Context> context = v8::Context::New(isolate);
+    CHECK(!context.IsEmpty());
+    v8::Context::Scope context_scope(context);
+    ExpectInt32("a.c", 2);
+  }
+  isolate->Dispose();
+  delete[] blob.data;
+}
+
 TEST(SerializationMemoryStats) {
   FLAG_profile_deserialization = true;
   FLAG_always_opt = false;

--- a/lib/net.js
+++ b/lib/net.js
@@ -1338,7 +1338,7 @@ Server.prototype.listen = function() {
     self.once('listening', lastArg);
   }
 
-  var port = toNumber(arguments[0]);
+  var port = typeof arguments[0] === 'undefined' ? 0 : toNumber(arguments[0]);
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -219,6 +219,8 @@ inline Environment::Environment(v8::Local<v8::Context> context,
     : isolate_(context->GetIsolate()),
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate(), loop)),
       timer_base_(uv_now(loop)),
+      cares_query_last_ok_(true),
+      cares_is_servers_default_(true),
       using_domains_(false),
       printed_error_(false),
       trace_sync_io_(false),
@@ -451,6 +453,22 @@ inline ares_channel Environment::cares_channel() {
 // Only used in the call to ares_init_options().
 inline ares_channel* Environment::cares_channel_ptr() {
   return &cares_channel_;
+}
+
+inline bool Environment::cares_query_last_ok() {
+  return cares_query_last_ok_;
+}
+
+inline void Environment::set_cares_query_last_ok(bool ok) {
+  cares_query_last_ok_ = ok;
+}
+
+inline bool Environment::cares_is_servers_default() {
+  return cares_is_servers_default_;
+}
+
+inline void Environment::set_cares_is_servers_default(bool is_default) {
+  cares_is_servers_default_ = is_default;
 }
 
 inline node_ares_task_list* Environment::cares_task_list() {

--- a/src/env.h
+++ b/src/env.h
@@ -437,6 +437,10 @@ class Environment {
   inline uv_timer_t* cares_timer_handle();
   inline ares_channel cares_channel();
   inline ares_channel* cares_channel_ptr();
+  inline bool cares_query_last_ok();
+  inline void set_cares_query_last_ok(bool ok);
+  inline bool cares_is_servers_default();
+  inline void set_cares_is_servers_default(bool is_default);
   inline node_ares_task_list* cares_task_list();
 
   inline bool using_domains() const;
@@ -555,6 +559,8 @@ class Environment {
   const uint64_t timer_base_;
   uv_timer_t cares_timer_handle_;
   ares_channel cares_channel_;
+  bool cares_query_last_ok_;
+  bool cares_is_servers_default_;
   node_ares_task_list cares_task_list_;
   bool using_domains_;
   bool printed_error_;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -127,7 +127,6 @@ const char* const root_certs[] = {
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
 X509_STORE* root_cert_store;
-std::vector<X509*> root_certs_vector;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;
@@ -710,6 +709,7 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
+  static std::vector<X509*> root_certs_vector;
   if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -120,13 +120,13 @@ static X509_NAME *cnnic_ev_name =
 
 static Mutex* mutexes;
 
-const char* const root_certs[] = {
+static const char* const root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
 };
 
-std::string extra_root_certs_file;  // NOLINT(runtime/string)
+static std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
-X509_STORE* root_cert_store;
+static X509_STORE* root_cert_store;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -63,8 +63,6 @@ enum CheckResult {
 
 extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 
-extern X509_STORE* root_cert_store;
-
 extern void UseExtraCaCerts(const std::string& file);
 
 // Forward declaration

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -26,3 +26,38 @@ net.Server().listen({ port: '' + common.PORT }, close);
     net.Server().listen({ port: port }, common.fail);
   }, /invalid listen argument/i);
 });
+
+// Repeat the tests, passing port as an argument, which validates somewhat
+// differently.
+
+net.Server().listen(undefined, close);
+net.Server().listen('0', close);
+
+// 'nan', skip, treated as a path, not a port
+//'+Infinity', skip, treated as a path, not a port
+//'-Infinity' skip, treated as a path, not a port
+
+// 4.x treats these as 0, but 6.x treats them as invalid numbers.
+[
+  -1,
+  123.456,
+  0x10000,
+  1 / 0,
+  -1 / 0,
+].forEach(function(port) {
+  assert.throws(function() {
+    net.Server().listen(port, common.fail);
+  }, /"port" argument must be >= 0 and < 65536/i);
+});
+
+// null is treated as 0
+net.Server().listen(null, close);
+
+// false/true are converted to 0/1, arguably a bug, but fixing would be
+// semver-major. Note that true fails because ports that low can't be listened
+// on by unprivileged processes.
+net.Server().listen(false, close);
+
+net.Server().listen(true).on('error', common.mustCall(function(err) {
+  assert.strictEqual(err.code, 'EACCES');
+}));


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/13076

Fix the bug that you start process without network at first, but it connected lately, `dns.resolve` will stay failed with ECONNREFUSED because c-ares servers fallback to 127.0.0.1 at the very beginning.

If c-ares servers "127.0.0.1" is detected and its not set by user self, and last query is not OK, recreating `ares_channel` operation will be triggered to reload servers.

You can test with this script:

```javascript
const dns = require("dns");

function test() {
    dns.resolve("google.com", function(err, ret) {
        console.log(err, ret, dns.getServers());
        setTimeout(test, 10000);
    });
}

test();
```

**Turn off your network at first before starting this script. Then try to open the network and then turn off. Make the steps above in a loop and you will get the result.**

Fixes: https://github.com/nodejs/node/issues/1644

<sub>refack: added ref to original PR</sub>
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test`
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
dns