### PR TITLE
lib: remove commented out checks

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -156,11 +156,6 @@ function setupNextTick() {
         const callback = tock.callback;
         const args = tock.args;
 
-        // CHECK(Number.isSafeInteger(tock[async_id_symbol]))
-        // CHECK(tock[async_id_symbol] > 0)
-        // CHECK(Number.isSafeInteger(tock[trigger_id_symbol]))
-        // CHECK(tock[trigger_id_symbol] > 0)
-
         emitBefore(tock[async_id_symbol], tock[trigger_id_symbol]);
         // emitDestroy() places the async_id_symbol into an asynchronous queue
         // that calls the destroy callback in the future. It's called before
@@ -200,11 +195,6 @@ function setupNextTick() {
         const args = tock.args;
         if (domain)
           domain.enter();
-
-        // CHECK(Number.isSafeInteger(tock[async_id_symbol]))
-        // CHECK(tock[async_id_symbol] > 0)
-        // CHECK(Number.isSafeInteger(tock[trigger_id_symbol]))
-        // CHECK(tock[trigger_id_symbol] > 0)
 
         emitBefore(tock[async_id_symbol], tock[trigger_id_symbol]);
         // TODO(trevnorris): See comment in _tickCallback() as to why this
@@ -275,8 +265,6 @@ function setupNextTick() {
   function internalNextTick(triggerAsyncId, callback) {
     if (typeof callback !== 'function')
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
-    // CHECK(Number.isSafeInteger(triggerAsyncId) || triggerAsyncId === null)
-    // CHECK(triggerAsyncId > 0 || triggerAsyncId === null)
 
     if (process._exiting)
       return;


### PR DESCRIPTION
There are a number of checks in next_tick.js that are commented out and
I was not sure if this was intentional or not. Just bringing this up in
case this was overlooked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib