### PR TITLE
http2: fix closedCode NaN, increase test coverage

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -249,7 +249,8 @@ class Http2ServerRequest extends Readable {
     const state = this[kState];
     if (state.closed)
       return;
-    state.closedCode = code;
+    if (code !== undefined)
+      state.closedCode = code;
     state.closed = true;
     this.push(null);
     this[kStream] = undefined;
@@ -522,7 +523,8 @@ class Http2ServerResponse extends Stream {
     const state = this[kState];
     if (state.closed)
       return;
-    state.closedCode = code;
+    if (code !== undefined)
+      state.closedCode = code;
     state.closed = true;
     this.end();
     this[kStream] = undefined;

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -21,6 +21,9 @@ server.listen(0, common.mustCall(function() {
       httpVersionMinor: 0
     };
 
+    assert.strictEqual(request.closed, false);
+    assert.strictEqual(request.code, h2.constants.NGHTTP2_NO_ERROR);
+
     assert.strictEqual(request.statusCode, expected.statusCode);
     assert.strictEqual(request.httpVersion, expected.version);
     assert.strictEqual(request.httpVersionMajor, expected.httpVersionMajor);
@@ -31,6 +34,8 @@ server.listen(0, common.mustCall(function() {
     assert.strictEqual(request.socket, request.connection);
 
     response.on('finish', common.mustCall(function() {
+      assert.strictEqual(request.closed, true);
+      assert.strictEqual(request.code, h2.constants.NGHTTP2_NO_ERROR);
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -84,7 +84,10 @@ server.listen(0, common.mustCall(function() {
     response.sendDate = false;
     assert.strictEqual(response.sendDate, false);
 
+    assert.strictEqual(response.code, h2.constants.NGHTTP2_NO_ERROR);
+
     response.on('finish', common.mustCall(function() {
+      assert.strictEqual(response.code, h2.constants.NGHTTP2_NO_ERROR);
       server.close();
     }));
     response.end();


### PR DESCRIPTION
`[kFinish](code)` can be triggered without passing `code`. Until now, the method tried to set closedCode to `undefined` resulting in `NaN` closedCode instead of `NGHTTP2_NO_ERROR`. Added a check for `code !== undefined` before setting. 

Also adds tests for `closed` (request only, response covered by another PR previously) and `closedCode` (both).

~~Adds tests for Http2ServerRequest and Http2ServerResponse `setTimeout`.~~ Edit: separate PR now: https://github.com/nodejs/node/pull/15156

Let me know if there's anything I can change. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test