### PR TITLE
buffer: remove a wrongly added attribute specifier

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -34,7 +34,7 @@ namespace Buffer {
 static const unsigned int kMaxLength =
     sizeof(int32_t) == sizeof(intptr_t) ? 0x3fffffff : 0x7fffffff;
 
-NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
+typedef void (*FreeCallback)(char* data, void* hint);
 
 NODE_EXTERN bool HasInstance(v8::Local<v8::Value> val);
 NODE_EXTERN bool HasInstance(v8::Local<v8::Object> val);


### PR DESCRIPTION
It doesn't seem to make much sense to have the mentioned typedef
declaration equipped with NODE_EXTERN. In fact, when compiling with GCC,
an attribute specifier like `__attribute__((visibility("default")))` in
such a typedef declaration will cause the following warning message:

  warning: ‘visibility’ attribute ignored [-Wattributes]

The issue goes unnoticed because NODE_EXTERN is defined as nothing for
GCC builds, but for correctness it's better to not specify it here at
all.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer
