### PR TITLE
src: avoid creating local data variable

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -280,10 +280,8 @@ template <typename T>
 inline Environment* Environment::GetCurrent(
     const v8::PropertyCallbackInfo<T>& info) {
   CHECK(info.Data()->IsExternal());
-  // XXX(bnoordhuis) Work around a g++ 4.9.2 template type inferrer bug
-  // when the expression is written as info.Data().As<v8::External>().
-  v8::Local<v8::Value> data = info.Data();
-  return static_cast<Environment*>(data.As<v8::External>()->Value());
+  return static_cast<Environment*>(
+      info.Data().template As<v8::External>()->Value());
 }
 
 inline Environment::Environment(IsolateData* isolate_data,


### PR DESCRIPTION
This commit removes the following comment and attempts to fix the issue
as the the requirement of g++ version is now 4.9.4 or newer:

```c++
// XXX(bnoordhuis) Work around a g++ 4.9.2 template type inferrer bug
// when the expression is written as info.Data().As<v8::External>().
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src