### PR TITLE
deps: backport d727680 from V8 upstream

### DIFF
--- a/deps/v8/src/heap/page-parallel-job.h
+++ b/deps/v8/src/heap/page-parallel-job.h
@@ -69,7 +69,7 @@ class PageParallelJob {
   void Run(int num_tasks, Callback per_task_data_callback) {
     if (num_items_ == 0) return;
     DCHECK_GE(num_tasks, 1);
-    uint32_t task_ids[kMaxNumberOfTasks];
+    CancelableTaskManager::Id task_ids[kMaxNumberOfTasks];
     const int max_num_tasks = Min(
         kMaxNumberOfTasks,
         static_cast<int>(

--- a/deps/v8/src/libplatform/default-platform.cc
+++ b/deps/v8/src/libplatform/default-platform.cc
@@ -47,25 +47,25 @@ v8::Platform* CreateDefaultPlatform(int thread_pool_size,
 
 bool PumpMessageLoop(v8::Platform* platform, v8::Isolate* isolate,
                      MessageLoopBehavior behavior) {
-  return reinterpret_cast<DefaultPlatform*>(platform)->PumpMessageLoop(
-      isolate, behavior);
+  return static_cast<DefaultPlatform*>(platform)->PumpMessageLoop(isolate,
+                                                                  behavior);
 }
 
 void EnsureEventLoopInitialized(v8::Platform* platform, v8::Isolate* isolate) {
-  return reinterpret_cast<DefaultPlatform*>(platform)
-      ->EnsureEventLoopInitialized(isolate);
+  return static_cast<DefaultPlatform*>(platform)->EnsureEventLoopInitialized(
+      isolate);
 }
 
 void RunIdleTasks(v8::Platform* platform, v8::Isolate* isolate,
                   double idle_time_in_seconds) {
-  reinterpret_cast<DefaultPlatform*>(platform)->RunIdleTasks(
-      isolate, idle_time_in_seconds);
+  static_cast<DefaultPlatform*>(platform)->RunIdleTasks(isolate,
+                                                        idle_time_in_seconds);
 }
 
 void SetTracingController(
     v8::Platform* platform,
     v8::platform::tracing::TracingController* tracing_controller) {
-  return reinterpret_cast<DefaultPlatform*>(platform)->SetTracingController(
+  return static_cast<DefaultPlatform*>(platform)->SetTracingController(
       tracing_controller);
 }
 


### PR DESCRIPTION
Original commit message:

[d8] Bring PredictablePlatform in line with default platform
This removes a lot of special handling for the predictable platform.
Instead of executing spawned foreground and background tasks
immediately (i.e. inside the scope that spawns the tasks), just add
both to the foreground task queue.

This avoids existing special handling for predictable mode in wasm
async compilation, and should fix current failures on the predictable
bot.

BUG=v8:6427

Change-Id: Idbaa764a3dc8c230c29f3937d885e12174691ac4
Reviewed-on: https://chromium-review.googlesource.com/509694
Reviewed-by: Jochen Eisinger <jochen@chromium.org>
Commit-Queue: Clemens Hammacher <clemensh@chromium.org>
Cr-Commit-Position: refs/heads/master@{#45538}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
