### PR TITLE
test: remove erroneous assert message from test

### DIFF
--- a/test/parallel/test-process-external-stdio-close-spawn.js
+++ b/test/parallel/test-process-external-stdio-close-spawn.js
@@ -22,7 +22,7 @@ if (process.argv[2] === 'child') {
   });
 
   child.on('close', common.mustCall((exitCode, signal) => {
-    assert.strictEqual(exitCode, 0, 'exit successfully');
+    assert.strictEqual(exitCode, 0);
     assert.strictEqual(signal, null);
   }));
 


### PR DESCRIPTION
Removes the incorrect 'exit successfully' message from test when the
exit code is 0.

We expect the exit code to be 0, so when it fails it should say 'exit unsuccessful'. Adding a message will hide the exit code from the error, so IMO we should remove the message. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test