### PR TITLE
build: better support for python3 systems

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,15 @@
-#!/usr/bin/env python
+#!/bin/sh
+
+# Locate python2 interpreter and re-execute the script.  Note that the
+# mix of single and double quotes is intentional, as is the fact that
+# the ] goes on a new line.
+_=[ 'exec' '/bin/sh' '-c' '''
+which python2.7 >/dev/null && exec python2.7 "$0" "$@"
+which python2 >/dev/null && exec python2 "$0" "$@"
+exec python "$0" "$@"
+''' "$0" "$@"
+]
+del _
 
 import sys
 if sys.version_info[0] != 2 or sys.version_info[1] not in (6, 7):


### PR DESCRIPTION
Improve support for systems where `python` is actually `python3`.

Not all systems have a `python2` binary, so simply updating the shebang
won't work.

What we can do is apply some cleverness: start life as a shell script,
locate the python binary, then re-execute the script but this time as
python code.

Special care is taken to ensure that spaces in arguments are passed on
verbatim.

This would need to be applied to other python scripts as well but I figured
I'd start with a single script in case everyone hates the approach.

CI: https://ci.nodejs.org/job/node-test-pull-request/9594/