### PR TITLE
test: refactor test-benchmark-timers

### DIFF
--- a/test/parallel/test-benchmark-timers.js
+++ b/test/parallel/test-benchmark-timers.js
@@ -10,8 +10,9 @@ const fork = require('child_process').fork;
 const path = require('path');
 
 const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
-const argv = ['--set', 'thousands=0.001',
+const argv = ['--set', 'type=depth',
               '--set', 'millions=0.000001',
+              '--set', 'thousands=0.001',
               'timers'];
 
 const child = fork(runjs, argv, { env: { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 } });


### PR DESCRIPTION
* add `type` option to reduce combinations of benchmarks run (saves
  about 15% on run duration of test on my local machine)
* alphabetize options

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark timers