### PR TITLE
http: send 400 bad request on parse error

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -36,6 +36,7 @@ const httpSocketSetup = common.httpSocketSetup;
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const { outHeadersKey, ondrain } = require('internal/http');
 const errors = require('internal/errors');
+const Buffer = require('buffer').Buffer;
 
 const STATUS_CODES = {
   100: 'Continue',
@@ -449,13 +450,21 @@ function onParserExecute(server, socket, parser, state, ret, d) {
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);
 }
 
+const badRequestResponse = Buffer.from(
+  'HTTP/1.1 400 ' + STATUS_CODES[400] + CRLF + CRLF, 'ascii'
+);
 function socketOnError(e) {
   // Ignore further errors
   this.removeListener('error', socketOnError);
   this.on('error', () => {});
 
-  if (!this.server.emit('clientError', e, this))
+  if (!this.server.emit('clientError', e, this)) {
+    if (this.writable) {
+      this.end(badRequestResponse);
+      return;
+    }
     this.destroy(e);
+  }
 }
 
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -38,6 +38,7 @@ const server = http.createServer(common.mustCall((req, res) => {
 
 server.listen(0, common.mustCall(() => {
   const c = net.createConnection(server.address().port);
+  let received = '';
 
   c.on('connect', common.mustCall(() => {
     c.write('GET /blah HTTP/1.1\r\n' +
@@ -47,7 +48,12 @@ server.listen(0, common.mustCall(() => {
             '\r\n\r\nhello world'
     );
   }));
-
-  c.on('end', common.mustCall(() => c.end()));
+  c.on('data', common.mustCall((data) => {
+    received += data.toString();
+  }));
+  c.on('end', common.mustCall(() => {
+    assert.strictEqual('HTTP/1.1 400 Bad Request\r\n\r\n', received);
+    c.end();
+  }));
   c.on('close', common.mustCall(() => server.close()));
 }));


### PR DESCRIPTION
A web server such as nginx assumes that upstream is dead
if upstream closes the socket without any response.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http