### PR TITLE
test: missing fixture test-esm-pkg-over-ext.mjs

### DIFF
--- a/test/es-module/test-esm-pkg-over-ext.mjs
+++ b/test/es-module/test-esm-pkg-over-ext.mjs
@@ -1,7 +1,7 @@
 // Flags: --experimental-modules
 /* eslint-disable required-modules */
 
-import resolved from '../fixtures/module-pkg-over-ext/inner';
+import resolved from '../fixtures/module-pkg-over-ext/inner/package';
 import expected from '../fixtures/module-pkg-over-ext/inner/package.json';
 import assert from 'assert';
 

--- a/test/fixtures/module-pkg-over-ext/inner/package.json
+++ b/test/fixtures/module-pkg-over-ext/inner/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "bin": "node bar.js"
+}


### PR DESCRIPTION
I think I figured out the issue causing the test suite to fail (see #15276) with the following error:

```bash
=== release test-esm-pkg-over-ext ===                                          
Path: es-module/test-esm-pkg-over-ext
(node:12584) ExperimentalWarning: The ESM module loader is experimental.
Error: module ../fixtures/module-pkg-over-ext/inner not found
    at module.exports (internal/loader/search.js:16:12)
    at resolveRequestUrl (internal/loader/resolveRequestUrl.js:81:13)
    at Loader.getModuleJob (internal/loader/Loader.js:50:27)
    at ModuleWrap.module.link (internal/loader/ModuleJob.js:30:25)
    at linked (internal/loader/ModuleJob.js:28:21)
    at <anonymous>
```

1. there was a missing fixture `fixtures/module-pkg-over-ext/inner/package.json`.
2. I think the first import in the test should be `../fixtures/module-pkg-over-ext/inner/package` vs. `../fixtures/module-pkg-over-ext/inner`, _or at least at this time importing a directory does not seem to default to `package.json` if no `index.js` is found (is this expected behavior @bmeck?)._

##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test,es-module