### PR TITLE
http: revert #14024 writable is never set to false

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -780,7 +780,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     this.connection.uncork();
 
   this.finished = true;
-  this.writable = false;
 
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.

--- a/test/parallel/test-http-outgoing-finish-writable.js
+++ b/test/parallel/test-http-outgoing-finish-writable.js
@@ -4,13 +4,16 @@ const assert = require('assert');
 const http = require('http');
 
 // Verify that after calling end() on an `OutgoingMessage` (or a type that
-// inherits from `OutgoingMessage`), its `writable` property is set to false.
+// inherits from `OutgoingMessage`), its `writable` property is not set to false
 
 const server = http.createServer(common.mustCall(function(req, res) {
   assert.strictEqual(res.writable, true);
   assert.strictEqual(res.finished, false);
   res.end();
-  assert.strictEqual(res.writable, false);
+
+  // res.writable is set to false after it has finished sending
+  // Ref: https://github.com/nodejs/node/issues/15029
+  assert.strictEqual(res.writable, true);
   assert.strictEqual(res.finished, true);
 
   server.close();
@@ -27,5 +30,9 @@ server.on('listening', common.mustCall(function() {
 
   assert.strictEqual(clientRequest.writable, true);
   clientRequest.end();
-  assert.strictEqual(clientRequest.writable, false);
+
+  // writable is still true when close
+  // THIS IS LEGACY, we cannot change it
+  // unless we break error detection
+  assert.strictEqual(clientRequest.writable, true);
 }));

--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { get, createServer } = require('http');
+
+// res.writable should not be set to false after it has finished sending
+// Ref: https://github.com/nodejs/node/issues/15029
+
+let external;
+
+// Http server
+const internal = createServer((req, res) => {
+  res.writeHead(200);
+  setImmediate(common.mustCall(() => {
+    external.abort();
+    res.end('Hello World\n');
+  }));
+}).listen(0);
+
+// Proxy server
+const server = createServer(common.mustCall((req, res) => {
+  get(`http://127.0.0.1:${internal.address().port}`, common.mustCall((inner) => {
+    res.on('close', common.mustCall(() => {
+      assert.strictEqual(res.writable, true);
+    }));
+    inner.pipe(res);
+  }));
+})).listen(0, () => {
+  external = get(`http://127.0.0.1:${server.address().port}`);
+  external.on('error', common.mustCall((err) => {
+    server.close();
+    internal.close();
+  }));
+});


### PR DESCRIPTION
Setting writable = false in IncomingMessage.end made some errors
being swallowed in some very popular OSS libraries that we must
support. This commit add some of those use cases, so we avoid further
regressions.

See: https://github.com/nodejs/node/pull/14024
Fixes: https://github.com/nodejs/node/issues/15029

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http