### PR TITLE
test: add a test for Expect & checkExpectation

### DIFF
--- a/test/parallel/test-http2-compat-expect-handling.js
+++ b/test/parallel/test-http2-compat-expect-handling.js
@@ -1,0 +1,46 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const expectValue = 'meoww';
+
+const server = http2.createServer(common.mustNotCall());
+
+server.once('checkExpectation', common.mustCall((req, res) => {
+  assert.strictEqual(req.headers['expect'], expectValue);
+  res.statusCode = 417;
+  res.end();
+}));
+
+server.listen(0, common.mustCall(() => nextTest(2)));
+
+function nextTest(testsToRun) {
+  if (!testsToRun) {
+    return server.close();
+  }
+
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({
+    ':path': '/',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`,
+    expect: expectValue
+  });
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 417);
+    req.resume();
+  }));
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    nextTest(testsToRun - 1);
+  }));
+}


### PR DESCRIPTION
New test case for Expect header & checkExpectation event, based on the existing http test case with structural tweaks to make it a bit easier to follow. Part of increasing http2 code coverage as per https://github.com/nodejs/node/issues/14985

Let me know if I should change anything!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test