### PR TITLE
Fixed a typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -231,7 +231,7 @@ The externally maintained libraries used by Node.js are:
      #  ---------COPYING.libtabe ---- BEGIN--------------------
      #
      #  /*
-     #   * Copyrighy (c) 1999 TaBE Project.
+     #   * Copyright (c) 1999 TaBE Project.
      #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
      #   * All rights reserved.
      #   *


### PR DESCRIPTION
Line 234: "Copyrighy" instead of "Copyright".