### PR TITLE
src: replace deprecated method

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -512,10 +512,10 @@ void AsyncWrap::Initialize(Local<Object> target,
       static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
 
 #define FORCE_SET_TARGET_FIELD(obj, str, field)                               \
-  (obj)->ForceSet(context,                                                    \
-                  FIXED_ONE_BYTE_STRING(isolate, str),                        \
-                  field,                                                      \
-                  ReadOnlyDontDelete).FromJust()
+  (obj)->DefineOwnProperty(context,                                           \
+                           FIXED_ONE_BYTE_STRING(isolate, str),               \
+                           field,                                             \
+                           ReadOnlyDontDelete).FromJust()
 
   // Attach the uint32_t[] where each slot contains the count of the number of
   // callbacks waiting to be called on a particular event. It can then be


### PR DESCRIPTION
ForceSet() is marked to be deprecated. Replacing
it with DefineOwnProperty().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src
