### PR TITLE
missing V8 6.0 patch

### DIFF
--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -441,7 +441,10 @@ void V8::SetSnapshotDataBlob(StartupData* snapshot_blob) {
   i::V8::SetSnapshotBlob(snapshot_blob);
 }
 
-void* v8::ArrayBuffer::Allocator::Reserve(size_t length) { UNIMPLEMENTED(); }
+void* v8::ArrayBuffer::Allocator::Reserve(size_t length) {
+  UNIMPLEMENTED();
+  return nullptr;
+}
 
 void v8::ArrayBuffer::Allocator::Free(void* data, size_t length,
                                       AllocationMode mode) {


### PR DESCRIPTION
There were three missing patches that were included in https://github.com/nodejs/node/pull/13515/ that were missed in #14004 

It seems like these were missed because they either 

a) Directly touch the V8 system and were not upstreamed

or

b) Were backports that did not follow our backport process

I'm not sure the best process for landing these... please advise

/cc @nodejs/v8 