### PR TITLE
http: docs deprecation of 418 teapot status

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -660,6 +660,19 @@ Type: Runtime
 
 `REPLServer.parseREPLKeyword()` was removed from userland visibility.
 
+<a id="DEP00XX"></a>
+#### DEP00XX: HTTP 418 I'm a teapot Status
+
+Type: Documentation-only
+
+The HTTP `418 I'm a teapot` status code was defined in [RFC2324][] as an
+April Fools joke to illustrate the ways in which the HTTP protocol can be
+misused. The status code is not registered in the [IANA HTTP Status Codes][]
+registry and *may* be registered in the future for purposes other than those
+described in [RFC2324][].
+
+*Note*: This deprecation applies *only* to the use of the `418` status code
+to identify the [RFC2324][] defined `I'm a teapot` response semantics.
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
@@ -691,6 +704,7 @@ Type: Runtime
 [`os.networkInterfaces`]: os.html#os_os_networkinterfaces
 [`os.tmpdir()`]: os.html#os_os_tmpdir
 [`punycode`]: punycode.html
+[`REPLServer.clearBufferedCommand()`]: repl.html#repl_replserver_clearbufferedcommand
 [`require.extensions`]: globals.html#globals_require_extensions
 [`tls.CryptoStream`]: tls.html#tls_class_cryptostream
 [`tls.SecureContext`]: tls.html#tls_tls_createsecurecontext_options
@@ -724,4 +738,5 @@ Type: Runtime
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [from_arraybuffer]: buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length
 [from_string_encoding]: buffer.html#buffer_class_method_buffer_from_string_encoding
-[`REPLServer.clearBufferedCommand()`]: repl.html#repl_replserver_clearbufferedcommand
+[IANA HTTP Status Codes]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+[RFC2324]: https://www.ietf.org/rfc/rfc2324.txt

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -77,7 +77,7 @@ const STATUS_CODES = {
   415: 'Unsupported Media Type',
   416: 'Range Not Satisfiable',
   417: 'Expectation Failed',
-  418: 'I\'m a teapot',              // RFC 2324
+  418: 'I\'m a teapot',              // RFC 2324, Docs-Deprecated DEP00XX
   421: 'Misdirected Request',
   422: 'Unprocessable Entity',       // RFC 4918
   423: 'Locked',                     // RFC 4918

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -167,7 +167,7 @@ HTTP_KNOWN_HEADER_MAX
   V(UNSUPPORTED_MEDIA_TYPE, 415)                                              \
   V(RANGE_NOT_SATISFIABLE, 416)                                               \
   V(EXPECTATION_FAILED, 417)                                                  \
-  V(TEAPOT, 418)                                                              \
+  V(TEAPOT, 418)  /** docs deprecated, DEP00XX **/                            \
   V(MISDIRECTED_REQUEST, 421)                                                 \
   V(UNPROCESSABLE_ENTITY, 422)                                                \
   V(LOCKED, 423)                                                              \


### PR DESCRIPTION
Docs-only deprecation of the `I'm a teapot` status for 9.x, with the intent of removing the unregistered status code by 10.x

Fixes: https://github.com/nodejs/node/issues/14644

/cc @mnot

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
