### PR TITLE
test: read proper inspector message size

### DIFF
--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -68,7 +68,7 @@ function parseWSFrame(buffer, handler) {
     dataLen = buffer.readUInt16BE(2);
     bodyOffset = 4;
   } else if (dataLen === 127) {
-    dataLen = buffer.readUInt32BE(2);
+    dataLen = buffer.readUIntBE(2, 8);
     bodyOffset = 10;
   }
   if (buffer.length < bodyOffset + dataLen)

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -68,7 +68,9 @@ function parseWSFrame(buffer, handler) {
     dataLen = buffer.readUInt16BE(2);
     bodyOffset = 4;
   } else if (dataLen === 127) {
-    dataLen = buffer.readUIntBE(2, 8);
+    if (buffer[2] !== 0 || buffer[3] !== 0)
+      assert.fail('Inspector message to big');
+    dataLen = buffer.readUIntBE(4, 6);
     bodyOffset = 10;
   }
   if (buffer.length < bodyOffset + dataLen)

--- a/test/inspector/inspector-helper.js
+++ b/test/inspector/inspector-helper.js
@@ -53,6 +53,7 @@ function sendEnd(socket) {
 }
 
 function parseWSFrame(buffer, handler) {
+  // Protocol described in https://tools.ietf.org/html/rfc6455#section-5
   if (buffer.length < 2)
     return 0;
   if (buffer[0] === 0x88 && buffer[1] === 0x00) {
@@ -68,8 +69,7 @@ function parseWSFrame(buffer, handler) {
     dataLen = buffer.readUInt16BE(2);
     bodyOffset = 4;
   } else if (dataLen === 127) {
-    if (buffer[2] !== 0 || buffer[3] !== 0)
-      assert.fail('Inspector message to big');
+    assert(buffer[2] === 0 && buffer[3] === 0, 'Inspector message too big');
     dataLen = buffer.readUIntBE(4, 6);
     bodyOffset = 10;
   }


### PR DESCRIPTION
Fix a bug when messages bigger than 64kb where incorrectly parsed by the inspector-helper.
See https://github.com/nodejs/node/issues/14507#issuecomment-319653506

Fixes: https://github.com/nodejs/node/issues/14507

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

/cc @eugeneo @nodejs/v8-inspector 