### PR TITLE
test: make test-http-agent-maxsockets robust

### DIFF
--- a/test/parallel/test-http-agent-maxsockets.js
+++ b/test/parallel/test-http-agent-maxsockets.js
@@ -37,12 +37,12 @@ function dec() {
 }
 
 function onGet(res) {
+  if (res.req.path === '/1') {
+    get('/2', common.mustCall(onGet));
+  }
   assert.strictEqual(res.statusCode, 200);
   res.resume();
   res.on('end', common.mustCall(dec));
 }
 
-server.listen(0, common.mustCall(() => {
-  get('/1', common.mustCall(onGet));
-  get('/2', common.mustCall(onGet));
-}));
+server.listen(0, common.mustCall(() => { get('/1', common.mustCall(onGet)); }));


### PR DESCRIPTION
`test-http-agent-maxsockets` makes assumptions about the order in which
callbacks will be invoked. The assumption will not hold on a
resource-constratined host.

Refactor the test to guarantee that the callbacks fire in the order that
the test expects.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http