### PR TITLE
doc: explanation for browser support of HTTP/2

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -39,10 +39,10 @@ server.on('stream', (stream, headers) => {
 server.listen(80);
 ```
 
-Note that this is an HTTP server and does not support HTTPS.
-This is significant as most browsers support HTTP/2 only on HTTPS.
-To make the above server available for browsers, replace `http2.createServer()`
-with
+Note that the above example is an HTTP/2 server that does not support SSL.
+This is significant as most browsers support HTTP/2 only with SSL.
+To make the above server be able to serve content to browsers,
+replace `http2.createServer()` with
 `http2.createSecureServer({key: /* your SSL key */, cert: /* your SSL cert */})`.
 
 The following illustrates an HTTP/2 client:

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -39,6 +39,12 @@ server.on('stream', (stream, headers) => {
 server.listen(80);
 ```
 
+Note that this is an HTTP server and does not support HTTPS.
+This is significant as most browsers support HTTP/2 only on HTTPS.
+To make the above server available for browsers, replace `http2.createServer()`
+with
+`http2.createSecureServer({key: /* your SSL key */, cert: /* your SSL cert */})`.
+
 The following illustrates an HTTP/2 client:
 
 ```js


### PR DESCRIPTION
Since browsers support HTTP/2 only using SSL, the basic example
given in the docs won't work if the client is a browser.

Added a note in `http2` documentation explaining this and how to change
the code to make browser support it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
