### PR TITLE
build: stop support building addons with VS 2013

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -70,9 +70,7 @@ Depending on host platform, the selection of toolchains may vary.
 
 #### Windows
 
-* Building Node: Visual Studio 2015 or Visual C++ Build Tools 2015 or newer
-* Building native add-ons: Visual Studio 2013 or Visual C++ Build Tools 2015
-  or newer
+* Visual Studio 2015 or Visual C++ Build Tools 2015 or newer
 
 ## Building Node.js on supported platforms
 


### PR DESCRIPTION
With this we won't have to float a patch in future V8 upgrades.
Ref: https://github.com/nodejs/node/pull/14730#issuecomment-321609328

/cc @nodejs/platform-windows @nodejs/ctc 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)