### PR TITLE
tls: fix object prototype type confusion

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -176,14 +176,11 @@ exports.translatePeerCertificate = function translatePeerCertificate(c) {
   if (c.subject != null) c.subject = tls.parseCertString(c.subject);
   if (c.infoAccess != null) {
     var info = c.infoAccess;
-    c.infoAccess = {};
+    c.infoAccess = Object.create(null);
 
     // XXX: More key validation?
     info.replace(/([^\n:]*):([^\n]*)(?:\n|$)/g, function(all, key, val) {
-      if (key === '__proto__')
-        return;
-
-      if (c.infoAccess.hasOwnProperty(key))
+      if (key in c.infoAccess)
         c.infoAccess[key].push(val);
       else
         c.infoAccess[key] = [val];

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -231,7 +231,7 @@ exports.checkServerIdentity = function checkServerIdentity(host, cert) {
 // Example:
 // C=US\nST=CA\nL=SF\nO=Joyent\nOU=Node.js\nCN=ca1\nemailAddress=ry@clouds.org
 exports.parseCertString = function parseCertString(s) {
-  var out = {};
+  var out = Object.create(null);
   var parts = s.split('\n');
   for (var i = 0, len = parts.length; i < len; i++) {
     var sepIndex = parts[i].indexOf('=');

--- a/test/parallel/test-tls-parse-cert-string.js
+++ b/test/parallel/test-tls-parse-cert-string.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-proto */
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -11,6 +12,7 @@ const tls = require('tls');
                   'CN=ca1\nemailAddress=ry@clouds.org';
   const singlesOut = tls.parseCertString(singles);
   assert.deepStrictEqual(singlesOut, {
+    __proto__: null,
     C: 'US',
     ST: 'CA',
     L: 'SF',
@@ -26,6 +28,7 @@ const tls = require('tls');
                   'CN=*.nodejs.org';
   const doublesOut = tls.parseCertString(doubles);
   assert.deepStrictEqual(doublesOut, {
+    __proto__: null,
     OU: [ 'Domain Control Validated', 'PositiveSSL Wildcard' ],
     CN: '*.nodejs.org'
   });
@@ -34,5 +37,13 @@ const tls = require('tls');
 {
   const invalid = 'fhqwhgads';
   const invalidOut = tls.parseCertString(invalid);
-  assert.deepStrictEqual(invalidOut, {});
+  assert.deepStrictEqual(invalidOut, { __proto__: null });
+}
+
+{
+  const input = '__proto__=mostly harmless\nhasOwnProperty=not a function';
+  const expected = Object.create(null);
+  expected.__proto__ = 'mostly harmless';
+  expected.hasOwnProperty = 'not a function';
+  assert.deepStrictEqual(tls.parseCertString(input), expected);
 }


### PR DESCRIPTION
Fix for #11771.  Note that the other two are fixes for (arguably minor) security vulnerabilities.

I don't think core is directly affected but user applications might be susceptible to type confusion stemming from manipulating `__proto__` or properties inherited from `Object.prototype`.

CI: https://ci.nodejs.org/job/node-test-pull-request/9320/