### PR TITLE
docs: fix Buffer.allocUnsafeSlow is added in 5.12.0 instead of 5.10.0

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -616,7 +616,7 @@ additional performance that [`Buffer.allocUnsafe()`] provides.
 
 ### Class Method: Buffer.allocUnsafeSlow(size)
 <!-- YAML
-added: v5.10.0
+added: v5.12.0
 -->
 
 * `size` {integer} The desired length of the new `Buffer`


### PR DESCRIPTION
Updating docs: Buffer.allocUnsafeSlow() is added in v5.12.0 instead of 5.10.0

Fixed: #15279

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
None
