### PR TITLE
src: keep track of env properly in node_perf.cc

### DIFF
--- a/deps/v8/include/v8.h
+++ b/deps/v8/include/v8.h
@@ -7203,6 +7203,8 @@ class V8_EXPORT Isolate {
 
   typedef void (*GCCallback)(Isolate* isolate, GCType type,
                              GCCallbackFlags flags);
+  typedef void (*GCCallbackWithData)(Isolate* isolate, GCType type,
+                                     GCCallbackFlags flags, void* data);
 
   /**
    * Enables the host application to receive a notification before a
@@ -7213,6 +7215,8 @@ class V8_EXPORT Isolate {
    * not possible to register the same callback function two times with
    * different GCType filters.
    */
+  void AddGCPrologueCallback(GCCallbackWithData callback, void* data = nullptr,
+                             GCType gc_type_filter = kGCTypeAll);
   void AddGCPrologueCallback(GCCallback callback,
                              GCType gc_type_filter = kGCTypeAll);
 
@@ -7220,6 +7224,7 @@ class V8_EXPORT Isolate {
    * This function removes callback which was installed by
    * AddGCPrologueCallback function.
    */
+  void RemoveGCPrologueCallback(GCCallbackWithData, void* data = nullptr);
   void RemoveGCPrologueCallback(GCCallback callback);
 
   /**
@@ -7236,6 +7241,8 @@ class V8_EXPORT Isolate {
    * not possible to register the same callback function two times with
    * different GCType filters.
    */
+  void AddGCEpilogueCallback(GCCallbackWithData callback, void* data = nullptr,
+                             GCType gc_type_filter = kGCTypeAll);
   void AddGCEpilogueCallback(GCCallback callback,
                              GCType gc_type_filter = kGCTypeAll);
 
@@ -7243,6 +7250,8 @@ class V8_EXPORT Isolate {
    * This function removes callback which was installed by
    * AddGCEpilogueCallback function.
    */
+  void RemoveGCEpilogueCallback(GCCallbackWithData callback,
+                                void* data = nullptr);
   void RemoveGCEpilogueCallback(GCCallback callback);
 
   typedef size_t (*GetExternallyAllocatedMemoryInBytesCallback)();

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -57,6 +57,18 @@
 namespace v8 {
 namespace internal {
 
+bool Heap::GCCallbackPair::operator==(const Heap::GCCallbackPair& other) const {
+  return other.callback == callback;
+}
+
+Heap::GCCallbackPair& Heap::GCCallbackPair::operator=(
+    const Heap::GCCallbackPair& other) {
+  callback = other.callback;
+  gc_type = other.gc_type;
+  pass_isolate = other.pass_isolate;
+  return *this;
+}
+
 struct Heap::StrongRootsList {
   Object** start;
   Object** end;
@@ -1501,15 +1513,15 @@ bool Heap::PerformGarbageCollection(
 void Heap::CallGCPrologueCallbacks(GCType gc_type, GCCallbackFlags flags) {
   RuntimeCallTimerScope runtime_timer(isolate(),
                                       &RuntimeCallStats::GCPrologueCallback);
-  for (int i = 0; i < gc_prologue_callbacks_.length(); ++i) {
-    if (gc_type & gc_prologue_callbacks_[i].gc_type) {
-      if (!gc_prologue_callbacks_[i].pass_isolate) {
-        v8::GCCallback callback = reinterpret_cast<v8::GCCallback>(
-            gc_prologue_callbacks_[i].callback);
+  for (const GCCallbackPair& info : gc_prologue_callbacks_) {
+    if (gc_type & info.gc_type) {
+      if (!info.pass_isolate) {
+        v8::GCCallback callback =
+            reinterpret_cast<v8::GCCallback>(info.callback);
         callback(gc_type, flags);
       } else {
         v8::Isolate* isolate = reinterpret_cast<v8::Isolate*>(this->isolate());
-        gc_prologue_callbacks_[i].callback(isolate, gc_type, flags);
+        info.callback(isolate, gc_type, flags);
       }
     }
   }
@@ -1520,15 +1532,15 @@ void Heap::CallGCEpilogueCallbacks(GCType gc_type,
                                    GCCallbackFlags gc_callback_flags) {
   RuntimeCallTimerScope runtime_timer(isolate(),
                                       &RuntimeCallStats::GCEpilogueCallback);
-  for (int i = 0; i < gc_epilogue_callbacks_.length(); ++i) {
-    if (gc_type & gc_epilogue_callbacks_[i].gc_type) {
-      if (!gc_epilogue_callbacks_[i].pass_isolate) {
-        v8::GCCallback callback = reinterpret_cast<v8::GCCallback>(
-            gc_epilogue_callbacks_[i].callback);
+  for (const GCCallbackPair& info : gc_epilogue_callbacks_) {
+    if (gc_type & info.gc_type) {
+      if (!info.pass_isolate) {
+        v8::GCCallback callback =
+            reinterpret_cast<v8::GCCallback>(info.callback);
         callback(gc_type, gc_callback_flags);
       } else {
         v8::Isolate* isolate = reinterpret_cast<v8::Isolate*>(this->isolate());
-        gc_epilogue_callbacks_[i].callback(isolate, gc_type, gc_callback_flags);
+        info.callback(isolate, gc_type, gc_callback_flags);
       }
     }
   }
@@ -5964,18 +5976,20 @@ void Heap::TearDown() {
 
 void Heap::AddGCPrologueCallback(v8::Isolate::GCCallback callback,
                                  GCType gc_type, bool pass_isolate) {
-  DCHECK(callback != NULL);
-  GCCallbackPair pair(callback, gc_type, pass_isolate);
-  DCHECK(!gc_prologue_callbacks_.Contains(pair));
-  return gc_prologue_callbacks_.Add(pair);
+  DCHECK_NOT_NULL(callback);
+  DCHECK(gc_prologue_callbacks_.end() ==
+         std::find(gc_prologue_callbacks_.begin(), gc_prologue_callbacks_.end(),
+                   GCCallbackPair(callback, gc_type, pass_isolate)));
+  gc_prologue_callbacks_.emplace_back(callback, gc_type, pass_isolate);
 }
 
 
 void Heap::RemoveGCPrologueCallback(v8::Isolate::GCCallback callback) {
-  DCHECK(callback != NULL);
-  for (int i = 0; i < gc_prologue_callbacks_.length(); ++i) {
+  DCHECK_NOT_NULL(callback);
+  for (size_t i = 0; i < gc_prologue_callbacks_.size(); i++) {
     if (gc_prologue_callbacks_[i].callback == callback) {
-      gc_prologue_callbacks_.Remove(i);
+      gc_prologue_callbacks_[i] = gc_prologue_callbacks_.back();
+      gc_prologue_callbacks_.pop_back();
       return;
     }
   }
@@ -5985,18 +5999,20 @@ void Heap::RemoveGCPrologueCallback(v8::Isolate::GCCallback callback) {
 
 void Heap::AddGCEpilogueCallback(v8::Isolate::GCCallback callback,
                                  GCType gc_type, bool pass_isolate) {
-  DCHECK(callback != NULL);
-  GCCallbackPair pair(callback, gc_type, pass_isolate);
-  DCHECK(!gc_epilogue_callbacks_.Contains(pair));
-  return gc_epilogue_callbacks_.Add(pair);
+  DCHECK_NOT_NULL(callback);
+  DCHECK(gc_epilogue_callbacks_.end() ==
+         std::find(gc_epilogue_callbacks_.begin(), gc_epilogue_callbacks_.end(),
+                   GCCallbackPair(callback, gc_type, pass_isolate)));
+  gc_epilogue_callbacks_.emplace_back(callback, gc_type, pass_isolate);
 }
 
 
 void Heap::RemoveGCEpilogueCallback(v8::Isolate::GCCallback callback) {
-  DCHECK(callback != NULL);
-  for (int i = 0; i < gc_epilogue_callbacks_.length(); ++i) {
+  DCHECK_NOT_NULL(callback);
+  for (size_t i = 0; i < gc_epilogue_callbacks_.size(); i++) {
     if (gc_epilogue_callbacks_[i].callback == callback) {
-      gc_epilogue_callbacks_.Remove(i);
+      gc_epilogue_callbacks_[i] = gc_epilogue_callbacks_.back();
+      gc_epilogue_callbacks_.pop_back();
       return;
     }
   }

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1422,13 +1422,15 @@ class Heap {
   // Prologue/epilogue callback methods.========================================
   // ===========================================================================
 
-  void AddGCPrologueCallback(v8::Isolate::GCCallback callback,
-                             GCType gc_type_filter, bool pass_isolate = true);
-  void RemoveGCPrologueCallback(v8::Isolate::GCCallback callback);
+  void AddGCPrologueCallback(v8::Isolate::GCCallbackWithData callback,
+                             GCType gc_type_filter, void* data);
+  void RemoveGCPrologueCallback(v8::Isolate::GCCallbackWithData callback,
+                                void* data);
 
-  void AddGCEpilogueCallback(v8::Isolate::GCCallback callback,
-                             GCType gc_type_filter, bool pass_isolate = true);
-  void RemoveGCEpilogueCallback(v8::Isolate::GCCallback callback);
+  void AddGCEpilogueCallback(v8::Isolate::GCCallbackWithData callback,
+                             GCType gc_type_filter, void* data);
+  void RemoveGCEpilogueCallback(v8::Isolate::GCCallbackWithData callback,
+                                void* data);
 
   void CallGCPrologueCallbacks(GCType gc_type, GCCallbackFlags flags);
   void CallGCEpilogueCallbacks(GCType gc_type, GCCallbackFlags flags);
@@ -1588,17 +1590,17 @@ class Heap {
     RootListIndex index;
   };
 
-  struct GCCallbackPair {
-    GCCallbackPair(v8::Isolate::GCCallback callback, GCType gc_type,
-                   bool pass_isolate)
-        : callback(callback), gc_type(gc_type), pass_isolate(pass_isolate) {}
+  struct GCCallbackTuple {
+    GCCallbackTuple(v8::Isolate::GCCallbackWithData callback, GCType gc_type,
+                    void* data)
+        : callback(callback), gc_type(gc_type), data(data) {}
 
-    bool operator==(const GCCallbackPair& other) const;
-    GCCallbackPair& operator=(const GCCallbackPair& other);
+    bool operator==(const GCCallbackTuple& other) const;
+    GCCallbackTuple& operator=(const GCCallbackTuple& other);
 
-    v8::Isolate::GCCallback callback;
+    v8::Isolate::GCCallbackWithData callback;
     GCType gc_type;
-    bool pass_isolate;
+    void* data;
   };
 
   typedef String* (*ExternalStringTableUpdaterCallback)(Heap* heap,
@@ -2262,8 +2264,8 @@ class Heap {
 
   Object* encountered_transition_arrays_;
 
-  std::vector<GCCallbackPair> gc_epilogue_callbacks_;
-  std::vector<GCCallbackPair> gc_prologue_callbacks_;
+  std::vector<GCCallbackTuple> gc_epilogue_callbacks_;
+  std::vector<GCCallbackTuple> gc_prologue_callbacks_;
 
   GetExternallyAllocatedMemoryInBytesCallback external_memory_callback_;
 

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1593,9 +1593,8 @@ class Heap {
                    bool pass_isolate)
         : callback(callback), gc_type(gc_type), pass_isolate(pass_isolate) {}
 
-    bool operator==(const GCCallbackPair& other) const {
-      return other.callback == callback;
-    }
+    bool operator==(const GCCallbackPair& other) const;
+    GCCallbackPair& operator=(const GCCallbackPair& other);
 
     v8::Isolate::GCCallback callback;
     GCType gc_type;
@@ -2263,8 +2262,8 @@ class Heap {
 
   Object* encountered_transition_arrays_;
 
-  List<GCCallbackPair> gc_epilogue_callbacks_;
-  List<GCCallbackPair> gc_prologue_callbacks_;
+  std::vector<GCCallbackPair> gc_epilogue_callbacks_;
+  std::vector<GCCallbackPair> gc_prologue_callbacks_;
 
   GetExternallyAllocatedMemoryInBytesCallback external_memory_callback_;
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -174,13 +174,14 @@ void SetupPerformanceObservers(const FunctionCallbackInfo<Value>& args) {
   env->set_performance_entry_callback(args[0].As<Function>());
 }
 
-inline void PerformanceGCCallback(uv_async_t* handle) {
+void PerformanceGCCallback(uv_async_t* handle) {
   PerformanceEntry::Data* data =
       static_cast<PerformanceEntry::Data*>(handle->data);
-  Isolate* isolate = Isolate::GetCurrent();
+  Environment* env = data->env();
+  Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
-  Environment* env = Environment::GetCurrent(isolate);
   Local<Context> context = env->context();
+  Context::Scope context_scope(context);
   Local<Function> fn;
   Local<Object> obj;
   PerformanceGCKind kind = static_cast<PerformanceGCKind>(data->data());
@@ -203,28 +204,31 @@ inline void PerformanceGCCallback(uv_async_t* handle) {
   uv_close(reinterpret_cast<uv_handle_t*>(handle), closeCB);
 }
 
-inline void MarkGarbageCollectionStart(Isolate* isolate,
-                                       v8::GCType type,
-                                       v8::GCCallbackFlags flags) {
+void MarkGarbageCollectionStart(Isolate* isolate,
+                                v8::GCType type,
+                                v8::GCCallbackFlags flags) {
   performance_last_gc_start_mark_ = PERFORMANCE_NOW();
   performance_last_gc_type_ = type;
 }
 
-inline void MarkGarbageCollectionEnd(Isolate* isolate,
-                                     v8::GCType type,
-                                     v8::GCCallbackFlags flags) {
+void MarkGarbageCollectionEnd(Isolate* isolate,
+                              v8::GCType type,
+                              v8::GCCallbackFlags flags,
+                              void* data) {
+  Environment* env = static_cast<Environment*>(data);
   uv_async_t *async = new uv_async_t;
   async->data =
-      new PerformanceEntry::Data("gc", "gc",
+      new PerformanceEntry::Data(env, "gc", "gc",
                                  performance_last_gc_start_mark_,
                                  PERFORMANCE_NOW(), type);
-  uv_async_init(uv_default_loop(), async, PerformanceGCCallback);
+  uv_async_init(env->event_loop(), async, PerformanceGCCallback);
   uv_async_send(async);
 }
 
-inline void SetupGarbageCollectionTracking(Isolate* isolate) {
-  isolate->AddGCPrologueCallback(MarkGarbageCollectionStart);
-  isolate->AddGCEpilogueCallback(MarkGarbageCollectionEnd);
+inline void SetupGarbageCollectionTracking(Environment* env) {
+  env->isolate()->AddGCPrologueCallback(MarkGarbageCollectionStart);
+  env->isolate()->AddGCEpilogueCallback(MarkGarbageCollectionEnd,
+                                        static_cast<void*>(env));
 }
 
 inline Local<Value> GetName(Local<Function> fn) {
@@ -380,7 +384,7 @@ void Init(Local<Object> target,
                             constants,
                             attr).ToChecked();
 
-  SetupGarbageCollectionTracking(isolate);
+  SetupGarbageCollectionTracking(env);
 }
 
 }  // namespace performance

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -56,16 +56,22 @@ class PerformanceEntry : public BaseObject {
   class Data {
    public:
     Data(
+      Environment* env,
       const char* name,
       const char* type,
       uint64_t startTime,
       uint64_t endTime,
       int data = 0) :
+      env_(env),
       name_(name),
       type_(type),
       startTime_(startTime),
       endTime_(endTime),
       data_(data) {}
+
+    Environment* env() const {
+      return env_;
+    }
 
     std::string name() const {
       return name_;
@@ -88,6 +94,7 @@ class PerformanceEntry : public BaseObject {
     }
 
    private:
+    Environment* env_;
     std::string name_;
     std::string type_;
     uint64_t startTime_;


### PR DESCRIPTION
First commit is to avoid conflicts with the second, the second commit is needed for the “real” one.

---

Currently, measuring GC timing using `node_perf` is somewhat broken, because Isolates and Node Environments do not necessarily match 1:1; each environment adds its own hook, so possibly the hook code runs multiple times, but since it can’t reliably compute its corresponding event loop based on the Isolate, each run targets the same Environment right now.

This fixes that problem by using new overloads of the GC tracking APIs that can pass data to the callback through opaque pointers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

deps/v8, src/node_perf

@nodejs/v8 @jasnell 