### PR TITLE
test: fix flaky test-readline-interface

### DIFF
--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -291,30 +291,6 @@ function isWarned(emitter) {
     }), delay * 2);
   }
 
-  // Emit one line events when the delay between \r and \n is
-  // over the default crlfDelay but within the setting value
-  {
-    const fi = new FakeInput();
-    const delay = 125;
-    const crlfDelay = common.platformTimeout(1000);
-    const rli = new readline.Interface({
-      input: fi,
-      output: fi,
-      terminal: terminal,
-      crlfDelay
-    });
-    let callCount = 0;
-    rli.on('line', function(line) {
-      callCount++;
-    });
-    fi.emit('data', '\r');
-    setTimeout(common.mustCall(() => {
-      fi.emit('data', '\n');
-      assert.strictEqual(callCount, 1);
-      rli.close();
-    }), delay);
-  }
-
   // set crlfDelay to `Infinity` is allowed
   {
     const fi = new FakeInput();

--- a/test/sequential/test-readline-interface.js
+++ b/test/sequential/test-readline-interface.js
@@ -21,7 +21,7 @@
 
 // Flags: --expose_internals
 'use strict';
-require('../common');
+const common = require('../common');
 
 // These test cases are in `sequential` rather than the analogous test file in
 // `parallel` because they become unrelaible under load. The unreliability under
@@ -82,5 +82,29 @@ FakeInput.prototype.end = () => {};
     });
     assert.strictEqual(callCount, expectedLines.length);
     rli.close();
+  }
+
+  // Emit one line event when the delay between \r and \n is
+  // over the default crlfDelay but within the setting value.
+  {
+    const fi = new FakeInput();
+    const delay = 125;
+    const crlfDelay = common.platformTimeout(1000);
+    const rli = new readline.Interface({
+      input: fi,
+      output: fi,
+      terminal: terminal,
+      crlfDelay
+    });
+    let callCount = 0;
+    rli.on('line', function(line) {
+      callCount++;
+    });
+    fi.emit('data', '\r');
+    setTimeout(common.mustCall(() => {
+      fi.emit('data', '\n');
+      assert.strictEqual(callCount, 1);
+      rli.close();
+    }), delay);
   }
 });


### PR DESCRIPTION
Move test reliant on timer triggering in a timely fahion from parallel
to sequential. The test can fail under high load when the timer is
triggered too late and the `\r` and `\n` are treated as separate lines.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test readline