### PR TITLE
child_process: remove shell option before win32 fork spawn

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -93,7 +93,12 @@ exports.fork = function(modulePath /*, args, options*/) {
   }
 
   options.execPath = options.execPath || process.execPath;
-
+  
+  // Make sure we don't try to shell and fork on Win32
+  if (process.platform === 'win32') {
+    options.shell = false;
+  }
+  
   return spawn(options.execPath, args, options);
 };
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/13983

##### Checklist

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

##### Affected core subsystem(s)
child_process
