### PR TITLE
doc: add documentation for the 'timeout' event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -427,6 +427,16 @@ added: v0.5.3
 
 Emitted after a socket is assigned to this request.
 
+### Event: 'timeout'
+<!-- YAML
+added: v0.7.8
+-->
+
+Emitted when the underlying socket times out from inactivity. This only notifies
+that the socket has been idle. The request must be aborted manually.
+
+See also: [`request.setTimeout()`][]
+
 ### Event: 'upgrade'
 <!-- YAML
 added: v0.1.94
@@ -1966,6 +1976,7 @@ const req = http.request(options, (res) => {
 [`net.createConnection()`]: net.html#net_net_createconnection_options_connectlistener
 [`removeHeader(name)`]: #requestremoveheadername
 [`request.end()`]: #http_request_end_data_encoding_callback
+[`request.setTimeout()`]: #http_request_settimeout_timeout_callback
 [`request.socket`]: #http_request_socket
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`request.write(data, encoding)`]: #http_request_write_chunk_encoding_callback


### PR DESCRIPTION
Adds the `'timeout'` event to the `http.ClientRequest` documentation.

Fixes: https://github.com/nodejs/node/issues/14856

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
