### PR TITLE
build: use generic names for linting tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -880,26 +880,32 @@ bench: bench-net bench-http bench-fs bench-tls
 
 bench-ci: bench
 
-JSLINT_TARGETS = benchmark doc lib test tools
+LINT_JS_TARGETS = benchmark doc lib test tools
 
-jslint:
+lint-js:
 	@echo "Running JS linter..."
 	$(NODE) tools/eslint/bin/eslint.js --cache --rulesdir=tools/eslint-rules --ext=.js,.mjs,.md \
-	  $(JSLINT_TARGETS)
+	  $(LINT_JS_TARGETS)
 
-jslint-ci:
+jslint: lint-js
+	@echo "Please use lint-js instead of jslint"
+
+lint-js-ci:
 	@echo "Running JS linter..."
-	$(NODE) tools/jslint.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
-		$(JSLINT_TARGETS)
+	$(NODE) tools/lint-js.js $(PARALLEL_ARGS) -f tap -o test-eslint.tap \
+		$(LINT_JS_TARGETS)
 
-CPPLINT_EXCLUDE ?=
-CPPLINT_EXCLUDE += src/node_root_certs.h
-CPPLINT_EXCLUDE += $(wildcard test/addons/??_*/*.cc test/addons/??_*/*.h)
-CPPLINT_EXCLUDE += $(wildcard test/addons-napi/??_*/*.cc test/addons-napi/??_*/*.h)
+jslint-ci: lint-js-ci
+	@echo "Please use lint-js-ci instead of jslint-ci"
+
+LINT_CPP_EXCLUDE ?=
+LINT_CPP_EXCLUDE += src/node_root_certs.h
+LINT_CPP_EXCLUDE += $(wildcard test/addons/??_*/*.cc test/addons/??_*/*.h)
+LINT_CPP_EXCLUDE += $(wildcard test/addons-napi/??_*/*.cc test/addons-napi/??_*/*.h)
 # These files were copied more or less verbatim from V8.
-CPPLINT_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
+LINT_CPP_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
 
-CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard \
+LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	src/*.c \
 	src/*.cc \
 	src/*.h \
@@ -917,19 +923,22 @@ CPPLINT_FILES = $(filter-out $(CPPLINT_EXCLUDE), $(wildcard \
 	tools/icu/*.h \
 	))
 
-cpplint:
+lint-cpp:
 	@echo "Running C++ linter..."
-	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)
+	@$(PYTHON) tools/cpplint.py $(LINT_CPP_FILES)
 	@$(PYTHON) tools/check-imports.py
+
+cpplint: lint-cpp
+	@echo "Please use lint-cpp instead of cpplint"
 
 ifneq ("","$(wildcard tools/eslint/)")
 lint:
 	@EXIT_STATUS=0 ; \
-	$(MAKE) jslint || EXIT_STATUS=$$? ; \
-	$(MAKE) cpplint || EXIT_STATUS=$$? ; \
+	$(MAKE) lint-js || EXIT_STATUS=$$? ; \
+	$(MAKE) lint-cpp || EXIT_STATUS=$$? ; \
 	exit $$EXIT_STATUS
 CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+
-lint-ci: jslint-ci cpplint
+lint-ci: lint-js-ci lint-cpp
 	@if ! ( grep -IEqrs "$(CONFLICT_RE)" benchmark deps doc lib src test tools ) \
 		&& ! ( find . -maxdepth 1 -type f | xargs grep -IEqs "$(CONFLICT_RE)" ); then \
 		exit 0 ; \
@@ -976,7 +985,6 @@ endif
   coverage-build \
   coverage-clean \
   coverage-test \
-  cpplint \
   dist \
   distclean \
   doc \
@@ -987,10 +995,11 @@ endif
   install \
   install-bin \
   install-includes \
-  jslint \
-  jslint-ci \
   lint \
   lint-ci \
+  lint-cpp \
+  lint-js \
+  lint-js-ci \
   list-gtests \
   pkg \
   release-only \

--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -59,7 +59,7 @@ if (cluster.isMaster) {
       throw new Error('Bad parallel job count');
   }
 
-  // Check for custom JSLint report formatter
+  // Check for custom ESLint report formatter
   i = process.argv.indexOf('-f');
   if (i !== -1) {
     if (!process.argv[i + 1])
@@ -77,7 +77,7 @@ if (cluster.isMaster) {
     formatter = cli.getFormatter();
   }
 
-  // Check if outputting JSLint report to a file instead of stdout
+  // Check if outputting ESLint report to a file instead of stdout
   i = process.argv.indexOf('-o');
   if (i !== -1) {
     if (!process.argv[i + 1])

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -26,8 +26,8 @@ set package=
 set msi=
 set upload=
 set licensertf=
-set jslint=
-set cpplint=
+set lint_js=
+set lint_cpp=
 set build_testgc_addon=
 set noetw=
 set noetw_msi_arg=
@@ -72,7 +72,7 @@ if /i "%1"=="nosnapshot"    set nosnapshot=1&goto arg-ok
 if /i "%1"=="noetw"         set noetw=1&goto arg-ok
 if /i "%1"=="noperfctr"     set noperfctr=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
-if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set cpplint=1&set jslint=1&goto arg-ok
+if /i "%1"=="test"          set test_args=%test_args% -J %common_test_suites%&set lint_cpp=1&set lint_js=1&goto arg-ok
 if /i "%1"=="test-ci"       set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %common_test_suites%&set cctest_args=%cctest_args% --gtest_output=tap:cctest.tap&goto arg-ok
 if /i "%1"=="test-addons"   set test_args=%test_args% addons&set build_addons=1&goto arg-ok
 if /i "%1"=="test-addons-napi"   set test_args=%test_args% addons-napi&set build_addons_napi=1&goto arg-ok
@@ -85,17 +85,19 @@ if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
 if /i "%1"=="test-known-issues" set test_args=%test_args% known_issues&goto arg-ok
 if /i "%1"=="test-async-hooks"  set test_args=%test_args% async-hooks&goto arg-ok
-if /i "%1"=="test-all"      set test_args=%test_args% gc internet pummel %common_test_suites%&set build_testgc_addon=1&set cpplint=1&set jslint=1&goto arg-ok
+if /i "%1"=="test-all"      set test_args=%test_args% gc internet pummel %common_test_suites%&set build_testgc_addon=1&set lint_cpp=1&set lint_js=1&goto arg-ok
 if /i "%1"=="test-node-inspect" set test_node_inspect=1&goto arg-ok
 if /i "%1"=="test-check-deopts" set test_check_deopts=1&goto arg-ok
 if /i "%1"=="test-v8"       set test_v8=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-intl"  set test_v8_intl=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-benchmarks" set test_v8_benchmarks=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-all"       set test_v8=1&set test_v8_intl=1&set test_v8_benchmarks=1&set custom_v8_test=1&goto arg-ok
-if /i "%1"=="jslint"        set jslint=1&goto arg-ok
-if /i "%1"=="jslint-ci"     set jslint_ci=1&goto arg-ok
-if /i "%1"=="lint"          set cpplint=1&set jslint=1&goto arg-ok
-if /i "%1"=="lint-ci"       set cpplint=1&set jslint_ci=1&goto arg-ok
+if /i "%1"=="lint-js"       set lint_js=1&goto arg-ok
+if /i "%1"=="jslint"        set lint_js=1&echo Please use lint-js instead of jslint&goto arg-ok
+if /i "%1"=="lint-js-ci"    set lint_js_ci=1&goto arg-ok
+if /i "%1"=="jslint-ci"     set lint_js_ci=1&echo Please use lint-js-ci instead of jslint-ci&goto arg-ok
+if /i "%1"=="lint"          set lint_cpp=1&set lint_js=1&goto arg-ok
+if /i "%1"=="lint-ci"       set lint_cpp=1&set lint_js_ci=1&goto arg-ok
 if /i "%1"=="package"       set package=1&goto arg-ok
 if /i "%1"=="msi"           set msi=1&set licensertf=1&set download_arg="--download=all"&set i18n_arg=small-icu&goto arg-ok
 if /i "%1"=="build-release" set build_release=1&set sign=1&goto arg-ok
@@ -457,20 +459,20 @@ if defined enable_static goto test-v8
 call :run-python tools\test.py %test_args%
 
 :test-v8
-if not defined custom_v8_test goto cpplint
+if not defined custom_v8_test goto lint-cpp
 call tools/test-v8.bat
 if errorlevel 1 goto exit
-goto cpplint
+goto lint-cpp
 
-:cpplint
-if not defined cpplint goto jslint
-call :run-cpplint src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
+:lint-cpp
+if not defined lint_cpp goto lint-js
+call :run-lint-cpp src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
 call :run-python tools/check-imports.py
-goto jslint
+goto lint-js
 
-:run-cpplint
+:run-lint-cpp
 if "%*"=="" goto exit
-echo running cpplint '%*'
+echo running lint-cpp '%*'
 set cppfilelist=
 setlocal enabledelayedexpansion
 for /f "tokens=*" %%G in ('dir /b /s /a %*') do (
@@ -501,18 +503,18 @@ if %errorlevel% equ 0 goto exit
 set "localcppfilelist=%localcppfilelist% %1"
 goto exit
 
-:jslint
+:lint-js
 if defined enable_static goto exit
-if defined jslint_ci goto jslint-ci
-if not defined jslint goto exit
+if defined lint_js_ci goto lint-js-ci
+if not defined lint_js goto exit
 if not exist tools\eslint goto no-lint
-echo running jslint
+echo running lint-js
 %config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.md benchmark doc lib test tools
 goto exit
 
-:jslint-ci
-echo running jslint-ci
-%config%\node tools\jslint.js -J -f tap -o test-eslint.tap benchmark doc lib test tools
+:lint-js-ci
+echo running lint-js-ci
+%config%\node tools\lint-js.js -J -f tap -o test-eslint.tap benchmark doc lib test tools
 goto exit
 
 :no-lint


### PR DESCRIPTION
"jslint" is the name of a tool that actually is not used, which can cause confusion.

(I installed the jslint extension in VSCode and it took me a while to figure out why it's not working)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build