### PR TITLE
Http2 test respondfd

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -121,7 +121,7 @@ const {
   HTTP2_METHOD_CONNECT,
 
   HTTP_STATUS_CONTINUE,
-  HTTP_STATUS_CONTENT_RESET,
+  HTTP_STATUS_RESET_CONTENT,
   HTTP_STATUS_OK,
   HTTP_STATUS_NO_CONTENT,
   HTTP_STATUS_NOT_MODIFIED,
@@ -1879,7 +1879,7 @@ class ServerHttp2Stream extends Http2Stream {
     // the options.endStream option to true so that the underlying
     // bits do not attempt to send any.
     if (statusCode === HTTP_STATUS_NO_CONTENT ||
-        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_RESET_CONTENT ||
         statusCode === HTTP_STATUS_NOT_MODIFIED ||
         state.headRequest === true) {
       options.endStream = true;
@@ -1973,7 +1973,7 @@ class ServerHttp2Stream extends Http2Stream {
     const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
     // Payload/DATA frames are not permitted in these cases
     if (statusCode === HTTP_STATUS_NO_CONTENT ||
-        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_RESET_CONTENT ||
         statusCode === HTTP_STATUS_NOT_MODIFIED) {
       throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
     }
@@ -2050,7 +2050,7 @@ class ServerHttp2Stream extends Http2Stream {
     const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
     // Payload/DATA frames are not permitted in these cases
     if (statusCode === HTTP_STATUS_NO_CONTENT ||
-        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_RESET_CONTENT ||
         statusCode === HTTP_STATUS_NOT_MODIFIED) {
       throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
     }

--- a/test/parallel/test-http2-fd-nan-respondfd.js
+++ b/test/parallel/test-http2-fd-nan-respondfd.js
@@ -1,0 +1,49 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Test that ERR_INVALID_ARG_TYPE is thrown when ServerHttp2Stream.respondWithFD
+// is called with an fd value that is not of type number
+
+const types = {
+  function: () => {},
+  object: {},
+  array: [],
+  null: null,
+  symbol: Symbol('test')
+};
+
+const server = http2.createServer();
+
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  Object.keys(types).forEach((type) => {
+
+    common.expectsError(() => stream.respondWithFD(type), {
+      type: TypeError,
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "fd" argument must be of type number'
+    });
+
+  });
+  stream.end('hello world');
+}
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request();
+
+  req.resume();
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+}));

--- a/test/parallel/test-http2-forbidden-headers-respondfd.js
+++ b/test/parallel/test-http2-forbidden-headers-respondfd.js
@@ -1,0 +1,57 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Test that ERR_HTTP2_PAYLOAD_FORBIDDEN is thrown when 
+// ServerHttp2Stream.respondWithFD is called with a forbidden header status
+
+const server = http2.createServer();
+
+const {
+  HTTP2_HEADER_STATUS
+} = http2.constants;
+
+const {
+  constants
+} = process.binding('http2');
+
+const statuses = [
+  constants.HTTP_STATUS_NO_CONTENT,
+  constants.HTTP_STATUS_RESET_CONTENT,
+  constants.HTTP_STATUS_NOT_MODIFIED
+];
+
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  statuses.forEach((headerStatus) => {
+
+    common.expectsError(() => stream.respondWithFD(0, {
+      [HTTP2_HEADER_STATUS]: headerStatus
+    }), {
+      type: Error,
+      code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
+      message: `Responses with ${headerStatus} status must not have a payload`
+    });
+
+  });
+  stream.end('hello world');
+}
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request();
+
+  req.resume();
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+}));

--- a/test/parallel/test-http2-headers-sent-respondfd.js
+++ b/test/parallel/test-http2-headers-sent-respondfd.js
@@ -1,0 +1,49 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Test that ERR_HTTP2_HEADERS_SENT error is thrown when headers are sent before
+// calling ServerHttp2Stream.respondWithFD
+
+const server = http2.createServer();
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE
+} = http2.constants;
+
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+
+  common.expectsError(() => stream.respondWithFD(0, {
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+  }), {
+    type: Error,
+    code: 'ERR_HTTP2_HEADERS_SENT',
+    message: 'Response has already been initiated.'
+  });
+
+  stream.end('hello world');
+}
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request();
+
+  req.resume();
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+}));

--- a/test/parallel/test-http2-options-errors-respondfd.js
+++ b/test/parallel/test-http2-options-errors-respondfd.js
@@ -1,0 +1,71 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Test that ERR_INVALID_OPT_VALUE TypeErrors are thrown when passing invalid
+// options to ServerHttp2Stream.respondWithFD method
+
+const optionsToTest = {
+  offset: 'number',
+  length: 'number',
+  statCheck: 'function',
+  getTrailers: 'function'
+};
+
+const types = {
+  function: () => {},
+  number: 1,
+  object: {},
+  array: [],
+  null: null,
+  symbol: Symbol('test')
+};
+
+const server = http2.createServer();
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE
+} = http2.constants;
+
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  Object.keys(optionsToTest).forEach((option) => {
+    Object.keys(types).forEach((type) => {
+      if (type === optionsToTest[option]) {
+        return;
+      }
+
+      common.expectsError(() => stream.respondWithFD(0, {
+        [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+      }, {
+        [option]: types[type]
+      }), {
+        type: TypeError,
+        code: 'ERR_INVALID_OPT_VALUE',
+        message: `The value "${String(types[type])}" is invalid ` +
+          `for option "${option}"`
+      });
+
+    });
+  });
+  stream.end('hello world');
+}
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request();
+
+  req.resume();
+
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+}));

--- a/test/parallel/test-http2-server-destroy-before-respond-fd.js
+++ b/test/parallel/test-http2-server-destroy-before-respond-fd.js
@@ -1,0 +1,38 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+// Test that ERR_HTTP2_INVALID_STREAM is thrown when the stream session
+// is destroyed
+
+const server = http2.createServer();
+
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.session.destroy();
+
+  common.expectsError(
+    () => stream.respondWithFD(0), {
+      code: 'ERR_HTTP2_INVALID_STREAM',
+      message: /^The stream has been destroyed$/
+    });
+}
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustNotCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+}));


### PR DESCRIPTION
This PR increases test coverage in `ServerHttp2Stream.respondWithFD` and corrects `HTTP_STATUS_CONTENT_RESET` to `HTTP_STATUS_RESET_CONTENT` in `lib/internal/http2/core.js`.

Once I've got feedback on this PR I can do something similar for `ServerHttp2Stream.respondWithFile`.

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2, test
