### PR TITLE
fix --prof-process --preprocess flag

### DIFF
--- a/lib/internal/v8_prof_processor.js
+++ b/lib/internal/v8_prof_processor.js
@@ -32,6 +32,7 @@ if (process.platform === 'darwin') {
 tickArguments.push.apply(tickArguments, process.argv.slice(1));
 script = `(function() {
   arguments = ${JSON.stringify(tickArguments)};
+  function write (s) { process.stdout.write(s) }
   ${script}
 })()`;
 eval(script);

--- a/test/tick-processor/test-tick-processor-preprocess-flag.js
+++ b/test/tick-processor/test-tick-processor-preprocess-flag.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+
+if (!common.enoughTestCpu)
+  common.skip('test is CPU-intensive');
+
+if (common.isWindows ||
+    common.isSunOS ||
+    common.isAIX ||
+    common.isLinuxPPCBE ||
+    common.isFreeBSD)
+  common.skip('C++ symbols are not mapped for this os.');
+
+const base = require('./tick-processor-base.js');
+
+base.runTest({
+  pattern: /^{/,
+  code: `function f() {
+           require('vm').runInDebugContext('Debug');
+           setImmediate(function() { f(); });
+         };
+         f();`,
+  profProcessFlags: ['--preprocess']
+});

--- a/test/tick-processor/tick-processor-base.js
+++ b/test/tick-processor/tick-processor-base.js
@@ -24,23 +24,25 @@ function runTest(test) {
 
   // Try to match after timeout
   setTimeout(() => {
-    match(test.pattern, proc, () => ticks);
+    match(test.pattern, proc, () => ticks, test.profProcessFlags);
   }, RETRY_TIMEOUT);
 }
 
-function match(pattern, parent, ticks) {
+function match(pattern, parent, ticks, flags = []) {
   // Store current ticks log
   fs.writeFileSync(LOG_FILE, ticks());
 
   const proc = cp.spawn(process.execPath, [
     '--prof-process',
     '--call-graph-size=10',
+    ...flags,
     LOG_FILE
   ], {
     stdio: [ 'ignore', 'pipe', 'inherit' ]
   });
 
   let out = '';
+
   proc.stdout.on('data', (chunk) => out += chunk);
   proc.stdout.once('end', () => {
     proc.once('exit', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

tools


This is a one-line fix to prevent the --preprocess
option (used with --prof-process to output JSON)
to cause an isolate log file profiling process to crash.