### PR TITLE
src: properly manage timer in cares ChannelWrap

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -136,8 +136,9 @@ class ChannelWrap : public AsyncWrap {
 
   void Setup();
   void EnsureServers();
+  void CleanupTimer();
 
-  inline uv_timer_t* timer_handle() { return &timer_handle_; }
+  inline uv_timer_t* timer_handle() { return timer_handle_; }
   inline ares_channel cares_channel() { return channel_; }
   inline bool query_last_ok() const { return query_last_ok_; }
   inline void set_query_last_ok(bool ok) { query_last_ok_ = ok; }
@@ -152,7 +153,7 @@ class ChannelWrap : public AsyncWrap {
   static void AresTimeout(uv_timer_t* handle);
 
  private:
-  uv_timer_t timer_handle_;
+  uv_timer_t* timer_handle_;
   ares_channel channel_;
   bool query_last_ok_;
   bool is_servers_default_;
@@ -163,6 +164,7 @@ class ChannelWrap : public AsyncWrap {
 ChannelWrap::ChannelWrap(Environment* env,
                          Local<Object> object)
   : AsyncWrap(env, object, PROVIDER_DNSCHANNEL),
+    timer_handle_(nullptr),
     channel_(nullptr),
     query_last_ok_(true),
     is_servers_default_(true),
@@ -236,7 +238,8 @@ RB_GENERATE_STATIC(node_ares_task_list, node_ares_task, node, cmp_ares_tasks)
 /* This is called once per second by loop->timer. It is used to constantly */
 /* call back into c-ares for possibly processing timeouts. */
 void ChannelWrap::AresTimeout(uv_timer_t* handle) {
-  ChannelWrap* channel = ContainerOf(&ChannelWrap::timer_handle_, handle);
+  ChannelWrap* channel = static_cast<ChannelWrap*>(handle->data);
+  CHECK_EQ(channel->timer_handle(), handle);
   CHECK_EQ(false, RB_EMPTY(channel->task_list()));
   ares_process_fd(channel->cares_channel(), ARES_SOCKET_BAD, ARES_SOCKET_BAD);
 }
@@ -505,25 +508,29 @@ void ChannelWrap::Setup() {
 
   /* Initialize the timeout timer. The timer won't be started until the */
   /* first socket is opened. */
-  uv_timer_init(env()->event_loop(), &timer_handle_);
-  env()->RegisterHandleCleanup(
-      reinterpret_cast<uv_handle_t*>(&timer_handle_),
-      [](Environment* env, uv_handle_t* handle, void* arg) {
-        uv_close(handle, [](uv_handle_t* handle) {
-          ChannelWrap* channel = ContainerOf(
-              &ChannelWrap::timer_handle_,
-              reinterpret_cast<uv_timer_t*>(handle));
-          channel->env()->FinishHandleCleanup(handle);
-        });
-      },
-      nullptr);
+  CleanupTimer();
+  timer_handle_ = new uv_timer_t();
+  timer_handle_->data = static_cast<void*>(this);
+  uv_timer_init(env()->event_loop(), timer_handle_);
 }
 
 
 ChannelWrap::~ChannelWrap() {
   if (library_inited_)
     ares_library_cleanup();
+
   ares_destroy(channel_);
+  CleanupTimer();
+}
+
+void ChannelWrap::CleanupTimer() {
+  if (!timer_handle_) return;
+
+  uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
+           [](uv_handle_t* handle) {
+    delete reinterpret_cast<uv_timer_t*>(handle);
+  });
+  timer_handle_ = nullptr;
 }
 
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -529,7 +529,7 @@ void ChannelWrap::CleanupTimer() {
 
   uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
            [](uv_handle_t* handle) {
-    handle->data = NULL;
+    handle->data = nullptr;
     delete reinterpret_cast<uv_timer_t*>(handle);
   });
   timer_handle_ = nullptr;

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -525,7 +525,7 @@ ChannelWrap::~ChannelWrap() {
 
 
 void ChannelWrap::CleanupTimer() {
-  if (!timer_handle_) return;
+  if (timer_handle_ == nullptr) return;
 
   uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
            [](uv_handle_t* handle) {

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -523,11 +523,13 @@ ChannelWrap::~ChannelWrap() {
   CleanupTimer();
 }
 
+
 void ChannelWrap::CleanupTimer() {
   if (!timer_handle_) return;
 
   uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
            [](uv_handle_t* handle) {
+    handle->data = NULL;
     delete reinterpret_cast<uv_timer_t*>(handle);
   });
   timer_handle_ = nullptr;

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -529,7 +529,6 @@ void ChannelWrap::CleanupTimer() {
 
   uv_close(reinterpret_cast<uv_handle_t*>(timer_handle_),
            [](uv_handle_t* handle) {
-    handle->data = nullptr;
     delete reinterpret_cast<uv_timer_t*>(handle);
   });
   timer_handle_ = nullptr;


### PR DESCRIPTION
This fixes a bug introduced in 727b2911eca9f00cb7fa6a5f4ee8a73c7e9c94f0 where code managing the `uv_timer_t` for a `ChannelWrap` instance was left unchanged, when it should have changed the lifetime of the handle to being tied to the `ChannelWrap` instance’s lifetime.

Fixes: https://github.com/nodejs/node/issues/14599
Ref: https://github.com/nodejs/node/pull/14518

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (eeeeh … in the form of an existing test that was flaky)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/cares_wrap