### PR TITLE
perf_hooks: mark as experimental

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -3,6 +3,8 @@
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 The Performance Timing API provides an implementation of the
 [W3C Performance Timeline][] specification. The purpose of the API
 is to support collection of high resolution performance metrics.


### PR DESCRIPTION
Mark the perf_hooks API as experimental. 

/cc @mcollina @Fishrock123 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
perf_hooks