### PR TITLE
build: fix build break when omitting icu

### DIFF
--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include <unicode/ucnv.h>
 #include <string>
 
 #if defined(NODE_HAVE_I18N_SUPPORT)


### PR DESCRIPTION
When building without ICU (`vcbuild.bat intl-none`) the unicode/ucnv.h
header is not available, which caused compilation errors prior to this
change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Build