### PR TITLE
util: handle circular maps and sets in inspect()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -737,9 +737,7 @@ function formatTypedArray(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   value.forEach(function(v) {
-    var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
-    var str = formatValue(ctx, v, nextRecurseTimes);
-    output.push(str);
+    output.push(formatMapSetValue(ctx, v, recurseTimes));
   });
   for (var n = 0; n < keys.length; n++) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
@@ -752,17 +750,25 @@ function formatSet(ctx, value, recurseTimes, visibleKeys, keys) {
 function formatMap(ctx, value, recurseTimes, visibleKeys, keys) {
   var output = [];
   value.forEach(function(v, k) {
-    var nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
-    var str = formatValue(ctx, k, nextRecurseTimes);
-    str += ' => ';
-    str += formatValue(ctx, v, nextRecurseTimes);
-    output.push(str);
+    output.push(
+      formatMapSetValue(ctx, k, recurseTimes) +
+      ' => ' +
+      formatMapSetValue(ctx, v, recurseTimes)
+    );
   });
   for (var n = 0; n < keys.length; n++) {
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
                                keys[n], false));
   }
   return output;
+}
+
+function formatMapSetValue(ctx, value, recurseTimes) {
+  if (ctx.seen.includes(value)) {
+    return formatCircular(ctx);
+  }
+  const nextRecurseTimes = recurseTimes === null ? null : recurseTimes - 1;
+  return formatValue(ctx, value, nextRecurseTimes);
 }
 
 function formatCollectionIterator(ctx, value, recurseTimes, visibleKeys, keys) {
@@ -836,7 +842,7 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
         }
       }
     } else {
-      str = ctx.stylize('[Circular]', 'special');
+      str = formatCircular(ctx);
     }
   }
   if (name === undefined) {
@@ -859,6 +865,9 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
   return `${name}: ${str}`;
 }
 
+function formatCircular(ctx) {
+  return ctx.stylize('[Circular]', 'special');
+}
 
 function reduceToSingleString(output, base, braces, breakLength) {
   var length = output.reduce(function(prev, cur) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -794,6 +794,37 @@ if (typeof Symbol !== 'undefined') {
                      'Map { \'foo\' => null, [size]: 1, bar: 42 }');
 }
 
+// Test maps and sets with circular references
+{
+  const circularKeyMap = new Map();
+  circularKeyMap.set(circularKeyMap, 'value');
+  assert.strictEqual(
+    util.inspect(circularKeyMap),
+    'Map { [Circular] => \'value\' }'
+  );
+
+  const circularValueMap = new Map();
+  circularValueMap.set('key', circularValueMap);
+  assert.strictEqual(
+    util.inspect(circularValueMap),
+    'Map { \'key\' => [Circular] }'
+  );
+
+  const circularKeyValueMap = new Map();
+  circularKeyValueMap.set(circularKeyValueMap, circularKeyValueMap);
+  assert.strictEqual(
+    util.inspect(circularKeyValueMap),
+    'Map { [Circular] => [Circular] }'
+  );
+
+  const circularSet = new Set();
+  circularSet.add(circularSet);
+  assert.strictEqual(
+    util.inspect(circularSet),
+    'Set { [Circular] }'
+  );
+}
+
 // test Promise
 {
   const resolved = Promise.resolve(3);


### PR DESCRIPTION
Handle maps and sets with circular references in `util.inspect()` the
way objects and arrays are treated in this case.

Fixes: https://github.com/nodejs/node/issues/14758

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util