### PR TITLE
doc: add missing `changes:` metadata for recent PRs

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1740,6 +1740,13 @@ constructor and implement *both* the `readable._read()` and
 `writable._write()` methods.
 
 #### new stream.Duplex(options)
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/14636
+    description: The `readableHighWaterMark` and `writableHighWaterMark` options
+                 are supported now.
+-->
 
 * `options` {Object} Passed to both Writable and Readable
   constructors. Also has the following fields:

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -150,6 +150,10 @@ property take precedence over `--trace-deprecation` and
 ## util.format(format[, ...args])
 <!-- YAML
 added: v0.5.3
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/14558
+    description: The `%o` and `%O` specifiers are supported now.
 -->
 
 * `format` {string} A `printf`-like format string.


### PR DESCRIPTION
Ref: #14636
Ref: #14558

In separate commits because it’s not clear whether both features either get backported to LTS or not backported, and if they are, whether that happens at the same time.

@nodejs/collaborators As a small reminder, try to watch out for this when reviewing API changes :) Also, would be helpful if this could be fast-tracked.