### PR TITLE
lib: remove newReturn for Module._resolveLookupPaths

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -328,10 +328,10 @@ if (process.platform === 'win32') {
 // 'index.' character codes
 var indexChars = [ 105, 110, 100, 101, 120, 46 ];
 var indexLen = indexChars.length;
-Module._resolveLookupPaths = function(request, parent, newReturn) {
+Module._resolveLookupPaths = function(request, parent) {
   if (NativeModule.nonInternalExists(request)) {
     debug('looking for %j in []', request);
-    return (newReturn ? null : [request, []]);
+    return null;
   }
 
   // Check for relative path
@@ -358,7 +358,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
     }
 
     debug('looking for %j in %j', request, paths);
-    return (newReturn ? (paths.length > 0 ? paths : null) : [request, paths]);
+    return (paths.length > 0 ? paths : null);
   }
 
   // with --eval, parent.id is not set and parent.filename is null
@@ -368,7 +368,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
     var mainPaths = ['.'].concat(Module._nodeModulePaths('.'), modulePaths);
 
     debug('looking for %j in %j', request, mainPaths);
-    return (newReturn ? mainPaths : [request, mainPaths]);
+    return mainPaths;
   }
 
   // Is the parent an index module?
@@ -420,7 +420,7 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
 
   var parentDir = [path.dirname(parent.filename)];
   debug('looking for %j in %j', id, parentDir);
-  return (newReturn ? parentDir : [id, parentDir]);
+  return parentDir;
 };
 
 
@@ -481,7 +481,7 @@ Module._resolveFilename = function(request, parent, isMain) {
     return request;
   }
 
-  var paths = Module._resolveLookupPaths(request, parent, true);
+  var paths = Module._resolveLookupPaths(request, parent);
 
   // look up the filename first, since that's the cache key.
   var filename = Module._findPath(request, paths, isMain);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -638,7 +638,7 @@ REPLServer.prototype.createContext = function() {
   }
 
   var module = new Module('<repl>');
-  module.paths = Module._resolveLookupPaths('<repl>', parentModule, true) || [];
+  module.paths = Module._resolveLookupPaths('<repl>', parentModule) || [];
 
   var require = internalModule.makeRequireFunction(module);
   context.module = module;

--- a/test/parallel/test-module-relative-lookup.js
+++ b/test/parallel/test-module-relative-lookup.js
@@ -3,13 +3,12 @@
 require('../common');
 const assert = require('assert');
 const _module = require('module'); // avoid collision with global.module
-const lookupResults = _module._resolveLookupPaths('./lodash');
-let paths = lookupResults[1];
+let paths = _module._resolveLookupPaths('./lodash', null);
 
 assert.strictEqual(paths[0], '.',
                    'Current directory gets highest priority for local modules');
 
-paths = _module._resolveLookupPaths('./lodash', null, true);
+paths = _module._resolveLookupPaths('./lodash', null);
 
 assert.strictEqual(paths && paths[0], '.',
                    'Current directory gets highest priority for local modules');


### PR DESCRIPTION
The method Module._resolveLookupPaths's third parameter retNew
is always true.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
