### PR TITLE
Possible fix for #15374

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -435,7 +435,7 @@ Module._load = function(request, parent, isMain) {
     if (experimentalModules) {
       if (filename === null || /\.mjs$/.test(filename)) {
         try {
-          ESMLoader.import(request).catch((e) => {
+          ESMLoader.import(getURLFromFilePath(filename).href).catch((e) => {
             console.error(e);
             process.exit(1);
           });


### PR DESCRIPTION
This should fix the Windows path bug with drive letters being detected as the protocol, getting modules to work on Windows properly.

I still need to actually test this out on a Windows machine (won't have access again till tomorrow) but I'm 99% sure it'll work out.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
esmodules
