### PR TITLE
repl: do not consider `...` as a REPL command

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -419,7 +419,7 @@ function REPLServer(prompt,
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
     if (trimmedCmd) {
-      if (trimmedCmd.charAt(0) === '.' && isNaN(parseFloat(trimmedCmd))) {
+      if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) != '.' && isNaN(parseFloat(trimmedCmd))) {
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -419,7 +419,7 @@ function REPLServer(prompt,
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
     if (trimmedCmd) {
-      if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) != '.' && isNaN(parseFloat(trimmedCmd))) {
+      if (trimmedCmd.charAt(0) === '.' && trimmedCmd.charAt(1) !== '.' && isNaN(parseFloat(trimmedCmd))) {
         const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
         const keyword = matches && matches[1];
         const rest = matches && matches[2];

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -416,8 +416,12 @@ function error_test() {
     { client: client_unix, send: ' \t  \n',
       expect: prompt_unix },
     //Do not parse `...[]` as a REPL keyword
-    { client: client_unix, send: '...[]\n.break',
-      expect: `${prompt_multiline}${prompt_unix}` }
+    { client: client_unix, send: '...[]\n',
+      expect: `${prompt_multiline}` },
+    //bring back the repl to prompt
+    { client: client_unix, send: '.break',
+      expect: `${prompt_unix}` }
+
   ]);
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -414,7 +414,10 @@ function error_test() {
       expect: `${prompt_multiline}'foo \\n'\n${prompt_unix}` },
     // Whitespace is not evaluated.
     { client: client_unix, send: ' \t  \n',
-      expect: prompt_unix }
+      expect: prompt_unix },
+    //Do not parse `...[]` as a REPL keyword
+    { client: client_unix, send: '...[]',
+      expect: prompt_multiline }
   ]);
 }
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -416,8 +416,8 @@ function error_test() {
     { client: client_unix, send: ' \t  \n',
       expect: prompt_unix },
     //Do not parse `...[]` as a REPL keyword
-    { client: client_unix, send: '...[]',
-      expect: prompt_multiline }
+    { client: client_unix, send: '...[]\n.break',
+      expect: `${prompt_multiline}${prompt_unix}` }
   ]);
 }
 


### PR DESCRIPTION
This fix makes `...` in REPL to be considered as a javascript construct
rather than a REPL keyword

Fixes: https://github.com/nodejs/node/issues/14426

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl