### PR TITLE
src: fixup strings, general code cleanup

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -468,6 +468,13 @@ void AsyncWrap::QueueDestroyId(const FunctionCallbackInfo<Value>& args) {
   PushBackDestroyId(Environment::GetCurrent(args), args[0]->NumberValue());
 }
 
+void AsyncWrap::AddWrapMethods(Environment* env,
+                               Local<FunctionTemplate> constructor,
+                               int flag) {
+  env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
+  if (flag & kFlagHasReset)
+    env->SetProtoMethod(constructor, "asyncReset", AsyncWrap::AsyncReset);
+}
 
 void AsyncWrap::Initialize(Local<Object> target,
                            Local<Value> unused,

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -87,12 +87,21 @@ class AsyncWrap : public BaseObject {
     PROVIDERS_LENGTH,
   };
 
+  enum Flags {
+    kFlagNone = 0x0,
+    kFlagHasReset = 0x1
+  };
+
   AsyncWrap(Environment* env,
             v8::Local<v8::Object> object,
             ProviderType provider,
             bool silent = false);
 
   virtual ~AsyncWrap();
+
+  static void AddWrapMethods(Environment* env,
+                             v8::Local<v8::FunctionTemplate> constructor,
+                             int flags = kFlagNone);
 
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2190,28 +2190,28 @@ void Initialize(Local<Object> target,
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   aiw->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(aiw, "getAsyncId", AsyncWrap::GetAsyncId);
-  aiw->SetClassName(
-      FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap"),
-              aiw->GetFunction());
+  Local<String> addrInfoWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap");
+  aiw->SetClassName(addrInfoWrapString);
+  target->Set(addrInfoWrapString, aiw->GetFunction());
 
   Local<FunctionTemplate> niw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   niw->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(niw, "getAsyncId", AsyncWrap::GetAsyncId);
-  niw->SetClassName(
-      FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap"),
-              niw->GetFunction());
+  Local<String> nameInfoWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap");
+  niw->SetClassName(nameInfoWrapString);
+  target->Set(nameInfoWrapString, niw->GetFunction());
 
   Local<FunctionTemplate> qrw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   qrw->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(qrw, "getAsyncId", AsyncWrap::GetAsyncId);
-  qrw->SetClassName(
-      FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap"),
-              qrw->GetFunction());
+  Local<String> queryWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap");
+  qrw->SetClassName(queryWrapString);
+  target->Set(queryWrapString, qrw->GetFunction());
 
   Local<FunctionTemplate> channel_wrap =
       env->NewFunctionTemplate(ChannelWrap::New);
@@ -2235,10 +2235,10 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(channel_wrap, "setServers", SetServers);
   env->SetProtoMethod(channel_wrap, "cancel", Cancel);
 
-  channel_wrap->SetClassName(
-      FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap"),
-              channel_wrap->GetFunction());
+  Local<String> channelWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "ChannelWrap");
+  channel_wrap->SetClassName(channelWrapString);
+  target->Set(channelWrapString, channel_wrap->GetFunction());
 }
 
 }  // anonymous namespace

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2189,7 +2189,7 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> aiw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   aiw->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(aiw, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, aiw);
   Local<String> addrInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetAddrInfoReqWrap");
   aiw->SetClassName(addrInfoWrapString);
@@ -2198,7 +2198,7 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> niw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   niw->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(niw, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, niw);
   Local<String> nameInfoWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "GetNameInfoReqWrap");
   niw->SetClassName(nameInfoWrapString);
@@ -2207,7 +2207,7 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> qrw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   qrw->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(qrw, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, qrw);
   Local<String> queryWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "QueryReqWrap");
   qrw->SetClassName(queryWrapString);
@@ -2216,7 +2216,7 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> channel_wrap =
       env->NewFunctionTemplate(ChannelWrap::New);
   channel_wrap->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(channel_wrap, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, channel_wrap);
 
   env->SetProtoMethod(channel_wrap, "queryAny", Query<QueryAnyWrap>);
   env->SetProtoMethod(channel_wrap, "queryA", Query<QueryAWrap>);

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -94,7 +94,7 @@ void FSEventWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(fsevent_string);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "start", Start);
   env->SetProtoMethod(t, "close", Close);
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -218,7 +218,7 @@ void JSStream::Initialize(Local<Object> target,
   t->SetClassName(jsStreamString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
 
   env->SetProtoMethod(t, "doAlloc", DoAlloc);
   env->SetProtoMethod(t, "doRead", DoRead);

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -18,6 +18,7 @@ using v8::HandleScope;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 
@@ -212,7 +213,9 @@ void JSStream::Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "JSStream"));
+  Local<String> jsStreamString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "JSStream");
+  t->SetClassName(jsStreamString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
@@ -226,8 +229,7 @@ void JSStream::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "emitEOF", EmitEOF);
 
   StreamBase::AddMethods<JSStream>(env, t, StreamBase::kFlagHasWritev);
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "JSStream"),
-              t->GetFunction());
+  target->Set(jsStreamString, t->GetFunction());
   env->set_jsstream_constructor_template(t);
 }
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -105,7 +105,7 @@ static void InitConfig(Local<Object> target,
 
   debugOptions->DefineOwnProperty(
       context,
-      FIXED_ONE_BYTE_STRING(isolate, "port"),
+      env->port_string(),
       Integer::New(isolate, debug_options.port()),
       ReadOnly).FromJust();
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -312,7 +312,9 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(SecureContext::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"));
+  Local<String> secureContextString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext");
+  t->SetClassName(secureContextString);
 
   env->SetProtoMethod(t, "init", SecureContext::Init);
   env->SetProtoMethod(t, "setKey", SecureContext::SetKey);
@@ -359,8 +361,7 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
       static_cast<PropertyAttribute>(ReadOnly | DontDelete),
       AccessorSignature::New(env->isolate(), t));
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "SecureContext"),
-              t->GetFunction());
+  target->Set(secureContextString, t->GetFunction());
   env->set_secure_context_constructor_template(t);
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -2729,7 +2729,7 @@ void Connection::Initialize(Environment* env, Local<Object> target) {
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Connection"));
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "encIn", Connection::EncIn);
   env->SetProtoMethod(t, "clearOut", Connection::ClearOut);
   env->SetProtoMethod(t, "clearIn", Connection::ClearIn);
@@ -6129,14 +6129,14 @@ void InitCrypto(Local<Object> target,
 
   Local<FunctionTemplate> pb = FunctionTemplate::New(env->isolate());
   pb->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "PBKDF2"));
-  env->SetProtoMethod(pb, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, pb);
   Local<ObjectTemplate> pbt = pb->InstanceTemplate();
   pbt->SetInternalFieldCount(1);
   env->set_pbkdf2_constructor_template(pbt);
 
   Local<FunctionTemplate> rb = FunctionTemplate::New(env->isolate());
   rb->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "RandomBytes"));
-  env->SetProtoMethod(rb, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, rb);
   Local<ObjectTemplate> rbt = rb->InstanceTemplate();
   rbt->SetInternalFieldCount(1);
   env->set_randombytes_constructor_template(rbt);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1481,9 +1481,10 @@ void InitFs(Local<Object> target,
       FunctionTemplate::New(env->isolate(), NewFSReqWrap);
   fst->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(fst, "getAsyncId", AsyncWrap::GetAsyncId);
-  fst->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqWrap"),
-              fst->GetFunction());
+  Local<String> wrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqWrap");
+  fst->SetClassName(wrapString);
+  target->Set(wrapString, fst->GetFunction());
 }
 
 }  // end namespace node

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1480,7 +1480,7 @@ void InitFs(Local<Object> target,
   Local<FunctionTemplate> fst =
       FunctionTemplate::New(env->isolate(), NewFSReqWrap);
   fst->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(fst, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, fst);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "FSReqWrap");
   fst->SetClassName(wrapString);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1206,8 +1206,7 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "nghttp2ErrorString", HttpErrorString);
 
   Local<String> http2SessionClassName =
-    String::NewFromUtf8(isolate, "Http2Session",
-                        v8::NewStringType::kInternalized).ToLocalChecked();
+    FIXED_ONE_BYTE_STRING(isolate, "Http2Session");
 
   Local<FunctionTemplate> session =
       env->NewFunctionTemplate(Http2Session::New);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1212,7 +1212,7 @@ void Initialize(Local<Object> target,
       env->NewFunctionTemplate(Http2Session::New);
   session->SetClassName(http2SessionClassName);
   session->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(session, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, session);
   env->SetProtoMethod(session, "consume",
                       Http2Session::Consume);
   env->SetProtoMethod(session, "destroy",

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -794,7 +794,7 @@ void InitHttpParser(Local<Object> target,
 #undef V
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "methods"), methods);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "close", Parser::Close);
   env->SetProtoMethod(t, "execute", Parser::Execute);
   env->SetProtoMethod(t, "finish", Parser::Finish);

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -451,9 +451,11 @@ void InitializeSerdesBindings(Local<Object> target,
                       "_setTreatArrayBufferViewsAsHostObjects",
                       SerializerContext::SetTreatArrayBufferViewsAsHostObjects);
 
-  ser->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Serializer"));
+  Local<String> serializerString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "Serializer");
+  ser->SetClassName(serializerString);
   target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(), "Serializer"),
+              serializerString,
               ser->GetFunction(env->context()).ToLocalChecked()).FromJust();
 
   Local<FunctionTemplate> des =
@@ -474,9 +476,11 @@ void InitializeSerdesBindings(Local<Object> target,
   env->SetProtoMethod(des, "readDouble", DeserializerContext::ReadDouble);
   env->SetProtoMethod(des, "_readRawBytes", DeserializerContext::ReadRawBytes);
 
-  des->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Deserializer"));
+  Local<String> deserializerString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "Deserializer");
+  des->SetClassName(deserializerString);
   target->Set(env->context(),
-              FIXED_ONE_BYTE_STRING(env->isolate(), "Deserializer"),
+              deserializerString,
               des->GetFunction(env->context()).ToLocalChecked()).FromJust();
 }
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -39,6 +39,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 
@@ -47,14 +48,15 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(StatWatcher::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "StatWatcher"));
+  Local<String> statWatcherString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "StatWatcher");
+  t->SetClassName(statWatcherString);
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
   env->SetProtoMethod(t, "start", StatWatcher::Start);
   env->SetProtoMethod(t, "stop", StatWatcher::Stop);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "StatWatcher"),
-              t->GetFunction());
+  target->Set(statWatcherString, t->GetFunction());
 }
 
 

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -52,7 +52,7 @@ void StatWatcher::Initialize(Environment* env, Local<Object> target) {
       FIXED_ONE_BYTE_STRING(env->isolate(), "StatWatcher");
   t->SetClassName(statWatcherString);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
   env->SetProtoMethod(t, "start", StatWatcher::Start);
   env->SetProtoMethod(t, "stop", StatWatcher::Stop);
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -50,6 +50,7 @@ using v8::Local;
 using v8::Number;
 using v8::Object;
 using v8::Persistent;
+using v8::String;
 using v8::Uint32Array;
 using v8::Value;
 
@@ -693,8 +694,9 @@ void InitZlib(Local<Object> target,
   env->SetProtoMethod(z, "params", ZCtx::Params);
   env->SetProtoMethod(z, "reset", ZCtx::Reset);
 
-  z->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib"), z->GetFunction());
+  Local<String> zlibString = FIXED_ONE_BYTE_STRING(env->isolate(), "Zlib");
+  z->SetClassName(zlibString);
+  target->Set(zlibString, z->GetFunction());
 
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ZLIB_VERSION"),
               FIXED_ONE_BYTE_STRING(env->isolate(), ZLIB_VERSION));

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -686,7 +686,7 @@ void InitZlib(Local<Object> target,
 
   z->InstanceTemplate()->SetInternalFieldCount(1);
 
-  env->SetProtoMethod(z, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, z);
   env->SetProtoMethod(z, "write", ZCtx::Write<true>);
   env->SetProtoMethod(z, "writeSync", ZCtx::Write<false>);
   env->SetProtoMethod(z, "init", ZCtx::Init);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -72,7 +72,7 @@ void PipeWrap::Initialize(Local<Object> target,
   t->SetClassName(pipeString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
 
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
@@ -104,7 +104,7 @@ void PipeWrap::Initialize(Local<Object> target,
   };
   auto cwt = FunctionTemplate::New(env->isolate(), constructor);
   cwt->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(cwt, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, cwt);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap");
   cwt->SetClassName(wrapString);

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -44,6 +44,7 @@ using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 using AsyncHooks = Environment::AsyncHooks;
@@ -67,7 +68,8 @@ void PipeWrap::Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Pipe"));
+  Local<String> pipeString = FIXED_ONE_BYTE_STRING(env->isolate(), "Pipe");
+  t->SetClassName(pipeString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
@@ -92,7 +94,7 @@ void PipeWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setPendingInstances", SetPendingInstances);
 #endif
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Pipe"), t->GetFunction());
+  target->Set(pipeString, t->GetFunction());
   env->set_pipe_constructor_template(t);
 
   // Create FunctionTemplate for PipeConnectWrap.
@@ -103,9 +105,10 @@ void PipeWrap::Initialize(Local<Object> target,
   auto cwt = FunctionTemplate::New(env->isolate(), constructor);
   cwt->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(cwt, "getAsyncId", AsyncWrap::GetAsyncId);
-  cwt->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap"),
-              cwt->GetFunction());
+  Local<String> wrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "PipeConnectWrap");
+  cwt->SetClassName(wrapString);
+  target->Set(wrapString, cwt->GetFunction());
 }
 
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -57,7 +57,7 @@ class ProcessWrap : public HandleWrap {
         FIXED_ONE_BYTE_STRING(env->isolate(), "Process");
     constructor->SetClassName(processString);
 
-    env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
+    AsyncWrap::AddWrapMethods(env, constructor);
 
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -53,7 +53,9 @@ class ProcessWrap : public HandleWrap {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Process"));
+    Local<String> processString =
+        FIXED_ONE_BYTE_STRING(env->isolate(), "Process");
+    constructor->SetClassName(processString);
 
     env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
 
@@ -66,8 +68,7 @@ class ProcessWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);
     env->SetProtoMethod(constructor, "hasRef", HandleWrap::HasRef);
 
-    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Process"),
-                constructor->GetFunction());
+    target->Set(processString, constructor->GetFunction());
   }
 
   size_t self_size() const override { return sizeof(*this); }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -37,6 +37,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 namespace {
@@ -49,7 +50,9 @@ class SignalWrap : public HandleWrap {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Signal"));
+    Local<String> signalString =
+        FIXED_ONE_BYTE_STRING(env->isolate(), "Signal");
+    constructor->SetClassName(signalString);
 
     env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
@@ -59,8 +62,7 @@ class SignalWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 
-    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Signal"),
-                constructor->GetFunction());
+    target->Set(signalString, constructor->GetFunction());
   }
 
   size_t self_size() const override { return sizeof(*this); }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -54,7 +54,7 @@ class SignalWrap : public HandleWrap {
         FIXED_ONE_BYTE_STRING(env->isolate(), "Signal");
     constructor->SetClassName(signalString);
 
-    env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
+    AsyncWrap::AddWrapMethods(env, constructor);
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);
     env->SetProtoMethod(constructor, "unref", HandleWrap::Unref);

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -67,18 +67,20 @@ void StreamWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> sw =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   sw->InstanceTemplate()->SetInternalFieldCount(1);
-  sw->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap"));
+  Local<String> wrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap");
+  sw->SetClassName(wrapString);
   env->SetProtoMethod(sw, "getAsyncId", AsyncWrap::GetAsyncId);
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap"),
-              sw->GetFunction());
+  target->Set(wrapString, sw->GetFunction());
 
   Local<FunctionTemplate> ww =
       FunctionTemplate::New(env->isolate(), is_construct_call_callback);
   ww->InstanceTemplate()->SetInternalFieldCount(1);
-  ww->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap"));
+  Local<String> writeWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap");
+  ww->SetClassName(writeWrapString);
   env->SetProtoMethod(ww, "getAsyncId", AsyncWrap::GetAsyncId);
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap"),
-              ww->GetFunction());
+  target->Set(writeWrapString, ww->GetFunction());
   env->set_write_wrap_constructor_function(ww->GetFunction());
 }
 

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -70,7 +70,7 @@ void StreamWrap::Initialize(Local<Object> target,
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "ShutdownWrap");
   sw->SetClassName(wrapString);
-  env->SetProtoMethod(sw, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, sw);
   target->Set(wrapString, sw->GetFunction());
 
   Local<FunctionTemplate> ww =
@@ -79,7 +79,7 @@ void StreamWrap::Initialize(Local<Object> target,
   Local<String> writeWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "WriteWrap");
   ww->SetClassName(writeWrapString);
-  env->SetProtoMethod(ww, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, ww);
   target->Set(writeWrapString, ww->GetFunction());
   env->set_write_wrap_constructor_function(ww->GetFunction());
 }

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -71,11 +71,12 @@ void TCPWrap::Initialize(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "TCP"));
+  Local<String> tcpString = FIXED_ONE_BYTE_STRING(env->isolate(), "TCP");
+  t->SetClassName(tcpString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Init properties
-  t->InstanceTemplate()->Set(String::NewFromUtf8(env->isolate(), "reading"),
+  t->InstanceTemplate()->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "reading"),
                              Boolean::New(env->isolate(), false));
   t->InstanceTemplate()->Set(env->owner_string(), Null(env->isolate()));
   t->InstanceTemplate()->Set(env->onread_string(), Null(env->isolate()));
@@ -109,7 +110,7 @@ void TCPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setSimultaneousAccepts", SetSimultaneousAccepts);
 #endif
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "TCP"), t->GetFunction());
+  target->Set(tcpString, t->GetFunction());
   env->set_tcp_constructor_template(t);
 
   // Create FunctionTemplate for TCPConnectWrap.
@@ -120,9 +121,10 @@ void TCPWrap::Initialize(Local<Object> target,
   auto cwt = FunctionTemplate::New(env->isolate(), constructor);
   cwt->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(cwt, "getAsyncId", AsyncWrap::GetAsyncId);
-  cwt->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap"),
-              cwt->GetFunction());
+  Local<String> wrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap");
+  cwt->SetClassName(wrapString);
+  target->Set(wrapString, cwt->GetFunction());
 }
 
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -82,8 +82,7 @@ void TCPWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->Set(env->onread_string(), Null(env->isolate()));
   t->InstanceTemplate()->Set(env->onconnection_string(), Null(env->isolate()));
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
-  env->SetProtoMethod(t, "asyncReset", AsyncWrap::AsyncReset);
+  AsyncWrap::AddWrapMethods(env, t, AsyncWrap::kFlagHasReset);
 
   env->SetProtoMethod(t, "close", HandleWrap::Close);
 
@@ -120,7 +119,7 @@ void TCPWrap::Initialize(Local<Object> target,
   };
   auto cwt = FunctionTemplate::New(env->isolate(), constructor);
   cwt->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(cwt, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, cwt);
   Local<String> wrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "TCPConnectWrap");
   cwt->SetClassName(wrapString);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -59,7 +59,7 @@ class TimerWrap : public HandleWrap {
 
     env->SetTemplateMethod(constructor, "now", Now);
 
-    env->SetProtoMethod(constructor, "getAsyncId", AsyncWrap::GetAsyncId);
+    AsyncWrap::AddWrapMethods(env, constructor);
 
     env->SetProtoMethod(constructor, "close", HandleWrap::Close);
     env->SetProtoMethod(constructor, "ref", HandleWrap::Ref);

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -39,6 +39,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 const uint32_t kOnTimeout = 0;
@@ -50,8 +51,9 @@ class TimerWrap : public HandleWrap {
                          Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
+    Local<String> timerString = FIXED_ONE_BYTE_STRING(env->isolate(), "Timer");
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
-    constructor->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Timer"));
+    constructor->SetClassName(timerString);
     constructor->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kOnTimeout"),
                      Integer::New(env->isolate(), kOnTimeout));
 
@@ -67,8 +69,7 @@ class TimerWrap : public HandleWrap {
     env->SetProtoMethod(constructor, "start", Start);
     env->SetProtoMethod(constructor, "stop", Stop);
 
-    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "Timer"),
-                constructor->GetFunction());
+    target->Set(timerString, constructor->GetFunction());
   }
 
   size_t self_size() const override { return sizeof(*this); }

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -938,9 +938,13 @@ void TLSWrap::Initialize(Local<Object> target,
     CHECK(args.IsConstructCall());
     args.This()->SetAlignedPointerInInternalField(0, nullptr);
   };
+
+  Local<String> tlsWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "TLSWrap");
+
   auto t = env->NewFunctionTemplate(constructor);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "TLSWrap"));
+  t->SetClassName(tlsWrapString);
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
   env->SetProtoMethod(t, "asyncReset", AsyncWrap::AsyncReset);
