### PR TITLE
doc: maintain font size in narrow windows

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -559,9 +559,6 @@ th > *:last-child, td > *:last-child {
 }
 
 @media only screen and (max-width: 1024px) and (orientation: portrait) {
-  #content {
-    font-size: 3.5em;
-  }
   #gtoc {
     font-size: 0.6em;
   }


### PR DESCRIPTION
In Firefox (55 at least), this CSS rule triggers when the browser window
is placed on the left/right half of the screen. This makes the font size
to triple in size even on a desktop.

Before:

![before-narrow](https://user-images.githubusercontent.com/15712/30509910-21a6989c-9abb-11e7-8fad-186c9ea4b851.png)

After: (navigation pane is still collapsed, but font size is constant)

![after-narrow](https://user-images.githubusercontent.com/15712/30509908-21a49600-9abb-11e7-9450-c340c0285c10.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
