### PR TITLE
dgram: refactor SO_RCVBUF and SO_SNDBUF methods

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -40,6 +40,9 @@ const BIND_STATE_UNBOUND = 0;
 const BIND_STATE_BINDING = 1;
 const BIND_STATE_BOUND = 2;
 
+const RECV_BUFFER = true;
+const SEND_BUFFER = false;
+
 // Lazily loaded
 var cluster = null;
 
@@ -146,10 +149,10 @@ function startListening(socket) {
   socket.fd = -42; // compatibility hack
 
   if (socket[kOptionSymbol].recvBufferSize)
-    bufferSize(socket, socket[kOptionSymbol].recvBufferSize, 'recv');
+    bufferSize(socket, socket[kOptionSymbol].recvBufferSize, RECV_BUFFER);
 
   if (socket[kOptionSymbol].sendBufferSize)
-    bufferSize(socket, socket[kOptionSymbol].sendBufferSize, 'send');
+    bufferSize(socket, socket[kOptionSymbol].sendBufferSize, SEND_BUFFER);
 
   socket.emit('listening');
 }
@@ -172,10 +175,7 @@ function bufferSize(self, size, buffer) {
     throw new errors.TypeError('ERR_SOCKET_BAD_BUFFER_SIZE');
 
   try {
-    if (buffer === 'recv')
-      return self._handle.bufferSize(size, 0);
-    else
-      return self._handle.bufferSize(size, 1);
+    return self._handle.bufferSize(size, buffer);
   } catch (e) {
     throw new errors.Error('ERR_SOCKET_BUFFER_SIZE', e);
   }
@@ -677,22 +677,22 @@ Socket.prototype.unref = function() {
 
 
 Socket.prototype.setRecvBufferSize = function(size) {
-  bufferSize(this, size, 'recv');
+  bufferSize(this, size, RECV_BUFFER);
 };
 
 
 Socket.prototype.setSendBufferSize = function(size) {
-  bufferSize(this, size, 'send');
+  bufferSize(this, size, SEND_BUFFER);
 };
 
 
 Socket.prototype.getRecvBufferSize = function() {
-  return bufferSize(this, 0, 'recv');
+  return bufferSize(this, 0, RECV_BUFFER);
 };
 
 
 Socket.prototype.getSendBufferSize = function() {
-  return bufferSize(this, 0, 'send');
+  return bufferSize(this, 0, SEND_BUFFER);
 };
 
 


### PR DESCRIPTION
This commit refactors the get/set send/receive buffer size
methods in the following ways:

- Use booleans instead of strings and numbers to differentiate
between the send and receive buffers.
- Reduce the amount of branching and complexity in the C++ code.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dgram