### PR TITLE
clarify the position argument of fs.read

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -789,6 +789,7 @@ const defaults = {
 the file instead of the entire file.  Both `start` and `end` are inclusive and
 start counting at 0. If `fd` is specified and `start` is omitted or `undefined`,
 `fs.createReadStream()` reads sequentially from the current file position.
+.
 The `encoding` can be any one of those accepted by [`Buffer`][].
 
 If `fd` is specified, `ReadStream` will ignore the `path` argument and will use
@@ -1639,8 +1640,8 @@ Read data from the file specified by `fd`.
 
 `length` is an integer specifying the number of bytes to read.
 
-`position` is an integer specifying where to begin reading from in the file.
-If `position` is `null`, data will be read from the current file position.
+`position` is an integer specifying where to begin reading from in the file, in this case the current file position is not updated.
+If `position` is `null`, data will be read from the current file position and the file position is updated.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 


### PR DESCRIPTION
What happen to the file position after a read using a position null or integer was not clear and you can assume that the pointer to the file position is updated even if position is an integer. close #8397

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
