### PR TITLE
deps: cherry-pick 4229ca2 from V8 upstream

### DIFF
--- a/deps/v8/src/log-utils.cc
+++ b/deps/v8/src/log-utils.cc
@@ -164,7 +164,7 @@ void Log::MessageBuilder::Append(String* str) {
 }
 
 void Log::MessageBuilder::AppendAddress(Address addr) {
-  Append("%p", static_cast<void*>(addr));
+  Append("0x%" V8PRIxPTR, reinterpret_cast<intptr_t>(addr));
 }
 
 void Log::MessageBuilder::AppendSymbolName(Symbol* symbol) {

--- a/deps/v8/test/cctest/test-log.cc
+++ b/deps/v8/test/cctest/test-log.cc
@@ -376,8 +376,9 @@ TEST(LogCallbacks) {
     ObjMethod1_entry = *FUNCTION_ENTRYPOINT_ADDRESS(ObjMethod1_entry);
 #endif
     i::EmbeddedVector<char, 100> ref_data;
-    i::SNPrintF(ref_data, "code-creation,Callback,-2,-1,%p,1,\"method1\"",
-                static_cast<void*>(ObjMethod1_entry));
+    i::SNPrintF(ref_data,
+                "code-creation,Callback,-2,-1,0x%" V8PRIxPTR ",1,\"method1\"",
+                reinterpret_cast<intptr_t>(ObjMethod1_entry));
 
     CHECK(StrNStr(log.start(), ref_data.start(), log.length()));
     log.Dispose();
@@ -429,8 +430,8 @@ TEST(LogAccessorCallbacks) {
 #endif
     EmbeddedVector<char, 100> prop1_getter_record;
     i::SNPrintF(prop1_getter_record,
-                "code-creation,Callback,-2,-1,%p,1,\"get prop1\"",
-                static_cast<void*>(Prop1Getter_entry));
+                "code-creation,Callback,-2,-1,0x%" V8PRIxPTR ",1,\"get prop1\"",
+                reinterpret_cast<intptr_t>(Prop1Getter_entry));
     CHECK(StrNStr(log.start(), prop1_getter_record.start(), log.length()));
 
     Address Prop1Setter_entry = reinterpret_cast<Address>(Prop1Setter);
@@ -439,8 +440,8 @@ TEST(LogAccessorCallbacks) {
 #endif
     EmbeddedVector<char, 100> prop1_setter_record;
     i::SNPrintF(prop1_setter_record,
-                "code-creation,Callback,-2,-1,%p,1,\"set prop1\"",
-                static_cast<void*>(Prop1Setter_entry));
+                "code-creation,Callback,-2,-1,0x%" V8PRIxPTR ",1,\"set prop1\"",
+                reinterpret_cast<intptr_t>(Prop1Setter_entry));
     CHECK(StrNStr(log.start(), prop1_setter_record.start(), log.length()));
 
     Address Prop2Getter_entry = reinterpret_cast<Address>(Prop2Getter);
@@ -449,8 +450,8 @@ TEST(LogAccessorCallbacks) {
 #endif
     EmbeddedVector<char, 100> prop2_getter_record;
     i::SNPrintF(prop2_getter_record,
-                "code-creation,Callback,-2,-1,%p,1,\"get prop2\"",
-                static_cast<void*>(Prop2Getter_entry));
+                "code-creation,Callback,-2,-1,0x%" V8PRIxPTR ",1,\"get prop2\"",
+                reinterpret_cast<intptr_t>(Prop2Getter_entry));
     CHECK(StrNStr(log.start(), prop2_getter_record.start(), log.length()));
     log.Dispose();
   }


### PR DESCRIPTION
Running the profiler processor (`--prof-process`) with a profiler output file generated on Windows (with `--prof`) results in "UNKNOWN" code dominating the statistics. This is caused by the processor not correctly parsing the output of the "%p" format specifier on Windows.

This PR cherry-picks the upstream commit https://github.com/v8/v8/commit/4229ca207e1d139d57cd9c2e72c6174d4c81878c , that makes the output format be the same on Windows so it can be correctly parsed by `--prof-process`.

Original commit message:
  [profiler] Fix logging addresses on Windows.

  Change-Id: Iff0dcec95d04b85d31a452fed31b1500ad17a9f0
  Reviewed-on: https://chromium-review.googlesource.com/591373
  Commit-Queue: Jaroslav Sevcik <jarin@chromium.org>
  Reviewed-by: Camillo Bruni <cbruni@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#46976}

Fixes: https://github.com/nodejs/node/issues/8221
Refs: https://github.com/v8/v8/commit/4229ca207e1d139d57cd9c2e72c6174d4c81878c
Refs: https://github.com/nodejs/node/pull/14510

/cc @nodejs/v8

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps,v8,win