### PR TITLE
src: remove extra copy from Copy() in node_url.cc

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1007,7 +1007,7 @@ static inline void Copy(Environment* env,
 }
 
 static inline Local<Array> Copy(Environment* env,
-                                std::vector<std::string> vec) {
+                                const std::vector<std::string>& vec) {
   Isolate* isolate = env->isolate();
   Local<Array> ary = Array::New(isolate, vec.size());
   for (size_t n = 0; n < vec.size(); n++)


### PR DESCRIPTION
The was copying the whole array and the strings in it without any benefit.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_url.cc