### PR TITLE
[v6.x] deps: backport 071b655 from V8 upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 107
+#define V8_PATCH_LEVEL 108
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/debug/debug-scopes.cc
+++ b/deps/v8/src/debug/debug-scopes.cc
@@ -842,6 +842,12 @@ bool ScopeIterator::CopyContextExtensionToScopeObject(
 
 void ScopeIterator::GetNestedScopeChain(Isolate* isolate, Scope* scope,
                                         int position) {
+  if (scope->is_function_scope()) {
+    // Do not collect scopes of nested inner functions inside the current one.
+    Handle<JSFunction> function =
+        Handle<JSFunction>::cast(frame_inspector_->GetFunction());
+    if (scope->end_position() < function->shared()->end_position()) return;
+  }
   if (!scope->is_eval_scope()) {
     nested_scope_chain_.Add(ExtendedScopeInfo(scope->GetScopeInfo(isolate),
                                               scope->start_position(),

--- a/deps/v8/test/mjsunit/regress/regress-crbug-621361.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-621361.js
@@ -1,0 +1,40 @@
+// Copyright 2016 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-debug-as debug
+
+var Debug = debug.Debug;
+var steps = 0;
+var exception = null;
+
+function listener(event, execState, eventData, data) {
+  if (event != Debug.DebugEvent.Break) return;
+  try {
+    assertEquals([ debug.ScopeType.Local,
+                   debug.ScopeType.Script,
+                   debug.ScopeType.Global],
+                 execState.frame().allScopes().map(s => s.scopeType()));
+    var x_value = execState.frame().evaluate("x").value();
+    if (steps < 2) {
+      assertEquals(undefined, x_value);
+      execState.prepareStep(Debug.StepAction.StepIn);
+    } else {
+      assertEquals("l => l", x_value.toString());
+    }
+    steps++;
+  } catch (e) {
+    exception = e;
+  }
+}
+
+Debug.setListener(listener);
+
+(function() {
+  debugger;
+  var x = l => l;
+})();
+
+Debug.setListener(null);
+assertNull(exception);
+assertEquals(3, steps);


### PR DESCRIPTION
Original commit message:

    [PATCH] [debugger] Scope iterator should not visit inner function literals.

    R=marja@chromium.org
    BUG=chromium:621361

    Review-Url: https://codereview.chromium.org/2185913003
    Cr-Commit-Position: refs/heads/master@{#38087}

Fixes: https://github.com/nodejs/node/issues/15075

/cc @nodejs/v8 @hashseed 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
V8