### PR TITLE
util: implement %o as formatting specifier

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -169,9 +169,13 @@ corresponding argument. Supported placeholders are:
 contains circular references.
 * `%o` - Object. A string representation of an object 
   with optimally useful formatting.
+  This is equivalent to `JSON.stringify` with no replacer
+  and 1 space. This is not full representation of the object. 
+  Functions, for example, will not be displayed.
 * `%O` - Object. A string representation of an object 
   with generic JavaScript object formatting. 
   Similar to `util.inspect()` without options.
+  This is a full representation of the object.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
 If the placeholder does not have a corresponding argument, the placeholder is

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -167,15 +167,14 @@ corresponding argument. Supported placeholders are:
 * `%f` - Floating point value.
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
 contains circular references.
-* `%o` - Object. A string representation of an object 
-  with optimally useful formatting.
-  This is equivalent to `JSON.stringify` with no replacer
-  and 1 space. This is not full representation of the object. 
-  Functions, for example, will not be displayed.
+* `%o` - Object. A string representation of an object
+  with generic JavaScript object formatting.
+  Similar to `util.inspect()` with options `{ showHidden: true, depth: 4, showProxy: true }`.
+  This will show the full object including non-enumerable symbols and properties.
 * `%O` - Object. A string representation of an object 
   with generic JavaScript object formatting. 
   Similar to `util.inspect()` without options.
-  This is a full representation of the object.
+  This will show the full object not including non-enumerable symbols and properties.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
 If the placeholder does not have a corresponding argument, the placeholder is

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -167,9 +167,11 @@ corresponding argument. Supported placeholders are:
 * `%f` - Floating point value.
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
 contains circular references.
-* `%o` - Object. A string representation of an object. 
-Similar to `util.inspect()` without options.
-* `%O` - Object. Same as `%o`.
+* `%o` - Object. A string representation of an object 
+  with optimally useful formatting.
+* `%O` - Object. A string representation of an object 
+  with generic JavaScript object formatting. 
+  Similar to `util.inspect()` without options.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
 If the placeholder does not have a corresponding argument, the placeholder is

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -167,6 +167,9 @@ corresponding argument. Supported placeholders are:
 * `%f` - Floating point value.
 * `%j` - JSON.  Replaced with the string `'[Circular]'` if the argument
 contains circular references.
+* `%o` - Object. A string representation of an object. 
+Similar to `util.inspect()` without options.
+* `%O` - Object. Same as `%o`.
 * `%%` - single percent sign (`'%'`). This does not consume an argument.
 
 If the placeholder does not have a corresponding argument, the placeholder is

