### PR TITLE
doc: do not begin yaml value with backtick

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -575,7 +575,8 @@ changes:
     description: The `lookup` option is supported.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/13623
-    description: `recvBufferSize` and `sendBufferSize` options are supported now.
+    description: The `recvBufferSize` and `sendBufferSize` options are
+                 supported now.
 -->
 
 * `options` {Object} Available options are:


### PR DESCRIPTION
Will break YAML parsing otherwise!

Ref: #14930, cc @vsemozhetbyt 

---

Full details about error:

<details>
Original Node error:

```
Jonathans-MBP:node jon$ node tools/doc/generate.js --format=json doc/api/dgram.md
Input file = doc/api/dgram.md
{ Error
    at generateError (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
    at throwError (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
    at readBlockSequence (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:935:7)
    at composeNode (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1331:12)
    at readBlockMapping (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1062:11)
    at composeNode (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1332:12)
    at readDocument (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1492:3)
    at loadDocuments (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1548:5)
    at load (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1569:19)
    at Object.safeLoad (/Users/jon/code/nodejs/node/tools/eslint/node_modules/js-yaml/lib/js-yaml/loader.js:1591:10)
  name: 'YAMLException',
  reason: 'bad indentation of a sequence entry',
  mark:
   Mark {
     name: null,
     buffer: '\nadded: v0.11.13\nchanges:\n  - version: REPLACEME\n    pr-url: https://github.com/nodejs/node/pull/14560\n    description: The `lookup` option is supported.\n  - version: REPLACEME\n    pr-url: https://github.com/nodejs/node/pull/13623\n    description: `recvBufferSize` and `sendBufferSize` options are supported now.\n\u0000',
     position: 248,
     line: 8,
     column: 17 },
  message: 'bad indentation of a sequence entry at line 9, column 18:\n        description: `recvBufferSize` and `sendBuffer ... \n                     ^' }
```

Then I extracted out the problematic YAML, and tried running through Ruby as a
separate `.yml` file:

```
Psych::SyntaxError: (<unknown>): found character that cannot start any token while scanning for the next token at line 8 column 18
	from /Users/jon/.rbenv/versions/2.4.0/lib/ruby/2.4.0/psych.rb:377:in `parse'
	from /Users/jon/.rbenv/versions/2.4.0/lib/ruby/2.4.0/psych.rb:377:in `parse_stream'
	from /Users/jon/.rbenv/versions/2.4.0/lib/ruby/2.4.0/psych.rb:325:in `parse'
	from /Users/jon/.rbenv/versions/2.4.0/lib/ruby/2.4.0/psych.rb:252:in `load'
	from (irb):7
	from /Users/jon/.rbenv/versions/2.4.0/bin/irb:11:in `<main>'
```
</details>

---

Not intimately familiar, but `node-test-pull-request` / `node-test-commit` should be compiling the docs somewhere along the line, right? 😬 

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

doc