### PR TITLE
configure: fix type of arm_version

### DIFF
--- a/configure
+++ b/configure
@@ -773,16 +773,16 @@ def configure_arm(o):
 
   if is_arch_armv7():
     arm_fpu = 'vfpv3'
-    o['variables']['arm_version'] = '7'
+    o['variables']['arm_version'] = 7
   else:
-    o['variables']['arm_version'] = '6' if is_arch_armv6() else 'default'
+    o['variables']['arm_version'] = 6 if is_arch_armv6() else 'default'
 
   o['variables']['arm_thumb'] = 0      # -marm
   o['variables']['arm_float_abi'] = arm_float_abi
 
   if options.dest_os == 'android':
     arm_fpu = 'vfpv3'
-    o['variables']['arm_version'] = '7'
+    o['variables']['arm_version'] = 7
 
   o['variables']['arm_fpu'] = options.arm_fpu or arm_fpu
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -333,10 +333,10 @@ exports.platformTimeout = function(ms) {
 
   const armv = process.config.variables.arm_version;
 
-  if (armv === '6')
+  if (armv === 6)
     return 7 * ms;  // ARMv6
 
-  if (armv === '7')
+  if (armv === 7)
     return 2 * ms;  // ARMv7
 
   return ms; // ARMv8+

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
-if ((process.config.variables.arm_version === '6') ||
-    (process.config.variables.arm_version === '7'))
+if ((process.config.variables.arm_version === 6) ||
+    (process.config.variables.arm_version === 7))
   common.skip('Too slow for armv6 and armv7 bots');
 
 const assert = require('assert');


### PR DESCRIPTION
arm_version is compared with an integer 7 in V8's GYP files, instead of the string "7", so it seems that this variable should be an integer when it is representing a version number. Its default value in V8's
standalone.gypi seconds this.

It also seems that GYP can quietly convert an integer-like string to an integer in some scenarios, maybe during the merge of some dictionaries, so luckily no actual problem happens at the moment. However, the subtle difference between 7 and "7" will be observed when a new GYP variable is added to V8's toolchain.gypi like this:

```
{
  'variables': {
    ...
    'conditions': [
      ...
      ['arm_version==7', {
        'myvar%': 'abc',
      }],
    ],
    ...
  },
  ...
}
```

Interestingly no implicit conversion happens here when arm_version is "7", so GYP will complain about the undefined variable <(myvar) if it's referenced later on.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, arm