### PR TITLE
http2: correct emit error in onConnect, full tests

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -461,7 +461,7 @@ function requestOnConnect(headers, options) {
       break;
     case NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE:
       err = new errors.Error('ERR_HTTP2_OUT_OF_STREAMS');
-      process.nextTick(() => this.emit('error', err));
+      process.nextTick(() => session.emit('error', err));
       break;
     case NGHTTP2_ERR_INVALID_ARGUMENT:
       err = new errors.Error('ERR_HTTP2_STREAM_SELF_DEPENDENCY');

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -1,0 +1,124 @@
+// Flags: --expose-http2
+'use strict';
+
+const {
+  constants,
+  Http2Session,
+  nghttp2ErrorString
+} = process.binding('http2');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// tests error handling within requestOnConnect
+// - NGHTTP2_ERR_NOMEM (should emit session error)
+// - NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE (should emit session error)
+// - NGHTTP2_ERR_INVALID_ARGUMENT (should emit stream error)
+// - every other NGHTTP2 error from binding (should emit session error)
+
+const specificTestKeys = [
+  'NGHTTP2_ERR_NOMEM',
+  'NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE',
+  'NGHTTP2_ERR_INVALID_ARGUMENT'
+];
+
+const specificTests = [
+  {
+    ngError: constants.NGHTTP2_ERR_NOMEM,
+    error: {
+      code: 'ERR_OUTOFMEMORY',
+      type: Error,
+      message: 'Out of memory'
+    },
+    type: 'session'
+  },
+  {
+    ngError: constants.NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE,
+    error: {
+      code: 'ERR_HTTP2_OUT_OF_STREAMS',
+      type: Error,
+      message: 'No stream ID is available because ' +
+               'maximum stream ID has been reached'
+    },
+    type: 'session'
+  },
+  {
+    ngError: constants.NGHTTP2_ERR_INVALID_ARGUMENT,
+    error: {
+      code: 'ERR_HTTP2_STREAM_SELF_DEPENDENCY',
+      type: Error,
+      message: 'A stream cannot depend on itself'
+    },
+    type: 'stream'
+  },
+];
+
+const genericTests = Object.getOwnPropertyNames(constants)
+  .filter((key) => (
+    key.indexOf('NGHTTP2_ERR') === 0 && specificTestKeys.indexOf(key) < 0
+  ))
+  .map((key) => ({
+    ngError: constants[key],
+    error: {
+      code: 'ERR_HTTP2_ERROR',
+      type: Error,
+      message: nghttp2ErrorString(constants[key])
+    },
+    type: 'session'
+  }));
+
+const tests = specificTests.concat(genericTests);
+
+let currentError;
+
+// mock submitRequest because we only care about testing error handling
+Http2Session.prototype.submitRequest = () => currentError;
+
+const server = http2.createServer(common.mustNotCall());
+
+server.listen(0, common.mustCall(() => runTest(tests.shift())));
+
+function runTest(test) {
+  const port = server.address().port;
+  const url = `http://localhost:${port}`;
+  const headers = {
+    ':path': '/',
+    ':method': 'POST',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  };
+
+  const client = http2.connect(url);
+  const req = client.request(headers);
+
+  currentError = test.ngError;
+  req.resume();
+  req.end();
+
+  const errorMustCall = common.expectsError(test.error);
+  const errorMustNotCall = common.mustNotCall(
+    `${test.error.code} should emit on ${test.type}`
+  );
+
+  if (test.type === 'stream') {
+    client.on('error', errorMustNotCall);
+    req.on('error', errorMustCall);
+    req.on('error', common.mustCall(() => {
+      client.destroy();
+    }));
+  } else {
+    client.on('error', errorMustCall);
+    req.on('error', errorMustNotCall);
+  }
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+
+    if (!tests.length) {
+      server.close();
+    } else {
+      runTest(tests.shift());
+    }
+  }));
+}


### PR DESCRIPTION
Minor correction in `requestOnConnect` to emit session error on `NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE` rather than stream error. Mostly this is about adding a full test suite for the error handling within requestOnConnect.

The test cases are a bit complicated as I felt like it was important to actually test all available errors, in case someone ever goes in and expands the switch statement to handle any other specific errors (or removes one of the currently handled ones). This way it avoids any accidental regressions where errors start emitting somewhere different than expected.

I also have a version of this for `pushStream` that I'll adjust based on feedback here and then create a PR. (It's also emitting stream error on `NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE`.)

(I tried to find if there was any convention for mocking functions but it seemed like this is how it was done elsewhere.)

Let me know if there's anything I can adjust. Thanks!

Refs: https://github.com/nodejs/node/issues/14985

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test