### PR TITLE
src: remove unnecessary helper function

### DIFF
--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -242,13 +242,18 @@ void StreamWrap::OnReadImpl(ssize_t nread,
 }
 
 
-void StreamWrap::OnReadCommon(uv_stream_t* handle,
-                              ssize_t nread,
-                              const uv_buf_t* buf,
-                              uv_handle_type pending) {
+void StreamWrap::OnRead(uv_stream_t* handle,
+                        ssize_t nread,
+                        const uv_buf_t* buf) {
   StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
   HandleScope scope(wrap->env()->isolate());
   Context::Scope context_scope(wrap->env()->context());
+  uv_handle_type type = UV_UNKNOWN_HANDLE;
+
+  if (wrap->is_named_pipe_ipc() &&
+      uv_pipe_pending_count(reinterpret_cast<uv_pipe_t*>(handle)) > 0) {
+    type = uv_pipe_pending_type(reinterpret_cast<uv_pipe_t*>(handle));
+  }
 
   // We should not be getting this callback if someone as already called
   // uv_close() on the handle.
@@ -262,22 +267,7 @@ void StreamWrap::OnReadCommon(uv_stream_t* handle,
     }
   }
 
-  static_cast<StreamBase*>(wrap)->OnRead(nread, buf, pending);
-}
-
-
-void StreamWrap::OnRead(uv_stream_t* handle,
-                        ssize_t nread,
-                        const uv_buf_t* buf) {
-  StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
-  uv_handle_type type = UV_UNKNOWN_HANDLE;
-
-  if (wrap->is_named_pipe_ipc() &&
-      uv_pipe_pending_count(reinterpret_cast<uv_pipe_t*>(handle)) > 0) {
-    type = uv_pipe_pending_type(reinterpret_cast<uv_pipe_t*>(handle));
-  }
-
-  OnReadCommon(handle, nread, buf, type);
+  static_cast<StreamBase*>(wrap)->OnRead(nread, buf, type);
 }
 
 

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -104,10 +104,6 @@ class StreamWrap : public HandleWrap, public StreamBase {
   static void OnRead(uv_stream_t* handle,
                      ssize_t nread,
                      const uv_buf_t* buf);
-  static void OnReadCommon(uv_stream_t* handle,
-                           ssize_t nread,
-                           const uv_buf_t* buf,
-                           uv_handle_type pending);
   static void AfterWrite(uv_write_t* req, int status);
   static void AfterShutdown(uv_shutdown_t* req, int status);
 


### PR DESCRIPTION
Ever since e2fcfea46e, `OnReadCommon()` is no longer shared between more than one function.

CI: https://ci.nodejs.org/job/node-test-pull-request/9770/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* lib / src
