### PR TITLE
Link to correct "OS Constants" heading in docs

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -46,7 +46,7 @@ added: v6.3.0
 
 Returns an object containing commonly used operating system specific constants
 for error codes, process signals, and so on. The specific constants currently
-defined are described in [OS Constants][].
+defined are described in [OS Constants][#os_os_constants_1].
 
 ## os.cpus()
 <!-- YAML

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -46,7 +46,7 @@ added: v6.3.0
 
 Returns an object containing commonly used operating system specific constants
 for error codes, process signals, and so on. The specific constants currently
-defined are described in [OS Constants][#os_os_constants_1].
+defined are described in [OS Constants](#os_os_constants_1).
 
 ## os.cpus()
 <!-- YAML


### PR DESCRIPTION
There are two sections with the name "os(.)constants", the link from inside `# os.constants` means to link to `# OS Constants` but its hash is `os_os_constants_1` so right now its linking to itself.