### PR TITLE
lib: guard inspector console using process var

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -327,10 +327,10 @@
   }
 
   function setupInspector(originalConsole, wrappedConsole, Module) {
-    const { addCommandLineAPI, consoleCall } = process.binding('inspector');
-    if (!consoleCall) {
+    if (!process.config.variables.v8_enable_inspector) {
       return;
     }
+    const { addCommandLineAPI, consoleCall } = process.binding('inspector');
     // Setup inspector command line API
     const { makeRequireFunction } = NativeModule.require('internal/module');
     const path = NativeModule.require('path');

--- a/test/fixtures/overwrite-config-preload-module.js
+++ b/test/fixtures/overwrite-config-preload-module.js
@@ -1,0 +1,5 @@
+'use strict'
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+process.config = {};

--- a/test/sequential/test-inspector-overwrite-config.js
+++ b/test/sequential/test-inspector-overwrite-config.js
@@ -1,0 +1,41 @@
+// Flags: --require ./test/fixtures/overwrite-config-preload-module.js
+'use strict';
+
+// This test ensures that overwriting a process configuration
+// value does not affect code in bootstrap_node.js. Specifically this tests
+// that the inspector console functions are bound even though
+// overwrite-config-preload-module.js overwrote the process.config variable.
+
+// We cannot do a check for the inspector because the configuration variables
+// were reset/removed by overwrite-config-preload-module.js.
+/* eslint-disable inspector-check */
+
+const common = require('../common');
+const assert = require('assert');
+const inspector = require('inspector');
+const msg = 'Test inspector logging';
+let asserted = false;
+
+async function testConsoleLog() {
+  const session = new inspector.Session();
+  session.connect();
+  session.on('inspectorNotification', (data) => {
+    if (data.method === 'Runtime.consoleAPICalled') {
+      assert.strictEqual(data.params.args.length, 1);
+      assert.strictEqual(data.params.args[0].value, msg);
+      asserted = true;
+    }
+  });
+  session.post('Runtime.enable');
+  console.log(msg);
+  session.disconnect();
+}
+
+common.crashOnUnhandledRejection();
+
+async function runTests() {
+  await testConsoleLog();
+  assert.ok(asserted, 'log statement did not reach the inspector');
+}
+
+runTests();


### PR DESCRIPTION
Currently the inspector module is always loaded and if it does not
return anything the inspector console setup is skipped.

This commit uses the process.config.variables.v8_enable_inspector
variable to only load the inspector module if it is enabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib