### PR TITLE
path: remove unnecessary string copies

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1040,7 +1040,7 @@ const win32 = {
               if (len === 3) {
                 // `path` contains just a drive root, exit early to avoid
                 // unnecessary work
-                ret.root = ret.dir = path.slice(0, 3);
+                ret.root = ret.dir = path;
                 return ret;
               }
               isAbsolute = true;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1049,7 +1049,7 @@ const win32 = {
           } else {
             // `path` contains just a drive root, exit early to avoid
             // unnecessary work
-            ret.root = ret.dir = path.slice(0, 2);
+            ret.root = ret.dir = path;
             return ret;
           }
         }

--- a/lib/path.js
+++ b/lib/path.js
@@ -788,7 +788,9 @@ const win32 = {
         }
       }
     } else if (code === 47/*/*/ || code === 92/*\*/) {
-      return path[0];
+      // `path` contains just a path separator, exit early to avoid
+      // unnecessary work
+      return path;
     }
 
     for (var i = len - 1; i >= offset; --i) {
@@ -1057,7 +1059,7 @@ const win32 = {
     } else if (code === 47/*/*/ || code === 92/*\*/) {
       // `path` contains just a path separator, exit early to avoid
       // unnecessary work
-      ret.root = ret.dir = path[0];
+      ret.root = ret.dir = path;
       return ret;
     }
 

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -32,6 +32,8 @@ const winPaths = [
   'file',
   '.\\file',
   'C:\\',
+  'C:',
+  '\\',
   '',
 
   // unc

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -44,7 +44,9 @@ const winPaths = [
 ];
 
 const winSpecialCaseParseTests = [
-  ['/foo/bar', { root: '/' }]
+  ['/foo/bar', { root: '/' }],
+  ['C:', { root: 'C:', dir: 'C:', base: '' }],
+  ['C:\\', { root: 'C:\\', dir: 'C:\\', base: '' }]
 ];
 
 const winSpecialCaseFormatTests = [


### PR DESCRIPTION
The length of `path` is known, so `path.slice(0, len) === path`. Unless I am missing something, these calls are unnecessary.

Partial CI: https://ci.nodejs.org/job/node-test-commit-linuxone/7511/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
path