### PR TITLE
(v6.x backport) process: add --redirect-warnings command line argument

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -122,6 +122,16 @@ added: v6.0.0
 
 Print stack traces for process warnings (including deprecations).
 
+### `--redirect-warnings=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+Write process warnings to the given file instead of printing to stderr. The
+file will be created if it does not exist, and will be appended to if it does.
+If an error occurs while attempting to write the warning to the file, the
+warning will be written to stderr instead.
+
 ### `--trace-sync-io`
 <!-- YAML
 added: v2.1.0
@@ -382,6 +392,17 @@ containing trusted certificates.
 Note: Be aware that unless the child environment is explicitly set, this
 evironment variable will be inherited by any child processes, and if they use
 OpenSSL, it may cause them to trust the same CAs as node.
+
+### `NODE_REDIRECT_WARNINGS=file`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set, process warnings will be emitted to the given file instead of
+printing to stderr. The file will be created if it does not exist, and will be
+appended to if it does. If an error occurs while attempting to write the
+warning to the file, the warning will be written to stderr instead. This is
+equivalent to using the `--redirect-warnings=file` command-line flag.
 
 [emit_warning]: process.html#process_process_emitwarning_warning_name_ctor
 [Buffer]: buffer.html#buffer_buffer

--- a/doc/node.1
+++ b/doc/node.1
@@ -113,6 +113,10 @@ Silence all process warnings (including deprecations).
 Print stack traces for process warnings (including deprecations).
 
 .TP
+.BR \-\-redirect\-warnings=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+
+.TP
 .BR \-\-trace\-sync\-io
 Print a stack trace whenever synchronous I/O is detected after the first turn
 of the event loop.
@@ -254,6 +258,12 @@ containing trusted certificates.
 .BR SSL_CERT_FILE = \fIfile\fR
 If \fB\-\-use\-openssl\-ca\fR is enabled, this overrides and sets OpenSSL's
 file containing trusted certificates.
+
+.TP
+.BR NODE_REDIRECT_WARNINGS=\fIfile\fR
+Write process warnings to the given file instead of printing to stderr.
+(equivalent to using the \-\-redirect\-warnings=\fIfile\fR command-line
+argument).
 
 .SH BUGS
 Bugs are tracked in GitHub Issues:

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -4,9 +4,80 @@ const traceWarnings = process.traceProcessWarnings;
 const noDeprecation = process.noDeprecation;
 const traceDeprecation = process.traceDeprecation;
 const throwDeprecation = process.throwDeprecation;
+const config = process.binding('config');
 const prefix = `(${process.release.name}:${process.pid}) `;
 
 exports.setup = setupProcessWarnings;
+
+var fs;
+var cachedFd;
+var acquiringFd = false;
+function nop() {}
+
+function lazyFs() {
+  if (!fs)
+    fs = require('fs');
+  return fs;
+}
+
+function writeOut(message) {
+  if (console && typeof console.error === 'function')
+    return console.error(message);
+  process._rawDebug(message);
+}
+
+function onClose(fd) {
+  return function() {
+    lazyFs().close(fd, nop);
+  };
+}
+
+function onOpen(cb) {
+  return function(err, fd) {
+    acquiringFd = false;
+    if (fd !== undefined) {
+      cachedFd = fd;
+      process.on('exit', onClose(fd));
+    }
+    cb(err, fd);
+    process.emit('_node_warning_fd_acquired', err, fd);
+  };
+}
+
+function onAcquired(message) {
+  // make a best effort attempt at writing the message
+  // to the fd. Errors are ignored at this point.
+  return function(err, fd) {
+    if (err)
+      return writeOut(message);
+    lazyFs().appendFile(fd, `${message}\n`, nop);
+  };
+}
+
+function acquireFd(cb) {
+  if (cachedFd === undefined && !acquiringFd) {
+    acquiringFd = true;
+    lazyFs().open(config.warningFile, 'a', onOpen(cb));
+  } else if (cachedFd !== undefined && !acquiringFd) {
+    cb(null, cachedFd);
+  } else {
+    process.once('_node_warning_fd_acquired', cb);
+  }
+}
+
+function output(message) {
+  if (typeof config.warningFile === 'string') {
+    acquireFd(onAcquired(message));
+    return;
+  }
+  writeOut(message);
+}
+
+function doEmitWarning(warning) {
+  return function() {
+    process.emit('warning', warning);
+  };
+}
 
 function setupProcessWarnings() {
   if (!process.noProcessWarnings && process.env.NODE_NO_WARNINGS !== '1') {
@@ -21,7 +92,7 @@ function setupProcessWarnings() {
         var toString = warning.toString;
         if (typeof toString !== 'function')
           toString = Error.prototype.toString;
-        console.error(`${prefix}${toString.apply(warning)}`);
+        output(`${prefix}${toString.apply(warning)}`);
       }
     });
   }
@@ -44,6 +115,6 @@ function setupProcessWarnings() {
     if (throwDeprecation && warning.name === 'DeprecationWarning')
       throw warning;
     else
-      process.nextTick(() => process.emit('warning', warning));
+      process.nextTick(doEmitWarning(warning));
   };
 }

--- a/src/node.cc
+++ b/src/node.cc
@@ -199,11 +199,15 @@ bool trace_warnings = false;
 // that is used by lib/module.js
 bool config_preserve_symlinks = false;
 
+
 // Set in node.cc by ParseArgs when --expose-internals or --expose_internals is
 // used.
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/internal/bootstrap_node.js
 bool config_expose_internals = false;
+
+// Set in node.cc by ParseArgs when --redirect-warnings= is used.
+const char* config_warning_file;
 
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
@@ -3701,6 +3705,8 @@ static void PrintHelp() {
          "function is used\n"
          "  --no-warnings         silence all process warnings\n"
          "  --trace-warnings      show stack traces on process warnings\n"
+         "  --redirect-warnings=path\n"
+         "                        write warnings to path instead of stderr\n"
          "  --trace-sync-io       show stack trace when use of sync IO\n"
          "                        is detected after the first tick\n"
          "  --track-heap-objects  track heap object allocations for heap "
@@ -3765,6 +3771,7 @@ static void PrintHelp() {
          "                        prefixed to the module search path\n"
          "NODE_REPL_HISTORY       path to the persistent REPL history file\n"
          "OPENSSL_CONF            load OpenSSL configuration from file\n"
+         "NODE_REDIRECT_WARNINGS  write warnings to path instead of stderr\n"
          "\n"
          "Documentation can be found at https://nodejs.org/\n");
 }
