### PR TITLE
build: display HTTP2 configure --help options

### DIFF
--- a/configure
+++ b/configure
@@ -420,6 +420,8 @@ http2_optgroup.add_option('--debug-nghttp2',
     dest='debug_nghttp2',
     help='build nghttp2 with DEBUGBUILD (default is false)')
 
+parser.add_option_group(http2_optgroup)
+
 parser.add_option('--with-perfctr',
     action='store_true',
     dest='with_perfctr',


### PR DESCRIPTION
Currently the options available for HTTP2 are not displayed when running
configure --help.

This commit enables the following HTTP2 section to be included in the
help output:
```console
HTTP2:
  Flags that allows you to control HTTP2 features in Node.js

  --debug-http2       build with http2 debug statements on (default is
                      false)
  --debug-nghttp2     build nghttp2 with DEBUGBUILD (default is false)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
bulid