### PR TITLE
console: coerce label to string in console.time()

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -321,7 +321,7 @@ See [`util.format()`][] for more information.
 <!-- YAML
 added: v0.1.104
 -->
-* `label` {string}
+* `label` {string} Defaults to `'default'`.
 
 Starts a timer that can be used to compute the duration of an operation. Timers
 are identified by a unique `label`. Use the same `label` when calling
@@ -337,7 +337,7 @@ changes:
     description: This method no longer supports multiple calls that don’t map
                  to individual `console.time()` calls; see below for details.
 -->
-* `label` {string}
+* `label` {string} Defaults to `'default'`.
 
 Stops a timer that was previously started by calling [`console.time()`][] and
 prints the result to `stdout`:

--- a/lib/console.js
+++ b/lib/console.js
@@ -140,11 +140,13 @@ Console.prototype.dir = function dir(object, options) {
 
 
 Console.prototype.time = function time(label) {
+  label = `${label}`;
   this._times.set(label, process.hrtime());
 };
 
 
 Console.prototype.timeEnd = function timeEnd(label) {
+  label = `${label}`;
   const time = this._times.get(label);
   if (!time) {
     process.emitWarning(`No such label '${label}' for console.timeEnd()`);

--- a/lib/console.js
+++ b/lib/console.js
@@ -139,13 +139,13 @@ Console.prototype.dir = function dir(object, options) {
 };
 
 
-Console.prototype.time = function time(label) {
+Console.prototype.time = function time(label = 'default') {
   label = `${label}`;
   this._times.set(label, process.hrtime());
 };
 
 
-Console.prototype.timeEnd = function timeEnd(label) {
+Console.prototype.timeEnd = function timeEnd(label = 'default') {
   label = `${label}`;
   const time = this._times.get(label);
   if (!time) {

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -42,6 +42,12 @@ assert.doesNotThrow(function() {
   console.timeEnd('label');
 });
 
+assert.throws(() => console.time(Symbol('test')),
+              /^TypeError: Cannot convert a Symbol value to a string$/);
+assert.throws(() => console.timeEnd(Symbol('test')),
+              /^TypeError: Cannot convert a Symbol value to a string$/);
+
+
 // an Object with a custom .inspect() function
 const custom_inspect = { foo: 'bar', inspect: () => 'inspect' };
 
@@ -102,6 +108,18 @@ console.time('constructor');
 console.timeEnd('constructor');
 console.time('hasOwnProperty');
 console.timeEnd('hasOwnProperty');
+
+// verify that values are coerced to strings
+console.time([]);
+console.timeEnd([]);
+console.time({});
+console.timeEnd({});
+console.time(null);
+console.timeEnd(null);
+console.time(undefined);
+console.timeEnd(undefined);
+console.time(NaN);
+console.timeEnd(NaN);
 
 assert.strictEqual(strings.length, process.stdout.writeTimes);
 assert.strictEqual(errStrings.length, process.stderr.writeTimes);

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -117,7 +117,9 @@ console.timeEnd({});
 console.time(null);
 console.timeEnd(null);
 console.time(undefined);
-console.timeEnd(undefined);
+console.timeEnd('default');
+console.time('default');
+console.timeEnd();
 console.time(NaN);
 console.timeEnd(NaN);
 


### PR DESCRIPTION
Per the console [spec](https://console.spec.whatwg.org/#time), the label in console.time() is a string. Change is made for consistency with browser behavior.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console