### PR TITLE
test: use ciphers supported by shared openssl

### DIFF
--- a/test/parallel/test-tls-ecdh-disable.js
+++ b/test/parallel/test-tls-ecdh-disable.js
@@ -35,7 +35,7 @@ const fs = require('fs');
 const options = {
   key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
   cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
-  ciphers: 'ECDHE-RSA-RC4-SHA',
+  ciphers: 'ECDHE-RSA-AES128-SHA',
   ecdhCurve: false
 };
 

--- a/test/parallel/test-tls-set-ciphers.js
+++ b/test/parallel/test-tls-set-ciphers.js
@@ -36,7 +36,7 @@ const fs = require('fs');
 const options = {
   key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
   cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
-  ciphers: 'DES-CBC3-SHA'
+  ciphers: 'AES256-SHA'
 };
 
 const reply = 'I AM THE WALRUS'; // something recognizable


### PR DESCRIPTION
On debian with openssl 1.1 cli, the ciphers used in those tests were
unknown.
