### PR TITLE
doc: fix emitKeypressEvents stream type

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -453,7 +453,7 @@ added: v0.7.7
 * `stream` {Readable}
 * `interface` {readline.Interface}
 
-The `readline.emitKeypressEvents()` method causes the given [Writable][]
+The `readline.emitKeypressEvents()` method causes the given [Readable][]
 `stream` to begin emitting `'keypress'` events corresponding to received input.
 
 Optionally, `interface` specifies a `readline.Interface` instance for which


### PR DESCRIPTION
Fixes the type of the `stream` argument in the description of `readline.emitKeyPressEvents`, from `Writable` to `Readable`.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc