### PR TITLE
module: refine for check index module

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -159,6 +159,35 @@ function tryExtensions(p, exts, isMain) {
   return false;
 }
 
+// 'index.' character codes
+var indexChars = [ 105, 110, 100, 101, 120, 46 ];
+var indexLen = indexChars.length;
+
+function isIndexModule(base) {
+  if (base.length > indexLen) {
+    var i = 0;
+    for (; i < indexLen; ++i) {
+      if (indexChars[i] !== base.charCodeAt(i))
+        break;
+    }
+    if (i === indexLen) {
+      // We matched 'index.', let's validate the rest
+      for (; i < base.length; ++i) {
+        const code = base.charCodeAt(i);
+        if (code !== 95/*_*/ &&
+            (code < 48/*0*/ || code > 57/*9*/) &&
+            (code < 65/*A*/ || code > 90/*Z*/) &&
+            (code < 97/*a*/ || code > 122/*z*/))
+          break;
+      }
+      if (i === base.length) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 var warned = false;
 Module._findPath = function(request, paths, isMain) {
   if (path.isAbsolute(request)) {
@@ -325,9 +354,6 @@ if (process.platform === 'win32') {
 }
 
 
-// 'index.' character codes
-var indexChars = [ 105, 110, 100, 101, 120, 46 ];
-var indexLen = indexChars.length;
 Module._resolveLookupPaths = function(request, parent, newReturn) {
   if (NativeModule.nonInternalExists(request)) {
     debug('looking for %j in []', request);
@@ -375,38 +401,8 @@ Module._resolveLookupPaths = function(request, parent, newReturn) {
   // We can assume the parent has a valid extension,
   // as it already has been accepted as a module.
   const base = path.basename(parent.filename);
-  var parentIdPath;
-  if (base.length > indexLen) {
-    var i = 0;
-    for (; i < indexLen; ++i) {
-      if (indexChars[i] !== base.charCodeAt(i))
-        break;
-    }
-    if (i === indexLen) {
-      // We matched 'index.', let's validate the rest
-      for (; i < base.length; ++i) {
-        const code = base.charCodeAt(i);
-        if (code !== 95/*_*/ &&
-            (code < 48/*0*/ || code > 57/*9*/) &&
-            (code < 65/*A*/ || code > 90/*Z*/) &&
-            (code < 97/*a*/ || code > 122/*z*/))
-          break;
-      }
-      if (i === base.length) {
-        // Is an index module
-        parentIdPath = parent.id;
-      } else {
-        // Not an index module
-        parentIdPath = path.dirname(parent.id);
-      }
-    } else {
-      // Not an index module
-      parentIdPath = path.dirname(parent.id);
-    }
-  } else {
-    // Not an index module
-    parentIdPath = path.dirname(parent.id);
-  }
+  const parentIdPath =
+    isIndexModule(base) ? parent.id : path.dirname(parent.id);
   var id = path.resolve(parentIdPath, request);
 
   // make sure require('./path') and require('path') get distinct ids, even


### PR DESCRIPTION
The isIndexModule logic reduces the readability of
Module._resolveLookupPaths method.

Move the index module check out of Module._resolveLookupPaths.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
module