### PR TITLE
meta: allow vague objections to be dismissed

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -88,10 +88,11 @@ All pull requests that modify executable code should be subjected to
 continuous integration tests on the
 [project CI server](https://ci.nodejs.org/).
 
-If any Collaborator objects to a change without giving any additional
-explanation or context, and the objecting Collaborator fails to respond to
+If any Collaborator objects to a change *without giving any additional
+explanation or context*, and the objecting Collaborator fails to respond to
 explicit requests for explanation or context within a reasonable period of
-time, the objection may be dismissed.
+time, the objection may be dismissed. Note that this does not apply to
+objections that are explained.
 
 #### Useful CI Jobs
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -88,6 +88,11 @@ All pull requests that modify executable code should be subjected to
 continuous integration tests on the
 [project CI server](https://ci.nodejs.org/).
 
+If any Collaborator objects to a change without giving any additional
+explanation or context, and the objecting Collaborator fails to respond to
+explicit requests for explanation or context within a reasonable period of
+time, the objection may be dismissed.
+
 #### Useful CI Jobs
 
 * [`node-test-pull-request`](https://ci.nodejs.org/job/node-test-pull-request/)


### PR DESCRIPTION
Explicitly allow vague objections to change requests to be dismissed if requests for clarification go unanswered

/cc @nodejs/collaborators 

