### PR TITLE
doc: do not compact stability text to one line

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -95,6 +95,7 @@ em code {
   font-family: "Lato", "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Verdana, Tahoma, sans-serif;
   padding: 1em;
   line-height: 1.5;
+  white-space: pre-wrap;
 }
 
 .api_stability * {


### PR DESCRIPTION
Previously, stability descriptions were strung together as one long
horizontal row at https://nodejs.org/api/documentation.html. Now, the text now will
auto-expand vertically, so you can see all of the text at once.

Note that the CSS options for how to handle this are somewhat
constrained since the paragraphs are being rendered through `pre`
elements, and the third party syntax highlighting library does apply its
own styling.

Before: https://cl.ly/2w2O0z1T2o0Y
After: https://cl.ly/3z1i1t2D2r41

This does not affect the stability boxes for features, as those were
not previously affected by this bug, and are only a few words long.

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc
