### PR TITLE
crypto: fix Node_SignFinal

### DIFF
--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -18,7 +18,7 @@ keylen_list.forEach(function(key) {
 
 var bench = common.createBenchmark(main, {
   writes: [500],
-  algo: ['RSA-SHA1', 'RSA-SHA224', 'RSA-SHA256', 'RSA-SHA384', 'RSA-SHA512'],
+  algo: ['SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512'],
   keylen: keylen_list,
   len: [1024, 102400, 2 * 102400, 3 * 102400, 1024 * 1024]
 });

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -916,24 +916,45 @@ of two ways:
 - Using the [`sign.update()`][] and [`sign.sign()`][] methods to produce the
   signature.
 
-The [`crypto.createSign()`][] method is used to create `Sign` instances. `Sign`
-objects are not to be created directly using the `new` keyword.
+The [`crypto.createSign()`][] method is used to create `Sign` instances. The
+argument is the string name of the hash function to use. `Sign` objects are not
+to be created directly using the `new` keyword.
 
 Example: Using `Sign` objects as streams:
 
 ```js
 const crypto = require('crypto');
-const sign = crypto.createSign('RSA-SHA256');
+const sign = crypto.createSign('SHA256');
 
 sign.write('some data to sign');
 sign.end();
 
 const privateKey = getPrivateKeySomehow();
 console.log(sign.sign(privateKey, 'hex'));
-// Prints: the calculated signature
+// Prints: the calculated signature using the specified private key and
+// SHA-256. For RSA keys, the algorithm is RSASSA-PKCS1-v1_5 (see padding
+// parameter below for RSASSA-PSS). For EC keys, the algorithm is ECDSA.
 ```
 
 Example: Using the [`sign.update()`][] and [`sign.sign()`][] methods:
+
+```js
+const crypto = require('crypto');
+const sign = crypto.createSign('SHA256');
+
+sign.update('some data to sign');
+
+const privateKey = getPrivateKeySomehow();
+console.log(sign.sign(privateKey, 'hex'));
+// Prints: the calculated signature
+```
+
+In some cases, a `Sign` instance can also be created by passing in a signature
+algorithm name, such as 'RSA-SHA256'. This will use the corresponding digest
+algorithm. This does not work for all signature algorithms, such as
+'ecdsa-with-SHA256'. Use digest names instead.
+
+Example: signing using legacy signature algorithm name
 
 ```js
 const crypto = require('crypto');
@@ -944,29 +965,6 @@ sign.update('some data to sign');
 const privateKey = getPrivateKeySomehow();
 console.log(sign.sign(privateKey, 'hex'));
 // Prints: the calculated signature
-```
-
-A `Sign` instance can also be created by just passing in the digest
-algorithm name, in which case OpenSSL will infer the full signature algorithm
-from the type of the PEM-formatted private key, including algorithms that
-do not have directly exposed name constants, e.g. 'ecdsa-with-SHA256'.
-
-Example: signing using ECDSA with SHA256
-
-```js
-const crypto = require('crypto');
-const sign = crypto.createSign('sha256');
-
-sign.update('some data to sign');
-
-const privateKey =
-`-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIF+jnWY1D5kbVYDNvxxo/Y+ku2uJPDwS0r/VuPZQrjjVoAoGCCqGSM49
-AwEHoUQDQgAEurOxfSxmqIRYzJVagdZfMMSjRNNhB8i3mXyIMq704m2m52FdfKZ2
-pQhByd5eyj3lgZ7m7jbchtdgyOF8Io/1ng==
------END EC PRIVATE KEY-----`;
-
-console.log(sign.sign(privateKey).toString('hex'));
 ```
 
 ### sign.sign(privateKey[, outputFormat])
@@ -1049,7 +1047,7 @@ Example: Using `Verify` objects as streams:
 
 ```js
 const crypto = require('crypto');
-const verify = crypto.createVerify('RSA-SHA256');
+const verify = crypto.createVerify('SHA256');
 
 verify.write('some data to sign');
 verify.end();
@@ -1064,7 +1062,7 @@ Example: Using the [`verify.update()`][] and [`verify.verify()`][] methods:
 
 ```js
 const crypto = require('crypto');
-const verify = crypto.createVerify('RSA-SHA256');
+const verify = crypto.createVerify('SHA256');
 
 verify.update('some data to sign');
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3976,7 +3976,8 @@ void SignBase::CheckThrow(SignBase::Error error) {
 
 static bool ApplyRSAOptions(EVP_PKEY* pkey, EVP_PKEY_CTX* pkctx, int padding,
                             int salt_len) {
-  if (pkey->type == EVP_PKEY_RSA || pkey->type == EVP_PKEY_RSA2) {
+  if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA ||
+      EVP_PKEY_id(pkey) == EVP_PKEY_RSA2) {
     if (EVP_PKEY_CTX_set_rsa_padding(pkctx, padding) <= 0)
       return false;
     if (padding == RSA_PKCS1_PSS_PADDING) {
@@ -4085,33 +4086,23 @@ static int Node_SignFinal(EVP_MD_CTX* mdctx, unsigned char* md,
   if (!EVP_DigestFinal_ex(mdctx, m, &m_len))
     return rv;
 
-  if (mdctx->digest->flags & EVP_MD_FLAG_PKEY_METHOD_SIGNATURE) {
-    size_t sltmp = static_cast<size_t>(EVP_PKEY_size(pkey));
-    pkctx = EVP_PKEY_CTX_new(pkey, nullptr);
-    if (pkctx == nullptr)
-      goto err;
-    if (EVP_PKEY_sign_init(pkctx) <= 0)
-      goto err;
-    if (!ApplyRSAOptions(pkey, pkctx, padding, pss_salt_len))
-      goto err;
-    if (EVP_PKEY_CTX_set_signature_md(pkctx, mdctx->digest) <= 0)
-      goto err;
-    if (EVP_PKEY_sign(pkctx, md, &sltmp, m, m_len) <= 0)
-      goto err;
-    *sig_len = sltmp;
-    rv = 1;
-   err:
-    EVP_PKEY_CTX_free(pkctx);
-    return rv;
-  }
-
-  if (mdctx->digest->sign == nullptr) {
-    EVPerr(EVP_F_EVP_SIGNFINAL, EVP_R_NO_SIGN_FUNCTION_CONFIGURED);
-    return 0;
-  }
-
-  return mdctx->digest->sign(mdctx->digest->type, m, m_len, md, sig_len,
-                             pkey->pkey.ptr);
+  size_t sltmp = static_cast<size_t>(EVP_PKEY_size(pkey));
+  pkctx = EVP_PKEY_CTX_new(pkey, nullptr);
+  if (pkctx == nullptr)
+    goto err;
+  if (EVP_PKEY_sign_init(pkctx) <= 0)
+    goto err;
+  if (!ApplyRSAOptions(pkey, pkctx, padding, pss_salt_len))
+    goto err;
+  if (EVP_PKEY_CTX_set_signature_md(pkctx, EVP_MD_CTX_md(mdctx)) <= 0)
+    goto err;
+  if (EVP_PKEY_sign(pkctx, md, &sltmp, m, m_len) <= 0)
+    goto err;
+  *sig_len = sltmp;
+  rv = 1;
+ err:
+  EVP_PKEY_CTX_free(pkctx);
+  return rv;
 }
 
 SignBase::Error Sign::SignFinal(const char* key_pem,

--- a/test/fixtures/0-dns/create-cert.js
+++ b/test/fixtures/0-dns/create-cert.js
@@ -8,7 +8,7 @@ const BN = asn1.bignum;
 const id_at_commonName = [ 2, 5, 4, 3 ];
 const rsaEncryption = [1, 2, 840, 113549, 1, 1, 1];
 const sha256WithRSAEncryption = [1, 2, 840, 113549, 1, 1, 11];
-const sigalg = 'RSA-SHA256';
+const digest = 'SHA256';
 
 const private_key = fs.readFileSync('./0-dns-key.pem');
 // public key file can be generated from the private key with
@@ -59,7 +59,7 @@ const tbs = {
 
 const tbs_der = rfc5280.TBSCertificate.encode(tbs, 'der');
 
-const sign = crypto.createSign(sigalg);
+const sign = crypto.createSign(digest);
 sign.update(tbs_der);
 const signature = sign.sign(private_key);
 

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -424,28 +424,28 @@ assert.throws(function() {
 }, /^Error: Digest method not supported$/);
 
 // Test signing and verifying
-const s1 = crypto.createSign('RSA-SHA1')
+const s1 = crypto.createSign('SHA1')
                .update('Test123')
                .sign(keyPem, 'base64');
-const s1Verified = crypto.createVerify('RSA-SHA1')
+const s1Verified = crypto.createVerify('SHA1')
                        .update('Test')
                        .update('123')
                        .verify(certPem, s1, 'base64');
 assert.strictEqual(s1Verified, true, 'sign and verify (base 64)');
 
-const s2 = crypto.createSign('RSA-SHA256')
+const s2 = crypto.createSign('SHA256')
                .update('Test123')
                .sign(keyPem); // binary
-const s2Verified = crypto.createVerify('RSA-SHA256')
+const s2Verified = crypto.createVerify('SHA256')
                        .update('Test')
                        .update('123')
                        .verify(certPem, s2); // binary
 assert.strictEqual(s2Verified, true, 'sign and verify (binary)');
 
-const s3 = crypto.createSign('RSA-SHA1')
+const s3 = crypto.createSign('SHA1')
                .update('Test123')
                .sign(keyPem, 'buffer');
-const s3Verified = crypto.createVerify('RSA-SHA1')
+const s3Verified = crypto.createVerify('SHA1')
                        .update('Test')
                        .update('123')
                        .verify(certPem, s3);
@@ -589,8 +589,8 @@ const d = crypto.createDiffieHellman(p, 'hex');
 assert.strictEqual(d.verifyError, DH_NOT_SUITABLE_GENERATOR);
 
 // Test RSA key signing/verification
-const rsaSign = crypto.createSign('RSA-SHA1');
-const rsaVerify = crypto.createVerify('RSA-SHA1');
+const rsaSign = crypto.createSign('SHA1');
+const rsaVerify = crypto.createVerify('SHA1');
 assert.ok(rsaSign instanceof crypto.Sign);
 assert.ok(rsaVerify instanceof crypto.Verify);
 
@@ -625,13 +625,13 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
       '8195e0268da7eda23d9825ac43c724e86ceeee0d0d4465678652ccaf6501' +
       '0ddfb299bedeb1ad';
 
-  const sign = crypto.createSign('RSA-SHA256');
+  const sign = crypto.createSign('SHA256');
   sign.update(input);
 
   const output = sign.sign(privateKey, 'hex');
   assert.strictEqual(output, signature);
 
-  const verify = crypto.createVerify('RSA-SHA256');
+  const verify = crypto.createVerify('SHA256');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);
@@ -649,11 +649,11 @@ assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('SHA1');
   sign.update(input);
   const signature = sign.sign(privateKey, 'hex');
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('SHA1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);

--- a/test/parallel/test-crypto-rsa-dsa.js
+++ b/test/parallel/test-crypto-rsa-dsa.js
@@ -131,8 +131,8 @@ test_rsa('RSA_PKCS1_PADDING');
 test_rsa('RSA_PKCS1_OAEP_PADDING');
 
 // Test RSA key signing/verification
-let rsaSign = crypto.createSign('RSA-SHA1');
-let rsaVerify = crypto.createVerify('RSA-SHA1');
+let rsaSign = crypto.createSign('SHA1');
+let rsaVerify = crypto.createVerify('SHA1');
 assert.ok(rsaSign);
 assert.ok(rsaVerify);
 
@@ -151,7 +151,7 @@ rsaVerify.update(rsaPubPem);
 assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
 // Test RSA key signing/verification with encrypted key
-rsaSign = crypto.createSign('RSA-SHA1');
+rsaSign = crypto.createSign('SHA1');
 rsaSign.update(rsaPubPem);
 assert.doesNotThrow(() => {
   const signOptions = { key: rsaKeyPemEncrypted, passphrase: 'password' };
@@ -159,11 +159,11 @@ assert.doesNotThrow(() => {
 });
 assert.strictEqual(rsaSignature, expectedSignature);
 
-rsaVerify = crypto.createVerify('RSA-SHA1');
+rsaVerify = crypto.createVerify('SHA1');
 rsaVerify.update(rsaPubPem);
 assert.strictEqual(rsaVerify.verify(rsaPubPem, rsaSignature, 'hex'), true);
 
-rsaSign = crypto.createSign('RSA-SHA1');
+rsaSign = crypto.createSign('SHA1');
 rsaSign.update(rsaPubPem);
 assert.throws(() => {
   const signOptions = { key: rsaKeyPemEncrypted, passphrase: 'wrong' };
@@ -186,16 +186,28 @@ assert.throws(() => {
       '8195e0268da7eda23d9825ac43c724e86ceeee0d0d4465678652ccaf6501' +
       '0ddfb299bedeb1ad';
 
-  const sign = crypto.createSign('RSA-SHA256');
+  const sign = crypto.createSign('SHA256');
   sign.update(input);
 
   const output = sign.sign(privateKey, 'hex');
   assert.strictEqual(signature, output);
 
-  const verify = crypto.createVerify('RSA-SHA256');
+  const verify = crypto.createVerify('SHA256');
   verify.update(input);
 
   assert.strictEqual(verify.verify(publicKey, signature, 'hex'), true);
+
+  // Test the legacy signature algorithm name.
+  const sign2 = crypto.createSign('RSA-SHA256');
+  sign2.update(input);
+
+  const output2 = sign2.sign(privateKey, 'hex');
+  assert.strictEqual(signature, output2);
+
+  const verify2 = crypto.createVerify('SHA256');
+  verify2.update(input);
+
+  assert.strictEqual(verify2.verify(publicKey, signature, 'hex'), true);
 }
 
 
@@ -207,14 +219,24 @@ assert.throws(() => {
 
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('SHA1');
   sign.update(input);
   const signature = sign.sign(dsaKeyPem, 'hex');
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('SHA1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(dsaPubPem, signature, 'hex'), true);
+
+  // Test the legacy 'DSS1' name.
+  const sign2 = crypto.createSign('DSS1');
+  sign2.update(input);
+  const signature2 = sign2.sign(dsaKeyPem, 'hex');
+
+  const verify2 = crypto.createVerify('DSS1');
+  verify2.update(input);
+
+  assert.strictEqual(verify2.verify(dsaPubPem, signature2, 'hex'), true);
 }
 
 
@@ -224,7 +246,7 @@ assert.throws(() => {
 const input = 'I AM THE WALRUS';
 
 {
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('SHA1');
   sign.update(input);
   assert.throws(() => {
     sign.sign({ key: dsaKeyPemEncrypted, passphrase: 'wrong' }, 'hex');
@@ -234,7 +256,7 @@ const input = 'I AM THE WALRUS';
 {
   // DSA signatures vary across runs so there is no static string to verify
   // against
-  const sign = crypto.createSign('DSS1');
+  const sign = crypto.createSign('SHA1');
   sign.update(input);
 
   let signature;
@@ -243,7 +265,7 @@ const input = 'I AM THE WALRUS';
     signature = sign.sign(signOptions, 'hex');
   });
 
-  const verify = crypto.createVerify('DSS1');
+  const verify = crypto.createVerify('SHA1');
   verify.update(input);
 
   assert.strictEqual(verify.verify(dsaPubPem, signature, 'hex'), true);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -17,15 +17,15 @@ const modSize = 1024;
 
 // Test signing and verifying
 {
-  const s1 = crypto.createSign('RSA-SHA1')
+  const s1 = crypto.createSign('SHA1')
                    .update('Test123')
                    .sign(keyPem, 'base64');
-  let s1stream = crypto.createSign('RSA-SHA1');
+  let s1stream = crypto.createSign('SHA1');
   s1stream.end('Test123');
   s1stream = s1stream.sign(keyPem, 'base64');
   assert.strictEqual(s1, s1stream, 'Stream produces same output');
 
-  const verified = crypto.createVerify('RSA-SHA1')
+  const verified = crypto.createVerify('SHA1')
                          .update('Test')
                          .update('123')
                          .verify(certPem, s1, 'base64');
@@ -33,21 +33,21 @@ const modSize = 1024;
 }
 
 {
-  const s2 = crypto.createSign('RSA-SHA256')
+  const s2 = crypto.createSign('SHA256')
                    .update('Test123')
                    .sign(keyPem, 'latin1');
-  let s2stream = crypto.createSign('RSA-SHA256');
+  let s2stream = crypto.createSign('SHA256');
   s2stream.end('Test123');
   s2stream = s2stream.sign(keyPem, 'latin1');
   assert.strictEqual(s2, s2stream, 'Stream produces same output');
 
-  let verified = crypto.createVerify('RSA-SHA256')
+  let verified = crypto.createVerify('SHA256')
                        .update('Test')
                        .update('123')
                        .verify(certPem, s2, 'latin1');
   assert.strictEqual(verified, true, 'sign and verify (latin1)');
 
-  const verStream = crypto.createVerify('RSA-SHA256');
+  const verStream = crypto.createVerify('SHA256');
   verStream.write('Tes');
   verStream.write('t12');
   verStream.end('3');
@@ -56,16 +56,16 @@ const modSize = 1024;
 }
 
 {
-  const s3 = crypto.createSign('RSA-SHA1')
+  const s3 = crypto.createSign('SHA1')
                    .update('Test123')
                    .sign(keyPem, 'buffer');
-  let verified = crypto.createVerify('RSA-SHA1')
+  let verified = crypto.createVerify('SHA1')
                        .update('Test')
                        .update('123')
                        .verify(certPem, s3);
   assert.strictEqual(verified, true, 'sign and verify (buffer)');
 
-  const verStream = crypto.createVerify('RSA-SHA1');
+  const verStream = crypto.createVerify('SHA1');
   verStream.write('Tes');
   verStream.write('t12');
   verStream.end('3');
@@ -167,8 +167,8 @@ const modSize = 1024;
     });
   }
 
-  testPSS('RSA-SHA1', 20);
-  testPSS('RSA-SHA256', 32);
+  testPSS('SHA1', 20);
+  testPSS('SHA256', 32);
 }
 
 // Test vectors for RSA_PKCS1_PSS_PADDING provided by the RSA Laboratories:
@@ -176,7 +176,7 @@ const modSize = 1024;
 {
   // We only test verification as we cannot specify explicit salts when signing
   function testVerify(cert, vector) {
-    const verified = crypto.createVerify('RSA-SHA1')
+    const verified = crypto.createVerify('SHA1')
                           .update(Buffer.from(vector.message, 'hex'))
                           .verify({
                             key: cert,
@@ -203,7 +203,7 @@ const modSize = 1024;
   [null, undefined, NaN, 'boom', {}, [], true, false]
     .forEach((invalidValue) => {
       assert.throws(() => {
-        crypto.createSign('RSA-SHA256')
+        crypto.createSign('SHA256')
           .update('Test123')
           .sign({
             key: keyPem,
@@ -212,7 +212,7 @@ const modSize = 1024;
       }, paddingNotInteger);
 
       assert.throws(() => {
-        crypto.createSign('RSA-SHA256')
+        crypto.createSign('SHA256')
           .update('Test123')
           .sign({
             key: keyPem,
@@ -223,7 +223,7 @@ const modSize = 1024;
     });
 
   assert.throws(() => {
-    crypto.createSign('RSA-SHA1')
+    crypto.createSign('SHA1')
       .update('Test123')
       .sign({
         key: keyPem,
@@ -235,7 +235,7 @@ const modSize = 1024;
 // Test throws exception when key options is null
 {
   assert.throws(() => {
-    crypto.createSign('RSA-SHA1').update('Test123').sign(null, 'base64');
+    crypto.createSign('SHA1').update('Test123').sign(null, 'base64');
   }, /^Error: No key provided to sign$/);
 }
 
@@ -248,7 +248,7 @@ const modSize = 1024;
   const privkey = fixtures.readKey('rsa_private_2048.pem');
 
   const msg = 'Test123';
-  const s5 = crypto.createSign('RSA-SHA256')
+  const s5 = crypto.createSign('SHA256')
     .update(msg)
     .sign({
       key: privkey,

--- a/test/parallel/test-crypto-verify-failure.js
+++ b/test/parallel/test-crypto-verify-failure.js
@@ -48,7 +48,7 @@ const server = tls.Server(options, (socket) => {
 });
 
 function verify() {
-  crypto.createVerify('RSA-SHA1')
+  crypto.createVerify('SHA1')
     .update('Test')
     .verify(certPem, 'asdfasdfas', 'base64');
 }

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -146,11 +146,11 @@ assert.throws(function() {
 }, /^TypeError: Bad input string$/);
 
 assert.throws(function() {
-  crypto.createSign('RSA-SHA1').update('0', 'hex');
+  crypto.createSign('SHA1').update('0', 'hex');
 }, /^TypeError: Bad input string$/);
 
 assert.throws(function() {
-  crypto.createVerify('RSA-SHA1').update('0', 'hex');
+  crypto.createVerify('SHA1').update('0', 'hex');
 }, /^TypeError: Bad input string$/);
 
 assert.throws(function() {
@@ -163,7 +163,7 @@ assert.throws(function() {
     '-----END RSA PRIVATE KEY-----',
     ''
   ].join('\n');
-  crypto.createSign('RSA-SHA256').update('test').sign(priv);
+  crypto.createSign('SHA256').update('test').sign(priv);
 }, /digest too big for rsa key$/);
 
 assert.throws(function() {

--- a/test/parallel/test-dsa-fips-invalid-key.js
+++ b/test/parallel/test-dsa-fips-invalid-key.js
@@ -11,7 +11,7 @@ const input = 'hello';
 
 const dsapri = fs.readFileSync(
   `${common.fixturesDir}/keys/dsa_private_1025.pem`);
-const sign = crypto.createSign('DSS1');
+const sign = crypto.createSign('SHA1');
 sign.update(input);
 
 assert.throws(function() {


### PR DESCRIPTION
This is a bit of a mess. Originally, OpenSSL mixed up hashes with
signature algorithms. An EVP_MD was nominally a hash, but they sometimes
had key types associated with them for signining purposes. So
EVP_sha256() was secretly associated with RSA (and named both "SHA256"
and "RSA-SHA256"), but DSA was not usable with EVP_sha256() and instead
one used EVP_dss1() which is identical to EVP_sha1() but associated with
DSA instead.

Way back in OpenSSL 1.0.0, OpenSSL added the newer EVP_DigestSign* and
EVP_DigestVerify* functions which should be used instead of the legacy
EVP_Sign* and EVP_Verify* functions which Node used up until recently.
The newer functions no longer confuse hash functions and signature
algorithms and are the supported way to use more complex algorithms like
RSA-PSS. This is also why Node has this caveat about
"ecdsa-with-SHA256". It's not that OpenSSL is missing this. Node was
using the wrong API.

As part of the 1.0.0 changes, hash functions like EVP_sha256() in
OpenSSL are no longer are tied to signature algorithms and may be used
with any key. This means that "RSA-SHA256" in Node just means "SHA256".
Even before this patch, replacing "DSS1" with "RSA-SHA1" in
test-crypto-binary-default.js worked fine.

Unfortunately, the Node crypto.createSign API is incompatible with
EVP_DigestVerify* due to parameters and key being specified late, which
means it can only be used with signature algorithms which sign a
pre-hashed digest rather than something more complex. Fortunately,
that's all of them right now (though Node will need new APIs for Ed25519
in the future).

PR #11705 switched Node away from using EVP_Sign*, but not to the new
APIs. In doing so, it copied bits of EVP_SignFinal but missed a critical
check that prevents pkey->pkey.ptr from being downcast to the wrong
pointer type. That codepath is problematic for OpenSSL 1.1.0 and
redundant (note how the verify half does not have this).

Moreover, using "RSA-SHA256" with RSA-PSS does not make sense.
"RSA-SHA256" is the name of the sha256WithRSAEncryption OID, used with
PKCS#1 v1.5, *not* RSA-PSS. That "RSA-SHA256" works in place of "SHA256"
is the same legacy quirk of EVP_Sign* that allows it to be used with
(EC)DSA.

Rather than all this, always use the EVP_PKEY_sign codepath.  Everything
that previously worked still works, but more safely and consistently.
Update the documentation to call the parameter the hash function, not
the signature algorithm, finishing a change that PR #11705 effectively
did, but not fully.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto
