### PR TITLE
doc: document missing error codes

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -588,6 +588,18 @@ Used as special type of error that can be triggered whenever Node.js detects an
 exceptional logic violation that should never occur. These are raised typically
 by the `assert` module.
 
+<a id="ERR_ASYNC_CALLBACK"></a>
+### ERR_ASYNC_CALLBACK
+
+Used with `AsyncHooks` to indicate an attempt of registering something that is
+not a function as a callback.
+
+<a id="ERR_ASYNC_TYPE"></a>
+### ERR_ASYNC_TYPE
+
+Used when the type of an asynchronous resource is invalid. Note that users are
+also able to define their own types when using the public embedder API.
+
 <a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
 ### ERR_BUFFER_OUT_OF_BOUNDS
 
@@ -614,6 +626,18 @@ Used when the native call from `process.cpuUsage` cannot be processed properly.
 
 Used when `c-ares` failed to set the DNS server.
 
+<a id="ERR_ENCODING_INVALID_ENCODED_DATA"></a>
+### ERR_ENCODING_INVALID_ENCODED_DATA
+
+Used by the `util.TextDecoder()` API when the data provided is invalid
+according to the encoding provided.
+
+<a id="ERR_ENCODING_NOT_SUPPORTED"></a>
+### ERR_ENCODING_NOT_SUPPORTED
+
+Used by the `util.TextDecoder()` API when the encoding provided is not one of
+the [WHATWG Supported Encodings][].
+
 <a id="ERR_FALSY_VALUE_REJECTION"></a>
 ### ERR_FALSY_VALUE_REJECTION
 
@@ -625,6 +649,12 @@ with a falsy value (e.g. `null`).
 
 Used when headers have already been sent and another attempt is made to add
 more headers.
+
+<a id="ERR_HTTP_INVALID_CHAR"></a>
+### ERR_HTTP_INVALID_CHAR
+
+Used when an invalid character is found in an HTTP response status message
+(reason phrase).
 
 <a id="ERR_HTTP_INVALID_STATUS_CODE"></a>
 ### ERR_HTTP_INVALID_STATUS_CODE
@@ -652,19 +682,31 @@ forbidden.
 <a id="ERR_HTTP2_CONNECT_SCHEME"></a>
 ### ERR_HTTP2_CONNECT_SCHEME
 
-The HTTP/2 requests using the `CONNECT` method, the `:scheme` pseudo-header is
+For HTTP/2 requests using the `CONNECT` method, the `:scheme` pseudo-header is
 forbidden.
-
-<a id="ERR_HTTP2_ERROR"></a>
-### ERR_HTTP2_ERROR
-
-A non-specific HTTP/2 error has occurred.
 
 <a id="ERR_HTTP2_FRAME_ERROR"></a>
 ### ERR_HTTP2_FRAME_ERROR
 
 Used when a failure occurs sending an individual frame on the HTTP/2
 session.
+
+<a id="ERR_HTTP2_HEADER_REQUIRED"></a>
+### ERR_HTTP2_HEADER_REQUIRED
+
+Used when a required header is missing in an HTTP/2 message.
+
+<a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
+### ERR_HTTP2_HEADER_SINGLE_VALUE
+
+Used when multiple values have been provided for an HTTP header field that
+required to have only a single value.
+
+<a id="ERR_HTTP2_HEADERS_AFTER_RESPOND"></a>
+### ERR_HTTP2_HEADERS_AFTER_RESPOND
+
+Used when trying to specify additional headers after an HTTP/2 response
+initiated.
 
 <a id="ERR_HTTP2_HEADERS_OBJECT"></a>
 ### ERR_HTTP2_HEADERS_OBJECT
@@ -675,12 +717,6 @@ Used when an HTTP/2 Headers Object is expected.
 ### ERR_HTTP2_HEADERS_SENT
 
 Used when an attempt is made to send multiple response headers.
-
-<a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
-### ERR_HTTP2_HEADER_SINGLE_VALUE
-
-Used when multiple values have been provided for an HTTP header field that
-required to have only a single value.
 
 <a id="ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND"></a>
 ### ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND
@@ -837,6 +873,12 @@ to a Node.js API.
 
 Used when an Array is not of the expected length or in a valid range.
 
+<a id="ERR_INVALID_ASYNC_ID"></a>
+### ERR_INVALID_ASYNC_ID
+
+Used with `AsyncHooks` when an invalid `asyncId` or `triggerAsyncId` is passed.
+An id less than -1 should never happen.
+
 <a id="ERR_INVALID_BUFFER_SIZE"></a>
 ### ERR_INVALID_BUFFER_SIZE
 
@@ -912,6 +954,12 @@ passed in an options object.
 ### ERR_INVALID_OPT_VALUE_ENCODING
 
 Used when an invalid or unknown file encoding is passed.
+
+<a id="ERR_INVALID_PERFORMANCE_MARK"></a>
+### ERR_INVALID_PERFORMANCE_MARK
+
+Used by the Performance Timing API (`perf_hooks`) when a performance mark is
+invalid.
 
 <a id="ERR_INVALID_PROTOCOL"></a>
 ### ERR_INVALID_PROTOCOL
@@ -1022,6 +1070,16 @@ Used when a callback is called more then once.
 can either be fulfilled or rejected but not both at the same time. The latter
 would be possible by calling a callback more then once.
 
