### PR TITLE
test: support odd value for kStringMaxLength

### DIFF
--- a/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
+++ b/test/addons/stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-2.js
@@ -26,4 +26,4 @@ if (!binding.ensureAllocation(2 * kStringMaxLength))
   common.skip(skipMessage);
 
 const maxString = buf.toString('utf16le');
-assert.strictEqual(maxString.length, (kStringMaxLength + 2) / 2);
+assert.strictEqual(maxString.length, Math.floor((kStringMaxLength + 2) / 2));


### PR DESCRIPTION
V8 6.2 will support a larger maximum string length on 64-bit platforms.
Update the test to take into account its odd value ((1 << 30) - 1 - 24).

Refs: https://github.com/v8/v8/commit/e8c9649e2570c7e278e70a6584738a3c3f828b2b
Example failing test on canary: https://ci.nodejs.org/job/node-test-commit-linux/11406/nodes=centos7-64/console

@nodejs/v8

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

buffer, V8