### PR TITLE
build: don't fail `make test` on source tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,7 +922,7 @@ cpplint:
 	@$(PYTHON) tools/cpplint.py $(CPPLINT_FILES)
 	@$(PYTHON) tools/check-imports.py
 
-ifneq ("","$(wildcard tools/eslint/bin/eslint.js)")
+ifneq ("","$(wildcard tools/eslint/)")
 lint:
 	@EXIT_STATUS=0 ; \
 	$(MAKE) jslint || EXIT_STATUS=$$? ; \
@@ -943,7 +943,6 @@ lint:
 	@echo "Linting is not available through the source tarball."
 	@echo "Use the git repo instead:" \
 		"$ git clone https://github.com/nodejs/node.git"
-	exit 1
 
 lint-ci: lint
 endif

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -502,7 +502,7 @@ goto exit
 if defined enable_static goto exit
 if defined jslint_ci goto jslint-ci
 if not defined jslint goto exit
-if not exist tools\eslint\bin\eslint.js goto no-lint
+if not exist tools\eslint goto no-lint
 echo running jslint
 %config%\node tools\eslint\bin\eslint.js --cache --rule "linebreak-style: 0" --rulesdir=tools\eslint-rules --ext=.js,.md benchmark doc lib test tools
 goto exit
@@ -515,7 +515,7 @@ goto exit
 :no-lint
 echo Linting is not available through the source tarball.
 echo Use the git repo instead: $ git clone https://github.com/nodejs/node.git
-exit /b 1
+goto exit
 
 :create-msvs-files-failed
 echo Failed to create vc project files.


### PR DESCRIPTION
Tries to achieve the same effect as https://github.com/nodejs/node/pull/13658 without breaking source tarballs. Presumably if `tools/eslint` wasn't there at all, people would notice in the PR review!

Fixes: https://github.com/nodejs/node/issues/14513

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build