### PR TITLE
src: fix compiler warning in udp_wrap.cc

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -233,9 +233,8 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[0]->IsUint32());
   CHECK(args[1]->IsUint32());
-  int size = static_cast<int>(args[0].As<Uint32>()->Value());
 
-  if (size != args[0].As<Uint32>()->Value()) {
+  if (!args[0]->IsInt32()) {
     if (args[1].As<Uint32>()->Value() == 0)
       return env->ThrowUVException(EINVAL, "uv_recv_buffer_size");
     else
@@ -243,6 +242,7 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
   }
 
   int err;
+  int size = static_cast<int>(args[0].As<Uint32>()->Value());
   if (args[1].As<Uint32>()->Value() == 0) {
     err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
                               &size);


### PR DESCRIPTION
Currently the following compiler warning is generated:

```console
1 warning generated.
../src/udp_wrap.cc:238:12: warning: comparison of integers of different
signs: 'int' and 'uint32_t' (aka 'unsigned int') [-Wsign-compare]
  if (size != args[0].As<Uint32>()->Value()) {
      ~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
This commit changes the check to see that the Uint32 value does not
exceed the max int size instead of first casting and then comparing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src