### PR TITLE
util: use constructor name

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -590,11 +590,9 @@ function formatValue(ctx, value, recurseTimes, ln) {
     return ctx.stylize('[Circular]', 'special');
 
   if (recurseTimes != null) {
-    if (recurseTimes < 0) {
-      if (Array.isArray(value))
-        return ctx.stylize('[Array]', 'special');
-      return ctx.stylize('[Object]', 'special');
-    }
+    if (recurseTimes < 0)
+      return ctx.stylize(`[${constructor ? constructor.name : 'Object'}]`,
+                         'special');
     recurseTimes -= 1;
   }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -994,6 +994,10 @@ if (typeof Symbol !== 'undefined') {
                      'MapSubclass { \'foo\' => 42 }');
   assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
                      'PromiseSubclass { <pending> }');
+  assert.strictEqual(
+    util.inspect({ a: { b: new ArraySubclass([1, [2], 3]) } }, { depth: 1 }),
+    '{ a: { b: [ArraySubclass] } }'
+  );
 }
 
 // Empty and circular before depth


### PR DESCRIPTION
For circular references util.inspect always prints Array
or Object not matter if it is a subclass or not.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util