### PR TITLE
child_process: set shell to false in fork() 

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -356,6 +356,9 @@ output on this fd is expected to be line delimited JSON objects.
 *Note*: Unlike the fork(2) POSIX system call, `child_process.fork()` does
 not clone the current process.
 
+*Note*: The `shell` option available in [`child_process.spawn()`][] is not
+supported by `child_process.fork()` and will be ignored if set.
+
 ### child_process.spawn(command[, args][, options])
 <!-- YAML
 added: v0.1.90

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -93,6 +93,7 @@ exports.fork = function(modulePath /*, args, options*/) {
   }
 
   options.execPath = options.execPath || process.execPath;
+  options.shell = false;
 
   return spawn(options.execPath, args, options);
 };

--- a/test/parallel/test-child-process-fork-no-shell.js
+++ b/test/parallel/test-child-process-fork-no-shell.js
@@ -1,0 +1,20 @@
+'use strict';
+// This test verifies that the shell option is not supported by fork().
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const expected = common.isWindows ? '%foo%' : '$foo';
+
+if (process.argv[2] === undefined) {
+  const child = cp.fork(__filename, [expected], {
+    shell: true,
+    env: { foo: 'bar' }
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+} else {
+  assert.strictEqual(process.argv[2], expected);
+}


### PR DESCRIPTION
In this PR I picked up the `lib/` and `doc/` changes from the abandoned #15299. I also added a test for the changes.

Refs: https://github.com/nodejs/node/pull/15299
Fixes: https://github.com/nodejs/node/issues/13983

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
child_process, test