### PR TITLE
build: run es-module tests in ci environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ test-all-valgrind: test-build
 
 CI_NATIVE_SUITES := addons addons-napi
 CI_ASYNC_HOOKS := async-hooks
-CI_JS_SUITES := abort doctool inspector known_issues message parallel pseudo-tty sequential
+CI_JS_SUITES := abort doctool es-module inspector known_issues message parallel pseudo-tty sequential
 
 # Build and test addons without building anything else
 test-ci-native: LOGLEVEL := info

--- a/test/README.md
+++ b/test/README.md
@@ -12,10 +12,11 @@ On how to run tests in this directory, see
 
 |Directory          |Runs on CI     |Purpose        |
 |-------------------|---------------|---------------|
-|abort              |No             |Tests for when the  ``` --abort-on-uncaught-exception ``` flag is used.|
+|abort              |Yes            |Tests for when the  ``` --abort-on-uncaught-exception ``` flag is used.|
 |addons             |Yes            |Tests for [addon](https://nodejs.org/api/addons.html) functionality along with some tests that require an addon to function  properly.|
 |cctest             |Yes            |C++ test that is run as part of the build process.|
 |common             |               |Common modules shared among many tests. [Documentation](./common/README.md)|
+|es-module          |Yes            |Test ESM module loading.|
 |fixtures           |               |Test fixtures used in various tests throughout the test suite.|
 |gc                 |No             |Tests for garbage collection related functionality.|
 |inspector          |Yes            |Tests for the V8 inspector integration.|
@@ -29,3 +30,7 @@ On how to run tests in this directory, see
 |testpy             |               |Test configuration utility used by various test suites.|
 |tick-processor     |No             |Tests for the V8 tick processor integration. The tests are for the logic in ```lib/internal/v8_prof_processor.js``` and  ```lib/internal/v8_prof_polyfill.js```. The tests confirm that the profile processor packages the correct set of scripts from V8 and introduces the correct platform specific logic.|
 |timers             |No             |Tests for [timing utilities](https://nodejs.org/api/timers.html) (```setTimeout``` and ```setInterval```).|
+
+_When a new test directory is added, make sure to update the `CI_JS_SUITES`
+variable in the `Makefile` and the `js_test_suites` variable in
+`vcbuild.bat`._

--- a/test/es-module/test-esm-pkg-over-ext.mjs
+++ b/test/es-module/test-esm-pkg-over-ext.mjs
@@ -1,8 +1,0 @@
-// Flags: --experimental-modules
-/* eslint-disable required-modules */
-
-import resolved from '../fixtures/module-pkg-over-ext/inner';
-import expected from '../fixtures/module-pkg-over-ext/inner/package.json';
-import assert from 'assert';
-
-assert.strictEqual(resolved, expected);

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,7 +44,7 @@ set enable_static=
 set build_addons_napi=
 set test_node_inspect=
 set test_check_deopts=
-set js_test_suites=abort async-hooks inspector known_issues message parallel sequential
+set js_test_suites=abort async-hooks es-module inspector known_issues message parallel sequential
 set v8_test_options=
 set v8_build_options=
 set "common_test_suites=%js_test_suites% doctool addons addons-napi&set build_addons=1&set build_addons_napi=1"


### PR DESCRIPTION
I noticed that there was no coverage for @bmeck's new [module loading work in CI](https://coverage.nodejs.org/coverage-703a3b53884a2751/root/internal/loader/index.html), I believe the issue might be that `es-module` was not added to the `CI_JS_SUITES` variable. I've:

* updated this variable.
* updated the test/README listing the new es-module directory.
* I also updated the table to indicate that `abort` runs in CI, since I noted this listed in the list of suites listed in `CI_JS_SUITES`. 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test,build
