### PR TITLE
build: move FreeBSD to experimental

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,10 +43,10 @@ in production.
 | macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7 / 2008 R2           | x86, x64             | vs2015 or vs2017 |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
-| FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
 | AIX          | Tier 2       | >= 7.1 TL04                      | ppc64be >=power7     |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.10, glibc >= 2.17    | s390x                |                  |
+| FreeBSD      | Experimental | >= 10                            | x64                  |                  |
 | macOS        | Experimental | >= 10.8 < 10.10                  | x64                  | no test coverage |
 | Linux (musl) | Experimental | musl >= 1.0                      | x64                  |                  |
 


### PR DESCRIPTION
The FreeBSD platform arguably doesn't have enough dedicated maintainers
to be considered a Tier 2 platform. However I think it does match the
requirements for Experimental:

```
These are often working to be promoted to Tier 2 but are not quite ready.
There is at least one individual actively providing maintenance and the team
is striving to broaden quality and reliability of support.
```

AFAICT Johan (@jbergstroem) has been singlehandedly maintaining support. We get a fair number of FreeBSD specific issues, most recently with V8 6.0 (which I don't _think_ officially supports FreeBSD).

This is intended as a conversation starter, I have no strong feelings about this. If there are actually a bunch of people in @nodejs/platform-freebsd who have the time to fix issues (or if I just
didn't notice...) then this can be closed.

To clarify, making FreeBSD experimental doesn't mean that we'll stop testing our xLinux builds on the platform, it just means that we won't necessarily be blocked on FreeBSD specific issues on (for example) V8 upgrades.

We could also change it back any time, so this wouldn't have to be a permanent thing.

Refs: nodejs#14384
Refs: nodejs/build#723

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build