### PR TITLE
errors: backport ERR_INVALID_PROTOCOL to v8.x

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -835,6 +835,11 @@ communication channel to a child process. See [`subprocess.send()`] and
 Used generically to identify when an invalid or unexpected value has been
 passed in an options object.
 
+<a id="ERR_INVALID_PROTOCOL"></a>
+### ERR_INVALID_PROTOCOL
+
+Used when an invalid `options.protocol` is passed.
+
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -196,6 +196,8 @@ E('ERR_INVALID_OPT_VALUE',
     return `The value "${String(value)}" is invalid for option "${name}"`;
   });
 E('ERR_INVALID_PERFORMANCE_MARK', 'The "%s" performance mark has not been set');
+E('ERR_INVALID_PROTOCOL', (protocol, expectedProtocol) =>
+  `Protocol "${protocol}" not supported. Expected "${expectedProtocol}"`);
 E('ERR_INVALID_SYNC_FORK_INPUT',
   (value) => {
     return 'Asynchronous forks do not support Buffer, Uint8Array or string' +


### PR DESCRIPTION
This error code originally landed in a semver-major commit and is used
by the ESM implementation. This backport includes the error message
and the documentation for the error.

I did attempt to write a test for this, but it did not seem possible
to catch an exception during import, I was also unable to execute
`node --experimental-modules` properly inside of a child_process.

I'll dig more into getting a test together, but we should backport
this fix in the mean time.

Refs: https://github.com/nodejs/node/pull/14423
Fixes: https://github.com/nodejs/node/issues/15374
