### PR TITLE
assert: improve deep equal map

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -453,10 +453,13 @@ function mapHasLoosePrim(a, b, key1, memo, item1, item2) {
     return false;
 
   for (const val of setA) {
-    if (!setHasEqualElement(setB, val, false, memo))
+    if (typeof val === 'object' && val !== null) {
+      if (!setHasEqualElement(setB, val, false, memo))
+        return false;
+    } else if (!setB.has(val) && !setHasLoosePrim(setA, setB, val)) {
       return false;
+    }
   }
-
   return true;
 }
 
@@ -484,26 +487,20 @@ function mapEquiv(a, b, strict, memo) {
   var set = null;
 
   for (const [key, item1] of a) {
-    // By directly retrieving the value we prevent another b.has(key) check in
-    // almost all possible cases.
-    const item2 = b.get(key);
-    if (item2 === undefined) {
-      // Just like setEquiv above but in addition we have to make sure the
-      // values are also equal.
-      if (typeof key === 'object' && key !== null) {
-        if (set === null) {
-          set = new Set();
-        }
-        set.add(key);
-      // Note: we do not have to pass memo in this case as at least one item
-      // is undefined.
-      } else if ((!innerDeepEqual(item1, item2, strict) || !b.has(key)) &&
-        (strict || !mapHasLoosePrim(a, b, key, memo, item1))) {
+    if (typeof key === 'object' && key !== null) {
+      if (set === null) {
+        set = new Set();
+      }
+      set.add(key);
+    } else {
+      // By directly retrieving the value we prevent another b.has(key) check in
+      // almost all possible cases.
+      const item2 = b.get(key);
+      if ((item2 === undefined && !b.has(key) ||
+        !innerDeepEqual(item1, item2, strict, memo)) &&
+        (strict || !mapHasLoosePrim(a, b, key, memo, item1, item2))) {
         return false;
       }
-    } else if (!innerDeepEqual(item1, item2, strict, memo) &&
-      (strict || !mapHasLoosePrim(a, b, key, memo, item1, item2))) {
-      return false;
     }
   }
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -353,10 +353,6 @@ function setEquiv(a, b, strict, memo) {
   // This is a lazily initiated Set of entries which have to be compared
   // pairwise.
   var set = null;
-  // When the sets contain only value types (eg, lots of numbers), and we're in
-  // strict mode or if all entries strictly match, we don't need to match the
-  // entries in a pairwise way. In that case this initialization is done lazily
-  // to avoid the allocation & bookkeeping cost.
   for (const val of a) {
     // Note: Checking for the objects first improves the performance for object
     // heavy sets but it is a minor slow down for primitives. As they are fast
@@ -377,7 +373,7 @@ function setEquiv(a, b, strict, memo) {
 
   if (set !== null) {
     for (const val of b) {
-      // In non-strict-mode we have to check if a primitive value is already
+      // We have to check if a primitive value is already
       // matching and only if it's not, go hunting for it.
       if (typeof val === 'object' && val !== null) {
         if (!setHasEqualElement(set, val, strict, memo))
@@ -479,8 +475,6 @@ function mapHasEqualEntry(set, map, key1, item1, strict, memo) {
 }
 
 function mapEquiv(a, b, strict, memo) {
-  // Caveat: In non-strict mode, this implementation does not handle cases
-  // where maps contain two equivalent-but-not-reference-equal keys.
   if (a.size !== b.size)
     return false;
 


### PR DESCRIPTION
This improves the performance for maps with object keys and for deepEqual loose equal primitive keys that contain primitives as value. The first part decreases the performance of the common case a tiny bit (primitive keys) in favor of the much slower worst case. Even though the common case must do a typecheck more I think it is favorable as it is also better to read that way.
In addition I updated a few comments.

```
 assert/deepequal-map.js method="deepEqual_looseMatches" len=1000 n=1000               16.85 %        *** 1.740720e-44
 assert/deepequal-map.js method="deepEqual_mixed" len=1000 n=1000                       2.14 %        *** 4.011895e-04
 assert/deepequal-map.js method="deepEqual_objectOnly" len=1000 n=1000                  3.45 %        *** 4.751408e-12
 assert/deepequal-map.js method="deepEqual_primitiveOnly" len=1000 n=1000              -2.52 %         ** 2.808637e-03
 assert/deepequal-map.js method="deepStrictEqual_mixed" len=1000 n=1000                 3.00 %        *** 7.353710e-07
 assert/deepequal-map.js method="deepStrictEqual_objectOnly" len=1000 n=1000            3.28 %        *** 6.647043e-09
 assert/deepequal-map.js method="deepStrictEqual_primitiveOnly" len=1000 n=1000        -1.01 %            4.022507e-01
 assert/deepequal-map.js method="notDeepEqual_looseMatches" len=1000 n=1000            16.35 %        *** 8.956366e-27
 assert/deepequal-map.js method="notDeepEqual_mixed" len=1000 n=1000                   -1.30 %            5.267886e-01
 assert/deepequal-map.js method="notDeepEqual_objectOnly" len=1000 n=1000               4.62 %        *** 2.039886e-14
 assert/deepequal-map.js method="notDeepEqual_primitiveOnly" len=1000 n=1000           -1.48 %          * 3.809026e-02
 assert/deepequal-map.js method="notDeepStrictEqual_mixed" len=1000 n=1000              0.92 %            6.739208e-01
 assert/deepequal-map.js method="notDeepStrictEqual_objectOnly" len=1000 n=1000         5.44 %        *** 4.738282e-19
 assert/deepequal-map.js method="notDeepStrictEqual_primitiveOnly" len=1000 n=1000     -1.59 %            1.132915e-01
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert