### PR TITLE
test: add http2 test for method CONNECT

### DIFF
--- a/test/parallel/test-http2-compat-method-connect.js
+++ b/test/parallel/test-http2-compat-method-connect.js
@@ -1,0 +1,41 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer(common.mustNotCall());
+
+server.listen(0, common.mustCall(() => testMethodConnect(2)));
+
+server.once('connect', common.mustCall((req, res) => {
+  assert.strictEqual(req.headers[':method'], 'CONNECT');
+  res.statusCode = 405;
+  res.end();
+}));
+
+function testMethodConnect(testsToRun) {
+  if (!testsToRun) {
+    return server.close();
+  }
+
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({
+    ':method': 'CONNECT',
+    ':authority': `localhost:${port}`
+  });
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[':status'], 405);
+  }));
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    testMethodConnect(testsToRun - 1);
+  }));
+  req.end();
+}


### PR DESCRIPTION
Adds test case for default handling of method CONNECT, as well as the ability to bind a connect listener and handle the request. Part of the request for increased code coverage for http2, as per https://github.com/nodejs/node/issues/14985

Let me know if I can change anything. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test