### PR TITLE
zlib: check cleanup return values

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -111,16 +111,18 @@ class ZCtx : public AsyncWrap {
     CHECK(init_done_ && "close before init");
     CHECK_LE(mode_, UNZIP);
 
+    int status = Z_OK;
     if (mode_ == DEFLATE || mode_ == GZIP || mode_ == DEFLATERAW) {
-      (void)deflateEnd(&strm_);
+      status = deflateEnd(&strm_);
       int64_t change_in_bytes = -static_cast<int64_t>(kDeflateContextSize);
       env()->isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
     } else if (mode_ == INFLATE || mode_ == GUNZIP || mode_ == INFLATERAW ||
                mode_ == UNZIP) {
-      (void)inflateEnd(&strm_);
+      status = inflateEnd(&strm_);
       int64_t change_in_bytes = -static_cast<int64_t>(kInflateContextSize);
       env()->isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
     }
+    CHECK(status == Z_OK || status == Z_DATA_ERROR);
     mode_ = NONE;
 
     if (dictionary_ != nullptr) {


### PR DESCRIPTION
Tests seem to always pass without #14666, so unfortunately can’t be used as a test for that, but it should still be worth doing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

zlib