### PR TITLE
test: Http2Stream destroyed handling

### DIFF
--- a/test/parallel/test-http2-server-destroy-before-priority.js
+++ b/test/parallel/test-http2-server-destroy-before-priority.js
@@ -1,0 +1,44 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+// Test that ERR_HTTP2_INVALID_STREAM is thrown when a stream is destroyed
+// before calling stream.priority
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.session.destroy();
+  assert.throws(() => stream.priority(),
+                common.expectsError({
+                  code: 'ERR_HTTP2_INVALID_STREAM',
+                  message: /^The stream has been destroyed$/
+                }));
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustNotCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));
+
+
+

--- a/test/parallel/test-http2-server-destroy-before-priority.js
+++ b/test/parallel/test-http2-server-destroy-before-priority.js
@@ -39,6 +39,3 @@ server.on('listening', common.mustCall(() => {
   req.end();
 
 }));
-
-
-

--- a/test/parallel/test-http2-server-destroy-before-rst.js
+++ b/test/parallel/test-http2-server-destroy-before-rst.js
@@ -1,0 +1,44 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+// Test that ERR_HTTP2_INVALID_STREAM is thrown when a stream is destroyed
+// before calling stream.rstStream
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.session.destroy();
+  assert.throws(() => stream.rstStream(),
+                common.expectsError({
+                  code: 'ERR_HTTP2_INVALID_STREAM',
+                  message: /^The stream has been destroyed$/
+                }));
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustNotCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));
+
+
+

--- a/test/parallel/test-http2-server-destroy-before-rst.js
+++ b/test/parallel/test-http2-server-destroy-before-rst.js
@@ -39,6 +39,3 @@ server.on('listening', common.mustCall(() => {
   req.end();
 
 }));
-
-
-

--- a/test/parallel/test-http2-server-destroy-before-state.js
+++ b/test/parallel/test-http2-server-destroy-before-state.js
@@ -5,9 +5,9 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
-const h2 = require('http2');
+const http2 = require('http2');
 
-const server = h2.createServer();
+const server = http2.createServer();
 
 // Test that stream.state getter returns and empty object
 // if the stream session has been destroyed
@@ -15,14 +15,14 @@ server.on('stream', common.mustCall(onStream));
 
 function onStream(stream, headers, flags) {
   stream.session.destroy();
-  assert.deepEqual({}, stream.state);
+  assert.deepStrictEqual(Object.create(null), stream.state);
 }
 
 server.listen(0);
 
 server.on('listening', common.mustCall(() => {
 
-  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const client = http2.connect(`http://localhost:${server.address().port}`);
 
   const req = client.request({ ':path': '/' });
 
@@ -35,6 +35,3 @@ server.on('listening', common.mustCall(() => {
   req.end();
 
 }));
-
-
-

--- a/test/parallel/test-http2-server-destroy-before-state.js
+++ b/test/parallel/test-http2-server-destroy-before-state.js
@@ -1,0 +1,40 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+// Test that stream.state getter returns and empty object
+// if the stream session has been destroyed
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.session.destroy();
+  assert.deepEqual({}, stream.state);
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustNotCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));
+
+
+


### PR DESCRIPTION
This PR includes a few test cases for the handling of `stream.session.destroy()` within the `Http2Stream` class.

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
