### PR TITLE
test,doc: make module name match gyp target name

### DIFF
--- a/benchmark/misc/function_call/binding.cc
+++ b/benchmark/misc/function_call/binding.cc
@@ -14,4 +14,4 @@ extern "C" void init (Local<Object> target) {
   NODE_SET_METHOD(target, "hello", Hello);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -74,7 +74,7 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(addon, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)
 
 }  // namespace demo
 ```
@@ -84,7 +84,7 @@ the pattern:
 
 ```cpp
 void Initialize(Local<Object> exports);
-NODE_MODULE(module_name, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 ```
 
 There is no semi-colon after `NODE_MODULE` as it's not a function (see
@@ -330,7 +330,7 @@ void Init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "add", Add);
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
 
 }  // namespace demo
 ```
@@ -378,7 +378,7 @@ void Init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", RunCallback);
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
 
 }  // namespace demo
 ```
@@ -434,7 +434,7 @@ void Init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", CreateObject);
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
 
 }  // namespace demo
 ```
@@ -493,7 +493,7 @@ void Init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", CreateFunction);
 }
 
-NODE_MODULE(addon, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
 
 }  // namespace demo
 ```
@@ -529,7 +529,7 @@ void InitAll(Local<Object> exports) {
   MyObject::Init(exports);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(NODE_GYP_MODULE_NAME, InitAll)
 
 }  // namespace demo
 ```
@@ -713,7 +713,7 @@ void InitAll(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", CreateObject);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(NODE_GYP_MODULE_NAME, InitAll)
 
 }  // namespace demo
 ```
@@ -926,7 +926,7 @@ void InitAll(Local<Object> exports) {
   NODE_SET_METHOD(exports, "add", Add);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE(NODE_GYP_MODULE_NAME, InitAll)
 
 }  // namespace demo
 ```
@@ -1117,7 +1117,7 @@ void init(Local<Object> exports) {
   AtExit(sanity_check);
 }
 
-NODE_MODULE(addon, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)
 
 }  // namespace demo
 ```

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -877,7 +877,7 @@ except that instead of using the `NODE_MODULE` macro the following
 is used:
 
 ```C
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
 ```
 
 The next difference is the signature for the `Init` method. For a N-API
@@ -2874,7 +2874,7 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   if (status != napi_ok) return;
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)
 ```
 
 Given the above code, the add-on can be used from JavaScript as follows:

--- a/test/addons-napi/1_hello_world/binding.c
+++ b/test/addons-napi/1_hello_world/binding.c
@@ -15,4 +15,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 1, &desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/2_function_arguments/binding.c
+++ b/test/addons-napi/2_function_arguments/binding.c
@@ -34,4 +34,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 1, &desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/3_callbacks/binding.c
+++ b/test/addons-napi/3_callbacks/binding.c
@@ -53,4 +53,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, exports, 2, desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/4_object_factory/binding.c
+++ b/test/addons-napi/4_object_factory/binding.c
@@ -20,4 +20,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/5_function_factory/binding.c
+++ b/test/addons-napi/5_function_factory/binding.c
@@ -22,4 +22,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/6_object_wrap/binding.cc
+++ b/test/addons-napi/6_object_wrap/binding.cc
@@ -4,4 +4,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   MyObject::Init(env, exports);
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/7_factory_wrap/binding.cc
+++ b/test/addons-napi/7_factory_wrap/binding.cc
@@ -20,4 +20,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/8_passing_wrapped/binding.cc
+++ b/test/addons-napi/8_passing_wrapped/binding.cc
@@ -41,4 +41,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     napi_define_properties(env, exports, sizeof(desc) / sizeof(*desc), desc));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_array/test_array.c
+++ b/test/addons-napi/test_array/test_array.c
@@ -182,4 +182,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_async/test_async.cc
+++ b/test/addons-napi/test_async/test_async.cc
@@ -170,4 +170,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_buffer/test_buffer.c
+++ b/test/addons-napi/test_buffer/test_buffer.c
@@ -141,4 +141,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(methods) / sizeof(methods[0]), methods));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_constructor/test_constructor.c
+++ b/test/addons-napi/test_constructor/test_constructor.c
@@ -87,4 +87,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     napi_create_reference(env, cons, 1, &constructor_));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_conversions/test_conversions.c
+++ b/test/addons-napi/test_conversions/test_conversions.c
@@ -148,4 +148,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_dataview/test_dataview.c
+++ b/test/addons-napi/test_dataview/test_dataview.c
@@ -46,4 +46,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
       env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_env_sharing/compare_env.c
+++ b/test/addons-napi/test_env_sharing/compare_env.c
@@ -19,4 +19,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* context) {
   NAPI_CALL_RETURN_VOID(env, napi_define_properties(env, module, 1, &prop));
 }
 
-NAPI_MODULE(compare_env, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_env_sharing/store_env.c
+++ b/test/addons-napi/test_env_sharing/store_env.c
@@ -9,4 +9,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* context) {
     napi_set_named_property(env, module, "exports", external));
 }
 
