### PR TITLE
test: refactor test-fs-readfile-unlink

### DIFF
--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -20,22 +20,15 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const fixtures = require('../common/fixtures');
 
-const dirName = fixtures.path('test-readfile-unlink');
-const fileName = path.resolve(dirName, 'test.bin');
+const fileName = path.resolve(common.tmpDir, 'test.bin');
 const buf = Buffer.alloc(512 * 1024, 42);
 
-try {
-  fs.mkdirSync(dirName);
-} catch (e) {
-  // Ignore if the directory already exists.
-  if (e.code !== 'EEXIST') throw e;
-}
+common.refreshTmpDir();
 
 fs.writeFileSync(fileName, buf);
 
@@ -44,6 +37,7 @@ fs.readFile(fileName, function(err, data) {
   assert.strictEqual(data.length, buf.length);
   assert.strictEqual(buf[0], 42);
 
+  // Unlink should not throw. This is part of the test. It used to throw on
+  // Windows due to a bug.
   fs.unlinkSync(fileName);
-  fs.rmdirSync(dirName);
 });


### PR DESCRIPTION
* Use tmp directory instead of mutating the fixtures directory.
* Add comment explaining that the unlinkSync() at the end of the test is
  part of the test. Otherwise it may be tempting to remove it as
  unnecessary tmp directory cleanup.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs