### PR TITLE
tls: Add PSK support (v9.0.0-pre)

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -912,13 +912,12 @@ changes:
     client should continue to negotiate PSK ciphers, the return value of this
     function must be an object in the form `{psk: <string>, identity:
     <string>}`.
-    * *Note*: PSK ciphers are disabled by default, and using
-    TLS-PSK thus requires explicitly specifying a cipher suite with the
-    `ciphers` option. Additionally, it may be necessary to disable
-    `rejectUnauthorized` if a client attempts to specify a certificate for the
-    session.
-    * *Note*: `psk` must be a hexadecimal string,
-    `identity` must use UTF-8 encoding.
+    Note that PSK ciphers are disabled by default, and using TLS-PSK thus
+    requires explicitly specifying a cipher suite with the `ciphers` option.
+    Additionally, it may be necessary to disable `rejectUnauthorized` if a
+    client attempts to specify a certificate for the session.
+    Note that `psk` must be a hexadecimal string, `identity` must use UTF-8
+    encoding.
   * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing the supported ALPN protocols. `Buffer`s should have
@@ -1202,7 +1201,7 @@ changes:
   * `ticketKeys`: A 48-byte `Buffer` instance consisting of a 16-byte prefix,
     a 16-byte HMAC key, and a 16-byte AES key. This can be used to accept TLS
     session tickets on multiple instances of the TLS server.
-  * ...: Any [`tls.createSecureContext()`][] options can be provided. For
+  * ...: Any [`tls.createSecureContext()`][] option can be provided. For
     servers, the identity options (`pfx`, `key`/`cert` or `pskCallback`)
     are usually required.
 * `secureConnectionListener` {Function}

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -920,7 +920,8 @@ changes:
     `ciphers` option. Additionally, it may be necessary to disable
     `rejectUnauthorized` if a client attempts to specify a certificate for the
     session.
