### PR TITLE
test: add http2 compat setTimeout tests

### DIFF
--- a/test/parallel/test-http2-compat-serverrequest-settimeout.js
+++ b/test/parallel/test-http2-compat-serverrequest-settimeout.js
@@ -1,0 +1,32 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+server.on('request', (req, res) => {
+  req.setTimeout(common.platformTimeout(1), common.mustCall(() => {
+    res.end();
+  }));
+});
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({
+    ':path': '/',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.resume();
+  req.end();
+}));

--- a/test/parallel/test-http2-compat-serverresponse-settimeout.js
+++ b/test/parallel/test-http2-compat-serverresponse-settimeout.js
@@ -1,0 +1,32 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+server.on('request', (req, res) => {
+  res.setTimeout(common.platformTimeout(1), common.mustCall(() => {
+    res.end();
+  }));
+});
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({
+    ':path': '/',
+    ':method': 'GET',
+    ':scheme': 'http',
+    ':authority': `localhost:${port}`
+  });
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.resume();
+  req.end();
+}));


### PR DESCRIPTION
Add tests for Http2ServerRequest and Http2ServerResponse `setTimeout`. Let me know if I should adjust anything!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test