### PR TITLE
tools: bump vswhere helper to 2.0.0

### DIFF
--- a/tools/msvs/vswhere_usability_wrapper.cmd
+++ b/tools/msvs/vswhere_usability_wrapper.cmd
@@ -1,20 +1,32 @@
 :: Copyright 2017 - Refael Ackermann
 :: Distributed under MIT style license
 :: See accompanying file LICENSE at https://github.com/node4good/windows-autoconf
-:: version: 1.14.0
+:: version: 2.0.0
 
 @if not defined DEBUG_HELPER @ECHO OFF
 setlocal
+if "%~1"=="prerelease" set VSWHERE_WITH_PRERELEASE=1
+set "InstallerPath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" set "InstallerPath=%ProgramFiles%\Microsoft Visual Studio\Installer"
+if not exist "%InstallerPath%" goto :no-vswhere
+:: Manipulate %Path% for easier " handeling
+set "Path=%Path%;%InstallerPath%"
+where vswhere 2> nul > nul
+if errorlevel 1 goto :no-vswhere
 set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version "[15.0,16.0)"
+vswhere -prerelease > nul
+if not errorlevel 1 if "%VSWHERE_WITH_PRERELEASE%"=="1" set "VSWHERE_LMT=%VSWHERE_LMT% -prerelease"
 SET VSWHERE_ARGS=-latest -products * %VSWHERE_REQ% %VSWHERE_PRP% %VSWHERE_LMT%
-set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer"
-if not exist "%VSWHERE%" exit /B 1
-set Path=%Path%;%VSWHERE%
 for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
     endlocal
     set "VCINSTALLDIR=%%i\VC\"
     set "VS150COMNTOOLS=%%i\Common7\Tools\"
-    exit /B 0)
+    exit /B 0
+)
+
+:no-vswhere
+endlocal
+echo could not find "vswhere"
+exit /B 1


### PR DESCRIPTION
* enable explicit detection of prerelease VS versions with
  `set VSWHERE_WITH_PRERELASE=1`

/cc @nodejs/platform-windows @nodejs/build 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools,build,windows
