### PR TITLE
util: improve format performance

### DIFF
--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -2,35 +2,30 @@
 
 const util = require('util');
 const common = require('../common');
-const types = [
-  'string',
-  'number',
-  'object',
-  'unknown',
-  'no-replace'
-];
-const bench = common.createBenchmark(main, {
-  n: [2e6],
-  type: types
-});
 
 const inputs = {
-  'string': ['Hello, my name is %s', 'fred'],
-  'number': ['Hi, I was born in %d', 1942],
-  'object': ['An error occurred %j', { msg: 'This is an error', code: 'ERR' }],
+  'string': ['Hello, my name is %s', 'Fred'],
+  'string-2': ['Hello, %s is my name', 'Fred'],
+  'number': ['Hi, I was born in %d', 1989],
+  'replace-object': ['An error occurred %j', { msg: 'This is an error' }],
   'unknown': ['hello %a', 'test'],
-  'no-replace': [1, 2]
+  'no-replace': [1, 2],
+  'no-replace-2': ['foobar', 'yeah', 'mensch', 5],
+  'only-objects': [{ msg: 'This is an error' }, { msg: 'This is an error' }],
+  'many-%': ['replace%%%%s%%%%many%s%s%s', 'percent'],
 };
 
-function main(conf) {
-  const n = conf.n | 0;
-  const type = conf.type;
+const bench = common.createBenchmark(main, {
+  n: [4e6],
+  type: Object.keys(inputs)
+});
 
-  const input = inputs[type];
+function main({ n, type }) {
+  const [first, second] = inputs[type];
 
   bench.start();
   for (var i = 0; i < n; i++) {
-    util.format(input[0], input[1]);
+    util.format(first, second);
   }
   bench.end(n);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -196,8 +196,9 @@ function format(f) {
   var lastPos = 0;
   for (i = 0; i < f.length - 1; i++) {
     if (f.charCodeAt(i) === 37) { // '%'
+      const nextChar = f.charCodeAt(++i);
       if (a !== arguments.length) {
-        switch (f.charCodeAt(i + 1)) {
+        switch (nextChar) {
           case 115: // 's'
             tempStr = String(arguments[a++]);
             break;
@@ -221,25 +222,19 @@ function format(f) {
             tempStr = `${parseFloat(arguments[a++])}`;
             break;
           case 37: // '%'
-            i++;
             str += f.slice(lastPos, i);
             lastPos = i + 1;
             continue;
           default: // any other character is not a correct placeholder
-            i++;
             continue;
         }
-        if (lastPos !== i)
-          str += f.slice(lastPos, i);
+        if (lastPos !== i - 1)
+          str += f.slice(lastPos, i - 1);
         str += tempStr;
-        i++;
         lastPos = i + 1;
-      } else {
-        i++;
-        if (f.charCodeAt(i) === 37) {
-          str += f.slice(lastPos, i);
-          lastPos = i + 1;
-        }
+      } else if (nextChar === 37) {
+        str += f.slice(lastPos, i);
+        lastPos = i + 1;
       }
     }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -177,12 +177,16 @@ function tryStringify(arg) {
 }
 
 function format(f) {
+  var i, tempStr;
   if (typeof f !== 'string') {
-    const objects = new Array(arguments.length);
-    for (var index = 0; index < arguments.length; index++) {
-      objects[index] = inspect(arguments[index]);
+    if (arguments.length === 0) return '';
+    var res = '';
+    for (i = 0; i < arguments.length - 1; i++) {
+      res += inspect(arguments[i]);
+      res += ' ';
     }
-    return objects.join(' ');
+    res += inspect(arguments[i]);
+    return res;
   }
 
   if (arguments.length === 1) return f;
@@ -190,49 +194,54 @@ function format(f) {
   var str = '';
   var a = 1;
   var lastPos = 0;
-  for (var i = 0; i < f.length;) {
-    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
-      if (f.charCodeAt(i + 1) !== 37/*'%'*/ && a >= arguments.length) {
-        ++i;
-        continue;
+  for (i = 0; i < f.length - 1; i++) {
+    if (f.charCodeAt(i) === 37) { // '%'
+      if (a !== arguments.length) {
+        switch (f.charCodeAt(i + 1)) {
+          case 115: // 's'
+            tempStr = String(arguments[a++]);
+            break;
+          case 106: // 'j'
+            tempStr = tryStringify(arguments[a++]);
+            break;
+          case 100: // 'd'
+            tempStr = `${Number(arguments[a++])}`;
+            break;
+          case 79: // 'O'
+            tempStr = inspect(arguments[a++]);
+            break;
+          case 111: // 'o'
+            tempStr = inspect(arguments[a++],
+                              { showHidden: true, depth: 4, showProxy: true });
+            break;
+          case 105: // 'i'
+            tempStr = `${parseInt(arguments[a++])}`;
+            break;
+          case 102: // 'f'
+            tempStr = `${parseFloat(arguments[a++])}`;
+            break;
+          case 37: // '%'
+            i++;
+            str += f.slice(lastPos, i);
+            lastPos = i + 1;
+            continue;
+          default: // any other character is not a correct placeholder
+            i++;
+            continue;
+        }
+        if (lastPos !== i)
+          str += f.slice(lastPos, i);
+        str += tempStr;
+        i++;
+        lastPos = i + 1;
+      } else {
+        i++;
+        if (f.charCodeAt(i) === 37) {
+          str += f.slice(lastPos, i);
+          lastPos = i + 1;
+        }
       }
-      if (lastPos < i)
-        str += f.slice(lastPos, i);
-      switch (f.charCodeAt(i + 1)) {
-        case 100: // 'd'
-          str += Number(arguments[a++]);
-          break;
-        case 105: // 'i'
-          str += parseInt(arguments[a++]);
-          break;
-        case 102: // 'f'
-          str += parseFloat(arguments[a++]);
-          break;
-        case 106: // 'j'
-          str += tryStringify(arguments[a++]);
-          break;
-        case 115: // 's'
-          str += String(arguments[a++]);
-          break;
-        case 79: // 'O'
-          str += inspect(arguments[a++]);
-          break;
-        case 111: // 'o'
-          str += inspect(arguments[a++],
-                         { showHidden: true, depth: 4, showProxy: true });
-          break;
-        case 37: // '%'
-          str += '%';
-          break;
-        default: // any other character is not a correct placeholder
-          str += '%';
-          lastPos = i = i + 1;
-          continue;
-      }
-      lastPos = i = i + 2;
-      continue;
     }
-    ++i;
   }
   if (lastPos === 0)
     str = f;
@@ -240,7 +249,7 @@ function format(f) {
     str += f.slice(lastPos);
   while (a < arguments.length) {
     const x = arguments[a++];
-    if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
+    if ((typeof x !== 'object' && typeof x !== 'symbol') || x === null) {
       str += ` ${x}`;
     } else {
       str += ` ${inspect(x)}`;


### PR DESCRIPTION
After working on `util.inspect` I thought it might be worth also checking `util.format` as that is called by `console.log`.

```
 util/format.js type="many-%" n=4000000             19.53 %        *** 5.126437e-12
 util/format.js type="no-replace-2" n=4000000       -1.31 %            4.251080e-01
 util/format.js type="no-replace" n=4000000        105.66 %        *** 4.607428e-46
 util/format.js type="number" n=4000000             17.39 %        *** 3.052166e-20
 util/format.js type="only-objects" n=4000000       17.92 %        *** 6.714987e-15
 util/format.js type="replace-object" n=4000000      8.11 %         ** 1.005488e-03
 util/format.js type="string-2" n=4000000           29.12 %        *** 2.679828e-26
 util/format.js type="string" n=4000000             19.40 %        *** 3.171563e-18
 util/format.js type="unknown" n=4000000           103.28 %        *** 1.826116e-40
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util