### PR TITLE
util: use proper circular reference checking

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -612,10 +612,13 @@ function formatValue(ctx, value, recurseTimes) {
     }
   }
 
+  // TODO(addaleax): Make `seen` a Set to avoid linear-time lookup.
+  if (ctx.seen.includes(value)) {
+    return ctx.stylize('[Circular]', 'special');
+  }
+
   ctx.seen.push(value);
-
-  var output = formatter(ctx, value, recurseTimes, visibleKeys, keys);
-
+  const output = formatter(ctx, value, recurseTimes, visibleKeys, keys);
   ctx.seen.pop();
 
   return reduceToSingleString(output, base, braces, ctx.breakLength);
@@ -835,21 +838,17 @@ function formatProperty(ctx, value, recurseTimes, visibleKeys, key, array) {
     }
   }
   if (!str) {
-    if (ctx.seen.indexOf(desc.value) < 0) {
-      if (recurseTimes === null) {
-        str = formatValue(ctx, desc.value, null);
-      } else {
-        str = formatValue(ctx, desc.value, recurseTimes - 1);
-      }
-      if (str.indexOf('\n') > -1) {
-        if (array) {
-          str = str.replace(/\n/g, '\n  ');
-        } else {
-          str = str.replace(/^|\n/g, '\n   ');
-        }
-      }
+    if (recurseTimes === null) {
+      str = formatValue(ctx, desc.value, null);
     } else {
-      str = ctx.stylize('[Circular]', 'special');
+      str = formatValue(ctx, desc.value, recurseTimes - 1);
+    }
+    if (str.indexOf('\n') > -1) {
+      if (array) {
+        str = str.replace(/\n/g, '\n  ');
+      } else {
+        str = str.replace(/^|\n/g, '\n   ');
+      }
     }
   }
   if (name === undefined) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -799,6 +799,13 @@ if (typeof Symbol !== 'undefined') {
   );
 }
 
+// Test circular Set
+{
+  const set = new Set();
+  set.add(set);
+  assert.strictEqual(util.inspect(set), 'Set { [Circular] }');
+}
+
 // test Map
 {
   assert.strictEqual(util.inspect(new Map()), 'Map {}');
@@ -808,6 +815,18 @@ if (typeof Symbol !== 'undefined') {
   map.bar = 42;
   assert.strictEqual(util.inspect(map, true),
                      'Map { \'foo\' => null, [size]: 1, bar: 42 }');
+}
+
+// Test circular Map
+{
+  const map = new Map();
+  map.set(map, 'map');
+  assert.strictEqual(util.inspect(map), "Map { [Circular] => 'map' }");
+  map.set(map, map);
+  assert.strictEqual(util.inspect(map), 'Map { [Circular] => [Circular] }');
+  map.delete(map);
+  map.set('map', map);
+  assert.strictEqual(util.inspect(map), "Map { 'map' => [Circular] }");
 }
 
 // test Promise


### PR DESCRIPTION
Circular references are conceptually nothing that should be checked for objects (or Sets or Maps) only, but applies to recursive structures in general, so move the `seen` checks into a position where it is part of the recursion itself.

Fixes: #14758

Tests are taken from https://github.com/nodejs/node/pull/14775

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

util

@BridgeAR @TimothyGu @not-an-aardvark @aqrln 