### PR TITLE
benchmark: refactor to remove duplicate code

### DIFF
--- a/benchmark/dns/lookup.js
+++ b/benchmark/dns/lookup.js
@@ -6,33 +6,26 @@ const lookup = require('dns').lookup;
 const bench = common.createBenchmark(main, {
   name: ['', '127.0.0.1', '::1'],
   all: ['true', 'false'],
-  n: [5e6]
+  n: [5e4],
 });
 
 function main(conf) {
-  const name = conf.name;
-  const n = +conf.n;
-  const all = conf.all === 'true' ? true : false;
-  var i = 0;
-
-  if (all) {
-    const opts = { all: true };
-    bench.start();
-    (function cb() {
-      if (i++ === n) {
-        bench.end(n);
-        return;
-      }
-      lookup(name, opts, cb);
-    })();
-  } else {
-    bench.start();
-    (function cb() {
-      if (i++ === n) {
-        bench.end(n);
-        return;
-      }
-      lookup(name, cb);
-    })();
+  const argv = [conf.name];
+  if (conf.all === 'true') {
+    argv.push({ all: true });
   }
+
+  const n = +conf.n;
+  let i = 0;
+
+  bench.start();
+
+  (function cb() {
+    if (i++ === n) {
+      bench.end(n);
+      return;
+    }
+    lookup(...argv, cb);
+  })();
+
 }


### PR DESCRIPTION
The dns benchmark script contained an if-then-else branch which
executed almost the same code in both cases, apart from the number
of args passed to the core dns lookup function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
