### PR TITLE
http2: set decodeStrings to false, test for createWriteReq

### DIFF
--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common.js');
+const PORT = common.PORT;
+
+var bench = common.createBenchmark(main, {
+  streams: [100, 200, 1000],
+  length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
+}, { flags: ['--expose-http2', '--no-warnings'] });
+
+function main(conf) {
+  const m = +conf.streams;
+  const l = +conf.length;
+  const http2 = require('http2');
+  const server = http2.createServer();
+  server.on('stream', (stream) => {
+    stream.respond();
+    stream.write('ü'.repeat(l));
+    stream.end();
+  });
+  server.listen(PORT, () => {
+    bench.http({
+      path: '/',
+      requests: 10000,
+      maxConcurrentStreams: m,
+    }, () => { server.close(); });
+  });
+}

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1154,11 +1154,6 @@ class ClientHttp2Session extends Http2Session {
 
 function createWriteReq(req, handle, data, encoding) {
   switch (encoding) {
-    case 'latin1':
-    case 'binary':
-      return handle.writeLatin1String(req, data);
-    case 'buffer':
-      return handle.writeBuffer(req, data);
     case 'utf8':
     case 'utf-8':
       return handle.writeUtf8String(req, data);
@@ -1169,6 +1164,11 @@ function createWriteReq(req, handle, data, encoding) {
     case 'utf16le':
     case 'utf-16le':
       return handle.writeUcs2String(req, data);
+    case 'latin1':
+    case 'binary':
+      return handle.writeLatin1String(req, data);
+    case 'buffer':
+      return handle.writeBuffer(req, data);
     default:
       return handle.writeBuffer(req, Buffer.from(data, encoding));
   }
@@ -1280,6 +1280,7 @@ function abort(stream) {
 class Http2Stream extends Duplex {
   constructor(session, options) {
     options.allowHalfOpen = true;
+    options.decodeStrings = false;
     super(options);
     this.cork();
     this[kSession] = session;

--- a/test/parallel/test-http2-createwritereq.js
+++ b/test/parallel/test-http2-createwritereq.js
@@ -1,0 +1,68 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// Tests that write uses the correct encoding when writing
+// using the helper function createWriteReq
+
+const testString = 'a\u00A1\u0100\uD83D\uDE00';
+
+const encodings = {
+  'buffer': 'utf8',
+  'ascii': 'ascii',
+  'latin1': 'latin1',
+  'binary': 'latin1',
+  'utf8': 'utf8',
+  'utf-8': 'utf8',
+  'ucs2': 'ucs2',
+  'ucs-2': 'ucs2',
+  'utf16le': 'ucs2',
+  'utf-16le': 'ucs2',
+  'UTF8': 'utf8' // should fall through to Buffer.from
+};
+
+const testsToRun = Object.keys(encodings).length;
+let testsFinished = 0;
+
+const server = http2.createServer(common.mustCall((req, res) => {
+  const testEncoding = encodings[req.path.slice(1)];
+
+  req.on('data', common.mustCall((chunk) => assert.ok(
+    Buffer.from(testString, testEncoding).equals(chunk)
+  )));
+
+  req.on('end', () => res.end());
+}, Object.keys(encodings).length));
+
+server.listen(0, common.mustCall(function() {
+  Object.keys(encodings).forEach((writeEncoding) => {
+    const client = http2.connect(`http://localhost:${this.address().port}`);
+    const req = client.request({
+      ':path': `/${writeEncoding}`,
+      ':method': 'POST'
+    });
+
+    assert.strictEqual(req._writableState.decodeStrings, false);
+    req.write(
+      writeEncoding !== 'buffer' ? testString : Buffer.from(testString),
+      writeEncoding !== 'buffer' ? writeEncoding : undefined
+    );
+    req.resume();
+
+    req.on('end', common.mustCall(function() {
+      client.destroy();
+      testsFinished++;
+
+      if (testsFinished === testsToRun) {
+        server.close();
+      }
+    }));
+
+    req.end();
+  });
+}));


### PR DESCRIPTION
Adds a test for all the encodings in createWriteReq, including the default case. The other option was mocking all the handlers but that didn't seem any better. Also, don't think there's a way to set objectMode without digging into `_writableState`.

If anyone has better ideas on how to properly test this, I'm happy to adjust. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

**Update Sep 6, 2017:** This has now become a change in http2 core to not convert strings to Buffer as it really improves performance if we don't do it.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test