### PR TITLE
test: fix flaky test-stdout-buffer-flush-on-exit

### DIFF
--- a/test/known_issues/test-stdout-buffer-flush-on-exit.js
+++ b/test/known_issues/test-stdout-buffer-flush-on-exit.js
@@ -15,7 +15,7 @@ if (process.argv[2] === 'child') {
   process.exit();
 }
 
-[22, 21, 20, 19, 18, 17, 16, 16, 17, 18, 19, 20, 21, 22].forEach((exponent) => {
+[1, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 3, 2, 1].forEach((exponent) => {
   const bigNum = Math.pow(2, exponent);
   const longLine = lineSeed.repeat(bigNum);
   const cmd =


### PR DESCRIPTION
* The test failed due to buffer limitations. This patch makes sure
  we are within the buffer limitations and still tests the buffer
  being flush on exit.

Fixes: #13638 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
