### PR TITLE
Changed value for hostname to allow for two failing tests to pass. Th…

### DIFF
--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -4,12 +4,12 @@ const net = require('net');
 const assert = require('assert');
 
 // Using port 0 as hostname used is already invalid.
-const c = net.createConnection(0, '***');
+const c = net.createConnection(0, 'this.hostname.is.invalid');
 
 c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
   assert.strictEqual(e.code, 'ENOTFOUND');
   assert.strictEqual(e.port, 0);
-  assert.strictEqual(e.hostname, '***');
+  assert.strictEqual(e.hostname, 'this.hostname.is.invalid');
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -24,14 +24,17 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const client = net.connect({ host: '***', port: common.PORT });
+const client = net.connect({
+  host: 'this.hostname.is.invalid',
+  port: common.PORT
+});
 
 client.once('error', common.mustCall((err) => {
   assert(err);
   assert.strictEqual(err.code, err.errno);
   assert.strictEqual(err.code, 'ENOTFOUND');
   assert.strictEqual(err.host, err.hostname);
-  assert.strictEqual(err.host, '***');
+  assert.strictEqual(err.host, 'this.hostname.is.invalid');
   assert.strictEqual(err.syscall, 'getaddrinfo');
 }));
 


### PR DESCRIPTION
…e tests in question were test-net-better-error-messages-port-hostname and test-net-connect-immediate-finish.

Instead of changing the test to permit 'ENOTFOUND' or 'EAI_AGAIN', the value '***' was changed to 'this.hostname.is.invalid'. The change is also reflected in the fact that RFC 2606 reserves the '.invalid' TLD for invalid domain names.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
node test package 