### PR TITLE
perf: fix presumed typo in node_perf.cc

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -224,7 +224,7 @@ inline void MarkGarbageCollectionEnd(Isolate* isolate,
 
 inline void SetupGarbageCollectionTracking(Isolate* isolate) {
   isolate->AddGCPrologueCallback(MarkGarbageCollectionStart);
-  isolate->AddGCPrologueCallback(MarkGarbageCollectionEnd);
+  isolate->AddGCEpilogueCallback(MarkGarbageCollectionEnd);
 }
 
 inline Local<Value> GetName(Local<Function> fn) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_perf