--- a/lib/util.js
+++ b/lib/util.js
@@ -145,7 +145,8 @@ function format(f) {
         case 111: // 'o'
           if (lastPos < i)
             str += f.slice(lastPos, i);
-          str += tryStringify(arguments[a++], null, ' ');
+          str += inspect(arguments[a++],
+                         { showHidden: true, depth: 4, showProxy: true });
           break;
         case 37: // '%'
           if (lastPos < i)

--- a/lib/util.js
+++ b/lib/util.js
@@ -138,10 +138,14 @@ function format(f) {
           str += String(arguments[a++]);
           break;
         case 79: // 'O'
-        case 111: // 'o'
           if (lastPos < i)
             str += f.slice(lastPos, i);
           str += inspect(arguments[a++]);
+          break;
+        case 111: // 'o'
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += tryStringify(arguments[a++], null, ' ');
           break;
         case 37: // '%'
           if (lastPos < i)

--- a/lib/util.js
+++ b/lib/util.js
@@ -137,6 +137,12 @@ function format(f) {
             str += f.slice(lastPos, i);
           str += String(arguments[a++]);
           break;
+        case 79: // 'O'
+        case 111: // 'o'
+          if (lastPos < i)
+            str += f.slice(lastPos, i);
+          str += inspect(arguments[a++]);
+          break;
         case 37: // '%'
           if (lastPos < i)
             str += f.slice(lastPos, i);

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -116,20 +116,19 @@ const nestedObj = {
 };
 assert.strictEqual(util.format('%o'), '%o');
 assert.strictEqual(util.format('%o', 42), '42');
-assert.strictEqual(util.format('%o', 'foo'), '\'foo\'');
+assert.strictEqual(util.format('%o', 'foo'), '"foo"');
 assert.strictEqual(
   util.format('%o', obj),
-  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+  '{"foo":"bar","foobar":1}');
 assert.strictEqual(
   util.format('%o', nestedObj),
-  '{ foo: \'bar\', foobar: { foo: \'bar\', func: [Function: func] } }');
+  '{"foo":"bar","foobar":{"foo":"bar"}}');
 assert.strictEqual(
   util.format('%o %o', obj, obj),
-  '{ foo: \'bar\', foobar: 1, func: [Function: func] } ' +
-  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+  '{"foo":"bar","foobar":1} {"foo":"bar","foobar":1}');
 assert.strictEqual(
   util.format('%o %o', obj),
-  '{ foo: \'bar\', foobar: 1, func: [Function: func] } %o');
+  '{"foo":"bar","foobar":1} %o');
 
 assert.strictEqual(util.format('%O'), '%O');
 assert.strictEqual(util.format('%O', 42), '42');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -101,6 +101,53 @@ assert.strictEqual(util.format('%j', '42'), '"42"');
 assert.strictEqual(util.format('%j %j', 42, 43), '42 43');
 assert.strictEqual(util.format('%j %j', 42), '42 %j');
 
+// Object format specifier
+const obj = {
+  foo: 'bar',
+  foobar: 1,
+  func: function() {}
+};
+const nestedObj = {
+  foo: 'bar',
+  foobar: {
+    foo: 'bar',
+    func: function() {}
+  }
+};
+assert.strictEqual(util.format('%o'), '%o');
+assert.strictEqual(util.format('%o', 42), '42');
+assert.strictEqual(util.format('%o', 'foo'), '\'foo\'');
+assert.strictEqual(
+  util.format('%o', obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+assert.strictEqual(
+  util.format('%o', nestedObj),
+  '{ foo: \'bar\', foobar: { foo: \'bar\', func: [Function: func] } }');
+assert.strictEqual(
+  util.format('%o %o', obj, obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] } ' +
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+assert.strictEqual(
+  util.format('%o %o', obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] } %o');
+
+assert.strictEqual(util.format('%O'), '%O');
+assert.strictEqual(util.format('%O', 42), '42');
+assert.strictEqual(util.format('%O', 'foo'), '\'foo\'');
+assert.strictEqual(
+  util.format('%O', obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+assert.strictEqual(
+  util.format('%O', nestedObj),
+  '{ foo: \'bar\', foobar: { foo: \'bar\', func: [Function: func] } }');
+assert.strictEqual(
+  util.format('%O %O', obj, obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] } ' +
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] }');
+assert.strictEqual(
+  util.format('%O %O', obj),
+  '{ foo: \'bar\', foobar: 1, func: [Function: func] } %O');
+
 // Various format specifiers
 assert.strictEqual(util.format('%%s%s', 'foo'), '%sfoo');
 assert.strictEqual(util.format('%s:%s'), '%s:%s');
@@ -125,6 +172,10 @@ assert.strictEqual(util.format('%f:%f'), '%f:%f');
 assert.strictEqual(util.format('o: %j, a: %j', {}, []), 'o: {}, a: []');
 assert.strictEqual(util.format('o: %j, a: %j', {}), 'o: {}, a: %j');
 assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
+assert.strictEqual(util.format('o: %o, a: %O', {}, []), 'o: {}, a: []');
+assert.strictEqual(util.format('o: %o, a: %o', {}), 'o: {}, a: %o');
+assert.strictEqual(util.format('o: %O, a: %O'), 'o: %O, a: %O');
+
 
 // Invalid format specifiers
 assert.strictEqual(util.format('a% b', 'x'), 'a% b x');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -116,19 +116,51 @@ const nestedObj = {
 };
 assert.strictEqual(util.format('%o'), '%o');
 assert.strictEqual(util.format('%o', 42), '42');
-assert.strictEqual(util.format('%o', 'foo'), '"foo"');
+assert.strictEqual(util.format('%o', 'foo'), '\'foo\'');
 assert.strictEqual(
   util.format('%o', obj),
-  '{"foo":"bar","foobar":1}');
+  '{ foo: \'bar\',\n' +
+  '  foobar: 1,\n' +
+  '  func: \n' +
+  '   { [Function: func]\n' +
+  '     [length]: 0,\n' +
+  '     [name]: \'func\',\n' +
+  '     [prototype]: func { [constructor]: [Circular] } } }');
 assert.strictEqual(
   util.format('%o', nestedObj),
-  '{"foo":"bar","foobar":{"foo":"bar"}}');
+  '{ foo: \'bar\',\n' +
+  '  foobar: \n' +
+  '   { foo: \'bar\',\n' +
+  '     func: \n' +
+  '      { [Function: func]\n' +
+  '        [length]: 0,\n' +
+  '        [name]: \'func\',\n' +
+  '        [prototype]: func { [constructor]: [Circular] } } } }');
 assert.strictEqual(
   util.format('%o %o', obj, obj),
-  '{"foo":"bar","foobar":1} {"foo":"bar","foobar":1}');
+  '{ foo: \'bar\',\n' +
+  '  foobar: 1,\n' +
+  '  func: \n' +
+  '   { [Function: func]\n' +
+  '     [length]: 0,\n' +
+  '     [name]: \'func\',\n' +
+  '     [prototype]: func { [constructor]: [Circular] } } }' +
+  ' { foo: \'bar\',\n' +
+  '  foobar: 1,\n' +
+  '  func: \n' +
+  '   { [Function: func]\n' +
+  '     [length]: 0,\n' +
+  '     [name]: \'func\',\n' +
+  '     [prototype]: func { [constructor]: [Circular] } } }');
 assert.strictEqual(
   util.format('%o %o', obj),
-  '{"foo":"bar","foobar":1} %o');
+  '{ foo: \'bar\',\n' +
+  '  foobar: 1,\n' +
+  '  func: \n' +
+  '   { [Function: func]\n' +
+  '     [length]: 0,\n' +
+  '     [name]: \'func\',\n' +
+  '     [prototype]: func { [constructor]: [Circular] } } } %o');
 
 assert.strictEqual(util.format('%O'), '%O');
 assert.strictEqual(util.format('%O', 42), '42');


### PR DESCRIPTION
Implementing the %o and %O as formatting specifier for util.format.
Based on discussion in issue, this specifier should just call
util.inspect to format passed in value.

Fixes: https://github.com/nodejs/node/issues/14545

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util 
