### PR TITLE
src: remove unnecessary check of more boolean

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4567,7 +4567,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
         if (uv_run(env.event_loop(), UV_RUN_NOWAIT) != 0)
           more = true;
       }
-    } while (more == true);
+    } while (more);
   }
 
   env.set_trace_sync_io(false);


### PR DESCRIPTION
Having an explicit true check of the more variable in the while clause
does not seem to be consistent with other such while clauses in the
code base.

This commit removes the check.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src