### PR TITLE
test: fix flaky test-force-repl

### DIFF
--- a/test/parallel/test-force-repl.js
+++ b/test/parallel/test-force-repl.js
@@ -3,16 +3,13 @@ const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
-// spawn a node child process in "interactive" mode (force the repl)
+// Spawn a node child process in interactive mode (enabling the REPL) and
+// confirm the '> ' prompt is included in the output.
 const cp = spawn(process.execPath, ['-i']);
-// give node + the repl 5 seconds to start
-const timeoutId = setTimeout(common.mustNotCall(),
-                             common.platformTimeout(5000));
 
 cp.stdout.setEncoding('utf8');
 
 cp.stdout.once('data', common.mustCall(function(b) {
-  clearTimeout(timeoutId);
   assert.strictEqual(b, '> ');
   cp.kill();
 }));


### PR DESCRIPTION
test/parallel/test-force-repl.js has an unnecessary timer that makes the
test flaky under load. Remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl