### PR TITLE
src: add O_DSYNC flag

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2809,6 +2809,11 @@ The following constants are meant for use with `fs.open()`.
     <td>Flag indicating that the file is opened for synchronous I/O.</td>
   </tr>
   <tr>
+    <td><code>O_DSYNC</code></td>
+    <td>Flag indicating that the file is opened for synchronous I/O
+    with write operations waiting for data integrity.</td>
+  </tr>
+  <tr>
     <td><code>O_SYMLINK</code></td>
     <td>Flag indicating to open the symbolic link itself rather than the
     resource it is pointing to.</td>

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1089,6 +1089,11 @@ void DefineSystemConstants(Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, O_SYNC);
 #endif
 
+#ifdef O_DSYNC
+  NODE_DEFINE_CONSTANT(target, O_DSYNC);
+#endif
+
+
 #ifdef O_SYMLINK
   NODE_DEFINE_CONSTANT(target, O_SYMLINK);
 #endif

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -22,6 +22,7 @@
 // Flags: --expose_internals
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
 const fs = require('fs');
@@ -32,6 +33,7 @@ const O_EXCL = fs.constants.O_EXCL || 0;
 const O_RDONLY = fs.constants.O_RDONLY || 0;
 const O_RDWR = fs.constants.O_RDWR || 0;
 const O_SYNC = fs.constants.O_SYNC || 0;
+const O_DSYNC = fs.constants.O_DSYNC || 0;
 const O_TRUNC = fs.constants.O_TRUNC || 0;
 const O_WRONLY = fs.constants.O_WRONLY || 0;
 
@@ -78,3 +80,11 @@ common.expectsError(
   () => stringToFlags(null),
   { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
 );
+
+if (common.isLinux === true) {
+  const file = fixtures.path('a.js');
+
+  fs.open(file, O_DSYNC, common.mustCall(function(err, fd) {
+    assert.ifError(err);
+  }));
+}


### PR DESCRIPTION
Added support for O_DSYNC file open flag. (issue #15425)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src
