### PR TITLE
http2: Allow using a shared nghttp2 library

### DIFF
--- a/configure
+++ b/configure
@@ -182,6 +182,27 @@ shared_optgroup.add_option('--shared-http-parser-libpath',
     dest='shared_http_parser_libpath',
     help='a directory to search for the shared http_parser DLL')
 
+shared_optgroup.add_option('--shared-nghttp2',
+    action='store_true',
+    dest='shared_nghttp2',
+    help='link to a shared nghttp2 DLL instead of static linking')
+
+shared_optgroup.add_option('--shared-nghttp2-includes',
+    action='store',
+    dest='shared_nghttp2_includes',
+    help='directory containing nghttp2 header files')
+
+shared_optgroup.add_option('--shared-nghttp2-libname',
+    action='store',
+    dest='shared_nghttp2_libname',
+    default='nghttp2',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-nghttp2-libpath',
+    action='store',
+    dest='shared_nghttp2_libpath',
+    help='a directory to search for the shared nghttp2 DLL')
+
 shared_optgroup.add_option('--shared-libuv',
     action='store_true',
     dest='shared_libuv',
@@ -1360,6 +1381,7 @@ flavor = GetFlavor(flavor_params)
 configure_node(output)
 configure_library('zlib', output)
 configure_library('http_parser', output)
+configure_library('nghttp2', output)
 configure_library('libuv', output)
 configure_library('libcares', output)
 # stay backwards compatible with shared cares builds

--- a/node.gyp
+++ b/node.gyp
@@ -14,6 +14,7 @@
     'node_module_version%': '',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
+    'node_shared_nghttp2%': 'false',
     'node_shared_cares%': 'false',
     'node_shared_libuv%': 'false',
     'node_use_openssl%': 'true',
@@ -149,11 +150,6 @@
       'target_name': '<(node_core_target_name)',
       'type': '<(node_target_type)',
 
-      'dependencies': [
-        'node_js2c#host',
-        'deps/nghttp2/nghttp2.gyp:nghttp2'
-      ],
-
       'includes': [
         'node.gypi'
       ],
@@ -162,8 +158,7 @@
         'src',
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
-        '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
-        'deps/nghttp2/lib/includes'
+        '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
       ],
 
       'sources': [
@@ -276,8 +271,6 @@
         'NODE_WANT_INTERNALS=1',
         # Warn when using deprecated V8 APIs.
         'V8_DEPRECATION_WARNINGS=1',
-        # We're using the nghttp2 static lib
-        'NGHTTP2_STATICLIB'
       ],
     },
     {
@@ -687,6 +680,14 @@
             [ 'node_shared_http_parser=="false"', {
               'dependencies': [
                 'deps/http_parser/http_parser.gyp:http_parser'
+              ]
+            }],
+            [ 'node_shared_nghttp2=="false"', {
+              'dependencies': [
+                'deps/nghttp2/nghttp2.gyp:nghttp2'
+              ],
+              'include_dirs': [
+                'deps/nghttp2/lib/includes'
               ]
             }],
             [ 'node_shared_libuv=="false"', {


### PR DESCRIPTION
As nice as it is to bundle several libraries for builders' convenience, it also exposes builders to several kinds of security problems (until you release a new version with the bundled libraries updated) and it duplicates the number of versions of a library present on systems. For instance, with libcurl/curl installed and built against nghttp2, having a bundled (and older) version of libnghttp2 statically linked into /usr/bin/node duplicates the other version already present in /usr/lib. Additionally, the currently bundled version 1.22.0 has several problems that were already fixed in later versions, notably the current 1.24.0 which has been out since early July 2017.