### PR TITLE
test: allow specifying more known globals via ENV

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -412,6 +412,11 @@ if (global.Symbol) {
   knownGlobals.push(Symbol);
 }
 
+if (process.env.NODE_TEST_KNOWN_GLOBALS) {
+  const knownFromEnv = process.env.NODE_TEST_KNOWN_GLOBALS.split(',');
+  allowGlobals(...knownFromEnv);
+}
+
 function allowGlobals(...whitelist) {
   knownGlobals = knownGlobals.concat(whitelist);
 }


### PR DESCRIPTION
<sub>update</sub>
In order to provide a smoother test dev experience, with less false positives, we should allow specifying more known global symbols. This implementation uses an ENV var for said specification.

### Example
<sub>end update</sub>

When debugging `/test/` using JetBrains' debugger sometimes it leaked a global symbol `_jb_debug_helper`:
```js
C:\bin\dev\node\node.exe --inspect-brk=58577 D:\code\node\test\parallel\test-setproctitle.js
Debugger listening on ws://127.0.0.1:58577/bd9a5439-00dd-4040-8f4d-a9c8f983834e
For help see https://nodejs.org/en/docs/inspector
Debugger attached.
assert.js:60
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Unexpected global(s) found: _jb_debug_helper
    at process.<anonymous> (D:\code\node\test\common\index.js:453:12)
    at emitOne (events.js:120:20)
    at process.emit (events.js:210:7)
Waiting for the debugger to disconnect...

Process finished with exit code 1
``` 

<ins>A bug report was opened upstream for said IDE</ins>
Refs: https://youtrack.jetbrains.com/issue/WEB-27528

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
