### PR TITLE
test: make totalLen snake case

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -36,12 +36,12 @@ struct Argv {
 
   Argv(const std::initializer_list<const char*> &args) {
     nr_args_ = args.size();
-    int totalLen = 0;
+    int total_len = 0;
     for (auto it = args.begin(); it != args.end(); ++it) {
-      totalLen += strlen(*it) + 1;
+      total_len += strlen(*it) + 1;
     }
     argv_ = static_cast<char**>(malloc(nr_args_ * sizeof(char*)));
-    argv_[0] = static_cast<char*>(malloc(totalLen));
+    argv_[0] = static_cast<char*>(malloc(total_len));
     int i = 0;
     int offset = 0;
     for (auto it = args.begin(); it != args.end(); ++it, ++i) {


### PR DESCRIPTION
For consistency, use snake case (total_len) for the local totalLen
variable.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test