@@ -3866,6 +3873,8 @@ static void ParseArgs(int* argc,
       no_process_warnings = true;
     } else if (strcmp(arg, "--trace-warnings") == 0) {
       trace_warnings = true;
+    } else if (strncmp(arg, "--redirect-warnings=", 20) == 0) {
+      config_warning_file = arg + 20;
     } else if (strcmp(arg, "--trace-deprecation") == 0) {
       trace_deprecation = true;
     } else if (strcmp(arg, "--trace-sync-io") == 0) {
@@ -4400,6 +4409,10 @@ void Init(int* argc,
 
   if (openssl_config.empty())
     SafeGetenv("OPENSSL_CONF", &openssl_config);
+
+  if (auto redirect_warnings = secure_getenv("NODE_REDIRECT_WARNINGS")) {
+    config_warning_file = redirect_warnings;
+  }
 
   // Parse a few arguments which are specific to Node.
   int v8_argc;

--- a/src/node.cc
+++ b/src/node.cc
@@ -207,7 +207,7 @@ bool config_preserve_symlinks = false;
 bool config_expose_internals = false;
 
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
-const char* config_warning_file;
+std::string config_warning_file;
 
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
@@ -4410,9 +4410,8 @@ void Init(int* argc,
   if (openssl_config.empty())
     SafeGetenv("OPENSSL_CONF", &openssl_config);
 
-  if (auto redirect_warnings = secure_getenv("NODE_REDIRECT_WARNINGS")) {
-    config_warning_file = redirect_warnings;
-  }
+  if (config_warning_file.empty())
+    SafeGetenv("NODE_REDIRECT_WARNINGS", &config_warning_file);
 
   // Parse a few arguments which are specific to Node.
   int v8_argc;

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -12,6 +12,7 @@ using v8::Context;
 using v8::Local;
 using v8::Object;
 using v8::ReadOnly;
+using v8::String;
 using v8::Value;
 
 // The config binding is used to provide an internal view of compile or runtime
@@ -47,6 +48,15 @@ void InitConfig(Local<Object> target,
 
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
+
+  if (config_warning_file != nullptr) {
+    Local<String> name = OneByteString(env->isolate(), "warningFile");
+    Local<String> value = String::NewFromUtf8(env->isolate(),
+                                              config_warning_file,
+                                              v8::NewStringType::kNormal)
+                                                .ToLocalChecked();
+    target->DefineOwnProperty(env->context(), name, value).FromJust();
+  }
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -49,11 +49,12 @@ void InitConfig(Local<Object> target,
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
 
-  if (config_warning_file != nullptr) {
+  if (!config_warning_file.empty()) {
     Local<String> name = OneByteString(env->isolate(), "warningFile");
     Local<String> value = String::NewFromUtf8(env->isolate(),
-                                              config_warning_file,
-                                              v8::NewStringType::kNormal)
+                                              config_warning_file.data(),
+                                              v8::NewStringType::kNormal,
+                                              config_warning_file.size())
                                                 .ToLocalChecked();
     target->DefineOwnProperty(env->context(), name, value).FromJust();
   }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -52,7 +52,7 @@ extern bool config_expose_internals;
 // Set in node.cc by ParseArgs when --redirect-warnings= is used.
 // Used to redirect warning output to a file rather than sending
 // it to stderr.
-extern const char* config_warning_file;
+extern std::string config_warning_file;
 
 // Forward declaration
 class Environment;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -49,6 +49,11 @@ extern bool config_preserve_symlinks;
 // that is used by lib/internal/bootstrap_node.js
 extern bool config_expose_internals;
 
+// Set in node.cc by ParseArgs when --redirect-warnings= is used.
+// Used to redirect warning output to a file rather than sending
+// it to stderr.
+extern const char* config_warning_file;
+
 // Forward declaration
 class Environment;
 

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the NODE_REDIRECT_WARNINGS environment variable by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {env: {NODE_REDIRECT_WARNINGS: warnpath}})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Tests the --redirect-warnings command line flag by spawning
+// a new child node process that emits a warning into a temporary
+// warnings file. Once the process completes, the warning file is
+// opened and the contents are validated
+
+const common = require('../common');
+const fs = require('fs');
+const fork = require('child_process').fork;
+const path = require('path');
+const assert = require('assert');
+
+common.refreshTmpDir();
+
+const warnmod = require.resolve(common.fixturesDir + '/warnings.js');
+const warnpath = path.join(common.tmpDir, 'warnings.txt');
+
+fork(warnmod, {execArgv: [`--redirect-warnings=${warnpath}`]})
+  .on('exit', common.mustCall(() => {
+    fs.readFile(warnpath, 'utf8', common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert(/\(node:\d+\) Warning: a bad practice warning/.test(data));
+    }));
+  }));


### PR DESCRIPTION
The --redirect-warnings command line argument allows process warnings
to be written to a specified file rather than printed to stderr.

Also adds an equivalent NODE_REDIRECT_WARNINGS environment variable.

If the specified file cannot be opened or written to for any reason,
the argument is ignored and the warning is printed to stderr.

If the file already exists, it will be appended to.

PR-URL: https://github.com/nodejs/node/pull/10116
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>
Reviewed-By: Michal Zasso <targos@protonmail.com>
Reviewed-By: Fedor Indutny <fedor.indutny@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
