### PR TITLE
crypto: Remove useless if statement and convert if-else-if chain

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -584,17 +584,22 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   var f;
   if (format) {
-    if (typeof format === 'number')
-      f = format;
-    if (format === 'compressed')
-      f = constants.POINT_CONVERSION_COMPRESSED;
-    else if (format === 'hybrid')
-      f = constants.POINT_CONVERSION_HYBRID;
-    // Default
-    else if (format === 'uncompressed')
-      f = constants.POINT_CONVERSION_UNCOMPRESSED;
-    else
-      throw new TypeError('Bad format: ' + format);
+    switch (format.length) {
+      case 6:
+        if (format === 'hybrid')
+          f = constants.POINT_CONVERSION_HYBRID;
+        break;
+      case 10:
+        if (format === 'compressed')
+          f = constants.POINT_CONVERSION_COMPRESSED;
+        break;
+      case 12:
+        if (format === 'uncompressed')
+          f = constants.POINT_CONVERSION_UNCOMPRESSED;
+        break;
+      default:
+        throw new TypeError('Bad format: ' + format);
+    }
   } else {
     f = constants.POINT_CONVERSION_UNCOMPRESSED;
   }


### PR DESCRIPTION
One if statement in `ECDH.getPublicKey` is useless. This change
is to remove it and convert the following  `if-else-if` chain to a `switch`
statement, which is more efficient.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto