### PR TITLE
buffer: fix wrong value of buffer.constants.MAX_LENGTH

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -76,7 +76,7 @@ Buffer.prototype = FastBuffer.prototype;
 
 const constants = Object.defineProperties({}, {
   MAX_LENGTH: {
-    value: kStringMaxLength,
+    value: kMaxLength,
     writable: false,
     enumerable: true
   },

--- a/test/parallel/test-buffer-max-length.js
+++ b/test/parallel/test-buffer-max-length.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const buffer = require('buffer');
+
+assert.strictEqual(buffer.kMaxLength,
+                   buffer.constants.MAX_LENGTH);
+assert.strictEqual(buffer.kStringMaxLength,
+                   buffer.constants.MAX_STRING_LENGTH);


### PR DESCRIPTION
The value of `buffer.kMaxLength` is different from `buffer.constants.MAX_LENGT`.This change is to fix it.

Fixes: https://github.com/nodejs/node/issues/14819

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer