### PR TITLE
child_process: ignore undef/proto values of env

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -438,6 +438,8 @@ If not given, the default is to inherit the current working directory.
 Use `env` to specify environment variables that will be visible to the new
 process, the default is [`process.env`][].
 
+`undefined` values in `env` will be ignored.
+
 Example of running `ls -lh /usr`, capturing `stdout`, `stderr`, and the
 exit code:
 

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -504,8 +504,11 @@ function normalizeSpawnArguments(file, args, options) {
   var env = options.env || process.env;
   var envPairs = [];
 
-  for (var key in env) {
-    envPairs.push(`${key}=${env[key]}`);
+  for (const key of Object.keys(env)) {
+    const value = env[key];
+    if (value !== undefined) {
+      envPairs.push(`${key}=${value}`);
+    }
   }
 
   _convertCustomFds(options);

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const os = require('os');
 
 const spawn = require('child_process').spawn;
 
@@ -59,5 +60,5 @@ process.on('exit', function() {
   assert.ok(!response.includes('FOO='));
   assert.ok(!response.includes('UNDEFINED=undefined'));
   assert.ok(response.includes('NULL=null'));
-  assert.ok(response.includes('EMPTY=\n'));
+  assert.ok(response.includes(`EMPTY=${os.EOL}`));
 });

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -26,7 +26,10 @@ const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 const env = {
-  'HELLO': 'WORLD'
+  'HELLO': 'WORLD',
+  'UNDEFINED': undefined,
+  'NULL': null,
+  'EMPTY': ''
 };
 Object.setPrototypeOf(env, {
   'FOO': 'BAR'
@@ -53,5 +56,8 @@ child.stdout.on('data', function(chunk) {
 
 process.on('exit', function() {
   assert.ok(response.includes('HELLO=WORLD'));
-  assert.ok(response.includes('FOO=BAR'));
+  assert.ok(!response.includes('FOO='));
+  assert.ok(!response.includes('UNDEFINED=undefined'));
+  assert.ok(response.includes('NULL=null'));
+  assert.ok(response.includes('EMPTY=\n'));
 });


### PR DESCRIPTION
At present, undefined values of env option will be transferred as an "undefined" string value and values in the prototype will also be included, which are not usual behaviors.

Since non-string env values & prototype values are undocumented, this change may be treated as a bugfix or a breaking change.

Tested on Mac, Windows not yet.

Fixes: https://github.com/nodejs/node/issues/15087

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
child_process