### PR TITLE
deps: cherry-pick 1aead19 from upstream V8

### DIFF
--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -72,6 +72,7 @@ consts_misc = [
     { 'name': 'ConsStringTag',          'value': 'kConsStringTag' },
     { 'name': 'ExternalStringTag',      'value': 'kExternalStringTag' },
     { 'name': 'SlicedStringTag',        'value': 'kSlicedStringTag' },
+    { 'name': 'ThinStringTag',          'value': 'kThinStringTag' },
 
     { 'name': 'HeapObjectTag',          'value': 'kHeapObjectTag' },
     { 'name': 'HeapObjectTagMask',      'value': 'kHeapObjectTagMask' },


### PR DESCRIPTION
Original commit message:

    Add postmortem metadata for thin strings.

    See: https://github.com/nodejs/llnode/issues/117
    Change-Id: Icc2830c8e9096610df33ffdc2f89e74cb1b35662
    Reviewed-on: https://chromium-review.googlesource.com/618986
    Reviewed-by: Michael Achenbach <machenbach@chromium.org>
    Commit-Queue: Ben Noordhuis <info@bnoordhuis.nl>
    Cr-Commit-Position: refs/heads/master@{#47778}

Refs: https://github.com/nodejs/llnode/issues/117
Refs: https://github.com/nodejs/llnode/pull/121

cc @joyeecheung