### PR TITLE
meta: improve definition of a collaborator

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,17 +8,22 @@ Committee (CTC) which is responsible for high-level guidance of the project.
 The [nodejs/node](https://github.com/nodejs/node) GitHub repository is
 maintained by Collaborators who are added by the CTC on an ongoing basis.
 
-A Collaborator is defined as any individual having commit access to any
-respository in the Node.js GitHub Organization.
-
 Individuals identified by the CTC as making significant and valuable
 contributions across any Node.js repository may be made Collaborators and given
-commit access to the project. Consideration should be given to more than just
-code commits and pull requests. Responding to issues, contributing to
-documentation, work on the website and various community efforts should be
-considered as well. If individuals making such contributions do not believe
-they have been considered for commit access, they may log an issue or contact a
-CTC member directly.
+commit access to the project. Activities taken into consideration include (but
+are not limited to) the quality of:
+
+* code commits and pull requests
+* documentation commits and pull requests
+* comments on issues and pull requests
+* contributions to the Node.js website
+* assistance provided to end users and novice contributors
+* participation in Working Groups
+* other participation in the wider Node.js community
+
+If individuals making valuable contributions do not believe they have been
+considered for commit access, they may log an issue or contact a CTC member
+directly.
 
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,10 +8,17 @@ Committee (CTC) which is responsible for high-level guidance of the project.
 The [nodejs/node](https://github.com/nodejs/node) GitHub repository is
 maintained by Collaborators who are added by the CTC on an ongoing basis.
 
+A Collaborator is defined as any individual having commit access to any
+respository in the Node.js GitHub Organization.
+
 Individuals identified by the CTC as making significant and valuable
-contributions are made Collaborators and given commit access to the project. If
-you make a significant contribution and are not considered for commit access,
-log an issue or contact a CTC member directly.
+contributions across any Node.js repository may be made Collaborators and given
+commit access to the project. Consideration should be given to more than just
+code commits and pull requests. Responding to issues, contributing to
+documentation, work on the website and various community efforts should be
+considered as well. If individuals making such contributions do not believe
+they have been considered for commit access, they may log an issue or contact a
+CTC member directly.
 
 Modifications of the contents of the nodejs/node repository are made on
 a collaborative basis. Anybody with a GitHub account may propose a


### PR DESCRIPTION
Expand definition of Collaborator to include individuals
with commit access to any Node.js GitHub repository.

Clarify the kinds of things that should be considered when
considering inviting new collaborators
