### PR TITLE
dns: fix issues in dns benchmark

### DIFF
--- a/benchmark/dns/lookup.js
+++ b/benchmark/dns/lookup.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const name = conf.name;
   const n = +conf.n;
-  const all = !!conf.all;
+  const all = conf.all === 'true' ? true : false;
   var i = 0;
 
   if (all) {

--- a/benchmark/dns/lookup.js
+++ b/benchmark/dns/lookup.js
@@ -5,7 +5,7 @@ const lookup = require('dns').lookup;
 
 const bench = common.createBenchmark(main, {
   name: ['', '127.0.0.1', '::1'],
-  all: [true, false],
+  all: ['true', 'false'],
   n: [5e6]
 });
 
@@ -18,7 +18,7 @@ function main(conf) {
   if (all) {
     const opts = { all: true };
     bench.start();
-    (function cb(err, results) {
+    (function cb() {
       if (i++ === n) {
         bench.end(n);
         return;
@@ -27,7 +27,7 @@ function main(conf) {
     })();
   } else {
     bench.start();
-    (function cb(err, result) {
+    (function cb() {
       if (i++ === n) {
         bench.end(n);
         return;

--- a/test/parallel/test-benchmark-dns.js
+++ b/test/parallel/test-benchmark-dns.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for dns benchmarks. This makes sure the benchmarks aren't
+// horribly broken but nothing more than that.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const path = require('path');
+
+const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
+
+const env = Object.assign({}, process.env,
+                          { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+
+const child = fork(runjs,
+                   ['--set', 'n=5e4',
+                    'dns'],
+                   { env });
+
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});

--- a/test/parallel/test-benchmark-dns.js
+++ b/test/parallel/test-benchmark-dns.js
@@ -15,7 +15,9 @@ const env = Object.assign({}, process.env,
                           { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
 
 const child = fork(runjs,
-                   ['--set', 'n=5e4',
+                   ['--set', 'n=1',
+                    '--set', 'all=false',
+                    '--set', 'name=127.0.0.1',
                     'dns'],
                    { env });
 


### PR DESCRIPTION
The benchmark script for dns contained functions with args declared
but never used. This fix removes those arguments from the function
signatures.

No test existed for the dns benchmark so one was added to the
parallel suite.

The dns benchmark uses the core dns.lookup() function which does not
access the network but instead uses "an operating system facility
that can associate names with addresses, and vice versa" e.g. similar
to ping; however, it is a synchronous call which runs on the libuv
threadpool - the number of test calls was therefore reduced to 5e4
(from 5e6).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
