### PR TITLE
doc: fix incorrect api version for Buffer.allocUnsafeSlow

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -616,7 +616,7 @@ additional performance that [`Buffer.allocUnsafe()`] provides.
 
 ### Class Method: Buffer.allocUnsafeSlow(size)
 <!-- YAML
-added: v5.10.0
+added: v5.12.0
 -->
 
 * `size` {integer} The desired length of the new `Buffer`


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/15279

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