-    * *Note*: `psk` must be a hexadecimal string, `identity` must use UTF-8 encoding.
+    * *Note*: `psk` must be a hexadecimal string,
+    `identity` must use UTF-8 encoding.
   * `NPNProtocols` {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing supported NPN protocols. `Buffer`s should have the
@@ -1211,7 +1212,8 @@ changes:
     a 16-byte HMAC key, and a 16-byte AES key. This can be used to accept TLS
     session tickets on multiple instances of the TLS server.
   * ...: Any [`tls.createSecureContext()`][] options can be provided. For
-    servers, the identity options (`pfx`, `key`/`cert` or `pskCallback`) are usually required.
+    servers, the identity options (`pfx`, `key`/`cert` or `pskCallback`)
+    are usually required.
 * `secureConnectionListener` {Function}
 
 Creates a new [`tls.Server`][]. The `secureConnectionListener`, if provided, is
@@ -1369,20 +1371,6 @@ changes:
   certificate from a connecting client. Only applies when `isServer` is `true`.
 * `rejectUnauthorized` {boolean} If not `false` a server automatically reject
   clients with invalid certificates. Only applies when `isServer` is `true`.
-* `pskCallback(hint)` {Function} When negotiating TLS-PSK, this optional
-   function is called with the identity hint provided by the server. If the
-   client should continue to negotiate PSK ciphers, the return value of this
-   function must be an object in the form `{psk: <string>, identity:
-   <string>}`.
-   * *Note*: PSK ciphers are disabled by default, and using
-   TLS-PSK thus requires explicitly specifying a cipher suite with the
-   `ciphers` option. Additionally, it may be necessary to disable
-   `rejectUnauthorized` if a client attempts to specify a certificate for the
-   session.
-   * *Note*: `psk` must be a hexadecimal string.
-* `pskIdentityHint`: {string} The identity hint to send to clients when
-  negotiating TLS-PSK.
-  * *Note*: Must use UTF-8 encoding.
 * `options`
   * `secureContext`: A TLS context object from [`tls.createSecureContext()`][]
   * `isServer`: If `true` the TLS socket will be instantiated in server-mode.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1380,7 +1380,7 @@ changes:
    `rejectUnauthorized` if a client attempts to specify a certificate for the
    session.
    * *Note*: `psk` must be a hexadecimal string.
-* `pskIdentity`: {string} The identity hint to send to clients when
+* `pskIdentityHint`: {string} The identity hint to send to clients when
   negotiating TLS-PSK.
   * *Note*: Must use UTF-8 encoding.
 * `options`

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -115,9 +115,6 @@ SNI (Server Name Indication) are TLS handshake extensions:
 * SNI - Allows the use of one TLS server for multiple hostnames with different
   SSL certificates.
 
-*Note*: Use of ALPN is recommended over NPN. The NPN extension has never been
-formally defined or documented and generally not recommended for use.
-
 ### Pre-shared keys
 
 <!-- type=misc -->
@@ -922,12 +919,6 @@ changes:
     session.
     * *Note*: `psk` must be a hexadecimal string,
     `identity` must use UTF-8 encoding.
-  * `NPNProtocols` {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
-    An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
-    `Uint8Array` containing supported NPN protocols. `Buffer`s should have the
-    format `[len][name][len][name]...` e.g. `0x05hello0x05world`, where the
-    first byte is the length of the next protocol name. Passing an array is
-    usually much simpler, e.g. `['hello', 'world']`.
   * `ALPNProtocols`: {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing the supported ALPN protocols. `Buffer`s should have

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -913,14 +913,14 @@ changes:
   * `pskCallback(hint)` {Function} When negotiating TLS-PSK, this optional
     function is called with the identity hint provided by the server. If the
     client should continue to negotiate PSK ciphers, the return value of this
-    function must be an object in the form `{psk: <string|buffer>, identity:
+    function must be an object in the form `{psk: <string>, identity:
     <string>}`.
     * *Note*: PSK ciphers are disabled by default, and using
     TLS-PSK thus requires explicitly specifying a cipher suite with the
     `ciphers` option. Additionally, it may be necessary to disable
     `rejectUnauthorized` if a client attempts to specify a certificate for the
     session.
-    * *Note*: `identity` must use UTF-8 encoding.
+    * *Note*: `psk` must be a hexadecimal string, `identity` must use UTF-8 encoding.
   * `NPNProtocols` {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing supported NPN protocols. `Buffer`s should have the
@@ -1369,12 +1369,17 @@ changes:
   certificate from a connecting client. Only applies when `isServer` is `true`.
 * `rejectUnauthorized` {boolean} If not `false` a server automatically reject
   clients with invalid certificates. Only applies when `isServer` is `true`.
-* `pskCallback(identity)` {Function} When negotiating TLS-PSK, this optional
-  function is called with the identity provided by the client. If the server
-  should continue to negotiate PSK ciphers, the return value of this function
-  must be an object in the form `{psk: <string|buffer>}`. Note that PSK ciphers
-  are disabled by default, and using TLS-PSK thus requires explicitly
-  specifying a cipher suite with the `ciphers` option.
+* `pskCallback(hint)` {Function} When negotiating TLS-PSK, this optional
+   function is called with the identity hint provided by the server. If the
+   client should continue to negotiate PSK ciphers, the return value of this
+   function must be an object in the form `{psk: <string>, identity:
+   <string>}`.
+   * *Note*: PSK ciphers are disabled by default, and using
+   TLS-PSK thus requires explicitly specifying a cipher suite with the
+   `ciphers` option. Additionally, it may be necessary to disable
+   `rejectUnauthorized` if a client attempts to specify a certificate for the
+   session.
+   * *Note*: `psk` must be a hexadecimal string.
 * `pskIdentity`: {string} The identity hint to send to clients when
   negotiating TLS-PSK.
   * *Note*: Must use UTF-8 encoding.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -874,6 +874,9 @@ similar to:
 <!-- YAML
 added: v0.11.3
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/14978
+    description: The `pskCallback` option is now supported.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/12839
     description: The `lookup` option is supported now.
@@ -915,7 +918,8 @@ changes:
     * *Note*: PSK ciphers are disabled by default, and using
     TLS-PSK thus requires explicitly specifying a cipher suite with the
     `ciphers` option. Additionally, it may be necessary to disable
-    `rejectUnauthorized` when not intending to use certificates.
+    `rejectUnauthorized` if a client attempts to specify a certificate for the
+    session.
     * *Note*: `identity` must use UTF-8 encoding.
   * `NPNProtocols` {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -911,10 +911,12 @@ changes:
     function is called with the identity hint provided by the server. If the
     client should continue to negotiate PSK ciphers, the return value of this
     function must be an object in the form `{psk: <string|buffer>, identity:
-    <string>}`. Note that PSK ciphers are disabled by default, and using
+    <string>}`.
+    * *Note*: PSK ciphers are disabled by default, and using
     TLS-PSK thus requires explicitly specifying a cipher suite with the
     `ciphers` option. Additionally, it may be necessary to disable
     `rejectUnauthorized` when not intending to use certificates.
+    * *Note*: `identity` must use UTF-8 encoding.
   * `NPNProtocols` {string[]|Buffer[]|Uint8Array[]|Buffer|Uint8Array}
     An array of strings, `Buffer`s or `Uint8Array`s, or a single `Buffer` or
     `Uint8Array` containing supported NPN protocols. `Buffer`s should have the
@@ -1371,6 +1373,7 @@ changes:
   specifying a cipher suite with the `ciphers` option.
 * `pskIdentity`: {string} The identity hint to send to clients when
   negotiating TLS-PSK.
+  * *Note*: Must use UTF-8 encoding.
 * `options`
   * `secureContext`: A TLS context object from [`tls.createSecureContext()`][]
   * `isServer`: If `true` the TLS socket will be instantiated in server-mode.

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -164,7 +164,8 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.pskCallback && c.context.enablePskCallback) {
     if (typeof options.pskCallback !== 'function') {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pskCallback', 'function', options.pskCallback);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pskCallback',
+                                 'function', options.pskCallback);
     }
 
     c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -70,6 +70,52 @@ function validateKeyCert(name, value) {
 exports.SecureContext = SecureContext;
 
 
+function ecdhCurveWarning() {
+  if (ecdhCurveWarning.emitted) return;
+  process.emitWarning('{ ecdhCurve: false } is deprecated.',
+                      'DeprecationWarning',
+                      'DEP0083');
+  ecdhCurveWarning.emitted = true;
+}
+ecdhCurveWarning.emitted = false;
+
+function onpskexchange(pskCallback) {
+  return (identity, maxPskLen, maxIdentLen) => {
+    let ret = pskCallback(identity);
+    if (typeof ret !== 'object' || ret == null) {
+      ret = undefined;
+    }
+
+    if (ret) {
+      ret = { psk: ret.psk, identity: ret.identity };
+
+      if (!typeof ret.psk === 'string') {
+        throw new ERR_INVALID_ARG_TYPE('psk', ['string']);
+      }
+      if (ret.psk.length / 2 > maxPskLen) {
+        throw new ERR_ASSERTION(
+          `Pre-shared key exceeds ${maxPskLen} bytes`
+        );
+      }
+
+      // Only set for the client callback, which must provide an identity.
+      if (maxIdentLen) {
+        if (typeof ret.identity !== 'string') {
+          throw new ERR_INVALID_ARG_TYPE('identity',
+                                         'string');
+        }
+        if (ret.identity.length > maxIdentLen) {
+          throw new ERR_ASSERTION(
+            `PSK identity exceeds ${maxIdentLen} bytes`
+          );
+        }
+      }
+    }
+
+    return ret;
+  };
+}
+
 exports.createSecureContext = function createSecureContext(options, context) {
   if (!options) options = {};
 
@@ -168,44 +214,20 @@ exports.createSecureContext = function createSecureContext(options, context) {
                                      'function', options.pskCallback);
     }
 
-    c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {
-      let ret = options.pskCallback(identity);
-      if (typeof ret !== 'object' || ret == null) {
-        ret = undefined;
-      }
-
-      if (ret) {
-        ret = { psk: ret.psk, identity: ret.identity };
-
-        if (!typeof ret.psk === 'string') {
-          throw new ERR_INVALID_ARG_TYPE('psk', ['string']);
-        }
-        if (ret.psk.length / 2 > maxPskLen) {
-          throw new ERR_ASSERTION(
-            `Pre-shared key exceeds ${maxPskLen} bytes`
-          );
-        }
-
-        // Only set for the client callback, which must provide an identity.
-        if (maxIdentLen) {
-          if (typeof ret.identity !== 'string') {
-            throw new ERR_INVALID_ARG_TYPE('identity',
-                                           'string');
-          }
-          if (ret.identity.length > maxIdentLen) {
-            throw new ERR_ASSERTION(
-              `PSK identity exceeds ${maxIdentLen} bytes`
-            );
-          }
-        }
-      }
-
-      return ret;
-    };
+    c.context.onpskexchange = onpskexchange(options.pskCallback);
     c.context.enablePskCallback();
 
-    if (options.pskIdentityHint)
+    if (options.pskIdentityHint) {
+      if (typeof options.pskIdentityHint !== 'string') {
+        throw new ERR_INVALID_ARG_TYPE(
+          'options.pskIdentityHint',
+          ['string'],
+          options.pskIdentityHint
+        );
+      }
+
       c.context.setPskIdentity(options.pskIdentityHint);
+    }
   }
 
   if (options.sessionIdContext) {

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -69,6 +69,37 @@ function validateKeyCert(name, value) {
 
 exports.SecureContext = SecureContext;
 
+function onpskexchange(pskCallback) {
+  return (identity, maxPskLen, maxIdentLen) => {
+    let ret = pskCallback(identity);
+    if (typeof ret !== 'object' || ret == null) {
+      ret = undefined;
+    }
+
+    if (ret) {
+      ret = { psk: ret.psk, identity: ret.identity };
+
+      if (!typeof ret.psk === 'string') {
+        throw new ERR_INVALID_ARG_TYPE('psk', ['string']);
+      }
+      if (ret.psk.length / 2 > maxPskLen) {
+        throw new ERR_ASSERTION(`Pre-shared key exceeds ${maxPskLen} bytes`);
+      }
+
+      // Only set for the client callback, which must provide an identity.
+      if (maxIdentLen) {
+        if (typeof ret.identity !== 'string') {
+          throw new ERR_INVALID_ARG_TYPE('identity', 'string');
+        }
+        if (ret.identity.length > maxIdentLen) {
+          throw new ERR_ASSERTION(`PSK identity exceeds ${maxIdentLen} bytes`);
+        }
+      }
+    }
+
+    return ret;
+  };
+}
 
 function ecdhCurveWarning() {
   if (ecdhCurveWarning.emitted) return;
@@ -211,7 +242,8 @@ exports.createSecureContext = function createSecureContext(options, context) {
   if (options.pskCallback && c.context.enablePskCallback) {
     if (typeof options.pskCallback !== 'function') {
       throw new ERR_INVALID_ARG_TYPE('pskCallback',
-                                     'function', options.pskCallback);
+                                     'function',
+                                     options.pskCallback);
     }
 
     c.context.onpskexchange = onpskexchange(options.pskCallback);
@@ -221,7 +253,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
       if (typeof options.pskIdentityHint !== 'string') {
         throw new ERR_INVALID_ARG_TYPE(
           'options.pskIdentityHint',
-          ['string'],
+          'string',
           options.pskIdentityHint
         );
       }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -172,15 +172,10 @@ exports.createSecureContext = function createSecureContext(options, context) {
       if (ret) {
         ret = { psk: ret.psk, identity: ret.identity };
 
-        if (typeof ret.psk === 'string') {
-          ret.psk = Buffer.from(ret.psk);
-        } else if (!ArrayBuffer.isView(ret.psk)) {
-          throw new errors.TypeError(
-            'ERR_INVALID_ARG_TYPE', 'psk',
-            ['string', 'Buffer', 'TypedArray', 'DataView']
-          );
+        if (!typeof ret.psk === 'string') {
+          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk', ['string']);
         }
-        if (ret.psk.length > maxPskLen) {
+        if (ret.psk.length / 2 > maxPskLen) {
           throw new errors.RangeError(
             'ERR_ASSERTION',
             `Pre-shared key exceed ${maxPskLen} bytes`
@@ -189,9 +184,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
         // Only set for the client callback, which must provide an identity.
         if (maxIdentLen) {
-          if (typeof ret.identity === 'string') {
-            ret.identity = Buffer.from(ret.identity + '\0');
-          } else {
+          if (typeof ret.identity !== 'string') {
             throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'identity',
                                        'string');
           }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -164,7 +164,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
   if (options.pskCallback && c.context.enablePskCallback) {
     if (typeof options.pskCallback !== 'function') {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pskCallback',
+      throw new ERR_INVALID_ARG_TYPE('pskCallback',
                                  'function', options.pskCallback);
     }
 
@@ -178,19 +178,19 @@ exports.createSecureContext = function createSecureContext(options, context) {
         ret = { psk: ret.psk, identity: ret.identity };
 
         if (!typeof ret.psk === 'string') {
-          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk', ['string']);
+          throw new ERR_INVALID_ARG_TYPE('psk', ['string']);
         }
         if (ret.psk.length / 2 > maxPskLen) {
           throw new errors.RangeError(
             'ERR_ASSERTION',
-            `Pre-shared key exceed ${maxPskLen} bytes`
+            `Pre-shared key exceeds ${maxPskLen} bytes`
           );
         }
 
         // Only set for the client callback, which must provide an identity.
         if (maxIdentLen) {
           if (typeof ret.identity !== 'string') {
-            throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'identity',
+            throw new ERR_INVALID_ARG_TYPE('identity',
                                        'string');
           }
           if (ret.identity.length > maxIdentLen) {
@@ -206,8 +206,8 @@ exports.createSecureContext = function createSecureContext(options, context) {
     };
     c.context.enablePskCallback();
 
-    if (options.pskIdentity)
-      c.context.setPskIdentity(options.pskIdentity);
+    if (options.pskIdentityHint)
+      c.context.setPskIdentity(options.pskIdentityHint);
   }
 
   if (options.sessionIdContext) {

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -163,9 +163,13 @@ exports.createSecureContext = function createSecureContext(options, context) {
   }
 
   if (options.pskCallback && c.context.enablePskCallback) {
+    if (typeof options.pskCallback !== 'function') {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pskCallback', 'function', options.pskCallback);
+    }
+
     c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {
       let ret = options.pskCallback(identity);
-      if (typeof ret !== 'object') {
+      if (typeof ret !== 'object' || ret == null) {
         ret = undefined;
       }
 

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -25,10 +25,10 @@ const { parseCertString } = require('internal/tls');
 const { isArrayBufferView } = require('internal/util/types');
 const tls = require('tls');
 const {
+  ERR_ASSERTION,
   ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED,
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
-const Buffer = require('buffer').Buffer;
 
 const { SSL_OP_CIPHER_SERVER_PREFERENCE } = process.binding('constants').crypto;
 
@@ -165,7 +165,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
   if (options.pskCallback && c.context.enablePskCallback) {
     if (typeof options.pskCallback !== 'function') {
       throw new ERR_INVALID_ARG_TYPE('pskCallback',
-                                 'function', options.pskCallback);
+                                     'function', options.pskCallback);
     }
 
     c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {
@@ -181,8 +181,7 @@ exports.createSecureContext = function createSecureContext(options, context) {
           throw new ERR_INVALID_ARG_TYPE('psk', ['string']);
         }
         if (ret.psk.length / 2 > maxPskLen) {
-          throw new errors.RangeError(
-            'ERR_ASSERTION',
+          throw new ERR_ASSERTION(
             `Pre-shared key exceeds ${maxPskLen} bytes`
           );
         }
@@ -191,11 +190,10 @@ exports.createSecureContext = function createSecureContext(options, context) {
         if (maxIdentLen) {
           if (typeof ret.identity !== 'string') {
             throw new ERR_INVALID_ARG_TYPE('identity',
-                                       'string');
+                                           'string');
           }
           if (ret.identity.length > maxIdentLen) {
-            throw new errors.RangeError(
-              'ERR_ASSERTION',
+            throw new ERR_ASSERTION(
               `PSK identity exceeds ${maxIdentLen} bytes`
             );
           }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -161,6 +161,46 @@ exports.createSecureContext = function createSecureContext(options, context) {
     }
   }
 
+  if (options.pskCallback && c.context.enablePskCallback) {
+    c.context.onpskexchange = (identity, maxPskLen, maxIdentLen) => {
+      let ret = options.pskCallback(identity);
+      if (typeof ret !== 'object') {
+        ret = undefined;
+      }
+
+      if (ret) {
+        ret = { psk: ret.psk, identity: ret.identity };
+
+        if (typeof ret.psk === 'string') {
+          ret.psk = Buffer.from(ret.psk);
+        } else if (!Buffer.isBuffer(ret.psk)) {
+          throw new TypeError('Pre-shared key is not a string or buffer');
+        }
+        if (ret.psk.length > maxPskLen) {
+          throw new TypeError(`Pre-shared key exceed ${maxPskLen} bytes`);
+        }
+
+        // Only set for the client callback, which must provide an identity.
+        if (maxIdentLen) {
+          if (typeof ret.identity === 'string') {
+            ret.identity = Buffer.from(ret.identity + '\0');
+          } else {
+            throw new TypeError('PSK identity is not a string');
+          }
+          if (ret.identity.length > maxIdentLen) {
+            throw new TypeError(`PSK identity exceeds ${maxIdentLen} bytes`);
+          }
+        }
+      }
+
+      return ret;
+    };
+    c.context.enablePskCallback();
+
+    if (options.pskIdentity)
+      c.context.setPskIdentity(options.pskIdentity);
+  }
+
   if (options.sessionIdContext) {
     c.context.setSessionIdContext(options.sessionIdContext);
   }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -174,14 +174,17 @@ exports.createSecureContext = function createSecureContext(options, context) {
 
         if (typeof ret.psk === 'string') {
           ret.psk = Buffer.from(ret.psk);
-        } else if (!Buffer.isBuffer(ret.psk)) {
-          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk',
-                                     ['string', 'buffer']);
+        } else if (!ArrayBuffer.isView(ret.psk)) {
+          throw new errors.TypeError(
+            'ERR_INVALID_ARG_TYPE', 'psk',
+            ['string', 'Buffer', 'TypedArray', 'DataView']
+          );
         }
         if (ret.psk.length > maxPskLen) {
           throw new errors.RangeError(
             'ERR_ASSERTION',
-            `Pre-shared key exceed ${maxPskLen} bytes`);
+            `Pre-shared key exceed ${maxPskLen} bytes`
+          );
         }
 
         // Only set for the client callback, which must provide an identity.
@@ -195,7 +198,8 @@ exports.createSecureContext = function createSecureContext(options, context) {
           if (ret.identity.length > maxIdentLen) {
             throw new errors.RangeError(
               'ERR_ASSERTION',
-              `PSK identity exceeds ${maxIdentLen} bytes`);
+              `PSK identity exceeds ${maxIdentLen} bytes`
+            );
           }
         }
       }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -28,6 +28,7 @@ const {
   ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED,
   ERR_INVALID_ARG_TYPE
 } = require('internal/errors').codes;
+const Buffer = require('buffer').Buffer;
 
 const { SSL_OP_CIPHER_SERVER_PREFERENCE } = process.binding('constants').crypto;
 
@@ -174,10 +175,13 @@ exports.createSecureContext = function createSecureContext(options, context) {
         if (typeof ret.psk === 'string') {
           ret.psk = Buffer.from(ret.psk);
         } else if (!Buffer.isBuffer(ret.psk)) {
-          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk', ['string', 'buffer']);
+          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk',
+                                     ['string', 'buffer']);
         }
         if (ret.psk.length > maxPskLen) {
-          throw new errors.RangeError('ERR_ASSERTION', `Pre-shared key exceed ${maxPskLen} bytes`);
+          throw new errors.RangeError(
+            'ERR_ASSERTION',
+            `Pre-shared key exceed ${maxPskLen} bytes`);
         }
 
         // Only set for the client callback, which must provide an identity.
@@ -185,10 +189,13 @@ exports.createSecureContext = function createSecureContext(options, context) {
           if (typeof ret.identity === 'string') {
             ret.identity = Buffer.from(ret.identity + '\0');
           } else {
-            throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'identity', 'string');
+            throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'identity',
+                                       'string');
           }
           if (ret.identity.length > maxIdentLen) {
-            throw new errors.RangeError('ERR_ASSERTION', `PSK identity exceeds ${maxIdentLen} bytes`);
+            throw new errors.RangeError(
+              'ERR_ASSERTION',
+              `PSK identity exceeds ${maxIdentLen} bytes`);
           }
         }
       }

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -174,10 +174,10 @@ exports.createSecureContext = function createSecureContext(options, context) {
         if (typeof ret.psk === 'string') {
           ret.psk = Buffer.from(ret.psk);
         } else if (!Buffer.isBuffer(ret.psk)) {
-          throw new TypeError('Pre-shared key is not a string or buffer');
+          throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'psk', ['string', 'buffer']);
         }
         if (ret.psk.length > maxPskLen) {
-          throw new TypeError(`Pre-shared key exceed ${maxPskLen} bytes`);
+          throw new errors.RangeError('ERR_ASSERTION', `Pre-shared key exceed ${maxPskLen} bytes`);
         }
 
         // Only set for the client callback, which must provide an identity.
@@ -185,10 +185,10 @@ exports.createSecureContext = function createSecureContext(options, context) {
           if (typeof ret.identity === 'string') {
             ret.identity = Buffer.from(ret.identity + '\0');
           } else {
-            throw new TypeError('PSK identity is not a string');
+            throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'identity', 'string');
           }
           if (ret.identity.length > maxIdentLen) {
-            throw new TypeError(`PSK identity exceeds ${maxIdentLen} bytes`);
+            throw new errors.RangeError('ERR_ASSERTION', `PSK identity exceeds ${maxIdentLen} bytes`);
           }
         }
       }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -938,7 +938,6 @@ Server.prototype.setOptions = function(options) {
   if (secureOptions) this.secureOptions = secureOptions;
   if (options.pskIdentityHint) this.pskIdentityHint = options.pskIdentityHint;
   if (options.pskCallback) this.pskCallback = options.pskCallback;
-  if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.ALPNProtocols)
     tls.convertALPNProtocols(options.ALPNProtocols, this);
   if (options.sessionIdContext) {

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -847,7 +847,7 @@ function Server(options, listener) {
     secureProtocol: this.secureProtocol,
     secureOptions: this.secureOptions,
     pskCallback: this.pskCallback,
-    pskIdentity: this.pskIdentity,
+    pskIdentityHint: this.pskIdentityHint,
     honorCipherOrder: this.honorCipherOrder,
     crl: this.crl,
     sessionIdContext: this.sessionIdContext
@@ -936,7 +936,7 @@ Server.prototype.setOptions = function(options) {
   else
     this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
-  if (options.pskIdentity) this.pskIdentity = options.pskIdentity;
+  if (options.pskIdentityHint) this.pskIdentityHint = options.pskIdentityHint;
   if (options.pskCallback) this.pskCallback = options.pskCallback;
   if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.ALPNProtocols)

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -689,7 +689,7 @@ TLSSocket.prototype.getCipher = function(err) {
   return null;
 };
 
-// TODO: support anonymous (nocert) and PSK
+// TODO: support anonymous (nocert)
 
 
 function onSocketSecure() {
@@ -846,6 +846,8 @@ function Server(options, listener) {
     dhparam: this.dhparam,
     secureProtocol: this.secureProtocol,
     secureOptions: this.secureOptions,
+    pskCallback: this.pskCallback,
+    pskIdentity: this.pskIdentity,
     honorCipherOrder: this.honorCipherOrder,
     crl: this.crl,
     sessionIdContext: this.sessionIdContext
@@ -934,6 +936,9 @@ Server.prototype.setOptions = function(options) {
   else
     this.honorCipherOrder = true;
   if (secureOptions) this.secureOptions = secureOptions;
+  if (options.pskIdentity) this.pskIdentity = options.pskIdentity;
+  if (options.pskCallback) this.pskCallback = options.pskCallback;
+  if (options.NPNProtocols) tls.convertNPNProtocols(options.NPNProtocols, this);
   if (options.ALPNProtocols)
     tls.convertALPNProtocols(options.ALPNProtocols, this);
   if (options.sessionIdContext) {

--- a/src/env.h
+++ b/src/env.h
@@ -260,7 +260,6 @@ struct PackageConfig {
   V(promise_string, "promise")                                                \
   V(pubkey_string, "pubkey")                                                  \
   V(query_string, "query")                                                    \
-  V(produce_cached_data_string, "produceCachedData")                          \
   V(psk_string, "psk")                                                        \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \

--- a/src/env.h
+++ b/src/env.h
@@ -154,10 +154,7 @@ struct PackageConfig {
   V(duration_string, "duration")                                              \
   V(emit_warning_string, "emitWarning")                                       \
   V(exchange_string, "exchange")                                              \
-  V(enumerable_string, "enumerable")                                          \
   V(identity_string, "identity")                                              \
-  V(idle_string, "idle")                                                      \
-  V(irq_string, "irq")                                                        \
   V(enablepush_string, "enablePush")                                          \
   V(encoding_string, "encoding")                                              \
   V(entries_string, "entries")                                                \

--- a/src/env.h
+++ b/src/env.h
@@ -154,6 +154,11 @@ struct PackageConfig {
   V(duration_string, "duration")                                              \
   V(emit_warning_string, "emitWarning")                                       \
   V(exchange_string, "exchange")                                              \
+  V(enumerable_string, "enumerable")                                          \
+  V(identity_string, "identity")                                              \
+  V(idle_string, "idle")                                                      \
+  V(irq_string, "irq")                                                        \
+  V(enablepush_string, "enablePush")                                          \
   V(encoding_string, "encoding")                                              \
   V(entries_string, "entries")                                                \
   V(entry_type_string, "entryType")                                           \
@@ -223,6 +228,7 @@ struct PackageConfig {
   V(onmessage_string, "onmessage")                                            \
   V(onnewsession_string, "onnewsession")                                      \
   V(onocspresponse_string, "onocspresponse")                                  \
+  V(onpskexchange_string, "onpskexchange")                                    \
   V(ongoawaydata_string, "ongoawaydata")                                      \
   V(onorigin_string, "onorigin")                                              \
   V(onpriority_string, "onpriority")                                          \
@@ -257,6 +263,8 @@ struct PackageConfig {
   V(promise_string, "promise")                                                \
   V(pubkey_string, "pubkey")                                                  \
   V(query_string, "query")                                                    \
+  V(produce_cached_data_string, "produceCachedData")                          \
+  V(psk_string, "psk")                                                        \
   V(raw_string, "raw")                                                        \
   V(read_host_object_string, "_readHostObject")                               \
   V(readable_string, "readable")                                              \

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1517,7 +1517,7 @@ unsigned int SecureContext::PskClientCallback(SSL *ssl,
 
   MaybeLocal<Value> maybe_ret;
   if (value->IsFunction()) {
-    Local<Function> func = Local<Function>::Cast(value);
+    Local<Function> func = value.As<Function>();
     maybe_ret = func->Call(env->context(), sc->object(), arraysize(argv), argv);
   } else {
     return 0;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1396,7 +1396,7 @@ void SecureContext::SetPskIdentity(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   String::Utf8Value identity(args.GetIsolate(), args[0]);
-  if (!SSL_CTX_use_psk_identity_hint(wrap->ctx_, *identity)) {
+  if (!SSL_CTX_use_psk_identity_hint(wrap->ctx_.get(), *identity)) {
     return ThrowCryptoError(env,
                             ERR_get_error(),
                             "Failed to set PSK identity hint");
@@ -1407,9 +1407,9 @@ void SecureContext::EnablePskCallback(
     const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
 
-  SSL_CTX_set_psk_server_callback(wrap->ctx_,
+  SSL_CTX_set_psk_server_callback(wrap->ctx_.get(),
                                   SecureContext::PskServerCallback);
-  SSL_CTX_set_psk_client_callback(wrap->ctx_,
+  SSL_CTX_set_psk_client_callback(wrap->ctx_.get(),
                                   SecureContext::PskClientCallback);
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1418,7 +1418,7 @@ unsigned int SecureContext::PskServerCallback(SSL *ssl,
                                               unsigned char *psk,
                                               unsigned int max_psk_len) {
   SecureContext* sc = static_cast<SecureContext*>(
-      SSL_CTX_get_app_data(ssl->ctx));
+      SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl)));
 
   Environment* env = sc->env();
   Isolate* isolate = env->isolate();
@@ -1489,7 +1489,7 @@ unsigned int SecureContext::PskClientCallback(SSL *ssl,
                                               unsigned char *psk,
                                               unsigned int max_psk_len) {
   SecureContext* sc = static_cast<SecureContext*>(
-      SSL_CTX_get_app_data(ssl->ctx));
+      SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl)));
 
   Environment* env = sc->env();
   Isolate* isolate = env->isolate();

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -68,7 +68,6 @@ using v8::DontDelete;
 using v8::EscapableHandleScope;
 using v8::Exception;
 using v8::External;
-using v8::False;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -1397,7 +1396,7 @@ void SecureContext::SetPskIdentity(const FunctionCallbackInfo<Value>& args) {
     return wrap->env()->ThrowTypeError("Argument must be a string");
   }
 
-  String::Utf8Value identity(args[0]);
+  String::Utf8Value identity(args.GetIsolate(), args[0]);
   if (!SSL_CTX_use_psk_identity_hint(wrap->ctx_, *identity)) {
     return wrap->env()->ThrowError("Failed to set PSK identity hint");
   }
@@ -1559,7 +1558,7 @@ unsigned int SecureContext::PskClientCallback(SSL *ssl,
 
   Local<String> identity_str = identity_val.As<String>();
   size_t identity_len = identity_str->Length();
-  String::Utf8Value identity_buf(identity_str);
+  String::Utf8Value identity_buf(isolate, identity_str);
 
   CHECK_LE(identity_len, max_identity_len);
   memcpy(identity, *identity_buf, identity_len);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1444,7 +1444,7 @@ unsigned int SecureContext::PskServerCallback(SSL *ssl,
 
   MaybeLocal<Value> maybe_ret;
   if (value->IsFunction()) {
-    Local<Function> func = Local<Function>::Cast(value);
+    Local<Function> func = value.As<Function>();
     maybe_ret = func->Call(env->context(), sc->object(), arraysize(argv), argv);
   } else {
     return 0;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1391,7 +1391,7 @@ void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 void SecureContext::SetPskIdentity(const FunctionCallbackInfo<Value>& args) {
   SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
 
-  if (args.Length() != 1 || !args[0]->IsString()) {
+  if (!args[0]->IsString()) {
     return wrap->env()->ThrowTypeError("Argument must be a string");
   }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -355,6 +355,13 @@ void SecureContext::Initialize(Environment* env, Local<Object> target) {
   env->SetProtoMethodNoSideEffect(t, "getCertificate", GetCertificate<true>);
   env->SetProtoMethodNoSideEffect(t, "getIssuer", GetCertificate<false>);
 
+#ifdef OPENSSL_PSK_SUPPORT
+  env->SetProtoMethod(t, "setPskIdentity", SecureContext::SetPskIdentity);
+  env->SetProtoMethod(t,
+                      "enablePskCallback",
+                      SecureContext::EnablePskCallback);
+#endif
+
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kTicketKeyReturnIndex"),
          Integer::NewFromUnsigned(env->isolate(), kTicketKeyReturnIndex));
   t->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kTicketKeyHMACIndex"),
@@ -1377,6 +1384,120 @@ void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(buff);
 }
+
+
+#ifdef OPENSSL_PSK_SUPPORT
+
+void SecureContext::SetPskIdentity(const FunctionCallbackInfo<Value>& args) {
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
+
+  if (args.Length() != 1 || !args[0]->IsString()) {
+    return wrap->env()->ThrowTypeError("Argument must be a string");
+  }
+
+  String::Utf8Value identity(args[0]);
+  if (!SSL_CTX_use_psk_identity_hint(wrap->ctx_, *identity)) {
+    return wrap->env()->ThrowError("Failed to set PSK identity hint");
+  }
+}
+
+void SecureContext::EnablePskCallback(
+    const FunctionCallbackInfo<Value>& args) {
+  SecureContext* wrap = Unwrap<SecureContext>(args.Holder());
+
+  SSL_CTX_set_psk_server_callback(wrap->ctx_,
+                                  SecureContext::PskServerCallback);
+  SSL_CTX_set_psk_client_callback(wrap->ctx_,
+                                  SecureContext::PskClientCallback);
+}
+
+unsigned int SecureContext::PskServerCallback(SSL *ssl,
+                                              const char *identity,
+                                              unsigned char *psk,
+                                              unsigned int max_psk_len) {
+  SecureContext* sc = static_cast<SecureContext*>(
+      SSL_CTX_get_app_data(ssl->ctx));
+
+  Environment* env = sc->env();
+  Isolate* isolate = env->isolate();
+
+  Local<Value> argv[] = {
+    String::NewFromUtf8(isolate, identity),
+    Integer::NewFromUnsigned(isolate, max_psk_len),
+    Integer::NewFromUnsigned(isolate, 0)
+  };
+  Local<Value> ret = node::MakeCallback(env->isolate(),
+                                        sc->object(),
+                                        env->onpskexchange_string(),
+                                        arraysize(argv),
+                                        argv);
+
+  // The result is expected to be an object. If it isn't, then return 0,
+  // indicating the identity wasn't found.
+  if (!ret->IsObject()) {
+    return 0;
+  }
+  Local<Object> obj = ret.As<Object>();
+
+  Local<Value> psk_buf = obj->Get(env->psk_string());
+  assert(Buffer::HasInstance(psk_buf));
+  size_t psk_len = Buffer::Length(psk_buf);
+  assert(psk_len <= max_psk_len);
+  memcpy(psk, Buffer::Data(psk_buf), max_psk_len);
+
+  return psk_len;
+}
+
+unsigned int SecureContext::PskClientCallback(SSL *ssl,
+                                              const char *hint,
+                                              char *identity,
+                                              unsigned int max_identity_len,
+                                              unsigned char *psk,
+                                              unsigned int max_psk_len) {
+  SecureContext* sc = static_cast<SecureContext*>(
+      SSL_CTX_get_app_data(ssl->ctx));
+
+  Environment* env = sc->env();
+  Isolate* isolate = env->isolate();
+
+  Local<Value> argv[] = {
+    Null(isolate),
+    Integer::NewFromUnsigned(isolate, max_psk_len),
+    Integer::NewFromUnsigned(isolate, max_identity_len)
+  };
+  if (hint != nullptr) {
+    argv[0] = String::NewFromUtf8(isolate, hint);
+  }
+  Local<Value> ret = node::MakeCallback(env->isolate(),
+                                        sc->object(),
+                                        env->onpskexchange_string(),
+                                        arraysize(argv),
+                                        argv);
+
+  // The result is expected to be an object. If it isn't, then return 0,
+  // indicating the identity wasn't found.
+  if (!ret->IsObject()) {
+    return 0;
+  }
+  Local<Object> obj = ret.As<Object>();
+
+  Local<Value> psk_buf = obj->Get(env->psk_string());
+  assert(Buffer::HasInstance(psk_buf));
+  size_t psk_len = Buffer::Length(psk_buf);
+  assert(psk_len <= max_psk_len);
+  memcpy(psk, Buffer::Data(psk_buf), psk_len);
+
+  Local<Value> identity_buf = obj->Get(env->identity_string());
+  assert(Buffer::HasInstance(identity_buf));
+  size_t identity_len = Buffer::Length(identity_buf);
+  assert(identity_len <= max_identity_len);
+  memcpy(identity, Buffer::Data(identity_buf), identity_len);
+  assert(identity[identity_len - 1] == '\0');
+
+  return psk_len;
+}
+
+#endif
 
 
 template <class Base>

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1502,15 +1502,15 @@ unsigned int SecureContext::PskClientCallback(SSL *ssl,
   Local<Object> obj = ret.As<Object>();
 
   Local<Value> psk_buf = obj->Get(env->psk_string());
-  assert(Buffer::HasInstance(psk_buf));
+  CHECK(psk_buf->IsArrayBufferView());
   size_t psk_len = Buffer::Length(psk_buf);
-  assert(psk_len <= max_psk_len);
+  CHECK_LE(psk_len, max_psk_len);
   memcpy(psk, Buffer::Data(psk_buf), psk_len);
 
   Local<Value> identity_buf = obj->Get(env->identity_string());
-  assert(Buffer::HasInstance(identity_buf));
+  CHECK(identity_buf->IsArrayBufferView());
   size_t identity_len = Buffer::Length(identity_buf);
-  assert(identity_len <= max_identity_len);
+  CHECK_LE(identity_len, max_identity_len);
   memcpy(identity, Buffer::Data(identity_buf), identity_len);
   assert(identity[identity_len - 1] == '\0');
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -53,15 +53,8 @@
 #include <openssl/rand.h>
 #include <openssl/pkcs12.h>
 
-#if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-# define NODE__HAVE_TLSEXT_STATUS_CB
-#endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
-
-// TLS-PSK support requires OpenSSL v1.0.0 or later built with PSK enabled
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
 #ifndef OPENSSL_NO_PSK
 #define OPENSSL_PSK_SUPPORT
-#endif
 #endif
 
 namespace node {
@@ -191,15 +184,15 @@ class SecureContext : public BaseObject {
   static void EnablePskCallback(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static unsigned int PskServerCallback(SSL *ssl,
-                                        const char *identity,
-                                        unsigned char *psk,
+  static unsigned int PskServerCallback(SSL* ssl,
+                                        const char* identity,
+                                        unsigned char* psk,
                                         unsigned int max_psk_len);
-  static unsigned int PskClientCallback(SSL *ssl,
-                                        const char *hint,
-                                        char *identity,
+  static unsigned int PskClientCallback(SSL* ssl,
+                                        const char* hint,
+                                        char* identity,
                                         unsigned int max_identity_len,
-                                        unsigned char *psk,
+                                        unsigned char* psk,
                                         unsigned int max_psk_len);
 #endif
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -53,6 +53,17 @@
 #include <openssl/rand.h>
 #include <openssl/pkcs12.h>
 
+#if !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
+# define NODE__HAVE_TLSEXT_STATUS_CB
+#endif  // !defined(OPENSSL_NO_TLSEXT) && defined(SSL_CTX_set_tlsext_status_cb)
+
+// TLS-PSK support requires OpenSSL v1.0.0 or later built with PSK enabled
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#ifndef OPENSSL_NO_PSK
+#define OPENSSL_PSK_SUPPORT
+#endif
+#endif
+
 namespace node {
 namespace crypto {
 
@@ -174,6 +185,23 @@ class SecureContext : public BaseObject {
 
   template <bool primary>
   static void GetCertificate(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+#ifdef OPENSSL_PSK_SUPPORT
+  static void SetPskIdentity(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void EnablePskCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static unsigned int PskServerCallback(SSL *ssl,
+                                        const char *identity,
+                                        unsigned char *psk,
+                                        unsigned int max_psk_len);
+  static unsigned int PskClientCallback(SSL *ssl,
+                                        const char *hint,
+                                        char *identity,
+                                        unsigned int max_identity_len,
+                                        unsigned char *psk,
+                                        unsigned int max_psk_len);
+#endif
 
   static int TicketKeyCallback(SSL* ssl,
                                unsigned char* name,

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -1,0 +1,94 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  console.log('1..0 # Skipped: missing crypto');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+
+const CIPHERS = 'PSK+HIGH';
+const USERS = {
+  UserA: Buffer.from('d731ef57be09e5204f0b205b60627028', 'hex'),
+  UserB: Buffer.from('82072606b502b0f4025e90eb75fe137d', 'hex')
+};
+const CLIENT_IDENTITIES = [
+  { psk: USERS.UserA, identity: 'UserA' },
+  { psk: USERS.UserB, identity: 'UserB' },
+  // unrecognized user should fail handshake
+  { psk: USERS.UserB, identity: 'UserC' },
+  // recognized user but incorrect secret should fail handshake
+  { psk: USERS.UserA, identity: 'UserB' },
+  { psk: USERS.UserB, identity: 'UserB' }
+];
+const TEST_DATA = 'Hello from test!';
+
+let serverConnections = 0;
+const clientResults = [];
+const connectingIds = [];
+
+const serverOptions = {
+  ciphers: CIPHERS,
+  pskCallback(id) {
+    connectingIds.push(id);
+    if (id in USERS) {
+      return { psk: USERS[id] };
+    }
+  }
+};
+
+const server = tls.createServer(serverOptions, (c) => {
+  serverConnections++;
+  c.once('data', (data) => {
+    assert.strictEqual(data.toString(), TEST_DATA);
+    c.end(data);
+  });
+});
+server.listen(common.PORT, startTest);
+
+function startTest() {
+  function connectClient(options, next) {
+    const client = tls.connect(common.PORT, 'localhost', options, () => {
+      clientResults.push('connect');
+
+      client.end(TEST_DATA);
+
+      client.on('data', (data) => {
+        assert.strictEqual(data.toString(), TEST_DATA);
+      });
+
+      client.on('close', next);
+    });
+    client.on('error', (err) => {
+      clientResults.push(err.message);
+      next();
+    });
+  }
+
+  function doTestCase(tcnum) {
+    if (tcnum >= CLIENT_IDENTITIES.length) {
+      server.close();
+    } else {
+      connectClient({
+        ciphers: CIPHERS,
+        rejectUnauthorized: false,
+        pskCallback: () => CLIENT_IDENTITIES[tcnum]
+      }, () => {
+        doTestCase(tcnum + 1);
+      });
+    }
+  }
+  doTestCase(0);
+}
+
+process.on('exit', () => {
+  assert.strictEqual(serverConnections, 3);
+  assert.deepStrictEqual(clientResults, [
+    'connect', 'connect', 'socket hang up', 'socket hang up', 'connect'
+  ]);
+  assert.deepStrictEqual(connectingIds, [
+    'UserA', 'UserB', 'UserC', 'UserB', 'UserB'
+  ]);
+});

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -42,20 +42,22 @@ const server = tls.createServer(serverOptions, common.mustCall((c) => {
     c.end(data);
   });
 }, 3));
-server.listen(common.PORT, startTest);
+server.listen(0, function() {
+  startTest(this.address().port);
+});
 
-function startTest() {
+function startTest(port) {
   function connectClient(options, next) {
-    const client = tls.connect(common.PORT, 'localhost', options, () => {
+    const client = tls.connect(port, 'localhost', options, () => {
       clientResults.push('connect');
 
       client.end(TEST_DATA);
 
-      client.on('data', (data) => {
+      client.on('data', common.mustCallAtLeast((data) => {
         assert.strictEqual(data.toString(), TEST_DATA);
-      });
+      }));
 
-      client.on('close', next);
+      client.on('close', common.mustCall(next));
     });
 
     let errored = false;

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -87,12 +87,16 @@ function startTest(port) {
   doTestCase(0);
 }
 
+const DISCONNECT_MESSAGE =
+  'Client network socket disconnected before ' +
+  'secure TLS connection was established';
+
 process.on('exit', () => {
   assert.deepStrictEqual(clientResults, [
     'connect',
     'connect',
-    'Client network socket disconnected before secure TLS connection was established',
-    'Client network socket disconnected before secure TLS connection was established',
+    DISCONNECT_MESSAGE,
+    DISCONNECT_MESSAGE,
     'connect'
   ]);
   assert.deepStrictEqual(connectingIds, [

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -42,8 +42,9 @@ const server = tls.createServer(serverOptions, common.mustCall((c) => {
     c.end(data);
   });
 }, 3));
-server.listen(0, function() {
-  startTest(this.address().port);
+
+server.listen(0, () => {
+  startTest(server.address().port);
 });
 
 function startTest(port) {
@@ -88,7 +89,11 @@ function startTest(port) {
 
 process.on('exit', () => {
   assert.deepStrictEqual(clientResults, [
-    'connect', 'connect', 'socket hang up', 'socket hang up', 'connect'
+    'connect',
+    'connect',
+    'Client network socket disconnected before secure TLS connection was established',
+    'Client network socket disconnected before secure TLS connection was established',
+    'connect'
   ]);
   assert.deepStrictEqual(connectingIds, [
     'UserA', 'UserB', 'UserC', 'UserB', 'UserB'

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -9,8 +9,8 @@ const tls = require('tls');
 
 const CIPHERS = 'PSK+HIGH';
 const USERS = {
-  UserA: Buffer.from('d731ef57be09e5204f0b205b60627028', 'hex'),
-  UserB: Buffer.from('82072606b502b0f4025e90eb75fe137d', 'hex')
+  UserA: 'd731ef57be09e5204f0b205b60627028',
+  UserB: '82072606b502b0f4025e90eb75fe137d'
 };
 const CLIENT_IDENTITIES = [
   { psk: USERS.UserA, identity: 'UserA' },

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -62,7 +62,7 @@ function startTest() {
       client.on('close', next);
     });
 
-    let errored = false
+    let errored = false;
     client.on('error', (err) => {
       if (!errored) {
         clientResults.push(err.message);

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -61,9 +61,14 @@ function startTest() {
 
       client.on('close', next);
     });
+
+    let errored = false
     client.on('error', (err) => {
-      clientResults.push(err.message);
-      next();
+      if (!errored) {
+        clientResults.push(err.message);
+        errored = true;
+        next();
+      }
     });
   }
 

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -1,10 +1,8 @@
 'use strict';
 const common = require('../common');
 
-if (!common.hasCrypto) {
-  console.log('1..0 # Skipped: missing crypto');
-  return;
-}
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 const assert = require('assert');
 const tls = require('tls');
@@ -25,7 +23,6 @@ const CLIENT_IDENTITIES = [
 ];
 const TEST_DATA = 'Hello from test!';
 
-let serverConnections = 0;
 const clientResults = [];
 const connectingIds = [];
 
@@ -39,13 +36,12 @@ const serverOptions = {
   }
 };
 
-const server = tls.createServer(serverOptions, (c) => {
-  serverConnections++;
+const server = tls.createServer(serverOptions, common.mustCall((c) => {
   c.once('data', (data) => {
     assert.strictEqual(data.toString(), TEST_DATA);
     c.end(data);
   });
-});
+}, 3));
 server.listen(common.PORT, startTest);
 
 function startTest() {
@@ -89,7 +85,6 @@ function startTest() {
 }
 
 process.on('exit', () => {
-  assert.strictEqual(serverConnections, 3);
   assert.deepStrictEqual(clientResults, [
     'connect', 'connect', 'socket hang up', 'socket hang up', 'connect'
   ]);

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -14,7 +14,7 @@ const IDENTITY = 'Client_identity';  // Hardcoded by openssl
 
 const server = spawn(common.opensslCli, [
   's_server',
-  '-accept', common.PORT,
+  '-accept', 54323 /*common.PORT*/,
   '-cipher', CIPHERS,
   '-psk', KEY,
   '-psk_hint', IDENTITY,
@@ -68,7 +68,7 @@ server.on('exit', (code) => {
 
 
 function startClient() {
-  const s = tls.connect(common.PORT, {
+  const s = tls.connect(54323 /*common.PORT*/, {
     ciphers: CIPHERS,
     rejectUnauthorized: false,
     pskCallback(hint) {

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -10,7 +10,7 @@ const spawn = require('child_process').spawn;
 
 const CIPHERS = 'PSK+HIGH';
 const KEY = 'd731ef57be09e5204f0b205b60627028';
-const IDENTITY = 'Client_identity';  // Hardcoded by openssl
+const IDENTITY = 'Client_identity';  // Hardcoded by `openssl s_server`
 
 const server = spawn(common.opensslCli, [
   's_server',

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -14,7 +14,7 @@ const IDENTITY = 'Client_identity';  // Hardcoded by openssl
 
 const server = spawn(common.opensslCli, [
   's_server',
-  '-accept', 54323 /*common.PORT*/,
+  '-accept', 54323 /* common.PORT */,
   '-cipher', CIPHERS,
   '-psk', KEY,
   '-psk_hint', IDENTITY,
@@ -68,7 +68,7 @@ server.on('exit', (code) => {
 
 
 function startClient() {
-  const s = tls.connect(54323 /*common.PORT*/, {
+  const s = tls.connect(54323 /* common.PORT */, {
     ciphers: CIPHERS,
     rejectUnauthorized: false,
     pskCallback(hint) {

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -53,7 +53,6 @@ server.stdout.on('data', (s) => {
   }
 });
 
-
 const timeout = setTimeout(() => {
   server.kill();
   process.exit(1);
@@ -76,7 +75,7 @@ function startClient() {
       if (hint === IDENTITY) {
         return {
           identity: IDENTITY,
-          psk: Buffer.from(KEY, 'hex')
+          psk: KEY
         };
       }
     }

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -74,7 +74,7 @@ function startClient() {
   const s = tls.connect(common.PORT, {
     ciphers: CIPHERS,
     rejectUnauthorized: false,
-    pskCallback: (hint) => {
+    pskCallback(hint) {
       if (hint === IDENTITY) {
         return {
           identity: IDENTITY,
@@ -96,6 +96,4 @@ process.on('exit', () => {
   assert.strictEqual(0, serverExitCode);
   assert.strictEqual('WAIT-SERVER-CLOSE', state);
   assert.ok(gotWriteCallback);
-
-  console.log(serverExitCode, state, gotWriteCallback)
 });

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -1,10 +1,8 @@
 'use strict';
 const common = require('../common');
 
-if (!common.opensslCli) {
-  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  return;
-}
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 const assert = require('assert');
 const tls = require('tls');

--- a/test/parallel/test-tls-psk-client.js
+++ b/test/parallel/test-tls-psk-client.js
@@ -1,0 +1,101 @@
+'use strict';
+const common = require('../common');
+
+if (!common.opensslCli) {
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
+  return;
+}
+
+const assert = require('assert');
+const tls = require('tls');
+const spawn = require('child_process').spawn;
+
+const CIPHERS = 'PSK+HIGH';
+const KEY = 'd731ef57be09e5204f0b205b60627028';
+const IDENTITY = 'Client_identity';  // Hardcoded by openssl
+
+const server = spawn(common.opensslCli, [
+  's_server',
+  '-accept', common.PORT,
+  '-cipher', CIPHERS,
+  '-psk', KEY,
+  '-psk_hint', IDENTITY,
+  '-nocert'
+]);
+
+
+let state = 'WAIT-ACCEPT';
+
+let serverStdoutBuffer = '';
+server.stdout.setEncoding('utf8');
+server.stdout.on('data', (s) => {
+  serverStdoutBuffer += s;
+  switch (state) {
+    case 'WAIT-ACCEPT':
+      if (/ACCEPT/g.test(serverStdoutBuffer)) {
+        // Give s_server half a second to start up.
+        setTimeout(startClient, 500);
+        state = 'WAIT-HELLO';
+      }
+      break;
+
+    case 'WAIT-HELLO':
+      if (/hello/g.test(serverStdoutBuffer)) {
+
+        // End the current SSL connection and exit.
+        // See s_server(1ssl).
+        server.stdin.write('Q');
+
+        state = 'WAIT-SERVER-CLOSE';
+      }
+      break;
+
+    default:
+      break;
+  }
+});
+
+
+const timeout = setTimeout(() => {
+  server.kill();
+  process.exit(1);
+}, 5000);
+
+let gotWriteCallback = false;
+let serverExitCode = -1;
+
+server.on('exit', (code) => {
+  serverExitCode = code;
+  clearTimeout(timeout);
+});
+
+
+function startClient() {
+  const s = tls.connect(common.PORT, {
+    ciphers: CIPHERS,
+    rejectUnauthorized: false,
+    pskCallback: (hint) => {
+      if (hint === IDENTITY) {
+        return {
+          identity: IDENTITY,
+          psk: Buffer.from(KEY, 'hex')
+        };
+      }
+    }
+  });
+
+  s.on('secureConnect', () => {
+    s.write('hello\r\n', () => {
+      gotWriteCallback = true;
+    });
+  });
+}
+
+
+process.on('exit', () => {
+  assert.strictEqual(0, serverExitCode);
+  assert.strictEqual('WAIT-SERVER-CLOSE', state);
+  assert.ok(gotWriteCallback);
+
+  console.log(serverExitCode, state, gotWriteCallback)
+});

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -1,0 +1,88 @@
+'use strict';
+const common = require('../common');
+
+if (!common.opensslCli) {
+  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
+  return;
+}
+
+const assert = require('assert');
+
+const tls = require('tls');
+const spawn = require('child_process').spawn;
+
+const CIPHERS = 'PSK+HIGH';
+const KEY = 'd731ef57be09e5204f0b205b60627028';
+const IDENTITY = 'TestUser';
+
+let connections = 0;
+
+const server = tls.createServer({
+  ciphers: CIPHERS,
+  pskIdentity: IDENTITY,
+  pskCallback: (identity) => {
+    if (identity === IDENTITY) {
+      return {
+        psk: Buffer.from(KEY, 'hex')
+      };
+    }
+  }
+});
+
+server.on('connection', (socket) => {
+  connections++;
+});
+
+server.on('secureConnection', (socket) => {
+  socket.write('hello\r\n');
+
+  socket.on('data', (data) => {
+    socket.write(data);
+  });
+});
+
+let gotHello = false;
+let sentWorld = false;
+let gotWorld = false;
+let opensslExitCode = -1;
+
+server.listen(common.PORT, () => {
+  const client = spawn(common.opensslCli, [
+    's_client',
+    '-connect', '127.0.0.1:' + common.PORT,
+    '-cipher', CIPHERS,
+    '-psk', KEY,
+    '-psk_identity', IDENTITY
+  ]);
+
+  let out = '';
+
+  client.stdout.setEncoding('utf8');
+  client.stdout.on('data', (d) => {
+    out += d;
+
+    if (!gotHello && /hello/.test(out)) {
+      gotHello = true;
+      client.stdin.write('world\r\n');
+      sentWorld = true;
+    }
+
+    if (!gotWorld && /world/.test(out)) {
+      gotWorld = true;
+      client.stdin.end();
+    }
+  });
+
+  client.on('exit', (code) => {
+    opensslExitCode = code;
+    server.close();
+  });
+});
+
+process.on('exit', () => {
+  assert.strictEqual(1, connections);
+  assert.ok(gotHello);
+  assert.ok(sentWorld);
+  assert.ok(gotWorld);
+  assert.strictEqual(0, opensslExitCode);
+});

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -74,4 +74,3 @@ server.listen(0, () => {
     server.close();
   }));
 });
-

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -40,10 +40,10 @@ let sentWorld = false;
 let gotWorld = false;
 let opensslExitCode = -1;
 
-server.listen(common.PORT, () => {
+server.listen(0, function() {
   const client = spawn(common.opensslCli, [
     's_client',
-    '-connect', '127.0.0.1:' + common.PORT,
+    '-connect', '127.0.0.1:' + this.address().port,
     '-cipher', CIPHERS,
     '-psk', KEY,
     '-psk_identity', IDENTITY

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -1,10 +1,8 @@
 'use strict';
 const common = require('../common');
 
-if (!common.opensslCli) {
-  console.log('1..0 # Skipped: node compiled without OpenSSL CLI.');
-  return;
-}
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 const assert = require('assert');
 
@@ -14,8 +12,6 @@ const spawn = require('child_process').spawn;
 const CIPHERS = 'PSK+HIGH';
 const KEY = 'd731ef57be09e5204f0b205b60627028';
 const IDENTITY = 'TestUser';
-
-let connections = 0;
 
 const server = tls.createServer({
   ciphers: CIPHERS,
@@ -29,9 +25,7 @@ const server = tls.createServer({
   }
 });
 
-server.on('connection', (socket) => {
-  connections++;
-});
+server.on('connection', common.mustCall((socket) => {}, 1));
 
 server.on('secureConnection', (socket) => {
   socket.write('hello\r\n');
@@ -80,7 +74,6 @@ server.listen(common.PORT, () => {
 });
 
 process.on('exit', () => {
-  assert.strictEqual(1, connections);
   assert.ok(gotHello);
   assert.ok(sentWorld);
   assert.ok(gotWorld);

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -20,7 +20,7 @@ let connections = 0;
 const server = tls.createServer({
   ciphers: CIPHERS,
   pskIdentity: IDENTITY,
-  pskCallback: (identity) => {
+  pskCallback(identity) {
     if (identity === IDENTITY) {
       return {
         psk: Buffer.from(KEY, 'hex')

--- a/test/parallel/test-tls-psk-server.js
+++ b/test/parallel/test-tls-psk-server.js
@@ -19,7 +19,7 @@ const server = tls.createServer({
   pskCallback(identity) {
     if (identity === IDENTITY) {
       return {
-        psk: Buffer.from(KEY, 'hex')
+        psk: KEY
       };
     }
   }


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tls, crypto

This is an updated PR based off of #6701 that supports Node.js v9.0.0.

I understand that the Node.js team is waiting for FIPS support in OpenSSL-1.1, but this will get the ball rolling for TLS-PSK support in the latest Node.js versions.