### PR TITLE
test: make timers-blocking-callback more reliable

### DIFF
--- a/test/sequential/test-timers-blocking-callback.js
+++ b/test/sequential/test-timers-blocking-callback.js
@@ -63,7 +63,7 @@ function blockingCallback(retry, callback) {
         retries--;
         return retry(callback);
       }
-      assert.fail(`timeout delayed by more than 100ms (${latestDelay}ms)`);
+      assert.fail(`timeout delayed by more than 100% (${latestDelay}ms)`);
     }
     if (callback)
       return callback();

--- a/test/sequential/test-timers-blocking-callback.js
+++ b/test/sequential/test-timers-blocking-callback.js
@@ -33,13 +33,14 @@ let nbBlockingCallbackCalls;
 let latestDelay;
 let timeCallbackScheduled;
 
-// These tests are somewhat probablistic so they may fail even when the bug is
-// not present. However, they fail 100% of the time when the bug *is* present,
-// so to increase reliability, allow for a small number of retries. (Keep it
-// small because as currently written, one failure could result in multiple
-// simultaneous retries of the test. Don't want to timer-bomb ourselves.
-// Observed failures are infrequent anyway, so only a small number of retries
-// is hopefully more than sufficient.)
+// These tests are timing dependent so they may fail even when the bug is
+// not present (if the host is sufficiently busy that the timers are delayed 
+// significantly). However, they fail 100% of the time when the bug *is*
+// present, so to increase reliability, allow for a small number of retries.
+// (Keep it small because as currently written, one failure could result in
+// multiple simultaneous retries of the test. Don't want to timer-bomb
+// ourselves. Observed failures are infrequent anyway, so only a small number of
+// retries is hopefully more than sufficient.)
 let retries = 2;
 
 function initTest() {

--- a/test/sequential/test-timers-blocking-callback.js
+++ b/test/sequential/test-timers-blocking-callback.js
@@ -59,7 +59,7 @@ function blockingCallback(retry, callback) {
     // But they are guaranteed to be at least 100ms late given the bug in
     // https://github.com/nodejs/node-v0.x-archive/issues/15447 and
     // https://github.com/nodejs/node-v0.x-archive/issues/9333.
-    if (latestDelay > TIMEOUT * 2) {
+    if (latestDelay >= TIMEOUT * 2) {
       if (retries > 0) {
         retries--;
         return retry(callback);


### PR DESCRIPTION
test-timers-blocking-callback may fail erroneously on
resource-constrained machines due to the timing nature of the test.

There is likely no way around the timing issue. This change tries to
decrease the probability of the test failing erroneously by having it
retry a small number of times on failure.

Tested on 0.10.38 (which has a bug that this test was written for) and
(modifying the test slightly to remove ES6 stuff) the test still seems
to fail 100% of the time there, which is what we want/expect.

Fixes: #14792 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test timers