### PR TITLE
http2: fix [kInspect]() output for Http2Stream

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1315,7 +1315,7 @@ class Http2Stream extends Duplex {
       id: this[kID],
       state: this.state,
       readableState: this._readableState,
-      writeableSate: this._writableState
+      writableState: this._writableState
     };
     return `Http2Stream ${util.format(obj)}`;
   }

--- a/test/parallel/test-http2-stream-client.js
+++ b/test/parallel/test-http2-stream-client.js
@@ -1,0 +1,29 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const util = require('util');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  assert.strictEqual(stream.aborted, false);
+  const insp = util.inspect(stream);
+  assert.ok(/Http2Stream { id/.test(insp));
+  assert.ok(/  state:/.test(insp));
+  assert.ok(/  readableState:/.test(insp));
+  assert.ok(/  writableState:/.test(insp));
+  stream.end('ok');
+}));
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  req.resume();
+  req.on('streamClosed', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
This fixes a typo in the util.inspect output of Http2Stream. It previously had
writeableSate instead of writableState.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2