### PR TITLE
test: older shared zlib doesnt throw on create

### DIFF
--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -1,9 +1,14 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 const assert = require('assert');
 const zlib = require('zlib');
+
+if (process.config.variables.node_shared_zlib &&
+    /^1\.2\.[0-8]$/.test(process.versions.zlib)) {
+  common.skip("older versions of shared zlib don't throw on create");
+}
 
 // For raw deflate encoding, requests for 256-byte windows are rejected as
 // invalid by zlib.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] `make lint` doesn't show any new lint
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, zlib