### PR TITLE
inspector: break in eval script

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -434,6 +434,13 @@
     }
   }
 
+  function wrapForBreakOnFirstLine(source) {
+    if (!process._breakFirstLine)
+      return source;
+    const fn = `function() {\n\n${source};\n\n}`;
+    return `process.binding('inspector').callAndPauseOnStart(${fn}, {})`;
+  }
+
   function evalScript(name) {
     const Module = NativeModule.require('module');
     const path = NativeModule.require('path');
@@ -442,7 +449,7 @@
     const module = new Module(name);
     module.filename = path.join(cwd, name);
     module.paths = Module._nodeModulePaths(cwd);
-    const body = process._eval;
+    const body = wrapForBreakOnFirstLine(process._eval);
     const script = `global.__filename = ${JSON.stringify(name)};\n` +
                    'global.exports = exports;\n' +
                    'global.module = module;\n' +

--- a/test/inspector/test-async-hook-setup-at-inspect-brk.js
+++ b/test/inspector/test-async-hook-setup-at-inspect-brk.js
@@ -13,9 +13,14 @@ setTimeout(() => {
 }, 50);
 `;
 
+async function skipBreakpointAtStart(session) {
+  await session.waitForBreakOnLine(0, '[eval]');
+  await session.send({ 'method': 'Debugger.resume' });
+}
+
 async function checkAsyncStackTrace(session) {
   console.error('[test]', 'Verify basic properties of asyncStackTrace');
-  const paused = await session.waitForBreakOnLine(2, '[eval]');
+  const paused = await session.waitForBreakOnLine(4, '[eval]');
   assert(paused.params.asyncStackTrace,
          `${Object.keys(paused.params)} contains "asyncStackTrace" property`);
   assert(paused.params.asyncStackTrace.description, 'Timeout');
@@ -35,7 +40,7 @@ async function runTests() {
       'params': { 'patterns': [] } },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-
+  await skipBreakpointAtStart(session);
   await checkAsyncStackTrace(session);
 
   await session.runToCompletion();

--- a/test/inspector/test-async-stack-traces-promise-then.js
+++ b/test/inspector/test-async-stack-traces-promise-then.js
@@ -31,15 +31,18 @@ async function runTests() {
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
 
+  await session.waitForBreakOnLine(0, '[eval]');
+  await session.send({ 'method': 'Debugger.resume' });
+
   console.error('[test] Waiting for break1');
-  debuggerPausedAt(await session.waitForBreakOnLine(4, '[eval]'),
-                   'break1', 'runTest:3');
+  debuggerPausedAt(await session.waitForBreakOnLine(6, '[eval]'),
+                   'break1', 'runTest:5');
 
   await session.send({ 'method': 'Debugger.resume' });
 
   console.error('[test] Waiting for break2');
-  debuggerPausedAt(await session.waitForBreakOnLine(7, '[eval]'),
-                   'break2', 'runTest:6');
+  debuggerPausedAt(await session.waitForBreakOnLine(9, '[eval]'),
+                   'break2', 'runTest:8');
 
   await session.runToCompletion();
   assert.strictEqual(0, (await instance.expectShutdown()).exitCode);

--- a/test/inspector/test-async-stack-traces-set-interval.js
+++ b/test/inspector/test-async-stack-traces-set-interval.js
@@ -8,9 +8,15 @@ const assert = require('assert');
 
 const script = 'setInterval(() => { debugger; }, 50);';
 
+async function skipFirstBreakpoint(session) {
+  console.log('[test]', 'Skipping the first breakpoint in the eval script');
+  await session.waitForBreakOnLine(0, '[eval]');
+  await session.send({ 'method': 'Debugger.resume' });
+}
+
 async function checkAsyncStackTrace(session) {
   console.error('[test]', 'Verify basic properties of asyncStackTrace');
-  const paused = await session.waitForBreakOnLine(0, '[eval]');
+  const paused = await session.waitForBreakOnLine(2, '[eval]');
   assert(paused.params.asyncStackTrace,
          `${Object.keys(paused.params)} contains "asyncStackTrace" property`);
   assert(paused.params.asyncStackTrace.description, 'Timeout');
@@ -31,6 +37,7 @@ async function runTests() {
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
 
+  await skipFirstBreakpoint(session);
   await checkAsyncStackTrace(session);
 
   console.error('[test]', 'Stopping child instance');

--- a/test/inspector/test-inspector-break-e.js
+++ b/test/inspector/test-inspector-break-e.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { NodeInstance } = require('./inspector-helper.js');
+
+async function runTests() {
+  const instance = new NodeInstance(undefined, 'console.log(10)');
+  const session = await instance.connectInspectorSession();
+  await session.send([
+    { 'method': 'Runtime.enable' },
+    { 'method': 'Debugger.enable' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' }
+  ]);
+  await session.waitForBreakOnLine(0, '[eval]');
+  await session.runToCompletion();
+  assert.strictEqual(0, (await instance.expectShutdown()).exitCode);
+}
+
+runTests();

--- a/test/inspector/test-scriptparsed-context.js
+++ b/test/inspector/test-scriptparsed-context.js
@@ -10,8 +10,6 @@ const script = `
   const assert = require('assert');
   const vm = require('vm');
   const { kParsingContext } = process.binding('contextify');
-  debugger;
-
   global.outer = true;
   global.inner = false;
   const context = vm.createContext({
@@ -61,7 +59,7 @@ async function runTests() {
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' }
   ]);
-  await session.waitForBreakOnLine(5, '[eval]');
+  await session.waitForBreakOnLine(0, '[eval]');
 
   await session.send({ 'method': 'Runtime.enable' });
   const topContext = await getContext(session);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/14577

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
eval scripts are now wrapped into inspector call to break on a first line.
