### PR TITLE
assert: handle sparse arrays in deepStrictEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -182,7 +182,14 @@ function strictDeepEqual(actual, expected) {
   if (Object.getPrototypeOf(actual) !== Object.getPrototypeOf(expected)) {
     return false;
   }
-  if (isObjectOrArrayTag(actualTag)) {
+  if (actualTag === '[object Array]') {
+    // Check for sparse arrays and general fast path
+    if (actual.length !== expected.length)
+      return false;
+    // Skip testing the part below and continue in the callee function.
+    return;
+  }
+  if (actualTag === '[object Object]') {
     // Skip testing the part below and continue in the callee function.
     return;
   }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -466,4 +466,7 @@ assertOnlyDeepEqual(
   assertDeepAndStrictEqual(m3, m4);
 }
 
+assertDeepAndStrictEqual([1, , , 3], [1, , , 3]);
+assertOnlyDeepEqual([1, , , 3], [1, , , 3, , , ]);
+
 /* eslint-enable */


### PR DESCRIPTION
Detect sparse array ends and add a fail early path for
unequal array length.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert