### PR TITLE
doc: erase unneeded eslint-plugin-markdown comment

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -235,7 +235,6 @@ abc: 1
 undefined
 >
 ```
-<!-- eslint-enable -->
 
 ### console.dir(obj[, options])
 <!-- YAML


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console, doc, tools

`eslint-plugin-markdown` comments affect only a code block below them, so there is no need to cancel them for the rest code blocks.

Refs: https://github.com/eslint/eslint-plugin-markdown#configuration-comments
