### PR TITLE
util: add bright ANSI color codes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -201,7 +201,7 @@ function inspect(obj, opts) {
   // default options
   var ctx = {
     seen: [],
-    stylize: stylizeNoColor
+    stylize: String
   };
   // legacy...
   if (arguments.length >= 3 && arguments[2] !== undefined) {
@@ -216,8 +216,10 @@ function inspect(obj, opts) {
   }
   // Set default and user-specified options
   ctx = Object.assign({}, inspect.defaultOptions, ctx, opts);
-  if (ctx.colors) ctx.stylize = stylizeWithColor;
-  if (ctx.maxArrayLength === null) ctx.maxArrayLength = Infinity;
+  if (ctx.colors)
+    ctx.stylize = stylizeWithColor;
+  if (ctx.maxArrayLength === null)
+    ctx.maxArrayLength = Infinity;
   return formatValue(ctx, obj, ctx.depth);
 }
 inspect.custom = customInspectSymbol;
@@ -237,22 +239,34 @@ Object.defineProperty(inspect, 'defaultOptions', {
 
 // http://en.wikipedia.org/wiki/ANSI_escape_code#graphics
 inspect.colors = Object.assign(Object.create(null), {
-  'bold': [1, 22],
-  'italic': [3, 23],
-  'underline': [4, 24],
-  'inverse': [7, 27],
-  'white': [37, 39],
-  'grey': [90, 39],
-  'black': [30, 39],
-  'blue': [34, 39],
-  'cyan': [36, 39],
-  'green': [32, 39],
-  'magenta': [35, 39],
-  'red': [31, 39],
-  'yellow': [33, 39]
+  'bold': ['1', '22'],
+  'bright': ['1', '22'],
+  'faint ': ['2', '22'],
+  'italic': ['3', '23'],
+  'underline': ['4', '24'],
+  'inverse': ['7', '27'],
+  'grey': ['90', '39'],
+  'black': ['30', '39'],
+  'red': ['31', '39'],
+  'green': ['32', '39'],
+  'yellow': ['33', '39'],
+  'blue': ['34', '39'],
+  'magenta': ['35', '39'],
+  'cyan': ['36', '39'],
+  'white': ['37', '39'],
+  'black;bright': ['30;1', '39;22'],
+  'red;bright': ['31;1', '39;22'],
+  'green;bright': ['32;1', '39;22'],
+  'yellow;bright': ['33;1', '39;22'],
+  'blue;bright': ['34;1', '39;22'],
+  'magenta;bright': ['35;1', '39;22'],
+  'cyan;bright': ['36;1', '39;22'],
+  'white;bright': ['37;1', '39;22']
 });
 
-// Don't use 'blue' not visible on cmd.exe
+// Don't use 'blue' not visible on cmd.exe.
+// 'magenta' has a known bug with the default Powershell configuration.
+// Refs: https://github.com/nodejs/node/issues/14243
 inspect.styles = Object.assign(Object.create(null), {
   'special': 'cyan',
   'number': 'yellow',
@@ -262,24 +276,19 @@ inspect.styles = Object.assign(Object.create(null), {
   'string': 'green',
   'symbol': 'green',
   'date': 'magenta',
-  // "name": intentionally not styling
+  // "name": intentionally no styling
   'regexp': 'red'
 });
 
 function stylizeWithColor(str, styleType) {
-  var style = inspect.styles[styleType];
+  const style = inspect.styles[styleType];
+  const [prefix, suffix] = (inspect.colors[style] || [])
 
-  if (style) {
-    return `\u001b[${inspect.colors[style][0]}m${str}` +
-           `\u001b[${inspect.colors[style][1]}m`;
+  if (style && prefix && suffix) {
+    return `\u001b[${prefix}m${str}\u001b[${suffix}m`;
   } else {
     return str;
   }
-}
-
-
-function stylizeNoColor(str, styleType) {
-  return str;
 }
 
 
@@ -647,7 +656,7 @@ function formatPrimitive(ctx, value) {
 
 function formatPrimitiveNoColor(ctx, value) {
   var stylize = ctx.stylize;
-  ctx.stylize = stylizeNoColor;
+  ctx.stylize = String;
   var str = formatPrimitive(ctx, value);
   ctx.stylize = stylize;
   return str;

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1104,3 +1104,21 @@ if (typeof Symbol !== 'undefined') {
 }
 
 assert.doesNotThrow(() => util.inspect(process));
+
+{
+  // Assert bad util.inspect.styles does not make 'inspect' throw
+  const oldStyle = util.inspect.styles.date;
+  util.inspect.styles.date = 'foo';
+  assert.doesNotThrow(() => util.inspect(new Date(), { colors: true }));
+  util.inspect.styles.date = oldStyle;
+}
+
+{
+  // Assert util.inspect.styles accepts 'bright' colors
+  const oldStyle = util.inspect.styles.date;
+  util.inspect.styles.date = 'yellow;bright';
+  const ret = util.inspect(new Date(), { colors: true });
+  assert.strictEqual(ret.includes('33;1'), true);
+  assert.strictEqual(ret.includes('39;22'), true);
+  util.inspect.styles.date = oldStyle;
+}


### PR DESCRIPTION
* sort colors by ANSI code
* some code cleanup and defenses

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util
