### PR TITLE
lint: wrap lines which include RegEx exceeding 80 chars

### DIFF
--- a/test/addons-napi/test_properties/test.js
+++ b/test/addons-napi/test_properties/test.js
@@ -1,7 +1,8 @@
 'use strict';
 const common = require('../../common');
 const assert = require('assert');
-const readonlyErrorRE = /^TypeError: Cannot assign to read only property '.*' of object '#<Object>'$/;
+const readonlyErrorRE =
+  /^TypeError: Cannot assign to read only property '.*' of object '#<Object>'$/;
 
 // Testing api calls for defining properties
 const test_object = require(`./build/${common.buildType}/test_properties`);

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -29,5 +29,6 @@ assert(commonTemplate.test(process.versions.node));
 assert(commonTemplate.test(process.versions.uv));
 assert(commonTemplate.test(process.versions.zlib));
 
-assert(/^\d+\.\d+\.\d+(?:\.\d+)?(?: \(candidate\))?$/.test(process.versions.v8));
+assert(/^\d+\.\d+\.\d+(?:\.\d+)?(?: \(candidate\))?$/
+  .test(process.versions.v8));
 assert(/^\d+$/.test(process.versions.modules));

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -142,7 +142,7 @@ function error_test() {
       expect: prompt_unix },
     // But passing the same string to eval() should throw
     { client: client_unix, send: 'eval("function test_func() {")',
-      expect: /\bSyntaxError: Unexpected end of input/ },
+      expect: /^SyntaxError: Unexpected end of input/ },
     // Can handle multiline template literals
     { client: client_unix, send: '`io.js',
       expect: prompt_multiline },
@@ -171,22 +171,22 @@ function error_test() {
     // invalid input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{invalid: \\\'json\\\'}\');',
-      expect: /\bSyntaxError: Unexpected token i/ },
+      expect: /^SyntaxError: Unexpected token i/ },
     // end of input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'066\');',
-      expect: /\bSyntaxError: Unexpected number/ },
+      expect: /^SyntaxError: Unexpected number/ },
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{\');',
-      expect: /\bSyntaxError: Unexpected end of JSON input/ },
+      expect: /^SyntaxError: Unexpected end of JSON input/ },
     // invalid RegExps are a special case of syntax error,
     // should throw
     { client: client_unix, send: '/(/;',
-      expect: /\bSyntaxError: Invalid regular expression:/ },
+      expect: /^SyntaxError: Invalid regular expression:/ },
     // invalid RegExp modifiers are a special case of syntax error,
     // should throw (GH-4012)
     { client: client_unix, send: 'new RegExp("foo", "wrong modifier");',
-      expect: /\bSyntaxError: Invalid flags supplied to RegExp constructor/ },
+      expect: /^SyntaxError: Invalid flags supplied to RegExp constructor/ },
     // strict mode syntax errors should be caught (GH-5178)
     { client: client_unix,
       send: '(function() { "use strict"; return 0755; })()',
@@ -194,7 +194,8 @@ function error_test() {
     {
       client: client_unix,
       send: '(function(a, a, b) { "use strict"; return a + b + c; })()',
-      expect: /\bSyntaxError: Duplicate parameter name not allowed in this context/
+      expect:
+        /\bSyntaxError: Duplicate parameter name not allowed in this context/
     },
     {
       client: client_unix,
@@ -204,7 +205,8 @@ function error_test() {
     {
       client: client_unix,
       send: '(function() { "use strict"; var x; delete x; })()',
-      expect: /\bSyntaxError: Delete of an unqualified identifier in strict mode/
+      expect:
+        /\bSyntaxError: Delete of an unqualified identifier in strict mode/
     },
     { client: client_unix,
       send: '(function() { "use strict"; eval = 17; })()',
@@ -212,7 +214,8 @@ function error_test() {
     {
       client: client_unix,
       send: '(function() { "use strict"; if (true) function f() { } })()',
-      expect: /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block\./
+      expect:
+        /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block\./
     },
     // Named functions can be used:
     { client: client_unix, send: 'function blah() { return 1; }',

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -20,6 +20,11 @@ const objects = [
   circular
 ];
 
+const serializerTypeError =
+  /^TypeError: Class constructor Serializer cannot be invoked without 'new'$/;
+const deserializerTypeError =
+  /^TypeError: Class constructor Deserializer cannot be invoked without 'new'$/;
+
 {
   const ser = new v8.DefaultSerializer();
   ser.writeHeader();
@@ -133,13 +138,6 @@ const objects = [
 }
 
 {
-  assert.throws(
-    () => { v8.Serializer(); },
-    /^TypeError: Class constructor Serializer cannot be invoked without 'new'$/
-  );
-
-  assert.throws(
-    () => { v8.Deserializer(); },
-    /^TypeError: Class constructor Deserializer cannot be invoked without 'new'$/
-  );
+  assert.throws(v8.Serializer, serializerTypeError);
+  assert.throws(v8.Deserializer, deserializerTypeError);
 }

--- a/test/parallel/test-whatwg-url-properties.js
+++ b/test/parallel/test-whatwg-url-properties.js
@@ -43,8 +43,10 @@ assert.strictEqual(url.searchParams, oldParams);  // [SameObject]
 // searchParams is readonly. Under strict mode setting a
 // non-writable property should throw.
 // Note: this error message is subject to change in V8 updates
-assert.throws(() => url.origin = 'http://foo.bar.com:22',
-              /TypeError: Cannot set property origin of \[object URL\] which has only a getter$/);
+assert.throws(
+  () => url.origin = 'http://foo.bar.com:22',
+  /^TypeError: Cannot set property origin of \[object URL\] which has only a getter$/
+);
 assert.strictEqual(url.origin, 'http://foo.bar.com:21');
 assert.strictEqual(url.toString(),
                    'http://user:pass@foo.bar.com:21/aaa/zzz?l=25#test');
@@ -118,8 +120,10 @@ assert.strictEqual(url.hash, '#abcd');
 // searchParams is readonly. Under strict mode setting a
 // non-writable property should throw.
 // Note: this error message is subject to change in V8 updates
-assert.throws(() => url.searchParams = '?k=88',
-              /^TypeError: Cannot set property searchParams of \[object URL\] which has only a getter$/);
+assert.throws(
+  () => url.searchParams = '?k=88',
+  /^TypeError: Cannot set property searchParams of \[object URL\] which has only a getter$/
+);
 assert.strictEqual(url.searchParams, oldParams);
 assert.strictEqual(url.toString(),
                    'https://user2:pass2@foo.bar.org:23/aaa/bbb?k=99#abcd');

--- a/test/parallel/test-zlib-not-string-or-buffer.js
+++ b/test/parallel/test-zlib-not-string-or-buffer.js
@@ -7,7 +7,8 @@ require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-const expected = /^TypeError: "buffer" argument must be a string, Buffer, TypedArray, or DataView$/;
+const expected =
+  /^TypeError: "buffer" argument must be a string, Buffer, TypedArray, or DataView$/;
 
 assert.throws(() => { zlib.deflateSync(undefined); }, expected);
 assert.throws(() => { zlib.deflateSync(null); }, expected);


### PR DESCRIPTION
Format commit wrapping lines containing RegEx and exceeding 80
chars.

Fixes: https://github.com/nodejs/node/issues/14586

Files Changed:
- test/addons-napi/test_properties/test.js
- test/parallel/test-process-versions.js
- test/parallel/test-repl.js 
- test/parallel/test-v8-serdes.js
- test/parallel/test-whatwg-url-properties.js 
- test/parallel/test-zlib-not-string-or-buffer.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test