### PR TITLE
http2: add compat trailers, adjust multi-headers

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -51,6 +51,13 @@ function onStreamData(chunk) {
     this.pause();
 }
 
+function onStreamTrailers(trailers) {
+  const request = this[kRequest];
+  request[kTrailers] = trailers;
+  // also causes the request stream to end
+  request.push(null);
+}
+
 function onStreamEnd() {
   // Cause the request stream to end as well.
   const request = this[kRequest];
@@ -120,6 +127,7 @@ class Http2ServerRequest extends Readable {
     // Pause the stream..
     stream.pause();
     stream.on('data', onStreamData);
+    stream.on('trailers', onStreamTrailers);
     stream.on('end', onStreamEnd);
     stream.on('error', onStreamError);
     stream.on('close', onStreamClosedRequest);
@@ -164,7 +172,16 @@ class Http2ServerRequest extends Readable {
   }
 
   get trailers() {
-    return this[kTrailers];
+    return this[kTrailers] || [];
+  }
+
+  get rawTrailers() {
+    const trailers = this[kTrailers];
+    if (trailers === undefined)
+      return [];
+    const tuples = Object.entries(trailers);
+    const flattened = Array.prototype.concat.apply([], tuples);
+    return flattened.map(String);
   }
 
   get httpVersionMajor() {
@@ -390,6 +407,16 @@ class Http2ServerResponse extends Stream {
     }
 
     return '';
+  }
+
+  set statusMessage(msg) {
+    if (statusMessageWarned === false) {
+      process.emitWarning(
+        'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
+        'UnsupportedWarning'
+      );
+      statusMessageWarned = true;
+    }
   }
 
   flushHeaders() {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -13,7 +13,9 @@ const kStream = Symbol('stream');
 const kRequest = Symbol('request');
 const kResponse = Symbol('response');
 const kHeaders = Symbol('headers');
+const kRawHeaders = Symbol('rawHeaders');
 const kTrailers = Symbol('trailers');
+const kRawTrailers = Symbol('rawTrailers');
 
 let statusMessageWarned = false;
 
@@ -45,15 +47,26 @@ function isPseudoHeader(name) {
   }
 }
 
+function statusMessageWarn() {
+  if (statusMessageWarned === false) {
+    process.emitWarning(
+      'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
+      'UnsupportedWarning'
+    );
+    statusMessageWarned = true;
+  }
+}
+
 function onStreamData(chunk) {
   const request = this[kRequest];
   if (!request.push(chunk))
     this.pause();
 }
 
-function onStreamTrailers(trailers) {
+function onStreamTrailers(trailers, flags, rawTrailers) {
   const request = this[kRequest];
-  request[kTrailers] = trailers;
+  Object.assign(request[kTrailers], trailers);
+  request[kRawTrailers].push(...rawTrailers);
   // also causes the request stream to end
   request.push(null);
 }
@@ -113,7 +126,7 @@ function onAborted(hadError, code) {
 }
 
 class Http2ServerRequest extends Readable {
-  constructor(stream, headers, options) {
+  constructor(stream, headers, options, rawHeaders) {
     super(options);
     this[kState] = {
       statusCode: null,
@@ -121,6 +134,9 @@ class Http2ServerRequest extends Readable {
       closedCode: constants.NGHTTP2_NO_ERROR
     };
     this[kHeaders] = headers;
+    this[kRawHeaders] = rawHeaders;
+    this[kTrailers] = {};
+    this[kRawTrailers] = [];
     this[kStream] = stream;
     stream[kRequest] = this;
 
@@ -163,25 +179,15 @@ class Http2ServerRequest extends Readable {
   }
 
   get rawHeaders() {
-    const headers = this[kHeaders];
-    if (headers === undefined)
-      return [];
-    const tuples = Object.entries(headers);
-    const flattened = Array.prototype.concat.apply([], tuples);
-    return flattened.map(String);
+    return this[kRawHeaders];
   }
 
   get trailers() {
-    return this[kTrailers] || [];
+    return this[kTrailers];
   }
 
   get rawTrailers() {
-    const trailers = this[kTrailers];
-    if (trailers === undefined)
-      return [];
-    const tuples = Object.entries(trailers);
-    const flattened = Array.prototype.concat.apply([], tuples);
-    return flattened.map(String);
+    return this[kRawTrailers];
   }
 
   get httpVersionMajor() {
@@ -398,25 +404,13 @@ class Http2ServerResponse extends Stream {
   }
 
   get statusMessage() {
-    if (statusMessageWarned === false) {
-      process.emitWarning(
-        'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
-        'UnsupportedWarning'
-      );
-      statusMessageWarned = true;
-    }
+    statusMessageWarn();
 
     return '';
   }
 
   set statusMessage(msg) {
-    if (statusMessageWarned === false) {
-      process.emitWarning(
-        'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
-        'UnsupportedWarning'
-      );
-      statusMessageWarned = true;
-    }
+    statusMessageWarn();
   }
 
   flushHeaders() {
@@ -425,13 +419,10 @@ class Http2ServerResponse extends Stream {
   }
 
   writeHead(statusCode, statusMessage, headers) {
-    if (typeof statusMessage === 'string' && statusMessageWarned === false) {
-      process.emitWarning(
-        'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
-        'UnsupportedWarning'
-      );
-      statusMessageWarned = true;
+    if (typeof statusMessage === 'string') {
+      statusMessageWarn();
     }
+
     if (headers === undefined && typeof statusMessage === 'object') {
       headers = statusMessage;
     }
@@ -567,9 +558,10 @@ class Http2ServerResponse extends Stream {
   }
 }
 
-function onServerStream(stream, headers, flags) {
+function onServerStream(stream, headers, flags, rawHeaders) {
   const server = this;
-  const request = new Http2ServerRequest(stream, headers);
+  const request = new Http2ServerRequest(stream, headers, undefined,
+                                         rawHeaders);
   const response = new Http2ServerResponse(stream);
 
   // Check for the CONNECT method

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -67,8 +67,6 @@ function onStreamTrailers(trailers, flags, rawTrailers) {
   const request = this[kRequest];
   Object.assign(request[kTrailers], trailers);
   request[kRawTrailers].push(...rawTrailers);
-  // also causes the request stream to end
-  request.push(null);
 }
 
 function onStreamEnd() {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -220,6 +220,9 @@ function onSessionHeaders(id, cat, flags, headers) {
     debug(`[${sessionName(owner[kType])}] emitting stream '${event}' event`);
     process.nextTick(emit.bind(stream, event, obj, flags, headers));
   }
+  if (endOfStream) {
+    stream.push(null);
+  }
 }
 
 // Called to determine if there are trailers to be sent at the end of a

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -185,7 +185,7 @@ function onSessionHeaders(id, cat, flags, headers) {
                     'report this as a bug in Node.js');
     }
     streams.set(id, stream);
-    process.nextTick(emit.bind(owner, 'stream', stream, obj, flags));
+    process.nextTick(emit.bind(owner, 'stream', stream, obj, flags, headers));
   } else {
     let event;
     let status;
@@ -218,7 +218,7 @@ function onSessionHeaders(id, cat, flags, headers) {
                     'report this as a bug in Node.js');
     }
     debug(`[${sessionName(owner[kType])}] emitting stream '${event}' event`);
-    process.nextTick(emit.bind(stream, event, obj, flags));
+    process.nextTick(emit.bind(stream, event, obj, flags, headers));
   }
 }
 
@@ -2266,9 +2266,9 @@ function socketOnTimeout() {
 
 // Handles the on('stream') event for a session and forwards
 // it on to the server object.
-function sessionOnStream(stream, headers, flags) {
+function sessionOnStream(stream, headers, flags, rawHeaders) {
   debug(`[${sessionName(this[kType])}] emit server stream event`);
-  this[kServer].emit('stream', stream, headers, flags);
+  this[kServer].emit('stream', stream, headers, flags, rawHeaders);
 }
 
 function sessionOnPriority(stream, parent, weight, exclusive) {

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -35,6 +35,7 @@ const {
   HTTP2_HEADER_RANGE,
   HTTP2_HEADER_REFERER,
   HTTP2_HEADER_RETRY_AFTER,
+  HTTP2_HEADER_SET_COOKIE,
   HTTP2_HEADER_USER_AGENT,
 
   HTTP2_HEADER_CONNECTION,
@@ -474,18 +475,36 @@ function toHeaderObject(headers) {
     if (existing === undefined) {
       obj[name] = value;
     } else if (!kSingleValueHeaders.has(name)) {
-      if (name === HTTP2_HEADER_COOKIE) {
-        // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
-        // "...If there are multiple Cookie header fields after decompression,
-        //  these MUST be concatenated into a single octet string using the
-        //  two-octet delimiter of 0x3B, 0x20 (the ASCII string "; ") before
-        //  being passed into a non-HTTP/2 context."
-        obj[name] = `${existing}; ${value}`;
-      } else {
-        if (Array.isArray(existing))
-          existing.push(value);
-        else
-          obj[name] = [existing, value];
+      switch (name) {
+        case HTTP2_HEADER_COOKIE:
+          // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+          // "...If there are multiple Cookie header fields after decompression,
+          //  these MUST be concatenated into a single octet string using the
+          //  two-octet delimiter of 0x3B, 0x20 (the ASCII string "; ") before
+          //  being passed into a non-HTTP/2 context."
+          obj[name] = `${existing}; ${value}`;
+          break;
+        case HTTP2_HEADER_SET_COOKIE:
+          // https://tools.ietf.org/html/rfc7230#section-3.2.2
+          // "Note: In practice, the "Set-Cookie" header field ([RFC6265]) often
+          // appears multiple times in a response message and does not use the
+          // list syntax, violating the above requirements on multiple header
+          // fields with the same name.  Since it cannot be combined into a
+          // single field-value, recipients ought to handle "Set-Cookie" as a
+          // special case while processing header fields."
+          if (Array.isArray(existing))
+            existing.push(value);
+          else
+            obj[name] = [existing, value];
+          break;
+        default:
+          // https://tools.ietf.org/html/rfc7230#section-3.2.2
+          // "A recipient MAY combine multiple header fields with the same field
+          // name into one "field-name: field-value" pair, without changing the
+          // semantics of the message, by appending each subsequent field value
+          // to the combined field value in order, separated by a comma."
+          obj[name] = `${existing}, ${value}`;
+          break;
       }
     }
   }

--- a/test/parallel/test-http2-compat-serverrequest-end.js
+++ b/test/parallel/test-http2-compat-serverrequest-end.js
@@ -1,0 +1,40 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+// Http2ServerRequest should always end readable stream
+// even on GET requests with no body
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function(request, response) {
+    request.on('data', () => {});
+    request.on('end', common.mustCall(() => {
+      response.on('finish', common.mustCall(function() {
+        server.close();
+      }));
+      response.end();
+    }));
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/foobar',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.resume();
+    request.on('end', common.mustCall(function() {
+      client.destroy();
+    }));
+    request.end();
+  }));
+}));

--- a/test/parallel/test-http2-compat-serverrequest-trailers.js
+++ b/test/parallel/test-http2-compat-serverrequest-trailers.js
@@ -1,0 +1,57 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Http2ServerRequest should have getter for trailers & rawTrailers
+
+const expectedTrailers = {
+  'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO'
+};
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function(request, response) {
+    let data = '';
+    request.setEncoding('utf8');
+    request.on('data', common.mustCall((chunk) => data += chunk));
+    request.on('end', common.mustCall(() => {
+      const trailers = request.trailers;
+      for (const [name, value] of Object.entries(expectedTrailers)) {
+        assert.strictEqual(trailers[name], value);
+      }
+      assert.strictEqual(data, 'test\ntest');
+      response.end();
+    }));
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/foobar',
+      ':method': 'POST',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers, {
+      getTrailers(trailers) {
+        trailers['x-fOo'] = 'xOxOxOx';
+        trailers['x-foO'] = 'OxOxOxO';
+        trailers['X-fOo'] = 'xOxOxOx';
+        trailers['X-foO'] = 'OxOxOxO';
+      }
+    });
+    request.resume();
+    request.on('end', common.mustCall(function() {
+      server.close();
+      client.destroy();
+    }));
+    request.write('test\n');
+    request.end('test');
+  }));
+}));

--- a/test/parallel/test-http2-compat-serverrequest-trailers.js
+++ b/test/parallel/test-http2-compat-serverrequest-trailers.js
@@ -10,7 +10,8 @@ const h2 = require('http2');
 // Http2ServerRequest should have getter for trailers & rawTrailers
 
 const expectedTrailers = {
-  'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO'
+  'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO',
+  'x-foo-test': 'test, test'
 };
 
 const server = h2.createServer();
@@ -25,6 +26,18 @@ server.listen(0, common.mustCall(function() {
       for (const [name, value] of Object.entries(expectedTrailers)) {
         assert.strictEqual(trailers[name], value);
       }
+      assert.deepStrictEqual([
+        'x-foo',
+        'xOxOxOx',
+        'x-foo',
+        'OxOxOxO',
+        'x-foo',
+        'xOxOxOx',
+        'x-foo',
+        'OxOxOxO',
+        'x-foo-test',
+        'test, test'
+      ], request.rawTrailers);
       assert.strictEqual(data, 'test\ntest');
       response.end();
     }));
@@ -44,6 +57,7 @@ server.listen(0, common.mustCall(function() {
         trailers['x-foO'] = 'OxOxOxO';
         trailers['X-fOo'] = 'xOxOxOx';
         trailers['X-foO'] = 'OxOxOxO';
+        trailers['x-foo-test'] = 'test, test';
       }
     });
     request.resume();

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
@@ -22,8 +22,9 @@ server.listen(0, common.mustCall(function() {
   const port = server.address().port;
   server.once('request', common.mustCall(function(request, response) {
     response.on('finish', common.mustCall(function() {
-      assert.strictEqual(response.statusMessage, '');
-      assert.strictEqual(response.statusMessage, ''); // only warn once
+      response.statusMessage = 'test';
+      response.statusMessage = 'test'; // only warn once
+      assert.strictEqual(response.statusMessage, ''); // no change
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -19,11 +19,8 @@ server.on('stream', common.mustCall(onStream));
 
 function onStream(stream, headers, flags) {
 
-  assert(Array.isArray(headers.abc));
-  assert.strictEqual(headers.abc.length, 3);
-  assert.strictEqual(headers.abc[0], '1');
-  assert.strictEqual(headers.abc[1], '2');
-  assert.strictEqual(headers.abc[2], '3');
+  assert.strictEqual(typeof headers.abc, 'string');
+  assert.strictEqual(headers.abc, '1, 2, 3');
   assert.strictEqual(typeof headers.cookie, 'string');
   assert.strictEqual(headers.cookie, 'a=b; c=d; e=f');
 

--- a/test/parallel/test-http2-multiheaders-raw.js
+++ b/test/parallel/test-http2-multiheaders-raw.js
@@ -1,0 +1,50 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+const src = Object.create(null);
+src['www-authenticate'] = 'foo';
+src['WWW-Authenticate'] = 'bar';
+src['WWW-AUTHENTICATE'] = 'baz';
+src['test'] = 'foo, bar, baz';
+
+server.on('stream', common.mustCall((stream, headers, flags, rawHeaders) => {
+  const expected = [
+    ':path',
+    '/',
+    ':scheme',
+    'http',
+    ':authority',
+    `localhost:${server.address().port}`,
+    ':method',
+    'GET',
+    'www-authenticate',
+    'foo',
+    'www-authenticate',
+    'bar',
+    'www-authenticate',
+    'baz',
+    'test',
+    'foo, bar, baz'
+  ];
+
+  assert.deepStrictEqual(expected, rawHeaders);
+  stream.respond(src);
+  stream.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request(src);
+  req.on('streamClosed', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+}));

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -31,15 +31,15 @@ src['__Proto__'] = 'baz';
 
 function checkHeaders(headers) {
   assert.deepStrictEqual(headers['accept'],
-                         [ 'abc', 'def', 'ghijklmnop' ]);
+                         'abc, def, ghijklmnop');
   assert.deepStrictEqual(headers['www-authenticate'],
-                         [ 'foo', 'bar', 'baz' ]);
+                         'foo, bar, baz');
   assert.deepStrictEqual(headers['proxy-authenticate'],
-                         [ 'foo', 'bar', 'baz' ]);
-  assert.deepStrictEqual(headers['x-foo'], [ 'foo', 'bar', 'baz' ]);
-  assert.deepStrictEqual(headers['constructor'], [ 'foo', 'bar', 'baz' ]);
+                         'foo, bar, baz');
+  assert.deepStrictEqual(headers['x-foo'], 'foo, bar, baz');
+  assert.deepStrictEqual(headers['constructor'], 'foo, bar, baz');
   // eslint-disable-next-line no-proto
-  assert.deepStrictEqual(headers['__proto__'], [ 'foo', 'bar', 'baz' ]);
+  assert.deepStrictEqual(headers['__proto__'], 'foo, bar, baz');
 }
 
 server.on('stream', common.mustCall((stream, headers) => {


### PR DESCRIPTION
Some changes to compatibility layer to bring it closer to the h1 implementation.

- Adds Http2ServerRequest `trailers` & `rawTrailers` functionality. Previously didn't work at all and the request would also never end. Which actually makes me wonder, is this even correct or am I compensating for a deeper issue?

- Fixes behaviour of multi-headers to conform with the spec (all values but set-cookie and cookie should be comma delimited, cookie should be semi-colon delimited and only set-cookie should be an array). I think it's important we conform to the spec and also be backwards compatible, even if arrays are easier to work with for multi-values. (H2 doesn't specify this directly but it links to https://tools.ietf.org/html/rfc7230#section-3.2.2)

- Adds setter for statusMessage that warns (same as the getter), for backwards compatibility. See https://github.com/expressjs/express/pull/3390#discussion_r136718729

@jasnell, @mcollina I would also like to start a discussion re: rawHeaders if possible. The current behaviour doesn't result in true rawHeaders as we have no way of knowing in what format something like cookie was sent to us based on the headers object (could've already been joined or could've been separate). Should we just emit the raw headers object alongside headers & flags from `onSessionHeaders` (and then pass to `onServerStream` too)? If we were to add it as the last argument then it wouldn't really interfere with anything but I'm open to alternate suggestions. (We could also hide it on the headers object as non-enumerable property but that seems really dirty.)

Thanks in advance for any feedback!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test