### PR TITLE
test: use dynamic port in test-tls-connect.js

### DIFF
--- a/test/parallel/test-tls-connect.js
+++ b/test/parallel/test-tls-connect.js
@@ -35,7 +35,7 @@ const path = require('path');
   const cert = fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'));
   const key = fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem'));
 
-  const options = { cert: cert, key: key, port: common.PORT };
+  const options = { cert: cert, key: key, port: 0 };
   const conn = tls.connect(options, common.mustNotCall());
 
   conn.on('error', common.mustCall());
@@ -49,7 +49,7 @@ const path = require('path');
   const conn = tls.connect({
     cert: cert,
     key: key,
-    port: common.PORT,
+    port: 0,
     ciphers: 'rick-128-roll'
   }, common.mustNotCall());
 


### PR DESCRIPTION
Usage of common.PORT in parallel tests is not completely safe

Change common.PORT to dynamic port to prevent collision
with other parallel test which use common.PORT

Refs: [#12376](https://github.com/nodejs/node/issues/12376)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test