### PR TITLE
http2: improve test coverage

### DIFF
--- a/test/parallel/test-http2-util-assert-valid-pseudoheader.js
+++ b/test/parallel/test-http2-util-assert-valid-pseudoheader.js
@@ -1,0 +1,31 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+// Tests the assertValidPseudoHeader function that is used within the
+// mapToHeaders function. The assert function is not exported so we
+// have to test it through mapToHeaders
+
+const { mapToHeaders } = require('internal/http2/util');
+const assert = require('assert');
+
+function isNotError(val) {
+  assert(!(val instanceof Error));
+}
+
+function isError(val) {
+  common.expectsError({
+    code: 'ERR_HTTP2_INVALID_PSEUDOHEADER',
+    type: Error,
+    message: '":foo" is an invalid pseudoheader or is used incorrectly'
+  })(val);
+}
+
+isNotError(mapToHeaders({ ':status': 'a' }));
+isNotError(mapToHeaders({ ':path': 'a' }));
+isNotError(mapToHeaders({ ':authority': 'a' }));
+isNotError(mapToHeaders({ ':scheme': 'a' }));
+isNotError(mapToHeaders({ ':method': 'a' }));
+
+isError(mapToHeaders({ ':foo': 'a' }));

--- a/test/parallel/test-http2-util-nghttp2error.js
+++ b/test/parallel/test-http2-util-nghttp2error.js
@@ -1,0 +1,16 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const { strictEqual } = require('assert');
+const { NghttpError } = require('internal/http2/util');
+
+common.expectsError(() => {
+  const err = new NghttpError(-501);
+  strictEqual(err.errno, -501);
+  throw err;
+}, {
+  code: 'ERR_HTTP2_ERROR',
+  type: NghttpError,
+  message: 'Invalid argument'
+});

--- a/test/parallel/test-http2-util-update-options-buffer.js
+++ b/test/parallel/test-http2-util-update-options-buffer.js
@@ -1,0 +1,67 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+// Test coverage for the updateOptionsBuffer method used internally
+// by the http2 implementation.
+
+const { updateOptionsBuffer } = require('internal/http2/util');
+const { optionsBuffer } = process.binding('http2');
+const { ok, strictEqual } = require('assert');
+
+const IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE = 0;
+const IDX_OPTIONS_MAX_RESERVED_REMOTE_STREAMS = 1;
+const IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH = 2;
+const IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS = 3;
+const IDX_OPTIONS_PADDING_STRATEGY = 4;
+const IDX_OPTIONS_FLAGS = 5;
+
+{
+  updateOptionsBuffer({
+    maxDeflateDynamicTableSize: 1,
+    maxReservedRemoteStreams: 2,
+    maxSendHeaderBlockLength: 3,
+    peerMaxConcurrentStreams: 4,
+    paddingStrategy: 5
+  });
+
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE], 1);
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_RESERVED_REMOTE_STREAMS], 2);
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH], 3);
+  strictEqual(optionsBuffer[IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS], 4);
+  strictEqual(optionsBuffer[IDX_OPTIONS_PADDING_STRATEGY], 5);
+
+  const flags = optionsBuffer[IDX_OPTIONS_FLAGS];
+
+  ok(flags & (1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE));
+  ok(flags & (1 << IDX_OPTIONS_MAX_RESERVED_REMOTE_STREAMS));
+  ok(flags & (1 << IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH));
+  ok(flags & (1 << IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS));
+  ok(flags & (1 << IDX_OPTIONS_PADDING_STRATEGY));
+}
+
+{
+  optionsBuffer[IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH] = 0;
+
+  updateOptionsBuffer({
+    maxDeflateDynamicTableSize: 1,
+    maxReservedRemoteStreams: 2,
+    peerMaxConcurrentStreams: 4,
+    paddingStrategy: 5
+  });
+
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE], 1);
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_RESERVED_REMOTE_STREAMS], 2);
+  strictEqual(optionsBuffer[IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH], 0);
+  strictEqual(optionsBuffer[IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS], 4);
+  strictEqual(optionsBuffer[IDX_OPTIONS_PADDING_STRATEGY], 5);
+
+  const flags = optionsBuffer[IDX_OPTIONS_FLAGS];
+
+  ok(flags & (1 << IDX_OPTIONS_MAX_DEFLATE_DYNAMIC_TABLE_SIZE));
+  ok(flags & (1 << IDX_OPTIONS_MAX_RESERVED_REMOTE_STREAMS));
+  ok(!(flags & (1 << IDX_OPTIONS_MAX_SEND_HEADER_BLOCK_LENGTH)));
+  ok(flags & (1 << IDX_OPTIONS_PEER_MAX_CONCURRENT_STREAMS));
+  ok(flags & (1 << IDX_OPTIONS_PADDING_STRATEGY));
+}


### PR DESCRIPTION
Few small new tests to help improve http2 test coverage

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2