### PR TITLE
src: remove not relevant todo from node_crypto.cc

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1627,7 +1627,6 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     const char hex[] = "0123456789ABCDEF";
     char fingerprint[EVP_MAX_MD_SIZE * 3];
 
-    // TODO(indutny): Unify it with buffer's code
     for (i = 0; i < md_size; i++) {
       fingerprint[3*i] = hex[(md[i] & 0xf0) >> 4];
       fingerprint[(3*i)+1] = hex[(md[i] & 0x0f)];


### PR DESCRIPTION
TODO comment from node_crypto is no longer relevant.
Unification of commented code and string_bytes code would bloat the latter.
Methods for hex encoding produce different output in both files (crypto adds colon and uses uppercase letters.)
Common path between those two is very limited now.

##### Checklist

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
