### PR TITLE
module: revert checking for package.json before extensions

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -215,6 +215,9 @@ Module._findPath = function(request, paths, isMain) {
   var exts;
   var trailingSlash = request.length > 0 &&
     request.charCodeAt(request.length - 1) === CHAR_FORWARD_SLASH;
+  if (!trailingSlash) {
+    trailingSlash = /(?:^|\/)\.?\.$/.test(request);
+  }
 
   // For each path
   for (var i = 0; i < paths.length; i++) {
@@ -232,10 +235,6 @@ Module._findPath = function(request, paths, isMain) {
         } else {
           filename = toRealPath(basePath);
         }
-      } else if (rc === 1) {  // Directory.
-        if (exts === undefined)
-          exts = Object.keys(Module._extensions);
-        filename = tryPackage(basePath, exts, isMain);
       }
 
       if (!filename) {
@@ -244,14 +243,17 @@ Module._findPath = function(request, paths, isMain) {
           exts = Object.keys(Module._extensions);
         filename = tryExtensions(basePath, exts, isMain);
       }
+
     }
 
     if (!filename && rc === 1) {  // Directory.
+      // try it with each of the extensions at "index"
       if (exts === undefined)
         exts = Object.keys(Module._extensions);
-      filename = tryPackage(basePath, exts, isMain) ||
-        // try it with each of the extensions at "index"
-        tryExtensions(path.resolve(basePath, 'index'), exts, isMain);
+      filename = tryPackage(basePath, exts, isMain);
+      if (!filename) {
+        filename = tryExtensions(path.resolve(basePath, 'index'), exts, isMain);
+      }
     }
 
     if (filename) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -243,7 +243,6 @@ Module._findPath = function(request, paths, isMain) {
           exts = Object.keys(Module._extensions);
         filename = tryExtensions(basePath, exts, isMain);
       }
-
     }
 
     if (!filename && rc === 1) {  // Directory.

--- a/test/fixtures/module-extension-over-directory/inner.js
+++ b/test/fixtures/module-extension-over-directory/inner.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/module-extension-over-directory/inner/package.json
+++ b/test/fixtures/module-extension-over-directory/inner/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "./package.json"
+}

--- a/test/parallel/test-require-extension-over-directory.js
+++ b/test/parallel/test-require-extension-over-directory.js
@@ -1,0 +1,26 @@
+'use strict';
+// fixes regression from v4
+require('../common');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const path = require('path');
+
+const fixturesRequire = require(
+  fixtures.path('module-extension-over-directory', 'inner'));
+
+assert.strictEqual(
+  fixturesRequire,
+  require(fixtures.path('module-extension-over-directory', 'inner.js')),
+  'test-require-extension-over-directory failed to import fixture' +
+  ' requirements'
+);
+
+const fakePath = [fixtures.path('module-extension-over-directory', 'inner'), 'fake', '..'].join(path.sep);
+const fixturesRequireDir = require(fakePath);
+
+assert.strictEqual(
+  fixturesRequireDir,
+  require(fixtures.path('module-extension-over-directory', 'inner/')),
+  'test-require-extension-over-directory failed to import fixture' +
+  ' requirements'
+);

--- a/test/parallel/test-require-extension-over-directory.js
+++ b/test/parallel/test-require-extension-over-directory.js
@@ -15,7 +15,11 @@ assert.strictEqual(
   ' requirements'
 );
 
-const fakePath = [fixtures.path('module-extension-over-directory', 'inner'), 'fake', '..'].join(path.sep);
+const fakePath = [
+  fixtures.path('module-extension-over-directory', 'inner'),
+  'fake',
+  '..'
+].join(path.sep);
 const fixturesRequireDir = require(fakePath);
 
 assert.strictEqual(

--- a/test/parallel/test-require-extensions-same-filename-as-dir.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir.js
@@ -28,5 +28,5 @@ const content = require(fixtures.path('json-with-directory-name-module',
                                       'module-stub', 'one', 'two',
                                       'three.js'));
 
-assert.notStrictEqual(content.rocko, 'artischocko');
-assert.strictEqual(content, 'hello from module-stub!');
+assert.strictEqual(content.rocko, 'artischocko');
+assert.notStrictEqual(content, 'hello from module-stub!');

--- a/test/parallel/test-require-extensions-same-filename-as-dir.js
+++ b/test/parallel/test-require-extensions-same-filename-as-dir.js
@@ -28,5 +28,5 @@ const content = require(fixtures.path('json-with-directory-name-module',
                                       'module-stub', 'one', 'two',
                                       'three.js'));
 
-assert.strictEqual(content.rocko, 'artischocko');
-assert.notStrictEqual(content, 'hello from module-stub!');
+assert.notStrictEqual(content.rocko, 'artischocko');
+assert.strictEqual(content, 'hello from module-stub!');


### PR DESCRIPTION
This PR reverts a regression from a change in behavior that deviated from the documented behavior of the module resolution algorithm. The deviation caused the module resolution algorithm to check for `package.json` files when traversing up to a parent directory before following the documented module resolution algorithm.

[Link discussing the regression in greater depth](https://github.com/nodejs/node/issues/14990)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module