### PR TITLE
test: fix test-stream2-httpclient-response-end

### DIFF
--- a/test/parallel/test-stream2-httpclient-response-end.js
+++ b/test/parallel/test-stream2-httpclient-response-end.js
@@ -11,7 +11,9 @@ const server = http.createServer(function(req, res) {
     let data = '';
     res.on('readable', common.mustCall(function() {
       console.log('readable event');
-      data += res.read();
+      let input = res.read();
+      if (input)
+        data += input;
     }));
     res.on('end', common.mustCall(function() {
       console.log('end event');


### PR DESCRIPTION
It is possible for test-stream2-httpclient-response-end to be
flaky if the http response is read via two syscalls.

This test ensures the output of res.read() is not null or
undefined before concatenating.