### PR TITLE
test: remove arbitrary timer in test-tls-fast-writing

### DIFF
--- a/test/parallel/test-tls-fast-writing.js
+++ b/test/parallel/test-tls-fast-writing.js
@@ -37,11 +37,6 @@ const server = tls.createServer(options, onconnection);
 let gotChunk = false;
 let gotDrain = false;
 
-setTimeout(function() {
-  console.log('not ok - timed out');
-  process.exit(1);
-}, common.platformTimeout(1000));
-
 function onconnection(conn) {
   conn.on('data', function(c) {
     if (!gotChunk) {


### PR DESCRIPTION
test-tls-fast-writing can fail on a heavily-loaded system due to an
arbitrary 1-second timeout. Remove the arbitrary timeout.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test