### PR TITLE
benchmark: correct assert benchmark

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -19,7 +19,7 @@ function main(conf) {
   data.copy(expected);
 
   switch (conf.method) {
-    case 'strict':
+    case 'nonstrict':
       bench.start();
       for (i = 0; i < n; ++i) {
         // eslint-disable-next-line no-restricted-properties
@@ -27,7 +27,7 @@ function main(conf) {
       }
       bench.end(n);
       break;
-    case 'nonstrict':
+    case 'strict':
       bench.start();
       for (i = 0; i < n; ++i) {
         assert.deepStrictEqual(actual, expected);


### PR DESCRIPTION
`benchmark/assert/deepequal-buffer.js` benchmarks `assert.deepEqual()`
if the `method` option is `strict` and `assert.deepStrictEqual()` if
`method` is `nonstrict`. That seems backwards and an error. This commit
fixes it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark