### PR TITLE
console,test: make message test more accurate

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -91,6 +91,10 @@ function write(ignoreErrors, stream, string, errorhandler) {
 
     stream.write(string, errorhandler);
   } catch (e) {
+    // console is a debugging utility, so it swalling errors is not desirable
+    // even in edge cases such as low stack space.
+    if (e.message === 'Maximum call stack size exceeded')
+      throw e;
     // Sorry, there’s no proper way to pass along the error here.
   } finally {
     stream.removeListener('error', noop);

--- a/test/message/console_low_stack_space.js
+++ b/test/message/console_low_stack_space.js
@@ -6,13 +6,20 @@ global.console = {};
 
 require('../common');
 
+// This test checks that, if Node cannot put together the `console` object
+// because it is low on stack space while doing so, it can succeed later
+// once the stack has unwound a little, and `console` is in a usable state then.
+
+let compiledConsole;
+
 function a() {
   try {
     return a();
   } catch (e) {
-    const console = consoleDescriptor.get();
-    if (console.log) {
-      console.log('Hello, World!');
+    compiledConsole = consoleDescriptor.get();
+    if (compiledConsole.log) {
+      // Using `console.log` itself might not succeed yet, but the code for it
+      // has been compiled.
     } else {
       throw e;
     }
@@ -20,3 +27,5 @@ function a() {
 }
 
 a();
+
+compiledConsole.log('Hello, World!');


### PR DESCRIPTION
Make a message test more accurate in what it’s testing for.
This requires not swallowing stack overflow RangeErrors in
`console.log` and similar methods, which I would consider a
bugfix in itself.

Fixes: https://github.com/nodejs/node-v8/issues/5 (i.e. this is required for upgrading to V8 > 6.0)

/cc @targos

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

console, test