### PR TITLE
test: fix test-readline-interface short delay

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -331,8 +331,8 @@ function isWarned(emitter) {
   // over the default crlfDelay but within the setting value
   {
     const fi = new FakeInput();
-    const delay = 200;
-    const crlfDelay = 500;
+    const delay = common.platformTimeout(125);
+    const crlfDelay = common.platformTimeout(1000);
     const rli = new readline.Interface({
       input: fi,
       output: fi,

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -331,7 +331,7 @@ function isWarned(emitter) {
   // over the default crlfDelay but within the setting value
   {
     const fi = new FakeInput();
-    const delay = common.platformTimeout(125);
+    const delay = 125;
     const crlfDelay = common.platformTimeout(1000);
     const rli = new readline.Interface({
       input: fi,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
Previous unit test delay is too short for parallel test on raspberry pi, it will fail sometimes.
This PR use `common.platformTimeout` and widen the time gap, a patch of https://github.com/nodejs/node/pull/13497

Refs: https://github.com/nodejs/node/issues/14674
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline
* test-readline-interface