### PR TITLE
build: remove unused configuration variable

### DIFF
--- a/configure
+++ b/configure
@@ -843,8 +843,6 @@ def configure_node(o):
   want_snapshots = not options.without_snapshot
   o['variables']['want_separate_host_toolset'] = int(
       cross_compiling and want_snapshots)
-  o['variables']['want_separate_host_toolset_mkpeephole'] = int(
-      cross_compiling)
 
   if target_arch == 'arm':
     configure_arm(o)


### PR DESCRIPTION
`want_separate_host_toolset_mkpeephole` was removed when V8 was upgraded
to version 5.9 in commit 3dc8c3b from June.