### PR TITLE
doc: environmental->environment & NodeJS->Node.js

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -352,15 +352,15 @@ added: v6.11.0
 -->
 
 Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by
-current NodeJS version. The default store is selectable at build-time.
+current Node.js version. The default store is selectable at build-time.
 
 Using OpenSSL store allows for external modifications of the store. For most
 Linux and BSD distributions, this store is maintained by the distribution
 maintainers and system administrators. OpenSSL CA store location is dependent on
 configuration of the OpenSSL library but this can be altered at runtime using
-environmental variables.
+environment variables.
 
-The bundled CA store, as supplied by NodeJS, is a snapshot of Mozilla CA store
+The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store
 that is fixed at release time. It is identical on all supported platforms.
 
 See `SSL_CERT_DIR` and `SSL_CERT_FILE`.

--- a/doc/api/intl.md
+++ b/doc/api/intl.md
@@ -112,7 +112,7 @@ at runtime so that the JS methods would work for all ICU locales. Assuming the
 data file is stored at `/some/directory`, it can be made available to ICU
 through either:
 
-* The [`NODE_ICU_DATA`][] environmental variable:
+* The [`NODE_ICU_DATA`][] environment variable:
 
   ```shell
   env NODE_ICU_DATA=/some/directory node

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -523,7 +523,7 @@ by the `NODE_REPL_HISTORY` variable, as documented in the
 
 ### Using the Node.js REPL with advanced line-editors
 
-For advanced line-editors, start Node.js with the environmental variable
+For advanced line-editors, start Node.js with the environment variable
 `NODE_NO_READLINE=1`. This will start the main and debugger REPL in canonical
 terminal settings, which will allow use with `rlwrap`.
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -223,15 +223,15 @@ used to enable FIPS-compliant crypto if Node.js is built with
 .TP
 .BR \-\-use\-openssl\-ca,\-\-use\-bundled\-ca
 Use OpenSSL's default CA store or use bundled Mozilla CA store as supplied by
-current NodeJS version. The default store is selectable at build-time.
+current Node.js version. The default store is selectable at build-time.
 
 Using OpenSSL store allows for external modifications of the store. For most
 Linux and BSD distributions, this store is maintained by the distribution
 maintainers and system administrators. OpenSSL CA store location is dependent on
 configuration of the OpenSSL library but this can be altered at runtime using
-environmental variables.
+environment variables.
 
-The bundled CA store, as supplied by NodeJS, is a snapshot of Mozilla CA store
+The bundled CA store, as supplied by Node.js, is a snapshot of Mozilla CA store
 that is fixed at release time. It is identical on all supported platforms.
 
 See \fBSSL_CERT_DIR\fR and \fBSSL_CERT_FILE\fR.


### PR DESCRIPTION
s/environmental/environment and s/NodeJS/Node.js

Noticed these while I was poking at the new external CA trust store options

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc