### PR TITLE
test: make test-http-agent-maxsockets robust

### DIFF
--- a/test/parallel/test-http-agent-maxsockets.js
+++ b/test/parallel/test-http-agent-maxsockets.js
@@ -15,6 +15,8 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end('hello world');
 }, 2));
 
+server.keepAliveTimeout = 0;
+
 function get(path, callback) {
   return http.get({
     host: 'localhost',


### PR DESCRIPTION
On a slow/busy machine, `test-http-agent-maxsockets` can fail if the
test takes longer than 5 seconds because that is the default value for
`server.keepAliveTimeout`. Disable `keepAliveTimeout` to make the test
robust.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http