### PR TITLE
test: add test-fs-read-buffer-to-string-fail as pass and flaky to all platforms

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1338,7 +1338,7 @@ Server.prototype.listen = function() {
     self.once('listening', lastArg);
   }
 
-  var port = toNumber(arguments[0]);
+  var port = typeof arguments[0] === 'undefined' ? 0 : toNumber(arguments[0]);
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -127,7 +127,6 @@ const char* const root_certs[] = {
 std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
 X509_STORE* root_cert_store;
-std::vector<X509*> root_certs_vector;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;
@@ -710,6 +709,7 @@ static int X509_up_ref(X509* cert) {
 
 
 static X509_STORE* NewRootCertStore() {
+  static std::vector<X509*> root_certs_vector;
   if (root_certs_vector.empty()) {
     for (size_t i = 0; i < arraysize(root_certs); i++) {
       BIO* bp = NodeBIO::NewFixed(root_certs[i], strlen(root_certs[i]));

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -120,13 +120,13 @@ static X509_NAME *cnnic_ev_name =
 
 static Mutex* mutexes;
 
-const char* const root_certs[] = {
+static const char* const root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
 };
 
-std::string extra_root_certs_file;  // NOLINT(runtime/string)
+static std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
-X509_STORE* root_cert_store;
+static X509_STORE* root_cert_store;
 
 // Just to generate static methods
 template class SSLWrap<TLSWrap>;

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -63,8 +63,6 @@ enum CheckResult {
 
 extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 
-extern X509_STORE* root_cert_store;
-
 extern void UseExtraCaCerts(const std::string& file);
 
 // Forward declaration

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,6 +5,7 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+test-fs-read-buffer-tostring-fail      : PASS,FLAKY
 
 [$system==win32]
 

--- a/test/parallel/test-net-listen-port-option.js
+++ b/test/parallel/test-net-listen-port-option.js
@@ -26,3 +26,38 @@ net.Server().listen({ port: '' + common.PORT }, close);
     net.Server().listen({ port: port }, common.fail);
   }, /invalid listen argument/i);
 });
+
+// Repeat the tests, passing port as an argument, which validates somewhat
+// differently.
+
+net.Server().listen(undefined, close);
+net.Server().listen('0', close);
+
+// 'nan', skip, treated as a path, not a port
+//'+Infinity', skip, treated as a path, not a port
+//'-Infinity' skip, treated as a path, not a port
+
+// 4.x treats these as 0, but 6.x treats them as invalid numbers.
+[
+  -1,
+  123.456,
+  0x10000,
+  1 / 0,
+  -1 / 0,
+].forEach(function(port) {
+  assert.throws(function() {
+    net.Server().listen(port, common.fail);
+  }, /"port" argument must be >= 0 and < 65536/i);
+});
+
+// null is treated as 0
+net.Server().listen(null, close);
+
+// false/true are converted to 0/1, arguably a bug, but fixing would be
+// semver-major. Note that true fails because ports that low can't be listened
+// on by unprivileged processes.
+net.Server().listen(false, close);
+
+net.Server().listen(true).on('error', common.mustCall(function(err) {
+  assert.strictEqual(err.code, 'EACCES');
+}));


### PR DESCRIPTION
Fixes nodejs#14430 [v6.x] test: investigate test-fs-read-buffer-tostring-fail