### PR TITLE
BREAKING: deprecate loading files with unknown or missing extensions

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -684,12 +684,12 @@ difference is that `querystring.parse()` does url encoding:
 { '%E5%A5%BD': '1' }
 ```
 
-<a id="DEP0077"></a>
-### DEP0077: Loading files without a known file extension 
+<a id="DEP00XX"></a>
+### DEP00XX: Loading files without a known file extension 
 
 Type: Runtime
 
-Files without file extensions, or unknown file extensions will not be loaded.
+Files without file extensions or unknown file extensions will not be loaded.
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -684,6 +684,13 @@ difference is that `querystring.parse()` does url encoding:
 { '%E5%A5%BD': '1' }
 ```
 
+<a id="DEP0077"></a>
+### DEP0077: Loading files without a known file extension 
+
+Type: Runtime
+
+Files without file extensions, or unknown file extensions will not be loaded.
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer

--- a/lib/module.js
+++ b/lib/module.js
@@ -24,6 +24,7 @@
 const NativeModule = require('native_module');
 const util = require('util');
 const internalModule = require('internal/module');
+const internalUtil = require('internal/util');
 const { getURLFromFilePath } = require('internal/url');
 const vm = require('vm');
 const assert = require('assert').ok;
@@ -516,8 +517,12 @@ Module.prototype.load = function(filename) {
   this.filename = filename;
   this.paths = Module._nodeModulePaths(path.dirname(filename));
 
-  var extension = path.extname(filename) || '.js';
-  if (!Module._extensions[extension]) extension = '.js';
+  var extension = path.extname(filename);
+  if (!extension || !Module._extensions[extension]) {
+    internalUtil.deprecate(() => {
+      extension = '.js';
+    }, 'Loading files without an extension or unknown extension is deprecated', 'DEP0077')();
+  };
   Module._extensions[extension](this, filename);
   this.loaded = true;
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -509,8 +509,10 @@ Module._resolveFilename = function(request, parent, isMain) {
 };
 
 const DEPRECATED_EXTENSION_FILLING = internalUtil.deprecate(() => {
-  return '.js';
-}, 'Loading files without an extension or unknown extension is deprecated', 'DEP0077');
+    return '.js';
+  },
+  'Loading files without an extension or unknown extension is deprecated',
+  'DEP0077');
 // Given a file name, pass it to the proper extension handler.
 Module.prototype.load = function(filename) {
   debug('load %j for module %j', filename, this.id);

--- a/lib/module.js
+++ b/lib/module.js
@@ -508,7 +508,9 @@ Module._resolveFilename = function(request, parent, isMain) {
   return filename;
 };
 
-
+const DEPRECATED_EXTENSION_FILLING = internalUtil.deprecate(() => {
+  return '.js';
+}, 'Loading files without an extension or unknown extension is deprecated', 'DEP0077');
 // Given a file name, pass it to the proper extension handler.
 Module.prototype.load = function(filename) {
   debug('load %j for module %j', filename, this.id);
@@ -519,9 +521,7 @@ Module.prototype.load = function(filename) {
 
   var extension = path.extname(filename);
   if (!extension || !Module._extensions[extension]) {
-    internalUtil.deprecate(() => {
-      extension = '.js';
-    }, 'Loading files without an extension or unknown extension is deprecated', 'DEP0077')();
+    extension = DEPRECATED_EXTENSION_FILLING();
   };
   Module._extensions[extension](this, filename);
   this.loaded = true;


### PR DESCRIPTION
This prevents treating files as CJS when they are not specified as
.js explicitly. Package managers create links without the extension
already so the use of "bin" still works. Also, node continues to do
path searching and can find a .js file with the same location via
command line.

This fixes some problems with ESM loading from CLI arguments since we cannot reliably know if a file is supposed to be loaded via CJS normally. This will also be desired once loader hooks come around so that they can capture all modules loaded via CLI arguments.

Right now we have a [very simplistic check](https://github.com/nodejs/node/blob/6ccb9fe8097b4199e0bb56e06ff567bd3fa73ca5/lib/module.js#L436) for if a main entry point should be loaded as ESM. However, this still has collisions and doesn't have a path forward for loader hooks wishing to change how main entry points/preloading via `--require` works.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module