### PR TITLE
tools: fix update-eslint.sh

### DIFF
--- a/tools/update-eslint.sh
+++ b/tools/update-eslint.sh
@@ -11,6 +11,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 rm -rf eslint
 mkdir eslint-tmp
 cd eslint-tmp
+npm init --yes
 
 npm install --global-style --no-bin-links --production eslint@latest
 cd node_modules/eslint


### PR DESCRIPTION
The script currently assumes that there is a package.json in
`eslint-tmp`. If there isn't the logic of the script fails.
This adds a call to `npm init --yes` ensuring there is a package.json
and that the script can do it's thing.
