### PR TITLE
test: expand http2 maxSendHeaderBlockLength test case

### DIFF
--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -16,7 +16,7 @@ server.listen(0);
 server.on('listening', common.mustCall(() => {
 
   // Setting the maxSendHeaderBlockLength, then attempting to send a
-  // headers block that is too big should cause a 'meError' to
+  // headers block that is too big should cause a 'frameError' to
   // be emitted, and will cause the stream to be shutdown.
   const options = {
     maxSendHeaderBlockLength: 10
@@ -31,7 +31,6 @@ server.on('listening', common.mustCall(() => {
 
   req.resume();
   req.on('end', common.mustCall(() => {
-    server.close();
     client.destroy();
   }));
 
@@ -39,12 +38,38 @@ server.on('listening', common.mustCall(() => {
     assert.strictEqual(code, h2.constants.NGHTTP2_ERR_FRAME_SIZE_ERROR);
   }));
 
-  req.on('error', common.mustCall(common.expectsError({
+  req.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
     type: Error,
     message: 'Stream closed with error code 7'
-  })));
+  }));
 
   req.end();
+
+  // if no frameError listener, should emit 'error' with
+  // code ERR_HTTP2_FRAME_ERROR
+  const req2 = client.request({ ':path': '/' });
+
+  req2.on('response', common.mustNotCall());
+
+  req2.resume();
+  req2.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+
+  req2.once('error', common.mustCall((err) => {
+    common.expectsError({
+      code: 'ERR_HTTP2_FRAME_ERROR',
+      type: Error
+    })(err);
+    req2.on('error', common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      type: Error,
+      message: 'Stream closed with error code 7'
+    }));
+  }));
+
+  req2.end();
 
 }));


### PR DESCRIPTION
Just a tiny change to expand `maxSendHeaderBlockLength` test to check what happens if `frameError` listener isn't available.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test