### PR TITLE
deps: cherry-pick 5005faed5 from V8 upstream

### DIFF
--- a/deps/v8/test/mjsunit/compiler/regress-726554.js
+++ b/deps/v8/test/mjsunit/compiler/regress-726554.js
@@ -1,0 +1,27 @@
+// Copyright 2017 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax
+
+function h(a,b){
+  for(var i=0; i<a.length; i++) {h(a[i],b[i]); }
+}
+
+function g() {
+  h(arguments.length, 2);
+}
+
+function f() {
+  return g(1, 2);
+}
+
+b = [1,,];
+b[1] = 3.5;
+
+h(b, [1073741823, 2147483648, -12]);
+
+f();
+f();
+%OptimizeFunctionOnNextCall(f);
+f();


### PR DESCRIPTION
Original commit message:
```
[turbofan] Improve representation selection for type guard.

This takes into account the type of the type guard when choosing
representation for a node. To make the representation changes
unambiguous, we pass the restricted type to the changer.

BUG=chromium:726554

Review-Url: https://codereview.chromium.org/2920193004
Cr-Commit-Position: refs/heads/master@{#45734}
```