### PR TITLE
benchmark: removed unused arguments from callbacks

### DIFF
--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -64,7 +64,7 @@ function server() {
     }, dur * 1000);
   });
 
-  socket.on('message', function(buf, rinfo) {
+  socket.on('message', function() {
     received++;
   });
 

--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -56,7 +56,7 @@ function server() {
     }, dur * 1000);
   });
 
-  socket.on('message', function(buf, rinfo) {
+  socket.on('message', function() {
     received++;
   });
 

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -56,7 +56,7 @@ function server() {
     }, dur * 1000);
   });
 
-  socket.on('message', function(buf, rinfo) {
+  socket.on('message', function() {
     received++;
   });
 


### PR DESCRIPTION
Removed unused arguments 'buf' and 'rinfo' from the callbacks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark