### PR TITLE
stream: fix Writable instanceof for subclasses

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -179,6 +179,8 @@ if (typeof Symbol === 'function' && Symbol.hasInstance) {
     value: function(object) {
       if (realHasInstance.call(this, object))
         return true;
+      if (this !== Writable)
+        return false;
 
       return object && object._writableState instanceof WritableState;
     }

--- a/test/parallel/test-stream-inheritance.js
+++ b/test/parallel/test-stream-inheritance.js
@@ -56,3 +56,8 @@ common.expectsError(
     message: 'undefined does not inherit from CustomWritable'
   }
 );
+
+class OtherCustomWritable extends Writable {}
+
+assert(!(new OtherCustomWritable() instanceof CustomWritable));
+assert(!(new CustomWritable() instanceof OtherCustomWritable));


### PR DESCRIPTION
The current custom instanceof for `Writable` subclasses previously
returned false positives for instances of *other* subclasses of
`Writable` because it was inherited by these subclasses.

Fixes: https://github.com/nodejs/node/issues/14943

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

stream