### PR TITLE
zlib: fix crash when initializing failed

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -557,6 +557,7 @@ class ZCtx : public AsyncWrap {
         delete[] dictionary;
         ctx->dictionary_ = nullptr;
       }
+      ctx->mode_ = NONE;
       ctx->env()->ThrowError("Init error");
     }
 


### PR DESCRIPTION
Unset `mode_` when initializing the zlib stream failed, so that we don’t try to call the zlib end functions (`deflateEnd()` etc.) when cleaning up in `ZCtx::Close()`.

Fixes: https://github.com/nodejs/node/issues/14178
Ref: https://github.com/nodejs/node/pull/13098

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/zlib