### PR TITLE
querystring: avoid indexOf when parsing

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -285,7 +285,6 @@ function parse(qs, sep, eq, options) {
   }
   const customDecode = (decode !== qsUnescape);
 
-  const keys = [];
   var lastPos = 0;
   var sepIdx = 0;
   var eqIdx = 0;
@@ -326,11 +325,8 @@ function parse(qs, sep, eq, options) {
         if (value.length > 0 && valEncoded)
           value = decodeStr(value, decode);
 
-        // Use a key array lookup instead of using hasOwnProperty(), which is
-        // slower
-        if (keys.indexOf(key) === -1) {
+        if (obj[key] === undefined) {
           obj[key] = value;
-          keys[keys.length] = key;
         } else {
           const curValue = obj[key];
           // A simple Array-specific property check is enough here to
@@ -428,10 +424,8 @@ function parse(qs, sep, eq, options) {
     key = decodeStr(key, decode);
   if (value.length > 0 && valEncoded)
     value = decodeStr(value, decode);
-  // Use a key array lookup instead of using hasOwnProperty(), which is slower
-  if (keys.indexOf(key) === -1) {
+  if (obj[key] === undefined) {
     obj[key] = value;
-    keys[keys.length] = key;
   } else {
     const curValue = obj[key];
     // A simple Array-specific property check is enough here to


### PR DESCRIPTION
Fixes a performance regression in body-parser with V8 6.0.
Removes the use of an auxiliary array, and just query the object
directly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

querystring
