### PR TITLE
test: check crypto before requiring tls module

### DIFF
--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -21,6 +21,8 @@
 
 'use strict';
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const tls = require('tls');
@@ -29,8 +31,6 @@ const { spawn } = require('child_process');
 if (!common.opensslCli)
   common.skip('node compiled without OpenSSL CLI.');
 
-if (!common.hasCrypto)
-  common.skip('missing crypto');
 
 doTest({ tickets: false }, function() {
   doTest({ tickets: true }, function() {


### PR DESCRIPTION
test-tls-session-cache currently fails if built --without-ssl:
```console
internal/util.js:82
    throw new errors.Error('ERR_NO_CRYPTO');
    ^

Error [ERR_NO_CRYPTO]: Node.js is not compiled with OpenSSL crypto
support
    at Object.assertCrypto (internal/util.js:82:11)
    at tls.js:26:14
    at NativeModule.compile (bootstrap_node.js:586:7)
    at Function.NativeModule.require (bootstrap_node.js:531:18)
    at Function.Module._load (module.js:449:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous>
(/node/test/parallel/test-tls-session-cache.js:26:13)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
```
The test has a crypto check but it come after the require of the tls
module.

This commit moves the crypto check to come before the require of tls and
allows the test to pass.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test