### PR TITLE
[v8.x backport] assert: fix incorrect use of ERR_INVALID_ARG_TYPE

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -521,7 +521,7 @@ function innerThrows(shouldThrow, block, expected, message) {
   if (typeof block !== 'function') {
     const errors = lazyErrors();
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'function',
-                               typeof block);
+                               block);
   }
 
   if (typeof expected === 'string') {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -670,10 +670,9 @@ try {
 
 {
   // Verify that throws() and doesNotThrow() throw on non-function block
-  const validationFunction = common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
+  function typeName(value) {
+    return value === null ? 'null' : typeof value;
+  }
 
   const testBlockTypeError = (method, block) => {
     let threw = true;
@@ -682,7 +681,12 @@ try {
       method(block);
       threw = false;
     } catch (e) {
-      validationFunction(e);
+      common.expectsError({
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "block" argument must be of type function. Received ' +
+                 'type ' + typeName(block)
+      })(e);
     }
 
     assert.ok(threw);


### PR DESCRIPTION
Partial backport of https://github.com/nodejs/node/pull/14011 to v8.x.