### PR TITLE
clarify the position argument for fs.read

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1640,7 +1640,9 @@ Read data from the file specified by `fd`.
 `length` is an integer specifying the number of bytes to read.
 
 `position` is an integer specifying where to begin reading from in the file.
-If `position` is `null`, data will be read from the current file position.
+If `position` is `null`, data will be read from the current file position, 
+and the file position will be updated for subsequent read.
+If `position` is an integer, the file position will remain unchanged.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1641,7 +1641,7 @@ Read data from the file specified by `fd`.
 
 `position` is an integer specifying where to begin reading from in the file.
 If `position` is `null`, data will be read from the current file position, 
-and the file position will be updated for subsequent read.
+and the file position will be updated for subsequent reads.
 If `position` is an integer, the file position will remain unchanged.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.


### PR DESCRIPTION
What happen to the file position after a read using a position null or integer was not clear and you can assume that the cursor of the file descriptor is updated even if position is an integer. 
close #8397

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
