### PR TITLE
test, async_hooks: remove unused param in test-graph.pipe

### DIFF
--- a/test/async-hooks/test-graph.pipe.js
+++ b/test/async-hooks/test-graph.pipe.js
@@ -14,7 +14,7 @@ sleep
   .on('exit', common.mustCall(onsleepExit))
   .on('close', common.mustCall(onsleepClose));
 
-function onsleepExit(code) {}
+function onsleepExit() {}
 
 function onsleepClose() {}
 


### PR DESCRIPTION
Removes an unused param in test-graph.pipe.js.

Refs: https://twitter.com/NodeTodo/status/900502354834800645

##### Checklist

- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, async_hooks
