### PR TITLE
test: fix flaky test-http2-session-timeout

### DIFF
--- a/test/parallel/test-http2-session-timeout.js
+++ b/test/parallel/test-http2-session-timeout.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const h2 = require('http2');
 
-const serverTimeout = common.platformTimeout(200);
+const serverTimeout = common.platformTimeout(1200);
 const callTimeout = common.platformTimeout(10);
 
 const server = h2.createServer();


### PR DESCRIPTION
Increase server timeout to reduce likelihood of triggering race
conditions.

Fixes: https://github.com/nodejs/node/issues/15326

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http2