@@ -962,8 +966,7 @@ void TLSWrap::Initialize(Local<Object> target,
   env->set_tls_wrap_constructor_template(t);
   env->set_tls_wrap_constructor_function(t->GetFunction());
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "TLSWrap"),
-              t->GetFunction());
+  target->Set(tlsWrapString, t->GetFunction());
 }
 
 }  // namespace node

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -946,8 +946,7 @@ void TLSWrap::Initialize(Local<Object> target,
   t->InstanceTemplate()->SetInternalFieldCount(1);
   t->SetClassName(tlsWrapString);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
-  env->SetProtoMethod(t, "asyncReset", AsyncWrap::AsyncReset);
+  AsyncWrap::AddWrapMethods(env, t, AsyncWrap::kFlagHasReset);
   env->SetProtoMethod(t, "receive", Receive);
   env->SetProtoMethod(t, "start", Start);
   env->SetProtoMethod(t, "setVerifyMode", SetVerifyMode);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -56,7 +56,7 @@ void TTYWrap::Initialize(Local<Object> target,
   t->SetClassName(ttyString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
 
   env->SetProtoMethod(t, "close", HandleWrap::Close);
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -41,6 +41,7 @@ using v8::FunctionTemplate;
 using v8::Integer;
 using v8::Local;
 using v8::Object;
+using v8::String;
 using v8::Value;
 
 
@@ -49,8 +50,10 @@ void TTYWrap::Initialize(Local<Object> target,
                          Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
+  Local<String> ttyString = FIXED_ONE_BYTE_STRING(env->isolate(), "TTY");
+
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "TTY"));
+  t->SetClassName(ttyString);
   t->InstanceTemplate()->SetInternalFieldCount(1);
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
@@ -68,7 +71,7 @@ void TTYWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "isTTY", IsTTY);
   env->SetMethod(target, "guessHandleType", GuessHandleType);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "TTY"), t->GetFunction());
+  target->Set(ttyString, t->GetFunction());
   env->set_tty_constructor_template(t);
 }
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -106,7 +106,9 @@ void UDPWrap::Initialize(Local<Object> target,
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
-  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "UDP"));
+  Local<String> udpString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "UDP");
+  t->SetClassName(udpString);
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
@@ -139,7 +141,7 @@ void UDPWrap::Initialize(Local<Object> target,
 
   env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
 
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "UDP"), t->GetFunction());
+  target->Set(udpString, t->GetFunction());
   env->set_udp_constructor_function(t->GetFunction());
 
   // Create FunctionTemplate for SendWrap
@@ -147,9 +149,10 @@ void UDPWrap::Initialize(Local<Object> target,
       FunctionTemplate::New(env->isolate(), NewSendWrap);
   swt->InstanceTemplate()->SetInternalFieldCount(1);
   env->SetProtoMethod(swt, "getAsyncId", AsyncWrap::GetAsyncId);
-  swt->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap"));
-  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap"),
-              swt->GetFunction());
+  Local<String> sendWrapString =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap");
+  swt->SetClassName(sendWrapString);
+  target->Set(sendWrapString, swt->GetFunction());
 }
 
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -139,7 +139,7 @@ void UDPWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "unref", HandleWrap::Unref);
   env->SetProtoMethod(t, "hasRef", HandleWrap::HasRef);
 
-  env->SetProtoMethod(t, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, t);
 
   target->Set(udpString, t->GetFunction());
   env->set_udp_constructor_function(t->GetFunction());
@@ -148,7 +148,7 @@ void UDPWrap::Initialize(Local<Object> target,
   Local<FunctionTemplate> swt =
       FunctionTemplate::New(env->isolate(), NewSendWrap);
   swt->InstanceTemplate()->SetInternalFieldCount(1);
-  env->SetProtoMethod(swt, "getAsyncId", AsyncWrap::GetAsyncId);
+  AsyncWrap::AddWrapMethods(env, swt);
   Local<String> sendWrapString =
       FIXED_ONE_BYTE_STRING(env->isolate(), "SendWrap");
   swt->SetClassName(sendWrapString);


### PR DESCRIPTION
Some general source cleanups

* Reduce duplicate strings
* Add `AsyncWrap::AddWrapMethods`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src