### PR TITLE
test: increase coverage for http2.connect

### DIFF
--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -1,31 +1,49 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall, hasCrypto, skip } = require('../common');
+const { mustCall, hasCrypto, skip, expectsError } = require('../common');
 if (!hasCrypto)
   skip('missing crypto');
-const { doesNotThrow } = require('assert');
+const { doesNotThrow, throws } = require('assert');
 const { createServer, connect } = require('http2');
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const authority = `http://localhost:${server.address().port}`;
+    const options = {};
+    const listener = () => mustCall();
 
-const server = createServer();
-server.listen(0, mustCall(() => {
-  const authority = `http://localhost:${server.address().port}`;
-  const options = {};
-  const listener = () => mustCall();
+    const clients = new Set();
+    doesNotThrow(() => clients.add(connect(authority)));
+    doesNotThrow(() => clients.add(connect(authority, options)));
+    doesNotThrow(() => clients.add(connect(authority, options, listener())));
+    doesNotThrow(() => clients.add(connect(authority, listener())));
 
-  const clients = new Set();
-  doesNotThrow(() => clients.add(connect(authority)));
-  doesNotThrow(() => clients.add(connect(authority, options)));
-  doesNotThrow(() => clients.add(connect(authority, options, listener())));
-  doesNotThrow(() => clients.add(connect(authority, listener())));
+    for (const client of clients) {
+      client.once('connect', mustCall((headers) => {
+        client.destroy();
+        clients.delete(client);
+        if (clients.size === 0) {
+          server.close();
+        }
+      }));
+    }
+  }));
+}
 
-  for (const client of clients) {
-    client.once('connect', mustCall((headers) => {
-      client.destroy();
-      clients.delete(client);
-      if (clients.size === 0) {
-        server.close();
-      }
-    }));
-  }
-}));
+// check for https as protocol
+{
+  const authority = 'https://localhost';
+  doesNotThrow(() => connect(authority));
+}
+
+// check for error for an invalid protocol (not http or https)
+{
+  const authority = 'ssh://localhost';
+  throws(() => {
+    connect(authority);
+  }, expectsError({
+    code: 'ERR_HTTP2_UNSUPPORTED_PROTOCOL',
+    type: Error
+  }));
+}


### PR DESCRIPTION
Added tests to check for `connect` using HTTPS working as intended and `ERR_HTTP2_UNSUPPORTED_PROTOCOL` being thrown for using an unsupported protocol.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2
