### PR TITLE
src: use InstantiateModule instead of deprecated

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -23,6 +23,7 @@ using v8::IntegrityLevel;
 using v8::Isolate;
 using v8::JSON;
 using v8::Local;
+using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Module;
 using v8::Object;
@@ -184,12 +185,12 @@ void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
 
   ModuleWrap* obj = Unwrap<ModuleWrap>(that);
   Local<Module> mod = obj->module_.Get(iso);
-  bool ok = mod->Instantiate(ctx, ModuleWrap::ResolveCallback);
+  Maybe<bool> ok = mod->InstantiateModule(ctx, ModuleWrap::ResolveCallback);
 
   // clear resolve cache on instantiate
   obj->resolve_cache_.clear();
 
-  if (!ok) {
+  if (!ok.FromMaybe(false)) {
     return;
   }
 }


### PR DESCRIPTION
The following deprecation warning is displayed when compiling:
```console
../src/module_wrap.cc:187:18: warning: 'Instantiate' is deprecated
[-Wdeprecated-declarations]
  bool ok = mod->Instantiate(ctx, ModuleWrap::ResolveCallback);
                 ^
../deps/v8/include/v8.h:1158:22: note: 'Instantiate' has been explicitly
marked deprecated here
                bool Instantiate(Local<Context> context,
                     ^
```
This commit changes this function call to use InstantiateModule instead
which returns a Maybe<bool>.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src