### PR TITLE
http2: correct behaviour for enablePush unpack

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2538,7 +2538,7 @@ function getUnpackedSettings(buf, options = {}) {
         settings.headerTableSize = value;
         break;
       case NGHTTP2_SETTINGS_ENABLE_PUSH:
-        settings.enablePush = Boolean(value);
+        settings.enablePush = value;
         break;
       case NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS:
         settings.maxConcurrentStreams = value;
@@ -2560,6 +2560,9 @@ function getUnpackedSettings(buf, options = {}) {
     assertWithinRange('headerTableSize',
                       settings.headerTableSize,
                       0, 2 ** 32 - 1);
+    assertWithinRange('enablePush',
+                      settings.enablePush,
+                      0, 1);
     assertWithinRange('initialWindowSize',
                       settings.initialWindowSize,
                       0, 2 ** 32 - 1);
@@ -2572,13 +2575,10 @@ function getUnpackedSettings(buf, options = {}) {
     assertWithinRange('maxHeaderListSize',
                       settings.maxHeaderListSize,
                       0, 2 ** 32 - 1);
-    if (settings.enablePush !== undefined &&
-        typeof settings.enablePush !== 'boolean') {
-      const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
-                                       'enablePush', settings.enablePush);
-      err.actual = settings.enablePush;
-      throw err;
-    }
+  }
+
+  if (settings.enablePush !== undefined) {
+    settings.enablePush = !!settings.enablePush;
   }
 
   return settings;

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -126,6 +126,27 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
   assert.strictEqual(settings.enablePush, true);
 }
 
+//should throw if enablePush is not 0 or 1
+{
+  const packed = Buffer.from([
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x00]);
+
+  const settings = http2.getUnpackedSettings(packed, { validate: true });
+  assert.strictEqual(settings.enablePush, false);
+}
+{
+  const packed = Buffer.from([
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x64]);
+
+  assert.throws(() => {
+    http2.getUnpackedSettings(packed, { validate: true });
+  }, common.expectsError({
+    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+    type: RangeError,
+    message: 'Invalid value for setting "enablePush": 100'
+  }));
+}
+
 //check for what happens if passing {validate: true} and no errors happen
 {
   const packed = Buffer.from([


### PR DESCRIPTION
So, as per the spec, the only valid values for `enablePush` should be 0 or 1. nghttp2 already handles this correctly but the JS unpacker exposed to the end-user doesn't. That said, I'm not sure as to the desired behaviour:

1) Set value to the actual value, validate it's within range (if validation requested) and finally set to Boolean (even if it's not 0 or 1, as long as they didn't request validation which would throw).

2) Set value to the actual value, validate it's within range (if validation requested) and only set to Boolean if it's 0 or 1, otherwise leave as the actual value for the end-user to handle.

I think we should follow the spec here, at least to the extent that we shouldn't just cast everything to Boolean when validating. If validation is requested then it clearly needs to throw if it's not 0 or 1 (it wasn't doing this before).

But not sure what we actually want to output to the end-user if it's not 0 or 1 and no validation was requested.

And here's the spec btw:

> SETTINGS_ENABLE_PUSH (0x2):
This setting can be used to disable server push (Section 8.2). An endpoint MUST NOT send a PUSH_PROMISE frame if it receives this parameter set to a value of 0. An endpoint that has both set this parameter to 0 and had it acknowledged MUST treat the receipt of a PUSH_PROMISE frame as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

> The initial value is 1, which indicates that server push is permitted. Any value other than 0 or 1 MUST be treated as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test