### PR TITLE
n-api: refactor napi_addon_register_func

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -873,7 +873,7 @@ JavaScript Object associated with the `napi_ref`. Otherise, result
 will be NULL.
 
 ## Module registration
-N-API modules are registered in the same manner as other modules
+N-API modules are registered in a manner similar to other modules
 except that instead of using the `NODE_MODULE` macro the following
 is used:
 
@@ -885,32 +885,39 @@ The next difference is the signature for the `Init` method. For a N-API
 module it is as follows:
 
 ```C
-void Init(napi_env env, napi_value exports, napi_value module, void* priv);
+napi_value Init(napi_env env, napi_value exports);
 ```
 
-As with any other module, functions are exported by either adding them to
-the `exports` or `module` objects passed to the `Init` method.
+The return value from `Init` is treated as the `exports` object for the module.
+The `Init` method is passed an empty object via the `exports` parameter as a
+convenience. If `Init` returns NULL, the parameter passed as `exports` is
+exported by the module. N-API modules cannot modify the `module` object but can
+specify anything as the `exports` property of the module.
 
 For example, to add the method `hello` as a function so that it can be called
 as a method provided by the addon:
 
 ```C
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor desc =
     {"hello", Method, 0, 0, 0, napi_default, 0};
+  if (status != napi_ok) return nullptr;
   status = napi_define_properties(env, exports, 1, &desc);
+  if (status != napi_ok) return nullptr;
+  return exports;
 }
 ```
 
 For example, to set a function to be returned by the `require()` for the addon:
 
 ```C
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value method;
   napi_status status;
-  napi_property_descriptor desc =
-    {"exports", Method, 0, 0, 0, napi_default, 0};
-  status = napi_define_properties(env, module, 1, &desc);
+  status = napi_create_function(env, "exports", Method, NULL, &method));
+  if (status != napi_ok) return nullptr;
+  return method;
 }
 ```
 
@@ -919,28 +926,30 @@ For example, to define a class so that new instances can be created
 
 ```C
 // NOTE: partial example, not all referenced code is included
-
-napi_status status;
-napi_property_descriptor properties[] = {
+napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
+  napi_property_descriptor properties[] = {
     { "value", nullptr, GetValue, SetValue, 0, napi_default, 0 },
     DECLARE_NAPI_METHOD("plusOne", PlusOne),
     DECLARE_NAPI_METHOD("multiply", Multiply),
-};
+  };
 
-napi_value cons;
-status =
-    napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons);
-if (status != napi_ok) return;
+  napi_value cons;
+  status =
+      napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons);
+  if (status != napi_ok) return nullptr;
 
-status = napi_create_reference(env, cons, 1, &constructor);
-if (status != napi_ok) return;
+  status = napi_create_reference(env, cons, 1, &constructor);
+  if (status != napi_ok) return nullptr;
 
-status = napi_set_named_property(env, exports, "MyObject", cons);
-if (status != napi_ok) return;
+  status = napi_set_named_property(env, exports, "MyObject", cons);
+  if (status != napi_ok) return nullptr;
+
+  return exports;
+}
 ```
 
-For more details on setting properties on either the `exports` or `module`
-objects, see the section on
+For more details on setting properties on objects, see the section on
 [Working with JavaScript Properties][].
 
 For more details on building addon modules in general, refer to the existing API

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -824,11 +824,17 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
   // one is found.
   napi_env env = v8impl::GetEnv(context);
 
-  mod->nm_register_func(
-    env,
-    v8impl::JsValueFromV8LocalValue(exports),
-    v8impl::JsValueFromV8LocalValue(module),
-    mod->nm_priv);
+  napi_value _exports =
+      mod->nm_register_func(env, v8impl::JsValueFromV8LocalValue(exports));
+
+  // If register function returned a non-null exports object different from
+  // the exports object we passed it, set that as the "exports" property of
+  // the module.
+  if (_exports != nullptr &&
+      _exports != v8impl::JsValueFromV8LocalValue(exports)) {
+    napi_value _module = v8impl::JsValueFromV8LocalValue(module);
+    napi_set_named_property(env, _module, "exports", _exports);
+  }
 }
 
 }  // end of anonymous namespace

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -44,10 +44,8 @@
 #endif
 
 
-typedef void (*napi_addon_register_func)(napi_env env,
-                                         napi_value exports,
-                                         napi_value module,
-                                         void* priv);
+typedef napi_value (*napi_addon_register_func)(napi_env env,
+                                               napi_value exports);
 
 typedef struct {
   int nm_version;

--- a/test/addons-napi/1_hello_world/binding.c
+++ b/test/addons-napi/1_hello_world/binding.c
@@ -10,9 +10,10 @@ napi_value Method(napi_env env, napi_callback_info info) {
   return world;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("hello", Method);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 1, &desc));
+  NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/2_function_arguments/binding.c
+++ b/test/addons-napi/2_function_arguments/binding.c
@@ -15,7 +15,7 @@ napi_value Add(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype0 == napi_number && valuetype1 == napi_number,
-    "Wrong argument type. Numbers expected.");
+      "Wrong argument type. Numbers expected.");
 
   double value0;
   NAPI_CALL(env, napi_get_value_double(env, args[0], &value0));
@@ -29,9 +29,10 @@ napi_value Add(napi_env env, napi_callback_info info) {
   return sum;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor desc = DECLARE_NAPI_PROPERTY("add", Add);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 1, &desc));
+  NAPI_CALL(env, napi_define_properties(env, exports, 1, &desc));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -8,17 +8,17 @@ napi_value RunCallback(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
 
   NAPI_ASSERT(env, argc == 1,
-    "Wrong number of arguments. Expects a single argument.");
+      "Wrong number of arguments. Expects a single argument.");
 
   napi_valuetype valuetype0;
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
   NAPI_ASSERT(env, valuetype0 == napi_function,
-    "Wrong type of arguments. Expects a function as first argument.");
+      "Wrong type of arguments. Expects a function as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
   NAPI_ASSERT(env, valuetype1 == napi_undefined,
-    "Additional arguments should be undefined.");
+      "Additional arguments should be undefined.");
 
   napi_value argv[1];
   const char* str = "hello world";
@@ -45,12 +45,13 @@ napi_value RunCallbackWithRecv(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor desc[2] = {
     DECLARE_NAPI_PROPERTY("RunCallback", RunCallback),
     DECLARE_NAPI_PROPERTY("RunCallbackWithRecv", RunCallbackWithRecv),
   };
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 2, desc));
+  NAPI_CALL(env, napi_define_properties(env, exports, 2, desc));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/4_object_factory/binding.c
+++ b/test/addons-napi/4_object_factory/binding.c
@@ -14,10 +14,10 @@ napi_value CreateObject(napi_env env, napi_callback_info info) {
   return obj;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
-  napi_property_descriptor desc =
-    DECLARE_NAPI_PROPERTY("exports", CreateObject);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
+napi_value Init(napi_env env, napi_value exports) {
+  NAPI_CALL(env,
+      napi_create_function(env, "exports", CreateObject, NULL, &exports));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/5_function_factory/binding.c
+++ b/test/addons-napi/5_function_factory/binding.c
@@ -11,15 +11,15 @@ napi_value MyFunction(napi_env env, napi_callback_info info) {
 napi_value CreateFunction(napi_env env, napi_callback_info info) {
   napi_value fn;
   NAPI_CALL(env,
-    napi_create_function(env, "theFunction", MyFunction, NULL, &fn));
+      napi_create_function(env, "theFunction", MyFunction, NULL, &fn));
 
   return fn;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
-  napi_property_descriptor desc =
-    DECLARE_NAPI_PROPERTY("exports", CreateFunction);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
+napi_value Init(napi_env env, napi_value exports) {
+  NAPI_CALL(env,
+      napi_create_function(env, "exports", CreateFunction, NULL, &exports));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/6_object_wrap/binding.cc
+++ b/test/addons-napi/6_object_wrap/binding.cc
@@ -1,7 +1,9 @@
 #include "myobject.h"
+#include "../common.h"
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   MyObject::Init(env, exports);
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/6_object_wrap/myobject.cc
+++ b/test/addons-napi/6_object_wrap/myobject.cc
@@ -23,12 +23,12 @@ void MyObject::Init(napi_env env, napi_value exports) {
 
   napi_value cons;
   NAPI_CALL_RETURN_VOID(env,
-    napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons));
+      napi_define_class(env, "MyObject", New, nullptr, 3, properties, &cons));
 
   NAPI_CALL_RETURN_VOID(env, napi_create_reference(env, cons, 1, &constructor));
 
   NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, exports, "MyObject", cons));
+      napi_set_named_property(env, exports, "MyObject", cons));
 }
 
 napi_value MyObject::New(napi_env env, napi_callback_info info) {
@@ -55,11 +55,11 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
 
     obj->env_ = env;
     NAPI_CALL(env, napi_wrap(env,
-                            _this,
-                            obj,
-                            MyObject::Destructor,
-                            nullptr,  // finalize_hint
-                            &obj->wrapper_));
+                             _this,
+                             obj,
+                             MyObject::Destructor,
+                             nullptr,  // finalize_hint
+                             &obj->wrapper_));
 
     return _this;
   }
@@ -80,7 +80,7 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
 napi_value MyObject::GetValue(napi_env env, napi_callback_info info) {
   napi_value _this;
   NAPI_CALL(env,
-    napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
+      napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
   NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));
@@ -108,7 +108,7 @@ napi_value MyObject::SetValue(napi_env env, napi_callback_info info) {
 napi_value MyObject::PlusOne(napi_env env, napi_callback_info info) {
   napi_value _this;
   NAPI_CALL(env,
-    napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
+      napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
   NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));

--- a/test/addons-napi/7_factory_wrap/binding.cc
+++ b/test/addons-napi/7_factory_wrap/binding.cc
@@ -12,12 +12,12 @@ napi_value CreateObject(napi_env env, napi_callback_info info) {
   return instance;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
-  NAPI_CALL_RETURN_VOID(env, MyObject::Init(env));
+napi_value Init(napi_env env, napi_value exports) {
+  NAPI_CALL(env, MyObject::Init(env));
 
-  napi_property_descriptor desc =
-    DECLARE_NAPI_PROPERTY("exports", CreateObject);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
+  NAPI_CALL(env,
+      napi_create_function(env, "exports", CreateObject, NULL, &exports));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/7_factory_wrap/myobject.cc
+++ b/test/addons-napi/7_factory_wrap/myobject.cc
@@ -50,11 +50,11 @@ napi_value MyObject::New(napi_env env, napi_callback_info info) {
 
   obj->env_ = env;
   NAPI_CALL(env, napi_wrap(env,
-                          _this,
-                          obj,
-                          MyObject::Destructor,
-                          nullptr, /* finalize_hint */
-                          &obj->wrapper_));
+                           _this,
+                           obj,
+                           MyObject::Destructor,
+                           nullptr, /* finalize_hint */
+                           &obj->wrapper_));
 
   return _this;
 }
@@ -80,7 +80,7 @@ napi_status MyObject::NewInstance(napi_env env,
 napi_value MyObject::PlusOne(napi_env env, napi_callback_info info) {
   napi_value _this;
   NAPI_CALL(env,
-    napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
+      napi_get_cb_info(env, info, nullptr, nullptr, &_this, nullptr));
 
   MyObject* obj;
   NAPI_CALL(env, napi_unwrap(env, _this, reinterpret_cast<void**>(&obj)));

--- a/test/addons-napi/8_passing_wrapped/binding.cc
+++ b/test/addons-napi/8_passing_wrapped/binding.cc
@@ -29,7 +29,7 @@ napi_value Add(napi_env env, napi_callback_info info) {
   return sum;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   MyObject::Init(env);
 
   napi_property_descriptor desc[] = {
@@ -37,8 +37,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("add", Add),
   };
 
-  NAPI_CALL_RETURN_VOID(env,
-    napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc));
+  NAPI_CALL(env,
+      napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -13,13 +13,13 @@ napi_value TestGetElement(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an array as first argument.");
+      "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_number,
-    "Wrong type of arguments. Expects an integer as second argument.");
+      "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
   int32_t index;
@@ -56,13 +56,13 @@ napi_value TestHasElement(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an array as first argument.");
+      "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_number,
-    "Wrong type of arguments. Expects an integer as second argument.");
+      "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
   int32_t index;
@@ -94,12 +94,12 @@ napi_value TestDeleteElement(napi_env env, napi_callback_info info) {
   napi_valuetype valuetype0;
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an array as first argument.");
+      "Wrong type of arguments. Expects an array as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
   NAPI_ASSERT(env, valuetype1 == napi_number,
-    "Wrong type of arguments. Expects an integer as second argument.");
+      "Wrong type of arguments. Expects an integer as second argument.");
 
   napi_value array = args[0];
   int32_t index;
@@ -130,7 +130,7 @@ napi_value New(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an array as first argument.");
+      "Wrong type of arguments. Expects an array as first argument.");
 
   napi_value ret;
   NAPI_CALL(env, napi_create_array(env, &ret));
@@ -158,7 +158,7 @@ napi_value NewWithLength(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_number,
-    "Wrong type of arguments. Expects an integer the first argument.");
+      "Wrong type of arguments. Expects an integer the first argument.");
 
   int32_t array_length;
   NAPI_CALL(env, napi_get_value_int32(env, args[0], &array_length));
@@ -169,7 +169,7 @@ napi_value NewWithLength(napi_env env, napi_callback_info info) {
   return ret;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("TestGetElement", TestGetElement),
     DECLARE_NAPI_PROPERTY("TestHasElement", TestHasElement),
@@ -178,8 +178,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("NewWithLength", NewWithLength),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_async/test_async.cc
+++ b/test/addons-napi/test_async/test_async.cc
@@ -55,13 +55,13 @@ void Complete(napi_env env, napi_status status, void* data) {
   NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, c->_output, &argv[1]));
   napi_value callback;
   NAPI_CALL_RETURN_VOID(env,
-    napi_get_reference_value(env, c->_callback, &callback));
+      napi_get_reference_value(env, c->_callback, &callback));
   napi_value global;
   NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
 
   napi_value result;
   NAPI_CALL_RETURN_VOID(env,
-    napi_make_callback(env, global, callback, 2, argv, &result));
+      napi_make_callback(env, global, callback, 2, argv, &result));
 
   NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
@@ -73,27 +73,27 @@ napi_value Test(napi_env env, napi_callback_info info) {
   napi_value _this;
   void* data;
   NAPI_CALL(env,
-    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+      napi_get_cb_info(env, info, &argc, argv, &_this, &data));
   NAPI_ASSERT(env, argc >= 2, "Not enough arguments, expected 2.");
 
   napi_valuetype t;
   NAPI_CALL(env, napi_typeof(env, argv[0], &t));
   NAPI_ASSERT(env, t == napi_number,
-    "Wrong first argument, integer expected.");
+      "Wrong first argument, integer expected.");
   NAPI_CALL(env, napi_typeof(env, argv[1], &t));
   NAPI_ASSERT(env, t == napi_function,
-    "Wrong second argument, function expected.");
+      "Wrong second argument, function expected.");
 
   the_carrier._output = 0;
 
   NAPI_CALL(env,
-    napi_get_value_int32(env, argv[0], &the_carrier._input));
+      napi_get_value_int32(env, argv[0], &the_carrier._input));
   NAPI_CALL(env,
-    napi_create_reference(env, argv[1], 1, &the_carrier._callback));
+      napi_create_reference(env, argv[1], 1, &the_carrier._callback));
   NAPI_CALL(env, napi_create_async_work(
-    env, Execute, Complete, &the_carrier, &the_carrier._request));
+      env, Execute, Complete, &the_carrier, &the_carrier._request));
   NAPI_CALL(env,
-    napi_queue_async_work(env, the_carrier._request));
+      napi_queue_async_work(env, the_carrier._request));
 
   return nullptr;
 }
@@ -111,12 +111,12 @@ void CancelComplete(napi_env env, napi_status status, void* data) {
     // indicate the cancel succeeded.
     napi_value callback;
     NAPI_CALL_RETURN_VOID(env,
-      napi_get_reference_value(env, c->_callback, &callback));
+        napi_get_reference_value(env, c->_callback, &callback));
     napi_value global;
     NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
     napi_value result;
     NAPI_CALL_RETURN_VOID(env,
-      napi_make_callback(env, global, callback, 0, nullptr, &result));
+        napi_make_callback(env, global, callback, 0, nullptr, &result));
   }
 
   NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
@@ -141,7 +141,7 @@ napi_value TestCancel(napi_env env, napi_callback_info info) {
   // able to start by using all the threads in the pool
   for (int i = 1; i < MAX_CANCEL_THREADS; i++) {
     NAPI_CALL(env, napi_create_async_work(env, CancelExecute,
-      BusyCancelComplete, &async_carrier[i], &async_carrier[i]._request));
+        BusyCancelComplete, &async_carrier[i], &async_carrier[i]._request));
     NAPI_CALL(env, napi_queue_async_work(env, async_carrier[i]._request));
   }
 
@@ -150,24 +150,26 @@ napi_value TestCancel(napi_env env, napi_callback_info info) {
   // we have prevented it from starting by consuming all of the
   // workers above.
   NAPI_CALL(env,
-    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+      napi_get_cb_info(env, info, &argc, argv, &_this, &data));
   NAPI_CALL(env, napi_create_async_work(env, CancelExecute,
-    CancelComplete, &async_carrier[0], &async_carrier[0]._request));
+      CancelComplete, &async_carrier[0], &async_carrier[0]._request));
   NAPI_CALL(env,
-    napi_create_reference(env, argv[0], 1, &async_carrier[0]._callback));
+      napi_create_reference(env, argv[0], 1, &async_carrier[0]._callback));
   NAPI_CALL(env, napi_queue_async_work(env, async_carrier[0]._request));
   NAPI_CALL(env, napi_cancel_async_work(env, async_carrier[0]._request));
   return nullptr;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
     DECLARE_NAPI_PROPERTY("TestCancel", TestCancel),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(properties) / sizeof(*properties), properties));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -62,7 +62,7 @@ napi_value getDeleterCallCount(napi_env env, napi_callback_info info) {
 napi_value copyBuffer(napi_env env, napi_callback_info info) {
   napi_value theBuffer;
   NAPI_CALL(env, napi_create_buffer_copy(
-    env, sizeof(theText), theText, NULL, &theBuffer));
+      env, sizeof(theText), theText, NULL, &theBuffer));
   return theBuffer;
 }
 
@@ -76,8 +76,8 @@ napi_value bufferHasInstance(napi_env env, napi_callback_info info) {
   napi_valuetype theType;
   NAPI_CALL(env, napi_typeof(env, theBuffer, &theType));
   NAPI_ASSERT(env,
-            theType == napi_object,
-            "bufferHasInstance: instance is not an object");
+              theType == napi_object,
+              "bufferHasInstance: instance is not an object");
   NAPI_CALL(env, napi_is_buffer(env, theBuffer, &hasInstance));
   NAPI_ASSERT(env, hasInstance, "bufferHasInstance: instance is not a buffer");
   napi_value returnValue;
@@ -101,8 +101,8 @@ napi_value bufferInfo(napi_env env, napi_callback_info info) {
                 (void**)(&bufferData),
                 &bufferLength));
   NAPI_CALL(env, napi_get_boolean(env,
-    !strcmp(bufferData, theText) && bufferLength == sizeof(theText),
-    &returnValue));
+      !strcmp(bufferData, theText) && bufferLength == sizeof(theText),
+      &returnValue));
   return returnValue;
 }
 
@@ -119,13 +119,12 @@ napi_value staticBuffer(napi_env env, napi_callback_info info) {
   return theBuffer;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value theValue;
 
-  NAPI_CALL_RETURN_VOID(env,
-    napi_create_string_utf8(env, theText, sizeof(theText), &theValue));
-  NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, exports, "theText", theValue));
+  NAPI_CALL(env,
+      napi_create_string_utf8(env, theText, sizeof(theText), &theValue));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "theText", theValue));
 
   napi_property_descriptor methods[] = {
     DECLARE_NAPI_PROPERTY("newBuffer", newBuffer),
@@ -137,8 +136,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("staticBuffer", staticBuffer),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(methods) / sizeof(methods[0]), methods));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(methods) / sizeof(methods[0]), methods));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -59,9 +59,9 @@ napi_value GetStaticValue(napi_env env, napi_callback_info info) {
 }
 
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value number;
-  NAPI_CALL_RETURN_VOID(env, napi_create_double(env, value_, &number));
+  NAPI_CALL(env, napi_create_double(env, value_, &number));
 
   napi_property_descriptor properties[] = {
     { "echo", 0, Echo, 0, 0, 0, napi_enumerable, 0 },
@@ -77,14 +77,12 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   };
 
   napi_value cons;
-  NAPI_CALL_RETURN_VOID(env, napi_define_class(env, "MyObject", New,
-    NULL, sizeof(properties)/sizeof(*properties), properties, &cons));
+  NAPI_CALL(env, napi_define_class(env, "MyObject", New,
+      NULL, sizeof(properties)/sizeof(*properties), properties, &cons));
 
-  NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, module, "exports", cons));
+  NAPI_CALL(env, napi_create_reference(env, cons, 1, &constructor_));
 
-  NAPI_CALL_RETURN_VOID(env,
-    napi_create_reference(env, cons, 1, &constructor_));
+  return cons;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -130,7 +130,7 @@ napi_value ToString(napi_env env, napi_callback_info info) {
   return output;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("asBool", AsBool),
     DECLARE_NAPI_PROPERTY("asInt32", AsInt32),
@@ -144,8 +144,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("toString", ToString),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_dataview/test_dataview.c
+++ b/test/addons-napi/test_dataview/test_dataview.c
@@ -37,13 +37,15 @@ napi_value CreateDataView(napi_env env, napi_callback_info info) {
   return output_dataview;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("CreateDataView", CreateDataView)
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+  NAPI_CALL(env, napi_define_properties(
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_env_sharing/compare_env.c
+++ b/test/addons-napi/test_env_sharing/compare_env.c
@@ -14,9 +14,9 @@ napi_value compare(napi_env env, napi_callback_info info) {
   return return_value;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* context) {
-  napi_property_descriptor prop = DECLARE_NAPI_PROPERTY("exports", compare);
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &prop));
+napi_value Init(napi_env env, napi_value exports) {
+  NAPI_CALL(env, napi_create_function(env, "exports", compare, NULL, &exports));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_env_sharing/store_env.c
+++ b/test/addons-napi/test_env_sharing/store_env.c
@@ -1,12 +1,10 @@
 #include <node_api.h>
 #include "../common.h"
 
-void Init(napi_env env, napi_value exports, napi_value module, void* context) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value external;
-  NAPI_CALL_RETURN_VOID(env,
-    napi_create_external(env, env, NULL, NULL, &external));
-  NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, module, "exports", external));
+  NAPI_CALL(env, napi_create_external(env, env, NULL, NULL, &external));
+  return external;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_error/test_error.cc
+++ b/test/addons-napi/test_error/test_error.cc
@@ -119,7 +119,7 @@ napi_value createTypeErrorCode(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("checkError", checkError),
     DECLARE_NAPI_PROPERTY("throwExistingError", throwExistingError),
@@ -137,8 +137,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("createTypeErrorCode", createTypeErrorCode),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_exception/test_exception.c
+++ b/test/addons-napi/test_exception/test_exception.c
@@ -45,15 +45,17 @@ napi_value wasPending(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("returnException", returnException),
     DECLARE_NAPI_PROPERTY("allowException", allowException),
     DECLARE_NAPI_PROPERTY("wasPending", wasPending),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_fatal/test_fatal.c
+++ b/test/addons-napi/test_fatal/test_fatal.c
@@ -6,13 +6,15 @@ napi_value Test(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
+  NAPI_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_function/test_function.c
+++ b/test/addons-napi/test_function/test_function.c
@@ -12,7 +12,7 @@ napi_value Test(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_function,
-    "Wrong type of arguments. Expects a function as first argument.");
+      "Wrong type of arguments. Expects a function as first argument.");
 
   napi_value* argv = args + 1;
   argc = argc - 1;
@@ -26,10 +26,11 @@ napi_value Test(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL_RETURN_VOID(env, napi_create_function(env, NULL, Test, NULL, &fn));
-  NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env, exports, "Test", fn));
+  NAPI_CALL(env, napi_create_function(env, NULL, Test, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "Test", fn));
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -92,9 +92,9 @@ napi_value createNapiError(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_get_last_error_info(env, &error_info));
 
   NAPI_ASSERT(env, error_info->error_code == status,
-    "Last error info code should match last status");
+      "Last error info code should match last status");
   NAPI_ASSERT(env, error_info->error_message,
-    "Last error info message should not be null");
+      "Last error info message should not be null");
 
   return NULL;
 }
@@ -224,7 +224,7 @@ napi_value testNapiRun(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("testStrictEquals", testStrictEquals),
     DECLARE_NAPI_PROPERTY("testGetPrototype", testGetPrototype),
@@ -245,8 +245,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("testAdjustExternalMemory", testAdjustExternalMemory)
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -54,19 +54,19 @@ napi_value NewScopeWithException(napi_env env, napi_callback_info info) {
 
   argc = 1;
   NAPI_CALL(env, napi_get_cb_info(
-    env, info, &argc, &exception_function, NULL, NULL));
+      env, info, &argc, &exception_function, NULL, NULL));
 
-	status = napi_call_function(
-    env, output, exception_function, 0, NULL, NULL);
+  status = napi_call_function(
+      env, output, exception_function, 0, NULL, NULL);
   NAPI_ASSERT(env, status == napi_pending_exception,
-    "Function should have thrown.");
+      "Function should have thrown.");
 
   // Closing a handle scope should still work while an exception is pending.
   NAPI_CALL(env, napi_close_handle_scope(env, scope));
   return NULL;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("NewScope", NewScope),
     DECLARE_NAPI_PROPERTY("NewScopeEscape", NewScopeEscape),
@@ -74,8 +74,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("NewScopeWithException", NewScopeWithException),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(properties) / sizeof(*properties), properties));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_make_callback/binding.cc
+++ b/test/addons-napi/test_make_callback/binding.cc
@@ -35,12 +35,11 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL_RETURN_VOID(env,
-    napi_create_function(env, NULL, MakeCallback, NULL, &fn));
-  NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, exports, "makeCallback", fn));
+  NAPI_CALL(env, napi_create_function(env, NULL, MakeCallback, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  return exports;
 }
 
 }  // namespace

--- a/test/addons-napi/test_make_callback_recurse/binding.cc
+++ b/test/addons-napi/test_make_callback_recurse/binding.cc
@@ -13,19 +13,17 @@ napi_value MakeCallback(napi_env env, napi_callback_info info) {
   napi_value func = args[1];
 
   napi_make_callback(env,
-    recv, func, 0 /* argc */, nullptr /* argv */, nullptr /* result */);
+      recv, func, 0 /* argc */, nullptr /* argv */, nullptr /* result */);
 
   return recv;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value fn;
-  NAPI_CALL_RETURN_VOID(env,
-    napi_create_function(env, NULL, MakeCallback, NULL, &fn));
-  NAPI_CALL_RETURN_VOID(env,
-    napi_set_named_property(env, exports, "makeCallback", fn));
+  NAPI_CALL(env, napi_create_function(env, NULL, MakeCallback, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  return exports;
 }
-
 
 }  // namespace
 

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -12,7 +12,7 @@ napi_value Test(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_number,
-    "Wrong type of arguments. Expects a number as first argument.");
+      "Wrong type of arguments. Expects a number as first argument.");
 
   double input;
   NAPI_CALL(env, napi_get_value_double(env, args[0], &input));
@@ -34,7 +34,7 @@ napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_number,
-    "Wrong type of arguments. Expects a number as first argument.");
+      "Wrong type of arguments. Expects a number as first argument.");
 
   int32_t input;
   NAPI_CALL(env, napi_get_value_int32(env, args[0], &input));
@@ -45,14 +45,16 @@ napi_value TestInt32Truncation(napi_env env, napi_callback_info info) {
   return output;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Test", Test),
     DECLARE_NAPI_PROPERTY("TestInt32Truncation", TestInt32Truncation),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_object/test_object.c
+++ b/test/addons-napi/test_object/test_object.c
@@ -16,13 +16,13 @@ napi_value Get(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
-    "Wrong type of arguments. Expects a string or symbol as second.");
+      "Wrong type of arguments. Expects a string or symbol as second.");
 
   napi_value object = args[0];
   napi_value output;
@@ -42,13 +42,13 @@ napi_value Set(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
-    "Wrong type of arguments. Expects a string or symbol as second.");
+      "Wrong type of arguments. Expects a string or symbol as second.");
 
   NAPI_CALL(env, napi_set_property(env, args[0], args[1], args[2]));
 
@@ -69,13 +69,13 @@ napi_value Has(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
-    "Wrong type of arguments. Expects a string or symbol as second.");
+      "Wrong type of arguments. Expects a string or symbol as second.");
 
   bool has_property;
   NAPI_CALL(env, napi_has_property(env, args[0], args[1], &has_property));
@@ -97,7 +97,7 @@ napi_value HasOwn(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   // napi_valuetype valuetype1;
   // NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
@@ -124,12 +124,12 @@ napi_value Delete(napi_env env, napi_callback_info info) {
   napi_valuetype valuetype0;
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
   NAPI_ASSERT(env, valuetype1 == napi_string || valuetype1 == napi_symbol,
-    "Wrong type of arguments. Expects a string or symbol as second.");
+      "Wrong type of arguments. Expects a string or symbol as second.");
 
   bool result;
   napi_value ret;
@@ -169,7 +169,7 @@ napi_value Inflate(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of arguments. Expects an object as first argument.");
+      "Wrong type of arguments. Expects an object as first argument.");
 
   napi_value obj = args[0];
   napi_value propertynames;
@@ -219,7 +219,7 @@ napi_value Unwrap(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Get", Get),
     DECLARE_NAPI_PROPERTY("Set", Set),
@@ -232,8 +232,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("Unwrap", Unwrap),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_promise/test_promise.c
+++ b/test/addons-napi/test_promise/test_promise.c
@@ -46,15 +46,17 @@ napi_value isPromise(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("createPromise", createPromise),
     DECLARE_NAPI_PROPERTY("concludeCurrentPromise", concludeCurrentPromise),
     DECLARE_NAPI_PROPERTY("isPromise", isPromise),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -48,7 +48,7 @@ napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
   char buffer[128];
   size_t copied;
   NAPI_CALL(env,
-    napi_get_value_string_utf8(env, args[1], buffer, sizeof(buffer), &copied));
+      napi_get_value_string_utf8(env, args[1], buffer, sizeof(buffer), &copied));
 
   // do the check and create the boolean return value
   bool value;
@@ -59,25 +59,25 @@ napi_value HasNamedProperty(napi_env env, napi_callback_info info) {
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_value number;
-  NAPI_CALL_RETURN_VOID(env, napi_create_double(env, value_, &number));
+  NAPI_CALL(env, napi_create_double(env, value_, &number));
 
   napi_value name_value;
-  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env,
-                                                     "NameKeyValue",
-                                                     -1,
-                                                     &name_value));
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         "NameKeyValue",
+                                         -1,
+                                         &name_value));
 
   napi_value symbol_description;
   napi_value name_symbol;
-  NAPI_CALL_RETURN_VOID(env, napi_create_string_utf8(env,
-                                                     "NameKeySymbol",
-                                                      -1,
-                                                     &symbol_description));
-  NAPI_CALL_RETURN_VOID(env, napi_create_symbol(env,
-                                                symbol_description,
-                                                &name_symbol));
+  NAPI_CALL(env, napi_create_string_utf8(env,
+                                         "NameKeySymbol",
+                                         -1,
+                                         &symbol_description));
+  NAPI_CALL(env, napi_create_symbol(env,
+                                    symbol_description,
+                                    &name_symbol));
 
   napi_property_descriptor properties[] = {
     { "echo", 0, Echo, 0, 0, 0, napi_enumerable, 0 },
@@ -93,8 +93,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     { "hasNamedProperty", 0, HasNamedProperty, 0, 0, 0, napi_default, 0 },
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(properties) / sizeof(*properties), properties));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_reference/test_reference.c
+++ b/test/addons-napi/test_reference/test_reference.c
@@ -22,11 +22,11 @@ napi_value CreateExternal(napi_env env, napi_callback_info info) {
 
   napi_value result;
   NAPI_CALL(env,
-    napi_create_external(env,
-                         data,
-                         NULL, /* finalize_cb */
-                         NULL, /* finalize_hint */
-                         &result));
+      napi_create_external(env,
+                           data,
+                           NULL, /* finalize_cb */
+                           NULL, /* finalize_hint */
+                           &result));
 
   finalize_count = 0;
   return result;
@@ -38,11 +38,11 @@ napi_value CreateExternalWithFinalize(napi_env env, napi_callback_info info) {
 
   napi_value result;
   NAPI_CALL(env,
-    napi_create_external(env,
-                         data,
-                         FinalizeExternal,
-                         NULL, /* finalize_hint */
-                         &result));
+      napi_create_external(env,
+                           data,
+                           FinalizeExternal,
+                           NULL, /* finalize_hint */
+                           &result));
 
   finalize_count = 0;
   return result;
@@ -64,14 +64,14 @@ napi_value CheckExternal(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_get_value_external(env, arg, &data));
 
   NAPI_ASSERT(env, data != NULL && *(int*)data == test_value,
-    "An external data value of 1 was expected.");
+      "An external data value of 1 was expected.");
 
   return NULL;
 }
 
 napi_value CreateReference(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, test_reference == NULL,
-    "The test allows only one reference at a time.");
+      "The test allows only one reference at a time.");
 
   size_t argc = 2;
   napi_value args[2];
@@ -82,17 +82,17 @@ napi_value CreateReference(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_get_value_uint32(env, args[1], &initial_refcount));
 
   NAPI_CALL(env,
-    napi_create_reference(env, args[0], initial_refcount, &test_reference));
+      napi_create_reference(env, args[0], initial_refcount, &test_reference));
 
   NAPI_ASSERT(env, test_reference != NULL,
-    "A reference should have been created.");
+      "A reference should have been created.");
 
   return NULL;
 }
 
 napi_value DeleteReference(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, test_reference != NULL,
-    "A reference must have been created.");
+      "A reference must have been created.");
 
   NAPI_CALL(env, napi_delete_reference(env, test_reference));
   test_reference = NULL;
@@ -101,7 +101,7 @@ napi_value DeleteReference(napi_env env, napi_callback_info info) {
 
 napi_value IncrementRefcount(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, test_reference != NULL,
-    "A reference must have been created.");
+      "A reference must have been created.");
 
   uint32_t refcount;
   NAPI_CALL(env, napi_reference_ref(env, test_reference, &refcount));
@@ -113,7 +113,7 @@ napi_value IncrementRefcount(napi_env env, napi_callback_info info) {
 
 napi_value DecrementRefcount(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, test_reference != NULL,
-    "A reference must have been created.");
+      "A reference must have been created.");
 
   uint32_t refcount;
   NAPI_CALL(env, napi_reference_unref(env, test_reference, &refcount));
@@ -125,19 +125,19 @@ napi_value DecrementRefcount(napi_env env, napi_callback_info info) {
 
 napi_value GetReferenceValue(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, test_reference != NULL,
-    "A reference must have been created.");
+      "A reference must have been created.");
 
   napi_value result;
   NAPI_CALL(env, napi_get_reference_value(env, test_reference, &result));
   return result;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_GETTER("finalizeCount", GetFinalizeCount),
     DECLARE_NAPI_PROPERTY("createExternal", CreateExternal),
     DECLARE_NAPI_PROPERTY("createExternalWithFinalize",
-      CreateExternalWithFinalize),
+        CreateExternalWithFinalize),
     DECLARE_NAPI_PROPERTY("checkExternal", CheckExternal),
     DECLARE_NAPI_PROPERTY("createReference", CreateReference),
     DECLARE_NAPI_PROPERTY("deleteReference", DeleteReference),
@@ -146,8 +146,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_GETTER("referenceValue", GetReferenceValue),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -12,14 +12,14 @@ napi_value TestLatin1(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
@@ -38,14 +38,14 @@ napi_value TestUtf8(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
@@ -64,14 +64,14 @@ napi_value TestUtf16(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char16_t buffer[128];
   size_t buffer_size = 128;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
@@ -90,14 +90,14 @@ napi_value TestLatin1Insufficient(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_latin1(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_latin1(env, buffer, copied, &output));
@@ -116,14 +116,14 @@ napi_value TestUtf8Insufficient(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_utf8(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf8(env, buffer, copied, &output));
@@ -142,14 +142,14 @@ napi_value TestUtf16Insufficient(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   char16_t buffer[4];
   size_t buffer_size = 4;
   size_t copied;
 
   NAPI_CALL(env,
-    napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
+      napi_get_value_string_utf16(env, args[0], buffer, buffer_size, &copied));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf16(env, buffer, copied, &output));
@@ -168,7 +168,7 @@ napi_value Utf16Length(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   size_t length;
   NAPI_CALL(env, napi_get_value_string_utf16(env, args[0], NULL, 0, &length));
@@ -190,7 +190,7 @@ napi_value Utf8Length(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_string,
-    "Wrong type of argment. Expects a string.");
+      "Wrong type of argment. Expects a string.");
 
   size_t length;
   NAPI_CALL(env, napi_get_value_string_utf8(env, args[0], NULL, 0, &length));
@@ -201,7 +201,7 @@ napi_value Utf8Length(napi_env env, napi_callback_info info) {
   return output;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("TestLatin1", TestLatin1),
     DECLARE_NAPI_PROPERTY("TestLatin1Insufficient", TestLatin1Insufficient),
@@ -213,8 +213,10 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     DECLARE_NAPI_PROPERTY("Utf8Length", Utf8Length),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(properties) / sizeof(*properties), properties));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_symbol/test_symbol.c
+++ b/test/addons-napi/test_symbol/test_symbol.c
@@ -12,13 +12,13 @@ napi_value Test(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
   NAPI_ASSERT(env, valuetype == napi_symbol,
-    "Wrong type of argments. Expects a symbol.");
+      "Wrong type of argments. Expects a symbol.");
 
   char buffer[128];
   size_t buffer_size = 128;
 
   NAPI_CALL(env, napi_get_value_string_utf8(
-    env, args[0], buffer, buffer_size, NULL));
+      env, args[0], buffer, buffer_size, NULL));
 
   napi_value output;
   NAPI_CALL(env, napi_create_string_utf8(env, buffer, buffer_size, &output));
@@ -37,7 +37,7 @@ napi_value New(napi_env env, napi_callback_info info) {
     NAPI_CALL(env, napi_typeof(env, args[0], &valuetype));
 
     NAPI_ASSERT(env, valuetype == napi_string,
-      "Wrong type of arguments. Expects a string.");
+        "Wrong type of arguments. Expects a string.");
 
     description = args[0];
   }
@@ -48,13 +48,15 @@ napi_value New(napi_env env, napi_callback_info info) {
   return symbol;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("New", New),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(properties) / sizeof(*properties), properties));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -13,20 +13,20 @@ napi_value Multiply(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of argments. Expects a typed array as first argument.");
+      "Wrong type of argments. Expects a typed array as first argument.");
 
   napi_value input_array = args[0];
   bool is_typedarray;
   NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
 
   NAPI_ASSERT(env, is_typedarray,
-    "Wrong type of argments. Expects a typed array as first argument.");
+      "Wrong type of argments. Expects a typed array as first argument.");
 
   napi_valuetype valuetype1;
   NAPI_CALL(env, napi_typeof(env, args[1], &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_number,
-    "Wrong type of argments. Expects a number as second argument.");
+      "Wrong type of argments. Expects a number as second argument.");
 
   double multiplier;
   NAPI_CALL(env, napi_get_value_double(env, args[1], &multiplier));
@@ -36,17 +36,17 @@ napi_value Multiply(napi_env env, napi_callback_info info) {
   size_t byte_offset;
   size_t i, length;
   NAPI_CALL(env, napi_get_typedarray_info(
-    env, input_array, &type, &length, NULL, &input_buffer, &byte_offset));
+      env, input_array, &type, &length, NULL, &input_buffer, &byte_offset));
 
   void* data;
   size_t byte_length;
   NAPI_CALL(env, napi_get_arraybuffer_info(
-    env, input_buffer, &data, &byte_length));
+      env, input_buffer, &data, &byte_length));
 
   napi_value output_buffer;
   void* output_ptr = NULL;
   NAPI_CALL(env, napi_create_arraybuffer(
-    env, byte_length, &output_ptr, &output_buffer));
+      env, byte_length, &output_ptr, &output_buffer));
 
   napi_value output_array;
   NAPI_CALL(env, napi_create_typedarray(
@@ -65,7 +65,8 @@ napi_value Multiply(napi_env env, napi_callback_info info) {
       output_doubles[i] = input_doubles[i] * multiplier;
     }
   } else {
-    napi_throw_error(env, NULL, "Typed array was of a type not expected by test.");
+    napi_throw_error(env, NULL,
+        "Typed array was of a type not expected by test.");
     return NULL;
   }
 
@@ -77,20 +78,20 @@ napi_value External(napi_env env, napi_callback_info info) {
 
   napi_value output_buffer;
   NAPI_CALL(env, napi_create_external_arraybuffer(
-    env,
-    externalData,
-    sizeof(externalData),
-    NULL,  // finalize_callback
-    NULL,  // finalize_hint
-    &output_buffer));
+      env,
+      externalData,
+      sizeof(externalData),
+      NULL,  // finalize_callback
+      NULL,  // finalize_hint
+      &output_buffer));
 
   napi_value output_array;
   NAPI_CALL(env, napi_create_typedarray(env,
-    napi_int8_array,
-    sizeof(externalData) / sizeof(int8_t),
-    output_buffer,
-    0,
-    &output_array));
+      napi_int8_array,
+      sizeof(externalData) / sizeof(int8_t),
+      output_buffer,
+      0,
+      &output_array));
 
   return output_array;
 }
@@ -107,33 +108,33 @@ napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   NAPI_CALL(env, napi_typeof(env, input_array, &valuetype0));
 
   NAPI_ASSERT(env, valuetype0 == napi_object,
-    "Wrong type of argments. Expects a typed array as first argument.");
+      "Wrong type of argments. Expects a typed array as first argument.");
 
   bool is_typedarray;
   NAPI_CALL(env, napi_is_typedarray(env, input_array, &is_typedarray));
 
   NAPI_ASSERT(env, is_typedarray,
-    "Wrong type of argments. Expects a typed array as first argument.");
+      "Wrong type of argments. Expects a typed array as first argument.");
 
   napi_valuetype valuetype1;
   napi_value input_buffer = args[1];
   NAPI_CALL(env, napi_typeof(env, input_buffer, &valuetype1));
 
   NAPI_ASSERT(env, valuetype1 == napi_object,
-    "Wrong type of argments. Expects an array buffer as second argument.");
+      "Wrong type of argments. Expects an array buffer as second argument.");
 
   bool is_arraybuffer;
   NAPI_CALL(env, napi_is_arraybuffer(env, input_buffer, &is_arraybuffer));
 
   NAPI_ASSERT(env, is_arraybuffer,
-    "Wrong type of argments. Expects an array buffer as second argument.");
+      "Wrong type of argments. Expects an array buffer as second argument.");
 
   napi_typedarray_type type;
   napi_value in_array_buffer;
   size_t byte_offset;
   size_t length;
   NAPI_CALL(env, napi_get_typedarray_info(
-    env, input_array, &type, &length, NULL, &in_array_buffer, &byte_offset));
+      env, input_array, &type, &length, NULL, &in_array_buffer, &byte_offset));
 
   napi_value output_array;
   NAPI_CALL(env, napi_create_typedarray(
@@ -142,15 +143,17 @@ napi_value CreateTypedArray(napi_env env, napi_callback_info info) {
   return output_array;
 }
 
-void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
+napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NAPI_PROPERTY("Multiply", Multiply),
     DECLARE_NAPI_PROPERTY("External", External),
     DECLARE_NAPI_PROPERTY("CreateTypedArray", CreateTypedArray),
   };
 
-  NAPI_CALL_RETURN_VOID(env, napi_define_properties(
-    env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
 }
 
 NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
As per discussion in abi-stable-node:
https://github.com/nodejs/abi-stable-node/issues/256,
take a refactor to napi_addon_register_func such that
the result from the register function is assigned to
the module exports property. By making this change,
native module can be agnostic about which type of
module the environment supports.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api
