### PR TITLE
doc,net: assign deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -634,8 +634,8 @@ Type: End-of-Life
 
 *Note*: change was made while `async_hooks` was an experimental API.
 
-<a id="DEP00XX"></a>
-### DEP00XX: Several internal properties of net.Server
+<a id="DEP0073"></a>
+### DEP0073: Several internal properties of net.Server
 
 Type: Runtime
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1708,27 +1708,27 @@ if (process.platform === 'win32') {
 Object.defineProperty(Server.prototype, '_usingSlaves', {
   get: internalUtil.deprecate(function() {
     return this._usingWorkers;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP00XX'),
+  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
   set: internalUtil.deprecate((val) => {
     this._usingWorkers = val;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP00XX'),
+  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
   configurable: true, enumerable: false
 });
 
 Object.defineProperty(Server.prototype, '_slaves', {
   get: internalUtil.deprecate(function() {
     return this._workers;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP00XX'),
+  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
   set: internalUtil.deprecate((val) => {
     this._workers = val;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP00XX'),
+  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
   configurable: true, enumerable: false
 });
 
 Object.defineProperty(Server.prototype, '_setupSlave', {
   value: internalUtil.deprecate(function(socketList) {
     return this._setupWorker(socketList);
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP00XX'),
+  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
   configurable: true, enumerable: false
 });
 


### PR DESCRIPTION
I missed this while landing 75a19fb379c2d936c6945e63de7c4a28e93eb17d.

Ref: https://github.com/nodejs/node/pull/14449

I’d suggest to fast-track this as it’s a trivial fix (if CI is green).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (presumably, V8 is taking forever to compile and it’s not like there’s much I could have done wrong here :smile:)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

net