### PR TITLE
errors,crypto: use internal/errors.js

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -45,6 +45,7 @@ const stream = require('stream');
 const util = require('util');
 const { isUint8Array } = process.binding('util');
 const LazyTransform = require('internal/streams/lazy_transform');
+const errors = require('internal/errors');
 
 const DH_GENERATOR = 2;
 
@@ -302,7 +303,7 @@ Sign.prototype.update = Hash.prototype.update;
 
 Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
-    throw new Error('No key provided to sign');
+    throw new errors.Error('ERR_CTYPTO_MISSING_KEY');
 
   var key = options.key || options;
   var passphrase = options.passphrase || null;
@@ -313,7 +314,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new TypeError('padding must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding', 'integer');
     }
   }
 
@@ -322,7 +323,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new TypeError('saltLength must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength', 'integer');
     }
   }
 
@@ -363,7 +364,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new TypeError('padding must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding', 'integer');
     }
   }
 
@@ -372,7 +373,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new TypeError('saltLength must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength', 'integer');
     }
   }
 
@@ -417,8 +418,8 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   if (typeof sizeOrKey !== 'number' &&
       typeof sizeOrKey !== 'string' &&
       !ArrayBuffer.isView(sizeOrKey)) {
-    throw new TypeError('First argument should be number, string, ' +
-                        'Buffer, TypedArray, or DataView');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
+      ['number', 'string', 'Buffer', 'TypedArray', 'DataView']);
   }
 
   if (keyEncoding) {
@@ -561,7 +562,7 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
 
 function ECDH(curve) {
   if (typeof curve !== 'string')
-    throw new TypeError('"curve" argument should be a string');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
 
   this._handle = new binding.ECDH(curve);
 }
@@ -594,7 +595,7 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
     else if (format === 'uncompressed')
       f = constants.POINT_CONVERSION_UNCOMPRESSED;
     else
-      throw new TypeError('Bad format: ' + format);
+      throw new error.TypeError('ERR_INVALID_FORMAT', format);
   } else {
     f = constants.POINT_CONVERSION_UNCOMPRESSED;
   }
@@ -618,7 +619,7 @@ exports.pbkdf2 = function(password,
   }
 
   if (typeof callback !== 'function')
-    throw new Error('No callback provided to pbkdf2');
+    throw new errors.Error('ERR_CRYPTO_MISSING_PBKDF2_CALLBACK');
 
   return pbkdf2(password, salt, iterations, keylen, digest, callback);
 };
@@ -632,8 +633,7 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen, digest) {
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
   if (digest === undefined) {
-    throw new TypeError(
-      'The "digest" argument is required and must not be undefined');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'digest', 'not undefined');
   }
 
   password = toBuf(password);
@@ -685,10 +685,10 @@ Certificate.prototype.exportChallenge =
 
 exports.setEngine = function setEngine(id, flags) {
   if (typeof id !== 'string')
-    throw new TypeError('"id" argument should be a string');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'id', 'string');
 
   if (flags && typeof flags !== 'number')
-    throw new TypeError('"flags" argument should be a number, if present');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags', 'number or undefined');
   flags = flags >>> 0;
 
   // Use provided engine for everything by default
@@ -702,7 +702,7 @@ const kMaxUint32 = Math.pow(2, 32) - 1;
 
 function randomFillSync(buf, offset = 0, size) {
   if (!isUint8Array(buf)) {
-    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf', 'Buffer or Uint8Array');
   }
 
   assertOffset(offset, buf.length);
@@ -717,7 +717,7 @@ exports.randomFillSync = randomFillSync;
 
 function randomFill(buf, offset, size, cb) {
   if (!isUint8Array(buf)) {
-    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf', 'Buffer or Uint8Array');
   }
 
   if (typeof offset === 'function') {
@@ -728,7 +728,7 @@ function randomFill(buf, offset, size, cb) {
     cb = size;
     size = buf.length - offset;
   } else if (typeof cb !== 'function') {
-    throw new TypeError('"cb" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'cb', 'function');
   }
 
   assertOffset(offset, buf.length);
@@ -740,29 +740,29 @@ exports.randomFill = randomFill;
 
 function assertOffset(offset, length) {
   if (typeof offset !== 'number' || offset !== offset) {
-    throw new TypeError('offset must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset', 'number');
   }
 
   if (offset > kMaxUint32 || offset < 0) {
-    throw new TypeError('offset must be a uint32');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset', 'unit32');
   }
 
   if (offset > kBufferMaxLength || offset > length) {
-    throw new RangeError('offset out of range');
+    throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'offset');
   }
 }
 
 function assertSize(size, offset, length) {
   if (typeof size !== 'number' || size !== size) {
-    throw new TypeError('size must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number');
   }
 
   if (size > kMaxUint32 || size < 0) {
-    throw new TypeError('size must be a uint32');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'unit32');
   }
 
   if (size + offset > length || size > kBufferMaxLength) {
-    throw new RangeError('buffer too small');
+    throw new errors.RangeError('ERR_BUFFER_TOO_SMALL');
   }
 }
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -323,7 +323,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'saltLength', options.saltLength);
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'saltLength', options.saltLength);
     }
   }
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -314,7 +314,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding', 'integer');
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'padding', options.padding);
     }
   }
 
@@ -323,7 +323,7 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength', 'integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'saltLength', options.saltLength);
     }
   }
 
@@ -364,7 +364,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding', 'integer');
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'padding', options.padding);
     }
   }
 
@@ -373,7 +373,7 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength', 'integer');
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'saltLength', options.saltLength);
     }
   }
 
@@ -619,7 +619,7 @@ exports.pbkdf2 = function(password,
   }
 
   if (typeof callback !== 'function')
-    throw new errors.Error('ERR_CRYPTO_MISSING_PBKDF2_CALLBACK');
+    throw new errors.Error('ERR_INVALID_CALLBACK');
 
   return pbkdf2(password, salt, iterations, keylen, digest, callback);
 };
@@ -688,7 +688,8 @@ exports.setEngine = function setEngine(id, flags) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'id', 'string');
 
   if (flags && typeof flags !== 'number')
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags', 'number or undefined');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags',
+      ['number', 'undefined']);
   flags = flags >>> 0;
 
   // Use provided engine for everything by default
@@ -702,7 +703,8 @@ const kMaxUint32 = Math.pow(2, 32) - 1;
 
 function randomFillSync(buf, offset = 0, size) {
   if (!isUint8Array(buf)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf', 'Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
+      ['Buffer', 'Uint8Array']);
   }
 
   assertOffset(offset, buf.length);
@@ -717,7 +719,8 @@ exports.randomFillSync = randomFillSync;
 
 function randomFill(buf, offset, size, cb) {
   if (!isUint8Array(buf)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf', 'Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
+      ['Buffer', 'Uint8Array']);
   }
 
   if (typeof offset === 'function') {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -303,7 +303,7 @@ Sign.prototype.update = Hash.prototype.update;
 
 Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
-    throw new errors.Error('ERR_CTYPTO_MISSING_KEY');
+    throw new errors.Error('ERR_CRYPTO_MISSING_SIGN_KEY');
 
   var key = options.key || options;
   var passphrase = options.passphrase || null;
@@ -595,7 +595,7 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
     else if (format === 'uncompressed')
       f = constants.POINT_CONVERSION_UNCOMPRESSED;
     else
-      throw new error.TypeError('ERR_INVALID_FORMAT', format);
+      throw new error.TypeError('ERR_INVALID_OPT_VALUE', 'format', format);
   } else {
     f = constants.POINT_CONVERSION_UNCOMPRESSED;
   }
