### PR TITLE
buffer: improve Buffer.from performance

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -193,7 +193,7 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   if (isAnyArrayBuffer(value))
     return fromArrayBuffer(value, encodingOrOffset, length);
 
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE',
       'first argument',
@@ -208,7 +208,7 @@ Buffer.from = function from(value, encodingOrOffset, length) {
     );
 
   const valueOf = value.valueOf && value.valueOf();
-  if (valueOf != null && valueOf !== value)
+  if (valueOf !== null && valueOf !== undefined && valueOf !== value)
     return Buffer.from(valueOf, encodingOrOffset, length);
 
   var b = fromObject(value);
@@ -322,9 +322,9 @@ function allocate(size) {
 function fromString(string, encoding) {
   var length;
   if (typeof encoding !== 'string' || encoding.length === 0) {
-    encoding = 'utf8';
     if (string.length === 0)
       return new FastBuffer();
+    encoding = 'utf8';
     length = byteLengthUtf8(string);
   } else {
     length = byteLength(string, encoding, true);


### PR DESCRIPTION
Using `== null` in code paths that are expected to mostly receive objects, arrays or other more complex data types is not great because typecasting these types is very slow. Change to instead check `=== null || === undefined`.

Here's the benchmark:

```
buffers/buffer-from.js n=2048 len=10 source="array"                     7.26 %        *** 4.653123e-04
buffers/buffer-from.js n=2048 len=10 source="arraybuffer-middle"        2.50 %            1.937961e-01
buffers/buffer-from.js n=2048 len=10 source="arraybuffer"               0.57 %            7.604131e-01
buffers/buffer-from.js n=2048 len=10 source="buffer"                    4.23 %            5.768482e-02
buffers/buffer-from.js n=2048 len=10 source="object"                   16.31 %        *** 1.128762e-09
buffers/buffer-from.js n=2048 len=10 source="string-base64"             0.08 %            9.655769e-01
buffers/buffer-from.js n=2048 len=10 source="string-utf8"              -1.90 %            2.904045e-01
buffers/buffer-from.js n=2048 len=10 source="string"                   -0.80 %            6.723524e-01
buffers/buffer-from.js n=2048 len=10 source="uint8array"                3.63 %            5.416784e-02
buffers/buffer-from.js n=2048 len=2048 source="array"                   1.42 %            4.821207e-01
buffers/buffer-from.js n=2048 len=2048 source="arraybuffer-middle"     -1.04 %            7.025216e-01
buffers/buffer-from.js n=2048 len=2048 source="arraybuffer"             0.36 %            8.475033e-01
buffers/buffer-from.js n=2048 len=2048 source="buffer"                  0.99 %            7.272932e-01
buffers/buffer-from.js n=2048 len=2048 source="object"                 18.59 %        *** 1.131309e-11
buffers/buffer-from.js n=2048 len=2048 source="string-base64"          -0.17 %            9.388870e-01
buffers/buffer-from.js n=2048 len=2048 source="string-utf8"            -0.35 %            8.910105e-01
buffers/buffer-from.js n=2048 len=2048 source="string"                  0.30 %            9.041955e-01
buffers/buffer-from.js n=2048 len=2048 source="uint8array"              0.41 %            8.854981e-01
```

and here's the old vs old, just to show that the string slowdown is probably just within margin of error:

```
buffers/buffer-from.js n=2048 len=10 source="array"                    -0.27 %            0.9122062
buffers/buffer-from.js n=2048 len=10 source="arraybuffer-middle"       -0.50 %            0.8118019
buffers/buffer-from.js n=2048 len=10 source="arraybuffer"               1.77 %            0.5688189
buffers/buffer-from.js n=2048 len=10 source="buffer"                    0.98 %            0.7024176
buffers/buffer-from.js n=2048 len=10 source="object"                    0.92 %            0.7081286
buffers/buffer-from.js n=2048 len=10 source="string-base64"            -0.92 %            0.7706629
buffers/buffer-from.js n=2048 len=10 source="string-utf8"              -3.24 %            0.1525157
buffers/buffer-from.js n=2048 len=10 source="string"                    1.52 %            0.4168377
buffers/buffer-from.js n=2048 len=10 source="uint8array"               -0.42 %            0.8494492
buffers/buffer-from.js n=2048 len=2048 source="array"                   0.71 %            0.7683624
buffers/buffer-from.js n=2048 len=2048 source="arraybuffer-middle"      1.05 %            0.5941559
buffers/buffer-from.js n=2048 len=2048 source="arraybuffer"             1.96 %            0.4494948
buffers/buffer-from.js n=2048 len=2048 source="buffer"                 -0.57 %            0.7376221
buffers/buffer-from.js n=2048 len=2048 source="object"                 -1.35 %            0.5914752
buffers/buffer-from.js n=2048 len=2048 source="string-base64"           0.93 %            0.7160677
buffers/buffer-from.js n=2048 len=2048 source="string-utf8"             0.32 %            0.8848240
buffers/buffer-from.js n=2048 len=2048 source="string"                  0.77 %            0.7390453
buffers/buffer-from.js n=2048 len=2048 source="uint8array"             -0.40 %            0.8145751
```

For reference, == vs === is about 10x slower: https://jsperf.com/triple-equals-vs-double-equals/3

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer