### PR TITLE
buffer: runtime-deprecate Buffer ctor by default

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -51,9 +51,6 @@ const {
   isArrayBufferView,
   isUint8Array
 } = require('internal/util/types');
-const {
-  pendingDeprecation
-} = process.binding('config');
 const errors = require('internal/errors');
 
 const internalBuffer = require('internal/buffer');
@@ -131,33 +128,23 @@ const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
 
-function showFlaggedDeprecation() {
+function showDeprecation() {
   if (bufferWarn) {
-    // This is a *pending* deprecation warning. It is not emitted by
-    // default unless the --pending-deprecation command-line flag is
-    // used or the NODE_PENDING_DEPRECATION=1 env var is set.
     process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
     bufferWarn = false;
   }
 }
 
-const doFlaggedDeprecation =
-  pendingDeprecation ?
-    showFlaggedDeprecation :
-    function() {};
-
 /**
- * The Buffer() constructor is deprecated in documentation and should not be
- * used moving forward. Rather, developers should use one of the three new
- * factory APIs: Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on
- * their specific needs. There is no runtime deprecation because of the extent
- * to which the Buffer constructor is used in the ecosystem currently -- a
- * runtime deprecation would introduce too much breakage at this time. It's not
- * likely that the Buffer constructors would ever actually be removed.
+ * The Buffer() constructor is deprecated and should not be used moving forward.
+ * Rather, developers should use one of the three new factory APIs:
+ * Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on their specific
+ * needs. It's not likely that the Buffer constructors would ever actually be
+ * removed.
  * Deprecation Code: DEP0005
  **/
 function Buffer(arg, encodingOrOffset, length) {
-  doFlaggedDeprecation();
+  showDeprecation();
   // Common case.
   if (typeof arg === 'number') {
     if (typeof encodingOrOffset === 'string') {

--- a/test/parallel/test-buffer-deprecation.js
+++ b/test/parallel/test-buffer-deprecation.js
@@ -1,4 +1,4 @@
-// Flags: --pending-deprecation --no-warnings
+// Flags: --no-warnings
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-buffer-nodep-map.js
+++ b/test/parallel/test-buffer-nodep-map.js
@@ -1,12 +1,12 @@
-// Flags: --no-warnings --pending-deprecation
+// Flags: --no-warnings
 'use strict';
 
 const common = require('../common');
 
 process.on('warning', common.mustNotCall('A warning should not be emitted'));
 
-// With the --pending-deprecation flag, the deprecation warning for
-// new Buffer() should not be emitted when Uint8Array methods are called.
+// The deprecation warning for new Buffer() should not be emitted when
+// Uint8Array methods are called.
 
 Buffer.from('abc').map((i) => i);
 Buffer.from('abc').filter((i) => i);


### PR DESCRIPTION
Creating a new PR as suggested in https://github.com/nodejs/node/pull/7152#issuecomment-299165077.

Some backstory:

* In Node.js 6.0.0, new Buffer APIs (`Buffer.from()`, `Buffer.allocUnsafe()` and `Buffer.alloc()`) were introduced to address security concerns of the Buffer constructor, which was deprecated in the docs in the same version. (see https://github.com/nodejs/node/pull/4682, https://github.com/nodejs/node/issues/4660)
* In Node.js 8.0.0, a "pending deprecation" for the Buffer constructor was introduced. When Node.js is launched with the `--pending-deprecation` flag, the use of `Buffer()` and `new Buffer()` causes a `DeprecationWarning` to be emitted. (see https://github.com/nodejs/node/pull/11968)
* It was proposed to revisit this and possibly move the warning from behind the flag in Node.js 9.0.0. (see https://github.com/nodejs/node/issues/9531#issuecomment-285772835, https://github.com/nodejs/node/issues/9531#issuecomment-291046546).

Several reasons for enabling runtime deprecation by default, in no particular order:

* Potentially prevents possible DoS vulnerabilities caused by accidentally calling `Buffer(num)` instead of `Buffer(string)` due to insufficient input validation.
* `Buffer(num)` zero-fills by default since 8.0.0, preventing accidental data disclosure. (see https://github.com/nodejs/node/pull/12141) However, it was not backported to earlier Node.js versions, which could result in security issues if new code is written with the assumption of zero-filling and then run on Node.js versions that don't zero-fill. (this and above is described in more detail [here](https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md))
* Some developers might be unaware that `Buffer(num)` zero-fills and still be using it in performance-critical code, where `Buffer.allocUnsafe()` might be more appropriate.
* Calling `Buffer()` without `new` would be runtime-deprecated as well, so this functionality could _potentially_ be removed in a later Node.js version. This would make it possible to refactor `Buffer` into a proper ES6 class that can be subclassed.
* Following "pending deprecation" with actual runtime deprecation will create a precedent that will cause more people to use the `--pending-deprecation` flag to test their code in the future. This will in turn allow us to introduce new runtime deprecations more smoothly by going through the "behind-the-flag" stage first.
* _Eventually_, most code will use the new Buffer API, which will make it less likely that people new to Node.js will ever need to learn about the deprecated API.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer