### PR TITLE
deps,profiler: parse Windows' "%p" in processor

### DIFF
--- a/deps/v8/tools/tickprocessor.js
+++ b/deps/v8/tools/tickprocessor.js
@@ -243,10 +243,10 @@ TickProcessor.prototype.printError = function(str) {
  */
 TickProcessor.prototype.parseIntAddressFormat = function(s, radix) {
   var re = /^([0-9A-Fa-f]{8}|[0-9A-Fa-f]{16})$/g
-  if(s.match(re)) {
-    return parseInt(s,16)
+  if (s.match(re)) {
+    return parseInt(s, 16)
   } else {
-    return parseInt(s,radix)
+    return parseInt(s, radix)
   }
 }
 

--- a/deps/v8/tools/tickprocessor.js
+++ b/deps/v8/tools/tickprocessor.js
@@ -105,25 +105,25 @@ function TickProcessor(
       'shared-library': { parsers: [null, parseInt, parseInt, parseInt],
           processor: this.processSharedLibrary },
       'code-creation': {
-          parsers: [null, parseInt, parseInt, parseInt, parseInt,
+          parsers: [null, parseInt, parseInt, this.parseIntAddressFormat, parseInt,
                     null, 'var-args'],
           processor: this.processCodeCreation },
       'code-deopt': {
-          parsers: [parseInt, parseInt, parseInt, parseInt, parseInt,
+          parsers: [parseInt, parseInt, this.parseIntAddressFormat, parseInt, parseInt,
                     null, null, null],
           processor: this.processCodeDeopt },
-      'code-move': { parsers: [parseInt, parseInt, ],
+      'code-move': { parsers: [this.parseIntAddressFormat, this.parseIntAddressFormat, ],
           processor: this.processCodeMove },
       'code-delete': { parsers: [parseInt],
           processor: this.processCodeDelete },
-      'sfi-move': { parsers: [parseInt, parseInt],
+      'sfi-move': { parsers: [this.parseIntAddressFormat, this.parseIntAddressFormat],
           processor: this.processFunctionMove },
       'active-runtime-timer': {
         parsers: [null],
         processor: this.processRuntimeTimerEvent },
       'tick': {
-          parsers: [parseInt, parseInt, parseInt,
-                    parseInt, parseInt, 'var-args'],
+          parsers: [this.parseIntAddressFormat, parseInt, parseInt,
+                    this.parseIntAddressFormat, parseInt, 'var-args'],
           processor: this.processTick },
       'heap-sample-begin': { parsers: [null, null, parseInt],
           processor: this.processHeapSampleBegin },
@@ -236,6 +236,20 @@ TickProcessor.prototype.printError = function(str) {
   printErr(str);
 };
 
+/**
+ * A thin wrapper around parseInt to accept the Windows %p pointer format,
+ * which is 8 hexadecimal characters on 32 bits, or 16 hexadecimal characters
+ * on 64 bits.
+ */
+TickProcessor.prototype.parseIntAddressFormat = function(s, radix) {
+  var re = /^([0-9A-Fa-f]{8}|[0-9A-Fa-f]{16})$/g
+  if(s.match(re)) {
+    return parseInt(s,16)
+  } else {
+    return parseInt(s,radix)
+  }
+}
+
 
 TickProcessor.prototype.setCodeType = function(name, type) {
   this.codeTypes_[name] = TickProcessor.CodeTypes[type];
@@ -292,7 +306,7 @@ TickProcessor.prototype.processCodeCreation = function(
     type, kind, timestamp, start, size, name, maybe_func) {
   name = this.deserializedEntriesNames_[start] || name;
   if (maybe_func.length) {
-    var funcAddr = parseInt(maybe_func[0]);
+    var funcAddr = this.parseIntAddressFormat(maybe_func[0]);
     var state = parseState(maybe_func[1]);
     this.profile_.addFuncCode(type, name, timestamp, start, size, funcAddr, state);
   } else {


### PR DESCRIPTION
When V8 was updated to [5.4](https://github.com/nodejs/node/pull/8317), the output format for memory addresses [was changed from `0x%x` to `%p`](https://github.com/targos/node/blob/ec02b811a8a5c999bab4de312be2d732b7d9d50b/deps/v8/src/log-utils.cc#L168). The `%p` format specified is [implementation specific](https://en.wikipedia.org/wiki/Printf_format_string#Type_field) and behaves differently on Windows.

Running the profiler processor ( `--prof-process`) with a profiler output file generated on Windows (with `--prof`) results in "UNKNOWN" code dominating the statistics. This is caused by the processor not correctly parsing the output of the `%p` format specifier on Windows, which prints 8 (in 32 bits) or 16 (in 64 bits) hexadecimal characters without the `0x` prefix. The profiler processor expects a format that is recognized by `parseInt`.

Example line from profiler output on Linux:
```
code-creation,Builtin,5,0x12e0553593e0,327,"MathMax"
```

Example line from profiler output on Windows:
```
code-creation,Builtin,5,000000BABADD9640,304,"MathMax"
```

While the `0x12e0553593e0` address string from Linux will be correctly parsed by `parseInt` in the profiler processor, the `000000BABADD9640` address string from Windows will not.

The commit on this PR creates a thin layer on top of `parseInt` to parse the Windows `%p` format for memory addresses correctly.

I've tried building V8 from source on windows to test the profiler behavior using `d8` and [`v8/tools/windows-tick-processor.bat`](https://github.com/v8/v8/blob/637b7d645c797003a295e91f9692079c0615b335/tools/windows-tick-processor.bat) and confirmed this profiler issue is also currently present on Windows in V8's master branch.

Fixes: https://github.com/nodejs/node/issues/8221
Refs: https://github.com/nodejs/node/pull/8317
Refs:
https://github.com/v8/v8/commit/90418336477d3ed94c610b65ace310db0ef51f64#diff-738e87867268a7b9c90329adc160855cR167

/cc @nodejs/v8

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
deps,v8,win