-NAPI_MODULE(store_env, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_error/test_error.cc
+++ b/test/addons-napi/test_error/test_error.cc
@@ -141,4 +141,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_exception/test_exception.c
+++ b/test/addons-napi/test_exception/test_exception.c
@@ -56,4 +56,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_fatal/test_fatal.c
+++ b/test/addons-napi/test_fatal/test_fatal.c
@@ -15,4 +15,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_function/test_function.c
+++ b/test/addons-napi/test_function/test_function.c
@@ -32,4 +32,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
   NAPI_CALL_RETURN_VOID(env, napi_set_named_property(env, exports, "Test", fn));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_general/test_general.c
+++ b/test/addons-napi/test_general/test_general.c
@@ -239,4 +239,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -78,4 +78,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_make_callback/binding.cc
+++ b/test/addons-napi/test_make_callback/binding.cc
@@ -45,4 +45,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
 
 }  // namespace
 
-NAPI_MODULE(binding, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_make_callback_recurse/binding.cc
+++ b/test/addons-napi/test_make_callback_recurse/binding.cc
@@ -29,4 +29,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
 
 }  // namespace
 
-NAPI_MODULE(binding, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_number/test_number.c
+++ b/test/addons-napi/test_number/test_number.c
@@ -55,4 +55,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_object/test_object.c
+++ b/test/addons-napi/test_object/test_object.c
@@ -236,4 +236,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_promise/test_promise.c
+++ b/test/addons-napi/test_promise/test_promise.c
@@ -57,4 +57,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_properties/test_properties.c
+++ b/test/addons-napi/test_properties/test_properties.c
@@ -97,4 +97,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_reference/test_reference.c
+++ b/test/addons-napi/test_reference/test_reference.c
@@ -150,4 +150,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -217,4 +217,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_symbol/test_symbol.c
+++ b/test/addons-napi/test_symbol/test_symbol.c
@@ -57,4 +57,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(properties) / sizeof(*properties), properties));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_typedarray/test_typedarray.c
+++ b/test/addons-napi/test_typedarray/test_typedarray.c
@@ -153,4 +153,4 @@ void Init(napi_env env, napi_value exports, napi_value module, void* priv) {
     env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -88,4 +88,4 @@ void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
   NODE_SET_METHOD(exports, "runMakeCallback", Method<true>);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/async-hooks-id/binding.cc
+++ b/test/addons/async-hooks-id/binding.cc
@@ -24,4 +24,4 @@ void Initialize(Local<Object> exports) {
 
 }  // namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/async-hooks-promise/binding.cc
+++ b/test/addons/async-hooks-promise/binding.cc
@@ -38,6 +38,6 @@ inline void Initialize(v8::Local<v8::Object> binding) {
   NODE_SET_METHOD(binding, "getPromiseField", GetPromiseField);
 }
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 
 }  // anonymous namespace

--- a/test/addons/async-resource/binding.cc
+++ b/test/addons/async-resource/binding.cc
@@ -111,4 +111,4 @@ void Initialize(Local<Object> exports) {
 
 }  // namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -39,4 +39,4 @@ void init(Local<Object> exports) {
   atexit(sanity_check);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -41,4 +41,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "check", Check);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/errno-exception/binding.cc
+++ b/test/addons/errno-exception/binding.cc
@@ -15,4 +15,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "errno", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/heap-profiler/binding.cc
+++ b/test/addons/heap-profiler/binding.cc
@@ -22,6 +22,6 @@ inline void Initialize(v8::Local<v8::Object> binding) {
                v8::FunctionTemplate::New(isolate, Test)->GetFunction());
 }
 
-NODE_MODULE(test, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 
 }  // anonymous namespace

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/load-long-path/binding.cc
+++ b/test/addons/load-long-path/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -28,4 +28,4 @@ void Initialize(Local<Object> exports) {
 
 }  // namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -36,4 +36,4 @@ void Initialize(v8::Local<v8::Object> exports) {
 
 }  // namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -11,6 +11,6 @@ inline void Initialize(v8::Local<v8::Object> binding) {
                v8::FunctionTemplate::New(isolate, NewClass)->GetFunction());
 }
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)
 
 }  // anonymous namespace

--- a/test/addons/null-buffer-neuter/binding.cc
+++ b/test/addons/null-buffer-neuter/binding.cc
@@ -38,4 +38,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "run", Run);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/parse-encoding/binding.cc
+++ b/test/addons/parse-encoding/binding.cc
@@ -35,4 +35,4 @@ void Initialize(v8::Local<v8::Object> exports) {
 
 }  // anonymous namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -42,4 +42,4 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "method", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/stringbytes-external-exceed-max/binding.cc
+++ b/test/addons/stringbytes-external-exceed-max/binding.cc
@@ -21,4 +21,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "ensureAllocation", EnsureAllocation);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/symlinked-module/binding.cc
+++ b/test/addons/symlinked-module/binding.cc
@@ -10,4 +10,4 @@ void init(v8::Local<v8::Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)


### PR DESCRIPTION
Currently the nm_modname does not match the file name of the resulting
module. In fact, the nm_modname is pretty arbitrary. This seeks to
introduce some consistency into the nm_modname property by having the
name of the module appear in exactly one place: the "target_name"
property of the gyp target that builds the module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test,doc