### PR TITLE
fs: add fs.copyFile{Sync}

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -750,6 +750,88 @@ Returns an object containing commonly used constants for file system
 operations. The specific constants currently defined are described in
 [FS Constants][].
 
+## fs.copyFile(src, dest[, flags], callback)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `src` {string|Buffer|URL} source filename to copy
+* `dest` {string|Buffer|URL} destination filename of the copy operation
+* `flags` {number} modifiers for copy operation. **Default:** `0`
+* `callback` {Function}
+
+Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it
+already exists. No arguments other than a possible exception are given to the
+callback function. Node.js makes no guarantees about the atomicity of the copy
+operation. If an error occurs after the destination file has been opened for
+writing, Node.js will attempt to remove the destination.
+
+`flags` is an optional integer that specifies the behavior
+of the copy operation. The only supported flag is `fs.constants.COPYFILE_EXCL`,
+which causes the copy operation to fail if `dest` already exists.
+
+Example:
+
+```js
+const fs = require('fs');
+
+// destination.txt will be created or overwritten by default.
+fs.copyFile('source.txt', 'destination.txt', (err) => {
+  if (err) throw err;
+  console.log('source.txt was copied to destination.txt');
+});
+```
+
+If the third argument is a number, then it specifies `flags`, as shown in the
+following example.
+
+```js
+const fs = require('fs');
+const { COPYFILE_EXCL } = fs.constants;
+
+// By using COPYFILE_EXCL, the operation will fail if destination.txt exists.
+fs.copyFile('source.txt', 'destination.txt', COPYFILE_EXCL, callback);
+```
+
+## fs.copyFileSync(src, dest[, flags])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `src` {string|Buffer|URL} source filename to copy
+* `dest` {string|Buffer|URL} destination filename of the copy operation
+* `flags` {number} modifiers for copy operation. **Default:** `0`
+
+Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
+already exists. Returns `undefined`. Node.js makes no guarantees about the
+atomicity of the copy operation. If an error occurs after the destination file
+has been opened for writing, Node.js will attempt to remove the destination.
+
+`flags` is an optional integer that specifies the behavior
+of the copy operation. The only supported flag is `fs.constants.COPYFILE_EXCL`,
+which causes the copy operation to fail if `dest` already exists.
+
+Example:
+
+```js
+const fs = require('fs');
+
+// destination.txt will be created or overwritten by default.
+fs.copyFileSync('source.txt', 'destination.txt');
+console.log('source.txt was copied to destination.txt');
+```
+
+If the third argument is a number, then it specifies `flags`, as shown in the
+following example.
+
+```js
+const fs = require('fs');
+const { COPYFILE_EXCL } = fs.constants;
+
+// By using COPYFILE_EXCL, the operation will fail if destination.txt exists.
+fs.copyFileSync('source.txt', 'destination.txt', COPYFILE_EXCL);
+```
+
 ## fs.createReadStream(path[, options])
 <!-- YAML
 added: v0.1.31

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1884,6 +1884,61 @@ fs.mkdtempSync = function(prefix, options) {
 };
 
 
+// Define copyFile() flags.
+Object.defineProperties(fs.constants, {
+  COPYFILE_EXCL: { enumerable: true, value: constants.UV_FS_COPYFILE_EXCL }
+});
+
+
+fs.copyFile = function(src, dest, flags, callback) {
+  if (typeof flags === 'function') {
+    callback = flags;
+    flags = 0;
+  } else if (typeof callback !== 'function') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'callback', 'function');
+  }
+
+  src = getPathFromURL(src);
+
+  if (handleError(src, callback))
+    return;
+
+  if (!nullCheck(src, callback))
+    return;
+
+  dest = getPathFromURL(dest);
+
+  if (handleError(dest, callback))
+    return;
+
+  if (!nullCheck(dest, callback))
+    return;
+
+  src = pathModule._makeLong(src);
+  dest = pathModule._makeLong(dest);
+  flags = flags | 0;
+  const req = new FSReqWrap();
+  req.oncomplete = makeCallback(callback);
+  binding.copyFile(src, dest, flags, req);
+};
+
+
+fs.copyFileSync = function(src, dest, flags) {
+  src = getPathFromURL(src);
+  handleError(src);
+  nullCheck(src);
+
+  dest = getPathFromURL(dest);
+  handleError(dest);
+  nullCheck(dest);
+
+  src = pathModule._makeLong(src);
+  dest = pathModule._makeLong(dest);
+  flags = flags | 0;
+  binding.copyFile(src, dest, flags);
+};
+
+
 var pool;
 
 function allocNewPool(poolSize) {

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1164,10 +1164,6 @@ void DefineSystemConstants(Local<Object> target) {
 #endif
 }
 
-void DefineUVConstants(Local<Object> target) {
-  NODE_DEFINE_CONSTANT(target, UV_UDP_REUSEADDR);
-}
-
 void DefineCryptoConstants(Local<Object> target) {
 #if HAVE_OPENSSL
   NODE_DEFINE_STRING_CONSTANT(target,
@@ -1274,11 +1270,14 @@ void DefineConstants(v8::Isolate* isolate, Local<Object> target) {
   DefineErrnoConstants(err_constants);
   DefineWindowsErrorConstants(err_constants);
   DefineSignalConstants(sig_constants);
-  DefineUVConstants(os_constants);
   DefineSystemConstants(fs_constants);
   DefineOpenSSLConstants(crypto_constants);
   DefineCryptoConstants(crypto_constants);
   DefineZlibConstants(zlib_constants);
+
+  // Define libuv constants.
+  NODE_DEFINE_CONSTANT(os_constants, UV_UDP_REUSEADDR);
+  NODE_DEFINE_CONSTANT(fs_constants, UV_FS_COPYFILE_EXCL);
 
   os_constants->Set(OneByteString(isolate, "errno"), err_constants);
   os_constants->Set(OneByteString(isolate, "signals"), sig_constants);

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -1,0 +1,104 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const src = path.join(common.fixturesDir, 'a.js');
+const dest = path.join(common.tmpDir, 'copyfile.out');
+const { COPYFILE_EXCL, UV_FS_COPYFILE_EXCL } = fs.constants;
+
+function verify(src, dest) {
+  const srcData = fs.readFileSync(src, 'utf8');
+  const srcStat = fs.statSync(src);
+  const destData = fs.readFileSync(dest, 'utf8');
+  const destStat = fs.statSync(dest);
+
+  assert.strictEqual(srcData, destData);
+  assert.strictEqual(srcStat.mode, destStat.mode);
+  assert.strictEqual(srcStat.size, destStat.size);
+}
+
+common.refreshTmpDir();
+
+// Verify that flags are defined.
+assert.strictEqual(typeof COPYFILE_EXCL, 'number');
+assert.strictEqual(typeof UV_FS_COPYFILE_EXCL, 'number');
+assert.strictEqual(COPYFILE_EXCL, UV_FS_COPYFILE_EXCL);
+
+// Verify that files are overwritten when no flags are provided.
+fs.writeFileSync(dest, '', 'utf8');
+const result = fs.copyFileSync(src, dest);
+assert.strictEqual(result, undefined);
+verify(src, dest);
+
+// Verify that files are overwritten with default flags.
+fs.copyFileSync(src, dest, 0);
+verify(src, dest);
+
+// Throws if destination exists and the COPYFILE_EXCL flag is provided.
+assert.throws(() => {
+  fs.copyFileSync(src, dest, COPYFILE_EXCL);
+}, /^Error: EEXIST|ENOENT:.+, copyfile/);
+
+// Throws if the source does not exist.
+assert.throws(() => {
+  fs.copyFileSync(src + '__does_not_exist', dest, COPYFILE_EXCL);
+}, /^Error: ENOENT: no such file or directory, copyfile/);
+
+// Copies asynchronously.
+fs.unlinkSync(dest);
+fs.copyFile(src, dest, common.mustCall((err) => {
+  assert.ifError(err);
+  verify(src, dest);
+
+  // Copy asynchronously with flags.
+  fs.copyFile(src, dest, COPYFILE_EXCL, common.mustCall((err) => {
+    assert(
+      /^Error: EEXIST: file already exists, copyfile/.test(err.toString())
+    );
+  }));
+}));
+
+// Throws if callback is not a function.
+common.expectsError(() => {
+  fs.copyFile(src, dest, 0, 0);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: TypeError,
+  message: 'The "callback" argument must be of type function'
+});
+
+// Throws if the source path is not a string.
+assert.throws(() => {
+  fs.copyFileSync(null, dest);
+}, /^TypeError: src must be a string$/);
+
+// Throws if the source path is an invalid path.
+common.expectsError(() => {
+  fs.copyFileSync('\u0000', dest);
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: Error,
+  message: 'The "path" argument must be of type string without null bytes.' +
+           ' Received type string'
+});
+
+// Throws if the destination path is not a string.
+assert.throws(() => {
+  fs.copyFileSync(src, null);
+}, /^TypeError: dest must be a string$/);
+
+// Throws if the destination path is an invalid path.
+common.expectsError(() => {
+  fs.copyFileSync(src, '\u0000');
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+  type: Error,
+  message: 'The "path" argument must be of type string without null bytes.' +
+           ' Received type string'
+});
+
+// Errors if invalid flags are provided.
+assert.throws(() => {
+  fs.copyFileSync(src, dest, -1);
+}, /^Error: EINVAL: invalid argument, copyfile/);


### PR DESCRIPTION
This PR adds `fs.copyFile()` and `fs.copyFileSync()`.

- ~~Ignore the first commit, which updates libuv. This PR depends on libuv functionality that hasn't landed in Node yet. This PR is blocked until #14866 lands - a few things are needed for a new libuv release.~~
- ~~The test currently crashes. Again, this needs a [fix](https://github.com/libuv/libuv/pull/1509) in libuv, but can be worked around in Node if that doesn't land. So, don't even kick off a CI run.~~
- ~~Needs documentation.~~

Fixes: https://github.com/nodejs/node/issues/14906

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs
