### PR TITLE
module: remove unnecessary nonInternalExists check

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -352,11 +352,6 @@ if (process.platform === 'win32') {
 var indexChars = [ 105, 110, 100, 101, 120, 46 ];
 var indexLen = indexChars.length;
 Module._resolveLookupPaths = function(request, parent, newReturn) {
-  if (NativeModule.nonInternalExists(request)) {
-    debug('looking for %j in []', request);
-    return (newReturn ? null : [request, []]);
-  }
-
   // Check for relative path
   if (request.length < 2 ||
       request.charCodeAt(0) !== 46/*.*/ ||


### PR DESCRIPTION
The NativeModule.nonInternalExists(request) is unnecessary in
Module._resolveLookupPaths(), because the check is pre-exist in
Module._resolveFilename()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
module