### PR TITLE
doc: fix entryTypes type and missing link in perf_hooks.md

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -202,7 +202,7 @@ const obs = new PerformanceObserver((list) => {
   obs.disconnect();
   performance.clearFunctions();
 });
-obs.observe({ entryTypes: 'function' });
+obs.observe({ entryTypes: ['function'] });
 
 // A performance timeline entry will be created
 wrapped();
@@ -656,3 +656,4 @@ require('some-module');
 
 [`timeOrigin`]: https://w3c.github.io/hr-time/#dom-performance-timeorigin
 [W3C Performance Timeline]: https://w3c.github.io/performance-timeline/
+[Async Hooks]: async_hooks.html

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -655,5 +655,5 @@ require('some-module');
 ```
 
 [`timeOrigin`]: https://w3c.github.io/hr-time/#dom-performance-timeorigin
-[W3C Performance Timeline]: https://w3c.github.io/performance-timeline/
 [Async Hooks]: async_hooks.html
+[W3C Performance Timeline]: https://w3c.github.io/performance-timeline/


### PR DESCRIPTION
Fixed `entryTypes` in `performance.timerify(fn)` example and `async_hooks` missing link in `perf_hooks.md`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
