### PR TITLE
buffer: improve error messages

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -224,7 +224,8 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   throw new errors.TypeError(
     'ERR_INVALID_ARG_TYPE',
     'first argument',
-    ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object']
+    ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object'],
+    value
   );
 };
 
@@ -507,7 +508,8 @@ function byteLength(string, encoding) {
     }
 
     throw new errors.TypeError(
-      'ERR_INVALID_ARG_TYPE', 'string', ['string', 'buffer', 'arrayBuffer']
+      'ERR_INVALID_ARG_TYPE', 'string',
+      ['string', 'buffer', 'arrayBuffer'], string
     );
   }
 
@@ -668,7 +670,8 @@ Buffer.prototype.toString = function toString(encoding, start, end) {
 Buffer.prototype.equals = function equals(b) {
   if (!isUint8Array(b)) {
     throw new errors.TypeError(
-      'ERR_INVALID_ARG_TYPE', 'otherBuffer', ['buffer', 'uint8Array']
+      'ERR_INVALID_ARG_TYPE', 'otherBuffer',
+      ['buffer', 'uint8Array'], b
     );
   }
   if (this === b)
@@ -696,7 +699,8 @@ Buffer.prototype.compare = function compare(target,
                                             thisEnd) {
   if (!isUint8Array(target)) {
     throw new errors.TypeError(
-      'ERR_INVALID_ARG_TYPE', 'target', ['buffer', 'uint8Array']
+      'ERR_INVALID_ARG_TYPE', 'target',
+      ['buffer', 'uint8Array'], target
     );
   }
   if (arguments.length === 1)
@@ -778,7 +782,8 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
   }
 
   throw new errors.TypeError(
-    'ERR_INVALID_ARG_TYPE', 'val', ['string', 'buffer', 'uint8Array']
+    'ERR_INVALID_ARG_TYPE', 'value',
+    ['string', 'buffer', 'uint8Array'], val
   );
 }
 
@@ -847,7 +852,8 @@ Buffer.prototype.fill = function fill(val, start, end, encoding) {
     }
 
     if (encoding !== undefined && typeof encoding !== 'string') {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'encoding', 'string');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'encoding',
+                                 'string', encoding);
     }
     var normalizedEncoding = normalizeEncoding(encoding);
     if (normalizedEncoding === undefined) {

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -5,17 +5,22 @@ const assert = require('assert');
 const SlowBuffer = require('buffer').SlowBuffer;
 const vm = require('vm');
 
-// coerce values to string
-const errMsg = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "string" argument must be one of type string, ' +
-           'buffer, or arrayBuffer'
-}, 4);
-assert.throws(() => { Buffer.byteLength(32, 'latin1'); }, errMsg);
-assert.throws(() => { Buffer.byteLength(NaN, 'utf8'); }, errMsg);
-assert.throws(() => { Buffer.byteLength({}, 'latin1'); }, errMsg);
-assert.throws(() => { Buffer.byteLength(); }, errMsg);
+[
+  [32, 'latin1'],
+  [NaN, 'utf8'],
+  [{}, 'latin1'],
+  []
+].forEach((args) => {
+  common.expectsError(
+    () => Buffer.byteLength(...args),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "string" argument must be one of type string, ' +
+               `buffer, or arrayBuffer. Received type ${typeof args[0]}`
+    }
+  );
+});
 
 assert.strictEqual(Buffer.byteLength('', undefined, true), -1);
 

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -69,5 +69,6 @@ assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
 assert.throws(() => a.compare(), common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "target" argument must be one of type buffer or uint8Array'
+  message: 'The "target" argument must be one of ' +
+           'type buffer or uint8Array. Received type undefined'
 }));

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -41,5 +41,6 @@ assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), errMsg);
 assert.throws(() => Buffer.alloc(1).compare('abc'), common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "target" argument must be one of type buffer or uint8Array'
+  message: 'The "target" argument must be one of ' +
+           'type buffer or uint8Array. Received type string'
 }));

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -14,10 +14,12 @@ assert.ok(!d.equals(e));
 assert.ok(d.equals(d));
 assert.ok(d.equals(new Uint8Array([0x61, 0x62, 0x63, 0x64, 0x65])));
 
-assert.throws(() => Buffer.alloc(1).equals('abc'),
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError,
-                message: 'The "otherBuffer" argument must be one of type ' +
-                         'buffer or uint8Array'
-              }));
+common.expectsError(
+  () => Buffer.alloc(1).equals('abc'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "otherBuffer" argument must be one of type ' +
+    'buffer or uint8Array. Received type string'
+  }
+);

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -192,45 +192,49 @@ deepStrictEqualValues(genBuffer(4, [hexBufFill, 1, -1]), [0, 0, 0, 0]);
 
 
 // Check exceptions
-assert.throws(
-  () => buf1.fill(0, -1),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
-assert.throws(
-  () => buf1.fill(0, 0, buf1.length + 1),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
-assert.throws(
-  () => buf1.fill('', -1),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
-assert.throws(
-  () => buf1.fill('', 0, buf1.length + 1),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
-assert.throws(
+[
+  [0, -1],
+  [0, 0, buf1.length + 1],
+  ['', -1],
+  ['', 0, buf1.length + 1]
+].forEach((args) => {
+  common.expectsError(
+    () => buf1.fill(...args),
+    { code: 'ERR_INDEX_OUT_OF_RANGE' }
+  );
+});
+
+common.expectsError(
   () => buf1.fill('a', 0, buf1.length, 'node rocks!'),
-  common.expectsError({
+  {
     code: 'ERR_UNKNOWN_ENCODING',
     type: TypeError,
     message: 'Unknown encoding: node rocks!'
-  }));
-assert.throws(
-  () => buf1.fill('a', 0, 0, NaN),
-  common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "encoding" argument must be of type string'
-  }));
-assert.throws(
-  () => buf1.fill('a', 0, 0, null),
-  common.expectsError({
-    code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "encoding" argument must be of type string'
-  }));
-assert.throws(
+  }
+);
+
+[
+  ['a', 0, 0, NaN],
+  ['a', 0, 0, null]
+].forEach((args) => {
+  common.expectsError(
+    () => buf1.fill(...args),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "encoding" argument must be of type ' +
+      `string. Received type ${args[3] === null ? 'null' : typeof args[3]}`
+    }
+  );
+});
+
+common.expectsError(
   () => buf1.fill('a', 0, 0, 'foo'),
-  common.expectsError({
+  {
     code: 'ERR_UNKNOWN_ENCODING',
     type: TypeError,
     message: 'Unknown encoding: foo'
-  }));
-
+  }
+);
 
 function genBuffer(size, args) {
   const b = Buffer.allocUnsafe(size);

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -36,18 +36,19 @@ deepStrictEqual(
 );
 
 [
-  {},
-  new Boolean(true),
-  { valueOf() { return null; } },
-  { valueOf() { return undefined; } },
-  { valueOf: null },
-  Object.create(null)
-].forEach((input) => {
+  [{}, 'object'],
+  [new Boolean(true), 'boolean'],
+  [{ valueOf() { return null; } }, 'object'],
+  [{ valueOf() { return undefined; } }, 'object'],
+  [{ valueOf: null }, 'object'],
+  [Object.create(null), 'object']
+].forEach(([input, actualType]) => {
   const err = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The first argument must be one of type string, buffer, ' +
-    'arrayBuffer, array, or array-like object'
+             'arrayBuffer, array, or array-like object. Received ' +
+             `type ${actualType}`
   });
   throws(() => Buffer.from(input), err);
 });

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -148,7 +148,7 @@ assert(twoByteString.includes(
 assert(!twoByteString.includes('\u03a3', -2, 'ucs2'));
 
 const mixedByteStringUcs2 =
-    Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395', 'ucs2');
+  Buffer.from('\u039a\u0391abc\u03a3\u03a3\u0395', 'ucs2');
 assert(mixedByteStringUcs2.includes('bc', 0, 'ucs2'));
 assert(mixedByteStringUcs2.includes('\u03a3', 0, 'ucs2'));
 assert(!mixedByteStringUcs2.includes('\u0396', 0, 'ucs2'));
@@ -261,7 +261,7 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
     const length = lengths[lengthIndex];
 
     const patternBufferUcs2 =
-        allCharsBufferUcs2.slice(index, index + length);
+      allCharsBufferUcs2.slice(index, index + length);
     assert.ok(
       allCharsBufferUcs2.includes(patternBufferUcs2, 0, 'ucs2'));
 
@@ -271,21 +271,21 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
   }
 }
 
-const expectedError = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "val" argument must be one of type ' +
-           'string, buffer, or uint8Array'
-}, 3);
-assert.throws(() => {
-  b.includes(() => {});
-}, expectedError);
-assert.throws(() => {
-  b.includes({});
-}, expectedError);
-assert.throws(() => {
-  b.includes([]);
-}, expectedError);
+[
+  () => { },
+  {},
+  []
+].forEach((val) => {
+  common.expectsError(
+    () => b.includes(val),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "value" argument must be one of type string, ' +
+               `buffer, or uint8Array. Received type ${typeof val}`
+    }
+  );
+});
 
 // test truncation of Number arguments to uint8
 {

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -344,24 +344,21 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
   }
 }
 
-const argumentExpected = common.expectsError({
-  code: 'ERR_INVALID_ARG_TYPE',
-  type: TypeError,
-  message: 'The "val" argument must be one of type ' +
-           'string, buffer, or uint8Array'
-}, 3);
-
-assert.throws(() => {
-  b.indexOf(() => { });
-}, argumentExpected);
-
-assert.throws(() => {
-  b.indexOf({});
-}, argumentExpected);
-
-assert.throws(() => {
-  b.indexOf([]);
-}, argumentExpected);
+[
+  () => {},
+  {},
+  []
+].forEach((val) => {
+  common.expectsError(
+    () => b.indexOf(val),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "value" argument must be one of type string, ' +
+               `buffer, or uint8Array. Received type ${typeof val}`
+    }
+  );
+});
 
 // Test weird offset arguments.
 // The following offsets coerce to NaN or 0, searching the whole Buffer


### PR DESCRIPTION
Some errors in buffer module losed some arguments or received wrong arguments when they were created. This PR added these losing arguments and fixed the wrong arguments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer, test