### PR TITLE
timers: Migrate to use internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1141,6 +1141,11 @@ are most likely an indication of a bug within Node.js itself.
 Used when the V8 BreakIterator API is used but the full ICU data set is not
 installed.
 
+<a id="ERR_VALUE_OUT_OF_RANGE"></a>
+### ERR_VALUE_OUT_OF_RANGE
+
+Used when a given value is out of the accepted range.
+
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`subprocess.kill()`]: child_process.html#child_process_subprocess_kill_signal
 [`subprocess.send()`]: child_process.html#child_process_subprocess_send_message_sendhandle_options_callback

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -269,6 +269,7 @@ E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required');
+E('ERR_VALUE_OUT_OF_RANGE', 'The value of "%s" must be %s. Received "%s"');
 
 function invalidArgType(name, expected, actual) {
   assert(name, 'name is required');

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -29,6 +29,7 @@ const { createPromise, promiseResolve } = process.binding('util');
 const async_hooks = require('async_hooks');
 const assert = require('assert');
 const util = require('util');
+const errors = require('internal/errors');
 const debug = util.debuglog('timer');
 const kOnTimeout = TimerWrap.kOnTimeout | 0;
 const initTriggerId = async_hooks.initTriggerId;
@@ -389,12 +390,13 @@ const unenroll = exports.unenroll = function(item) {
 // Using existing objects as timers slightly reduces object overhead.
 exports.enroll = function(item, msecs) {
   if (typeof msecs !== 'number') {
-    throw new TypeError('"msecs" argument must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'msecs',
+                               'number', msecs);
   }
 
   if (msecs < 0 || !isFinite(msecs)) {
-    throw new RangeError('"msecs" argument must be ' +
-                         'a non-negative finite number');
+    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE', 'msecs',
+                                'a non-negative finite number', msecs);
   }
 
   // if this item was already in a list somewhere
@@ -418,7 +420,7 @@ exports.enroll = function(item, msecs) {
 
 function setTimeout(callback, after, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var len = arguments.length;
@@ -515,7 +517,7 @@ const clearTimeout = exports.clearTimeout = function(timer) {
 
 exports.setInterval = function(callback, repeat, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var len = arguments.length;
@@ -810,7 +812,7 @@ function Immediate() {
 
 function setImmediate(callback, arg1, arg2, arg3) {
   if (typeof callback !== 'function') {
-    throw new TypeError('"callback" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   var i, args;

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -257,6 +257,11 @@ assert.strictEqual(
 );
 
 assert.strictEqual(
+  errors.message('ERR_VALUE_OUT_OF_RANGE', ['A', 'some values', 'B']),
+  'The value of "A" must be some values. Received "B"'
+);
+
+assert.strictEqual(
   errors.message('ERR_UNESCAPED_CHARACTERS', ['Request path']),
   'Request path contains unescaped characters'
 );

--- a/test/parallel/test-timers-enroll-invalid-msecs.js
+++ b/test/parallel/test-timers-enroll-invalid-msecs.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const common = require('../common');
+const timers = require('timers');
+const assert = require('assert');
+
+[
+  {},
+  [],
+  'foo',
+  () => { },
+  Symbol('foo')
+].forEach((val) => {
+  assert.throws(
+    () => timers.enroll({}, val),
+    common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    })
+  );
+});
+
+[
+  -1,
+  Infinity,
+  NaN
+].forEach((val) => {
+  assert.throws(
+    () => timers.enroll({}, val),
+    common.expectsError({
+      code: 'ERR_VALUE_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The value of "msecs" must be a non-negative ' +
+               `finite number. Received "${val}"`
+    })
+  );
+});

--- a/test/parallel/test-timers-throw-when-cb-not-function.js
+++ b/test/parallel/test-timers-throw-when-cb-not-function.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 function doSetTimeout(callback, after) {
@@ -8,7 +8,10 @@ function doSetTimeout(callback, after) {
   };
 }
 
-const errMessage = /"callback" argument must be a function/;
+const errMessage = common.expectsError({
+  code: 'ERR_INVALID_CALLBACK',
+  type: TypeError
+}, 18);
 
 assert.throws(doSetTimeout('foo'), errMessage);
 assert.throws(doSetTimeout({ foo: 'bar' }), errMessage);


### PR DESCRIPTION
ref: https://github.com/nodejs/node/issues/11273

Migrate the `timers` module to use `internal/errors`. And some tests are added for `timers.enroll()`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers, test, errors