### PR TITLE
async_hooks: CHECK that resource is not empty

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -645,6 +645,8 @@ void AsyncWrap::EmitAsyncInit(Environment* env,
                               Local<String> type,
                               double async_id,
                               double trigger_id) {
+  CHECK(!object.IsEmpty());
+  CHECK(!type.IsEmpty());
   AsyncHooks* async_hooks = env->async_hooks();
 
   // Nothing to execute, so can continue normally.


### PR DESCRIPTION
This condition can be triggered through the public C++ embedder API, so check for it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks