### PR TITLE
http2: connect promisify customization, other improvements

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -20,8 +20,9 @@ const { onServerStream,
         Http2ServerResponse,
 } = require('internal/http2/compat');
 const { utcDate } = require('internal/http');
+const { promisify } = require('internal/util');
 const { _connectionListener: httpConnectionListener } = require('http');
-const { isUint8Array } = process.binding('util');
+const { isUint8Array, createPromise, promiseResolve } = process.binding('util');
 const debug = util.debuglog('http2');
 
 
@@ -2453,6 +2454,17 @@ function connect(authority, options, listener) {
     session.once('connect', listener);
   return session;
 }
+
+// Support util.promisify
+Object.defineProperty(connect, promisify.custom, {
+  value: (authority, options) => {
+    const promise = createPromise();
+    const server = connect(authority,
+                           options,
+                           () => promiseResolve(promise, server));
+    return promise;
+  }
+});
 
 function createSecureServer(options, handler) {
   if (options == null || typeof options !== 'object') {

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -82,8 +82,8 @@ inline int Nghttp2Session::OnHeaderCallback(nghttp2_session* session,
   // If this is a push promise frame, we want to grab the handle of
   // the promised stream.
   int32_t id = (frame->hd.type == NGHTTP2_PUSH_PROMISE) ?
-    frame->push_promise.promised_stream_id :
-    frame->hd.stream_id;
+      frame->push_promise.promised_stream_id :
+      frame->hd.stream_id;
   Nghttp2Stream* stream = handle->FindStream(id);
   nghttp2_header_list* header = header_free_list.pop();
   header->name = name;

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -52,17 +52,19 @@ inline int Nghttp2Session::OnBeginHeadersCallback(nghttp2_session* session,
                                                   const nghttp2_frame* frame,
                                                   void* user_data) {
   Nghttp2Session* handle = static_cast<Nghttp2Session*>(user_data);
+  // If this is a push promise frame, we want to grab the handle of
+  // the promised stream.
   int32_t id = (frame->hd.type == NGHTTP2_PUSH_PROMISE) ?
-  frame->push_promise.promised_stream_id :
-  frame->hd.stream_id;
+      frame->push_promise.promised_stream_id :
+      frame->hd.stream_id;
   DEBUG_HTTP2("Nghttp2Session %s: beginning headers for stream %d\n",
               handle->TypeName(handle->type()), id);
 
   Nghttp2Stream* stream = handle->FindStream(id);
   if (stream == nullptr) {
-  Nghttp2Stream::Init(id, handle, frame->headers.cat);
+    Nghttp2Stream::Init(id, handle, frame->headers.cat);
   } else {
-  stream->StartHeaders(frame->headers.cat);
+    stream->StartHeaders(frame->headers.cat);
   }
   return 0;
 }
@@ -77,9 +79,11 @@ inline int Nghttp2Session::OnHeaderCallback(nghttp2_session* session,
                                             uint8_t flags,
                                             void* user_data) {
   Nghttp2Session* handle = static_cast<Nghttp2Session*>(user_data);
+  // If this is a push promise frame, we want to grab the handle of
+  // the promised stream.
   int32_t id = (frame->hd.type == NGHTTP2_PUSH_PROMISE) ?
-  frame->push_promise.promised_stream_id :
-  frame->hd.stream_id;
+    frame->push_promise.promised_stream_id :
+    frame->hd.stream_id;
   Nghttp2Stream* stream = handle->FindStream(id);
   nghttp2_header_list* header = header_free_list.pop();
   header->name = name;

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -141,9 +141,9 @@ class Nghttp2Session {
   inline ssize_t Write(const uv_buf_t* bufs, unsigned int nbufs);
 
   // Returns the nghttp2 library session
-  inline nghttp2_session* session() { return session_; }
+  inline nghttp2_session* session() const { return session_; }
 
-  nghttp2_session_type type() {
+  nghttp2_session_type type() const {
     return session_type_;
   }
 

--- a/test/parallel/test-http2-client-promisify-connect.js
+++ b/test/parallel/test-http2-client-promisify-connect.js
@@ -1,0 +1,34 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const util = require('util');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond();
+  stream.end('ok');
+}));
+server.listen(0, common.mustCall(() => {
+
+  const connect = util.promisify(http2.connect);
+
+  connect(`http://localhost:${server.address().port}`)
+    .catch(common.mustNotCall())
+    .then(common.mustCall((client) => {
+      assert(client);
+      const req = client.request();
+      let data = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => data += chunk);
+      req.on('end', common.mustCall(() => {
+        assert.strictEqual(data, 'ok');
+        client.destroy();
+        server.close();
+      }));
+    }));
+}));


### PR DESCRIPTION
custom promisify for `http2.connect()` and other miscellaneous improvements .

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
