### PR TITLE
test: keep coverage reports after coverage-clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ node_g
 icu_config.gypi
 .eslintcache
 node_trace.*.log
+coverage/
 
 /out
 

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ coverage-clean:
 	$(RM) -r node_modules
 	$(RM) -r gcovr testing
 	$(RM) -r out/$(BUILDTYPE)/.coverage
-	$(RM) -r .cov_tmp coverage
+	$(RM) -r .cov_tmp
 	$(RM) out/$(BUILDTYPE)/obj.target/node/{src,gen}/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/src/tracing/*.gcda
 	$(RM) out/$(BUILDTYPE)/obj.target/node/{src,gen}/*.gcno


### PR DESCRIPTION
This PR adds the `coverage` folder to `.gitignore` and removes it from `make coverage-clean`. I feel like this is a useful change for anyone working on tests. It's nice to be able to keep the coverage reports to reference while writing tests without keeping the rest of the coverage instrumentation (which makes tests slow) and also without having to manually rename the `coverage` dir (and then avoid adding it to commits).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, build