### PR TITLE
build: allow proper generation of html docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,14 +503,14 @@ gen-doc =	\
 		else \
 			cd tools/doc && node ../../$(NPM) install; \
 		fi;\
-	[ -x $(NODE) ] && $(NODE) $(gen-json) || node
+	[ -x $(NODE) ] && $(NODE) $(1) || node $(1)
 
 out/doc/api/%.json: doc/api/%.md
-	$(gen-doc) $(gen-json)
+	$(call gen-doc, $(gen-json))
 
 # check if ./node is actually set, else use user pre-installed binary
 out/doc/api/%.html: doc/api/%.md
-	$(gen-doc) $(gen-html)
+	$(call gen-doc, $(gen-html))
 
 docopen: $(apidocs_html)
 	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html


### PR DESCRIPTION
`gen-doc` always calls `gen-json`, which means it's impossible to generate
html docs. Changed this to pass in the command the user wants to run.
I'm a Makefile novice, so please let me know if there's a better way to
do this :)

Fixes: https://github.com/nodejs/node/issues/14930

##### Checklist

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

build
