### PR TITLE
net,tls,test: remove writeQueueSize and fix bufferSize

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -429,12 +429,6 @@ TLSSocket.prototype._init = function(socket, wrap) {
   var options = this._tlsOptions;
   var ssl = this._handle;
 
-  // lib/net.js expect this value to be non-zero if write hasn't been flushed
-  // immediately
-  // TODO(indutny): revise this solution, it might be 1 before handshake and
-  // represent real writeQueueSize during regular writes.
-  ssl.writeQueueSize = 1;
-
   this.server = options.server;
 
   // For clients, we will always have either a given ca list or be using

--- a/lib/net.js
+++ b/lib/net.js
@@ -465,7 +465,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 Object.defineProperty(Socket.prototype, 'bufferSize', {
   get: function() {
     if (this._handle) {
-      return this._handle.writeQueueSize + this._writableState.length;
+      return this._writableState.length;
     }
   }
 });
@@ -767,7 +767,7 @@ Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
 
   // If it was entirely flushed, we can write some more right now.
   // However, if more is left in the queue, then wait until that clears.
-  if (req.async && this._handle.writeQueueSize !== 0)
+  if (req.async)
     req.cb = cb;
   else
     cb();

--- a/test/parallel/test-tls-buffersize.js
+++ b/test/parallel/test-tls-buffersize.js
@@ -1,0 +1,36 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const options = {
+  key: fixtures.readSync('test_key.pem'),
+  cert: fixtures.readSync('test_cert.pem')
+};
+
+const iter = 10;
+
+const server = tls.createServer(options, (socket) => {
+  socket.pipe(socket);
+  socket.on('end', () => {
+    server.close();
+  });
+});
+
+server.listen(0, () => {
+  const client = tls.connect({
+    port: server.address().port,
+    rejectUnauthorized: false
+  }, () => {
+    for (let i = 1; i < iter; i++) {
+      client.write('a');
+      assert.strictEqual(client.bufferSize, i);
+    }
+    client.end();
+  });
+
+  client.on('finish', () => {
+    assert.strictEqual(client.bufferSize, 0);
+  });
+});


### PR DESCRIPTION
When use TLSSocket, bufferSize is always +1, this affects users who
rely on this property to make judgments. This commit removed legacy
code and corrected the calculation of bufferSize.

Fixes: https://github.com/nodejs/node/issues/15005

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

net, tls, test