### PR TITLE
lib: consistent `this` in callbacks

### DIFF
--- a/benchmark/process/next-tick-breadth-args.js
+++ b/benchmark/process/next-tick-breadth-args.js
@@ -24,10 +24,17 @@ function main(conf) {
     if (n === N)
       bench.end(n / 1e6);
   }
+  function cb4(arg1, arg2, arg3, arg4) {
+    n++;
+    if (n === N)
+      bench.end(n / 1e6);
+  }
 
   bench.start();
   for (var i = 0; i < N; i++) {
-    if (i % 3 === 0)
+    if (i % 4 === 0)
+      process.nextTick(cb4, 3.14, 1024, true, false);
+    else if (i % 3 === 0)
       process.nextTick(cb3, 512, true, null);
     else if (i % 2 === 0)
       process.nextTick(cb2, false, 5.1);

--- a/benchmark/process/next-tick-depth-args.js
+++ b/benchmark/process/next-tick-depth-args.js
@@ -10,9 +10,24 @@ process.maxTickDepth = Infinity;
 function main(conf) {
   var n = +conf.millions * 1e6;
 
+  function cb4(arg1, arg2, arg3, arg4) {
+    if (--n) {
+      if (n % 4 === 0)
+        process.nextTick(cb4, 3.14, 1024, true, false);
+      else if (n % 3 === 0)
+        process.nextTick(cb3, 512, true, null);
+      else if (n % 2 === 0)
+        process.nextTick(cb2, false, 5.1);
+      else
+        process.nextTick(cb1, 0);
+    } else
+      bench.end(+conf.millions);
+  }
   function cb3(arg1, arg2, arg3) {
     if (--n) {
-      if (n % 3 === 0)
+      if (n % 4 === 0)
+        process.nextTick(cb4, 3.14, 1024, true, false);
+      else if (n % 3 === 0)
         process.nextTick(cb3, 512, true, null);
       else if (n % 2 === 0)
         process.nextTick(cb2, false, 5.1);
@@ -23,7 +38,9 @@ function main(conf) {
   }
   function cb2(arg1, arg2) {
     if (--n) {
-      if (n % 3 === 0)
+      if (n % 4 === 0)
+        process.nextTick(cb4, 3.14, 1024, true, false);
+      else if (n % 3 === 0)
         process.nextTick(cb3, 512, true, null);
       else if (n % 2 === 0)
         process.nextTick(cb2, false, 5.1);
@@ -34,7 +51,9 @@ function main(conf) {
   }
   function cb1(arg1) {
     if (--n) {
-      if (n % 3 === 0)
+      if (n % 4 === 0)
+        process.nextTick(cb4, 3.14, 1024, true, false);
+      else if (n % 3 === 0)
         process.nextTick(cb3, 512, true, null);
       else if (n % 2 === 0)
         process.nextTick(cb2, false, 5.1);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -132,7 +132,7 @@ function makeCallback(cb) {
   }
 
   return function() {
-    return cb.apply(null, arguments);
+    return cb.apply(undefined, arguments);
   };
 }
 

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -141,7 +141,7 @@ function setupNextTick() {
           callback(args[0], args[1], args[2]);
           break;
         default:
-          callback.apply(null, args);
+          callback(...args);
       }
     }
   }

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -20,7 +20,7 @@ assert(common.fileExists(utf8));
 function handler(err, folder) {
   assert.ifError(err);
   assert(common.fileExists(folder));
-  assert.strictEqual(this, null);
+  assert.strictEqual(this, undefined);
 }
 
 fs.mkdtemp(path.join(common.tmpDir, 'bar.'), common.mustCall(handler));

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -66,7 +66,7 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
   // Confirm that we are not running in the context of the internal binding
   // layer.
   // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
-  assert.strictEqual(this, null);
+  assert.strictEqual(this, undefined);
 }));
 
 // fstatSync

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -19,15 +19,19 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/* eslint-disable strict */
+'use strict';
 const common = require('../common');
+
 const assert = require('assert');
 const fs = require('fs');
 
 fs.stat('.', common.mustCall(function(err, stats) {
   assert.ifError(err);
   assert.ok(stats.mtime instanceof Date);
-  assert.strictEqual(this, global);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
 }));
 
 fs.stat('.', common.mustCall(function(err, stats) {
@@ -38,22 +42,31 @@ fs.stat('.', common.mustCall(function(err, stats) {
 fs.lstat('.', common.mustCall(function(err, stats) {
   assert.ifError(err);
   assert.ok(stats.mtime instanceof Date);
-  assert.strictEqual(this, global);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, undefined);
 }));
 
 // fstat
 fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
-  assert.ok(!err);
+  assert.ifError(err);
   assert.ok(fd);
 
   fs.fstat(fd, common.mustCall(function(err, stats) {
     assert.ifError(err);
     assert.ok(stats.mtime instanceof Date);
     fs.close(fd, assert.ifError);
-    assert.strictEqual(this, global);
+    // Confirm that we are not running in the context of the internal binding
+    // layer.
+    // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+    assert.strictEqual(this, undefined);
   }));
 
-  assert.strictEqual(this, global);
+  // Confirm that we are not running in the context of the internal binding
+  // layer.
+  // Ref: https://github.com/nodejs/node/commit/463d6bac8b349acc462d345a6e298a76f7d06fb1
+  assert.strictEqual(this, null);
 }));
 
 // fstatSync
@@ -72,13 +85,13 @@ fs.open('.', 'r', undefined, common.mustCall(function(err, fd) {
 
 fs.stat(__filename, common.mustCall(function(err, s) {
   assert.ifError(err);
-  assert.strictEqual(false, s.isDirectory());
-  assert.strictEqual(true, s.isFile());
-  assert.strictEqual(false, s.isSocket());
-  assert.strictEqual(false, s.isBlockDevice());
-  assert.strictEqual(false, s.isCharacterDevice());
-  assert.strictEqual(false, s.isFIFO());
-  assert.strictEqual(false, s.isSymbolicLink());
+  assert.strictEqual(s.isDirectory(), false);
+  assert.strictEqual(s.isFile(), true);
+  assert.strictEqual(s.isSocket(), false);
+  assert.strictEqual(s.isBlockDevice(), false);
+  assert.strictEqual(s.isCharacterDevice(), false);
+  assert.strictEqual(s.isFIFO(), false);
+  assert.strictEqual(s.isSymbolicLink(), false);
   const keys = [
     'dev', 'mode', 'nlink', 'uid',
     'gid', 'rdev', 'ino', 'size',

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -51,7 +51,7 @@ process.nextTick((a, b) => {
 }, 42, obj);
 
 process.nextTick(function() {
-  assert.strictEqual(this, null);
+  assert.strictEqual(this, undefined);
 }, 1, 2, 3, 4);
 
 process.nextTick(() => {

--- a/test/parallel/test-next-tick.js
+++ b/test/parallel/test-next-tick.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+
 const assert = require('assert');
 
 process.nextTick(common.mustCall(function() {
@@ -40,7 +41,22 @@ const obj = {};
 process.nextTick(function(a, b) {
   assert.strictEqual(a, 42);
   assert.strictEqual(b, obj);
+  assert.strictEqual(this, undefined);
 }, 42, obj);
+
+process.nextTick((a, b) => {
+  assert.strictEqual(a, 42);
+  assert.strictEqual(b, obj);
+  assert.deepStrictEqual(this, {});
+}, 42, obj);
+
+process.nextTick(function() {
+  assert.strictEqual(this, null);
+}, 1, 2, 3, 4);
+
+process.nextTick(() => {
+  assert.deepStrictEqual(this, {});
+}, 1, 2, 3, 4);
 
 process.on('exit', function() {
   process.nextTick(common.mustNotCall());


### PR DESCRIPTION
This change normalizes a few situations where a callback might be invoked with `this` set to `undefined` in one case, but `null` in a very similar case.

First commit:

    test: refactor test-fs-stat
    
    * add `use strict'
    * change checks that `this` is mapped to `global` in sloppy mode to
      checks that `this` is `undefined`
    * modify arguments to assertions to match docs (actual first, expected
      second)
    * add blank line below `common` declaration per test writing guide
    * use `assert.ifError()` as appropriate

Second commit:

    fs: invoke callbacks with undefined context
    
    Many callbacks appear to be invoked with `this` set to `undefined`
    including `fs.stat()`, `fs.lstat()`, and `fs.fstat()`.
    
    However, some such as `fs.open()` and `fs.mkdtemp()` invoke their
    callbacks with `this` set to `null`.
    
    Use a consistent way to invoke callbacks to guarantee consistency.

Third commit:

    test: check `this` value for `nextTick()`
    
    Depending on how many arguments are provided, `nextTick()` may run its
    callback with `this` set to `null` or not. Add assertions for
    both cases.

Fourth commit:

    process: make `this` value consistent
    
    The value of `this` for callbacks of `nextTick()` can vary depending on
    the number of arguments. Make it consistent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test process lib fs