### PR TITLE
doc: fix external links with 404 status

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2368,7 +2368,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [Crypto Constants]: #crypto_crypto_constants_1
 [HTML5's `keygen` element]: http://www.w3.org/TR/html5/forms.html#the-keygen-element
 [NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
-[NIST SP 800-132]: http://csrc.nist.gov/publications/nistpubs/800-132/nist-sp800-132.pdf
+[NIST SP 800-132]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 [Nonce-Disrespecting Adversaries]: https://github.com/nonce-disrespect/nonce-disrespect
 [OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
 [RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -338,7 +338,7 @@ The `os.release()` method returns a string identifying the operating system
 release.
 
 *Note*: On POSIX systems, the operating system release is determined by
-calling uname(3). On Windows, `GetVersionExW()` is used. Please see
+calling [uname(3)][]. On Windows, `GetVersionExW()` is used. Please see
 https://en.wikipedia.org/wiki/Uname#Examples for more information.
 
 ## os.tmpdir()
@@ -374,11 +374,12 @@ added: v0.3.3
 * Returns: {string}
 
 The `os.type()` method returns a string identifying the operating system name
-as returned by uname(3). For example `'Linux'` on Linux, `'Darwin'` on macOS and
-`'Windows_NT'` on Windows.
+as returned by [uname(3)][]. For example `'Linux'` on Linux, `'Darwin'` on macOS
+and `'Windows_NT'` on Windows.
 
 Please see https://en.wikipedia.org/wiki/Uname#Examples for additional
-information about the output of running uname(3) on various operating systems.
+information about the output of running [uname(3)][] on various operating
+systems.
 
 ## os.uptime()
 <!-- YAML
@@ -1223,3 +1224,4 @@ information.
 [`process.arch`]: process.html#process_process_arch
 [`process.platform`]: process.html#process_process_platform
 [OS Constants]: #os_os_constants
+[uname(3)]: https://linux.die.net/man/3/uname


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

Fixes: https://github.com/nodejs/node/issues/15462


`uname(3)` links seem to be autogenerated (to 404 http://man7.org/linux/man-pages/man3/uname.3.html), so maybe we should check something in doc scripts.