### PR TITLE
deps: cherry-pick d288a87e33 from v8 upstream

### DIFF
--- a/deps/v8/src/libsampler/sampler.cc
+++ b/deps/v8/src/libsampler/sampler.cc
@@ -450,11 +450,18 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
   state->sp = reinterpret_cast<void*>(mcontext.gregs[29]);
   state->fp = reinterpret_cast<void*>(mcontext.gregs[30]);
 #elif V8_HOST_ARCH_PPC
+#if V8_LIBC_GLIBC
   state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->nip);
   state->sp =
       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R1]);
   state->fp =
       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
+#else
+  // Some C libraries, notably Musl, define the regs member as a void pointer
+  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
+  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
+  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);
+#endif
 #elif V8_HOST_ARCH_S390
 #if V8_TARGET_ARCH_32_BIT
   // 31-bit target will have bit 0 (MSB) of the PSW set to denote addressing


### PR DESCRIPTION
Original commit message:

    Fix build on PPC arch with musl

    Some C libraries, notably Musl, define the regs member as a void pointer,
    hence we need to use the gp_regs member instead.

    Change-Id: I1ca2dbdba79a03ff81c25438c87c767d7a7cece4
    Reviewed-on: https://chromium-review.googlesource.com/602327
    Reviewed-by: Jaideep Bajwa <bjaideep@ca.ibm.com>
    Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
    Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#47481}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
