### PR TITLE
timers: Implement conversion of timer argument

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -500,8 +500,30 @@ function rearm(timer) {
   }
 }
 
+function extractTimer(timer) {
+  if (Timeout.prototype.isPrototypeOf(timer) || typeof timer !== 'object' ||
+      timer === null || timer === undefined) {
+    return timer;
+  }
+
+  if (typeof timer[Symbol.toPrimitive] === 'function') {
+    return timer[Symbol.toPrimitive]('default');
+  }
+
+  if (timer.valueOf && Timeout.prototype.isPrototypeOf(timer.valueOf())) {
+    return timer.valueOf();
+  }
+
+  if (timer.toString && Timeout.prototype.isPrototypeOf(timer.toString())) {
+    return timer.toString();
+  }
+
+  return timer;
+}
+
 
 const clearTimeout = exports.clearTimeout = function(timer) {
+  timer = extractTimer(timer);
   if (timer && (timer[kOnTimeout] || timer._onTimeout)) {
     timer[kOnTimeout] = timer._onTimeout = null;
     if (timer instanceof Timeout) {
@@ -550,6 +572,7 @@ function createRepeatTimeout(callback, repeat, args) {
 }
 
 exports.clearInterval = function(timer) {
+  timer = extractTimer(timer);
   if (timer && timer._repeat) {
     timer._repeat = null;
     clearTimeout(timer);

--- a/test/parallel/test-timers-timer-argument-convert.js
+++ b/test/parallel/test-timers-timer-argument-convert.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+
+const cb = common.mustNotCall(() => { });
+
+const timer1 = setTimeout(cb, 1000);
+clearTimeout({
+  valueOf() { return timer1; }
+});
+
+const timer2 = setTimeout(cb, 1000);
+clearTimeout({
+  toString() { return timer2; }
+});
+
+const timer3 = setTimeout(cb, 1000);
+clearTimeout({
+  [Symbol.toPrimitive](hint) {
+    return timer3;
+  }
+});
+
+const timer4 = setTimeout(cb, 1000);
+clearTimeout({
+  valueOf() { return timer4; },
+  toString() { return {}; }
+});


### PR DESCRIPTION
"timer" argument should be converted to primitive, which makes the node API consistent with the browsers behavior.

Fix: https://github.com/nodejs/node/issues/7792

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers