### PR TITLE
src: use local isolate instead of args.GetIsolate

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1285,7 +1285,7 @@ void SetupPromises(const FunctionCallbackInfo<Value>& args) {
 
   env->process_object()->Delete(
       env->context(),
-      FIXED_ONE_BYTE_STRING(args.GetIsolate(), "_setupPromises")).FromJust();
+      FIXED_ONE_BYTE_STRING(isolate, "_setupPromises")).FromJust();
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
While stepping though SetupPromises I noticed that the environments
Isolate is used but not when creating the string "_setupPromises".

Is there a reason for using args.GetIsolate() instead of using the
environments isolate? I see that GetIsolate() is an inline call, but
could there be situations where it returns a different Isolate?
If not perhaps using the local isolate variable would be a litte
clearer.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src