### PR TITLE
src: detect nul bytes in InternalModuleReadFile()

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -503,6 +503,9 @@ static void InternalModuleReadFile(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
   node::Utf8Value path(env->isolate(), args[0]);
 
+  if (strlen(*path) != path.length())
+    return;  // Contains a nul byte.
+
   uv_fs_t open_req;
   const int fd = uv_fs_open(loop, &open_req, *path, O_RDONLY, 0, nullptr);
   uv_fs_req_cleanup(&open_req);

--- a/test/parallel/test-require-nul.js
+++ b/test/parallel/test-require-nul.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Nul bytes should throw, not abort.
+assert.throws(() => require('\u0000ab'), /Cannot find module '\u0000ab'/);
+assert.throws(() => require('a\u0000b'), /Cannot find module 'a\u0000b'/);
+assert.throws(() => require('ab\u0000'), /Cannot find module 'ab\u0000'/);


### PR DESCRIPTION
Throw an exception when the path contains nul bytes, don't abort.

Fixes: https://github.com/nodejs/node/issues/13787
CI: https://ci.nodejs.org/job/node-test-pull-request/9683/