### PR TITLE
test: update windows module load error message

### DIFF
--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -25,7 +25,7 @@ const assert = require('assert');
 const { execSync } = require('child_process');
 
 const errorMessagesByPlatform = {
-  win32: ['%1 is not a valid Win32 application'],
+  win32: ['is not a valid Win32 application'],
   linux: ['file too short', 'Exec format error'],
   sunos: ['unknown file type', 'not an ELF file'],
   darwin: ['file too short'],


### PR DESCRIPTION
libuv 1.14.0 includes a fix for the "%1 is not a valid Win32 application" error message.

Refs: https://github.com/nodejs/node/pull/14866
Refs: https://github.com/libuv/libuv/pull/1116

cc: @bnoordhuis 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test