### PR TITLE
test: don't skip when common.mustCall() is pending

### DIFF
--- a/test/parallel/test-dgram-multicast-set-interface.js
+++ b/test/parallel/test-dgram-multicast-set-interface.js
@@ -72,10 +72,11 @@ const dgram = require('dgram');
   }));
 }
 
-if (!common.hasIPv6) {
-  common.skip('Skipping udp6 tests, no IPv6 support.');
+// If IPv6 is not supported, skip the rest of the test. However, don't call
+// common.skip(), which calls process.exit() while there is outstanding
+// common.mustCall() activity.
+if (!common.hasIPv6)
   return;
-}
 
 {
   const socket = dgram.createSocket('udp6');


### PR DESCRIPTION
The test `parallel/test-dgram-multicast-set-interface.js` was calling `common.skip()` on hosts that do not support IPv6. However, by this point, there were several outstanding `common.mustCall()` invocations. The `process.exit()` in `common.skip()` triggered those `common.mustCall()`s as errors.

Fixes: https://github.com/nodejs/node/issues/15419

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test