### PR TITLE
doc: add missing doc for readable._destroy

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1601,6 +1601,15 @@ The `readable._read()` method is prefixed with an underscore because it is
 internal to the class that defines it, and should never be called directly by
 user programs.
 
+#### readable.\_destroy(err, callback)
+<!-- YAML
+added: v8.0.0
+-->
+
+* `err` {Error} An error.
+* `callback` {Function} A callback function that takes an optional error
+  argument which is invoked when the readable is destroyed.
+
 #### readable.push(chunk[, encoding])
 <!-- YAML
 changes:


### PR DESCRIPTION
Fixes: #15291

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc