### PR TITLE
[v4.x] deps: revert/re-apply 09db540 from upstream v8

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 4
 #define V8_MINOR_VERSION 5
 #define V8_BUILD_NUMBER 103
-#define V8_PATCH_LEVEL 48
+#define V8_PATCH_LEVEL 49
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -2614,13 +2614,6 @@ void MarkCompactCollector::ClearWeakCollections() {
           table->RemoveEntry(i);
         }
       }
-      // Rehash if more than 25% of the entries are deleted entries.
-      // TODO(jochen): Consider to shrink the fixed array in place.
-      if ((table->NumberOfDeletedElements() << kJSWeakCollectionLoadFactorExp) >
-          table->NumberOfElements()) {
-        HandleScope scope(heap()->isolate());
-        table->Rehash(heap()->isolate()->factory()->undefined_value());
-      }
     }
     weak_collection_obj = weak_collection->next();
     weak_collection->set_next(heap()->undefined_value());

--- a/deps/v8/src/heap/mark-compact.h
+++ b/deps/v8/src/heap/mark-compact.h
@@ -612,10 +612,6 @@ class MarkCompactCollector {
   static const uint32_t kSingleFreeEncoding = 0;
   static const uint32_t kMultiFreeEncoding = 1;
 
-  // If the number of deleted slots in a JSWeakCollection exceeds the number
-  // of entries / 2^(factor), we rehash the table.
-  static const int kJSWeakCollectionLoadFactorExp = 1;
-
   static inline bool IsMarked(Object* obj);
   static bool IsUnmarkedHeapObjectWithHeap(Heap* heap, Object** p);
 

--- a/deps/v8/src/objects.cc
+++ b/deps/v8/src/objects.cc
@@ -13744,16 +13744,6 @@ void HashTable<Derived, Shape, Key>::Rehash(Key key) {
       }
     }
   }
-  // Wipe deleted entries.
-  Heap* heap = GetHeap();
-  Object* the_hole = heap->the_hole_value();
-  Object* undefined = heap->undefined_value();
-  for (uint32_t current = 0; current < capacity; current++) {
-    if (get(EntryToIndex(current)) == the_hole) {
-      set(EntryToIndex(current), undefined);
-    }
-  }
-  SetNumberOfDeletedElements(0);
 }
 
 
@@ -14677,7 +14667,6 @@ Handle<CompilationCacheTable> CompilationCacheTable::PutRegExp(
 void CompilationCacheTable::Age() {
   DisallowHeapAllocation no_allocation;
   Object* the_hole_value = GetHeap()->the_hole_value();
-  uint32_t capacity = Capacity();
   for (int entry = 0, size = Capacity(); entry < size; entry++) {
     int entry_index = EntryToIndex(entry);
     int value_index = entry_index + 1;
@@ -14701,16 +14690,6 @@ void CompilationCacheTable::Age() {
       }
     }
   }
-  // Wipe deleted entries.
-  Heap* heap = GetHeap();
-  Object* the_hole = heap->the_hole_value();
-  Object* undefined = heap->undefined_value();
-  for (uint32_t current = 0; current < capacity; current++) {
-    if (get(EntryToIndex(current)) == the_hole) {
-      set(EntryToIndex(current), undefined);
-    }
-  }
-  SetNumberOfDeletedElements(0);
 }
 
 
@@ -15219,11 +15198,6 @@ Handle<ObjectHashTable> ObjectHashTable::Put(Handle<ObjectHashTable> table,
     return table;
   }
 
-  // Rehash if more than 25% of the entries are deleted entries.
-  // TODO(jochen): Consider to shrink the fixed array in place.
-  if ((table->NumberOfDeletedElements() << 1) > table->NumberOfElements()) {
-    table->Rehash(isolate->factory()->undefined_value());
-  }
   // If we're out of luck, we didn't get a GC recently, and so rehashing
   // isn't enough to avoid a crash.
   if (!table->HasSufficientCapacityToAdd(1)) {

--- a/deps/v8/test/cctest/test-weakmaps.cc
+++ b/deps/v8/test/cctest/test-weakmaps.cc
@@ -123,7 +123,7 @@ TEST(Weakness) {
   heap->CollectAllGarbage(false);
   CHECK_EQ(1, NumberOfWeakCalls);
   CHECK_EQ(0, ObjectHashTable::cast(weakmap->table())->NumberOfElements());
-  CHECK_EQ(0,
+  CHECK_EQ(2,
            ObjectHashTable::cast(weakmap->table())->NumberOfDeletedElements());
 }
 

--- a/deps/v8/test/cctest/test-weaksets.cc
+++ b/deps/v8/test/cctest/test-weaksets.cc
@@ -122,8 +122,8 @@ TEST(WeakSet_Weakness) {
   heap->CollectAllGarbage(false);
   CHECK_EQ(1, NumberOfWeakCalls);
   CHECK_EQ(0, ObjectHashTable::cast(weakset->table())->NumberOfElements());
-  CHECK_EQ(0,
-           ObjectHashTable::cast(weakset->table())->NumberOfDeletedElements());
+  CHECK_EQ(
+      1, ObjectHashTable::cast(weakset->table())->NumberOfDeletedElements());
 }
 
 


### PR DESCRIPTION
This PR aims to fix an improperly applied backport to the v8 deps on the v4.x series.

As discussed and discovered in https://github.com/nodejs/node/issues/14228, the original intention of https://github.com/nodejs/node/commit/3e8d7a73aa5d17f070ab17741e48249ea5a9853c was to apply https://github.com/v8/v8/commit/e093a04 and https://github.com/v8/v8/commit/09db540 but that backport commit failed to consider that the former commit (`e093`) was reverted in https://github.com/v8/v8/commit/5f5a3282d4b21eb0800f1d1af85926670ba0d904.  This led to inadvertent changes (which were never present on v8) to `MarkCompactCollector::ClearWeakCollections` being left in place on the Node.js 4.x series, in addition to the (incorrect) changes to the `weakset` and `weakmap` tests.

That `MarkCompactCollector` change is directly responsible for some errors, specifically noted in the stack traces of the post-mortems reported by myself and others in https://github.com/nodejs/node/issues/14228 and https://github.com/meteor/meteor/pull/8970#issuecomment-319877857.

Furthermore, while the correct fix to v8 was meant to apply the "Wipe deleted entries" logic to `HashTable::Rehash` it was also applied to `CompilationCacheTable::Age` as well.  You'll note that an additional, seemingly arbitrary `capacity` variable needed to be declared in the backport which was not present in the original patch.  Not too surprising as the patch applies cleanly to that class as well, albeit with a several thousand line patch offset.  (This caught me off guard during debugging as well and it looks as if the v8 team was also bit by this temporarily in https://github.com/v8/v8/commit/59c7657d642bf500c49da3c4bd0e6d7bf647ec7d!)

In this process, I also took the liberty to backport the very relevant https://github.com/v8/v8/commit/686558d which corrects the comment on the original commit.

It's my belief that this now matches up with the intended fix for https://github.com/nodejs/node/issues/6180 and crbug.com/v8/4909 and also maintains relevant follow-ups, such as https://github.com/v8/v8/commit/b93c80a6 and https://github.com/v8/v8/commit/a76d133f.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
V8 Engine

This is my first v8 commit, so happy to adjust accordingly, but this is what I've found!