+<a id="ERR_NAPI_CONS_FUNCTION"></a>
+### ERR_NAPI_CONS_FUNCTION
+
+Used by the `N-API` when a constructor passed is not a function.
+
+<a id="ERR_NAPI_CONS_PROTOTYPE_OBJECT"></a>
+### ERR_NAPI_CONS_PROTOTYPE_OBJECT
+
+Used by the `N-API` when `Constructor.prototype` is not an object.
+
 <a id="ERR_NO_CRYPTO"></a>
 ### ERR_NO_CRYPTO
 
@@ -1041,8 +1099,16 @@ Used when a Node.js API is called in an unsupported manner.
 
 For example: `Buffer.write(string, encoding, offset[, length])`
 
+<a id="ERR_OUTOFMEMORY"></a>
+### ERR_OUTOFMEMORY
+
+Used generically to identify that an operation caused an out of memory
+condition.
+
 <a id="ERR_PARSE_HISTORY_DATA"></a>
 ### ERR_PARSE_HISTORY_DATA
+
+Used by the `REPL` module when it cannot parse data from the REPL history file.
 
 <a id="ERR_SOCKET_ALREADY_BOUND"></a>
 ### ERR_SOCKET_ALREADY_BOUND
@@ -1065,6 +1131,11 @@ invalid value.
 ### ERR_SOCKET_CANNOT_SEND
 
 Used when data cannot be sent on a socket.
+
+<a id="ERR_SOCKET_CLOSED"></a>
+### ERR_SOCKET_CLOSED
+
+Used when an attempt is made to operate on an already closed socket.
 
 <a id="ERR_SOCKET_DGRAM_NOT_RUNNING"></a>
 ### ERR_SOCKET_DGRAM_NOT_RUNNING
@@ -1097,12 +1168,54 @@ const instance = new Socket();
 instance.setEncoding('utf-8');
 ```
 
-<a id="ERR_UNKNOWN_BUILTIN_MODULE"></a>
-### ERR_UNKNOWN_BUILTIN_MODULE
+<a id="ERR_TLS_CERT_ALTNAME_INVALID"></a>
+### ERR_TLS_CERT_ALTNAME_INVALID
 
-Used to identify a specific kind of internal Node.js error that should not
-typically be triggered by user code. Instances of this error point to an
-internal bug within the Node.js binary itself.
+Used with TLS, when the hostname/IP of the peer does not match any of the
+subjectAltNames in its certificate.
+
+<a id="ERR_TLS_DH_PARAM_SIZE"></a>
+### ERR_TLS_DH_PARAM_SIZE
+
+Used with TLS when the parameter offered for the Diffie-Hellman (`DH`)
+key-agreement protocol is too small. By default, the key length must be greater
+than or equal to 1024 bits to avoid vulnerabilities, even though it is strongly
+recommended to use 2048 bits or larger for stronger security.
+
+<a id="ERR_TLS_HANDSHAKE_TIMEOUT"></a>
+### ERR_TLS_HANDSHAKE_TIMEOUT
+
+A TLS error emitted by the server whenever a TLS/SSL handshake times out. In
+this case, the server must also abort the connection.
+
+<a id="ERR_TLS_RENEGOTIATION_FAILED"></a>
+### ERR_TLS_RENEGOTIATION_FAILED
+
+Used when a TLS renegotiation request has failed in a non-specific way.
+
+<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
+### ERR_TLS_REQUIRED_SERVER_NAME
+
+Used with TLS, when calling the `server.addContext()` method without providing
+a hostname in the first parameter.
+
+<a id="ERR_TLS_SESSION_ATTACK"></a>
+### ERR_TLS_SESSION_ATTACK
+
+Used when an excessive amount of TLS renegotiations is detected, which is a
+potential vector for denial-of-service attacks.
+
+<a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
+### ERR_TRANSFORM_ALREADY_TRANSFORMING
+
+Used in Transform streams when the stream finishes while it is still
+transforming.
+
+<a id="ERR_TRANSFORM_WITH_LENGTH_0"></a>
+### ERR_TRANSFORM_WITH_LENGTH_0
+
+Used in Transform streams when the stream finishes with data still in the write
+buffer.
 
 <a id="ERR_UNESCAPED_CHARACTERS"></a>
 ### ERR_UNESCAPED_CHARACTERS
@@ -1147,6 +1260,12 @@ Used when a number value is out of range.
 Used when the V8 BreakIterator API is used but the full ICU data set is not
 installed.
 
+<a id="ERR_VALID_PERFORMANCE_ENTRY_TYPE"></a>
+### ERR_VALID_PERFORMANCE_ENTRY_TYPE
+
+Used by the Performance Timing API (`perf_hooks`) when no valid performance
+entry types were found.
+
 <a id="ERR_VALUE_OUT_OF_RANGE"></a>
 ### ERR_VALUE_OUT_OF_RANGE
 
@@ -1179,3 +1298,4 @@ Used when a given value is out of the accepted range.
 [syscall]: http://man7.org/linux/man-pages/man2/syscall.2.html
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 [vm]: vm.html
+[WHATWG Supported Encodings]: util.md#whatwg-supported-encodings


### PR DESCRIPTION
There are discrepancies between the errors defined in
`lib/internal/errors.js` and those documented in `doc/api/errors.md`.
Some of the errors recently defined are not documented, while others
were removed, but still have entries in the docs. This commit fills in
those gaps in the documentation.

Fixes: https://github.com/nodejs/node/issues/15038

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc