### PR TITLE
test/dgram: Add support for IPv6 link local scope IDs in received UDP datagrams

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -94,6 +94,12 @@ The event handler function is passed two arguments: `msg` and `rinfo`.
   * `port` {number} The sender port.
   * `size` {number} The message size.
 
+If the source address of the incoming packet is an IPv6 link local
+address, the interface name is added to the `address`.  For
+example, a packet received on the `en0` interface might have the
+address field set to `'fe80::2618:1234:ab11:3b9c%en0'`, where `'%en0'`
+is the interface name as a zone id suffix.
+
 ### `socket.addMembership(multicastAddress[, multicastInterface])`
 <!-- YAML
 added: v0.6.9

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -337,9 +337,10 @@ Local<Object> AddressToJS(Environment* env,
                           const sockaddr* addr,
                           Local<Object> info) {
   EscapableHandleScope scope(env->isolate());
-  char ip[INET6_ADDRSTRLEN];
+  char ip[INET6_ADDRSTRLEN + UV_IF_NAMESIZE];
   const sockaddr_in* a4;
   const sockaddr_in6* a6;
+
   int port;
 
   if (info.IsEmpty())
@@ -349,6 +350,18 @@ Local<Object> AddressToJS(Environment* env,
   case AF_INET6:
     a6 = reinterpret_cast<const sockaddr_in6*>(addr);
     uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
+    // Add an interface identifier to a link local address.
+    if (IN6_IS_ADDR_LINKLOCAL(&a6->sin6_addr)) {
+        const size_t addrlen = strlen(ip);
+        CHECK_LT(addrlen, sizeof(ip));
+        ip[addrlen] = '%';
+        size_t scopeidlen = sizeof(ip) - addrlen - 1;
+        CHECK_GE(scopeidlen, UV_IF_NAMESIZE);
+        const int r = uv_if_indextoiid(a6->sin6_scope_id,
+                                       ip + addrlen + 1,
+                                       &scopeidlen);
+        CHECK_EQ(r, 0);
+    }
     port = ntohs(a6->sin6_port);
     info->Set(env->context(),
               env->address_string(),

--- a/test/parallel/test-dgram-udp6-link-local-address.js
+++ b/test/parallel/test-dgram-udp6-link-local-address.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common');
+if (!common.hasIPv6)
+  common.skip('no IPv6 support');
+
+const assert = require('assert');
+const dgram = require('dgram');
+const os = require('os');
+
+function linklocal() {
+  for (const [ifname, entries] of Object.entries(os.networkInterfaces())) {
+    for (const { address, family, scopeid } of entries) {
+      if (family === 'IPv6' && address.startsWith('fe80:')) {
+        return { address, ifname, scopeid };
+      }
+    }
+  }
+}
+const iface = linklocal();
+
+if (!iface)
+  common.skip('cannot find any IPv6 interfaces with a link local address');
+
+const address = `${iface.address}%${iface.ifname}`;
+const message = 'Hello, local world!';
+
+// Create a client socket for sending to the link-local address.
+const client = dgram.createSocket('udp6');
+
+// Create the server socket listening on the link-local address.
+const server = dgram.createSocket('udp6');
+
+server.on('listening', common.mustCall(() => {
+  const port = server.address().port;
+  client.send(message, 0, message.length, port, address);
+}));
+
+server.on('message', common.mustCall((buf, info) => {
+  const received = buf.toString();
+  assert.strictEqual(received, message);
+  // Check that the sender address is the one bound,
+  // including the link local scope identifier.
+  assert.strictEqual(
+    info.address,
+    common.isWindows ? `${iface.address}%${iface.scopeid}` : address
+  );
+  server.close();
+  client.close();
+}, 1));
+
+server.bind({ address });


### PR DESCRIPTION
A new test case to verify that IPv6 UDP datagrams
received from a link-local source address do contain
the scope ID suffix in the rinfo address field.

Add IPv6 link local scope ID suffix to the
rinfo address in those received upd6 datagrams
whose source address is a link local address.

When a packet is received from a link-local source
address, if the address does not contain the scope
ID suffix, it is impossible to reply back to the
sender, as the kernel is not able to determine
the right network interface to send the packet
through and returns with an error.

Ref: https://github.com/nodejs/node/issues/1649

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test, dgram
