### PR TITLE
deps: cherry-pick e020aae394 from V8 upstream

### DIFF
--- a/deps/v8/src/trap-handler/handler-shared.cc
+++ b/deps/v8/src/trap-handler/handler-shared.cc
@@ -23,7 +23,14 @@ namespace v8 {
 namespace internal {
 namespace trap_handler {
 
-THREAD_LOCAL bool g_thread_in_wasm_code = false;
+// We declare this as int rather than bool as a workaround for a glibc bug, in
+// which the dynamic loader cannot handle executables whose TLS area is only
+// 1 byte in size; see https://sourceware.org/bugzilla/show_bug.cgi?id=14898.
+THREAD_LOCAL int g_thread_in_wasm_code = false;
+
+static_assert(sizeof(g_thread_in_wasm_code) > 1,
+              "sizeof(thread_local_var) must be > 1, see "
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=14898");
 
 size_t gNumCodeObjects = 0;
 CodeProtectionInfoListEntry* gCodeObjects = nullptr;

--- a/deps/v8/src/trap-handler/trap-handler.h
+++ b/deps/v8/src/trap-handler/trap-handler.h
@@ -65,7 +65,7 @@ inline bool UseTrapHandler() {
   return FLAG_wasm_trap_handler && V8_TRAP_HANDLER_SUPPORTED;
 }
 
-extern THREAD_LOCAL bool g_thread_in_wasm_code;
+extern THREAD_LOCAL int g_thread_in_wasm_code;
 
 inline bool IsThreadInWasm() { return g_thread_in_wasm_code; }
 


### PR DESCRIPTION
Original commit message:

    Work around glibc thread-local storage bug

    glibc before 2.17 has a bug that makes it impossible to execute
    binaries that have single-byte thread-local variables:

        % node --version
        node: error while loading shared libraries: cannot allocate
        memory in static TLS block

    Work around that by making the one instance in the V8 code base
    an int.

    See: https://sourceware.org/bugzilla/show_bug.cgi?id=14898
    See: https://github.com/nodesource/distributions/issues/513
    See: https://github.com/nodejs/build/pull/809
    Change-Id: Iefd8009100cd93e26cf8dc5dc03f2d622b423385
    Reviewed-on: https://chromium-review.googlesource.com/612351
    Commit-Queue: Ben Noordhuis <info@bnoordhuis.nl>
    Reviewed-by: Eric Holk <eholk@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#47400}

Refs: https://github.com/nodejs/build/pull/809
