### PR TITLE
crypto: account for OpenSSL 1.1.0 function signature change.

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -162,7 +162,11 @@ template void SSLWrap<TLSWrap>::SetSNIContext(SecureContext* sc);
 template int SSLWrap<TLSWrap>::SetCACerts(SecureContext* sc);
 template SSL_SESSION* SSLWrap<TLSWrap>::GetSessionCallback(
     SSL* s,
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     unsigned char* key,
+#else
+    const unsigned char *key,
+#endif
     int len,
     int* copy);
 template int SSLWrap<TLSWrap>::NewSessionCallback(SSL* s,
@@ -1394,7 +1398,11 @@ void SSLWrap<Base>::InitNPN(SecureContext* sc) {
 
 template <class Base>
 SSL_SESSION* SSLWrap<Base>::GetSessionCallback(SSL* s,
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
                                                unsigned char* key,
+#else
+                                               const unsigned char* key,
+#endif
                                                int len,
                                                int* copy) {
   Base* w = static_cast<Base*>(SSL_get_app_data(s));

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -232,7 +232,11 @@ class SSLWrap {
   static void AddMethods(Environment* env, v8::Local<v8::FunctionTemplate> t);
 
   static SSL_SESSION* GetSessionCallback(SSL* s,
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
                                          unsigned char* key,
+#else
+                                         const unsigned char* key,
+#endif
                                          int len,
                                          int* copy);
   static int NewSessionCallback(SSL* s, SSL_SESSION* sess);


### PR DESCRIPTION
In OpenSSL 1.1.0, SSL_CTX_sess_set_get_cb's callback has a slightly
different function signature, see [1]. Account for that with an
OPENSSL_VERSION_NUMBER check. This gets a little closer to 1.1.0
compatibility.

[1] https://git.openssl.org/gitweb/?p=openssl.git;a=blob;f=include/openssl/ssl.h;h=41cb36e9438e1debf4f1abba47f2d8d273883ffa;hb=abd30777cc72029e8a44e4b67201cae8ed3d19c1#l618

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto
