### PR TITLE
src: use existing strings over creating new ones

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5666,9 +5666,7 @@ void RandomBytesBuffer(const FunctionCallbackInfo<Value>& args) {
                              data,
                              RandomBytesRequest::DONT_FREE_DATA);
   if (args[3]->IsFunction()) {
-    obj->Set(env->context(),
-             FIXED_ONE_BYTE_STRING(args.GetIsolate(), "ondone"),
-             args[3]).FromJust();
+    obj->Set(env->context(), env->ondone_string(), args[3]).FromJust();
 
     if (env->in_domain()) {
       obj->Set(env->context(),

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -77,13 +77,9 @@ void TCPWrap::Initialize(Local<Object> target,
   // Init properties
   t->InstanceTemplate()->Set(String::NewFromUtf8(env->isolate(), "reading"),
                              Boolean::New(env->isolate(), false));
-  t->InstanceTemplate()->Set(String::NewFromUtf8(env->isolate(), "owner"),
-                             Null(env->isolate()));
-  t->InstanceTemplate()->Set(String::NewFromUtf8(env->isolate(), "onread"),
-                             Null(env->isolate()));
-  t->InstanceTemplate()->Set(String::NewFromUtf8(env->isolate(),
-                                                 "onconnection"),
-                             Null(env->isolate()));
+  t->InstanceTemplate()->Set(env->owner_string(), Null(env->isolate()));
+  t->InstanceTemplate()->Set(env->onread_string(), Null(env->isolate()));
+  t->InstanceTemplate()->Set(env->onconnection_string(), Null(env->isolate()));
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
   env->SetProtoMethod(t, "asyncReset", AsyncWrap::AsyncReset);


### PR DESCRIPTION
This is a very very minor change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/tcp_wrap.cc