### PR TITLE
test: add missing console.error to exec-maxBuffer

### DIFF
--- a/test/parallel/test-child-process-exec-maxBuffer.js
+++ b/test/parallel/test-child-process-exec-maxBuffer.js
@@ -36,7 +36,7 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.('${unicode}');"`;
+  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
 
   cp.exec(cmd, { maxBuffer: 10 }, checkFactory('stderr'));
 }


### PR DESCRIPTION
While looking at this test I noticed that the final cmd calls `console.('${unicode}')`. To me, it wasn't clear if this was intentional or if it should be `console.error('${unicode}')`. 

https://github.com/nodejs/node/blob/master/test/parallel/test-child-process-exec-maxBuffer.js#L39

If it was intentional I am happy for this to be closed and/or I can add a comment to the test.

/cc @Trott as author of the test case

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test