### PR TITLE
src: fix compiler warnings in node_perf.cc

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -57,7 +57,7 @@ void PerformanceEntry::NotifyObservers(Environment* env,
   Local<Value> argv = entry->object();
   env->performance_entry_callback()->Call(context,
                                           v8::Undefined(isolate),
-                                          1, &argv);
+                                          1, &argv).ToLocalChecked();
 }
 
 void Mark(const FunctionCallbackInfo<Value>& args) {
@@ -290,7 +290,7 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
   v8::MaybeLocal<Object> instance = ctor->NewInstance(context);
   Local<Object> obj = instance.ToLocalChecked();
   for (idx = 0; idx < count; idx++) {
-    obj->Set(context, idx, args[idx]);
+    (void) obj->Set(context, idx, args[idx]);
   }
   new PerformanceEntry(env, obj, *name, "function", start, end);
 }
@@ -373,12 +373,12 @@ void Init(Local<Object> target,
   target->DefineOwnProperty(context,
                             FIXED_ONE_BYTE_STRING(isolate, "timeOrigin"),
                             v8::Number::New(isolate, timeOrigin / 1e6),
-                            attr);
+                            attr).ToChecked();
 
   target->DefineOwnProperty(context,
                             env->constants_string(),
                             constants,
-                            attr);
+                            attr).ToChecked();
 
   SetupGarbageCollectionTracking(isolate);
 }

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -290,7 +290,7 @@ void TimerFunctionCall(const FunctionCallbackInfo<Value>& args) {
   v8::MaybeLocal<Object> instance = ctor->NewInstance(context);
   Local<Object> obj = instance.ToLocalChecked();
   for (idx = 0; idx < count; idx++) {
-    (void) obj->Set(context, idx, args[idx]);
+    obj->Set(context, idx, args[idx]).ToChecked();
   }
   new PerformanceEntry(env, obj, *name, "function", start, end);
 }


### PR DESCRIPTION
Currently, there are a few compiler warnings generated from node_perf.cc
regarding unused return values:
```console
../src/node_perf.cc:58:3: warning: ignoring return value of function
declared with warn_unused_result attribute [-Wunused-result]
  env->performance_entry_callback()->Call(context,
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
../src/node_perf.cc:293:5: warning: ignoring return value of function
declared with warn_unused_result attribute [-Wunused-result]
    obj->Set(context, idx, args[idx]);
    ^~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~
../src/node_perf.cc:373:3: warning: ignoring return value of function
declared with warn_unused_result attribute [-Wunused-result]
  target->DefineOwnProperty(context,
  ^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
../src/node_perf.cc:378:3: warning: ignoring return value of function
declared with warn_unused_result attribute [-Wunused-result]
  target->DefineOwnProperty(context,
  ^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~
```
This commit add checks to avoid the warnings.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
