### PR TITLE
test: fix sequential/test-async-wrap-getasyncid

### DIFF
--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -56,8 +56,12 @@ function testInitialized(req, ctor_name) {
 
   testInitialized(dns.lookup('www.google.com', () => {}), 'GetAddrInfoReqWrap');
   testInitialized(dns.lookupService('::1', 22, () => {}), 'GetNameInfoReqWrap');
-  testInitialized(dns.resolve6('::1', () => {}), 'QueryReqWrap');
-  testInitialized(new cares.ChannelWrap(), 'ChannelWrap');
+
+  const resolver = new dns.Resolver();
+  resolver.setServers(['127.0.0.1']);
+  testInitialized(resolver._handle, 'ChannelWrap');
+  testInitialized(resolver.resolve6('::1', () => {}), 'QueryReqWrap');
+  resolver.cancel();
 }
 
 


### PR DESCRIPTION
Previously, this test would contain a DNS query that timed out
after 60 seconds, thus occupying one of the parallel test slots
for that period.

Fix that by creating a new channel for that request, and cancelling
it immediately.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test