@@ -728,7 +728,7 @@ function randomFill(buf, offset, size, cb) {
     cb = size;
     size = buf.length - offset;
   } else if (typeof cb !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'cb', 'function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   assertOffset(offset, buf.length);
@@ -744,7 +744,7 @@ function assertOffset(offset, length) {
   }
 
   if (offset > kMaxUint32 || offset < 0) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset', 'unit32');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset', 'uint32');
   }
 
   if (offset > kBufferMaxLength || offset > length) {
@@ -758,7 +758,7 @@ function assertSize(size, offset, length) {
   }
 
   if (size > kMaxUint32 || size < 0) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'unit32');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'uint32');
   }
 
   if (size + offset > length || size > kBufferMaxLength) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -102,10 +102,13 @@ module.exports = exports = {
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable');
 E('ERR_ASSERTION', '%s');
 E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
+E('ERR_BUFFER_TOO_SMALL', 'Buffer too small');
 E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+E('ERR_CRYPTO_MISSNG_KEY', 'No key provided to sign');
+E('ERR_CRYPTO_MISSING_PBKDF2_CALLBACK', 'No callback provided to pbkdf2');
 E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
   `c-ares failed to set servers: "${err}" [${servers}]`);
 E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
@@ -198,6 +201,7 @@ E('ERR_INVALID_FD', '"fd" must be a positive integer: %s');
 E('ERR_INVALID_FILE_URL_HOST',
   'File URL host must be "localhost" or empty on %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
+E('ERR_INVALID_FORMAT', 'Bad format: %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
 E('ERR_INVALID_HTTP_TOKEN', (name) => `${name} must be a valid HTTP token`);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -108,7 +108,6 @@ E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
 E('ERR_CRYPTO_MISSING_SIGN_KEY', 'No key provided to sign');
-E('ERR_CRYPTO_MISSING_PBKDF2_CALLBACK', 'No callback provided to pbkdf2');
 E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
   `c-ares failed to set servers: "${err}" [${servers}]`);
 E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -107,7 +107,7 @@ E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
-E('ERR_CRYPTO_MISSNG_KEY', 'No key provided to sign');
+E('ERR_CRYPTO_MISSING_SIGN_KEY', 'No key provided to sign');
 E('ERR_CRYPTO_MISSING_PBKDF2_CALLBACK', 'No callback provided to pbkdf2');
 E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
   `c-ares failed to set servers: "${err}" [${servers}]`);
@@ -201,7 +201,6 @@ E('ERR_INVALID_FD', '"fd" must be a positive integer: %s');
 E('ERR_INVALID_FILE_URL_HOST',
   'File URL host must be "localhost" or empty on %s');
 E('ERR_INVALID_FILE_URL_PATH', 'File URL path %s');
-E('ERR_INVALID_FORMAT', 'Bad format: %s');
 E('ERR_INVALID_HANDLE_TYPE', 'This handle type cannot be sent');
 E('ERR_INVALID_HTTP_TOKEN', (name) => `${name} must be a valid HTTP token`);
 E('ERR_INVALID_IP_ADDRESS', 'Invalid IP address: %s');

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -22,24 +22,29 @@ assert.strictEqual(secret2.toString('base64'), secret1);
 assert.strictEqual(dh1.verifyError, 0);
 assert.strictEqual(dh2.verifyError, 0);
 
-const argumentsError =
-  /^TypeError: First argument should be number, string, Buffer, TypedArray, or DataView$/;
-
-assert.throws(() => {
+common.expectsError(function() {
   crypto.createDiffieHellman([0x1, 0x2]);
-}, argumentsError);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
 
-assert.throws(() => {
+common.expectsError(function() {
   crypto.createDiffieHellman(() => { });
-}, argumentsError);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
 
-assert.throws(() => {
+common.expectsError(function() {
   crypto.createDiffieHellman(/abc/);
-}, argumentsError);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
 
-assert.throws(() => {
+common.expectsError(function() {
   crypto.createDiffieHellman({});
-}, argumentsError);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
 
 // Create "another dh1" using generated keys from dh1,
 // and compute secret again
@@ -198,9 +203,12 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
   firstByte = ecdh1.getPublicKey('buffer', 'hybrid')[0];
   assert(firstByte === 6 || firstByte === 7);
   // format value should be string
-  assert.throws(() => {
+  common.expectsError(function() {
     ecdh1.getPublicKey('buffer', 10);
-  }, /^TypeError: Bad format: 10$/);
+  }, {
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: /"format"/,
+  });
 
   // ECDH should check that point is on curve
   const ecdh3 = crypto.createECDH('secp256k1');
@@ -331,6 +339,9 @@ if (availableCurves.has('prime256v1') && availableHashes.has('sha256')) {
 }
 
 // invalid test: curve argument is undefined
-assert.throws(() => {
+common.expectsError(function() {
   crypto.createECDH();
-}, /^TypeError: "curve" argument should be a string$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /"curve"/,
+});

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -7,10 +7,16 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-assert.throws(function() {
+common.expectsError(function() {
   crypto.setEngine(true);
-}, /^TypeError: "id" argument should be a string$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /"id"/,
+});
 
-assert.throws(function() {
+common.expectsError(function() {
   crypto.setEngine('/path/to/engine', 'notANumber');
-}, /^TypeError: "flags" argument should be a number, if present$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /"flags"/,
+});

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -55,9 +55,11 @@ function ondone(err, key) {
 }
 
 // Error path should not leak memory (check with valgrind).
-assert.throws(function() {
+common.expectsError(function() {
   crypto.pbkdf2('password', 'salt', 1, 20, null);
-}, /^Error: No callback provided to pbkdf2$/);
+}, {
+  code: 'ERR_INVALID_CALLBACK',
+});
 
 // Should not work with Infinity key length
 assert.throws(function() {
@@ -95,10 +97,16 @@ assert.doesNotThrow(() => {
   }));
 });
 
-assert.throws(() => {
+common.expectsError(function() {
   crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall());
-}, /^TypeError: The "digest" argument is required and must not be undefined$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /"digest"/,
+});
 
-assert.throws(() => {
+common.expectsError(function() {
   crypto.pbkdf2Sync('password', 'salt', 8, 8);
-}, /^TypeError: The "digest" argument is required and must not be undefined$/);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /"digest"/,
+});

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -140,12 +140,29 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     new Uint8Array(new Array(10).fill(0))
   ];
   const errMessages = {
-    offsetNotNumber: /^TypeError: offset must be a number$/,
-    offsetOutOfRange: /^RangeError: offset out of range$/,
-    offsetNotUInt32: /^TypeError: offset must be a uint32$/,
-    sizeNotNumber: /^TypeError: size must be a number$/,
-    sizeNotUInt32: /^TypeError: size must be a uint32$/,
-    bufferTooSmall: /^RangeError: buffer too small$/,
+    offsetNotNumber: {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"offset" .* number/,
+    },
+    offsetOutOfRange: {
+      code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+      message: /"offset"/,
+    },
+    offsetNotUInt32: {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"offset" .* unint32/,
+    },
+    sizeNotNumber: {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"size" .* number/,
+    },
+    sizeNotUInt32: {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /"size" .* unint32/,
+    },
+    bufferTooSmall: {
+      code: 'ERR_BUFFER_TOO_SMALL',
+    },
   };
 
   const max = require('buffer').kMaxLength + 1;
@@ -154,106 +171,106 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     const len = Buffer.byteLength(buf);
     assert.strictEqual(len, 10, `Expected byteLength of 10, got ${len}`);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 'test');
     }, errMessages.offsetNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, NaN);
     }, errMessages.offsetNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 'test', common.mustNotCall());
     }, errMessages.offsetNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, NaN, common.mustNotCall());
     }, errMessages.offsetNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 11);
     }, errMessages.offsetOutOfRange);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, max);
     }, errMessages.offsetOutOfRange);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 11, common.mustNotCall());
     }, errMessages.offsetOutOfRange);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, max, common.mustNotCall());
     }, errMessages.offsetOutOfRange);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 0, 'test');
     }, errMessages.sizeNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 0, NaN);
     }, errMessages.sizeNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 0, 'test', common.mustNotCall());
     }, errMessages.sizeNotNumber);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 0, NaN, common.mustNotCall());
     }, errMessages.sizeNotNumber);
 
     {
       const size = (-1 >>> 0) + 1;
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFillSync(buf, 0, -10);
       }, errMessages.sizeNotUInt32);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFillSync(buf, 0, size);
       }, errMessages.sizeNotUInt32);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFill(buf, 0, -10, common.mustNotCall());
       }, errMessages.sizeNotUInt32);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFill(buf, 0, size, common.mustNotCall());
       }, errMessages.sizeNotUInt32);
     }
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, -10);
     }, errMessages.offsetNotUInt32);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, -10, common.mustNotCall());
     }, errMessages.offsetNotUInt32);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 1, 10);
     }, errMessages.bufferTooSmall);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 1, 10, common.mustNotCall());
     }, errMessages.bufferTooSmall);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFillSync(buf, 0, 12);
     }, errMessages.bufferTooSmall);
 
