### PR TITLE
Error alphabetization fixes

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1249,11 +1249,6 @@ Used when an attempt is made to launch a Node.js process with an unknown
 by errors in user code, although it is not impossible. Occurrences of this error
 are most likely an indication of a bug within Node.js itself.
 
-<a id="ERR_VALUE_OUT_OF_RANGE"></a>
-### ERR_VALUE_OUT_OF_RANGE
-
-Used when a number value is out of range.
-
 <a id="ERR_V8BREAKITERATOR"></a>
 ### ERR_V8BREAKITERATOR
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -272,14 +272,13 @@ E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s');
 E('ERR_UNKNOWN_SIGNAL', 'Unknown signal: %s');
 E('ERR_UNKNOWN_STDIN_TYPE', 'Unknown stdin file type');
 E('ERR_UNKNOWN_STREAM_TYPE', 'Unknown stream file type');
-E('ERR_VALUE_OUT_OF_RANGE', (start, end, value) => {
-  return `The value of "${start}" must be ${end}. Received "${value}"`;
-});
 E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required');
-E('ERR_VALUE_OUT_OF_RANGE', 'The value of "%s" must be %s. Received "%s"');
+E('ERR_VALUE_OUT_OF_RANGE', (start, end, value) => {
+  return `The value of "${start}" must be ${end}. Received "${value}"`;
+});
 
 function invalidArgType(name, expected, actual) {
   assert(name, 'name is required');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1,4 +1,4 @@
-/* eslint-enable alphabetize-errors */
+/* eslint alphabetize-errors: "error" */
 
 'use strict';
 


### PR DESCRIPTION
A few things going on here:

- Properly enable `alphabetize-errors` lint rule (thank you @MylesBorins for pointing this out via #15305!)
- Fix alphabetization of `lib/internal/errors.js`, by removing a duplicate error definition (two for one special, I guess!)


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
errors, test