### PR TITLE
test: exclude write-coverage from coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !.gitignore
 !.gitkeep
 !.mailmap
+!.nycrc
 !.remarkrc
 
 core

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,6 @@
+{
+  "exclude": [
+    "**/internal/process/write-coverage.js"
+  ],
+  "reporter": ["html", "text"]
+}

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ coverage-test: coverage-build
 	$(NODE) ./node_modules/.bin/istanbul-merge --out \
 		.cov_tmp/libcov.json 'out/Release/.coverage/coverage-*.json'
 	(cd lib && .$(NODE) ../node_modules/.bin/nyc report \
-		--temp-directory "$(CURDIR)/.cov_tmp" -r html \
+		--temp-directory "$(CURDIR)/.cov_tmp" \
 		--report-dir "../coverage")
 	-(cd out && "../gcovr/scripts/gcovr" --gcov-exclude='.*deps' \
 		--gcov-exclude='.*usr' -v -r Release/obj.target/node \


### PR DESCRIPTION
With a goal of pitching in/familiarizing myself with the Node.js codebase, I wanted to help inch test coverage towards 100%.

With this in mind, I noticed that `write-coverage.js` is not tested. Since this is a utility used for outputting test coverage reports it seemed appropriate to add this to a list of excluded files (this [just became possible](https://github.com/istanbuljs/nyc/pull/637)).

In this pull request:

* I've added a `.nycrc` configuration file, which can be used to configure the nyc test coverage tool.
* I've added an exclude rule that removes `write-coverage.js` from coverage reports.
* I've pulled reporter configuration into the `.nycrc` config file (I also added the additional `text` reporter, which I find provides useful high-level information for folks playing the test-coverage MMORPG).

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test, coverage
