### PR TITLE
n-api: add napi-performance-mark/measure

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3334,6 +3334,56 @@ the `complete` callback will be invoked with a status value of
 `napi_cancelled`. The work should not be deleted before the `complete`
 callback invocation, even if it has been successfully cancelled.
 
+## Performance API
+
+### *napi_performance_mark*
+<!-- YAML
+added: REPLACEME
+-->
+```C
+napi_status napi_performance_mark(napi_env env,
+                                  const char* utf8name);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] utf8name`: The name of the performance entry mark to create.
+
+Returns `napi_ok`.
+
+Creates a new Mark performance entry in the [Performance API][] timeline.
+
+```C
+  napi_performance_mark(env, "A");
+```
+
+### *napi_performance_measure*
+<!-- YAML
+added: REPLACEME
+-->
+```C
+napi_status napi_performance_measure(napi_env env,
+                                     const char* utf8name
+                                     const char* utf8start,
+                                     const char* utf8end);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[in] utf8name`: The name of the performance entry measure to create.
+- `[in] utf8start`: The name of the starting performance entry mark.
+- `[in] utf8end`: The name of the ending performance entry mark.
+
+Returns `napi_ok`.
+
+Creates a new Measure performance entry measuring the duration between the two
+identified marks.
+
+```C
+  napi_performance_mark(env, "A");
+  // do something time consuming
+  napi_performance_mark(env, "B");
+  napi_performance_measure(env, "A to B", "A", "B");
+```
+
 ## Version Management
 
 ### napi_get_node_version
@@ -3403,6 +3453,7 @@ support it:
 [Native Abstractions for Node.js]: https://github.com/nodejs/nan
 [Object Lifetime Management]: #n_api_object_lifetime_management
 [Object Wrap]: #n_api_object_wrap
+[Performance API]: perf_hooks.html
 [Section 9.1.6]: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
 [Section 12.5.5]: https://tc39.github.io/ecma262/#sec-typeof-operator
 [Section 24.3]: https://tc39.github.io/ecma262/#sec-dataview-objects

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -18,6 +18,7 @@
 #include "node_api.h"
 #include "node_internals.h"
 #include "util.h"
+#include "node_perf.h"
 
 #define NAPI_VERSION  1
 
@@ -3331,4 +3332,32 @@ napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
   CALL_UV(env, uv_cancel(reinterpret_cast<uv_req_t*>(w->Request())));
 
   return napi_clear_last_error(env);
+}
+
+// Methods for performance timing
+napi_status napi_performance_mark(napi_env env,
+                                  const char* name) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, name);
+  v8::Isolate* isolate = env->isolate;
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  node::Environment* environ = node::Environment::GetCurrent(context);
+  node::performance::CreateMark(environ, name);
+  return napi_ok;
+}
+
+napi_status napi_performance_measure(
+    napi_env env,
+    const char* name,
+    const char* start,
+    const char* end) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, name);
+  CHECK_ARG(env, start);
+  CHECK_ARG(env, end);
+  v8::Isolate* isolate = env->isolate;
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  node::Environment* environ = node::Environment::GetCurrent(context);
+  node::performance::CreateMeasure(environ, name, start, end);
+  return napi_ok;
 }

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -536,6 +536,16 @@ NAPI_EXTERN napi_status napi_cancel_async_work(napi_env env,
                                                napi_async_work work);
 
 
+// Methods for performance user timing
+NAPI_EXTERN napi_status napi_performance_mark(
+    napi_env env,
+    const char* name);
+NAPI_EXTERN napi_status napi_performance_measure(
+    napi_env env,
+    const char* name,
+    const char* start,
+    const char* end);
+
 // version management
 NAPI_EXTERN napi_status napi_get_version(napi_env env, uint32_t* result);
 

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -49,6 +49,12 @@ NODE_EXTERN inline void MarkPerformanceMilestone(
     env->performance_state()->milestones[milestone] = PERFORMANCE_NOW();
   }
 
+NODE_EXTERN Local<Object> CreateMark(Environment* env, const char* name);
+NODE_EXTERN Local<Object> CreateMeasure(Environment* env,
+                                        const char* name,
+                                        const char* startMark,
+                                        const char* endMark);
+
 class PerformanceEntry : public BaseObject {
  public:
   // Used for temporary storage of performance entry details when the

--- a/test/addons-napi/test-perf/binding.gyp
+++ b/test/addons-napi/test-perf/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_perf",
+      "sources": [ "test_perf.c" ]
+    }
+  ]
+}

--- a/test/addons-napi/test-perf/test.js
+++ b/test/addons-napi/test-perf/test.js
@@ -1,0 +1,56 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const {
+  performance,
+  PerformanceObserver
+} = require('perf_hooks');
+
+// Testing api calls for arrays
+const {
+  TestMark,
+  TestMeasure
+} = require(`./build/${common.buildType}/test_perf`);
+
+const markreg =
+  /failed: Wrong type of argments\. Expects a string as first argument\./;
+
+[1, {}, [], NaN, Infinity, () => {}].forEach((i) => {
+  common.expectsError(() => TestMark(i),
+                      {
+                        type: Error,
+                        message: markreg
+                      });
+});
+
+const markA = new PerformanceObserver(common.mustCall((info) => {
+  const marks = info.getEntries();
+  assert.strictEqual(marks[0].name, 'A');
+  markA.disconnect();
+}));
+markA.observe({ entryTypes: ['mark'] });
+
+TestMark('A');
+
+// busy loop for a bit
+for (let n = 0; n < 1e6; n++) {}
+
+const markB = new PerformanceObserver(common.mustCall((info) => {
+  const marks = info.getEntries();
+  assert.strictEqual(marks[0].name, 'B');
+  markB.disconnect();
+}));
+markB.observe({ entryTypes: ['mark'] });
+
+TestMark('B');
+
+const measureA = new PerformanceObserver(common.mustCall((info) => {
+  const measures = info.getEntries();
+  assert.strictEqual(measures[0].name, 'A to B');
+  measureA.disconnect();
+  performance.clearMeasures();
+  performance.clearMarks();
+}));
+measureA.observe({ entryTypes: ['measure'] });
+
+TestMeasure('A to B', 'A', 'B');

--- a/test/addons-napi/test-perf/test_perf.c
+++ b/test/addons-napi/test-perf/test_perf.c
@@ -1,0 +1,71 @@
+#include <node_api.h>
+#include <string.h>
+#include "../common.h"
+
+napi_value TestMark(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+
+  NAPI_ASSERT(env, valuetype0 == napi_string,
+    "Wrong type of argments. Expects a string as first argument.");
+
+  char buffer[100];
+  size_t buffer_size = 100;
+  size_t copied;
+
+  NAPI_CALL(env,
+    napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+
+  NAPI_CALL(env, napi_performance_mark(env, buffer));
+
+  return napi_undefined;
+}
+
+napi_value TestMeasure(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value args[3];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 3, "Wrong number of arguments");
+
+  for (int n = 0; n < 3; n++) {
+    napi_valuetype valuetype;
+    NAPI_CALL(env, napi_typeof(env, args[n], &valuetype));
+    NAPI_ASSERT(env, valuetype == napi_string,
+      "Wrong type of argments. Expects a string as argument.");
+    }
+
+  char name[100];
+  char start[100];
+  char end[100];
+  size_t copied;
+
+  NAPI_CALL(env,
+    napi_get_value_string_utf8(env, args[0], name, sizeof(name), &copied));
+  NAPI_CALL(env,
+    napi_get_value_string_utf8(env, args[0], start, sizeof(start), &copied));
+  NAPI_CALL(env,
+    napi_get_value_string_utf8(env, args[0], end, sizeof(end), &copied));
+
+  NAPI_CALL(env, napi_performance_measure(env, name, start, end));
+
+  return napi_undefined;
+}
+
+void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NAPI_PROPERTY("TestMark", TestMark),
+    DECLARE_NAPI_PROPERTY("TestMeasure", TestMeasure)
+  };
+
+  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+}
+
+NAPI_MODULE(addon, Init)


### PR DESCRIPTION
Adds simple `napi_performance_mark()` and `napi_performance_measure()` APIs to N-API to allow native addon developers the ability to add user timing marks that are observable using `PerformanceObserver`

/cc @mcollina @mhdawson

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api