### PR TITLE
http2: fix subsequent end calls to not throw

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -458,12 +458,11 @@ class Http2ServerResponse extends Stream {
       cb = encoding;
       encoding = 'utf8';
     }
+    if (stream === undefined || stream.finished === true) {
+      return false;
+    }
     if (chunk !== null && chunk !== undefined) {
       this.write(chunk, encoding);
-    }
-
-    if (stream === undefined) {
-      return;
     }
 
     if (typeof cb === 'function') {

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -4,7 +4,7 @@
 const { mustCall, mustNotCall, hasCrypto, skip } = require('../common');
 if (!hasCrypto)
   skip('missing crypto');
-const { strictEqual } = require('assert');
+const { doesNotThrow, strictEqual } = require('assert');
 const {
   createServer,
   connect,
@@ -19,6 +19,9 @@ const {
   // but may be invoked repeatedly without throwing errors.
   const server = createServer(mustCall((request, response) => {
     strictEqual(response.closed, false);
+    response.on('finish', mustCall(() => process.nextTick(
+      mustCall(() => doesNotThrow(() => response.end('test', mustNotCall())))
+    )));
     response.end(mustCall(() => {
       server.close();
     }));


### PR DESCRIPTION
Calling `Http2ServerResponse.end` multiple times should never cause the code to throw an error, subsequent calls should instead return false. This adjusts the behaviour to match http1. Fixes https://github.com/nodejs/node/issues/15385

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test