### PR TITLE
http: be more specific when reporting errors

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -440,7 +440,8 @@ function storeHeader(self, state, key, value, validate) {
       throw new Error('Header "%s" value must not be undefined', key);
     } else if (checkInvalidHeaderChar(value)) {
       debug('Header "%s" contains invalid characters', key);
-      throw new TypeError('The header content contains invalid characters');
+      throw new TypeError(
+        'The header content contains invalid characters ["' + key + '"]');
     }
   }
   state.header += key + ': ' + escapeHeaderValue(value) + CRLF;
@@ -498,7 +499,8 @@ function validateHeader(msg, name, value) {
     throw new Error('Can\'t set headers after they are sent.');
   if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', name);
-    throw new TypeError('The header content contains invalid characters');
+    throw new TypeError(
+      'The header content contains invalid characters ["' + name + '"]');
   }
 }
 OutgoingMessage.prototype.setHeader = function setHeader(name, value) {

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -38,7 +38,7 @@ assert.throws(() => {
 assert.throws(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader('200', 'あ');
-}, /^TypeError: The header content contains invalid characters$/);
+}, /^TypeError: The header content contains invalid characters \["200"\]$/);
 
 // write
 assert.throws(() => {

--- a/test/parallel/test-http-response-splitting.js
+++ b/test/parallel/test-http-response-splitting.js
@@ -19,23 +19,26 @@ const y = 'foo⠊Set-Cookie: foo=bar';
 
 let count = 0;
 
-function test(res, code, header) {
+function test(res, code, header, failing) {
+  const expected =
+      '^TypeError: The header content contains invalid characters \\["' +
+      failing + '"\\]$';
   assert.throws(() => {
     res.writeHead(code, header);
-  }, /^TypeError: The header content contains invalid characters$/);
+  }, new RegExp(expected));
 }
 
 const server = http.createServer((req, res) => {
   switch (count++) {
     case 0:
       const loc = url.parse(req.url, true).query.lang;
-      test(res, 302, { Location: `/foo?lang=${loc}` });
+      test(res, 302, { Location: `/foo?lang=${loc}` }, 'Location');
       break;
     case 1:
-      test(res, 200, { 'foo': x });
+      test(res, 200, { 'foo': x }, 'foo');
       break;
     case 2:
-      test(res, 200, { 'foo': y });
+      test(res, 200, { 'foo': y }, 'foo');
       break;
     default:
       assert.fail('should not get to here.');


### PR DESCRIPTION
When reporting header content errors specify header name in the message
for easier debugging in user applications.

Fix: #14754

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http