### PR TITLE
src: remove unused persistent properties from env

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -295,13 +295,11 @@ struct http2_state;
   V(async_hooks_before_function, v8::Function)                                \
   V(async_hooks_after_function, v8::Function)                                 \
   V(binding_cache_object, v8::Object)                                         \
-  V(buffer_constructor_function, v8::Function)                                \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
   V(domain_array, v8::Array)                                                  \
   V(domains_stack_array, v8::Array)                                           \
   V(inspector_console_api_object, v8::Object)                                 \
-  V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
   V(pbkdf2_constructor_template, v8::ObjectTemplate)                          \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \
@@ -318,7 +316,6 @@ struct http2_state;
   V(tcp_constructor_template, v8::FunctionTemplate)                           \
   V(tick_callback_function, v8::Function)                                     \
   V(tls_wrap_constructor_function, v8::Function)                              \
-  V(tls_wrap_constructor_template, v8::FunctionTemplate)                      \
   V(tty_constructor_template, v8::FunctionTemplate)                           \
   V(udp_constructor_function, v8::Function)                                   \
   V(url_constructor_function, v8::Function)                                   \

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -230,7 +230,6 @@ void JSStream::Initialize(Local<Object> target,
 
   StreamBase::AddMethods<JSStream>(env, t, StreamBase::kFlagHasWritev);
   target->Set(jsStreamString, t->GetFunction());
-  env->set_jsstream_constructor_template(t);
 }
 
 }  // namespace node

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -962,7 +962,6 @@ void TLSWrap::Initialize(Local<Object> target,
   env->SetProtoMethod(t, "setServername", SetServername);
 #endif  // SSL_CRT_SET_TLSEXT_SERVERNAME_CB
 
-  env->set_tls_wrap_constructor_template(t);
   env->set_tls_wrap_constructor_function(t->GetFunction());
 
   target->Set(tlsWrapString, t->GetFunction());


### PR DESCRIPTION
Removes one unused and two write-only properties as general cleanup.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src/env