### PR TITLE
http2: adjust error types, increase test coverage

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -485,9 +485,9 @@ function validatePriorityOptions(options) {
   if (options.weight === undefined) {
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
   } else if (typeof options.weight !== 'number') {
-    const err = new errors.RangeError('ERR_INVALID_OPT_VALUE',
-                                      'weight',
-                                      options.weight);
+    const err = new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                     'weight',
+                                     options.weight);
     Error.captureStackTrace(err, validatePriorityOptions);
     throw err;
   }
@@ -495,9 +495,9 @@ function validatePriorityOptions(options) {
   if (options.parent === undefined) {
     options.parent = 0;
   } else if (typeof options.parent !== 'number' || options.parent < 0) {
-    const err = new errors.RangeError('ERR_INVALID_OPT_VALUE',
-                                      'parent',
-                                      options.parent);
+    const err = new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                     'parent',
+                                     options.parent);
     Error.captureStackTrace(err, validatePriorityOptions);
     throw err;
   }
@@ -505,9 +505,9 @@ function validatePriorityOptions(options) {
   if (options.exclusive === undefined) {
     options.exclusive = false;
   } else if (typeof options.exclusive !== 'boolean') {
-    const err = new errors.RangeError('ERR_INVALID_OPT_VALUE',
-                                      'exclusive',
-                                      options.exclusive);
+    const err = new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                     'exclusive',
+                                     options.exclusive);
     Error.captureStackTrace(err, validatePriorityOptions);
     throw err;
   }
@@ -515,9 +515,9 @@ function validatePriorityOptions(options) {
   if (options.silent === undefined) {
     options.silent = false;
   } else if (typeof options.silent !== 'boolean') {
-    const err = new errors.RangeError('ERR_INVALID_OPT_VALUE',
-                                      'silent',
-                                      options.silent);
+    const err = new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                     'silent',
+                                     options.silent);
     Error.captureStackTrace(err, validatePriorityOptions);
     throw err;
   }
@@ -1119,9 +1119,9 @@ class ClientHttp2Session extends Http2Session {
       // preference.
       options.endStream = isPayloadMeaningless(headers[HTTP2_HEADER_METHOD]);
     } else if (typeof options.endStream !== 'boolean') {
-      throw new errors.RangeError('ERR_INVALID_OPT_VALUE',
-                                  'endStream',
-                                  options.endStream);
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                 'endStream',
+                                 options.endStream);
     }
 
     if (options.getTrailers !== undefined &&

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -1,0 +1,63 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// Check if correct errors are emitted when wrong type of data is passed
+// to certain options of ClientHttp2Session request method
+
+const optionsToTest = {
+  endStream: 'boolean',
+  getTrailers: 'function',
+  weight: 'number',
+  parent: 'number',
+  exclusive: 'boolean',
+  silent: 'boolean'
+};
+
+const types = {
+  boolean: true,
+  function: () => {},
+  number: 1,
+  object: {},
+  array: [],
+  null: null,
+  symbol: Symbol('test')
+};
+
+const server = http2.createServer(common.mustNotCall());
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  Object.keys(optionsToTest).forEach((option) => {
+    Object.keys(types).forEach((type) => {
+      if (type === optionsToTest[option]) {
+        return;
+      }
+
+      assert.throws(
+        () => client.request({
+          ':method': 'CONNECT',
+          ':authority': `localhost:${port}`
+        }, {
+          [option]: types[type]
+        }),
+        common.expectsError({
+          type: TypeError,
+          code: 'ERR_INVALID_OPT_VALUE',
+          message: `The value "${String(types[type])}" is invalid ` +
+                   `for option "${option}"`
+        })
+      );
+    });
+  });
+
+  server.close();
+  client.destroy();
+}));


### PR DESCRIPTION
A few small things:

- changed error types emitted from `request` and `validatePriorityOptions` (when validating options provided) to be `TypeError` rather than `RangeError`
- added tests to confirm that errors for all options are thrown as expected (weight, parent, exclusive, silent, endStream and getTrailers)
- added test for method CONNECT (in client `request`) throwing errors on missing `:authority` or superfluous `:scheme` and `:path`

Please let me know if there's anything I can adjust. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test