### PR TITLE
build: for --enable-static, run only cctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,10 @@ v8:
 	tools/make-v8.sh
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
+ifeq ($(NODE_TARGET_TYPE),static_library)
+test: all
+	$(MAKE) cctest
+else
 test: all
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
@@ -200,6 +204,7 @@ test: all
 		$(CI_JS_SUITES) \
 		$(CI_NATIVE_SUITES)
 	$(MAKE) lint
+endif
 
 test-parallel: all
 	$(PYTHON) tools/test.py --mode=release parallel -J

--- a/configure
+++ b/configure
@@ -1408,6 +1408,8 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
+  'NODE_TARGET_TYPE': variables['node_target_type'] if options.enable_static \
+      else '',
 }
 
 if options.prefix:

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -107,7 +107,7 @@ if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
-if /i "%1"=="static"           set enable_static=1&goto arg-ok
+if /i "%1"=="static"        set enable_static=1&goto arg-ok
 if /i "%1"=="no-NODE-OPTIONS"	set no_NODE_OPTIONS=1&goto arg-ok
 if /i "%1"=="debug-http2"   set debug_http2=1&goto arg-ok
 if /i "%1"=="debug-nghttp2" set debug_nghttp2=1&goto arg-ok
@@ -445,10 +445,10 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-if not defined enable_static (
-  call :run-python tools\test.py %test_args%
-  goto test-v8
-)
+REM when building a static library there's no binary to run tests
+if defined enable_static goto test-v8
+call :run-python tools\test.py %test_args%
+
 :test-v8
 if not defined custom_v8_test goto cpplint
 call tools/test-v8.bat
@@ -495,6 +495,7 @@ set "localcppfilelist=%localcppfilelist% %1"
 goto exit
 
 :jslint
+if defined enable_static goto exit
 if defined jslint_ci goto jslint-ci
 if not defined jslint goto exit
 if not exist tools\eslint\bin\eslint.js goto no-lint

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -445,9 +445,10 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-call :run-python tools\test.py %test_args%
-goto test-v8
-
+if not defined enable_static (
+  call :run-python tools\test.py %test_args%
+  goto test-v8
+)
 :test-v8
 if not defined custom_v8_test goto cpplint
 call tools/test-v8.bat


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/14158

Currently when building with --enable-static and running the test target
the following error will be reported:
```console
Building addon
/node/test/addons/01_function_arguments/
env: ./node: No such file or directory
make[1]: *** [test/addons/.buildstamp] Error 1
```
Note that this is with a clean build where no prior node executable was
built.

This commit suggests only running the cctest target when --enable-static
is specified.

<sub>[refack: added refs]</sub>
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build