### PR TITLE
deps: cherry-pick fa4ec9f from V8 upstream

### DIFF
--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -2507,6 +2507,8 @@ v8_component("v8_libbase") {
 
   if (is_posix) {
     sources += [
+      "src/base/platform/platform-posix-time.cc",
+      "src/base/platform/platform-posix-time.h",
       "src/base/platform/platform-posix.cc",
       "src/base/platform/platform-posix.h",
     ]

--- a/deps/v8/src/base/platform/platform-freebsd.cc
+++ b/deps/v8/src/base/platform/platform-freebsd.cc
@@ -29,13 +29,16 @@
 #undef MAP_TYPE
 
 #include "src/base/macros.h"
+#include "src/base/platform/platform-posix-time.h"
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
 namespace v8 {
 namespace base {
 
-TimezoneCache* OS::CreateTimezoneCache() { return new PosixTimezoneCache(); }
+TimezoneCache* OS::CreateTimezoneCache() {
+  return new PosixDefaultTimezoneCache();
+}
 
 void* OS::Allocate(const size_t requested, size_t* allocated,
                    OS::MemoryPermission access) {

--- a/deps/v8/src/base/platform/platform-linux.cc
+++ b/deps/v8/src/base/platform/platform-linux.cc
@@ -44,6 +44,7 @@
 #undef MAP_TYPE
 
 #include "src/base/macros.h"
+#include "src/base/platform/platform-posix-time.h"
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
@@ -92,7 +93,9 @@ bool OS::ArmUsingHardFloat() {
 
 #endif  // def __arm__
 
-TimezoneCache* OS::CreateTimezoneCache() { return new PosixTimezoneCache(); }
+TimezoneCache* OS::CreateTimezoneCache() {
+  return new PosixDefaultTimezoneCache();
+}
 
 void* OS::Allocate(const size_t requested, size_t* allocated,
                    OS::MemoryPermission access) {

--- a/deps/v8/src/base/platform/platform-macos.cc
+++ b/deps/v8/src/base/platform/platform-macos.cc
@@ -36,9 +36,9 @@
 #undef MAP_TYPE
 
 #include "src/base/macros.h"
+#include "src/base/platform/platform-posix-time.h"
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
-
 
 namespace v8 {
 namespace base {
@@ -97,7 +97,9 @@ std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
 void OS::SignalCodeMovingGC() {
 }
 
-TimezoneCache* OS::CreateTimezoneCache() { return new PosixTimezoneCache(); }
+TimezoneCache* OS::CreateTimezoneCache() {
+  return new PosixDefaultTimezoneCache();
+}
 
 VirtualMemory::VirtualMemory() : address_(NULL), size_(0) { }
 

--- a/deps/v8/src/base/platform/platform-openbsd.cc
+++ b/deps/v8/src/base/platform/platform-openbsd.cc
@@ -27,13 +27,16 @@
 #undef MAP_TYPE
 
 #include "src/base/macros.h"
+#include "src/base/platform/platform-posix-time.h"
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
 namespace v8 {
 namespace base {
 
-TimezoneCache* OS::CreateTimezoneCache() { return new PosixTimezoneCache(); }
+TimezoneCache* OS::CreateTimezoneCache() {
+  return new PosixDefaultTimezoneCache();
+}
 
 void* OS::Allocate(const size_t requested, size_t* allocated,
                    OS::MemoryPermission access) {

--- a/deps/v8/src/base/platform/platform-posix-time.cc
+++ b/deps/v8/src/base/platform/platform-posix-time.cc
@@ -1,0 +1,31 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cmath>
+
+#include "src/base/platform/platform-posix-time.h"
+
+namespace v8 {
+namespace base {
+
+const char* PosixDefaultTimezoneCache::LocalTimezone(double time) {
+  if (std::isnan(time)) return "";
+  time_t tv = static_cast<time_t>(std::floor(time / msPerSecond));
+  struct tm tm;
+  struct tm* t = localtime_r(&tv, &tm);
+  if (!t || !t->tm_zone) return "";
+  return t->tm_zone;
+}
+
+double PosixDefaultTimezoneCache::LocalTimeOffset() {
+  time_t tv = time(NULL);
+  struct tm tm;
+  struct tm* t = localtime_r(&tv, &tm);
+  // tm_gmtoff includes any daylight savings offset, so subtract it.
+  return static_cast<double>(t->tm_gmtoff * msPerSecond -
+                             (t->tm_isdst > 0 ? 3600 * msPerSecond : 0));
+}
+
+}  // namespace base
+}  // namespace v8

--- a/deps/v8/src/base/platform/platform-posix-time.h
+++ b/deps/v8/src/base/platform/platform-posix-time.h
@@ -1,0 +1,19 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/base/platform/platform-posix.h"
+
+namespace v8 {
+namespace base {
+
+class PosixDefaultTimezoneCache : public PosixTimezoneCache {
+ public:
+  const char* LocalTimezone(double time_ms) override;
+  double LocalTimeOffset() override;
+
+  ~PosixDefaultTimezoneCache() override {}
+};
+
+}  // namespace base
+}  // namespace v8

--- a/deps/v8/src/base/platform/platform-posix.cc
+++ b/deps/v8/src/base/platform/platform-posix.cc
@@ -388,26 +388,6 @@ double OS::TimeCurrentMillis() {
   return Time::Now().ToJsTime();
 }
 
-#if !V8_OS_AIX && !V8_OS_SOLARIS && !V8_OS_CYGWIN
-const char* PosixTimezoneCache::LocalTimezone(double time) {
-  if (std::isnan(time)) return "";
-  time_t tv = static_cast<time_t>(std::floor(time / msPerSecond));
-  struct tm tm;
-  struct tm* t = localtime_r(&tv, &tm);
-  if (!t || !t->tm_zone) return "";
-  return t->tm_zone;
-}
-
-double PosixTimezoneCache::LocalTimeOffset() {
-  time_t tv = time(NULL);
-  struct tm tm;
-  struct tm* t = localtime_r(&tv, &tm);
-  // tm_gmtoff includes any daylight savings offset, so subtract it.
-  return static_cast<double>(t->tm_gmtoff * msPerSecond -
-                             (t->tm_isdst > 0 ? 3600 * msPerSecond : 0));
-}
-#endif
-
 double PosixTimezoneCache::DaylightSavingsOffset(double time) {
   if (std::isnan(time)) return std::numeric_limits<double>::quiet_NaN();
   time_t tv = static_cast<time_t>(std::floor(time/msPerSecond));

--- a/deps/v8/src/base/platform/platform-posix.h
+++ b/deps/v8/src/base/platform/platform-posix.h
@@ -13,9 +13,7 @@ namespace base {
 
 class PosixTimezoneCache : public TimezoneCache {
  public:
-  const char* LocalTimezone(double time_ms) override;
   double DaylightSavingsOffset(double time_ms) override;
-  double LocalTimeOffset() override;
   void Clear() override {}
   ~PosixTimezoneCache() override {}
 

--- a/deps/v8/src/base/platform/platform-qnx.cc
+++ b/deps/v8/src/base/platform/platform-qnx.cc
@@ -31,6 +31,7 @@
 #undef MAP_TYPE
 
 #include "src/base/macros.h"
+#include "src/base/platform/platform-posix-time.h"
 #include "src/base/platform/platform-posix.h"
 #include "src/base/platform/platform.h"
 
@@ -84,7 +85,9 @@ bool OS::ArmUsingHardFloat() {
 
 #endif  // __arm__
 
-TimezoneCache* OS::CreateTimezoneCache() { return new PosixTimezoneCache(); }
+TimezoneCache* OS::CreateTimezoneCache() {
+  return new PosixDefaultTimezoneCache();
+}
 
 void* OS::Allocate(const size_t requested, size_t* allocated,
                    OS::MemoryPermission access) {

--- a/deps/v8/src/v8.gyp
+++ b/deps/v8/src/v8.gyp
@@ -2063,6 +2063,8 @@
               'base/platform/platform-linux.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc',
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
             ],
           }
         ],
@@ -2071,6 +2073,8 @@
               'base/debug/stack_trace_android.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc',
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
             ],
             'link_settings': {
               'target_conditions': [
@@ -2127,6 +2131,8 @@
               'base/debug/stack_trace_posix.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc',
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
               'base/qnx-math.h'
             ],
             'target_conditions': [
@@ -2158,6 +2164,8 @@
               'base/platform/platform-freebsd.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc',
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
             ],
           }
         ],
@@ -2170,6 +2178,8 @@
               'base/platform/platform-openbsd.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc'
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
             ],
           }
         ],
@@ -2183,6 +2193,8 @@
               'base/platform/platform-openbsd.cc',
               'base/platform/platform-posix.h',
               'base/platform/platform-posix.cc',
+              'base/platform/platform-posix-time.h',
+              'base/platform/platform-posix-time.cc',
             ],
           }
         ],
@@ -2213,6 +2225,8 @@
             'base/platform/platform-macos.cc',
             'base/platform/platform-posix.h',
             'base/platform/platform-posix.cc',
+            'base/platform/platform-posix-time.h',
+            'base/platform/platform-posix-time.cc',
           ]},
         ],
         ['OS=="win"', {


### PR DESCRIPTION
Original commit message:

    [date] Refactor PosixTimezoneCache for different OS

    Follow up on https://codereview.chromium.org/2740353002. Created
    PosixDefaultTimezoneCache which is a subclass of PosixTimezoneCache
    containing definition of LocalTimezone and LocalTimeOffset which is
    separate for different OS.

    R=littledan@chromium.org, ulan@chromium.org

    BUG=v8:6578
    LOG=N

    Change-Id: I58342893aeefe79ac50e1df041d614fc473f15bf
    Reviewed-on: https://chromium-review.googlesource.com/568686
    Reviewed-by: Daniel Ehrenberg <littledan@chromium.org>
    Commit-Queue: Jaideep Bajwa <bjaideep@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#46604}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Fixes: #14080
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps/v8
