### PR TITLE
test: set module loading error for aix

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -28,7 +28,9 @@ const errorMessagesByPlatform = {
   win32: ['%1 is not a valid Win32 application'],
   linux: ['file too short', 'Exec format error'],
   sunos: ['unknown file type', 'not an ELF file'],
-  darwin: ['file too short']
+  darwin: ['file too short'],
+  aix: ['Cannot load module', 
+        'Cannot run a file that does not have a valid format.']
 };
 // If we don't know a priori what the error would be, we accept anything.
 const errorMessages = errorMessagesByPlatform[process.platform] || [''];


### PR DESCRIPTION
In test/parallel/test-module-loading-error.js, an attempt is made to
load a text file as a native executable. This gives error messages in a
platform specific manner.

AIX was not included in the list of platforms. This fix introduces
the AIX error messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