-    assert.throws(() => {
+    common.expectsError(() => {
       crypto.randomFill(buf, 0, 12, common.mustNotCall());
     }, errMessages.bufferTooSmall);
 
     {
       // Offset is too big
       const offset = (-1 >>> 0) + 1;
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFillSync(buf, offset, 10);
       }, errMessages.offsetNotUInt32);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.randomFill(buf, offset, 10, common.mustNotCall());
       }, errMessages.offsetNotUInt32);
     }

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -150,7 +150,7 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     },
     offsetNotUInt32: {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"offset" .* unint32/,
+      message: /"offset" .* uint32/,
     },
     sizeNotNumber: {
       code: 'ERR_INVALID_ARG_TYPE',
@@ -158,7 +158,7 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     },
     sizeNotUInt32: {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /"size" .* unint32/,
+      message: /"size" .* uint32/,
     },
     bufferTooSmall: {
       code: 'ERR_BUFFER_TOO_SMALL',

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -240,7 +240,7 @@ const modSize = 1024;
 
 // Test throws exception when key options is null
 {
-  expectsError(() => {
+  common.expectsError(() => {
     crypto.createSign('RSA-SHA1').update('Test123').sign(null, 'base64');
   }, {
     code: 'ERR_CRYPTO_MISSING_SIGN_KEY',

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -197,12 +197,18 @@ const modSize = 1024;
 
 // Test exceptions for invalid `padding` and `saltLength` values
 {
-  const paddingNotInteger = /^TypeError: padding must be an integer$/;
-  const saltLengthNotInteger = /^TypeError: saltLength must be an integer$/;
+  const paddingNotInteger = {
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: /"padding"/,
+  };
+  const saltLengthNotInteger = {
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: /"saltLength"/,
+  };
 
   [null, undefined, NaN, 'boom', {}, [], true, false]
     .forEach((invalidValue) => {
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.createSign('RSA-SHA256')
           .update('Test123')
           .sign({
@@ -211,7 +217,7 @@ const modSize = 1024;
           });
       }, paddingNotInteger);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         crypto.createSign('RSA-SHA256')
           .update('Test123')
           .sign({
@@ -234,9 +240,11 @@ const modSize = 1024;
 
 // Test throws exception when key options is null
 {
-  assert.throws(() => {
+  expectsError(() => {
     crypto.createSign('RSA-SHA1').update('Test123').sign(null, 'base64');
-  }, /^Error: No key provided to sign$/);
+  }, {
+    code: 'ERR_CRYPTO_MISSING_SIGN_KEY',
+  });
 }
 
 // RSA-PSS Sign test by verifying with 'openssl dgst -verify'


### PR DESCRIPTION
Change [crypto.js](https://github.com/nodejs/node/tree/master/lib/crypto.js) to use [internal/errors.js](https://github.com/nodejs/node/blob/master/lib/internal/errors.js) module.

See #11273 for more info.

cc @jasnell 

**Checklist**

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

**Affected core subsystem(s)**

errors, crypto