### PR TITLE
doc: fix return results description of napi_get_value_string_utf8

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1844,7 +1844,7 @@ insufficient, the returned string will be truncated.
 terminator.
 
 Returns `napi_ok` if the API succeeded. If a non-String `napi_value`
-x is passed in it returns `napi_string_expected`.
+is passed in it returns `napi_string_expected`.
 
 This API returns the UTF8-encoded string corresponding the value passed in.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1839,12 +1839,11 @@ napi_status napi_get_value_string_utf8(napi_env env,
 - `[in] buf`: Buffer to write the UTF8-encoded string into. If NULL is passed
 in, the length of the string (in bytes) is returned.
 - `[in] bufsize`: Size of the destination buffer.
-- `[out] result`: Number of bytes copied into the buffer including the null
-terminator. If the buffer size is insufficient, the string will be truncated
-including a null terminator.
+- `[out] result`: Number of bytes copied into the buffer, excluding the null
+terminator.
 
 Returns `napi_ok` if the API succeeded. If a non-String `napi_value`
-is passed in it returns `napi_string_expected`.
+x is passed in it returns `napi_string_expected`.
 
 This API returns the UTF8-encoded string corresponding the value passed in.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1811,10 +1811,10 @@ NAPI_EXTERN napi_status napi_get_value_string_latin1(napi_env env,
 - `[in] value`: `napi_value` representing JavaScript string.
 - `[in] buf`: Buffer to write the ISO-8859-1-encoded string into. If NULL is
 passed in, the length of the string (in bytes) is returned.
-- `[in] bufsize`: Size of the destination buffer.
-- `[out] result`: Number of bytes copied into the buffer including the null
-terminator. If the buffer size is insufficient, the string will be truncated
-including a null terminator.
+- `[in] bufsize`: Size of the destination buffer. When this value is
+insufficient, the returned string will be truncated.
+- `[out] result`: Number of bytes copied into the buffer, excluding the null
+terminator.
 
 Returns `napi_ok` if the API succeeded. If a non-String `napi_value`
 is passed in it returns `napi_string_expected`.
@@ -1864,10 +1864,10 @@ napi_status napi_get_value_string_utf16(napi_env env,
 - `[in] value`: `napi_value` representing JavaScript string.
 - `[in] buf`: Buffer to write the UTF16-LE-encoded string into. If NULL is
 passed in, the length of the string (in 2-byte code units) is returned.
-- `[in] bufsize`: Size of the destination buffer.
-- `[out] result`: Number of 2-byte code units copied into the buffer including
-the null terminator. If the buffer size is insufficient, the string will be
-truncated including a null terminator.
+- `[in] bufsize`: Size of the destination buffer. When this value is
+insufficient, the returned string will be truncated.
+- `[out] result`: Number of 2-byte code units copied into the buffer, excluding the null
+terminator.
 
 Returns `napi_ok` if the API succeeded. If a non-String `napi_value`
 is passed in it returns `napi_string_expected`.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1837,8 +1837,8 @@ napi_status napi_get_value_string_utf8(napi_env env,
 - `[in] env`: The environment that the API is invoked under.
 - `[in] value`: `napi_value` representing JavaScript string.
 - `[in] buf`: Buffer to write the UTF8-encoded string into. If NULL is passed
-in, the length of the string (in bytes) is returned.
-- `[in] bufsize`: Size of the destination buffer.
+ in, the length of the string (in bytes) is returned.
+- `[in] bufsize`: Size of the destination buffer. When this value is insufficient, the returned string will be truncated.
 - `[out] result`: Number of bytes copied into the buffer, excluding the null
 terminator.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -1838,7 +1838,8 @@ napi_status napi_get_value_string_utf8(napi_env env,
 - `[in] value`: `napi_value` representing JavaScript string.
 - `[in] buf`: Buffer to write the UTF8-encoded string into. If NULL is passed
  in, the length of the string (in bytes) is returned.
-- `[in] bufsize`: Size of the destination buffer. When this value is insufficient, the returned string will be truncated.
+- `[in] bufsize`: Size of the destination buffer. When this value is
+insufficient, the returned string will be truncated.
 - `[out] result`: Number of bytes copied into the buffer, excluding the null
 terminator.
 


### PR DESCRIPTION
The API for napi_get_value_string_utf8() appears to have been
previously changed. This improves the doc reflect the current design.

Fixes: https://github.com/nodejs/node/issues/14398

##### Checklist


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, n-api