### PR TITLE
buffer: add {read|write}[U]Int64{BE|LE} methods

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2424,7 +2424,7 @@ Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeInt64BE()` writes big endian, `writeInt64LE()` writes little
 endian). `value` *should* be a valid signed 64-bit integer or a String
 representation of one. Behavior is undefined when `value` is anything other than
-a signed 32-bit integer or a String representation of one.
+a signed 64-bit integer or a String representation of one.
 
 Setting `noAssert` to `true` allows the encoded form of `value` to extend beyond
 the end of `buf`, but the result should be considered undefined behavior.
@@ -2596,7 +2596,7 @@ Writes `value` to `buf` at the specified `offset` with specified endian
 format (`writeUInt64BE()` writes big endian, `writeUInt64LE()` writes little
 endian). `value` should be a valid unsigned 64-bit integer or a String
 representation of one. Behavior is undefined when `value` is anything other than
-an unsigned 32-bit integer or a String representation of one.
+an unsigned 64-bit integer or a String representation of one.
 
 Setting `noAssert` to `true` allows the encoded form of `value` to extend beyond
 the end of `buf`, but the result should be considered undefined behavior.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1722,6 +1722,22 @@ console.log(buf.readInt32LE());
 console.log(buf.readInt32LE(1));
 ```
 
+### buf.readInt64LE(offset[, noAssert])
+### buf.readInt64BE(offset[, noAssert])
+
+* `offset` {integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
+* Returns: {integer}
+
+Reads a signed 64-bit integer from `buf` at the specified `offset` with
+the specified endian format (`readInt64BE()` returns big endian,
+`readInt64LE()` return little endian).
+
+Setting `noAssert` to `true` allows `offset` to be beyond the end of `buf`, but
+the result should be considered undefined behavior.
+
+Integers read from a `Buffer` are interpreted as two's complement signed values.
+
 ### buf.readIntBE(offset, byteLength[, noAssert])
 ### buf.readIntLE(offset, byteLength[, noAssert])
 <!-- YAML
@@ -1852,6 +1868,35 @@ console.log(buf.readUInt32LE(0).toString(16));
 
 // Throws an exception: RangeError: Index out of range
 console.log(buf.readUInt32LE(1).toString(16));
+```
+
+### buf.readUInt64LE(offset[, noAssert])
+### buf.readUInt64BE(offset[, noAssert])
+
+* `offset` {integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
+* `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
+* Returns: {string}
+
+Reads an unsigned 64-bit integer from `buf` at the specified `offset` with
+specified endian format (`readUInt64BE()` returns big endian,
+`readUInt64LE()` returns little endian).
+
+Setting `noAssert` to `true` allows `offset` to be beyond the end of `buf`, but
+the result should be considered undefined behavior.
+
+Examples:
+
+```js
+var buf = Buffer.allocUnsafe(8);
+buf[0] = buf[1] = buf[2] = buf[3] = 0x00;
+buf[4] = buf[5] = buf[6] = buf[7] = 0xff;
+// <Buffer 00 00 00 00 ff ff ff ff>
+
+// Prints: '4294967295'
+console.log(buf.readUInt64BE(0));
+
+// Prints: '1844674406941458432'
+console.log(b.readUInt64LE(0));
 ```
 
 ### buf.readUIntBE(offset, byteLength[, noAssert])
@@ -2358,6 +2403,36 @@ buf.writeInt32LE(0x05060708, 4);
 console.log(buf);
 ```
 
+### buf.writeInt64(value, offset[, noAssert])
+### buf.writeInt64(value, offset[, noAssert])
+
+* `value` {integer|string} Number to be written to `buf`
+* `offset` {integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
+* Returns: {integer} `offset` plus the number of bytes written
+
+Writes `value` to `buf` at the specified `offset` with specified endian
+format (`writeInt64BE()` writes big endian, `writeInt64LE()` writes little
+endian). `value` *should* be a valid signed 64-bit integer or a String
+representation of one. Behavior is undefined when `value` is anything other than
+a signed 32-bit integer or a String representation of one.
+
+Setting `noAssert` to `true` allows the encoded form of `value` to extend beyond
+the end of `buf`, but the result should be considered undefined behavior.
+
+`value` is interpreted and written as a two's complement signed integer.
+
+Examples:
+
+```js
+const buf = Buffer.allocUnsafe(8);
+
+buf.writeInt64BE('0x0102030405060708', 0);
+
+// Prints: <Buffer 01 02 03 04 05 06 07 08>
+console.log(buf);
+```
+
 ### buf.writeIntBE(value, offset, byteLength[, noAssert])
 ### buf.writeIntLE(value, offset, byteLength[, noAssert])
 <!-- YAML
@@ -2494,6 +2569,34 @@ console.log(buf);
 buf.writeUInt32LE(0xfeedface, 0);
 
 // Prints: <Buffer ce fa ed fe>
+console.log(buf);
+```
+
+### buf.writeUInt64LE(value, offset[, noAssert])
+### buf.writeUInt64BE(value, offset[, noAssert])
+
+* `value` {integer|string} Number to be written to `buf`
+* `offset` {integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`
+* `noAssert` {boolean} Skip `value` and `offset` validation? **Default:** `false`
+* Returns: {integer} `offset` plus the number of bytes written
+
+Writes `value` to `buf` at the specified `offset` with specified endian
+format (`writeUInt64BE()` writes big endian, `writeUInt64LE()` writes little
+endian). `value` should be a valid unsigned 64-bit integer or a String
+representation of one. Behavior is undefined when `value` is anything other than
+an unsigned 32-bit integer or a String representation of one.
+
+Setting `noAssert` to `true` allows the encoded form of `value` to extend beyond
+the end of `buf`, but the result should be considered undefined behavior.
+
+Examples:
+
+```js
+var buf = Buffer.allocUnsafe(8);
+
+buf.writeUInt64LE('0xffffffffffff', 0);
+
+// Prints: <Buffer ff ff ff ff ff ff 00 00>
 console.log(buf);
 ```
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1730,7 +1730,7 @@ added: replaceme
 
 * `offset` {integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
 * `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
-* Returns: {integer}
+* Returns: {string}
 
 Reads a signed 64-bit integer from `buf` at the specified `offset` with
 the specified endian format (`readInt64BE()` returns big endian,

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1724,6 +1724,9 @@ console.log(buf.readInt32LE(1));
 
 ### buf.readInt64LE(offset[, noAssert])
 ### buf.readInt64BE(offset[, noAssert])
+<!-- YAML
+added: replaceme
+-->
 
 * `offset` {integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
 * `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
@@ -1872,6 +1875,9 @@ console.log(buf.readUInt32LE(1).toString(16));
 
 ### buf.readUInt64LE(offset[, noAssert])
 ### buf.readUInt64BE(offset[, noAssert])
+<!-- YAML
+added: replaceme
+-->
 
 * `offset` {integer} Where to start reading. Must satisfy: `0 <= offset <= buf.length - 8`
 * `noAssert` {boolean} Skip `offset` validation? **Default:** `false`
@@ -2405,6 +2411,9 @@ console.log(buf);
 
 ### buf.writeInt64(value, offset[, noAssert])
 ### buf.writeInt64(value, offset[, noAssert])
+<!-- YAML
+added: replaceme
+-->
 
 * `value` {integer|string} Number to be written to `buf`
 * `offset` {integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`
@@ -2574,6 +2583,9 @@ console.log(buf);
 
 ### buf.writeUInt64LE(value, offset[, noAssert])
 ### buf.writeUInt64BE(value, offset[, noAssert])
+<!-- YAML
+added: replaceme
+-->
 
 * `value` {integer|string} Number to be written to `buf`
 * `offset` {integer} Where to start writing. Must satisfy: `0 <= offset <= buf.length - 8`

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -35,6 +35,10 @@ const {
   readDoubleLE: _readDoubleLE,
   readFloatBE: _readFloatBE,
   readFloatLE: _readFloatLE,
+  readInt64BE: _readInt64BE,
+  readInt64LE: _readInt64LE,
+  readUInt64BE: _readUInt64BE,
+  readUInt64LE: _readUInt64LE,
   setupBufferJS,
   swap16: _swap16,
   swap32: _swap32,
@@ -43,6 +47,10 @@ const {
   writeDoubleLE: _writeDoubleLE,
   writeFloatBE: _writeFloatBE,
   writeFloatLE: _writeFloatLE,
+  writeInt64BE: _writeInt64BE,
+  writeInt64LE: _writeInt64LE,
+  writeUInt64BE: _writeUInt64BE,
+  writeUInt64LE: _writeUInt64LE,
   kMaxLength,
   kStringMaxLength
 } = process.binding('buffer');
@@ -1222,6 +1230,38 @@ Buffer.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
 };
 
 
+Buffer.prototype.readInt64LE = function readInt64LE(offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 8, this.length);
+  return _readInt64LE(this, offset);
+};
+
+
+Buffer.prototype.readInt64BE = function readInt64BE(offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 8, this.length);
+  return _readInt64BE(this, offset);
+};
+
+
+Buffer.prototype.readUInt64LE = function readUInt64LE(offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 8, this.length);
+  return _readUInt64LE(this, offset);
+};
+
+
+Buffer.prototype.readUInt64BE = function readUInt64BE(offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    checkOffset(offset, 8, this.length);
+  return _readUInt64BE(this, offset);
+};
+
+
 function checkInt(buffer, value, offset, ext, max, min) {
   if (value > max || value < min)
     throw new errors.RangeError('ERR_INVALID_OPT_VALUE', 'value', value);
@@ -1487,6 +1527,47 @@ Buffer.prototype.writeDoubleBE = function writeDoubleBE(val, offset, noAssert) {
     _writeDoubleBE(this, val, offset, true);
   return offset + 8;
 };
+
+
+Buffer.prototype.writeInt64LE = function writeInt64LE(val, offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    _writeInt64LE(this, val, offset);
+  else
+    _writeInt64LE(this, val, offset, true);
+  return offset + 8;
+};
+
+
+Buffer.prototype.writeInt64BE = function writeInt64BE(val, offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    _writeInt64BE(this, val, offset);
+  else
+    _writeInt64BE(this, val, offset, true);
+  return offset + 8;
+};
+
+
+Buffer.prototype.writeUInt64LE = function writeUInt64LE(val, offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    _writeUInt64LE(this, val, offset);
+  else
+    _writeUInt64LE(this, val, offset, true);
+  return offset + 8;
+};
+
+
+Buffer.prototype.writeUInt64BE = function writeUInt64BE(val, offset, noAssert) {
+  offset = offset >>> 0;
+  if (!noAssert)
+    _writeUInt64BE(this, val, offset);
+  else
+    _writeUInt64BE(this, val, offset, true);
+  return offset + 8;
+};
+
 
 function swap(b, n, m) {
   const i = b[n];

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -901,13 +901,13 @@ void WriteInt64Generic(const FunctionCallbackInfo<Value>& args) {
   const size_t ts_obj_offset = ts_obj->ByteOffset();
   const size_t ts_obj_length = ts_obj->ByteLength();
   char* const ts_obj_data =
-    static_cast<char*>(ts_obj_c.Data()) + ts_obj_offset;
+      static_cast<char*>(ts_obj_c.Data()) + ts_obj_offset;
   if (ts_obj_length > 0)
     CHECK_NE(ts_obj_data, nullptr);
 
   T val;
   if (args[1]->IsNumber()) {
-    val = args[1]->IntegerValue();
+    val = args[1]->IntegerValue(env->context()).FromMaybe(0);
   } else if (args[1]->IsString()) {
     node::Utf8Value str(env->isolate(), args[1]);
     const char* cstr = *str;

--- a/test/parallel/test-buffer-int64.js
+++ b/test/parallel/test-buffer-int64.js
@@ -1,0 +1,53 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const Buffer = require('buffer').Buffer;
+
+const buf = new Buffer(8);
+
+['LE', 'BE'].forEach(function(endianness) {
+  // should allow simple ints to be written and read
+  let val = 123456789;
+  buf['writeInt64' + endianness](val, 0);
+  let rtn = buf['readInt64' + endianness](0);
+  assert.strictEqual(val.toString(), rtn);
+
+  // should allow INT64_MAX to be written and read
+  val = '9223372036854775807';
+  buf['writeInt64' + endianness](val, 0);
+  rtn = buf['readInt64' + endianness](0);
+  assert.strictEqual(val, rtn);
+
+  // should read and write a negative signed 64-bit integer
+  val = -123456789;
+  buf['writeInt64' + endianness](val, 0);
+  assert.strictEqual(val.toString(), buf['readInt64' + endianness](0));
+
+  // should read and write an unsigned 64-bit integer
+  val = 123456789;
+  buf['writeUInt64' + endianness](val, 0);
+  assert.strictEqual(val.toString(), buf['readUInt64' + endianness](0));
+
+  // should throw a RangeError upon INT64_MAX+1 being written
+  assert.throws(function() {
+    const val = '9223372036854775808';
+    buf['writeInt64' + endianness](val, 0);
+  }, RangeError);
+
+  // should throw a RangeError upon UINT64_MAX+1 being written
+  assert.throws(function() {
+    const val = '18446744073709551616';
+    buf['writeUInt64' + endianness](val, 0);
+  }, RangeError);
+
+  // should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf['writeInt64' + endianness]('bad', 0);
+  }, TypeError);
+
+  // should throw a TypeError upon invalid input
+  assert.throws(function() {
+    buf['writeUInt64' + endianness]('bad', 0);
+  }, TypeError);
+});


### PR DESCRIPTION
This is basically a resurrection of @TooTallNate's PR https://github.com/nodejs/node/pull/1750 with a couple differences:

* `read[U]Int64{BE|LE}` always returns strings to make the output more predictable.
* No `address()` method, and thus no changes to the inspect output for Buffers

I'm not sure how to deal with attribution. @TooTallNate did most of the work here, but I also did significant work rebasing and updating.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer