### PR TITLE
async_hooks: updates async_hooks.js to use the new internal/errors.js structure

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 const async_wrap = process.binding('async_wrap');
 /* Both these arrays are used to communicate between JS and C++ with as little
  * overhead as possible.
@@ -83,13 +85,13 @@ function fatalError(e) {
 class AsyncHook {
   constructor({ init, before, after, destroy }) {
     if (init !== undefined && typeof init !== 'function')
-      throw new TypeError('init must be a function');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'init', 'function');
     if (before !== undefined && typeof before !== 'function')
-      throw new TypeError('before must be a function');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'before', 'function');
     if (after !== undefined && typeof after !== 'function')
-      throw new TypeError('after must be a function');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'after', 'function');
     if (destroy !== undefined && typeof destroy !== 'function')
-      throw new TypeError('destroy must be a function');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'destroy', 'function');
 
     this[init_symbol] = init;
     this[before_symbol] = before;
@@ -211,7 +213,7 @@ class AsyncResource {
     // Unlike emitInitScript, AsyncResource doesn't supports null as the
     // triggerAsyncId.
     if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < 0)
-      throw new RangeError('triggerAsyncId must be an unsigned integer');
+      throw new errors.RangeError('ERR_NOT_ASSIGNED_INTEGER', 'triggerAsyncId');
 
     this[async_id_symbol] = ++async_uid_fields[kAsyncUidCntr];
     this[trigger_id_symbol] = triggerAsyncId;
@@ -308,11 +310,11 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
   // TODO(trevnorris): I'd prefer allowing these checks to not exist, or only
   // throw in a debug build, in order to improve performance.
   if (!Number.isSafeInteger(asyncId) || asyncId < 0)
-    throw new RangeError('asyncId must be an unsigned integer');
+    throw new errors.RangeError('ERR_NOT_ASSIGNED_INTEGER', 'asyncId');
   if (typeof type !== 'string' || type.length <= 0)
-    throw new TypeError('type must be a string with length > 0');
+    throw new errors.TypeError('ERR_INVALID_STRING_LENGTH', 'type', '> 0', 0);
   if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < 0)
-    throw new RangeError('triggerAsyncId must be an unsigned integer');
+    throw new errors.RangeError('ERR_NOT_ASSIGNED_INTEGER', 'triggerAsyncId');
 
   emitInitNative(asyncId, type, triggerAsyncId, resource);
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -183,11 +183,7 @@ E('ERR_HTTP2_UNSUPPORTED_PROTOCOL',
   (protocol) => `protocol "${protocol}" is unsupported.`);
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
-E('ERR_INVALID_ARRAY_LENGTH',
-  (name, len, actual) => {
-    assert.strictEqual(typeof actual, 'number');
-    return `The array "${name}" (length ${actual}) must be of length ${len}.`;
-  });
+E('ERR_INVALID_ARRAY_LENGTH', invalidLength('array'));
 E('ERR_INVALID_BUFFER_SIZE', 'Buffer size must be a multiple of %s');
 E('ERR_INVALID_CALLBACK', 'Callback must be a function');
 E('ERR_INVALID_CHAR', 'Invalid character in %s');
@@ -211,6 +207,7 @@ E('ERR_INVALID_PROTOCOL', (protocol, expectedProtocol) =>
   `Protocol "${protocol}" not supported. Expected "${expectedProtocol}"`);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
+E('ERR_INVALID_STRING_LENGTH', invalidLength('string'));
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support Buffer, Uint8Array or string input: %s');
 E('ERR_INVALID_THIS', 'Value of "this" must be of type %s');
@@ -229,6 +226,7 @@ E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
 E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
+E('ERR_NOT_ASSIGNED_INTEGER', '%s must be an unsigned integer');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
@@ -263,6 +261,17 @@ E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
 E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 
+/**
+ * Receives a type and returns a function which creates a
+ * invalid length message.
+ * @param {*} type string that could any type with a length
+ */
+function invalidLength(type) {
+  return (name, len, actual) => {
+    assert.strictEqual(typeof actual, 'number');
+    return `The ${type} "${name}" (length ${actual}) must be of length ${len}.`;
+  };
+}
 
 function invalidArgType(name, expected, actual) {
   assert(name, 'name is required');

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -13,9 +13,9 @@ const hooks = initHooks();
 hooks.enable();
 
 assert.throws(() => new AsyncResource(),
-              /^TypeError: type must be a string with length > 0$/);
+              /^TypeError \[ERR_INVALID_STRING_LENGTH\]: The string "type" \(length 0\) must be of length > 0\.$/);
 assert.throws(() => new AsyncResource('invalid_trigger_id', null),
-              /^RangeError: triggerAsyncId must be an unsigned integer$/);
+              /^RangeError \[ERR_NOT_ASSIGNED_INTEGER\]: triggerAsyncId must be an unsigned integer$/);
 
 assert.strictEqual(
   new AsyncResource('default_trigger_id').triggerAsyncId(),

--- a/test/async-hooks/test-emit-init.js
+++ b/test/async-hooks/test-emit-init.js
@@ -26,11 +26,11 @@ const hooks1 = initHooks({
 hooks1.enable();
 
 assert.throws(() => async_hooks.emitInit(),
-              /^RangeError: asyncId must be an unsigned integer$/);
+              /^RangeError \[ERR_NOT_ASSIGNED_INTEGER\]: asyncId must be an unsigned integer$/);
 assert.throws(() => async_hooks.emitInit(expectedId),
-              /^TypeError: type must be a string with length > 0$/);
+              /^TypeError \[ERR_INVALID_STRING_LENGTH\]: The string "type" \(length 0\) must be of length > 0\.$/);
 assert.throws(() => async_hooks.emitInit(expectedId, expectedType, -1),
-              /^RangeError: triggerAsyncId must be an unsigned integer$/);
+              /^RangeError \[ERR_NOT_ASSIGNED_INTEGER\]: triggerAsyncId must be an unsigned integer$/);
 
 async_hooks.emitInit(expectedId, expectedType, expectedTriggerId,
                      expectedResource);

