### PR TITLE
doc: rephrase wording of child_process.execSync()

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -685,8 +685,8 @@ does not exit, the parent process will still wait until the child process has
 exited.
 
 If the process times out, or has a non-zero exit code, this method ***will***
-throw.  The [`Error`][] object will contain the entire result from
-[`child_process.spawnSync()`][]
+throw an [`Error`][] that will include the full result of the underlying
+[`spawnSync()`][].
 
 ### child_process.execSync(command[, options])
 <!-- YAML
@@ -1339,6 +1339,7 @@ unavailable.
 [`process.on('disconnect')`]: process.html#process_event_disconnect
 [`process.on('message')`]: process.html#process_event_message
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
+[`spawnSync()`]: #child_process_child_process_spawnsync_command_args_options
 [`stdio`]: #child_process_options_stdio
 [`util.promisify()`]: util.html#util_util_promisify_original
 [Default Windows Shell]: #child_process_default_windows_shell

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -686,7 +686,7 @@ exited.
 
 If the process times out, or has a non-zero exit code, this method ***will***
 throw an [`Error`][] that will include the full result of the underlying
-[`spawnSync()`][].
+[`child_process.spawnSync()`][].
 
 ### child_process.execSync(command[, options])
 <!-- YAML
@@ -1339,7 +1339,6 @@ unavailable.
 [`process.on('disconnect')`]: process.html#process_event_disconnect
 [`process.on('message')`]: process.html#process_event_message
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
-[`spawnSync()`]: #child_process_child_process_spawnsync_command_args_options
 [`stdio`]: #child_process_options_stdio
 [`util.promisify()`]: util.html#util_util_promisify_original
 [Default Windows Shell]: #child_process_default_windows_shell


### PR DESCRIPTION
Rephrases the error thrown by child_process.execSync().

Fixes: https://github.com/nodejs/node/issues/14944

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
