### PR TITLE
util: fix inspect array w. negative maxArrayLength

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -679,11 +679,12 @@ function formatObject(ctx, value, recurseTimes, visibleKeys, keys) {
 
 
 function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
+  const maxLength = Math.min(Math.max(0, ctx.maxArrayLength), value.length);
   var output = [];
   let visibleLength = 0;
   let index = 0;
   for (const elem of keys) {
-    if (visibleLength === ctx.maxArrayLength)
+    if (visibleLength === maxLength)
       break;
     // Symbols might have been added to the keys
     if (typeof elem !== 'string')
@@ -698,7 +699,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
       const message = `<${emptyItems} empty item${ending}>`;
       output.push(ctx.stylize(message, 'undefined'));
       index = i;
-      if (++visibleLength === ctx.maxArrayLength)
+      if (++visibleLength === maxLength)
         break;
     }
     output.push(formatProperty(ctx, value, recurseTimes, visibleKeys,
@@ -706,7 +707,7 @@ function formatArray(ctx, value, recurseTimes, visibleKeys, keys) {
     visibleLength++;
     index++;
   }
-  if (index < value.length && visibleLength !== ctx.maxArrayLength) {
+  if (index < value.length && visibleLength !== maxLength) {
     const len = value.length - index;
     const ending = len > 1 ? 's' : '';
     const message = `<${len} empty item${ending}>`;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -960,6 +960,10 @@ if (typeof Symbol !== 'undefined') {
 {
   const x = new Array(101).fill();
   assert(!util.inspect(x, { maxArrayLength: 101 }).endsWith('1 more item ]'));
+  assert.strictEqual(
+    util.inspect(x, { maxArrayLength: -1 }),
+    '[ ... 101 more items ]'
+  );
 }
 
 {


### PR DESCRIPTION
This fixes a regression introduced in 95bbb6817532a2cdf1991f452ebbc5a5b5d5a112.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util