### PR TITLE
test: add test-benchmark-assert

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -27,6 +27,8 @@ function main(conf) {
   data.copy(expectedWrong);
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -46,6 +46,8 @@ function main(conf) {
   var values, values2;
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly':
       values = array.map((_, i) => [`str_${i}`, 123]);
       benchmark(assert.deepEqual, n, values);

--- a/benchmark/assert/deepequal-object.js
+++ b/benchmark/assert/deepequal-object.js
@@ -37,6 +37,8 @@ function main(conf) {
   const expectedWrong = createObj(source, '4');
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-array-set.js
@@ -53,6 +53,8 @@ function main(conf) {
   const expectedWrongSet = new Set(expectedWrong);
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_Array':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -34,6 +34,8 @@ function main(conf) {
 
   // Creates new array to avoid loop invariant code motion
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -47,6 +47,8 @@ function main(conf) {
   var values, values2;
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual_primitiveOnly':
       values = array.map((_, i) => `str_${i}`);
       benchmark(assert.deepEqual, n, values);

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -33,7 +33,8 @@ function main(conf) {
   const actual = new clazz(len);
   const expected = new clazz(len);
   const expectedWrong = Buffer.alloc(len);
-  expectedWrong[100] = 123;
+  const wrongIndex = Math.floor(len / 2);
+  expectedWrong[wrongIndex] = 123;
   var i;
 
   switch (conf.method) {

--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -38,6 +38,8 @@ function main(conf) {
   var i;
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'deepEqual':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/benchmark/assert/throws.js
+++ b/benchmark/assert/throws.js
@@ -22,6 +22,8 @@ function main(conf) {
   var i;
 
   switch (conf.method) {
+    case '':
+      // Empty string falls through to next line as default, mostly for tests.
     case 'doesNotThrow':
       bench.start();
       for (i = 0; i < n; ++i) {

--- a/test/parallel/test-benchmark-assert.js
+++ b/test/parallel/test-benchmark-assert.js
@@ -1,0 +1,12 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for assert benchmarks. This makes sure the benchmarks aren't
+// completely broken but nothing more than that.
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark(
+  'assert', ['len=1', 'method=', 'n=1', 'prim=null', 'size=1', 'type=Int8Array']
+);


### PR DESCRIPTION
First commit:

    benchmark: enable assert benchmark with short len
    
    `deepequal-typedarrays.js` throws if `len` is set to 100 or less due to
    a hardcoded index. Calculate the index based on `len` so benchmark can
    be run with small `len` values if desired.

Second commit:

    benchmark: provide default methods for assert
    
    The benchmarks for `assert` all take a `method` configuration option,
    but the allowable values are different across the files. For each
    benchmark, provide an arbitrary default if `method` is set to an empty
    string. This allows all the `assert` benchmarks to be run with a single
    command but only on a single method. This is primarily useful for
    testing that the assert benchmark files don't contain egregious errors.
    (In other words, it's useful for testing.)

Third commit:

    test: add test-benchmark-assert
    
    Add minimal test for `assert` benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark assert