### PR TITLE
test: fix error when foo in path to git clone

### DIFF
--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -67,5 +67,5 @@ common.expectsError(() => {
 // The stackFrameFunction should exclude the foo frame
 assert.throws(
   function foo() { assert.fail('first', 'second', 'message', '!==', foo); },
-  (err) => !/\sat\sfoo\b/.test(err.stack)
+  (err) => !/^\s*at\sfoo\b/.test(err.stack)
 );

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -67,5 +67,5 @@ common.expectsError(() => {
 // The stackFrameFunction should exclude the foo frame
 assert.throws(
   function foo() { assert.fail('first', 'second', 'message', '!==', foo); },
-  (err) => !/\sat\sfoo/.test(err.stack)
+  (err) => !/\sat\sfoo\b/.test(err.stack)
 );

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -67,5 +67,5 @@ common.expectsError(() => {
 // The stackFrameFunction should exclude the foo frame
 assert.throws(
   function foo() { assert.fail('first', 'second', 'message', '!==', foo); },
-  (err) => !/foo(?!\/)/m.test(err.stack)
+  (err) => !/\sat\sfoo/.test(err.stack)
 );

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -67,5 +67,5 @@ common.expectsError(() => {
 // The stackFrameFunction should exclude the foo frame
 assert.throws(
   function foo() { assert.fail('first', 'second', 'message', '!==', foo); },
-  (err) => !/^\s*at\sfoo\b/.test(err.stack)
+  (err) => !/^\s*at\sfoo\b/m.test(err.stack)
 );

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -67,5 +67,5 @@ common.expectsError(() => {
 // The stackFrameFunction should exclude the foo frame
 assert.throws(
   function foo() { assert.fail('first', 'second', 'message', '!==', foo); },
-  (err) => !/foo/m.test(err.stack)
+  (err) => !/foo(?!\/)/m.test(err.stack)
 );


### PR DESCRIPTION
I fixed an error that occurred in the test case of the file
test/parallel/test-assert-fail.js when foo was in the path to
the git clone. This occurred due to a regex that looked only for the
word foo, and so it was updated to not look for foo/, but only
foo. This way it won't go off from foo being in the path to the
git clone.

What this part of the test verifies is that the last argument
to assert.fail in 
`function foo() { assert.fail('first', 'second', 'message', '!==', foo); }`,
 (the , foo one) is not ignored. If it is ignored an error would appear
stating at foo near the top of the error message, thus if the path
contains foo it will not trigger the error message

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test