### PR TITLE
crypto: accept decimal Number in randomBytes

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5616,13 +5616,13 @@ void RandomBytesProcessSync(Environment* env,
 void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!args[0]->IsUint32()) {
+  if (!args[0]->IsNumber() || args[0].As<v8::Number>()->Value() < 0) {
     return env->ThrowTypeError("size must be a number >= 0");
   }
 
   const int64_t size = args[0]->IntegerValue();
-  if (size < 0 || size > Buffer::kMaxLength)
-    return env->ThrowRangeError("size is not a valid Smi");
+  if (size > Buffer::kMaxLength)
+    return env->ThrowTypeError("size must be a uint32");
 
   Local<Object> obj = env->randombytes_constructor_template()->
       NewInstance(env->context()).ToLocalChecked();

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -33,6 +33,15 @@ crypto.DEFAULT_ENCODING = 'buffer';
 // bump, we register a lot of exit listeners
 process.setMaxListeners(256);
 
+const errMessages = {
+  offsetNotNumber: /^TypeError: offset must be a number$/,
+  offsetOutOfRange: /^RangeError: offset out of range$/,
+  offsetNotUInt32: /^TypeError: offset must be a uint32$/,
+  sizeNotNumber: /^TypeError: size must be a number$/,
+  sizeNotUInt32: /^TypeError: size must be a uint32$/,
+  bufferTooSmall: /^RangeError: buffer too small$/,
+};
+
 const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
 [crypto.randomBytes, crypto.pseudoRandomBytes].forEach(function(f) {
   [-1, undefined, null, false, true, {}, []].forEach(function(value) {
@@ -41,10 +50,10 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
                   expectedErrorRegexp);
   });
 
-  [0, 1, 2, 4, 16, 256, 1024].forEach(function(len) {
+  [0, 1, 2, 4, 16, 256, 1024, 101.2].forEach(function(len) {
     f(len, common.mustCall(function(ex, buf) {
       assert.strictEqual(ex, null);
-      assert.strictEqual(buf.length, len);
+      assert.strictEqual(buf.length, Math.floor(len));
       assert.ok(Buffer.isBuffer(buf));
     }));
   });
@@ -139,14 +148,6 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     Buffer.alloc(10),
     new Uint8Array(new Array(10).fill(0))
   ];
-  const errMessages = {
-    offsetNotNumber: /^TypeError: offset must be a number$/,
-    offsetOutOfRange: /^RangeError: offset out of range$/,
-    offsetNotUInt32: /^TypeError: offset must be a uint32$/,
-    sizeNotNumber: /^TypeError: size must be a number$/,
-    sizeNotUInt32: /^TypeError: size must be a uint32$/,
-    bufferTooSmall: /^RangeError: buffer too small$/,
-  };
 
   const max = require('buffer').kMaxLength + 1;
 
@@ -264,4 +265,4 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
 // length exceeds max acceptable value"
 assert.throws(function() {
   crypto.randomBytes((-1 >>> 0) + 1);
-}, /^TypeError: size must be a number >= 0$/);
+}, errMessages.sizeNotUInt32);


### PR DESCRIPTION
This change adds the ability to pass a double into randomBytes based on feedback from https://github.com/nodejs/node/issues/15118 which aligns the behavior with other core methods like `setTimeout`

Marking as semver-major out of caution but generally I think this is patch.

No docs were changed because this actually aligns with the documented behavior better.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto