### PR TITLE
test: explain sloppy mode for test-global

### DIFF
--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -19,28 +19,32 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// This test cannot run in strict mode because it tests that `baseFoo` is
+// treated as a global without being declared with `var`/`let`/`const`.
+
 /* eslint-disable strict */
 const common = require('../common');
-const path = require('path');
+
 const assert = require('assert');
+const path = require('path');
 
 common.globalCheck = false;
 
 baseFoo = 'foo'; // eslint-disable-line no-undef
 global.baseBar = 'bar';
 
-assert.strictEqual('foo', global.baseFoo,
+assert.strictEqual(global.baseFoo, 'foo',
                    'x -> global.x in base level not working');
 
-assert.strictEqual('bar',
-                   baseBar, // eslint-disable-line no-undef
+assert.strictEqual(baseBar, // eslint-disable-line no-undef
+                   'bar',
                    'global.x -> x in base level not working');
 
 const mod = require(path.join(common.fixturesDir, 'global', 'plain'));
 const fooBar = mod.fooBar;
 
-assert.strictEqual('foo', fooBar.foo, 'x -> global.x in sub level not working');
+assert.strictEqual(fooBar.foo, 'foo', 'x -> global.x in sub level not working');
 
-assert.strictEqual('bar', fooBar.bar, 'global.x -> x in sub level not working');
+assert.strictEqual(fooBar.bar, 'bar', 'global.x -> x in sub level not working');
 
 assert.strictEqual(Object.prototype.toString.call(global), '[object global]');


### PR DESCRIPTION
Add a comment explaining why test-global runs in sloppy mode rather than
strict mode. While in the file, make some minor changes to the module
ordering and spacing to conform with our test writing guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test