### PR TITLE
test: increase Http2ServerResponse test coverage

### DIFF
--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -1,0 +1,91 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// Check that destroying the Http2ServerResponse stream produces
+// the expected result, including the ability to throw an error
+// which is emitted on server.streamError
+
+const errors = [
+  'test-error',
+  Error('test')
+];
+let nextError;
+
+const server = http2.createServer(common.mustCall((req, res) => {
+  req.once('error', common.mustNotCall());
+  req.once('error', common.mustNotCall());
+
+  res.on('finish', common.mustCall(() => {
+    assert.doesNotThrow(() => res.destroy(nextError));
+    assert.strictEqual(res.closed, true);
+  }));
+
+  if (req.path !== '/') {
+    nextError = errors.shift();
+  }
+  res.destroy(nextError);
+}, 3));
+
+server.on(
+  'streamError',
+  common.mustCall((err) => assert.strictEqual(err, nextError), 2)
+);
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({
+    ':path': '/',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+
+  req.on('response', common.mustNotCall());
+  req.on('error', common.mustNotCall());
+  req.on('end', common.mustCall());
+
+  req.resume();
+  req.end();
+
+  const req2 = client.request({
+    ':path': '/error',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+
+  req2.on('response', common.mustNotCall());
+  req2.on('error', common.mustNotCall());
+  req2.on('end', common.mustCall());
+
+  req2.resume();
+  req2.end();
+
+  const req3 = client.request({
+    ':path': '/error',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+
+  req3.on('response', common.mustNotCall());
+  req3.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    type: Error,
+    message: 'Stream closed with error code 2'
+  }));
+  req3.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+
+  req3.resume();
+  req3.end();
+}));

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -18,8 +18,8 @@ const errors = [
 let nextError;
 
 const server = http2.createServer(common.mustCall((req, res) => {
-  req.once('error', common.mustNotCall());
-  req.once('error', common.mustNotCall());
+  req.on('error', common.mustNotCall());
+  res.on('error', common.mustNotCall());
 
   res.on('finish', common.mustCall(() => {
     assert.doesNotThrow(() => res.destroy(nextError));

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -18,10 +18,12 @@ const {
   // Http2ServerResponse.end callback is called only the first time,
   // but may be invoked repeatedly without throwing errors.
   const server = createServer(mustCall((request, response) => {
+    strictEqual(response.closed, false);
     response.end(mustCall(() => {
       server.close();
     }));
     response.end(mustNotCall());
+    strictEqual(response.closed, true);
   }));
   server.listen(0, mustCall(() => {
     const { port } = server.address();

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -15,8 +15,11 @@ const server = h2.createServer();
 server.listen(0, common.mustCall(function() {
   const port = server.address().port;
   server.once('request', common.mustCall(function(request, response) {
+    assert.strictEqual(response.headersSent, false);
     response.flushHeaders();
+    assert.strictEqual(response.headersSent, true);
     response.flushHeaders(); // Idempotent
+
     common.expectsError(() => {
       response.writeHead(400, { 'foo-bar': 'abc123' });
     }, {

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -80,6 +80,10 @@ server.listen(0, common.mustCall(function() {
     response.getHeaders()[fake] = fake;
     assert.strictEqual(response.hasHeader(fake), false);
 
+    assert.strictEqual(response.sendDate, true);
+    response.sendDate = false;
+    assert.strictEqual(response.sendDate, false);
+
     response.on('finish', common.mustCall(function() {
       server.close();
     }));


### PR DESCRIPTION
A few bundled changes, all for Http2ServerResponse, that are too small for separate PRs:

- Modified existing header tests for Http2ServerResponse to include `sendDate` (get and set) and `headersSent`
- Expanded existing test for `end` to include a check for `closed`
- New test for `destroy`

Refs: https://github.com/nodejs/node/issues/14985

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test