### PR TITLE
test: remove unused parameters

### DIFF
--- a/test/addons-napi/test_async/test.js
+++ b/test/addons-napi/test_async/test.js
@@ -9,7 +9,7 @@ const testException = 'test_async_cb_exception';
 // Exception thrown from async completion callback.
 // (Tested in a spawned process because the exception is fatal.)
 if (process.argv[2] === 'child') {
-  test_async.Test(1, common.mustCall(function(err, val) {
+  test_async.Test(1, common.mustCall(function() {
     throw new Error(testException);
   }));
   return;

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -44,7 +44,7 @@ const arrayTypes = [ Int8Array, Uint8Array, Uint8ClampedArray, Int16Array,
                      Uint16Array, Int32Array, Uint32Array, Float32Array,
                      Float64Array ];
 
-arrayTypes.forEach((currentType, key) => {
+arrayTypes.forEach((currentType) => {
   const template = Reflect.construct(currentType, buffer);
   const theArray = test_typedarray.CreateTypedArray(template, buffer);
 

--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -47,7 +47,7 @@ const lines = [
 const dInput = new stream.Readable();
 const dOutput = new stream.Writable();
 
-dInput._read = function _read(size) {
+dInput._read = function _read() {
   while (lines.length > 0 && this.push(lines.shift()));
   if (lines.length === 0)
     this.push(null);


### PR DESCRIPTION
Removed the unused arguments of functions defined in
test/addons-napi/test_async/test.js
test/addons-napi/test_typedarray/test.js
test/addons/repl-domain-abort/test.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
