### PR TITLE
url: remove unused code from autoEscapeStr

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -536,6 +536,9 @@ function autoEscapeStr(rest) {
         break;
     }
   }
+  if (lastEscapedPos === 0)  // Nothing has been escaped.
+    return rest;
+
   // There are ordinary characters at the end.
   if (lastEscapedPos < rest.length)
     escaped += rest.slice(lastEscapedPos);

--- a/lib/url.js
+++ b/lib/url.js
@@ -360,9 +360,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     // First, make 100% sure that any "autoEscape" chars get
     // escaped, even if encodeURIComponent doesn't think they
     // need to be.
-    const result = autoEscapeStr(rest);
-    if (result !== undefined)
-      rest = result;
+    rest = autoEscapeStr(rest);
   }
 
   var questionIdx = -1;
@@ -443,8 +441,7 @@ function validateHostname(self, rest, hostname) {
 
 // Automatically escape all delimiters and unwise characters from RFC 2396.
 // Also escape single quotes in case of an XSS attack.
-// Return undefined if the string doesn't need escaping,
-// otherwise return the escaped string.
+// Return the escaped string.
 function autoEscapeStr(rest) {
   var escaped = '';
   var lastEscapedPos = 0;
@@ -539,13 +536,11 @@ function autoEscapeStr(rest) {
         break;
     }
   }
-  if (lastEscapedPos === 0)  // Nothing has been escaped.
-    return;
   // There are ordinary characters at the end.
   if (lastEscapedPos < rest.length)
-    return escaped + rest.slice(lastEscapedPos);
-  else  // The last character is escaped.
-    return escaped;
+    escaped += rest.slice(lastEscapedPos);
+
+  return escaped;
 }
 
 // format a parsed object into a url string


### PR DESCRIPTION
autoEscapeStr returned undefined when no character are escaped but this
behaviour seems useless when used into the parse function

Tests are OK on Mac, untested on Windows yet