### PR TITLE
benchmark: Correct constructor for freelist

### DIFF
--- a/benchmark/misc/freelist.js
+++ b/benchmark/misc/freelist.js
@@ -9,7 +9,7 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  const FreeList = require('internal/freelist').FreeList;
+  const FreeList = require('internal/freelist');
   var n = conf.n;
   var poolSize = 1000;
   var list = new FreeList('test', poolSize, Object);


### PR DESCRIPTION
Updates to use current constructor for freelist, which was changed 
under pr #12644.

While setting up core benchmark tests in jenkins, i came across this benchmark that currently is broken in master.

This fixes the benchmark (functionally).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
benchmark
