### PR TITLE
crypto: remove useless if statement

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -191,8 +191,6 @@ ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
 ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
   var f;
   if (format) {
-    if (typeof format === 'number')
-      f = format;
     if (format === 'compressed')
       f = POINT_CONVERSION_COMPRESSED;
     else if (format === 'hybrid')


### PR DESCRIPTION
The if statement in `ECDH.getPublicKey` is useless. This change is to remove it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto