### PR TITLE
http2: improve perf of passing headers to JS

### DIFF
--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -5,7 +5,7 @@ const PORT = common.PORT;
 
 var bench = common.createBenchmark(main, {
   n: [1e3],
-  nheaders: [100, 1000],
+  nheaders: [0, 10, 100, 1000],
 }, { flags: ['--expose-http2', '--no-warnings'] });
 
 function main(conf) {
@@ -14,7 +14,16 @@ function main(conf) {
   const http2 = require('http2');
   const server = http2.createServer();
 
-  const headersObject = { ':path': '/' };
+  const headersObject = {
+    ':path': '/',
+    ':scheme': 'http',
+    'accept-encoding': 'gzip, deflate',
+    'accept-language': 'en',
+    'content-type': 'text/plain',
+    'referer': 'https://example.org/',
+    'user-agent': 'SuperBenchmarker 3000'
+  };
+
   for (var i = 0; i < nheaders; i++) {
     headersObject[`foo${i}`] = `some header value ${i}`;
   }

--- a/deps/nghttp2/lib/includes/nghttp2/nghttp2.h
+++ b/deps/nghttp2/lib/includes/nghttp2/nghttp2.h
@@ -470,6 +470,15 @@ NGHTTP2_EXTERN void nghttp2_rcbuf_decref(nghttp2_rcbuf *rcbuf);
 NGHTTP2_EXTERN nghttp2_vec nghttp2_rcbuf_get_buf(nghttp2_rcbuf *rcbuf);
 
 /**
+ * @function
+ *
+ * Returns 1 if the underlying buffer is statically allocated,
+ * and 0 otherwise. This can be useful for language bindings that wish to avoid
+ * creating duplicate strings for these buffers.
+ */
+NGHTTP2_EXTERN int nghttp2_rcbuf_is_static(const nghttp2_rcbuf *rcbuf);
+
+/**
  * @enum
  *
  * The flags for header field name/value pair.

--- a/deps/nghttp2/lib/nghttp2_rcbuf.c
+++ b/deps/nghttp2/lib/nghttp2_rcbuf.c
@@ -96,3 +96,7 @@ nghttp2_vec nghttp2_rcbuf_get_buf(nghttp2_rcbuf *rcbuf) {
   nghttp2_vec res = {rcbuf->base, rcbuf->len};
   return res;
 }
+
+int nghttp2_rcbuf_is_static(const nghttp2_rcbuf *rcbuf) {
+  return rcbuf->ref == -1;
+}

--- a/src/env.h
+++ b/src/env.h
@@ -40,6 +40,9 @@
 #include <stdint.h>
 #include <vector>
 #include <stack>
+#include <unordered_map>
+
+struct nghttp2_rcbuf;
 
 namespace node {
 
@@ -337,6 +340,8 @@ class IsolateData {
 #undef V
 #undef VS
 #undef VP
+
+  std::unordered_map<nghttp2_rcbuf*, v8::Eternal<v8::String>> http2_static_strs;
 
  private:
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -875,8 +875,10 @@ void Http2Session::OnHeaders(Nghttp2Stream* stream,
     while (headers != nullptr && j < arraysize(argv) / 2) {
       nghttp2_header_list* item = headers;
       // The header name and value are passed as external one-byte strings
-      name_str = ExternalHeader::New(isolate, item->name);
-      value_str = ExternalHeader::New(isolate, item->value);
+      name_str =
+          ExternalHeader::New<true>(env(), item->name).ToLocalChecked();
+      value_str =
+          ExternalHeader::New<false>(env(), item->value).ToLocalChecked();
       argv[j * 2] = name_str;
       argv[j * 2 + 1] = value_str;
       headers = item->next;

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -488,24 +488,48 @@ class ExternalHeader :
     return vec_.len;
   }
 
-  static Local<String> New(Isolate* isolate, nghttp2_rcbuf* buf) {
-    EscapableHandleScope scope(isolate);
+  static inline
+  MaybeLocal<String> GetInternalizedString(Environment* env,
+                                           const nghttp2_vec& vec) {
+    return String::NewFromOneByte(env->isolate(),
+                                  vec.base,
+                                  v8::NewStringType::kInternalized,
+                                  vec.len);
+  }
+
+  template<bool may_internalize>
+  static MaybeLocal<String> New(Environment* env, nghttp2_rcbuf* buf) {
+    if (nghttp2_rcbuf_is_static(buf)) {
+      auto& static_str_map = env->isolate_data()->http2_static_strs;
+      v8::Eternal<v8::String>& eternal = static_str_map[buf];
+      if (eternal.IsEmpty()) {
+        Local<String> str =
+            GetInternalizedString(env, nghttp2_rcbuf_get_buf(buf))
+                .ToLocalChecked();
+        eternal.Set(env->isolate(), str);
+        return str;
+      }
+      return eternal.Get(env->isolate());
+    }
+
     nghttp2_vec vec = nghttp2_rcbuf_get_buf(buf);
     if (vec.len == 0) {
       nghttp2_rcbuf_decref(buf);
-      return scope.Escape(String::Empty(isolate));
+      return String::Empty(env->isolate());
+    }
+
+    if (may_internalize && vec.len < 64) {
+      // This is a short header name, so there is a good chance V8 already has
+      // it internalized.
+      return GetInternalizedString(env, vec);
     }
 
     ExternalHeader* h_str = new ExternalHeader(buf);
-    MaybeLocal<String> str = String::NewExternalOneByte(isolate, h_str);
-    isolate->AdjustAmountOfExternalAllocatedMemory(vec.len);
-
-    if (str.IsEmpty()) {
+    MaybeLocal<String> str = String::NewExternalOneByte(env->isolate(), h_str);
+    if (str.IsEmpty())
       delete h_str;
-      return scope.Escape(String::Empty(isolate));
-    }
 
-    return scope.Escape(str.ToLocalChecked());
+    return str;
   }
 
  private:


### PR DESCRIPTION
- Make `ExternalString::New` return a `MaybeLocal`. Failing is left up to the caller.
- Allow creating internalized strings for short header names to reduce memory consumption and increase performance.
- Use persistent storage for statically allocated header names.

Each of the latter two gives about 2.5 % perf in the benchmark (which, again, does a lot more than just reading headers from the stream.)

```
$ ./node benchmark/compare.js --new ./node --old ./node-master-348dd66337e --runs 10 --filter headers http2 | Rscript benchmark/compare.R
[00:00:27|% 100| 1/1 files | 20/20 runs | 2/2 configs]: Done
                                      improvement confidence      p.value
 http2/headers.js nheaders=0 n=1000       4.01 %        *** 1.890685e-05
 http2/headers.js nheaders=10 n=1000      5.19 %        *** 8.936262e-06
```

This does not yet include any work regarding never-indexed header fields, but it should be sufficiently independent from that anyway.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/http2 
