### PR TITLE
doc: remove misterdjules from the CTC members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ more information about the governance of the Node.js project, see
 **Matteo Collina** &lt;matteo.collina@gmail.com&gt; (he/him)
 * [mhdawson](https://github.com/mhdawson) -
 **Michael Dawson** &lt;michael_dawson@ca.ibm.com&gt; (he/him)
-* [misterdjules](https://github.com/misterdjules) -
-**Julien Gilli** &lt;jgilli@nodejs.org&gt;
 * [mscdex](https://github.com/mscdex) -
 **Brian White** &lt;mscdex@mscdex.net&gt;
 * [MylesBorins](https://github.com/MylesBorins) -


### PR DESCRIPTION
My activity as a CTC member has progressively declined over the last two years, and it's both unfair to current members and counter productive for me to stay as a member of the CTC. This should have happened a while ago, and I do apologize for it taking so long.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

~~- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes~~ (irrelevant)
~~- [ ] tests and/or benchmarks are included~~ (irrelevant)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc