### PR TITLE
Alphabetize error list

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1,3 +1,5 @@
+/* eslint-enable alphabetize-errors */
+
 'use strict';
 
 // The whole point behind this internal module is to allow Node.js to no

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -112,18 +112,18 @@ E('ERR_CONSOLE_WRITABLE_STREAM',
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
 E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
   `c-ares failed to set servers: "${err}" [${servers}]`);
-E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
-E('ERR_ENCODING_NOT_SUPPORTED',
-  (enc) => `The "${enc}" encoding is not supported`);
 E('ERR_ENCODING_INVALID_ENCODED_DATA',
   (enc) => `The encoded data was not valid for encoding ${enc}`);
+E('ERR_ENCODING_NOT_SUPPORTED',
+  (enc) => `The "${enc}" encoding is not supported`);
+E('ERR_FALSY_VALUE_REJECTION', 'Promise was rejected with falsy value');
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot %s headers after they are sent to the client');
-E('ERR_HTTP_TRAILER_INVALID',
-  'Trailers are invalid with this transfer encoding');
 E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
 E('ERR_HTTP_INVALID_STATUS_CODE',
   (originalStatusCode) => `Invalid status code: ${originalStatusCode}`);
+E('ERR_HTTP_TRAILER_INVALID',
+  'Trailers are invalid with this transfer encoding');
 E('ERR_HTTP2_CONNECT_AUTHORITY',
   ':authority header is required for CONNECT requests');
 E('ERR_HTTP2_CONNECT_PATH',
@@ -142,10 +142,10 @@ E('ERR_HTTP2_HEADER_REQUIRED',
   (name) => `The ${name} header is required`);
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
   (name) => `Header field "${name}" must have only a single value`);
-E('ERR_HTTP2_HEADERS_OBJECT', 'Headers must be an object');
-E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
   'Cannot specify additional headers after response initiated');
+E('ERR_HTTP2_HEADERS_OBJECT', 'Headers must be an object');
+E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
 E('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND',
   'Cannot send informational headers after the HTTP message has been sent');
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
@@ -160,24 +160,24 @@ E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
 E('ERR_HTTP2_INVALID_PSEUDOHEADER',
   (name) => `"${name}" is an invalid pseudoheader or is used incorrectly`);
 E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed');
-E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed');
 E('ERR_HTTP2_INVALID_SETTING_VALUE',
   (name, value) => `Invalid value for setting "${name}": ${value}`);
+E('ERR_HTTP2_INVALID_STREAM', 'The stream has been destroyed');
 E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
   (max) => `Maximum number of pending settings acknowledgements (${max})`);
-E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
-  (code) => `Responses with ${code} status must not have a payload`);
 E('ERR_HTTP2_OUT_OF_STREAMS',
   'No stream ID is available because maximum stream ID has been reached');
+E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
+  (code) => `Responses with ${code} status must not have a payload`);
 E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
 E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
-E('ERR_HTTP2_STATUS_INVALID',
-  (code) => `Invalid status code: ${code}`);
 E('ERR_HTTP2_STATUS_101',
   'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2');
+E('ERR_HTTP2_STATUS_INVALID',
+  (code) => `Invalid status code: ${code}`);
 E('ERR_HTTP2_STREAM_CLOSED', 'The stream is already closed');
 E('ERR_HTTP2_STREAM_ERROR',
   (code) => `Stream closed with error code ${code}`);
@@ -211,6 +211,7 @@ E('ERR_INVALID_OPT_VALUE',
   });
 E('ERR_INVALID_OPT_VALUE_ENCODING',
   (value) => `The value "${String(value)}" is invalid for option "encoding"`);
+E('ERR_INVALID_PERFORMANCE_MARK', 'The "%s" performance mark has not been set');
 E('ERR_INVALID_PROTOCOL', (protocol, expectedProtocol) =>
   `Protocol "${protocol}" not supported. Expected "${expectedProtocol}"`);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
@@ -234,8 +235,8 @@ E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
 E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
+E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
-E('ERR_INVALID_PERFORMANCE_MARK', 'The "%s" performance mark has not been set');
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
 E('ERR_SOCKET_BAD_TYPE',
@@ -243,7 +244,6 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_CLOSED', 'Socket is closed');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
-E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_STDERR_CLOSE', 'process.stderr cannot be closed');
 E('ERR_STDOUT_CLOSE', 'process.stdout cannot be closed');
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode');

--- a/tools/eslint-rules/alphabetize-errors.js
+++ b/tools/eslint-rules/alphabetize-errors.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const message = 'Errors in lib/internal/errors.js must be alphabetized';
+
+function errorForNode(node) {
+  return node.expression.arguments[0].value;
+}
+
+function isAlphabetized(previousNode, node) {
+  return errorForNode(previousNode).localeCompare(errorForNode(node)) < 0;
+}
+
+function isDefiningError(node) {
+  return node.expression &&
+         node.expression.type === 'CallExpression' &&
+         node.expression.callee &&
+         node.expression.callee.name === 'E';
+}
+
+module.exports = {
+  create: function(context) {
+    var previousNode;
+
+    return {
+      ExpressionStatement: function(node) {
+        if (isDefiningError(node)) {
+          if (previousNode && !isAlphabetized(previousNode, node)) {
+            context.report({ node: node, message: message });
+          }
+
+          previousNode = node;
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
Includes a new ESLint rule to make sure the list doesn't become un-alphabetized again :)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

errors, tools
