### PR TITLE
tools: abstract make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,9 +199,9 @@ test: all
 test-build:
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
+	$(MAKE) cctest
 
 test-run:
-	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
 		$(CI_JS_SUITES) \
 		$(CI_NATIVE_SUITES)

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,14 @@ v8:
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
 test: all
+	$(MAKE) test-build
+	$(MAKE) test-run
+
+test-build:
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
+
+test-run:
 	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
 		$(CI_JS_SUITES) \


### PR DESCRIPTION
Currently `make test` includes both the build and test components
in a single command. This PR abstracts them into `make test-build` and
`make test-run` to allow individuals more granular control.