### PR TITLE
assert: improve AssertionError in case of "Errors"

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -35,21 +35,26 @@ class AssertionError extends Error {
     if (typeof options !== 'object' || options === null) {
       throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
     }
-    if (options.message) {
-      super(options.message);
+    var { actual, expected, message, operator, stackStartFunction } = options;
+    if (message) {
+      super(message);
     } else {
+      if (actual && actual.stack && actual instanceof Error)
+        actual = `${actual.name}: ${actual.message}`;
+      if (expected && expected.stack && expected instanceof Error)
+        expected = `${expected.name}: ${expected.message}`;
       if (util === null) util = require('util');
-      super(`${util.inspect(options.actual).slice(0, 128)} ` +
-        `${options.operator} ${util.inspect(options.expected).slice(0, 128)}`);
+      super(`${util.inspect(actual).slice(0, 128)} ` +
+        `${operator} ${util.inspect(expected).slice(0, 128)}`);
     }
 
-    this.generatedMessage = !options.message;
+    this.generatedMessage = !message;
     this.name = 'AssertionError [ERR_ASSERTION]';
     this.code = 'ERR_ASSERTION';
-    this.actual = options.actual;
-    this.expected = options.expected;
-    this.operator = options.operator;
-    Error.captureStackTrace(this, options.stackStartFunction);
+    this.actual = actual;
+    this.expected = expected;
+    this.operator = operator;
+    Error.captureStackTrace(this, stackStartFunction);
   }
 }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -715,3 +715,12 @@ assert.throws(() => {
       }));
   });
 }
+
+common.expectsError(
+  () => assert.strictEqual(new Error('foo'), new Error('foobar')),
+  {
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: /^'Error: foo' === 'Error: foobar'$/
+  }
+);


### PR DESCRIPTION
Showing the stack trace in a error message obfuscates the actual
message and should not be visible therefore.

I think this is actually part of the `assert` subsystem even though the `AssertionError` is placed in the internal/errors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert