### PR TITLE
os: make EOL configurable and readonly

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -140,7 +140,6 @@ function networkInterfaces() {
 module.exports = exports = {
   arch,
   cpus,
-  EOL: isWindows ? '\r\n' : '\n',
   endianness,
   freemem: getFreeMem,
   homedir: getHomeDirectory,
@@ -162,8 +161,17 @@ module.exports = exports = {
   tmpDir: deprecate(tmpdir, tmpDirDeprecationMsg, 'DEP0022')
 };
 
-Object.defineProperty(module.exports, 'constants', {
-  configurable: false,
-  enumerable: true,
-  value: constants
+Object.defineProperties(module.exports, {
+  constants: {
+    configurable: false,
+    enumerable: true,
+    value: constants
+  },
+
+  EOL: {
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: isWindows ? '\r\n' : '\n'
+  }
 });

--- a/test/parallel/test-os-eol.js
+++ b/test/parallel/test-os-eol.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const os = require('os');
+
+const eol = common.isWindows ? '\r\n' : '\n';
+
+assert.strictEqual(os.EOL, eol);
+
+common.expectsError(function() {
+  os.EOL = 123;
+}, {
+  type: TypeError,
+  message: /^Cannot assign to read only property 'EOL' of object '#<Object>'$/
+});
+
+const foo = 'foo';
+Object.defineProperties(os, {
+  EOL: {
+    configurable: true,
+    enumerable: true,
+    writable: false,
+    value: foo
+  }
+});
+assert.strictEqual(os.EOL, foo);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/14619

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
os