### PR TITLE
[v8.x backport] test: increase coverage for path.parse

### DIFF
--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -32,6 +32,8 @@ const winPaths = [
   'file',
   '.\\file',
   'C:\\',
+  'C:',
+  '\\',
   '',
 
   // unc
@@ -42,7 +44,9 @@ const winPaths = [
 ];
 
 const winSpecialCaseParseTests = [
-  ['/foo/bar', {root: '/'}]
+  ['/foo/bar', { root: '/' }],
+  ['C:', { root: 'C:', dir: 'C:', base: '' }],
+  ['C:\\', { root: 'C:\\', dir: 'C:\\', base: '' }]
 ];
 
 const winSpecialCaseFormatTests = [


### PR DESCRIPTION
Partial backport of https://github.com/nodejs/node/pull/14438 (https://github.com/nodejs/node/commit/f7f590c9a9fe7bb31719f7fb7427e4de1a0d9edc).