### PR TITLE
tools: simplify no-unescaped-regexp-dot rule

### DIFF
--- a/tools/eslint-rules/no-unescaped-regexp-dot.js
+++ b/tools/eslint-rules/no-unescaped-regexp-dot.js
@@ -4,12 +4,6 @@
  */
 'use strict';
 
-const path = require('path');
-const utilsPath = path.join(__dirname, '..', 'eslint', 'lib', 'ast-utils.js');
-const astUtils = require(utilsPath);
-const getLocationFromRangeIndex = astUtils.getLocationFromRangeIndex;
-const getRangeIndexFromLocation = astUtils.getRangeIndexFromLocation;
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -20,32 +14,11 @@ module.exports = function(context) {
   var regexpBuffer = [];
   var inRegExp = false;
 
-  var getLocFromIndex;
-  if (typeof sourceCode.getLocFromIndex === 'function') {
-    getLocFromIndex = function(index) {
-      return sourceCode.getLocFromIndex(index);
-    };
-  } else {
-    getLocFromIndex = function(index) {
-      return getLocationFromRangeIndex(sourceCode, index);
-    };
-  }
-
-  var getIndexFromLoc;
-  if (typeof sourceCode.getIndexFromLoc === 'function') {
-    getIndexFromLoc = function(loc) {
-      return sourceCode.getIndexFromLoc(loc);
-    };
-  } else {
-    getIndexFromLoc = function(loc) {
-      return getRangeIndexFromLocation(sourceCode, loc);
-    };
-  }
-
   function report(node, startOffset) {
+    const indexOfDot = sourceCode.getIndexFromLoc(node.loc.start) + startOffset;
     context.report({
       node,
-      loc: getLocFromIndex(getIndexFromLoc(node.loc.start) + startOffset),
+      loc: sourceCode.getLocFromIndex(indexOfDot),
       message: 'Unescaped dot character in regular expression'
     });
   }


### PR DESCRIPTION
no-unescaped-regexp-dot ESLint custom rule contains feature detection
that is not needed on master or the v6.x-staging branch. The rule does
not exist in the v4.x-staging branch. Remove the unnecessary complexity.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools