### PR TITLE
test: fix single test runner regression

### DIFF
--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -115,7 +115,7 @@ class SimpleTestConfiguration(test.TestConfiguration):
     all_tests = [current_path + [t] for t in self.Ls(join(self.root))]
     result = []
     for test in all_tests:
-      if self.Contains(path, test):
+      if self.Contains(path, [test[0], re.sub('\.m?js$', '', test[1])]):
         file_path = join(self.root, reduce(join, test[1:], ""))
         test_name = test[:-1] + [splitext(test[-1])[0]]
         result.append(SimpleTestCase(test_name, file_path, arch, mode,


### PR DESCRIPTION
A recent commit https://github.com/nodejs/node/commit/c8a389e19f172edbada83f59944cad7cc802d9d5 broke the ability to run single tests without adding * to the end of the name. This fixes it.

You can test by running `python tools/test.py -J --mode=release es-module/test-esm-pkg-over-ext` before and after this patch.

If there's a cleaner way to accomplish the same, please let me know. Thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test