### PR TITLE
util: improve util.inspect performance

### DIFF
--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const util = require('util');
+
+const bench = common.createBenchmark(main, {
+  n: [1e2],
+  len: [1e5],
+  type: [
+    'denseArray',
+    'sparseArray',
+    'mixedArray'
+  ]
+});
+
+function main(conf) {
+  const { n, len, type } = conf;
+  var arr = Array(len);
+  var i;
+
+  switch (type) {
+    case 'denseArray':
+      arr = arr.fill(0);
+      break;
+    case 'sparseArray':
+      break;
+    case 'mixedArray':
+      for (i = 0; i < n; i += 2)
+        arr[i] = i;
+      break;
+    default:
+      throw new Error(`Unsupported type ${type}`);
+  }
+  bench.start();
+  for (i = 0; i < n; i++) {
+    util.inspect(arr);
+  }
+  bench.end(n);
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -672,22 +672,33 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   let visibleLength = 0;
   let index = 0;
-  while (index < value.length && visibleLength < ctx.maxArrayLength) {
-    let emptyItems = 0;
-    while (index < value.length && !hasOwnProperty(value, String(index))) {
-      emptyItems++;
-      index++;
-    }
-    if (emptyItems > 0) {
+  for (const elem in value) {
+    if (visibleLength === ctx.maxArrayLength)
+      break;
+    const i = +elem;
+    if (index !== i) {
+      if (i !== i) // Fast NaN check
+        continue;
+      const emptyItems = i - index;
       const ending = emptyItems > 1 ? 's' : '';
       const message = `<${emptyItems} empty item${ending}>`;
       output.push(ctx.stylize(message, 'undefined'));
-    } else {
-      output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
-                                 String(index), true));
-      index++;
+      index = i;
+      visibleLength++;
+      if (visibleLength === ctx.maxArrayLength)
+        break;
     }
+    output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
+                               elem, true));
     visibleLength++;
+    index++;
+  }
+  if (index < value.length && visibleLength !== ctx.maxArrayLength) {
+    const len = value.length - index;
+    const ending = len > 1 ? 's' : '';
+    const message = `<${len} empty item${ending}>`;
+    output.push(ctx.stylize(message, 'undefined'));
+    index = value.length;
   }
   var remaining = value.length - index;
   if (remaining > 0) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,6 @@ const inspectDefaultOptions = Object.seal({
 
 const numbersOnlyRE = /^\d+$/;
 
-const objectHasOwnProperty = Object.prototype.hasOwnProperty;
 const propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
 const regExpToString = RegExp.prototype.toString;
 const dateToISOString = Date.prototype.toISOString;
@@ -814,7 +813,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
       str = ctx.stylize('[Setter]', 'special');
     }
   }
-  if (!hasOwnProperty(visibleKeys, key)) {
+  if (visibleKeys[key] === undefined) {
     if (typeof key === 'symbol') {
       name = `[${ctx.stylize(key.toString(), 'symbol')}]`;
     } else {
@@ -992,11 +991,6 @@ function _extend(target, source) {
   }
   return target;
 }
-
-function hasOwnProperty(obj, prop) {
-  return objectHasOwnProperty.call(obj, prop);
-}
-
 
 // Deprecated old stuff.
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -676,7 +676,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       break;
     const i = +elem;
     if (index !== i) {
-      if (i !== i) // Fast NaN check
+      if (i > 0 === false)
         continue;
       const emptyItems = i - index;
       const ending = emptyItems > 1 ? 's' : '';

--- a/lib/util.js
+++ b/lib/util.js
@@ -676,6 +676,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       break;
     const i = +elem;
     if (index !== i) {
+      // Skip zero and negative numbers as well as non numbers
       if (i > 0 === false)
         continue;
       const emptyItems = i - index;
@@ -683,8 +684,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       const message = `<${emptyItems} empty item${ending}>`;
       output.push(ctx.stylize(message, 'undefined'));
       index = i;
-      visibleLength++;
-      if (visibleLength === ctx.maxArrayLength)
+      if (++visibleLength === ctx.maxArrayLength)
         break;
     }
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,

--- a/lib/util.js
+++ b/lib/util.js
@@ -671,9 +671,12 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   let visibleLength = 0;
   let index = 0;
-  for (const elem in value) {
+  for (const elem of keys) {
     if (visibleLength === ctx.maxArrayLength)
       break;
+    // Symbols might have been added to the keys
+    if (typeof elem !== 'string')
+      continue;
     const i = +elem;
     if (index !== i) {
       // Skip zero and negative numbers as well as non numbers

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -298,8 +298,16 @@ assert.strictEqual(
       get: function() { this.push(true); return this.length; }
     }
   );
+  Object.defineProperty(
+    value,
+    '-1',
+    {
+      enumerable: true,
+      value: -1
+    }
+  );
   assert.strictEqual(util.inspect(value),
-                     '[ 1, 2, 3, growingLength: [Getter] ]');
+                     '[ 1, 2, 3, growingLength: [Getter], \'-1\': -1 ]');
 }
 
 // Function with properties

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -310,6 +310,14 @@ assert.strictEqual(
                      '[ 1, 2, 3, growingLength: [Getter], \'-1\': -1 ]');
 }
 
+// Array with inherited number properties
+{
+  class CustomArray extends Array {};
+  CustomArray.prototype[5] = 'foo';
+  const arr = new CustomArray(50);
+  assert.strictEqual(util.inspect(arr), 'CustomArray [ <50 empty items> ]');
+}
+
 // Function with properties
 {
   const value = () => {};


### PR DESCRIPTION
Fixes #14487

A hole in a sparse array is now in itself a O(1) operation instead of O(n) where n is the number of coherent elements of the hole.

In addition a `hasOwnProperty` check was replaced with a cheaper one.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util