### PR TITLE
util: remove duplicate code in format

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -111,51 +111,35 @@ function format(f) {
         ++i;
         continue;
       }
+      if (lastPos < i)
+        str += f.slice(lastPos, i);
       switch (f.charCodeAt(i + 1)) {
         case 100: // 'd'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += Number(arguments[a++]);
           break;
         case 105: // 'i'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += parseInt(arguments[a++]);
           break;
         case 102: // 'f'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += parseFloat(arguments[a++]);
           break;
         case 106: // 'j'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += tryStringify(arguments[a++]);
           break;
         case 115: // 's'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += String(arguments[a++]);
           break;
         case 79: // 'O'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += inspect(arguments[a++]);
           break;
         case 111: // 'o'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += inspect(arguments[a++],
                          { showHidden: true, depth: 4, showProxy: true });
           break;
         case 37: // '%'
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += '%';
           break;
         default: // any other character is not a correct placeholder
-          if (lastPos < i)
-            str += f.slice(lastPos, i);
           str += '%';
           lastPos = i = i + 1;
           continue;


### PR DESCRIPTION
`util.format` contained an identical if statement within each case of switch. Moved it before the switch statement for cleaner code and better performance. Passes all the current tests, plus here are the benchmark results (20 sets on old, 20 sets on new):

```
util/format.js type="no-replace" n=1000000      0.62 %            4.906062e-01
util/format.js type="number" n=1000000          4.80 %        *** 6.199638e-19
util/format.js type="object" n=1000000          3.07 %        *** 2.491792e-08
util/format.js type="string" n=1000000          6.60 %        *** 2.331874e-08
util/format.js type="unknown" n=1000000         0.68 %            2.174034e-01
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util