### PR TITLE
lib: move module system comment

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -475,16 +475,15 @@
     new vm.Script(source, { displayErrors: true, filename });
   }
 
-  // Below you find a minimal module system, which is used to load the node
-  // core modules found in lib/*.js. All core modules are compiled into the
-  // node binary, so they can be loaded faster.
-
   const ContextifyScript = process.binding('contextify').ContextifyScript;
   function runInThisContext(code, options) {
     const script = new ContextifyScript(code, options);
     return script.runInThisContext();
   }
 
+  // Below you find a minimal module system, which is used to load the node
+  // core modules found in lib/*.js. All core modules are compiled into the
+  // node binary, so they can be loaded faster.
   function NativeModule(id) {
     this.filename = `${id}.js`;
     this.id = id;


### PR DESCRIPTION
It looks like the comment about the module system has drifted slightly.
This commit moves the comment to be closer to the code the comment
refers to.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib