### PR TITLE
test: increase coverage for http2 response headers

### DIFF
--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -42,13 +42,20 @@ server.listen(0, common.mustCall(function() {
     response.removeHeader(denormalised);
     assert.strictEqual(response.hasHeader(denormalised), false);
 
-    assert.throws(function() {
-      response.setHeader(':status', 'foobar');
-    }, common.expectsError({
-      code: 'ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
-      type: Error,
-      message: 'Cannot set HTTP/2 pseudo-headers'
-    }));
+    [
+      ':status',
+      ':method',
+      ':path',
+      ':authority',
+      ':scheme'
+    ].forEach((header) => assert.throws(
+      () => response.setHeader(header, 'foobar'),
+      common.expectsError({
+        code: 'ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
+        type: Error,
+        message: 'Cannot set HTTP/2 pseudo-headers'
+      })
+    ));
     assert.throws(function() {
       response.setHeader(real, null);
     }, common.expectsError({


### PR DESCRIPTION
Expanded an existing test for setting pseudo-headers on response to include all pseudo-headers, not just `:status`. This is a part of the request for increasing coverage for http2 as per https://github.com/nodejs/node/issues/14985

This is my first pull request for this project but I'm hoping to continue working on additional tests for h2, so if there's any feedback I would love to hear it and incorporate it. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test