### PR TITLE
test: fix flaky test-http2-session-timeout

### DIFF
--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -7,20 +7,22 @@ if (!common.hasCrypto)
 const h2 = require('http2');
 
 const serverTimeout = common.platformTimeout(200);
-const callTimeout = common.platformTimeout(10);
+const callTimeout = common.platformTimeout(20);
+const minRuns = Math.ceil(serverTimeout / callTimeout) * 2;
+const mustNotCall = common.mustNotCall();
 
 const server = h2.createServer();
 server.timeout = serverTimeout;
 
 server.on('request', (req, res) => res.end());
-server.on('timeout', common.mustNotCall());
+server.on('timeout', mustNotCall);
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
 
   const url = `http://localhost:${port}`;
   const client = h2.connect(url);
-  makeReq(40);
+  makeReq(minRuns);
 
   function makeReq(attempts) {
     const request = client.request({
@@ -29,13 +31,17 @@ server.listen(0, common.mustCall(() => {
       ':scheme': 'http',
       ':authority': `localhost:${port}`,
     });
+    request.resume();
     request.end();
 
-    if (attempts) {
-      setTimeout(() => makeReq(attempts - 1), callTimeout);
-    } else {
-      server.close();
-      client.destroy();
-    }
+    request.on('end', () => {
+      if (attempts) {
+        setTimeout(() => makeReq(attempts - 1), callTimeout);
+      } else {
+        server.removeListener('timeout', mustNotCall);
+        client.destroy();
+        server.close();
+      }
+    });
   }
 }));


### PR DESCRIPTION
This is an alternative solution to https://github.com/nodejs/node/pull/15328. Increases server timeout, reduces frequency of calls and unbinds timeout after runs are done in order to avoid race conditions.

cc @Trott @mcollina @tniessen 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test