### PR TITLE
test: run 'abort' suite on Windows

### DIFF
--- a/test/abort/test-process-abort-exitcode.js
+++ b/test/abort/test-process-abort-exitcode.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'child') {
   const child = spawn(process.execPath, [__filename, 'child']);
   child.on('exit', common.mustCall((code, signal) => {
     if (common.isWindows) {
-      assert.strictEqual(code, 3);
+      assert.strictEqual(code, 134);
       assert.strictEqual(signal, null);
     } else {
       assert.strictEqual(code, null);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,7 +44,7 @@ set enable_static=
 set build_addons_napi=
 set test_node_inspect=
 set test_check_deopts=
-set js_test_suites=async-hooks inspector known_issues message parallel sequential
+set js_test_suites=abort async-hooks inspector known_issues message parallel sequential
 set v8_test_options=
 set v8_build_options=
 set "common_test_suites=%js_test_suites% doctool addons addons-napi&set build_addons=1&set build_addons_napi=1"


### PR DESCRIPTION
* ~For now a C++ `node::Abort()` failure exits with code 3 on Windows~

Fixes: https://github.com/nodejs/node/issues/14012
Refs: https://github.com/nodejs/node/pull/14013

CI: https://ci.nodejs.org/job/node-test-commit/12055/

/cc @nodejs/platform-windows @nodejs/testing 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test,process
