### PR TITLE
buffer: increase coverage by removing dead code

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -404,17 +404,15 @@ function fromObject(obj) {
     return b;
   }
 
-  if (obj != null) {
-    if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
-      if (typeof obj.length !== 'number' || obj.length !== obj.length) {
-        return new FastBuffer();
-      }
-      return fromArrayLike(obj);
+  if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
+    if (typeof obj.length !== 'number' || obj.length !== obj.length) {
+      return new FastBuffer();
     }
+    return fromArrayLike(obj);
+  }
 
-    if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
-      return fromArrayLike(obj.data);
-    }
+  if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
+    return fromArrayLike(obj.data);
   }
 }
 


### PR DESCRIPTION
Buffer.js file. L196 `if (value == null)` guarantees `obj != null` so L406 is unnecessary. 
Removing outer if statement L406 and L418.

Checklist


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

