### PR TITLE
test: add known issue for vm module

### DIFF
--- a/test/known_issues/test-vm-strict-mode.js
+++ b/test/known_issues/test-vm-strict-mode.js
@@ -1,0 +1,17 @@
+'use strict';
+// https://github.com/nodejs/node/issues/12300
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const ctx = vm.createContext({ x: 42 });
+
+// The following line wrongly throws an 
+// error because GlobalPropertySetterCallback()
+// does not check if the property exists
+// on the sandbox. It should just set x to 1
+// instead of throwing an error.
+vm.runInContext('"use strict"; x = 1', ctx);
+
+assert.strictEqual(ctx.x, 1);


### PR DESCRIPTION
GlobalPropertySetterCallback() does not check the
property on the sandbox. It wrongly throws an error
instead of updating `x`.

Since we can't fix this at the moment, I'm adding a known issue at least.

Refs: https://github.com/nodejs/node/issues/12300

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
