### PR TITLE
test: refactor test-debug-prompt

### DIFF
--- a/test/sequential/test-debug-prompt.js
+++ b/test/sequential/test-debug-prompt.js
@@ -11,5 +11,5 @@ let output = '';
 proc.stdout.on('data', (data) => {
   output += data;
   if (output.includes('debug> '))
-    proc.kill();
+    proc.stdin.write('.exit\n');
 });


### PR DESCRIPTION
* Use cleaner `process.stdin.write('.exit')` to exit the process rather
  than `proc.kill()`.
* Move test to sequential. It uses the default port 9229. It will fail
  if another inspector test (or test using port 0) is already using that
  port. So it needs to be run sequentially rather than in parallel with
  other tests. (We haven't seen many failures with it yet because there
  aren't a lot of other inspector tests in parallel at this time.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test