### PR TITLE
test: add test-benchmark-buffer

### DIFF
--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -19,6 +19,7 @@ function main(conf) {
   const len = +conf.len;
   const n = +conf.n;
   switch (conf.type) {
+    case '':
     case 'fast-alloc':
       bench.start();
       for (let i = 0; i < n * 1024; i++) {

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -17,12 +17,13 @@ var methods = {
 };
 
 function main(conf) {
-  var len = +conf.size;
-  var clazz = conf.type === 'fast' ? Buffer : SlowBuffer;
-  var buffer = new clazz(len);
+  const len = +conf.size;
+  const clazz = conf.type === 'fast' ? Buffer : SlowBuffer;
+  const buffer = new clazz(len);
   buffer.fill(0);
 
-  methods[conf.method](buffer, conf.n);
+  const method = conf.method || 'for';
+  methods[method](buffer, conf.n);
 }
 
 

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -26,14 +26,15 @@ var bench = common.createBenchmark(main, {
 });
 
 function main(conf) {
-  var noAssert = conf.noAssert === 'true';
-  var len = +conf.millions * 1e6;
-  var clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
-  var buff = new clazz(8);
-  var fn = `read${conf.type}`;
+  const noAssert = conf.noAssert === 'true';
+  const len = +conf.millions * 1e6;
+  const clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
+  const buff = new clazz(8);
+  const type = conf.type || 'UInt8';
+  const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0, noAssert);
-  var testFunction = new Function('buff', `
+  const testFunction = new Function('buff', `
     for (var i = 0; i !== ${len}; i++) {
       buff.${fn}(0, ${JSON.stringify(noAssert)});
     }

--- a/benchmark/buffers/buffer-swap.js
+++ b/benchmark/buffers/buffer-swap.js
@@ -73,7 +73,7 @@ function genMethod(method) {
 }
 
 function main(conf) {
-  const method = conf.method;
+  const method = conf.method || 'swap16';
   const len = conf.len | 0;
   const n = conf.n | 0;
   const aligned = conf.aligned || 'true';

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -46,11 +46,12 @@ var mod = {
 };
 
 function main(conf) {
-  var noAssert = conf.noAssert === 'true';
-  var len = +conf.millions * 1e6;
-  var clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
-  var buff = new clazz(8);
-  var fn = `write${conf.type}`;
+  const noAssert = conf.noAssert === 'true';
+  const len = +conf.millions * 1e6;
+  const clazz = conf.buf === 'fast' ? Buffer : require('buffer').SlowBuffer;
+  const buff = new clazz(8);
+  const type = conf.type || 'UInt8';
+  const fn = `write${type}`;
 
   if (/Int/.test(fn))
     benchInt(buff, fn, len, noAssert);

--- a/benchmark/buffers/dataview-set.js
+++ b/benchmark/buffers/dataview-set.js
@@ -40,11 +40,12 @@ var mod = {
 };
 
 function main(conf) {
-  var len = +conf.millions * 1e6;
-  var ab = new ArrayBuffer(8);
-  var dv = new DataView(ab, 0, 8);
-  var le = /LE$/.test(conf.type);
-  var fn = `set${conf.type.replace(/[LB]E$/, '')}`;
+  const len = +conf.millions * 1e6;
+  const ab = new ArrayBuffer(8);
+  const dv = new DataView(ab, 0, 8);
+  const type = conf.type || 'Uint8';
+  const le = /LE$/.test(type);
+  const fn = `set${type.replace(/[LB]E$/, '')}`;
 
   if (/int/i.test(fn))
     benchInt(dv, fn, len, le);

--- a/test/parallel/test-benchmark-buffer.js
+++ b/test/parallel/test-benchmark-buffer.js
@@ -1,0 +1,34 @@
+'use strict';
+
+require('../common');
+
+// Minimal test for buffer benchmarks. This makes sure the benchmarks aren't
+// completely broken but nothing more than that.
+
+const assert = require('assert');
+const fork = require('child_process').fork;
+const path = require('path');
+
+const runjs = path.join(__dirname, '..', '..', 'benchmark', 'run.js');
+const argv = ['--set', 'aligned=true',
+              '--set', 'args=1',
+              '--set', 'buffer=fast',
+              '--set', 'encoding=utf8',
+              '--set', 'len=2',
+              '--set', 'method=',
+              '--set', 'n=1',
+              '--set', 'noAssert=true',
+              '--set', 'pieces=1',
+              '--set', 'pieceSize=1',
+              '--set', 'search=@',
+              '--set', 'size=1',
+              '--set', 'source=array',
+              '--set', 'type=',
+              '--set', 'withTotalLength=0',
+              'buffers'];
+
+const child = fork(runjs, argv);
+child.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});


### PR DESCRIPTION
First commit:

    benchmark: add default configs to buffer benchmark
    
    Add default values to use for `type` and `method` in `buffer` benchmarks
    when the provided configuration value is an empty string. This is
    primarily useful for testing, so the test can request a single iteration
    without having to worry about providing different valid values for the
    different benchmarks.
    
    While making this change, some `var` instances in immediately
    surrounding code were changed to `const`. In some cases, `var` had been
    preserved so that the benchmarks would continue to run in versions of
    Node.js prior to 4.0.0. However, now that `const` has been introduced
    into the benchmark `common` module, the benchmarks will no longer run
    with those versions of Node.js anyway.

Second commit:

    test: add test-benchmark-buffer
    
    Add minimal test forbuffer benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark buffer