### PR TITLE
src: remove unused http2_socket_buffer from env

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -302,7 +302,6 @@ inline Environment::Environment(IsolateData* isolate_data,
 #endif
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
-      http2_socket_buffer_(nullptr),
       fs_stats_field_array_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
@@ -329,7 +328,6 @@ inline Environment::~Environment() {
   delete[] heap_statistics_buffer_;
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
-  delete[] http2_socket_buffer_;
 }
 
 inline v8::Isolate* Environment::isolate() const {
@@ -486,15 +484,6 @@ inline double* Environment::fs_stats_field_array() const {
 inline void Environment::set_fs_stats_field_array(double* fields) {
   CHECK_EQ(fs_stats_field_array_, nullptr);  // Should be set only once.
   fs_stats_field_array_ = fields;
-}
-
-inline char* Environment::http2_socket_buffer() const {
-  return http2_socket_buffer_;
-}
-
-inline void Environment::set_http2_socket_buffer(char* buffer) {
-  CHECK_EQ(http2_socket_buffer_, nullptr);  // Should be set only once.
-  http2_socket_buffer_ = buffer;
 }
 
 inline IsolateData* Environment::isolate_data() const {

--- a/src/env.h
+++ b/src/env.h
@@ -598,8 +598,6 @@ class Environment {
 
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
-  inline char* http2_socket_buffer() const;
-  inline void set_http2_socket_buffer(char* buffer);
 
   inline double* fs_stats_field_array() const;
   inline void set_fs_stats_field_array(double* fields);
@@ -707,7 +705,6 @@ class Environment {
   double* heap_space_statistics_buffer_ = nullptr;
 
   char* http_parser_buffer_;
-  char* http2_socket_buffer_;
 
   double* fs_stats_field_array_;
 


### PR DESCRIPTION
I’d go so far as to say that this doesn’t need to wait 48 hours.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2