### PR TITLE
Buffer.slice: Added description for the case when end is greater than…

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1907,6 +1907,9 @@ changes:
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
 
+Specifying 'end' greater than ['buf.length'] will return the same result as that of
+'end' equal to [buf.length]
+
 *Note*: Modifying the new `Buffer` slice will modify the memory in the
 original `Buffer` because the allocated memory of the two objects overlap.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1907,8 +1907,8 @@ changes:
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
 
-Specifying 'end' greater than ['buf.length'] will return the same result as that of
-'end' equal to [buf.length]
+Specifying `end` greater than [`buf.length`] will return the same result as that of
+`end` equal to [`buf.length`]
 
 *Note*: Modifying the new `Buffer` slice will modify the memory in the
 original `Buffer` because the allocated memory of the two objects overlap.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1907,8 +1907,8 @@ changes:
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
 
-Specifying `end` greater than [`buf.length`] will return the same result as that of
-`end` equal to [`buf.length`]
+Specifying `end` greater than [`buf.length`] will return the same result as that 
+of `end` equal to [`buf.length`]
 
 *Note*: Modifying the new `Buffer` slice will modify the memory in the
 original `Buffer` because the allocated memory of the two objects overlap.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1908,7 +1908,7 @@ Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
 
 Specifying `end` greater than [`buf.length`] will return the same result as that 
-of `end` equal to [`buf.length`]
+of `end` equal to [`buf.length`].
 
 *Note*: Modifying the new `Buffer` slice will modify the memory in the
 original `Buffer` because the allocated memory of the two objects overlap.


### PR DESCRIPTION
Buffer.slice: Added description for the case when 'end' is greater than buffer length 

Fixes #14714 - issue

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
