### PR TITLE
doc: mention that node options are space-separated

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -440,10 +440,10 @@ When set to `1`, process warnings are silenced.
 added: v8.0.0
 -->
 
-`options...` are interpreted as if they had been specified on the command line
-before the actual command line (so they can be overridden).  Node will exit with
-an error if an option that is not allowed in the environment is used, such as
-`-p` or a script file.
+A space-separated list of command line options. `options...` are interpreted as
+if they had been specified on the command line before the actual command line
+(so they can be overridden).  Node will exit with an error if an option that is
+not allowed in the environment is used, such as `-p` or a script file.
 
 Node options that are allowed are:
 - `--enable-fips`

--- a/doc/node.1
+++ b/doc/node.1
@@ -282,10 +282,10 @@ When set to \fI1\fR, process warnings are silenced.
 
 .TP
 .BR NODE_OPTIONS =\fIoptions...\fR
-\fBoptions...\fR are interpreted as if they had been specified on the command
-line before the actual command line (so they can be overridden).  Node will exit
-with an error if an option that is not allowed in the environment is used, such
-as \fB-p\fR or a script file.
+A space-separated list of command line options. \fBoptions...\fR are interpreted
+as if they had been specified on the command line before the actual command line
+(so they can be overridden).  Node will exit with an error if an option that is
+not allowed in the environment is used, such as \fB-p\fR or a script file.
 
 .TP
 .BR NODE_PATH =\fIpath\fR[:\fI...\fR]

--- a/src/node.cc
+++ b/src/node.cc
@@ -3721,6 +3721,7 @@ static void PrintHelp() {
          "NODE_NO_WARNINGS             set to 1 to silence process warnings\n"
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
          "NODE_OPTIONS                 set CLI options in the environment\n"
+         "                             via a space-separated list\n"
 #endif
 #ifdef _WIN32
          "NODE_PATH                    ';'-separated list of directories\n"


### PR DESCRIPTION
The documentation does not mention that the value of NODE_OPTIONS is a
space-separated list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc