### PR TITLE
repl: deprecate REPLServer.prototype.turnOffEditorMode

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -684,6 +684,7 @@ difference is that `querystring.parse()` does url encoding:
 { '%E5%A5%BD': '1' }
 ```
 
+<<<<<<< HEAD
 <a id="DEP0077"></a>
 ### DEP0077: Module.\_debug()
 
@@ -692,6 +693,15 @@ Type: Runtime
 `Module._debug()` has been deprecated.
 
 *Note*: `Module._debug()` was never documented as an officially supported API.
+=======
+<a id="DEP00XX"></a>
+### DEP00XX: REPLServer.turnOffEditorMode()
+
+Type: Runtime
+
+`REPLServer.turnOffEditorMode()` was removed from userland visibility.
+
+>>>>>>> repl: document REPLServer.turnOffEditorMode deprecation
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -401,17 +401,6 @@ deprecated: REPLACEME
 An internal method used to parse and execute `REPLServer` keywords.
 Returns `true` if `keyword` is a valid keyword, otherwise `false`.
 
-### replServer.turnOffEditorMode()
-<!-- YAML
-added: v6.4.0
-deprecated: REPLACEME
--->
-
-> Stability: 0 - Deprecated.
-
-An internal method used to turn off editor mode when entering
-code in the REPL.
-
 ## repl.start([options])
 <!-- YAML
 added: v0.1.91

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -401,6 +401,17 @@ deprecated: REPLACEME
 An internal method used to parse and execute `REPLServer` keywords.
 Returns `true` if `keyword` is a valid keyword, otherwise `false`.
 
+### replServer.turnOffEditorMode()
+<!-- YAML
+added: v6.4.0
+deprecated: REPLACEME
+-->
+
+> Stability: 0 - Deprecated.
+
+An internal method used to turn off editor mode when entering
+code in the REPL.
+
 ## repl.start([options])
 <!-- YAML
 added: v0.1.91

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -397,7 +397,7 @@ function REPLServer(prompt,
   self.on('SIGINT', function onSigInt() {
     var empty = self.line.length === 0;
     self.clearLine();
-    _turnOffEditorMode.call(self);
+    _turnOffEditorMode(self);
 
     const cmd = self[kBufferedCommandSymbol];
     if (!(cmd && cmd.length > 0) && empty) {
@@ -539,7 +539,7 @@ function REPLServer(prompt,
     if (key.ctrl && !key.shift) {
       switch (key.name) {
         case 'd': // End editor mode
-          _turnOffEditorMode.call(self);
+          _turnOffEditorMode(self);
           sawCtrlD = true;
           ttyWrite(d, { name: 'return' });
           break;
@@ -692,7 +692,7 @@ REPLServer.prototype.setPrompt = function setPrompt(prompt) {
 };
 
 REPLServer.prototype.turnOffEditorMode = util.deprecate(
-  _turnOffEditorMode,
+  function() { _turnOffEditorMode(this); },
   'REPLServer.turnOffEditorMode() is deprecated',
   'DEP00XX');
 
@@ -1186,9 +1186,9 @@ function _turnOnEditorMode(repl) {
   REPLServer.super_.prototype.setPrompt.call(repl, '');
 }
 
-function _turnOffEditorMode() {
-  this.editorMode = false;
-  this.setPrompt(this._initialPrompt);
+function _turnOffEditorMode(repl) {
+  repl.editorMode = false;
+  repl.setPrompt(repl._initialPrompt);
 }
 
 function defineDefaultCommands(repl) {
@@ -1270,7 +1270,7 @@ function defineDefaultCommands(repl) {
             if (lines[n])
               this.write(`${lines[n]}\n`);
           }
-          _turnOffEditorMode.call(this);
+          _turnOffEditorMode(this);
           this.write('\n');
         } else {
           this.outputStream.write('Failed to load:' + file +

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -696,6 +696,11 @@ REPLServer.prototype.turnOffEditorMode = function() {
   this.setPrompt(this._initialPrompt);
 };
 
+REPLServer.prototype.turnOnEditorMode = function() {
+  this.editorMode = true;
+  REPLServer.super_.prototype.setPrompt.call(this, '');
+};
+
 
 // A stream to push an array into a REPL
 // used in REPLServer.complete
@@ -1254,8 +1259,7 @@ function defineDefaultCommands(repl) {
       try {
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {
-          this.editorMode = true;
-          REPLServer.super_.prototype.setPrompt.call(this, '');
+          this.turnOnEditorMode();
           var data = fs.readFileSync(file, 'utf8');
           var lines = data.split('\n');
           for (var n = 0; n < lines.length; n++) {
@@ -1279,8 +1283,7 @@ function defineDefaultCommands(repl) {
     help: 'Enter editor mode',
     action() {
       if (!this.terminal) return;
-      this.editorMode = true;
-      REPLServer.super_.prototype.setPrompt.call(this, '');
+      this.turnOnEditorMode();
       this.outputStream.write(
         '// Entering editor mode (^D to finish, ^C to cancel)\n');
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -397,7 +397,7 @@ function REPLServer(prompt,
   self.on('SIGINT', function onSigInt() {
     var empty = self.line.length === 0;
     self.clearLine();
-    self.turnOffEditorMode();
+    _turnOffEditorMode.call(self);
 
     const cmd = self[kBufferedCommandSymbol];
     if (!(cmd && cmd.length > 0) && empty) {
@@ -539,7 +539,7 @@ function REPLServer(prompt,
     if (key.ctrl && !key.shift) {
       switch (key.name) {
         case 'd': // End editor mode
-          self.turnOffEditorMode();
+          _turnOffEditorMode.call(self);
           sawCtrlD = true;
           ttyWrite(d, { name: 'return' });
           break;
@@ -691,16 +691,10 @@ REPLServer.prototype.setPrompt = function setPrompt(prompt) {
   REPLServer.super_.prototype.setPrompt.call(this, prompt);
 };
 
-REPLServer.prototype.turnOffEditorMode = function() {
-  this.editorMode = false;
-  this.setPrompt(this._initialPrompt);
-};
-
-REPLServer.prototype.turnOnEditorMode = function() {
-  this.editorMode = true;
-  REPLServer.super_.prototype.setPrompt.call(this, '');
-};
-
+REPLServer.prototype.turnOffEditorMode = util.deprecate(
+  _turnOffEditorMode,
+  'REPLServer.turnOffEditorMode() is deprecated',
+  'DEP00XX');
 
 // A stream to push an array into a REPL
 // used in REPLServer.complete
@@ -1187,6 +1181,16 @@ function addStandardGlobals(completionGroups, filter) {
   }
 }
 
+function _turnOnEditorMode(repl) {
+  repl.editorMode = true;
+  REPLServer.super_.prototype.setPrompt.call(repl, '');
+}
+
+function _turnOffEditorMode() {
+  this.editorMode = false;
+  this.setPrompt(this._initialPrompt);
+}
+
 function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
@@ -1259,14 +1263,14 @@ function defineDefaultCommands(repl) {
       try {
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {
-          this.turnOnEditorMode();
+          _turnOnEditorMode(this);
           var data = fs.readFileSync(file, 'utf8');
           var lines = data.split('\n');
           for (var n = 0; n < lines.length; n++) {
             if (lines[n])
               this.write(`${lines[n]}\n`);
           }
-          this.turnOffEditorMode();
+          _turnOffEditorMode.call(this);
           this.write('\n');
         } else {
           this.outputStream.write('Failed to load:' + file +
@@ -1283,7 +1287,7 @@ function defineDefaultCommands(repl) {
     help: 'Enter editor mode',
     action() {
       if (!this.terminal) return;
-      this.turnOnEditorMode();
+      _turnOnEditorMode(this);
       this.outputStream.write(
         '// Entering editor mode (^D to finish, ^C to cancel)\n');
     }

--- a/test/parallel/test-repl-turn-off-editor-mode.js
+++ b/test/parallel/test-repl-turn-off-editor-mode.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+testTurnOffEditorMode();
+
+function testTurnOffEditorMode() {
+  const server = repl.start({ prompt: '> ' });
+  const warn = 'REPLServer.turnOffEditorMode() is deprecated';
+
+  common.expectWarning('DeprecationWarning', warn);
+  server.turnOffEditorMode();
+  server.close();
+}

--- a/test/parallel/test-repl-turn-off-editor-mode.js
+++ b/test/parallel/test-repl-turn-off-editor-mode.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const repl = require('repl');
 
 testTurnOffEditorMode();


### PR DESCRIPTION
This commit ~~exposes `REPLServer.prototype.turnOnEditorMode()` which handles the necessary internal changes to enter editor mode~~ **deprecates `REPLServer.prototype.turnOffEditorMode()`** in the REPL, ~~instead of having them scattered about~~ **and consolidates some duplicated code for turning on editor mode as a non-public function**.



##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl, doc
