### PR TITLE
src: remove unused file variable.

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -327,7 +327,7 @@ inline const struct read_result read_file(uv_file file) {
 struct file_check {
   bool failed = true;
   uv_file file = -1;
-} file_check;
+};
 inline const struct file_check check_file(URL search,
                                           bool close = false,
                                           bool allow_dir = false) {


### PR DESCRIPTION
Currently the following compiler warning is displayed:
```console
../src/module_wrap.cc:330:3: warning: unused variable 'file_check'
[-Wunused-variable]
} file_check;
  ^
```
This commit removes this unused variable.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src