### PR TITLE
(v4.x-backport) zlib: fix crash when initializing failed

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -373,6 +373,10 @@ added: v0.5.8
 
 Returns a new [DeflateRaw][] object with an [options][].
 
+*Note*: The zlib library rejects requests for 256-byte windows (i.e.,
+`{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating a
+[DeflateRaw][] object with this specific value of the `windowBits` option.
+
 ## zlib.createGunzip([options])
 <!-- YAML
 added: v0.5.8

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -372,9 +372,19 @@ function Zlib(opts, mode) {
   var strategy = exports.Z_DEFAULT_STRATEGY;
   if (typeof opts.strategy === 'number') strategy = opts.strategy;
 
-  this._handle.init(opts.windowBits || exports.Z_DEFAULT_WINDOWBITS,
+  var windowBits = exports.Z_DEFAULT_WINDOWBITS;
+  if (opts.windowBits && typeof opts.windowBits === 'number') {
+    windowBits = opts.windowBits;
+  }
+
+  var memLevel = exports.Z_DEFAULT_MEMLEVEL;
+  if (opts.memLevel && typeof opts.memLevel === 'number') {
+    memLevel = opts.memLevel;
+  }
+
+  this._handle.init(windowBits,
                     level,
-                    opts.memLevel || exports.Z_DEFAULT_MEMLEVEL,
+                    memLevel,
                     strategy,
                     opts.dictionary);
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -480,6 +480,7 @@ class ZCtx : public AsyncWrap {
         delete[] dictionary;
         ctx->dictionary_ = nullptr;
       }
+      ctx->mode_ = NONE;
       ctx->env()->ThrowError("Init error");
     }
   }

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -469,16 +469,19 @@ class ZCtx : public AsyncWrap {
         CHECK(0 && "wtf?");
     }
 
-    if (ctx->err_ != Z_OK) {
-      ZCtx::Error(ctx, "Init error");
-    }
-
-
     ctx->dictionary_ = reinterpret_cast<Bytef *>(dictionary);
     ctx->dictionary_len_ = dictionary_len;
 
     ctx->write_in_progress_ = false;
     ctx->init_done_ = true;
+
+    if (ctx->err_ != Z_OK) {
+      if (dictionary != nullptr) {
+        delete[] dictionary;
+        ctx->dictionary_ = nullptr;
+      }
+      ctx->env()->ThrowError("Init error");
+    }
   }
 
   static void SetDictionary(ZCtx* ctx) {

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -1,0 +1,13 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const zlib = require('zlib');
+
+// For raw deflate encoding, requests for 256-byte windows are rejected as
+// invalid by zlib.
+// (http://zlib.net/manual.html#Advanced)
+assert.throws(() => {
+  zlib.createDeflateRaw({ windowBits: 8 });
+}, /^Error: Init error$/);


### PR DESCRIPTION
First commit is a partial backport of semver-patch bits of #13098, cherry-picked from v6.x-staging (321c90f1c96ecad671768b1712178c366c5b5d2c, #13201). Second one is a backport of #14666.

/cc @MylesBorins

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
zlib