--- a/test/parallel/test-async-hooks-asyncresource-constructor.js
+++ b/test/parallel/test-async-hooks-asyncresource-constructor.js
@@ -14,16 +14,16 @@ async_hooks.createHook({
 
 assert.throws(() => {
   return new AsyncResource();
-}, /^TypeError: type must be a string with length > 0$/);
+}, /^TypeError \[ERR_INVALID_STRING_LENGTH\]: The string "type" \(length 0\) must be of length > 0\.$/);
 
 assert.throws(() => {
   new AsyncResource('');
-}, /^TypeError: type must be a string with length > 0$/);
+}, /^TypeError \[ERR_INVALID_STRING_LENGTH\]: The string "type" \(length 0\) must be of length > 0\.$/);
 
 assert.throws(() => {
   new AsyncResource('type', -4);
-}, /^RangeError: triggerAsyncId must be an unsigned integer$/);
+}, /^RangeError \[ERR_NOT_ASSIGNED_INTEGER\]: triggerAsyncId must be an unsigned integer$/);
 
 assert.throws(() => {
   new AsyncResource('type', Math.PI);
-}, /^RangeError: triggerAsyncId must be an unsigned integer$/);
+}, /^RangeError \[ERR_NOT_ASSIGNED_INTEGER\]: triggerAsyncId must be an unsigned integer$/);

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -10,6 +10,9 @@ for (const badArg of [0, 1, false, true, null, 'hello']) {
   for (const field of ['init', 'before', 'after', 'destroy']) {
     assert.throws(() => {
       async_hooks.createHook({ [field]: badArg });
-    }, new RegExp(`^TypeError: ${field} must be a function$`));
+    }, new RegExp(
+      '^TypeError \\[ERR_INVALID_ARG_TYPE\\]: ' +
+      `The "${field}" argument must be of type function$`)
+    );
   }
 }


### PR DESCRIPTION
Follows the instructions on #11273 to migrate async_hooks.js

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks
