### PR TITLE
crypto: convert to using internal/errors

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -31,6 +31,7 @@ exports.DEFAULT_ENCODING = 'buffer';
 
 const constants = process.binding('constants').crypto;
 const binding = process.binding('crypto');
+const errors = require('internal/errors');
 const randomBytes = binding.randomBytes;
 const getCiphers = binding.getCiphers;
 const getHashes = binding.getHashes;
@@ -302,7 +303,7 @@ Sign.prototype.update = Hash.prototype.update;
 
 Sign.prototype.sign = function sign(options, encoding) {
   if (!options)
-    throw new Error('No key provided to sign');
+    throw new errors.Error('ERR_MISSING_ARGS', 'options');
 
   var key = options.key || options;
   var passphrase = options.passphrase || null;
@@ -313,7 +314,8 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new TypeError('padding must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding',
+                                 'integer', options.padding);
     }
   }
 
@@ -322,7 +324,8 @@ Sign.prototype.sign = function sign(options, encoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new TypeError('saltLength must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength',
+                                 'integer', options.saltLength);
     }
   }
 
@@ -363,7 +366,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.padding === options.padding >> 0) {
       rsaPadding = options.padding;
     } else {
-      throw new TypeError('padding must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.padding',
+                                 'integer', options.padding);
     }
   }
 
@@ -372,7 +376,8 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
     if (options.saltLength === options.saltLength >> 0) {
       pssSaltLength = options.saltLength;
     } else {
-      throw new TypeError('saltLength must be an integer');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options.saltLength',
+                                 'integer', options.saltLength);
     }
   }
 
@@ -417,8 +422,11 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   if (typeof sizeOrKey !== 'number' &&
       typeof sizeOrKey !== 'string' &&
       !ArrayBuffer.isView(sizeOrKey)) {
-    throw new TypeError('First argument should be number, string, ' +
-                        'Buffer, TypedArray, or DataView');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                               'first argument',
+                               ['number', 'string', 'Buffer',
+                                'TypedArray', 'DataView'],
+                               sizeOrKey);
   }
 
   if (keyEncoding) {
@@ -560,8 +568,10 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
 
 
 function ECDH(curve) {
-  if (typeof curve !== 'string')
-    throw new TypeError('"curve" argument should be a string');
+  if (typeof curve !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve',
+                               'string', curve);
+  }
 
   this._handle = new binding.ECDH(curve);
 }
@@ -594,7 +604,10 @@ ECDH.prototype.getPublicKey = function getPublicKey(encoding, format) {
     else if (format === 'uncompressed')
       f = constants.POINT_CONVERSION_UNCOMPRESSED;
     else
-      throw new TypeError('Bad format: ' + format);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'format',
+                                 'string["compressed","hybrid","uncompressed"]',
+                                 format);
   } else {
     f = constants.POINT_CONVERSION_UNCOMPRESSED;
   }
@@ -618,7 +631,7 @@ exports.pbkdf2 = function(password,
   }
 
   if (typeof callback !== 'function')
-    throw new Error('No callback provided to pbkdf2');
+    throw new errors.Error('ERR_INVALID_CALLBACK');
 
   return pbkdf2(password, salt, iterations, keylen, digest, callback);
 };
@@ -632,8 +645,7 @@ exports.pbkdf2Sync = function(password, salt, iterations, keylen, digest) {
 function pbkdf2(password, salt, iterations, keylen, digest, callback) {
 
   if (digest === undefined) {
-    throw new TypeError(
-      'The "digest" argument is required and must not be undefined');
+    throw new errors.TypeError('ERR_MISSING_ARGS', 'digest');
   }
 
   password = toBuf(password);
@@ -684,11 +696,14 @@ Certificate.prototype.exportChallenge =
 
 
 exports.setEngine = function setEngine(id, flags) {
-  if (typeof id !== 'string')
-    throw new TypeError('"id" argument should be a string');
+  if (typeof id !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'id', 'string', id);
+  }
 
-  if (flags && typeof flags !== 'number')
-    throw new TypeError('"flags" argument should be a number, if present');
+  if (flags && typeof flags !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags',
+                               'non zero number', flags);
+  }
   flags = flags >>> 0;
 
   // Use provided engine for everything by default
@@ -702,7 +717,8 @@ const kMaxUint32 = Math.pow(2, 32) - 1;
 
 function randomFillSync(buf, offset = 0, size) {
   if (!isUint8Array(buf)) {
-    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
+                               ['Buffer', 'Uint8Array'], buf);
   }
 
   assertOffset(offset, buf.length);
@@ -717,7 +733,8 @@ exports.randomFillSync = randomFillSync;
 
 function randomFill(buf, offset, size, cb) {
   if (!isUint8Array(buf)) {
-    throw new TypeError('"buf" argument must be a Buffer or Uint8Array');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buf',
+                               ['Buffer', 'Uint8Array'], buf);
   }
 
   if (typeof offset === 'function') {
@@ -728,7 +745,7 @@ function randomFill(buf, offset, size, cb) {
     cb = size;
     size = buf.length - offset;
   } else if (typeof cb !== 'function') {
-    throw new TypeError('"cb" argument must be a function');
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
   assertOffset(offset, buf.length);
@@ -740,29 +757,32 @@ exports.randomFill = randomFill;
 
 function assertOffset(offset, length) {
   if (typeof offset !== 'number' || offset !== offset) {
-    throw new TypeError('offset must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'offset',
+                               'number', offset);
   }
 
   if (offset > kMaxUint32 || offset < 0) {
-    throw new TypeError('offset must be a uint32');
+    throw new errors.TypeError('ERR_VALUE_OUT_OF_RANGE', 'offset',
+                               `<= ${kMaxUint32} and >= 0`, offset);
   }
 
   if (offset > kBufferMaxLength || offset > length) {
-    throw new RangeError('offset out of range');
+    throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'offset');
   }
 }
 
 function assertSize(size, offset, length) {
   if (typeof size !== 'number' || size !== size) {
-    throw new TypeError('size must be a number');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number', size);
   }
 
   if (size > kMaxUint32 || size < 0) {
-    throw new TypeError('size must be a uint32');
+    throw new errors.TypeError('ERR_VALUE_OUT_OF_RANGE', 'size',
+                               `<= ${kMaxUint32} and >= 0`, size);
   }
 
   if (size + offset > length || size > kBufferMaxLength) {
-    throw new RangeError('buffer too small');
+    throw new errors.RangeError('ERR_BUFFER_OUT_OF_BOUNDS', 'size + offset');
   }
 }
 

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -22,24 +22,22 @@ assert.strictEqual(secret2.toString('base64'), secret1);
 assert.strictEqual(dh1.verifyError, 0);
 assert.strictEqual(dh2.verifyError, 0);
 
-const argumentsError =
-  /^TypeError: First argument should be number, string, Buffer, TypedArray, or DataView$/;
+const createDiffieHellmanErr = (arg) => {
+  common.expectsError(
+    () => {
+      crypto.createDiffieHellman(arg);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+};
 
-assert.throws(() => {
-  crypto.createDiffieHellman([0x1, 0x2]);
-}, argumentsError);
-
-assert.throws(() => {
-  crypto.createDiffieHellman(() => { });
-}, argumentsError);
-
-assert.throws(() => {
-  crypto.createDiffieHellman(/abc/);
-}, argumentsError);
-
-assert.throws(() => {
-  crypto.createDiffieHellman({});
-}, argumentsError);
+createDiffieHellmanErr([0x1, 0x2]);
+createDiffieHellmanErr(() => { });
+createDiffieHellmanErr(/abc/);
+createDiffieHellmanErr({});
 
 // Create "another dh1" using generated keys from dh1,
 // and compute secret again
@@ -198,9 +196,18 @@ if (availableCurves.has('prime256v1') && availableCurves.has('secp256k1')) {
   firstByte = ecdh1.getPublicKey('buffer', 'hybrid')[0];
   assert(firstByte === 6 || firstByte === 7);
   // format value should be string
-  assert.throws(() => {
-    ecdh1.getPublicKey('buffer', 10);
-  }, /^TypeError: Bad format: 10$/);
+  common.expectsError(
+    () => {
+      ecdh1.getPublicKey('buffer', 10);
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "format" argument must be of type ' +
+               'string["compressed","hybrid","uncompressed"]. ' +
+               'Received type number',
+      type: TypeError
+    }
+  );
 
   // ECDH should check that point is on curve
   const ecdh3 = crypto.createECDH('secp256k1');
@@ -331,6 +338,11 @@ if (availableCurves.has('prime256v1') && availableHashes.has('sha256')) {
 }
 
 // invalid test: curve argument is undefined
-assert.throws(() => {
-  crypto.createECDH();
-}, /^TypeError: "curve" argument should be a string$/);
+common.expectsError(
+  () => {
+    crypto.createECDH();
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }
+);

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -4,13 +4,24 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const crypto = require('crypto');
 
-assert.throws(function() {
-  crypto.setEngine(true);
-}, /^TypeError: "id" argument should be a string$/);
+common.expectsError(
+  () => {
+    crypto.setEngine(true);
+  },
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }
+);
 
-assert.throws(function() {
-  crypto.setEngine('/path/to/engine', 'notANumber');
-}, /^TypeError: "flags" argument should be a number, if present$/);
+common.expectsError(
+  () => {
+    crypto.setEngine('/path/to/engine', 'notANumber');
+  },
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  }
+);

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -55,9 +55,15 @@ function ondone(err, key) {
 }
 
 // Error path should not leak memory (check with valgrind).
-assert.throws(function() {
-  crypto.pbkdf2('password', 'salt', 1, 20, null);
-}, /^Error: No callback provided to pbkdf2$/);
+common.expectsError(
+  () => {
+    crypto.pbkdf2('password', 'salt', 1, 20, null);
+  },
+  {
+    code: 'ERR_INVALID_CALLBACK',
+    type: Error
+  }
+);
 
 // Should not work with Infinity key length
 assert.throws(function() {
@@ -95,10 +101,22 @@ assert.doesNotThrow(() => {
   }));
 });
 
-assert.throws(() => {
-  crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall());
-}, /^TypeError: The "digest" argument is required and must not be undefined$/);
+common.expectsError(
+  () => {
+    crypto.pbkdf2('password', 'salt', 8, 8, common.mustNotCall());
+  },
+  {
+    code: 'ERR_MISSING_ARGS',
+    type: Error
+  }
+);
 
-assert.throws(() => {
-  crypto.pbkdf2Sync('password', 'salt', 8, 8);
-}, /^TypeError: The "digest" argument is required and must not be undefined$/);
+common.expectsError(
+  () => {
+    crypto.pbkdf2Sync('password', 'salt', 8, 8);
+  },
+  {
+    code: 'ERR_MISSING_ARGS',
+    type: Error
+  }
+);

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -139,125 +139,303 @@ const expectedErrorRegexp = /^TypeError: size must be a number >= 0$/;
     Buffer.alloc(10),
     new Uint8Array(new Array(10).fill(0))
   ];
+
   const errMessages = {
-    offsetNotNumber: /^TypeError: offset must be a number$/,
-    offsetOutOfRange: /^RangeError: offset out of range$/,
-    offsetNotUInt32: /^TypeError: offset must be a uint32$/,
-    sizeNotNumber: /^TypeError: size must be a number$/,
-    sizeNotUInt32: /^TypeError: size must be a uint32$/,
-    bufferTooSmall: /^RangeError: buffer too small$/,
+    offsetOutOfBounds: '"offset" is outside of buffer bounds',
+    sizeOutOfBounds: '"size + offset" is outside of buffer bounds',
+    sizeOutOfRange: (size) => {
+      return 'The value of "size" must be <= 4294967295 and >= 0. ' +
+        `Received "${size}"`;
+    },
+    offsetOutOfRange: (offset) => {
+      return 'The value of "offset" must be <= 4294967295 and >= 0. ' +
+        `Received "${offset}"`;
+    }
   };
 
   const max = require('buffer').kMaxLength + 1;
+
+  const argTypeErr = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError
+  };
 
   for (const buf of bufs) {
     const len = Buffer.byteLength(buf);
     assert.strictEqual(len, 10, `Expected byteLength of 10, got ${len}`);
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 'test');
-    }, errMessages.offsetNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 'test');
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, NaN);
-    }, errMessages.offsetNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, NaN);
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 'test', common.mustNotCall());
-    }, errMessages.offsetNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 'test', common.mustNotCall());
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, NaN, common.mustNotCall());
-    }, errMessages.offsetNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, NaN, common.mustNotCall());
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 11);
-    }, errMessages.offsetOutOfRange);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 11);
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.offsetOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, max);
-    }, errMessages.offsetOutOfRange);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, max);
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.offsetOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 11, common.mustNotCall());
-    }, errMessages.offsetOutOfRange);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 11, common.mustNotCall());
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.offsetOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, max, common.mustNotCall());
-    }, errMessages.offsetOutOfRange);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, max, common.mustNotCall());
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.offsetOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 0, 'test');
-    }, errMessages.sizeNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 0, 'test');
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 0, NaN);
-    }, errMessages.sizeNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 0, NaN);
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 0, 'test', common.mustNotCall());
-    }, errMessages.sizeNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 0, 'test', common.mustNotCall());
+      },
+      argTypeErr
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 0, NaN, common.mustNotCall());
-    }, errMessages.sizeNotNumber);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 0, NaN, common.mustNotCall());
+      },
+      argTypeErr
+    );
 
     {
       const size = (-1 >>> 0) + 1;
 
-      assert.throws(() => {
-        crypto.randomFillSync(buf, 0, -10);
-      }, errMessages.sizeNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFillSync(buf, 0, -10);
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.sizeOutOfRange(-10),
+          type: TypeError
+        }
+      );
 
-      assert.throws(() => {
-        crypto.randomFillSync(buf, 0, size);
-      }, errMessages.sizeNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFillSync(buf, 0, size);
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.sizeOutOfRange(size),
+          type: TypeError
+        }
+      );
 
-      assert.throws(() => {
-        crypto.randomFill(buf, 0, -10, common.mustNotCall());
-      }, errMessages.sizeNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFill(buf, 0, -10, common.mustNotCall());
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.sizeOutOfRange(-10),
+          type: TypeError
+        }
+      );
 
-      assert.throws(() => {
-        crypto.randomFill(buf, 0, size, common.mustNotCall());
-      }, errMessages.sizeNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFill(buf, 0, size, common.mustNotCall());
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.sizeOutOfRange(size),
+          type: TypeError
+        }
+      );
     }
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, -10);
-    }, errMessages.offsetNotUInt32);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, -10);
+      },
+      {
+        code: 'ERR_VALUE_OUT_OF_RANGE',
+        message: errMessages.offsetOutOfRange(-10),
+        type: TypeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, -10, common.mustNotCall());
-    }, errMessages.offsetNotUInt32);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, -10, common.mustNotCall());
+      },
+      {
+        code: 'ERR_VALUE_OUT_OF_RANGE',
+        message: errMessages.offsetOutOfRange(-10),
+        type: TypeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 1, 10);
-    }, errMessages.bufferTooSmall);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 1, 10);
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.sizeOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 1, 10, common.mustNotCall());
-    }, errMessages.bufferTooSmall);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 1, 10, common.mustNotCall());
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.sizeOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFillSync(buf, 0, 12);
-    }, errMessages.bufferTooSmall);
+    common.expectsError(
+      () => {
+        crypto.randomFillSync(buf, 0, 12);
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.sizeOutOfBounds,
+        type: RangeError
+      }
+    );
 
-    assert.throws(() => {
-      crypto.randomFill(buf, 0, 12, common.mustNotCall());
-    }, errMessages.bufferTooSmall);
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 0, 12, common.mustNotCall());
+      },
+      {
+        code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+        message: errMessages.sizeOutOfBounds,
+        type: RangeError
+      }
+    );
+
+    common.expectsError(
+      () => {
+        crypto.randomFill(buf, 'test');
+      },
+      {
+        code: 'ERR_INVALID_CALLBACK',
+        type: TypeError
+      }
+    );
 
     {
       // Offset is too big
       const offset = (-1 >>> 0) + 1;
-      assert.throws(() => {
-        crypto.randomFillSync(buf, offset, 10);
-      }, errMessages.offsetNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFillSync(buf, offset, 10);
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.offsetOutOfRange(offset),
+          type: TypeError
+        }
+      );
 
-      assert.throws(() => {
-        crypto.randomFill(buf, offset, 10, common.mustNotCall());
-      }, errMessages.offsetNotUInt32);
+      common.expectsError(
+        () => {
+          crypto.randomFill(buf, offset, 10, common.mustNotCall());
+        },
+        {
+          code: 'ERR_VALUE_OUT_OF_RANGE',
+          message: errMessages.offsetOutOfRange(offset),
+          type: TypeError
+        }
+      );
     }
   }
+}
+
+// test randomFill buf type exception
+{
+  common.expectsError(
+    () => {
+      crypto.randomFillSync(1, 'test');
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+  common.expectsError(
+    () => {
+      crypto.randomFill(1, 'test');
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
 }
 
 // #5126, "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData()

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -197,29 +197,37 @@ const modSize = 1024;
 
 // Test exceptions for invalid `padding` and `saltLength` values
 {
-  const paddingNotInteger = /^TypeError: padding must be an integer$/;
-  const saltLengthNotInteger = /^TypeError: saltLength must be an integer$/;
-
-  [null, undefined, NaN, 'boom', {}, [], true, false]
+  [null, undefined, NaN, 'boom', {}, [], true, false, 1.5]
     .forEach((invalidValue) => {
-      assert.throws(() => {
-        crypto.createSign('RSA-SHA256')
-          .update('Test123')
-          .sign({
-            key: keyPem,
-            padding: invalidValue
-          });
-      }, paddingNotInteger);
-
-      assert.throws(() => {
-        crypto.createSign('RSA-SHA256')
-          .update('Test123')
-          .sign({
-            key: keyPem,
-            padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
-            saltLength: invalidValue
-          });
-      }, saltLengthNotInteger);
+      common.expectsError(
+        () => {
+          crypto.createSign('RSA-SHA256')
+            .update('Test123')
+            .sign({
+              key: keyPem,
+              padding: invalidValue
+            });
+        },
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          type: TypeError
+        }
+      );
+      common.expectsError(
+        () => {
+          crypto.createSign('RSA-SHA256')
+            .update('Test123')
+            .sign({
+              key: keyPem,
+              padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+              saltLength: invalidValue
+            });
+        },
+        {
+          code: 'ERR_INVALID_ARG_TYPE',
+          type: TypeError
+        }
+      );
     });
 
   assert.throws(() => {
@@ -234,9 +242,17 @@ const modSize = 1024;
 
 // Test throws exception when key options is null
 {
-  assert.throws(() => {
-    crypto.createSign('RSA-SHA1').update('Test123').sign(null, 'base64');
-  }, /^Error: No key provided to sign$/);
+  common.expectsError(
+    () => {
+      crypto.createSign('RSA-SHA1')
+            .update('Test123')
+            .sign(null, 'base64');
+    },
+    {
+      code: 'ERR_MISSING_ARGS',
+      type: Error
+    }
+  );
 }
 
 // RSA-PSS Sign test by verifying with 'openssl dgst -verify'
@@ -270,4 +286,33 @@ const modSize = 1024;
   exec(cmd, common.mustCall((err, stdout, stderr) => {
     assert(stdout.includes('Verified OK'));
   }));
+}
+
+//Test verify throws exception
+{
+  common.expectsError(
+    () => {
+      crypto.createVerify('RSA-SHA1')
+        .verify({
+          padding: 1.5
+        });
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+  common.expectsError(
+    () => {
+      crypto.createVerify('RSA-SHA1')
+        .verify({
+          padding: 1,
+          saltLength: 1.5
+        });
+    },
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
 }


### PR DESCRIPTION
convert lib/crypto.js over to using lib/internal/errors.js

ref: #11273

add missing tests for:
- crypto.randomFillSync() and crypto.randomFill() buf type error,
  crypto.randomFill() callback error in test-crypto-random.js
- crypto.verify() padding and saltLength type error in
  test-crypto-sign-verify.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
