### PR TITLE
doc: Use `readFileSync` instead of `fs.readFileSync` in ALPN sample

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1957,8 +1957,8 @@ The following example creates a server that supports both protocols:
 const { createSecureServer } = require('http2');
 const { readFileSync } = require('fs');
 
-const cert = fs.readFileSync('./cert.pem');
-const key = fs.readFileSync('./key.pem');
+const cert = readFileSync('./cert.pem');
+const key = readFileSync('./key.pem');
 
 const server = createSecureServer(
   { cert, key, allowHTTP1: true },


### PR DESCRIPTION
ALPN negotiation sample uses fs.readFileSync. However `readFileSync`
is imported into top level variable and should thus be used instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc