### PR TITLE
http2: store headersSent after stream destroyed

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -299,7 +299,7 @@ class Http2ServerResponse extends Stream {
 
   get headersSent() {
     const stream = this[kStream];
-    return stream.headersSent;
+    return stream !== undefined ? stream.headersSent : this[kState].headersSent;
   }
 
   get sendDate() {
@@ -526,6 +526,7 @@ class Http2ServerResponse extends Stream {
     if (code !== undefined)
       state.closedCode = code;
     state.closed = true;
+    state.headersSent = this[kStream].headersSent;
     this.end();
     this[kStream] = undefined;
     this.emit('finish');

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -88,6 +88,7 @@ server.listen(0, common.mustCall(function() {
 
     response.on('finish', common.mustCall(function() {
       assert.strictEqual(response.code, h2.constants.NGHTTP2_NO_ERROR);
+      assert.strictEqual(response.headersSent, true);
       server.close();
     }));
     response.end();


### PR DESCRIPTION
Store `headersSent` directly on response state after finish event is triggered, so that users can always access it.

Fixes: https://github.com/nodejs/node/issues/15226

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test