### PR TITLE
Fixed a typo in LICENSE

### DIFF
--- a/deps/icu-small/LICENSE
+++ b/deps/icu-small/LICENSE
@@ -131,7 +131,7 @@ property of their respective owners.
  #  ---------COPYING.libtabe ---- BEGIN--------------------
  #
  #  /*
- #   * Copyrighy (c) 1999 TaBE Project.
+ #   * Copyright (c) 1999 TaBE Project.
  #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
  #   * All rights reserved.
  #   *


### PR DESCRIPTION
Line 134: "Copyrighy" instead of "Copyright".

Refer #15261