### PR TITLE
assert: use same value equal for deepStrictEqual NaN

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -108,6 +108,9 @@ parameter is undefined, a default error message is assigned.
 added: v1.2.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15036
+    description: NaN is now compared using the [SameValueZero][] comparison.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/15001
     description: Error names and messages are now properly compared
   - version: v8.0.0
@@ -129,9 +132,10 @@ changes:
 
 Generally identical to `assert.deepEqual()` with three exceptions:
 
-1. Primitive values are compared using the [Strict Equality Comparison][]
-  ( `===` ). Set values and Map keys are compared using the [SameValueZero][]
-  comparison. (Which means they are free of the [caveats][]).
+1. Primitive values besides `NaN` are compared using the [Strict Equality
+   Comparison][] ( `===` ). Set and Map values, Map keys and `NaN` are compared
+   using the [SameValueZero][] comparison (which means they are free of the
+   [caveats][]).
 2. [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [Strict Equality Comparison][] too.
 3. [Type tags][Object.prototype.toString()] of objects should be the same.
@@ -164,6 +168,8 @@ assert.deepEqual(date, fakeDate);
 assert.deepStrictEqual(date, fakeDate);
 // AssertionError: 2017-03-11T14:25:31.849Z deepStrictEqual Date {}
 // Different type tags
+assert.deepStrictEqual(NaN, NaN);
+// OK, because of the SameValueZero comparison
 ```
 
 If the values are not equal, an `AssertionError` is thrown with a `message`
@@ -412,6 +418,9 @@ parameter is undefined, a default error message is assigned.
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15036
+    description: NaN is now compared using the [SameValueZero][] comparison.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/15001
     description: Error names and messages are now properly compared

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -20,6 +20,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15001
+    description: Error names and messages are now properly compared
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/12142
     description: Set and Map content is also compared
@@ -105,7 +108,7 @@ parameter is undefined, a default error message is assigned.
 added: v1.2.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/12142
+    pr-url: https://github.com/nodejs/node/pull/15001
     description: Error names and messages are now properly compared
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/12142
@@ -345,6 +348,22 @@ assert.ifError(new Error());
 ## assert.notDeepEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15001
+    description: Error names and messages are now properly compared
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12142
+    description: Set and Map content is also compared
+  - version: v6.4.0, v4.7.1
+    pr-url: https://github.com/nodejs/node/pull/8002
+    description: Typed array slices are handled correctly now.
+  - version: v6.1.0, v4.5.0
+    pr-url: https://github.com/nodejs/node/pull/6432
+    description: Objects with circular references can be used as inputs now.
+  - version: v5.10.1, v4.4.3
+    pr-url: https://github.com/nodejs/node/pull/5910
+    description: Handle non-`Uint8Array` typed arrays correctly.
 -->
 * `actual` {any}
 * `expected` {any}
@@ -392,6 +411,22 @@ parameter is undefined, a default error message is assigned.
 ## assert.notDeepStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v1.2.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15001
+    description: Error names and messages are now properly compared
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/12142
+    description: Set and Map content is also compared
+  - version: v6.4.0, v4.7.1
+    pr-url: https://github.com/nodejs/node/pull/8002
+    description: Typed array slices are handled correctly now.
+  - version: v6.1.0
+    pr-url: https://github.com/nodejs/node/pull/6432
+    description: Objects with circular references can be used as inputs now.
+  - version: v5.10.1, v4.4.3
+    pr-url: https://github.com/nodejs/node/pull/5910
+    description: Handle non-`Uint8Array` typed arrays correctly.
 -->
 * `actual` {any}
 * `expected` {any}

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -167,8 +167,11 @@ function isObjectOrArrayTag(tag) {
 // a) The same built-in type tags
 // b) The same prototypes.
 function strictDeepEqual(actual, expected) {
-  if (actual === null || expected === null ||
-    typeof actual !== 'object' || typeof expected !== 'object') {
+  if (typeof actual !== 'object') {
+    return typeof actual === 'number' && Number.isNaN(actual) &&
+      Number.isNaN(expected);
+  }
+  if (typeof expected !== 'object' || actual === null || expected === null) {
     return false;
   }
   const actualTag = objectToString(actual);

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -466,6 +466,7 @@ assertOnlyDeepEqual(
   assertDeepAndStrictEqual(m3, m4);
 }
 
+// Handle sparse arrays
 assertDeepAndStrictEqual([1, , , 3], [1, , , 3]);
 assertOnlyDeepEqual([1, , , 3], [1, , , 3, , , ]);
 
@@ -480,5 +481,12 @@ assertOnlyDeepEqual([1, , , 3], [1, , , 3, , , ]);
   // Date and any object that has the same keys but not the same prototype.
   assertOnlyDeepEqual(err1, {}, assert.AssertionError);
 }
+
+// Handle NaN
+assert.throws(() => { assert.deepEqual(NaN, NaN); }, assert.AssertionError);
+assert.doesNotThrow(() => { assert.deepStrictEqual(NaN, NaN); });
+assert.doesNotThrow(() => { assert.deepStrictEqual({ a: NaN }, { a: NaN }); });
+assert.doesNotThrow(
+  () => { assert.deepStrictEqual([ 1, 2, NaN, 4 ], [ 1, 2, NaN, 4 ]); });
 
 /* eslint-enable */


### PR DESCRIPTION
I think it makes sense to further improve assert a bit and to accept NaN as well. 

I also fixed the documentation a bit by adding missing changelogs to the assert docs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert, doc