### PR TITLE
test, build: Clean up package-lock.json after make coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ check: test
 # in place
 coverage-clean:
 	if [ -d lib_ ]; then $(RM) -r lib; mv lib_ lib; fi
+	$(RM) package-lock.json
 	$(RM) -r node_modules
 	$(RM) -r gcovr testing
 	$(RM) -r out/$(BUILDTYPE)/.coverage

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,6 @@ check: test
 # in place
 coverage-clean:
 	if [ -d lib_ ]; then $(RM) -r lib; mv lib_ lib; fi
-	$(RM) package-lock.json
 	$(RM) -r node_modules
 	$(RM) -r gcovr testing
 	$(RM) -r out/$(BUILDTYPE)/.coverage
@@ -140,8 +139,9 @@ coverage: coverage-test
 coverage-build: all
 	mkdir -p node_modules
 	if [ ! -d node_modules/istanbul-merge ]; then \
-		$(NODE) ./deps/npm install istanbul-merge; fi
-	if [ ! -d node_modules/nyc ]; then $(NODE) ./deps/npm install nyc; fi
+		$(NODE) ./deps/npm install istanbul-merge --no-save --no-package-lock; fi
+	if [ ! -d node_modules/nyc ]; then \
+		$(NODE) ./deps/npm install nyc --no-save --no-package-lock; fi
 	if [ ! -d gcovr ]; then git clone --depth=1 \
 		--single-branch git://github.com/gcovr/gcovr.git; fi
 	if [ ! -d testing ]; then git clone --depth=1 \


### PR DESCRIPTION
When running `make coverage`, npm installs `istanbul-merge` and `nyc` and
generates a `package-lock.json` file.

This PR adds the `rm package-lock.json` command to the Makefile.

Refs: https://github.com/nodejs/node/pull/15190/files#r136932786

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
