### PR TITLE
test: remove unused function args

### DIFF
--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 let nestedCall = false;
 
 async_hooks.createHook({
-  init: common.mustCall(function(id, type) {
+  init: common.mustCall(function() {
     nestedHook.disable();
     if (!nestedCall) {
       nestedCall = true;


### PR DESCRIPTION
Removed unused arguments 'id' and 'type'.

**Checklist**

- [x] `make-j4` test (UNIX), or `vcbuild` test (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

 Affected core subsystem(s)
test