### PR TITLE
lib: instantiate console methods eagerly

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -26,7 +26,8 @@
     setupProcessICUVersions();
 
     setupGlobalVariables();
-    if (!process._noBrowserGlobals) {
+    const browserGlobals = !process._noBrowserGlobals;
+    if (browserGlobals) {
       setupGlobalTimeouts();
       setupGlobalConsole();
     }
@@ -40,6 +41,22 @@
     NativeModule.require('internal/process/warning').setup();
     NativeModule.require('internal/process/next_tick').setup();
     NativeModule.require('internal/process/stdio').setup();
+    if (browserGlobals) {
+      // Instantiate eagerly in case the first call is under stack overflow
+      // conditions where instantiation doesn't work.
+      const console = global.console;
+      console.assert;
+      console.clear;
+      console.count;
+      console.countReset;
+      console.dir;
+      console.error;
+      console.log;
+      console.time;
+      console.timeEnd;
+      console.trace;
+      console.warn;
+    }
     _process.setupKillAndExit();
     _process.setupSignalHandlers();
     if (global.__coverage__)

--- a/test/message/stack_overflow_async.js
+++ b/test/message/stack_overflow_async.js
@@ -1,0 +1,18 @@
+// Flags: --stack_trace_limit=3
+
+'use strict';
+require('../common');
+
+async function f() {
+  await f();
+}
+
+async function g() {
+  try {
+    await f();
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+g();

--- a/test/message/stack_overflow_async.out
+++ b/test/message/stack_overflow_async.out
@@ -1,0 +1,4 @@
+RangeError: Maximum call stack size exceeded
+    at f (*test*message*stack_overflow_async.js:*)
+    at f (*test*message*stack_overflow_async.js:7:*)
+    at f (*test*message*stack_overflow_async.js:7:*)


### PR DESCRIPTION
Before this commit they were instantiated lazily but that fails when the
first call is under stack overflow conditions.

Fixes: https://github.com/nodejs/help/issues/778

CI: https://ci.nodejs.org/job/node-test-pull-request/9629/