### PR TITLE
src: handle uv_async_init() failure

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -327,7 +327,7 @@ inline const struct read_result read_file(uv_file file) {
 struct file_check {
   bool failed = true;
   uv_file file = -1;
-} file_check;
+};
 inline const struct file_check check_file(URL search,
                                           bool close = false,
                                           bool allow_dir = false) {

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -94,12 +94,12 @@ class PerformanceEntry : public BaseObject {
     }
 
    private:
-    Environment* env_;
-    std::string name_;
-    std::string type_;
-    uint64_t startTime_;
-    uint64_t endTime_;
-    int data_;
+    Environment* const env_;
+    const std::string name_;
+    const std::string type_;
+    const uint64_t startTime_;
+    const uint64_t endTime_;
+    const int data_;
   };
 
   static void NotifyObservers(Environment* env, PerformanceEntry* entry);
@@ -160,10 +160,10 @@ class PerformanceEntry : public BaseObject {
   }
 
  private:
-  std::string name_;
-  std::string type_;
-  uint64_t startTime_;
-  uint64_t endTime_;
+  const std::string name_;
+  const std::string type_;
+  const uint64_t startTime_;
+  const uint64_t endTime_;
 };
 
 enum PerformanceGCKind {

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -73,11 +73,11 @@ class PerformanceEntry : public BaseObject {
       return env_;
     }
 
-    std::string name() const {
+    const std::string& name() const {
       return name_;
     }
 
-    std::string type() const {
+    const std::string& type() const {
       return type_;
     }
 
@@ -135,11 +135,11 @@ class PerformanceEntry : public BaseObject {
 
   ~PerformanceEntry() {}
 
-  std::string name() const {
+  const std::string& name() const {
     return name_;
   }
 
-  std::string type() const {
+  const std::string& type() const {
     return type_;
   }
 


### PR DESCRIPTION
Fix CHECKED_RETURN, RESOURCE_LEAK) and UNINIT Coverity warnings in
MarkGarbageCollectionEnd().

edit: plus additional cleanup.

CI: https://ci.nodejs.org/job/node-test-pull-request/10124/