### PR TITLE
build: fix shared installing target

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -133,8 +133,10 @@ def files(action):
       if sys.platform != 'darwin':
         output_prefix += 'lib.target/'
 
-  action([output_prefix + output_file], (
-    'bin/' if 'false' == variables.get('node_shared') else 'lib/') + output_file)
+  if 'false' == variables.get('node_shared'):
+    action([output_prefix + output_file], 'bin/' + output_file)
+  else:
+    action([output_prefix + output_file], 'lib/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')

--- a/tools/install.py
+++ b/tools/install.py
@@ -123,6 +123,7 @@ def files(action):
   if 'false' == variables.get('node_shared'):
     if is_windows:
       output_file += '.exe'
+    action([output_prefix + output_file], 'lib/' + output_file)
   else:
     if is_windows:
       output_file += '.dll'
@@ -132,8 +133,7 @@ def files(action):
       # in its source - see the _InstallableTargetInstallPath function.
       if sys.platform != 'darwin':
         output_prefix += 'lib.target/'
-
-  action([output_prefix + output_file], 'bin/' + output_file)
+    action([output_prefix + output_file], 'bin/' + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')

--- a/tools/install.py
+++ b/tools/install.py
@@ -123,7 +123,6 @@ def files(action):
   if 'false' == variables.get('node_shared'):
     if is_windows:
       output_file += '.exe'
-    action([output_prefix + output_file], 'lib/' + output_file)
   else:
     if is_windows:
       output_file += '.dll'
@@ -133,7 +132,9 @@ def files(action):
       # in its source - see the _InstallableTargetInstallPath function.
       if sys.platform != 'darwin':
         output_prefix += 'lib.target/'
-    action([output_prefix + output_file], 'bin/' + output_file)
+
+  action([output_prefix + output_file], (
+    'bin/' if 'false' == variables.get('node_shared') else 'lib/') + output_file)
 
   if 'true' == variables.get('node_use_dtrace'):
     action(['out/Release/node.d'], 'lib/dtrace/node.d')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

This patch fixes the target location with `--shared` flag, we should install the lib under `$node_prefix/lib`