### PR TITLE
test: fix test-cluster-send-handle-large-payload

### DIFF
--- a/test/parallel/test-cluster-send-handle-large-payload.js
+++ b/test/parallel/test-cluster-send-handle-large-payload.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+
 const assert = require('assert');
 const cluster = require('cluster');
 const net = require('net');
@@ -9,7 +10,7 @@ const payload = 'a'.repeat(800004);
 if (cluster.isMaster) {
   const server = net.createServer();
 
-  server.on('connection', common.mustCall((socket) => socket.unref()));
+  server.on('connection', common.mustCall((socket) => { socket.unref(); }));
 
   const worker = cluster.fork();
   worker.on('message', common.mustCall(({ payload: received }, handle) => {
@@ -31,10 +32,23 @@ if (cluster.isMaster) {
   process.on('message', common.mustCall(({ payload: received }, handle) => {
     assert.strictEqual(payload, received);
     assert(handle instanceof net.Socket);
-    process.send({ payload }, handle);
+
+    // On macOS, the parent process might not receive a message if it is sent
+    // to soon, and then subsequent messages are also sometimes not received.
+    //
+    // (Is this a bug or expected operating system behavior like the way a file
+    // watcher is returned before it's actually watching the file system on
+    // macOS?)
+    //
+    // Send a second message after a delay on macOS.
+    //
+    // Refs: https://github.com/nodejs/node/issues/14747
+    if (common.isOSX)
+      setTimeout(() => { process.send({ payload }, handle); }, 1000);
+    else
+      process.send({ payload }, handle);
 
     // Prepare for a clean exit.
     process.channel.unref();
-    handle.unref();
   }));
 }


### PR DESCRIPTION
On macOS, the parent process might not receive a message if it
is sent to soon, and then subsequent messages are also sometimes not
received.

(Is this a bug or expected operating system behavior like the
way a file watcher is returned before it's actually watching the file
system on/ macOS?)

Send a second message after a delay on macOS.

While at it, minor refactoring to the test:

* Blank line after loading `common` module per test-writing guide
* Wrap arrow function in braces where implicit return is not needed
* Remove unnecessary unref in subprocess

Fixes: https://github.com/nodejs/node/issues/14747

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test cluster