### PR TITLE
build: update minimum kernel version to 3.10.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -39,7 +39,7 @@ in production.
 
 |  System      | Support type | Version                          | Architectures        | Notes            |
 |--------------|--------------|----------------------------------|----------------------|------------------|
-| GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x86, x64, arm, arm64 |                  |
+| GNU/Linux    | Tier 1       | kernel >= 3.10.0, glibc >= 2.17  | x86, x64, arm, arm64 |                  |
 | macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
 | Windows      | Tier 1       | >= Windows 7 / 2008 R2           | x86, x64             | vs2015 or vs2017 |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |


### PR DESCRIPTION
Also updates glibc version to 2.17. This means the minimum supported
distros are RHEL/CentOS 7 and Ubuntu 14.04.

| Distro       | Kernel | glibc |
|  ---         |  ---   |  ---  |
| Current      | 2.6.32 | 2.12  |
| New          | 3.10.0 | 2.17  |
| RHEL6        | 2.6.32 | 2.12  |
| Ubuntu 12.04 | 3.2 | 2.15  |
| RHEL7        | 3.10.0 | 2.17  |
| Ubuntu 14.04 | 3.13   | 2.19  |
| Ubuntu 16.04 | 4.4    | 2.23  |
| Latest       | 4.12.5 | 2.26  |

Refs: https://github.com/nodejs/build/pull/809

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

cc/ @nodejs/build @nodejs/release @bnoordhuis @seishun @rvagg 