### PR TITLE
test: --enable-static linked executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,6 @@ v8:
 	tools/make-v8.sh
 	$(MAKE) -C deps/v8 $(V8_ARCH).$(BUILDTYPE_LOWER) $(V8_BUILD_OPTIONS)
 
-ifeq ($(NODE_TARGET_TYPE),static_library)
-test: all
-	$(MAKE) cctest
-else
 test: all
 	$(MAKE) build-addons
 	$(MAKE) build-addons-napi
@@ -221,7 +217,6 @@ test: all
 		$(CI_NATIVE_SUITES) \
 		$(CI_DOC) \
 		known_issues
-endif
 
 # For a quick test, does not run linter or build doc
 test-only: all

--- a/common.gypi
+++ b/common.gypi
@@ -64,9 +64,9 @@
         'V8_BASE': '<(PRODUCT_DIR)/libv8_base.a',
       }],
       ['openssl_fips != ""', {
-        'OPENSSL_PRODUCT': 'libcrypto.a',
+        'OPENSSL_PRODUCT': '<(STATIC_LIB_PREFIX)crypto<(STATIC_LIB_SUFFIX)',
       }, {
-        'OPENSSL_PRODUCT': 'libopenssl.a',
+        'OPENSSL_PRODUCT': '<(STATIC_LIB_PREFIX)openssl<(STATIC_LIB_SUFFIX)',
       }],
       ['OS=="mac"', {
         'clang%': 1,

--- a/configure
+++ b/configure
@@ -1461,8 +1461,6 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
-  'NODE_TARGET_TYPE': variables['node_target_type'] if options.enable_static \
-      else '',
 }
 
 if options.prefix:

--- a/node.gyp
+++ b/node.gyp
@@ -341,7 +341,6 @@
         [ 'OS=="win"', {
           'sources': [
             'src/backtrace_win32.cc',
-            'src/res/node.rc',
           ],
           'conditions': [
             [ 'node_target_type!="static_library"', {

--- a/node.gyp
+++ b/node.gyp
@@ -979,23 +979,22 @@
           'xcode_settings': {
             'OTHER_LDFLAGS': [
               '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)'
-              '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+                  '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
             ],
           },
           'msvs_settings': {
             'VCLinkerTool': {
               'AdditionalOptions': [
                 '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/'
-                '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
               ],
             },
           },
           'conditions': [
             ['OS in "linux freebsd openbsd solaris android aix"', {
               'ldflags': [
-                '-Wl,--whole-archive,'
-                '<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
-                '<(node_core_target_name)<(STATIC_LIB_SUFFIX) ',
+                '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
+                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX) ',
                 '-Wl,--no-whole-archive',
               ],
             }],

--- a/node.gyp
+++ b/node.gyp
@@ -994,7 +994,7 @@
             ['OS in "linux freebsd openbsd solaris android aix"', {
               'ldflags': [
                 '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
-                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX) ',
+                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
                 '-Wl,--no-whole-archive',
               ],
             }],

--- a/node.gyp
+++ b/node.gyp
@@ -343,6 +343,13 @@
             'src/backtrace_win32.cc',
             'src/res/node.rc',
           ],
+          'conditions': [
+            [ 'node_target_type!="static_library"', {
+              'sources': [
+                'src/res/node.rc',
+              ],
+            }],
+          ],
           'defines!': [
             'NODE_PLATFORM="win"',
           ],
@@ -508,7 +515,7 @@
       'target_name': 'node_etw',
       'type': 'none',
       'conditions': [
-        [ 'node_use_etw=="true"', {
+        [ 'node_use_etw=="true" and node_target_type!="static_library"', {
           'actions': [
             {
               'action_name': 'node_etw',
@@ -529,7 +536,7 @@
       'target_name': 'node_perfctr',
       'type': 'none',
       'conditions': [
-        [ 'node_use_perfctr=="true"', {
+        [ 'node_use_perfctr=="true" and node_target_type!="static_library"', {
           'actions': [
             {
               'action_name': 'node_perfctr_man',
@@ -591,13 +598,15 @@
             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
           ],
           'conditions': [
-            [ 'node_use_dtrace=="false" and node_use_etw=="false"', {
+            [ 'node_use_dtrace=="false" and node_use_etw=="false" or '
+              'node_target_type=="static_library"', {
               'inputs': [ 'src/notrace_macros.py' ]
             }],
-            ['node_use_lttng=="false"', {
+            ['node_use_lttng=="false" or node_target_type=="static_library"', {
               'inputs': [ 'src/nolttng_macros.py' ]
             }],
-            [ 'node_use_perfctr=="false"', {
+            [ 'node_use_perfctr=="false" or '
+              'node_target_type=="static_library"', {
               'inputs': [ 'src/noperfctr_macros.py' ]
             }]
           ],
@@ -952,6 +961,48 @@
   ], # end targets
 
   'conditions': [
+    [ 'node_target_type=="static_library"', {
+      'targets': [
+        {
+          'target_name': 'static_node',
+          'type': 'executable',
+          'product_name': '<(node_core_target_name)',
+          'dependencies': [
+            '<(node_core_target_name)',
+          ],
+          'sources+': [
+            'src/node_main.cc',
+          ],
+          'include_dirs': [
+            'deps/v8/include',
+          ],
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)'
+              '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+            ],
+          },
+          'msvs_settings': {
+            'VCLinkerTool': {
+              'AdditionalOptions': [
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/'
+                '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+              ],
+            },
+          },
+          'conditions': [
+            ['OS in "linux freebsd openbsd solaris android aix"', {
+              'ldflags': [
+                '-Wl,--whole-archive,'
+                '<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
+                '<(node_core_target_name)<(STATIC_LIB_SUFFIX) ',
+                '-Wl,--no-whole-archive',
+              ],
+            }],
+          ],
+         },
+      ],
+    }],
     ['OS=="aix"', {
       'targets': [
         {

--- a/node.gyp
+++ b/node.gyp
@@ -991,7 +991,7 @@
             },
           },
           'conditions': [
-            ['OS in "linux freebsd openbsd solaris android aix"', {
+            ['OS in "linux freebsd openbsd solaris android"', {
               'ldflags': [
                 '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
                     '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',

--- a/node.gypi
+++ b/node.gypi
@@ -78,7 +78,7 @@
         'src/node_lttng.cc'
       ],
     } ],
-    [ 'node_use_etw=="true"', {
+    [ 'node_use_etw=="true" and node_target_type!="static_library"', {
       'defines': [ 'HAVE_ETW=1' ],
       'dependencies': [ 'node_etw' ],
       'sources': [
@@ -90,7 +90,7 @@
         'tools/msvs/genfiles/node_etw_provider.rc',
       ]
     } ],
-    [ 'node_use_perfctr=="true"', {
+    [ 'node_use_perfctr=="true" and node_target_type!="static_library"', {
       'defines': [ 'HAVE_PERFCTR=1' ],
       'dependencies': [ 'node_perfctr' ],
       'sources': [

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -1,12 +1,23 @@
 {
+  'includes': ['../../../config.gypi'],
+  'variables': {
+    'node_target_type%': '',
+  },
   'targets': [
     {
       'target_name': 'binding',
       'conditions': [
-         ['node_use_openssl=="true"', {
-           'sources': ['binding.cc'],
-           'include_dirs': ['../../../deps/openssl/openssl/include'],
-         }]
+        ['node_use_openssl=="true"', {
+          'sources': ['binding.cc'],
+          'include_dirs': ['../../../deps/openssl/openssl/include'],
+          'conditions': [
+            ['OS=="win" and node_target_type=="static_library"', {
+	      'libraries': [
+                '../../../../$(Configuration)/lib/<(OPENSSL_PRODUCT)'
+              ],
+            }],
+          ],
+        }]
       ]
     },
   ]

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -1,9 +1,22 @@
 {
+  'includes': ['../../../config.gypi'],
+  'variables': {
+    'node_target_type%': '',
+  },
   'targets': [
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
+      'conditions': [
+        ['node_target_type=="static_library"', {
+          'conditions': [
+            ['OS=="win"', {
+	      'libraries': ['../../../../$(Configuration)/lib/zlib.lib'],
+            }],
+          ],
+        }],
+      ],
     },
   ]
 }

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -110,7 +110,7 @@ if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
-if /i "%1"=="static"        set enable_static=1&goto arg-ok
+if /i "%1"=="static"           set enable_static=1&goto arg-ok
 if /i "%1"=="no-NODE-OPTIONS"	set no_NODE_OPTIONS=1&goto arg-ok
 if /i "%1"=="debug-http2"   set debug_http2=1&goto arg-ok
 if /i "%1"=="debug-nghttp2" set debug_nghttp2=1&goto arg-ok
@@ -465,9 +465,8 @@ if "%config%"=="Debug" set test_args=--mode=debug %test_args%
 if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
-REM when building a static library there's no binary to run tests
-if defined enable_static goto test-v8
 call :run-python tools\test.py %test_args%
+goto test-v8
 
 :test-v8
 if not defined custom_v8_test goto lint-cpp
@@ -520,7 +519,6 @@ set "localcppfilelist=%localcppfilelist% %1"
 goto exit
 
 :lint-js
-if defined enable_static goto exit
 if defined lint_js_ci goto lint-js-ci
 if not defined lint_js goto exit
 if not exist tools\eslint goto no-lint

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -110,7 +110,7 @@ if /i "%1"=="download-all"  set download_arg="--download=all"&goto arg-ok
 if /i "%1"=="ignore-flaky"  set test_args=%test_args% --flaky-tests=dontcare&goto arg-ok
 if /i "%1"=="enable-vtune"  set enable_vtune_arg=1&goto arg-ok
 if /i "%1"=="dll"           set dll=1&goto arg-ok
-if /i "%1"=="static"           set enable_static=1&goto arg-ok
+if /i "%1"=="static"        set enable_static=1&goto arg-ok
 if /i "%1"=="no-NODE-OPTIONS"	set no_NODE_OPTIONS=1&goto arg-ok
 if /i "%1"=="debug-http2"   set debug_http2=1&goto arg-ok
 if /i "%1"=="debug-nghttp2" set debug_nghttp2=1&goto arg-ok
@@ -466,7 +466,6 @@ if "%config%"=="Release" set test_args=--mode=release %test_args%
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
 call :run-python tools\test.py %test_args%
-goto test-v8
 
 :test-v8
 if not defined custom_v8_test goto lint-cpp


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/14158
Refs: https://github.com/nodejs/node/pull/14892

The motivation for this commit is to enable projects embedding Node.js
and building with --enable-static to be able to run the test suite and
linter.

Currently when building with --enable-static no node executable
will be created which means that the tests (apart from the cctest) and
linter cannot be run.

This is currently a work in progress and works on MacOS but I need to
run the CI, and manually on different environments to verify that it
works as expected.

<sub>[refack: added refs]</sub>
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, build