### PR TITLE
benchmark: remove unused parameters

### DIFF
--- a/benchmark/_benchmark_progress.js
+++ b/benchmark/_benchmark_progress.js
@@ -65,12 +65,12 @@ class BenchmarkProgress {
     this.updateProgress();
   }
 
-  completeConfig(data) {
+  completeConfig() {
     this.completedConfig++;
     this.updateProgress();
   }
 
-  completeRun(job) {
+  completeRun() {
     this.completedRuns++;
     this.updateProgress();
   }
@@ -108,7 +108,7 @@ class BenchmarkProgress {
            `${caption} `;
   }
 
-  updateProgress(finished) {
+  updateProgress() {
     if (!process.stderr.isTTY || process.stdout.isTTY) {
       return;
     }


### PR DESCRIPTION
Functions completeConfig, completeRun, and
updateProgress had unused parameters. These
were removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Benchmark