### PR TITLE
lib: disbanden circular dependency

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -117,7 +117,6 @@ function areSimilarRegExps(a, b) {
 // barrier including the Buffer.from operation takes the advantage of the faster
 // compare otherwise. 300 was the number after which compare became faster.
 function areSimilarTypedArrays(a, b) {
-  const { from } = require('buffer').Buffer;
   const len = a.byteLength;
   if (len !== b.byteLength) {
     return false;
@@ -130,8 +129,8 @@ function areSimilarTypedArrays(a, b) {
     }
     return true;
   }
-  return compare(from(a.buffer, a.byteOffset, len),
-                 from(b.buffer, b.byteOffset, b.byteLength)) === 0;
+  return compare(new Uint8Array(a.buffer, a.byteOffset, len),
+                 new Uint8Array(b.buffer, b.byteOffset, b.byteLength)) === 0;
 }
 
 function isFloatTypedArrayTag(tag) {

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -21,8 +21,7 @@
 'use strict';
 
 const { compare } = process.binding('buffer');
-const util = require('util');
-const { isSet, isMap } = process.binding('util');
+const { isSet, isMap, isDate, isRegExp } = process.binding('util');
 const { objectToString } = require('internal/util');
 const errors = require('internal/errors');
 
@@ -186,11 +185,11 @@ function strictDeepEqual(actual, expected) {
     // Skip testing the part below and continue in the callee function.
     return;
   }
-  if (util.isDate(actual)) {
+  if (isDate(actual)) {
     if (actual.getTime() !== expected.getTime()) {
       return false;
     }
-  } else if (util.isRegExp(actual)) {
+  } else if (isRegExp(actual)) {
     if (!areSimilarRegExps(actual, expected)) {
       return false;
     }
@@ -219,10 +218,10 @@ function looseDeepEqual(actual, expected) {
   if (expected === null || typeof expected !== 'object') {
     return false;
   }
-  if (util.isDate(actual) && util.isDate(expected)) {
+  if (isDate(actual) && isDate(expected)) {
     return actual.getTime() === expected.getTime();
   }
-  if (util.isRegExp(actual) && util.isRegExp(expected)) {
+  if (isRegExp(actual) && isRegExp(expected)) {
     return areSimilarRegExps(actual, expected);
   }
   const actualTag = objectToString(actual);

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -114,8 +114,8 @@ function areSimilarRegExps(a, b) {
 }
 
 // For small buffers it's faster to compare the buffer in a loop. The c++
-// barrier including the Buffer.from operation takes the advantage of the faster
-// compare otherwise. 300 was the number after which compare became faster.
+// barrier including the Uint8Array operation takes the advantage of the faster
+// binary compare otherwise. The break even point was at about 300 characters.
 function areSimilarTypedArrays(a, b) {
   const len = a.byteLength;
   if (len !== b.byteLength) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,6 +23,7 @@
 
 const errors = require('internal/errors');
 const { TextDecoder, TextEncoder } = require('internal/encoding');
+const { isBuffer } = require('buffer').Buffer;
 
 const { errname } = process.binding('uv');
 
@@ -1131,6 +1132,7 @@ module.exports = exports = {
   inspect,
   isArray: Array.isArray,
   isBoolean,
+  isBuffer,
   isNull,
   isNullOrUndefined,
   isNumber,
@@ -1162,18 +1164,3 @@ module.exports = exports = {
                   'util.puts is deprecated. Use console.log instead.',
                   'DEP0027')
 };
-
-// Avoid a circular dependency
-var isBuffer;
-Object.defineProperty(exports, 'isBuffer', {
-  configurable: true,
-  enumerable: true,
-  get() {
-    if (!isBuffer)
-      isBuffer = require('buffer').Buffer.isBuffer;
-    return isBuffer;
-  },
-  set(val) {
-    isBuffer = val;
-  }
-});


### PR DESCRIPTION
The circular dependency can be disbanded by directly using the binding functions in assert. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util, assert