### PR TITLE
doc: instructions for generating coverage reports

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -137,6 +137,14 @@ This will generate coverage reports for both JavaScript and C++ tests (if you
 only want to run the JavaScript tests then you do not need to run the first
 command `./configure --coverage`).
 
+The `make coverage` command downloads some tools to the project root directory
+and overwrites the `lib/` directory. To clean up after generating the coverage
+reports:
+
+```console
+make coverage-clean
+```
+
 To build the documentation:
 
 This will build Node.js first (if necessary) and then use it to build the docs:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -126,6 +126,17 @@ To run the tests:
 $ make test
 ```
 
+To run the tests and generate code coverage reports:
+
+```console
+$ ./configure --coverage
+$ make coverage
+```
+
+This will generate coverage reports for both JavaScript and C++ tests (if you
+only want to run the JavaScript tests then you do not need to run the first
+command `./configure --coverage`).
+
 To build the documentation:
 
 This will build Node.js first (if necessary) and then use it to build the docs:


### PR DESCRIPTION
This PR adds instructions for generating coverage reports. I only added the instructions to BUILDING.md but not CONTRIBUTING.md because that defers to BUILDING.md in the [Test](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#step-5-test) section `(See the BUILDING.md for more details.)`, but I'm happy to add the instructions to that document too if people think they're needed there.

##### Checklist

- [x] `make -j4 test`
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
