### PR TITLE
src: remove unused perf_hooks uv handles

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -523,33 +523,6 @@ inline std::map<std::string, uint64_t>* Environment::performance_marks() {
   return &performance_marks_;
 }
 
-inline Environment* Environment::from_performance_check_handle(
-    uv_check_t* handle) {
-  return ContainerOf(&Environment::performance_check_handle_, handle);
-}
-
-inline Environment* Environment::from_performance_idle_handle(
-    uv_idle_t* handle) {
-  return ContainerOf(&Environment::performance_idle_handle_, handle);
-}
-
-inline Environment* Environment::from_performance_prepare_handle(
-    uv_prepare_t* handle) {
-  return ContainerOf(&Environment::performance_prepare_handle_, handle);
-}
-
-inline uv_check_t* Environment::performance_check_handle() {
-  return &performance_check_handle_;
-}
-
-inline uv_idle_t* Environment::performance_idle_handle() {
-  return &performance_idle_handle_;
-}
-
-inline uv_prepare_t* Environment::performance_prepare_handle() {
-  return &performance_prepare_handle_;
-}
-
 inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -617,14 +617,6 @@ class Environment {
   inline performance::performance_state* performance_state();
   inline std::map<std::string, uint64_t>* performance_marks();
 
-  static inline Environment* from_performance_check_handle(uv_check_t* handle);
-  static inline Environment* from_performance_idle_handle(uv_idle_t* handle);
-  static inline Environment* from_performance_prepare_handle(
-      uv_prepare_t* handle);
-  inline uv_check_t* performance_check_handle();
-  inline uv_idle_t* performance_idle_handle();
-  inline uv_prepare_t* performance_prepare_handle();
-
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
   inline void ThrowRangeError(const char* errmsg);
@@ -704,9 +696,6 @@ class Environment {
   uv_timer_t destroy_ids_timer_handle_;
   uv_prepare_t idle_prepare_handle_;
   uv_check_t idle_check_handle_;
-  uv_prepare_t performance_prepare_handle_;
-  uv_check_t performance_check_handle_;
-  uv_idle_t performance_idle_handle_;
 
   AsyncHooks async_hooks_;
   DomainFlag domain_flag_;


### PR DESCRIPTION
A couple of unused uv handles were accidentally left in env.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src