### PR TITLE
console: implement minimal `console.group()`

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -286,6 +286,20 @@ If formatting elements (e.g. `%d`) are not found in the first string then
 [`util.inspect()`][] is called on each argument and the resulting string
 values are concatenated. See [`util.format()`][] for more information.
 
+### console.group()
+<!-- YAML
+added: REPLACEME
+-->
+
+Increases indentation of subsequent lines by one tab (`\t`).
+
+### console.groupEnd()
+<!-- YAML
+added: REPLACEME
+-->
+
+Decreases indentation of subsequent lines by one tab (`\t`).
+
 ### console.info([data][, ...args])
 <!-- YAML
 added: v0.1.100

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -298,6 +298,13 @@ Increases indentation of subsequent lines by two spaces.
 If one or more `label`s are provided, those are printed first without the
 additional indentation.
 
+### console.groupCollapsed()
+<!-- YAML
+  added: REPLACEME
+-->
+
+An alias for [`console.group()`][].
+
 ### console.groupEnd()
 <!-- YAML
 added: REPLACEME
@@ -409,6 +416,7 @@ added: v0.1.100
 The `console.warn()` function is an alias for [`console.error()`][].
 
 [`console.error()`]: #console_console_error_data_args
+[`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args
 [`console.time()`]: #console_console_time_label
 [`console.timeEnd()`]: #console_console_timeend_label

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -286,19 +286,24 @@ If formatting elements (e.g. `%d`) are not found in the first string then
 [`util.inspect()`][] is called on each argument and the resulting string
 values are concatenated. See [`util.format()`][] for more information.
 
-### console.group()
+### console.group([...label])
 <!-- YAML
 added: REPLACEME
 -->
 
-Increases indentation of subsequent lines by one tab (`\t`).
+* `label` {any}
+
+Increases indentation of subsequent lines by two spaces.
+
+If one or more `label`s are provided, those are printed first without the
+additional indentation.
 
 ### console.groupEnd()
 <!-- YAML
 added: REPLACEME
 -->
 
-Decreases indentation of subsequent lines by one tab (`\t`).
+Decreases indentation of subsequent lines by two spaces.
 
 ### console.info([data][, ...args])
 <!-- YAML

--- a/lib/console.js
+++ b/lib/console.js
@@ -25,6 +25,9 @@ const errors = require('internal/errors');
 const util = require('util');
 const kCounts = Symbol('counts');
 
+// Track amount of indentation required via `console.group()`.
+const groupIndent = Symbol('groupIndent');
+
 function Console(stdout, stderr, ignoreErrors = true) {
   if (!(this instanceof Console)) {
     return new Console(stdout, stderr, ignoreErrors);
@@ -64,6 +67,8 @@ function Console(stdout, stderr, ignoreErrors = true) {
     var k = keys[v];
     this[k] = this[k].bind(this);
   }
+
+  this[groupIndent] = '';
 }
 
 // Make a function that can serve as the callback passed to `stream.write()`.
@@ -111,7 +116,7 @@ function write(ignoreErrors, stream, string, errorhandler) {
 Console.prototype.log = function log(...args) {
   write(this._ignoreErrors,
         this._stdout,
-        `${util.format.apply(null, args)}\n`,
+        `${this[groupIndent]}${util.format.apply(null, args)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -122,7 +127,7 @@ Console.prototype.info = Console.prototype.log;
 Console.prototype.warn = function warn(...args) {
   write(this._ignoreErrors,
         this._stderr,
-        `${util.format.apply(null, args)}\n`,
+        `${this[groupIndent]}${util.format.apply(null, args)}\n`,
         this._stderrErrorHandler);
 };
 
@@ -134,7 +139,7 @@ Console.prototype.dir = function dir(object, options) {
   options = Object.assign({ customInspect: false }, options);
   write(this._ignoreErrors,
         this._stdout,
-        `${util.inspect(object, options)}\n`,
+        `${this[groupIndent]}${util.inspect(object, options)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -212,6 +217,14 @@ Console.prototype.count = function count(label = 'default') {
 Console.prototype.countReset = function countReset(label = 'default') {
   const counts = this[kCounts];
   counts.delete(`${label}`);
+};
+
+Console.prototype.group = function group() {
+  this[groupIndent] += '  ';
+};
+
+Console.prototype.groupEnd = function groupEnd() {
+  this[groupIndent] = this[groupIndent].slice(0, this[groupIndent].length - 2);
 };
 
 module.exports = new Console(process.stdout, process.stderr);

--- a/lib/console.js
+++ b/lib/console.js
@@ -219,7 +219,10 @@ Console.prototype.countReset = function countReset(label = 'default') {
   counts.delete(`${label}`);
 };
 
-Console.prototype.group = function group() {
+Console.prototype.group = function group(...data) {
+  if (data.length > 0) {
+    this.log(...data);
+  }
   this[groupIndent] += '  ';
 };
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -226,6 +226,8 @@ Console.prototype.group = function group(...data) {
   this[groupIndent] += '  ';
 };
 
+Console.prototype.groupCollapsed = Console.prototype.group;
+
 Console.prototype.groupEnd = function groupEnd() {
   this[groupIndent] = this[groupIndent].slice(0, this[groupIndent].length - 2);
 };

--- a/lib/console.js
+++ b/lib/console.js
@@ -26,7 +26,7 @@ const util = require('util');
 const kCounts = Symbol('counts');
 
 // Track amount of indentation required via `console.group()`.
-const groupIndent = Symbol('groupIndent');
+const kGroupIndent = Symbol('groupIndent');
 
 function Console(stdout, stderr, ignoreErrors = true) {
   if (!(this instanceof Console)) {
@@ -60,6 +60,7 @@ function Console(stdout, stderr, ignoreErrors = true) {
   Object.defineProperty(this, '_stderrErrorHandler', prop);
 
   this[kCounts] = new Map();
+  this[kGroupIndent] = '';
 
   // bind the prototype functions to this Console instance
   var keys = Object.keys(Console.prototype);
@@ -67,8 +68,6 @@ function Console(stdout, stderr, ignoreErrors = true) {
     var k = keys[v];
     this[k] = this[k].bind(this);
   }
-
-  this[groupIndent] = '';
 }
 
 // Make a function that can serve as the callback passed to `stream.write()`.
@@ -116,7 +115,7 @@ function write(ignoreErrors, stream, string, errorhandler) {
 Console.prototype.log = function log(...args) {
   write(this._ignoreErrors,
         this._stdout,
-        `${this[groupIndent]}${util.format.apply(null, args)}\n`,
+        `${this[kGroupIndent]}${util.format.apply(null, args)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -127,7 +126,7 @@ Console.prototype.info = Console.prototype.log;
 Console.prototype.warn = function warn(...args) {
   write(this._ignoreErrors,
         this._stderr,
-        `${this[groupIndent]}${util.format.apply(null, args)}\n`,
+        `${this[kGroupIndent]}${util.format.apply(null, args)}\n`,
         this._stderrErrorHandler);
 };
 
@@ -139,7 +138,7 @@ Console.prototype.dir = function dir(object, options) {
   options = Object.assign({ customInspect: false }, options);
   write(this._ignoreErrors,
         this._stdout,
-        `${this[groupIndent]}${util.inspect(object, options)}\n`,
+        `${this[kGroupIndent]}${util.inspect(object, options)}\n`,
         this._stdoutErrorHandler);
 };
 
@@ -223,13 +222,14 @@ Console.prototype.group = function group(...data) {
   if (data.length > 0) {
     this.log(...data);
   }
-  this[groupIndent] += '  ';
+  this[kGroupIndent] += '  ';
 };
 
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 Console.prototype.groupEnd = function groupEnd() {
-  this[groupIndent] = this[groupIndent].slice(0, this[groupIndent].length - 2);
+  this[kGroupIndent] =
+    this[kGroupIndent].slice(0, this[kGroupIndent].length - 2);
 };
 
 module.exports = new Console(process.stdout, process.stderr);

--- a/test/parallel/test-console-group.js
+++ b/test/parallel/test-console-group.js
@@ -23,6 +23,7 @@ function teardown() {
   common.restoreStderr();
 }
 
+// Basic group() functionality
 {
   setup();
   const expectedOut = 'This is the outer level\n' +
@@ -69,6 +70,21 @@ function teardown() {
   c1.group();
   c1.log('Now the first console is indenting');
   c2.log('But the second one does not');
+
+  assert.strictEqual(stdout, expectedOut);
+  assert.strictEqual(stderr, expectedErr);
+  teardown();
+}
+
+// Make sure labels work.
+{
+  setup();
+  const expectedOut = 'This is a label\n' +
+                      '  And this is the data for that label\n';
+  const expectedErr = '';
+
+  console.group('This is a label');
+  console.log('And this is the data for that label');
 
   assert.strictEqual(stdout, expectedOut);
   assert.strictEqual(stderr, expectedErr);

--- a/test/parallel/test-console-group.js
+++ b/test/parallel/test-console-group.js
@@ -1,0 +1,76 @@
+'use strict';
+const common = require('../common');
+
+const assert = require('assert');
+const Console = require('console').Console;
+
+let stdout, stderr;
+
+function setup() {
+  stdout = '';
+  common.hijackStdout(function(data) {
+    stdout += data;
+  });
+
+  stderr = '';
+  common.hijackStderr(function(data) {
+    stderr += data;
+  });
+}
+
+function teardown() {
+  common.restoreStdout();
+  common.restoreStderr();
+}
+
+{
+  setup();
+  const expectedOut = 'This is the outer level\n' +
+                      '  Level 2\n' +
+                      '    Level 3\n' +
+                      '  Back to level 2\n' +
+                      'Back to the outer level\n' +
+                      'Still at the outer level\n';
+
+
+  const expectedErr = '    More of level 3\n';
+
+  console.log('This is the outer level');
+  console.group();
+  console.log('Level 2');
+  console.group();
+  console.log('Level 3');
+  console.warn('More of level 3');
+  console.groupEnd();
+  console.log('Back to level 2');
+  console.groupEnd();
+  console.log('Back to the outer level');
+  console.groupEnd();
+  console.log('Still at the outer level');
+
+  assert.strictEqual(stdout, expectedOut);
+  assert.strictEqual(stderr, expectedErr);
+  teardown();
+}
+
+// Group indentation is tracked per Console instance.
+{
+  setup();
+  const expectedOut = 'No indentation\n' +
+                      'None here either\n' +
+                      '  Now the first console is indenting\n' +
+                      'But the second one does not\n';
+  const expectedErr = '';
+
+  const c1 = new Console(process.stdout, process.stderr);
+  const c2 = new Console(process.stdout, process.stderr);
+  c1.log('No indentation');
+  c2.log('None here either');
+  c1.group();
+  c1.log('Now the first console is indenting');
+  c2.log('But the second one does not');
+
+  assert.strictEqual(stdout, expectedOut);
+  assert.strictEqual(stderr, expectedErr);
+  teardown();
+}

--- a/test/parallel/test-console-group.js
+++ b/test/parallel/test-console-group.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const Console = require('console').Console;
 
-let stdout, stderr;
+let c, stdout, stderr;
 
 function setup() {
   stdout = '';
@@ -16,6 +16,8 @@ function setup() {
   common.hijackStderr(function(data) {
     stderr += data;
   });
+
+  c = new Console(process.stdout, process.stderr);
 }
 
 function teardown() {
@@ -36,18 +38,18 @@ function teardown() {
 
   const expectedErr = '    More of level 3\n';
 
-  console.log('This is the outer level');
-  console.group();
-  console.log('Level 2');
-  console.group();
-  console.log('Level 3');
-  console.warn('More of level 3');
-  console.groupEnd();
-  console.log('Back to level 2');
-  console.groupEnd();
-  console.log('Back to the outer level');
-  console.groupEnd();
-  console.log('Still at the outer level');
+  c.log('This is the outer level');
+  c.group();
+  c.log('Level 2');
+  c.group();
+  c.log('Level 3');
+  c.warn('More of level 3');
+  c.groupEnd();
+  c.log('Back to level 2');
+  c.groupEnd();
+  c.log('Back to the outer level');
+  c.groupEnd();
+  c.log('Still at the outer level');
 
   assert.strictEqual(stdout, expectedOut);
   assert.strictEqual(stderr, expectedErr);
@@ -63,12 +65,11 @@ function teardown() {
                       'But the second one does not\n';
   const expectedErr = '';
 
-  const c1 = new Console(process.stdout, process.stderr);
   const c2 = new Console(process.stdout, process.stderr);
-  c1.log('No indentation');
+  c.log('No indentation');
   c2.log('None here either');
-  c1.group();
-  c1.log('Now the first console is indenting');
+  c.group();
+  c.log('Now the first console is indenting');
   c2.log('But the second one does not');
 
   assert.strictEqual(stdout, expectedOut);
@@ -83,8 +84,26 @@ function teardown() {
                       '  And this is the data for that label\n';
   const expectedErr = '';
 
-  console.group('This is a label');
-  console.log('And this is the data for that label');
+  c.group('This is a label');
+  c.log('And this is the data for that label');
+
+  assert.strictEqual(stdout, expectedOut);
+  assert.strictEqual(stderr, expectedErr);
+  teardown();
+}
+
+// Check that console.groupCollapsed() is an alias of console.group()
+{
+  setup();
+  const expectedOut = 'Label\n' +
+                      '  Level 2\n' +
+                      '    Level 3\n';
+  const expectedErr = '';
+
+  c.groupCollapsed('Label');
+  c.log('Level 2');
+  c.groupCollapsed();
+  c.log('Level 3');
 
   assert.strictEqual(stdout, expectedOut);
   assert.strictEqual(stderr, expectedErr);


### PR DESCRIPTION
Node.js exposes `console.group()` and `console.groupEnd()` via the
inspector. These functions have no apparent effect when called from
Node.js without the inspector. We cannot easily hide them when Node.js
is started without the inspector because we support opening the
inspector during runtime via `inspector.port()`.

Implement a minimal `console.group()`/`console.groupEnd()`. More
sophisticated implementations are possible, but they can be done in
userland and/or features can be added to this at a later time. (It lacks
the `label` argument to `console.group()` right now, for example. How to
handle `label`, or even whether to handle it,  may become
a bikeshed discussion. Landing a minimal implementation first avoids the
pitfall of that discussion or a similar discussion delaying the
implementation indefinitely.)

Refs: https://github.com/nodejs/node/issues/12675
Fixes: https://github.com/nodejs/node/issues/1716

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
console