### PR TITLE
timers: fix eventloop block

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -227,7 +227,7 @@ function listOnTimeout() {
     if (diff < msecs) {
       var timeRemaining = msecs - (TimerWrap.now() - timer._idleStart);
       if (timeRemaining < 0) {
-        timeRemaining = 0;
+        timeRemaining = 1;
       }
       this.start(timeRemaining);
       debug('%d list wait because diff is %d', msecs, diff);

--- a/test/sequential/test-timers-block-eventloop.js
+++ b/test/sequential/test-timers-block-eventloop.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+const t1 = setInterval(() => {
+  common.busyLoop(12);
+}, 10);
+
+const t2 = setInterval(() => {
+  common.busyLoop(15);
+}, 10);
+
+const t3 = setTimeout(common.mustNotCall('eventloop blocked!'), 100);
+
+setTimeout(function() {
+  fs.stat('./nonexistent.txt', (err, stats) => {
+    clearInterval(t1);
+    clearInterval(t2);
+    clearTimeout(t3);
+  });
+}, 50);


### PR DESCRIPTION
When there are at least 2 timers set by setInterval whose callback
execution are longer than interval, the eventloop will be blocked.

This commit fix the above bug.

Fixes: https://github.com/nodejs/node/issues/15068

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
