### PR TITLE
test: add crypto check to http2 tests

### DIFF
--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -1,7 +1,9 @@
 // Flags: --expose-http2
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 
 assert.doesNotThrow(() => process.binding('http2'));

--- a/test/parallel/test-http2-client-data-end.js
+++ b/test/parallel/test-http2-client-data-end.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-client-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-destroy-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-client-destroy-before-request.js
+++ b/test/parallel/test-http2-client-destroy-before-request.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-client-priority-before-connect.js
+++ b/test/parallel/test-http2-client-priority-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-client-shutdown-before-connect.js
+++ b/test/parallel/test-http2-client-shutdown-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-client-socket-destroy.js
+++ b/test/parallel/test-http2-client-socket-destroy.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 const body =
   '<html><head></head><body><h1>this is some data</h2></body></html>';

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 const NGHTTP2_INTERNAL_ERROR = h2.constants.NGHTTP2_INTERNAL_ERROR;

--- a/test/parallel/test-http2-client-unescaped-path.js
+++ b/test/parallel/test-http2-client-unescaped-path.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -4,6 +4,8 @@
 // Verifies that uploading data from a client works
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 const fs = require('fs');

--- a/test/parallel/test-http2-client-write-before-connect.js
+++ b/test/parallel/test-http2-client-write-before-connect.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 const net = require('net');

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,7 +1,9 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall, mustNotCall } = require('../common');
+const { mustCall, mustNotCall, hasCrypto, skip } = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
 const { strictEqual } = require('assert');
 const {
   createServer,

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-trailers.js
+++ b/test/parallel/test-http2-compat-serverresponse-trailers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
+++ b/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
@@ -1,7 +1,12 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall, mustNotCall, expectsError } = require('../common');
+const { mustCall,
+        mustNotCall,
+        expectsError,
+        hasCrypto, skip } = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
 const { throws } = require('assert');
 const { createServer, connect } = require('http2');
 

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const net = require('net');
 const http2 = require('http2');

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -1,7 +1,9 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall } = require('../common');
+const { mustCall, hasCrypto, skip } = require('../common');
+if (!hasCrypto)
+  skip('missing crypto');
 const { doesNotThrow } = require('assert');
 const { createServer, connect } = require('http2');
 

--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -4,6 +4,8 @@
 // Tests http2.connect()
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const fs = require('fs');
 const h2 = require('http2');
 const path = require('path');

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 const body =

--- a/test/parallel/test-http2-date-header.js
+++ b/test/parallel/test-http2-date-header.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-dont-override.js
+++ b/test/parallel/test-http2-dont-override.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-head-request.js
+++ b/test/parallel/test-http2-head-request.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-methods.js
+++ b/test/parallel/test-http2-methods.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-misused-pseudoheaders.js
+++ b/test/parallel/test-http2-misused-pseudoheaders.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-multi-content-length.js
+++ b/test/parallel/test-http2-multi-content-length.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-multiplex.js
+++ b/test/parallel/test-http2-multiplex.js
@@ -5,6 +5,8 @@
 // connection and makes sure that the data for each is appropriately echoed.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-padding-callback.js
+++ b/test/parallel/test-http2-padding-callback.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 const { PADDING_STRATEGY_CALLBACK } = h2.constants;

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-compat.js
+++ b/test/parallel/test-http2-respond-file-compat.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const path = require('path');
 

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 

--- a/test/parallel/test-http2-respond-file-fd-range.js
+++ b/test/parallel/test-http2-respond-file-fd-range.js
@@ -4,6 +4,8 @@
 // Tests the ability to minimally request a byte range with respondWithFD
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-fd.js
+++ b/test/parallel/test-http2-respond-file-fd.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-push.js
+++ b/test/parallel/test-http2-respond-file-push.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file-range.js
+++ b/test/parallel/test-http2-respond-file-range.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');

--- a/test/parallel/test-http2-response-splitting.js
+++ b/test/parallel/test-http2-response-splitting.js
@@ -6,6 +6,8 @@
 // contain invalid characters.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 const { URL } = require('url');

--- a/test/parallel/test-http2-server-destroy-before-additional.js
+++ b/test/parallel/test-http2-server-destroy-before-additional.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-server-destroy-before-push.js
+++ b/test/parallel/test-http2-server-destroy-before-push.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-server-destroy-before-respond.js
+++ b/test/parallel/test-http2-server-destroy-before-respond.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-server-destroy-before-write.js
+++ b/test/parallel/test-http2-server-destroy-before-write.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-server-push-disabled.js
+++ b/test/parallel/test-http2-server-push-disabled.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 const body =

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-server-socket-destroy.js
+++ b/test/parallel/test-http2-server-socket-destroy.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 const assert = require('assert');
 

--- a/test/parallel/test-http2-server-socketerror.js
+++ b/test/parallel/test-http2-server-socketerror.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-server-timeout.js
+++ b/test/parallel/test-http2-server-timeout.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-session-stream-state.js
+++ b/test/parallel/test-http2-session-stream-state.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-single-headers.js
+++ b/test/parallel/test-http2-single-headers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const http2 = require('http2');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-status-code-invalid.js
+++ b/test/parallel/test-http2-status-code-invalid.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-status-code.js
+++ b/test/parallel/test-http2-status-code.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const h2 = require('http2');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -5,6 +5,8 @@
 // settings frames will result in a throw.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-trailers.js
+++ b/test/parallel/test-http2-trailers.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 const body =

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -7,6 +7,8 @@
 // on smaller / IoT platforms in case this poses problems for these targets.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
 

--- a/test/parallel/test-http2-withflag.js
+++ b/test/parallel/test-http2-withflag.js
@@ -1,7 +1,9 @@
 // Flags: --expose-http2
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 
 assert.doesNotThrow(() => require('http2'));

--- a/test/parallel/test-http2-write-callbacks.js
+++ b/test/parallel/test-http2-write-callbacks.js
@@ -4,6 +4,8 @@
 // Verifies that write callbacks are called
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-write-empty-string.js
+++ b/test/parallel/test-http2-write-empty-string.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 

--- a/test/parallel/test-http2-zero-length-write.js
+++ b/test/parallel/test-http2-zero-length-write.js
@@ -2,6 +2,8 @@
 'use strict';
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const http2 = require('http2');
 


### PR DESCRIPTION
When building `--without-ssl` and running the tests some of the http2 test
fail with the following error message:
```console
internal/util.js:82
    throw new errors.Error('ERR_NO_CRYPTO');
    ^

Error [ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto
support
    at Object.assertCrypto (internal/util.js:82:11)
    at internal/http2/core.js:5:26
    at NativeModule.compile (bootstrap_node.js:586:7)
    at NativeModule.require (bootstrap_node.js:531:18)
    at http2.js:17:5
    at NativeModule.compile (bootstrap_node.js:586:7)
    at Function.NativeModule.require (bootstrap_node.js:531:18)
    at Function.Module._load (module.js:449:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
```
This commit adds hasCrypto checks and skips the tests if there is no
crypto support.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, http2