### PR TITLE
lib: move deprecationWarned var

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -14,6 +14,8 @@ function getAsynchronousRejectionWarningObject(uid) {
 }
 
 function setupPromises(scheduleMicrotasks) {
+  var deprecationWarned = false;
+
   process._setupPromises(function(event, promise, reason) {
     if (event === promiseRejectEvent.unhandled)
       unhandledRejection(promise, reason);
@@ -73,7 +75,7 @@ function setupPromises(scheduleMicrotasks) {
         'DeprecationWarning', 'DEP0018');
     }
   }
-  var deprecationWarned = false;
+
   function emitPendingUnhandledRejections() {
     let hadListeners = false;
     while (pendingUnhandledRejections.length > 0) {


### PR DESCRIPTION
The variable deprecationWarned currently looks a little misplaced. It is
used in emitWarning but declared after it. This commit suggest moving
the var to the beginning of the function.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib