### PR TITLE
benchmark: remove unused parameters

### DIFF
--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -34,7 +34,7 @@ if (cluster.isMaster) {
     for (var i = 0; i < workers; ++i)
       cluster.fork().on('online', onOnline).on('message', onMessage);
 
-    function onOnline(msg) {
+    function onOnline() {
       if (++readies === workers) {
         bench.start();
         broadcast();
@@ -56,7 +56,7 @@ if (cluster.isMaster) {
       }
     }
 
-    function onMessage(msg) {
+    function onMessage() {
       if (++msgCount === expectedPerBroadcast) {
         msgCount = 0;
         broadcast();


### PR DESCRIPTION
Functions onOnline and onMessage in benchmark/cluster/echo.js
had unused parameters. They were removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
