### PR TITLE
test: fix hijackStdout behavior in console

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -803,10 +803,8 @@ function hijackStdWritable(name, listener) {
   stream.write = function(data, callback) {
     try {
       listener(data);
-    } catch(e) {
-      process.nextTick(function() {
-        throw e;
-      });
+    } catch (e) {
+      process.nextTick(() => { throw e; });
     }
 
     _write.call(stream, data, callback);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -801,7 +801,14 @@ function hijackStdWritable(name, listener) {
 
   stream.writeTimes = 0;
   stream.write = function(data, callback) {
-    listener(data);
+    try {
+      listener(data);
+    } catch(e) {
+      process.nextTick(function() {
+        throw e;
+      });
+    }
+
     _write.call(stream, data, callback);
     stream.writeTimes++;
   };

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -125,6 +125,7 @@ const HIJACK_TEST_ARRAY = [ 'foo\n', 'bar\n', 'baz\n' ];
 
 let uncaughtTimes = 0;
 process.on('uncaughtException', common.mustCallAtLeast(function(e) {
+  assert.strictEqual(uncaughtTimes < 2, true);
   assert.strictEqual(e instanceof Error, true);
   assert.strictEqual(
     e.message,

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -111,20 +111,22 @@ const HIJACK_TEST_ARRAY = [ 'foo\n', 'bar\n', 'baz\n' ];
 
 // hijackStderr and hijackStdout again
 // for console
-[ 'err', 'out' ].forEach((txt) => {
-  common[`hijackStd${txt}`](common.mustCall(function(data) {
+[[ 'err', 'error' ], [ 'out', 'log' ]].forEach(([ type, method ]) => {
+  common[`hijackStd${type}`](common.mustCall(function(data) {
     assert.strictEqual(data, 'test\n');
 
     // throw an error
-    throw new Error(`console ${txt} error`);
+    throw new Error(`console ${type} error`);
   }));
 
-  console[txt === 'err' ? 'error' : 'log']('test');
-  common[`restoreStd${txt}`]();
+  console[method]('test');
+  common[`restoreStd${type}`]();
 });
 
 let uncaughtTimes = 0;
 process.on('uncaughtException', common.mustCallAtLeast(function(e) {
   assert.strictEqual(e instanceof Error, true);
-  assert.strictEqual(e.message, `console ${([ 'err', 'out' ])[uncaughtTimes++]} error`);
+  assert.strictEqual(
+    e.message,
+    `console ${([ 'err', 'out' ])[uncaughtTimes++]} error`);
 }, 2));


### PR DESCRIPTION
`console.log` and some other function will swallow the exception in `stdout.write`. So an asynchronous exception is needed, or `common.hijackStdout` won't detect some exception.

Refs: https://github.com/nodejs/node/blob/v8.2.1/lib/console.js#L87

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test`
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test