### PR TITLE
string_decoder: Migrate to use internal/errors

### DIFF
--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -23,6 +23,7 @@
 
 const Buffer = require('buffer').Buffer;
 const internalUtil = require('internal/util');
+const errors = require('internal/errors');
 const isEncoding = Buffer[internalUtil.kIsEncodingSymbol];
 
 // Do not cache `Buffer.isEncoding` when checking encoding names as some
@@ -31,7 +32,7 @@ function normalizeEncoding(enc) {
   const nenc = internalUtil.normalizeEncoding(enc);
   if (typeof nenc !== 'string' &&
       (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc)))
-    throw new Error(`Unknown encoding: ${enc}`);
+    throw new errors.TypeError('ERR_UNKNOWN_ENCODING', enc);
   return nenc || enc;
 }
 

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const inspect = require('util').inspect;
 const StringDecoder = require('string_decoder').StringDecoder;
@@ -124,13 +124,23 @@ assert.strictEqual(decoder.write(Buffer.from('3DD8', 'hex')), '');
 assert.strictEqual(decoder.write(Buffer.from('4D', 'hex')), '');
 assert.strictEqual(decoder.end(), '\ud83d');
 
-assert.throws(() => {
-  new StringDecoder(1);
-}, /^Error: Unknown encoding: 1$/);
+common.expectsError(
+  () => new StringDecoder(1),
+  {
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: 1'
+  }
+);
 
-assert.throws(() => {
-  new StringDecoder('test');
-}, /^Error: Unknown encoding: test$/);
+common.expectsError(
+  () => new StringDecoder('test'),
+  {
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: test'
+  }
+);
 
 // test verifies that StringDecoder will correctly decode the given input
 // buffer with the given encoding to the expected output. It will attempt all


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/11273

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
string_decoder
