### PR TITLE
buffer: fix MAX_LENGTH constant export

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -76,7 +76,7 @@ Buffer.prototype = FastBuffer.prototype;
 
 const constants = Object.defineProperties({}, {
   MAX_LENGTH: {
-    value: kStringMaxLength,
+    value: kMaxLength,
     writable: false,
     enumerable: true
   },

--- a/test/parallel/test-buffer-constants.js
+++ b/test/parallel/test-buffer-constants.js
@@ -2,6 +2,7 @@
 require('../common');
 const assert = require('assert');
 
+const { kMaxLength, kStringMaxLength } = require('buffer');
 const { MAX_LENGTH, MAX_STRING_LENGTH } = require('buffer').constants;
 
 assert.strictEqual(typeof MAX_LENGTH, 'number');
@@ -11,3 +12,7 @@ assert.throws(() => ' '.repeat(MAX_STRING_LENGTH + 1),
               /^RangeError: Invalid string length$/);
 
 assert.doesNotThrow(() => ' '.repeat(MAX_STRING_LENGTH));
+
+// Legacy values match:
+assert.strictEqual(kMaxLength, MAX_LENGTH);
+assert.strictEqual(kStringMaxLength, MAX_STRING_LENGTH);


### PR DESCRIPTION
This was a typo and accidentally returned the wrong value.

Fixes: https://github.com/nodejs/node/issues/14819
Ref: https://github.com/nodejs/node/pull/13467

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

buffer