### PR TITLE
process: keep process prototype in inheritance chain

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -14,9 +14,7 @@
     process._eventsCount = 0;
 
     const origProcProto = Object.getPrototypeOf(process);
-    Object.setPrototypeOf(process, Object.create(EventEmitter.prototype, {
-      constructor: Object.getOwnPropertyDescriptor(origProcProto, 'constructor')
-    }));
+    Object.setPrototypeOf(origProcProto, EventEmitter.prototype);
 
     EventEmitter.call(process);
 

--- a/test/parallel/test-process-prototype.js
+++ b/test/parallel/test-process-prototype.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events');
 
 const proto = Object.getPrototypeOf(process);
 
+assert(process instanceof process.constructor);
 assert(proto instanceof EventEmitter);
 
 const desc = Object.getOwnPropertyDescriptor(proto, 'constructor');


### PR DESCRIPTION
The global `process` object had its prototype replaced with a
fresh object that had `EventEmitter.prototype` as its prototype.
With this change, the original `process.constructor.prototype` is
modified to have `EventEmitter.prototype` as its prototype, reflecting
that `process` objects are also `EventEmitter`s.

Fixes: https://github.com/nodejs/node/issues/14699

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process