### PR TITLE
doc: clarify fs.read()

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1640,7 +1640,9 @@ Read data from the file specified by `fd`.
 `length` is an integer specifying the number of bytes to read.
 
 `position` is an integer specifying where to begin reading from in the file.
-If `position` is `null`, data will be read from the current file position.
+If `position` is `null`, data will be read from the current file position, 
+and the file position will be updated for subsequent reads.
+If `position` is an integer, the file position will remain unchanged.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1639,9 +1639,9 @@ Read data from the file specified by `fd`.
 
 `length` is an integer specifying the number of bytes to read.
 
-`position` is an integer specifying where to begin reading from in the file.
-If `position` is `null`, data will be read from the current file position, 
-and the file position will be updated for subsequent reads.
+`position` is an argument specifying where to begin reading from in the file.
+If `position` is `null`, data will be read from the current file position,
+and the file position will be updated.
 If `position` is an integer, the file position will remain unchanged.
 
 The callback is given the three arguments, `(err, bytesRead, buffer)`.


### PR DESCRIPTION
First commit (originally from #14612, closed by OP, authorship of @dcharbonnier retained in the commit, hope this isn't rude of me, this PR is just me trying to get that across the finish line):

    doc: clarify the position argument for fs.read
    
    What happen to the file position after a read using a position null or
    integer was not clear and you can assume that the cursor of the file
    descriptor is updated even if position is an integer.
    
    Fixes: https://github.com/nodejs/node/issues/8397

Second commit (implements a few of the comments from that PR):

    doc: improve fs.read() doc text

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc fs