### PR TITLE
src: use UV_EINVAL instead of EINVAL in udp_wrap

### DIFF
--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -237,9 +237,9 @@ void UDPWrap::BufferSize(const FunctionCallbackInfo<Value>& args) {
 
   if (!args[0]->IsInt32()) {
     if (args[1].As<Uint32>()->Value() == 0)
-      return env->ThrowUVException(EINVAL, "uv_recv_buffer_size");
+      return env->ThrowUVException(UV_EINVAL, "uv_recv_buffer_size");
     else
-      return env->ThrowUVException(EINVAL, "uv_send_buffer_size");
+      return env->ThrowUVException(UV_EINVAL, "uv_send_buffer_size");
   }
 
   int err;

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -77,9 +77,9 @@ function checkBufferSizeError(type, size) {
   const errorObj = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
     type: Error,
-    message: new RegExp('^Could not get or set buffer' +
+    message: 'Could not get or set buffer' +
       ' size: Error: EINVAL: invalid argument,' +
-      ' uv_' + type + '_buffer_size$')
+      ' uv_' + type + '_buffer_size'
   };
   const functionName = 'set' + type.charAt(0).toUpperCase() +
     type.slice(1) + 'BufferSize';

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -77,12 +77,9 @@ function checkBufferSizeError(type, size) {
   const errorObj = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
     type: Error,
-    message: 'Could not get or set buffer' +
-      ' size: Error: EINVAL: invalid argument,' +
-      ' uv_' + type + '_buffer_size'
+    message: `Could not get or set buffer size: Error: EINVAL: invalid argument, uv_${type}_buffer_size` // eslint-disable-line max-len
   };
-  const functionName = 'set' + type.charAt(0).toUpperCase() +
-    type.slice(1) + 'BufferSize';
+  const functionName = `set${type.charAt(0).toUpperCase()}${type.slice(1)}BufferSize`; // eslint-disable-line max-len
   const socket = dgram.createSocket('udp4');
   socket.bind(common.mustCall(() => {
     assert.throws(() => {

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -77,9 +77,11 @@ function checkBufferSizeError(type, size) {
   const errorObj = {
     code: 'ERR_SOCKET_BUFFER_SIZE',
     type: Error,
-    message: `Could not get or set buffer size: Error: EINVAL: invalid argument, uv_${type}_buffer_size` // eslint-disable-line max-len
+    message: 'Could not get or set buffer size: Error: EINVAL: ' +
+      `invalid argument, uv_${type}_buffer_size`
   };
-  const functionName = `set${type.charAt(0).toUpperCase()}${type.slice(1)}BufferSize`; // eslint-disable-line max-len
+  const functionName = `set${type.charAt(0).toUpperCase()}${type.slice(1)}` +
+    'BufferSize';
   const socket = dgram.createSocket('udp4');
   socket.bind(common.mustCall(() => {
     assert.throws(() => {

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -72,3 +72,25 @@ const dgram = require('dgram');
     socket.close();
   }));
 }
+
+function checkBufferSizeError(type, size) {
+  const errorObj = {
+    code: 'ERR_SOCKET_BUFFER_SIZE',
+    type: Error,
+    message: new RegExp('^Could not get or set buffer' +
+      ' size: Error: EINVAL: invalid argument,' +
+      ' uv_' + type + '_buffer_size$')
+  };
+  const functionName = 'set' + type.charAt(0).toUpperCase() +
+    type.slice(1) + 'BufferSize';
+  const socket = dgram.createSocket('udp4');
+  socket.bind(common.mustCall(() => {
+    assert.throws(() => {
+      socket[functionName](size);
+    }, common.expectsError(errorObj));
+    socket.close();
+  }));
+}
+
+checkBufferSizeError('recv', 2147483648);
+checkBufferSizeError('send', 2147483648);


### PR DESCRIPTION
Currently if the buffer size exceeds the maximum int size the following
error will be thrown:
```console
dgram.js:180
    throw new errors.Error('ERR_SOCKET_BUFFER_SIZE', e);
    ^

Error [ERR_SOCKET_BUFFER_SIZE]: Could not get or set buffer size: Error:
Unknown system error 22: Unknown system error 22, uv_recv_buffer_size
    at bufferSize (dgram.js:180:11)
```
It looks like perhaps UV_EINVAL was intended to give the following error
message instead:
```console
dgram.js:180
    throw new errors.Error('ERR_SOCKET_BUFFER_SIZE', e);
    ^

Error [ERR_SOCKET_BUFFER_SIZE]: Could not get or set buffer size: Error:
EINVAL: invalid argument, uv_recv_buffer_size
    at bufferSize (dgram.js:180:11)
```
This commit changes EINVAL to use UV_EINVAL.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src