### PR TITLE
doc,stream: remove wrong remark on readable.read

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -894,7 +894,7 @@ in object mode.
 The optional `size` argument specifies a specific number of bytes to read. If
 `size` bytes are not available to be read, `null` will be returned *unless*
 the stream has ended, in which case all of the data remaining in the internal
-buffer will be returned (*even if it exceeds `size` bytes*).
+buffer will be returned.
 
 If the `size` argument is not specified, all of the data contained in the
 internal buffer will be returned.


### PR DESCRIPTION
The returned chunk is *never* longer than `size`, if I read the code correctly. I even tested it:

```js
const stream = require('stream')

const readable = new stream.Readable({
  read (size) {
    this.push(Buffer.from('0123456789'))
    this.push(null)
  }
})

readable.on('readable', () => {
  let buf
  while ((buf = readable.read(4))) {
    console.log(buf)
  }
})
```

Output:
```
<Buffer 30 31 32 33>
<Buffer 34 35 36 37>
<Buffer 38 39>
```

Even tough the stream has ended, the data returned does *not* exceed `size` bytes.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream