### PR TITLE
test: do not write fixture in test-require-symlink

### DIFF
--- a/test/fixtures/module-require-symlink/symlinked.js
+++ b/test/fixtures/module-require-symlink/symlinked.js
@@ -1,11 +1,12 @@
 'use strict';
 const assert = require('assert');
-const foo = require('./foo');
-const fixtures = require('../../common/fixtures');
+const path = require('path');
 
-const linkScriptTarget = fixtures.path('module-require-symlink', 'symlinked.js');
+const foo = require('./foo');
+
+const linkScriptEnding = path.join('module-require-symlink', 'symlinked.js');
 
 assert.strictEqual(foo.dep1.bar.version, 'CORRECT_VERSION');
 assert.strictEqual(foo.dep2.bar.version, 'CORRECT_VERSION');
-assert.strictEqual(__filename, linkScriptTarget);
+assert(__filename.endsWith(linkScriptEnding));
 assert(__filename in require.cache);


### PR DESCRIPTION
test-require-symlink modifies the fixture directory by adding a symlink.
Copy the fixture to the test tmpdir instead of modifying the fixture
directory.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test module