### PR TITLE
test: remove --no-crankshaft

### DIFF
--- a/test/parallel/test-crypto-dh-leak.js
+++ b/test/parallel/test-crypto-dh-leak.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc --nocrankshaft --noconcurrent_recompilation
+// Flags: --expose-gc --noconcurrent_recompilation
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
The option `--no-crankshaft` is no longer available as of V8 6.0

This needs to land to get the test suite working for #14004