### PR TITLE
benchmark: fix dgram/bind-params.js benchmark

### DIFF
--- a/benchmark/dgram/bind-params.js
+++ b/benchmark/dgram/bind-params.js
@@ -10,6 +10,7 @@ const configs = {
 };
 
 const bench = common.createBenchmark(main, configs);
+const noop = () => {};
 
 function main(conf) {
   const n = +conf.n;
@@ -20,7 +21,7 @@ function main(conf) {
     bench.start();
     for (let i = 0; i < n; i++) {
       dgram.createSocket('udp4').bind(port, address)
-        .on('error', () => {})
+        .on('error', noop)
         .unref();
     }
     bench.end(n);
@@ -29,7 +30,7 @@ function main(conf) {
     for (let i = 0; i < n; i++) {
       dgram.createSocket('udp4')
         .bind(port)
-        .on('error', () => {})
+        .on('error', noop)
         .unref();
     }
     bench.end(n);
@@ -38,7 +39,7 @@ function main(conf) {
     for (let i = 0; i < n; i++) {
       dgram.createSocket('udp4')
         .bind()
-        .on('error', () => {})
+        .on('error', noop)
         .unref();
     }
     bench.end(n);

--- a/benchmark/dgram/bind-params.js
+++ b/benchmark/dgram/bind-params.js
@@ -19,19 +19,27 @@ function main(conf) {
   if (port !== undefined && address !== undefined) {
     bench.start();
     for (let i = 0; i < n; i++) {
-      dgram.createSocket('udp4').bind(port, address).unref();
+      dgram.createSocket('udp4').bind(port, address)
+        .on('error', () => {})
+        .unref();
     }
     bench.end(n);
   } else if (port !== undefined) {
     bench.start();
     for (let i = 0; i < n; i++) {
-      dgram.createSocket('udp4').bind(port).unref();
+      dgram.createSocket('udp4')
+        .bind(port)
+        .on('error', () => {})
+        .unref();
     }
     bench.end(n);
   } else if (port === undefined && address === undefined) {
     bench.start();
     for (let i = 0; i < n; i++) {
-      dgram.createSocket('udp4').bind().unref();
+      dgram.createSocket('udp4')
+        .bind()
+        .on('error', () => {})
+        .unref();
     }
     bench.end(n);
   }


### PR DESCRIPTION
`benchmark/dgram/bind-params` exits with an error frequently in its
current form because no error handler is applied. Add no-op error
handlers to avoid the problem.

```console
$ node benchmark/run.js --filter bind-params dgram

dgram/bind-params.js
dgram/bind-params.js address="true" port="true" n=10000:
193,347.42178656923
events.js:182
      throw er; // Unhandled 'error' event
      ^

Error: bind ENFILE 0.0.0.0
    at Object._errnoException (util.js:1041:11)
    at _exceptionWithHostPort (util.js:1064:20)
    at _handle.lookup (dgram.js:242:18)
    at _combinedTickCallback (internal/process/next_tick.js:141:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
    at Function.Module.runMain (module.js:611:11)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:598:3
$
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark dgram