### PR TITLE
test: changed error message validator

### DIFF
--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../../common');
 const assert = require('assert');
+const readonlyErrorRE = /^TypeError: Cannot assign to read only property '.*' of object '#<Object>'$/;
 
 // Testing api calls for defining properties
 const test_object = require(`./build/${common.buildType}/test_properties`);
@@ -12,7 +13,7 @@ assert.strictEqual(test_object.readwriteValue, 1);
 test_object.readwriteValue = 2;
 assert.strictEqual(test_object.readwriteValue, 2);
 
-assert.throws(() => { test_object.readonlyValue = 3; }, TypeError);
+assert.throws(() => { test_object.readonlyValue = 3; }, readonlyErrorRE);
 
 assert.ok(test_object.hiddenValue);
 
@@ -42,11 +43,11 @@ assert.strictEqual(symbolDescription, 'NameKeySymbol');
 test_object.readwriteAccessor1 = 1;
 assert.strictEqual(test_object.readwriteAccessor1, 1);
 assert.strictEqual(test_object.readonlyAccessor1, 1);
-assert.throws(() => { test_object.readonlyAccessor1 = 3; }, TypeError);
+assert.throws(() => { test_object.readonlyAccessor1 = 3; }, readonlyErrorRE);
 test_object.readwriteAccessor2 = 2;
 assert.strictEqual(test_object.readwriteAccessor2, 2);
 assert.strictEqual(test_object.readonlyAccessor2, 2);
-assert.throws(() => { test_object.readonlyAccessor2 = 3; }, TypeError);
+assert.throws(() => { test_object.readonlyAccessor2 = 3; }, readonlyErrorRE);
 
 assert.strictEqual(test_object.hasNamedProperty(test_object, 'echo'), true);
 assert.strictEqual(test_object.hasNamedProperty(test_object, 'hiddenValue'),


### PR DESCRIPTION
Replaced TypeError with RegEx to match the exact error message in file
test/addons-napi/test_properties/test.js. The RegEx will check the
validity of the error being thrown.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
