### PR TITLE
docs: update 8.5.0 changelog

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -113,7 +113,7 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/15001
   - version: v8.5.0
-    pr-url: https://github.com/nodejs/node/pull/12142
+    pr-url: https://github.com/nodejs/node/pull/15001
     description: Error names and messages are now properly compared
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/12142

--- a/doc/changelogs/CHANGELOG_V8.md
+++ b/doc/changelogs/CHANGELOG_V8.md
@@ -72,8 +72,7 @@
 * **perf_hooks**
   * An initial implementation of the Performance Timing API for Node.js. This is the
     same Performance Timing API implemented by modern browsers with a number of Node.js
-    specific properties. The User Timing mark() and measure() APIs are implemented,
-    as is a Node.js specific flavor of the Frame Timing for measuring event loop duration.
+    specific properties. The User Timing mark() and measure() APIs are implemented.
     [#14680](https://github.com/nodejs/node/pull/14680)
 * **tls**
   * multiple PFX in createSecureContext


### PR DESCRIPTION
The original changelog included incorrect information regarding
the new perf_hooks api.

refs: https://github.com/nodejs/node/pull/15308#issuecomment-328874385
