### PR TITLE
test, win: fix IPv6 detection on Windows

### DIFF
--- a/test/async-hooks/test-graph.tcp.js
+++ b/test/async-hooks/test-graph.tcp.js
@@ -17,7 +17,7 @@ const server = net
 
 server.listen(common.PORT);
 
-net.connect({ port: server.address().port, host: server.address().address },
+net.connect({ port: server.address().port, host: '::1' },
             common.mustCall(onconnected));
 
 function onlistening() {}

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -38,7 +38,7 @@ const server = net
 // Calling net.connect creates another TCPWRAP synchronously
 {
   net.connect(
-    { port: server.address().port, host: server.address().address },
+    { port: server.address().port, host: '::1' },
     common.mustCall(onconnected));
   const tcps = hooks.activitiesOfTypes('TCPWRAP');
   assert.strictEqual(tcps.length, 2);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -262,7 +262,7 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 
 {
   const iFaces = os.networkInterfaces();
-  const re = /lo/;
+  const re = exports.isWindows ? /Loopback Pseudo-Interface/ : /lo/;
   exports.hasIPv6 = Object.keys(iFaces).some(function(name) {
     return re.test(name) && iFaces[name].some(function(info) {
       return info.family === 'IPv6';


### PR DESCRIPTION
I've noticed that `common.hasIPv6` is set to `false` on my Win box.  This adds proper IPv6 detection on loopback devices on Windows.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

/cc @nodejs/testing 