### PR TITLE
http: emit 'aborted' event for ClientRequest

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -363,7 +363,6 @@ function socketCloseListener() {
 
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.
-    req.emit('aborted');
     req.res.emit('aborted');
     var res = req.res;
     res.on('end', function() {
@@ -375,8 +374,8 @@ function socketCloseListener() {
     // receive a response. The error needs to
     // fire on the request.
     req.socket._hadError = true;
-    req.emit('aborted');
     req.emit('error', createHangUpError());
+    req.emit('aborted');
   }
 
   req.emit('close');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -360,9 +360,10 @@ function socketCloseListener() {
   // NOTE: It's important to get parser here, because it could be freed by
   // the `socketOnData`.
   var parser = socket.parser;
-  req.emit('close');
+
   if (req.res && req.res.readable) {
     // Socket closed before we emitted 'end' below.
+    req.emit('aborted');
     req.res.emit('aborted');
     var res = req.res;
     res.on('end', function() {
@@ -374,8 +375,11 @@ function socketCloseListener() {
     // receive a response. The error needs to
     // fire on the request.
     req.socket._hadError = true;
+    req.emit('aborted');
     req.emit('error', createHangUpError());
   }
+
+  req.emit('close');
 
   // Too bad.  That output wasn't getting written.
   // This is pretty terrible that it doesn't raise an error.


### PR DESCRIPTION
Not sure if this is entirely correct. I think we need a check for whether the request completed normally before emitting `aborted`.

It also needs a test case.

