### PR TITLE
src: prepare platform for upstream V8 changes

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1339,30 +1339,6 @@ void AddPromiseHook(v8::Isolate* isolate, promise_hook_func fn, void* arg) {
   env->AddPromiseHook(fn, arg);
 }
 
-class InternalCallbackScope {
- public:
-  InternalCallbackScope(Environment* env,
-                        Local<Object> object,
-                        const async_context& asyncContext);
-  ~InternalCallbackScope();
-  void Close();
-
-  inline bool Failed() const { return failed_; }
-  inline void MarkAsFailed() { failed_ = true; }
-  inline bool IsInnerMakeCallback() const {
-    return callback_scope_.in_makecallback();
-  }
-
- private:
-  Environment* env_;
-  async_context async_context_;
-  v8::Local<v8::Object> object_;
-  Environment::AsyncCallbackScope callback_scope_;
-  bool failed_ = false;
-  bool pushed_ids_ = false;
-  bool closed_ = false;
-};
-
 CallbackScope::CallbackScope(Isolate* isolate,
                              Local<Object> object,
                              async_context asyncContext)
@@ -1381,17 +1357,21 @@ CallbackScope::~CallbackScope() {
 
 InternalCallbackScope::InternalCallbackScope(Environment* env,
                                              Local<Object> object,
-                                             const async_context& asyncContext)
+                                             const async_context& asyncContext,
+                                             ResourceExpectation expect)
   : env_(env),
     async_context_(asyncContext),
     object_(object),
     callback_scope_(env) {
-  CHECK(!object.IsEmpty());
+  if (expect == kRequireResource) {
+    CHECK(!object.IsEmpty());
+  }
 
+  HandleScope handle_scope(env->isolate());
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
-  if (env->using_domains()) {
+  if (env->using_domains() && !object_.IsEmpty()) {
     DomainEnter(env, object_);
   }
 
@@ -1413,6 +1393,7 @@ InternalCallbackScope::~InternalCallbackScope() {
 void InternalCallbackScope::Close() {
   if (closed_) return;
   closed_ = true;
+  HandleScope handle_scope(env_->isolate());
 
   if (pushed_ids_)
     env_->async_hooks()->pop_ids(async_context_.async_id);
@@ -1423,7 +1404,7 @@ void InternalCallbackScope::Close() {
     AsyncWrap::EmitAfter(env_, async_context_.async_id);
   }
 
-  if (env_->using_domains()) {
+  if (env_->using_domains() && !object_.IsEmpty()) {
     DomainExit(env_, object_);
   }
 
@@ -1463,6 +1444,7 @@ MaybeLocal<Value> InternalMakeCallback(Environment* env,
                                        int argc,
                                        Local<Value> argv[],
                                        async_context asyncContext) {
+  CHECK(!recv.IsEmpty());
   InternalCallbackScope scope(env, recv, asyncContext);
   if (scope.Failed()) {
     return Undefined(env->isolate());
@@ -4726,9 +4708,14 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
     do {
       uv_run(env.event_loop(), UV_RUN_DEFAULT);
 
+      v8_platform.DrainVMTasks();
+
+      more = uv_loop_alive(env.event_loop());
+      if (more)
+        continue;
+
       EmitBeforeExit(&env);
 
-      v8_platform.DrainVMTasks();
       // Emit `beforeExit` if the loop became alive either after emitting
       // event, or after running some callbacks.
       more = uv_loop_alive(env.event_loop());

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -294,7 +294,34 @@ v8::MaybeLocal<v8::Value> InternalMakeCallback(
     v8::Local<v8::Value> argv[],
     async_context asyncContext);
 
+class InternalCallbackScope {
+ public:
+  enum ResourceExpectation { kRequireResource, kAllowEmptyResource };
+  InternalCallbackScope(Environment* env,
+                        v8::Local<v8::Object> object,
+                        const async_context& asyncContext,
+                        ResourceExpectation expect = kRequireResource);
+  ~InternalCallbackScope();
+  void Close();
+
+  inline bool Failed() const { return failed_; }
+  inline void MarkAsFailed() { failed_ = true; }
+  inline bool IsInnerMakeCallback() const {
+    return callback_scope_.in_makecallback();
+  }
+
+ private:
+  Environment* env_;
+  async_context async_context_;
+  v8::Local<v8::Object> object_;
+  Environment::AsyncCallbackScope callback_scope_;
+  bool failed_ = false;
+  bool pushed_ids_ = false;
+  bool closed_ = false;
+};
+
 }  // namespace node
+
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -296,6 +296,7 @@ v8::MaybeLocal<v8::Value> InternalMakeCallback(
 
 class InternalCallbackScope {
  public:
+  // Tell the constructor whether its `object` parameter may be empty or not.
   enum ResourceExpectation { kRequireResource, kAllowEmptyResource };
   InternalCallbackScope(Environment* env,
                         v8::Local<v8::Object> object,

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -22,6 +22,7 @@ class TaskQueue {
   void NotifyOfCompletion();
   void BlockingDrain();
   void Stop();
+  bool HasPending();
 
  private:
   Mutex lock_;

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -39,7 +39,7 @@ class NodePlatform : public v8::Platform {
   virtual ~NodePlatform() {}
 
   void DrainBackgroundTasks();
-  // returns true iff work was dispatched or executed
+  // Returns true iff work was dispatched or executed.
   bool FlushForegroundTasksInternal();
   void Shutdown();
 

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -22,7 +22,6 @@ class TaskQueue {
   void NotifyOfCompletion();
   void BlockingDrain();
   void Stop();
-  bool HasPending();
 
  private:
   Mutex lock_;
@@ -40,7 +39,8 @@ class NodePlatform : public v8::Platform {
   virtual ~NodePlatform() {}
 
   void DrainBackgroundTasks();
-  void FlushForegroundTasksInternal();
+  // returns true iff work was dispatched or executed
+  bool FlushForegroundTasksInternal();
   void Shutdown();
 
   // v8::Platform implementation.


### PR DESCRIPTION
V8 platform tasks may schedule other tasks (both background and foreground), and may perform asynchronous operations like resolving Promises.

To address that:

- Run the task queue drain call inside a callback scope. This makes sure asynchronous operations inside it, like resolving promises, lead to the microtask queue and any subsequent operations not being silently forgotten.
- Move the task queue drain call before `EmitBeforeExit()` and only run `EmitBeforeExit()` if there is no new event loop work.
- Account for possible new foreground tasks scheduled by background tasks in `DrainBackgroundTasks()`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
~~- [ ] tests and/or benchmarks are included~~ (no, because right now everything still works without this – in the future, some things like WASM would fail otherwise)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_platform

/cc @nodejs/v8 @matthewloring @gahaas @natorion