### PR TITLE
https: disallow boolean types for `key` and `cert` options

### DIFF
--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const tls = require('tls');
-const Buffer = require('buffer').Buffer;
 const errors = require('internal/errors');
 
 const SSL_OP_CIPHER_SERVER_PREFERENCE =
@@ -55,9 +54,10 @@ function SecureContext(secureProtocol, secureOptions, context) {
 }
 
 function validateKeyCert(value, type) {
-  if (typeof value !== 'string' && !(value instanceof Buffer))
+  if (typeof value !== 'string' && !ArrayBuffer.isView(value))
     throw new errors.TypeError(
-      'ERR_INVALID_ARG_TYPE', type, ['string', 'buffer']
+      'ERR_INVALID_ARG_TYPE', type,
+      ['string', 'Buffer', 'TypedArray', 'DataView']
     );
 }
 

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -22,6 +22,8 @@
 'use strict';
 
 const tls = require('tls');
+const Buffer = require('buffer').Buffer;
+const errors = require('internal/errors');
 
 const SSL_OP_CIPHER_SERVER_PREFERENCE =
     process.binding('constants').crypto.SSL_OP_CIPHER_SERVER_PREFERENCE;
@@ -52,6 +54,13 @@ function SecureContext(secureProtocol, secureOptions, context) {
   if (secureOptions) this.context.setOptions(secureOptions);
 }
 
+function validateKeyCert(value, type) {
+  if (typeof value !== 'string' && !(value instanceof Buffer))
+    throw new errors.TypeError(
+      'ERR_INVALID_ARG_TYPE', type, ['string', 'buffer']
+    );
+}
+
 exports.SecureContext = SecureContext;
 
 
@@ -71,10 +80,12 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // cert's issuer in C++ code.
   if (options.ca) {
     if (Array.isArray(options.ca)) {
-      for (i = 0; i < options.ca.length; i++) {
-        c.context.addCACert(options.ca[i]);
-      }
+      options.ca.map((ca) => {
+        validateKeyCert(ca, 'ca');
+        c.context.addCACert(ca);
+      });
     } else {
+      validateKeyCert(options.ca, 'ca');
       c.context.addCACert(options.ca);
     }
   } else {
@@ -83,9 +94,12 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.cert) {
     if (Array.isArray(options.cert)) {
-      for (i = 0; i < options.cert.length; i++)
-        c.context.setCert(options.cert[i]);
+      options.cert.map((cert) => {
+        validateKeyCert(cert, 'cert');
+        c.context.setCert(cert);
+      });
     } else {
+      validateKeyCert(options.cert, 'cert');
       c.context.setCert(options.cert);
     }
   }
@@ -96,12 +110,12 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // which leads to the crash later on.
   if (options.key) {
     if (Array.isArray(options.key)) {
-      for (i = 0; i < options.key.length; i++) {
-        const key = options.key[i];
-        const passphrase = key.passphrase || options.passphrase;
-        c.context.setKey(key.pem || key, passphrase);
-      }
+      options.key.map((k) => {
+        validateKeyCert(k.pem || k, 'key');
+        c.context.setKey(k.pem || k, k.passphrase || options.passphrase);
+      });
     } else {
+      validateKeyCert(options.key, 'key');
       c.context.setKey(options.key, options.passphrase);
     }
   }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -80,7 +80,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // cert's issuer in C++ code.
   if (options.ca) {
     if (Array.isArray(options.ca)) {
-      options.ca.map((ca) => {
+      options.ca.forEach((ca) => {
         validateKeyCert(ca, 'ca');
         c.context.addCACert(ca);
       });
@@ -94,7 +94,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.cert) {
     if (Array.isArray(options.cert)) {
-      options.cert.map((cert) => {
+      options.cert.forEach((cert) => {
         validateKeyCert(cert, 'cert');
         c.context.setCert(cert);
       });
@@ -110,7 +110,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   // which leads to the crash later on.
   if (options.key) {
     if (Array.isArray(options.key)) {
-      options.key.map((k) => {
+      options.key.forEach((k) => {
         validateKeyCert(k.pem || k, 'key');
         c.context.setKey(k.pem || k, k.passphrase || options.passphrase);
       });

--- a/lib/https.js
+++ b/lib/https.js
@@ -40,6 +40,12 @@ function Server(opts, requestListener) {
   }
   opts = util._extend({}, opts);
 
+  if (opts && typeof opts.key === 'boolean')
+    throw new Error('"options.key" must not be a boolean');
+
+  if (opts && typeof opts.cert === 'boolean')
+    throw new Error('"options.cert" must not be a boolean');
+
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }

--- a/lib/https.js
+++ b/lib/https.js
@@ -40,12 +40,6 @@ function Server(opts, requestListener) {
   }
   opts = util._extend({}, opts);
 
-  if (opts && typeof opts.key === 'boolean')
-    throw new Error('"options.key" must not be a boolean');
-
-  if (opts && typeof opts.cert === 'boolean')
-    throw new Error('"options.cert" must not be a boolean');
-
   if (process.features.tls_npn && !opts.NPNProtocols) {
     opts.NPNProtocols = ['http/1.1', 'http/1.0'];
   }

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -1,28 +1,46 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 
-const keyBuff = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
-const certBuff = fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`);
-const keyBuff2 = fs.readFileSync(`${common.fixturesDir}/keys/ec-key.pem`);
-const certBuff2 = fs.readFileSync(`${common.fixturesDir}/keys/ec-cert.pem`);
-const caCert = fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`);
-const caCert2 = fs.readFileSync(`${common.fixturesDir}/keys/ca2-cert.pem`);
+function toArrayBuffer(buf) {
+  const ab = new ArrayBuffer(buf.length);
+  const view = new Uint8Array(ab);
+  return buf.map((b, i) => view[i] = b);
+}
+
+function toDataView(buf) {
+  const ab = new ArrayBuffer(buf.length);
+  const view = new DataView(ab);
+  return buf.map((b, i) => view[i] = b);
+}
+
+const keyBuff = fixtures.readKey('agent1-key.pem');
+const certBuff = fixtures.readKey('agent1-cert.pem');
+const keyBuff2 = fixtures.readKey('ec-key.pem');
+const certBuff2 = fixtures.readKey('ec-cert.pem');
+const caCert = fixtures.readKey('ca1-cert.pem');
+const caCert2 = fixtures.readKey('ca2-cert.pem');
 const keyStr = keyBuff.toString();
 const certStr = certBuff.toString();
 const keyStr2 = keyBuff2.toString();
 const certStr2 = certBuff2.toString();
 const caCertStr = caCert.toString();
 const caCertStr2 = caCert2.toString();
-const invalidKeyRE = /^The "key" argument must be one of type string or buffer$/;
-const invalidCertRE = /^The "cert" argument must be one of type string or buffer$/;
+const keyArrBuff = toArrayBuffer(keyBuff);
+const certArrBuff = toArrayBuffer(certBuff);
+const caArrBuff = toArrayBuffer(caCert);
+const keyDataView = toDataView(keyBuff);
+const certDataView = toDataView(certBuff);
+const caArrDataView = toDataView(caCert);
+const invalidKeyRE = /^The "key" argument must be one of type string, Buffer, TypedArray, or DataView$/;
+const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, TypedArray, or DataView$/;
 
 // Checks to ensure https.createServer doesn't throw an error
 // Format ['key', 'cert']
@@ -34,6 +52,12 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [false, certStr],
   [keyStr, false],
   [false, false],
+  [keyArrBuff, certArrBuff],
+  [keyArrBuff, false],
+  [false, certArrBuff],
+  [keyDataView, certDataView],
+  [keyDataView, false],
+  [false, certDataView],
   [[keyBuff, keyBuff2], [certBuff, certBuff2]],
   [[keyStr, keyStr2], [certStr, certStr2]],
   [[keyStr, keyStr2], false],
@@ -56,6 +80,10 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [keyBuff, true, invalidCertRE],
   [true, certStr, invalidKeyRE],
   [keyStr, true, invalidCertRE],
+  [true, certArrBuff, invalidKeyRE],
+  [keyArrBuff, true, invalidCertRE],
+  [true, certDataView, invalidKeyRE],
+  [keyDataView, true, invalidCertRE],
   [true, true, invalidCertRE],
   [true, false, invalidKeyRE],
   [false, true, invalidCertRE],
@@ -92,6 +120,8 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [keyBuff, certBuff, [caCert, caCert2]],
   [keyBuff, certBuff, caCertStr],
   [keyBuff, certBuff, [caCertStr, caCertStr2]],
+  [keyBuff, certBuff, caArrBuff],
+  [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
 ].map((params) => {
   assert.doesNotThrow(() => {
@@ -121,6 +151,6 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "ca" argument must be one of type string or buffer$/
+    message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
   }));
 });

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -1,0 +1,84 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const https = require('https');
+const fs = require('fs');
+
+assert.doesNotThrow(() =>
+  https.createServer({
+    key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  }));
+
+assert.throws(() =>
+  https.createServer({
+    key: true,
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  }), /"options\.key" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: false,
+    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  }), /"options\.key" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+    cert: true
+  }), /"options\.cert" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
+    cert: false
+  }), /"options\.cert" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: false,
+    cert: false
+  }), /"options\.key" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: true,
+    cert: true
+  }), /"options\.key" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: true,
+    cert: false
+  }), /"options\.key" must not be a boolean/);
+
+assert.throws(() =>
+  https.createServer({
+    key: false,
+    cert: true
+  }), /"options\.key" must not be a boolean/);

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const https = require('https');
+const tls = require('tls');
 const fs = require('fs');
 
 const keyBuff = fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`);
@@ -24,7 +24,7 @@ const caCertStr2 = caCert2.toString();
 const invalidKeyRE = /^The "key" argument must be one of type string or buffer$/;
 const invalidCertRE = /^The "cert" argument must be one of type string or buffer$/;
 
-// Checks to ensure https.createServer doesn't throw an error
+// Checks to ensure tls.createServer doesn't throw an error
 // Format ['key', 'cert']
 [
   [keyBuff, certBuff],
@@ -42,14 +42,14 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
 ].map((params) => {
   assert.doesNotThrow(() => {
-    https.createServer({
+    tls.createServer({
       key: params[0],
       cert: params[1]
     });
   });
 });
 
-// Checks to ensure https.createServer predictably throws an error
+// Checks to ensure tls.createServer predictably throws an error
 // Format ['key', 'cert', 'expected message']
 [
   [true, certBuff, invalidKeyRE],
@@ -74,7 +74,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [true, [certBuff, certBuff2], invalidKeyRE]
 ].map((params) => {
   assert.throws(() => {
-    https.createServer({
+    tls.createServer({
       key: params[0],
       cert: params[1]
     });
@@ -85,7 +85,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   }));
 });
 
-// Checks to ensure https.createServer works with the CA parameter
+// Checks to ensure tls.createServer works with the CA parameter
 // Format ['key', 'cert', 'ca']
 [
   [keyBuff, certBuff, caCert],
@@ -95,7 +95,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [keyBuff, certBuff, false],
 ].map((params) => {
   assert.doesNotThrow(() => {
-    https.createServer({
+    tls.createServer({
       key: params[0],
       cert: params[1],
       ca: params[2]
@@ -103,7 +103,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   });
 });
 
-// Checks to ensure https.createServer throws an error for CA assignment
+// Checks to ensure tls.createServer throws an error for CA assignment
 // Format ['key', 'cert', 'ca']
 [
   [keyBuff, certBuff, true],
@@ -113,7 +113,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string or buffer
   [keyBuff, certBuff, [caCert, true]]
 ].map((params) => {
   assert.throws(() => {
-    https.createServer({
+    tls.createServer({
       key: params[0],
       cert: params[1],
       ca: params[2]


### PR DESCRIPTION
*This is my first PR on the Node repository, your feedback is greatly appreciated.*

When using https.createServer, passing boolean values for `key` and `cert` properties in the options object parameter doesn't throw an error an could lead to potential issues if they're accidentally passed.

This PR aims to throw a reasonable error if a boolean was passed to either of those properties.

Fixes: https://github.com/nodejs/node/issues/12802

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
https