### PR TITLE
src: fix typo in probe description

### DIFF
--- a/src/v8ustack.d
+++ b/src/v8ustack.d
@@ -522,7 +522,7 @@ dtrace:helper:ustack:
 		NO_SHARED_FUNCTION_NAME_SENTINEL;
 }
 
-dtracr:helper:ustack:
+dtrace:helper:ustack:
 /!this->done && this->hassharedname/
 {
 	LOAD_STRFIELDS(this->funcrawnamestr, this->funcnamelen,


### PR DESCRIPTION
This fixes a typo in a probe description added in
dc1996dd1f87ba0e90201ffbc7cb133e2ea6b1b2.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src