### PR TITLE
doc: clarify async/asynchronous in deprecations.md

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -152,7 +152,7 @@ Type: Runtime
 explicitly via error event handlers set on the domain instead.
 
 <a id="DEP0013"></a>
-### DEP0013: fs async function without callback
+### DEP0013: fs asynchronous function without callback
 
 Type: Runtime
 


### PR DESCRIPTION
Change _async_ to _asynchronous_ in `deprecations.md` to avoid confusion
with the `async` keyword. This has the additional minor benefit of being
more formal and less conversational prose.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc