### PR TITLE
fs: initial experimental promisified API

### DIFF
--- a/benchmark/fs/promises-access.js
+++ b/benchmark/fs/promises-access.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const common = require('../common');
+const { access, async } = require('fs');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+
+const bench = common.createBenchmark(main, {
+  n: [20e4],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    access(__filename, () => countdown.dec());
+  }
+}
+
+function usePromisify(n) {
+  const _access = promisify(access);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _access(__filename).then(() => countdown.dec());
+  }
+}
+
+function usePromise(n) {
+  const _access = async.access;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _access(__filename).then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const method = conf.method;
+
+  switch (method) {
+    case 'legacy': return useLegacy(n);
+    case 'promisify': return usePromisify(n);
+    case 'promise': return usePromise(n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/benchmark/fs/promises-chmod.js
+++ b/benchmark/fs/promises-chmod.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const common = require('../common');
+const {
+  chmod,
+  async,
+  unlinkSync,
+  openSync,
+  closeSync
+} = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const mode = process.platform === 'win32' ? 0o600 : 0o644;
+
+const bench = common.createBenchmark(main, {
+  n: [20e4],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    chmod(filename, mode, () => countdown.dec());
+  }
+}
+
+function usePromisify(n) {
+  const _chmod = promisify(chmod);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _chmod(filename, mode).then(() => countdown.dec());
+  }
+}
+
+function usePromise(n) {
+  const _chmod = async.chmod;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _chmod(filename, mode).then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const method = conf.method;
+
+  closeSync(openSync(filename, 'w'));
+
+  switch (method) {
+    case 'legacy': return useLegacy(n);
+    case 'promisify': return usePromisify(n);
+    case 'promise': return usePromise(n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/benchmark/fs/promises-chown.js
+++ b/benchmark/fs/promises-chown.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const common = require('../common');
+
+if (process.platform === 'win32') {
+  console.error('Benchmark unsupported on Windows');
+  process.exit(1);
+}
+
+const {
+  chown,
+  async,
+  unlinkSync,
+  openSync,
+  closeSync
+} = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const uid = process.getuid();
+const gid = process.getgid();
+
+const bench = common.createBenchmark(main, {
+  n: [20e4],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    chown(filename, uid, gid, () => countdown.dec());
+  }
+}
+
+function usePromisify(n) {
+  const _chown = promisify(chown);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _chown(filename, uid, gid).then(() => countdown.dec());
+  }
+}
+
+function usePromise(n) {
+  const _chown = async.chown;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _chown(filename, uid, gid).then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const method = conf.method;
+
+  closeSync(openSync(filename, 'w'));
+
+  switch (method) {
+    case 'legacy': return useLegacy(n);
+    case 'promisify': return usePromisify(n);
+    case 'promise': return usePromise(n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/benchmark/fs/promises-copyfile.js
+++ b/benchmark/fs/promises-copyfile.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  async,
+  unlinkSync,
+  openSync,
+  closeSync,
+  copyFile
+} = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+const src = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const dest = path.resolve(__dirname, '.removeme-benchmark-garbage2');
+
+const bench = common.createBenchmark(main, {
+  n: [20000],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(src);
+    unlinkSync(dest);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    copyFile(src, dest, (err) => countdown.dec());
+  }
+}
+
+function usePromisify(n) {
+  const _copyFile = promisify(copyFile);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(src);
+    unlinkSync(dest);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _copyFile(src, dest)
+      .then(() => countdown.dec());
+  }
+}
+
+function usePromise(n) {
+  const _copyFile = async.copyFile;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(src);
+    unlinkSync(dest);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _copyFile(src, dest)
+      .then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const method = conf.method;
+
+  closeSync(openSync(src, 'w'));
+
+  switch (method) {
+    case 'legacy': return useLegacy(n);
+    case 'promisify': return usePromisify(n);
+    case 'promise': return usePromise(n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/benchmark/fs/promises-open-close.js
+++ b/benchmark/fs/promises-open-close.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  async,
+  unlinkSync,
+  open,
+  close
+} = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+
+const bench = common.createBenchmark(main, {
+  n: [20000],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    open(filename, 'w', (err, fd) => {
+      close(fd, () => {
+        countdown.dec();
+      });
+    });
+  }
+}
+
+function usePromisify(n) {
+  const _open = promisify(open);
+  const _close = promisify(close);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _open(filename, 'w')
+      .then(_close)
+      .then(() => countdown.dec());
+  }
+}
+
+function usePromise(n) {
+  const _open = async.open;
+  const _close = async.close;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+    unlinkSync(filename);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _open(filename, 'w')
+      .then(_close)
+      .then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const method = conf.method;
+
+  switch (method) {
+    case 'legacy': return useLegacy(n);
+    case 'promisify': return usePromisify(n);
+    case 'promise': return usePromise(n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/benchmark/fs/promises-readfile.js
+++ b/benchmark/fs/promises-readfile.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+const { readFile, async } = require('fs');
+const { promisify } = require('util');
+const Countdown = require('../../test/common/countdown');
+
+const bench = common.createBenchmark(main, {
+  n: [2000],
+  file: [__filename, 'benchmark/fixtures/alice.html'],
+  method: ['legacy', 'promisify', 'promise']
+});
+
+function useLegacy(file, n) {
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    readFile(file, () => countdown.dec());
+  }
+}
+
+function usePromisify(file, n) {
+  const _readFile = promisify(readFile);
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _readFile(file).then(() => countdown.dec());
+  }
+}
+
+function usePromise(file, n) {
+  const _readFile = async.readFile;
+  const countdown = new Countdown(n, () => {
+    bench.end(n);
+  });
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    _readFile(file).then(() => countdown.dec());
+  }
+}
+
+function main(conf) {
+  const n = conf.n >>> 0;
+  const file = conf.file;
+  const method = conf.method;
+
+  switch (method) {
+    case 'legacy': return useLegacy(file, n);
+    case 'promisify': return usePromisify(file, n);
+    case 'promise': return usePromise(file, n);
+    default:
+      throw new Error('invalid method');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -38,12 +38,25 @@ const Stream = require('stream').Stream;
 const EventEmitter = require('events');
 const FSReqWrap = binding.FSReqWrap;
 const FSEvent = process.binding('fs_event_wrap').FSEvent;
-const internalFS = require('internal/fs');
 const internalURL = require('internal/url');
 const internalUtil = require('internal/util');
-const assertEncoding = internalFS.assertEncoding;
-const stringToFlags = internalFS.stringToFlags;
 const getPathFromURL = internalURL.getPathFromURL;
+
+const {
+  assertEncoding,
+  getOptions,
+  modeNum,
+  preprocessSymlinkDestination,
+  realpathCacheKey,
+  stringToFlags,
+  stringToSymlinkType,
+  toUnixTimestamp,
+  statsFromValues,
+  statsFromPrevValues,
+  statValues,
+  Stats,
+  SyncWriteStream: _SyncWriteStream
+} = require('internal/fs');
 
 Object.defineProperty(exports, 'constants', {
   configurable: false,
@@ -61,28 +74,6 @@ const isWindows = process.platform === 'win32';
 
 const DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
 const errnoException = util._errnoException;
-
-function getOptions(options, defaultOptions) {
-  if (options === null || options === undefined ||
-      typeof options === 'function') {
-    return defaultOptions;
-  }
-
-  if (typeof options === 'string') {
-    defaultOptions = util._extend({}, defaultOptions);
-    defaultOptions.encoding = options;
-    options = defaultOptions;
-  } else if (typeof options !== 'object') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'options',
-                               ['string', 'object'],
-                               options);
-  }
-
-  if (options.encoding !== 'buffer')
-    assertEncoding(options.encoding);
-  return options;
-}
 
 function copyObject(source) {
   var target = {};
@@ -176,86 +167,7 @@ function isFd(path) {
   return (path >>> 0) === path;
 }
 
-// Constructor for file stats.
-function Stats(
-  dev,
-  mode,
-  nlink,
-  uid,
-  gid,
-  rdev,
-  blksize,
-  ino,
-  size,
-  blocks,
-  atim_msec,
-  mtim_msec,
-  ctim_msec,
-  birthtim_msec
-) {
-  this.dev = dev;
-  this.mode = mode;
-  this.nlink = nlink;
-  this.uid = uid;
-  this.gid = gid;
-  this.rdev = rdev;
-  this.blksize = blksize;
-  this.ino = ino;
-  this.size = size;
-  this.blocks = blocks;
-  this.atimeMs = atim_msec;
-  this.mtimeMs = mtim_msec;
-  this.ctimeMs = ctim_msec;
-  this.birthtimeMs = birthtim_msec;
-  this.atime = new Date(atim_msec + 0.5);
-  this.mtime = new Date(mtim_msec + 0.5);
-  this.ctime = new Date(ctim_msec + 0.5);
-  this.birthtime = new Date(birthtim_msec + 0.5);
-}
 fs.Stats = Stats;
-
-Stats.prototype._checkModeProperty = function(property) {
-  return ((this.mode & S_IFMT) === property);
-};
-
-Stats.prototype.isDirectory = function() {
-  return this._checkModeProperty(constants.S_IFDIR);
-};
-
-Stats.prototype.isFile = function() {
-  return this._checkModeProperty(S_IFREG);
-};
-
-Stats.prototype.isBlockDevice = function() {
-  return this._checkModeProperty(constants.S_IFBLK);
-};
-
-Stats.prototype.isCharacterDevice = function() {
-  return this._checkModeProperty(constants.S_IFCHR);
-};
-
-Stats.prototype.isSymbolicLink = function() {
-  return this._checkModeProperty(S_IFLNK);
-};
-
-Stats.prototype.isFIFO = function() {
-  return this._checkModeProperty(S_IFIFO);
-};
-
-Stats.prototype.isSocket = function() {
-  return this._checkModeProperty(S_IFSOCK);
-};
-
-const statValues = binding.getStatValues();
-
-function statsFromValues() {
-  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
-                   statValues[4], statValues[5],
-                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
-                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
-                   statValues[10], statValues[11], statValues[12],
-                   statValues[13]);
-}
 
 // Don't allow mode to accidentally be overwritten.
 Object.defineProperties(fs, {
@@ -265,14 +177,9 @@ Object.defineProperties(fs, {
   X_OK: { enumerable: true, value: constants.X_OK || 0 },
 });
 
-function handleError(val, callback) {
-  if (val instanceof Error) {
-    if (typeof callback === 'function') {
-      process.nextTick(callback, val);
-      return true;
-    } else throw val;
-  }
-  return false;
+function handleError(val) {
+  if (val instanceof Error)
+    throw val;
 }
 
 fs.access = function(path, mode, callback) {
@@ -283,35 +190,41 @@ fs.access = function(path, mode, callback) {
     throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
 
-  if (!nullCheck(path, callback))
-    return;
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  if (!Number.isInteger(mode)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  }
 
-  mode = mode | 0;
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.access(pathModule._makeLong(path), mode, req);
 };
 
-fs.accessSync = function(path, mode) {
-  handleError((path = getPathFromURL(path)));
+fs.accessSync = function(path, mode = fs.F_OK) {
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
 
-  if (mode === undefined)
-    mode = fs.F_OK;
-  else
-    mode = mode | 0;
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  if (!Number.isInteger(mode)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  }
 
   binding.access(pathModule._makeLong(path), mode);
 };
 
 fs.exists = function(path, callback) {
-  if (handleError((path = getPathFromURL(path)), cb))
-    return;
-  if (!nullCheck(path, cb)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  const req = new FSReqWrap();
   req.oncomplete = cb;
   binding.stat(pathModule._makeLong(path), req);
   function cb(err) {
@@ -329,9 +242,9 @@ Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
 
 
 fs.existsSync = function(path) {
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
   try {
-    handleError((path = getPathFromURL(path)));
-    nullCheck(path);
     binding.stat(pathModule._makeLong(path));
     return true;
   } catch (e) {
@@ -343,14 +256,12 @@ fs.readFile = function(path, options, callback) {
   callback = maybeCallback(callback || options);
   options = getOptions(options, { flag: 'r' });
 
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback))
-    return;
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
 
-  var context = new ReadFileContext(callback, options.encoding);
+  const context = new ReadFileContext(callback, options.encoding);
   context.isUserFd = isFd(path); // file descriptor ownership
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.context = context;
   req.oncomplete = readFileAfterOpen;
 
@@ -361,8 +272,13 @@ fs.readFile = function(path, options, callback) {
     return;
   }
 
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   binding.open(pathModule._makeLong(path),
-               stringToFlags(options.flag || 'r'),
+               stringToFlags(options.flag || 'r', true),
                0o666,
                req);
 };
@@ -615,50 +531,65 @@ fs.readFileSync = function(path, options) {
 // list to make the arguments clear.
 
 fs.close = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.close(fd, req);
 };
 
 fs.closeSync = function(fd) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
   return binding.close(fd);
 };
 
-function modeNum(m, def) {
-  if (typeof m === 'number')
-    return m;
-  if (typeof m === 'string')
-    return parseInt(m, 8);
-  if (def)
-    return modeNum(def);
-  return undefined;
-}
-
 fs.open = function(path, flags, mode, callback_) {
-  var callback = makeCallback(arguments[arguments.length - 1]);
+  const callback = makeCallback(arguments[arguments.length - 1]);
   mode = modeNum(mode, 0o666);
+  flags = stringToFlags(flags);
 
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
 
-  var req = new FSReqWrap();
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
 
-  binding.open(pathModule._makeLong(path),
-               stringToFlags(flags),
-               mode,
-               req);
+  binding.open(pathModule._makeLong(path), flags, mode, req);
 };
 
 fs.openSync = function(path, flags, mode) {
   mode = modeNum(mode, 0o666);
-  handleError((path = getPathFromURL(path)));
+  flags = stringToFlags(flags);
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
-  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  return binding.open(pathModule._makeLong(path), flags, mode);
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  if (!isUint8Array(buffer)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                               ['Buffer', 'Uint8Array']);
+  }
   if (length === 0) {
     return process.nextTick(function() {
       callback && callback(null, 0, buffer);
@@ -670,7 +601,7 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
     callback && callback(err, bytesRead || 0, buffer);
   }
 
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = wrapper;
 
   binding.read(fd, buffer, offset, length, position, req);
@@ -680,6 +611,14 @@ Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
 
 fs.readSync = function(fd, buffer, offset, length, position) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  if (!isUint8Array(buffer)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                               ['Buffer', 'Uint8Array']);
+  }
   if (length === 0) {
     return 0;
   }
@@ -692,25 +631,34 @@ fs.readSync = function(fd, buffer, offset, length, position) {
 // OR
 //  fs.write(fd, string[, position[, encoding]], callback);
 fs.write = function(fd, buffer, offset, length, position, callback) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
   function wrapper(err, written) {
     // Retain a reference to buffer so that it can't be GC'ed too soon.
     callback(err, written || 0, buffer);
   }
 
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = wrapper;
 
   if (isUint8Array(buffer)) {
     callback = maybeCallback(callback || position || length || offset);
-    if (typeof offset !== 'number') {
+    if (typeof offset !== 'number')
       offset = 0;
-    }
-    if (typeof length !== 'number') {
+    if (typeof length !== 'number')
       length = buffer.length - offset;
-    }
-    if (typeof position !== 'number') {
+    if (typeof position !== 'number')
       position = null;
-    }
+
+    if (offset > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'offset');
+    if (length > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'length');
+    if (offset + length < offset)
+      throw new errors.RangeError('ERR_OVERFLOW');
+
     return binding.writeBuffer(fd, buffer, offset, length, position, req);
   }
 
@@ -726,6 +674,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     length = 'utf8';
   }
   callback = maybeCallback(position);
+  assertEncoding(length);
   return binding.writeString(fd, buffer, offset, length, req);
 };
 
@@ -737,6 +686,10 @@ Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
 // OR
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
   if (isUint8Array(buffer)) {
     if (position === undefined)
       position = null;
@@ -744,26 +697,43 @@ fs.writeSync = function(fd, buffer, offset, length, position) {
       offset = 0;
     if (typeof length !== 'number')
       length = buffer.length - offset;
+
+    if (offset > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'offset');
+    if (length > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'length');
+    if (offset + length < offset)
+      throw new errors.RangeError('ERR_OVERFLOW');
+
     return binding.writeBuffer(fd, buffer, offset, length, position);
   }
   if (typeof buffer !== 'string')
     buffer += '';
   if (offset === undefined)
     offset = null;
-  return binding.writeString(fd, buffer, offset, length, position);
+  assertEncoding(length);
+  return binding.writeString(fd, buffer, offset, length);
 };
 
 fs.rename = function(oldPath, newPath, callback) {
   callback = makeCallback(callback);
-  if (handleError((oldPath = getPathFromURL(oldPath)), callback))
-    return;
+  handleError(oldPath = getPathFromURL(oldPath));
+  handleError(newPath = getPathFromURL(newPath));
 
-  if (handleError((newPath = getPathFromURL(newPath)), callback))
-    return;
+  nullCheck(oldPath);
+  nullCheck(newPath);
 
-  if (!nullCheck(oldPath, callback)) return;
-  if (!nullCheck(newPath, callback)) return;
-  var req = new FSReqWrap();
+  if (typeof oldPath !== 'string' && !Buffer.isBuffer(oldPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.rename(pathModule._makeLong(oldPath),
                  pathModule._makeLong(newPath),
@@ -771,10 +741,21 @@ fs.rename = function(oldPath, newPath, callback) {
 };
 
 fs.renameSync = function(oldPath, newPath) {
-  handleError((oldPath = getPathFromURL(oldPath)));
-  handleError((newPath = getPathFromURL(newPath)));
+  handleError(oldPath = getPathFromURL(oldPath));
+  handleError(newPath = getPathFromURL(newPath));
   nullCheck(oldPath);
   nullCheck(newPath);
+
+  if (typeof oldPath !== 'string' && !Buffer.isBuffer(oldPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   return binding.rename(pathModule._makeLong(oldPath),
                         pathModule._makeLong(newPath));
 };
@@ -786,14 +767,14 @@ fs.truncate = function(path, len, callback) {
   if (typeof len === 'function') {
     callback = len;
     len = 0;
-  } else if (len === undefined) {
+  } else if (len == null) {
     len = 0;
   }
 
   callback = maybeCallback(callback);
   fs.open(path, 'r+', function(er, fd) {
     if (er) return callback(er);
-    var req = new FSReqWrap();
+    const req = new FSReqWrap();
     req.oncomplete = function oncomplete(er) {
       fs.close(fd, function(er2) {
         callback(er || er2);
@@ -808,11 +789,11 @@ fs.truncateSync = function(path, len) {
     // legacy
     return fs.ftruncateSync(path, len);
   }
-  if (len === undefined) {
+  if (len == null) {
     len = 0;
   }
   // allow error to be thrown, but still close fd.
-  var fd = fs.openSync(path, 'r+');
+  const fd = fs.openSync(path, 'r+');
   var ret;
 
   try {
@@ -827,117 +808,192 @@ fs.ftruncate = function(fd, len, callback) {
   if (typeof len === 'function') {
     callback = len;
     len = 0;
-  } else if (len === undefined) {
+  } else if (len == null) {
     len = 0;
   }
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  if (!Number.isInteger(len) || len < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len',
+                               'unsigned integer');
+  }
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.ftruncate(fd, len, req);
 };
 
 fs.ftruncateSync = function(fd, len) {
-  if (len === undefined) {
+  if (len == null)
     len = 0;
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  if (!Number.isInteger(len) || len < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len',
+                               'unsigned integer');
   }
   return binding.ftruncate(fd, len);
 };
 
 fs.rmdir = function(path, callback) {
   callback = maybeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.rmdir(pathModule._makeLong(path), req);
 };
 
 fs.rmdirSync = function(path) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   return binding.rmdir(pathModule._makeLong(path));
 };
 
 fs.fdatasync = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fdatasync(fd, req);
 };
 
 fs.fdatasyncSync = function(fd) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
   return binding.fdatasync(fd);
 };
 
 fs.fsync = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fsync(fd, req);
 };
 
 fs.fsyncSync = function(fd) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
   return binding.fsync(fd);
 };
 
 fs.mkdir = function(path, mode, callback) {
   if (typeof mode === 'function') callback = mode;
   callback = makeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  mode = modeNum(0o777);
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
-  binding.mkdir(pathModule._makeLong(path),
-                modeNum(mode, 0o777),
-                req);
+  binding.mkdir(pathModule._makeLong(path), mode, req);
 };
 
 fs.mkdirSync = function(path, mode) {
-  handleError((path = getPathFromURL(path)));
+  mode = modeNum(0o777);
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
-  return binding.mkdir(pathModule._makeLong(path),
-                       modeNum(mode, 0o777));
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  return binding.mkdir(pathModule._makeLong(path), mode);
 };
 
 fs.readdir = function(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.readdir(pathModule._makeLong(path), options.encoding, req);
 };
 
 fs.readdirSync = function(path, options) {
   options = getOptions(options, {});
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   return binding.readdir(pathModule._makeLong(path), options.encoding);
 };
 
 fs.fstat = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  const req = new FSReqWrap();
   req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
 };
 
 fs.lstat = function(path, callback) {
   callback = makeStatsCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.lstat(pathModule._makeLong(path), req);
 };
 
 fs.stat = function(path, callback) {
   callback = makeStatsCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.stat(pathModule._makeLong(path), req);
 };
@@ -948,14 +1004,14 @@ fs.fstatSync = function(fd) {
 };
 
 fs.lstatSync = function(path) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
   binding.lstat(pathModule._makeLong(path));
   return statsFromValues();
 };
 
 fs.statSync = function(path) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
   binding.stat(pathModule._makeLong(path));
   return statsFromValues();
@@ -964,83 +1020,101 @@ fs.statSync = function(path) {
 fs.readlink = function(path, options, callback) {
   callback = makeCallback(typeof options === 'function' ? options : callback);
   options = getOptions(options, {});
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.readlink(pathModule._makeLong(path), options.encoding, req);
 };
 
 fs.readlinkSync = function(path, options) {
   options = getOptions(options, {});
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
   return binding.readlink(pathModule._makeLong(path), options.encoding);
 };
 
-function preprocessSymlinkDestination(path, type, linkPath) {
-  if (!isWindows) {
-    // No preprocessing is needed on Unix.
-    return path;
-  } else if (type === 'junction') {
-    // Junctions paths need to be absolute and \\?\-prefixed.
-    // A relative target is relative to the link's parent directory.
-    path = pathModule.resolve(linkPath, '..', path);
-    return pathModule._makeLong(path);
-  } else {
-    // Windows symlinks don't tolerate forward slashes.
-    return ('' + path).replace(/\//g, '\\');
+fs.symlink = function(target, path, type, callback) {
+  if (typeof type === 'function') {
+    callback = type;
+    type = 'file';
   }
-}
+  const _type = stringToSymlinkType(type);
 
-fs.symlink = function(target, path, type_, callback_) {
-  var type = (typeof type_ === 'string' ? type_ : null);
-  var callback = makeCallback(arguments[arguments.length - 1]);
+  handleError(target = getPathFromURL(target));
+  handleError(path = getPathFromURL(path));
 
-  if (handleError((target = getPathFromURL(target)), callback))
-    return;
-
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-
-  if (!nullCheck(target, callback)) return;
-  if (!nullCheck(path, callback)) return;
-
-  var req = new FSReqWrap();
-  req.oncomplete = callback;
-
-  binding.symlink(preprocessSymlinkDestination(target, type, path),
-                  pathModule._makeLong(path),
-                  type,
-                  req);
-};
-
-fs.symlinkSync = function(target, path, type) {
-  type = (typeof type === 'string' ? type : null);
-  handleError((target = getPathFromURL(target)));
-  handleError((path = getPathFromURL(path)));
   nullCheck(target);
   nullCheck(path);
 
+  if (typeof target !== 'string' && !Buffer.isBuffer(target)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const req = new FSReqWrap();
+  req.oncomplete = makeCallback(callback);
+
+  binding.symlink(preprocessSymlinkDestination(target, type, path),
+                  pathModule._makeLong(path),
+                  _type,
+                  req);
+};
+
+fs.symlinkSync = function(target, path, type = 'file') {
+  const _type = stringToSymlinkType(type);
+  handleError(target = getPathFromURL(target));
+  handleError(path = getPathFromURL(path));
+  nullCheck(target);
+  nullCheck(path);
+
+  if (typeof target !== 'string' && !Buffer.isBuffer(target)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
                          pathModule._makeLong(path),
-                         type);
+                         _type);
 };
 
 fs.link = function(existingPath, newPath, callback) {
   callback = makeCallback(callback);
 
-  if (handleError((existingPath = getPathFromURL(existingPath)), callback))
-    return;
+  handleError(existingPath = getPathFromURL(existingPath));
+  handleError(newPath = getPathFromURL(newPath));
 
-  if (handleError((newPath = getPathFromURL(newPath)), callback))
-    return;
+  nullCheck(existingPath);
+  nullCheck(newPath);
 
-  if (!nullCheck(existingPath, callback)) return;
-  if (!nullCheck(newPath, callback)) return;
+  if (typeof existingPath !== 'string' && !Buffer.isBuffer(existingPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                               ['string', 'Buffer', 'URL']);
+  }
 
-  var req = new FSReqWrap();
+  if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
 
   binding.link(pathModule._makeLong(existingPath),
@@ -1049,38 +1123,67 @@ fs.link = function(existingPath, newPath, callback) {
 };
 
 fs.linkSync = function(existingPath, newPath) {
-  handleError((existingPath = getPathFromURL(existingPath)));
-  handleError((newPath = getPathFromURL(newPath)));
+  handleError(existingPath = getPathFromURL(existingPath));
+  handleError(newPath = getPathFromURL(newPath));
   nullCheck(existingPath);
   nullCheck(newPath);
+  if (typeof existingPath !== 'string' && !Buffer.isBuffer(existingPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                               ['string', 'Buffer', 'URL']);
+  }
   return binding.link(pathModule._makeLong(existingPath),
                       pathModule._makeLong(newPath));
 };
 
 fs.unlink = function(path, callback) {
   callback = makeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.unlink(pathModule._makeLong(path), req);
 };
 
 fs.unlinkSync = function(path) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
   return binding.unlink(pathModule._makeLong(path));
 };
 
 fs.fchmod = function(fd, mode, callback) {
-  var req = new FSReqWrap();
+  mode = modeNum(mode);
+
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
-  binding.fchmod(fd, modeNum(mode), req);
+  binding.fchmod(fd, mode, req);
 };
 
 fs.fchmodSync = function(fd, mode) {
-  return binding.fchmod(fd, modeNum(mode));
+  mode = modeNum(mode);
+
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+  return binding.fchmod(fd, mode);
 };
 
 if (constants.O_SYMLINK !== undefined) {
@@ -1102,7 +1205,7 @@ if (constants.O_SYMLINK !== undefined) {
   };
 
   fs.lchmodSync = function(path, mode) {
-    var fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
+    const fd = fs.openSync(path, constants.O_WRONLY | constants.O_SYMLINK);
 
     // Prefer to return the chmod error, if one occurs,
     // but still try to close, and report closing errors if they occur.
@@ -1123,20 +1226,39 @@ if (constants.O_SYMLINK !== undefined) {
 
 fs.chmod = function(path, mode, callback) {
   callback = makeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  mode = modeNum(mode);
+  if (!Number.isInteger(mode) || mode < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode',
+                               'unsigned integer');
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
-  binding.chmod(pathModule._makeLong(path),
-                modeNum(mode),
-                req);
+  binding.chmod(pathModule._makeLong(path), mode, req);
 };
 
 fs.chmodSync = function(path, mode) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
-  return binding.chmod(pathModule._makeLong(path), modeNum(mode));
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  mode = modeNum(mode);
+  if (!Number.isInteger(mode) || mode < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode',
+                               'unsigned integer');
+  }
+
+  return binding.chmod(pathModule._makeLong(path), mode);
 };
 
 if (constants.O_SYMLINK !== undefined) {
@@ -1158,62 +1280,99 @@ if (constants.O_SYMLINK !== undefined) {
 }
 
 fs.fchown = function(fd, uid, gid, callback) {
-  var req = new FSReqWrap();
+
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  if (!Number.isInteger(uid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
+  }
+
+  if (!Number.isInteger(gid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fchown(fd, uid, gid, req);
 };
 
 fs.fchownSync = function(fd, uid, gid) {
+
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
+  if (!Number.isInteger(uid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
+  }
+
+  if (!Number.isInteger(gid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  }
+
   return binding.fchown(fd, uid, gid);
 };
 
 fs.chown = function(path, uid, gid, callback) {
   callback = makeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (!Number.isInteger(uid) || uid < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid',
+                               'unsigned integer');
+  }
+
+  if (!Number.isInteger(gid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  }
+
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.chown(pathModule._makeLong(path), uid, gid, req);
 };
 
 fs.chownSync = function(path, uid, gid) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (!Number.isInteger(uid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
+  }
+
+  if (!Number.isInteger(gid)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  }
+
   return binding.chown(pathModule._makeLong(path), uid, gid);
 };
-
-// converts Date or number to a fractional UNIX timestamp
-function toUnixTimestamp(time) {
-  // eslint-disable-next-line eqeqeq
-  if (typeof time === 'string' && +time == time) {
-    return +time;
-  }
-  if (Number.isFinite(time)) {
-    if (time < 0) {
-      return Date.now() / 1000;
-    }
-    return time;
-  }
-  if (util.isDate(time)) {
-    // convert to 123.456 UNIX timestamp
-    return time.getTime() / 1000;
-  }
-  throw new errors.Error('ERR_INVALID_ARG_TYPE',
-                         'time',
-                         ['Date', 'time in seconds'],
-                         time);
-}
 
 // exported for unit tests, not for public consumption
 fs._toUnixTimestamp = toUnixTimestamp;
 
 fs.utimes = function(path, atime, mtime, callback) {
   callback = makeCallback(callback);
-  if (handleError((path = getPathFromURL(path)), callback))
-    return;
-  if (!nullCheck(path, callback)) return;
-  var req = new FSReqWrap();
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+  const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.utimes(pathModule._makeLong(path),
                  toUnixTimestamp(atime),
@@ -1222,22 +1381,36 @@ fs.utimes = function(path, atime, mtime, callback) {
 };
 
 fs.utimesSync = function(path, atime, mtime) {
-  handleError((path = getPathFromURL(path)));
+  handleError(path = getPathFromURL(path));
   nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
   atime = toUnixTimestamp(atime);
   mtime = toUnixTimestamp(mtime);
   binding.utimes(pathModule._makeLong(path), atime, mtime);
 };
 
 fs.futimes = function(fd, atime, mtime, callback) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
   atime = toUnixTimestamp(atime);
   mtime = toUnixTimestamp(mtime);
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.futimes(fd, atime, mtime, req);
 };
 
 fs.futimesSync = function(fd, atime, mtime) {
+  if (!Number.isInteger(fd) || fd < 0) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                               'unsigned integer');
+  }
+
   atime = toUnixTimestamp(atime);
   mtime = toUnixTimestamp(mtime);
   binding.futimes(fd, atime, mtime);
@@ -1357,20 +1530,19 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
-  var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
 
-  this._handle.onchange = function(status, eventType, filename) {
+  this._handle.onchange = (status, eventType, filename) => {
     if (status < 0) {
-      self._handle.close();
+      this._handle.close();
       const error = !filename ?
         errnoException(status, 'Error watching file for changes:') :
         errnoException(status, `Error watching file ${filename} for changes:`);
       error.filename = filename;
-      self.emit('error', error);
+      this.emit('error', error);
     } else {
-      self.emit('change', eventType, filename);
+      this.emit('change', eventType, filename);
     }
   };
 }
@@ -1380,7 +1552,7 @@ FSWatcher.prototype.start = function(filename,
                                      persistent,
                                      recursive,
                                      encoding) {
-  handleError((filename = getPathFromURL(filename)));
+  handleError(filename = getPathFromURL(filename));
   nullCheck(filename);
   var err = this._handle.start(pathModule._makeLong(filename),
                                persistent,
@@ -1399,7 +1571,7 @@ FSWatcher.prototype.close = function() {
 };
 
 fs.watch = function(filename, options, listener) {
-  handleError((filename = getPathFromURL(filename)));
+  handleError(filename = getPathFromURL(filename));
   nullCheck(filename);
 
   if (typeof options === 'function') {
@@ -1433,15 +1605,6 @@ function emitStop(self) {
   self.emit('stop');
 }
 
-function statsFromPrevValues() {
-  return new Stats(statValues[14], statValues[15], statValues[16],
-                   statValues[17], statValues[18], statValues[19],
-                   statValues[20] < 0 ? undefined : statValues[20],
-                   statValues[21], statValues[22],
-                   statValues[23] < 0 ? undefined : statValues[23],
-                   statValues[24], statValues[25], statValues[26],
-                   statValues[27]);
-}
 function StatWatcher() {
   EventEmitter.call(this);
 
@@ -1469,7 +1632,7 @@ util.inherits(StatWatcher, EventEmitter);
 
 
 StatWatcher.prototype.start = function(filename, persistent, interval) {
-  handleError((filename = getPathFromURL(filename)));
+  handleError(filename = getPathFromURL(filename));
   nullCheck(filename);
   this._handle.start(pathModule._makeLong(filename), persistent, interval);
 };
@@ -1483,7 +1646,7 @@ StatWatcher.prototype.stop = function() {
 const statWatchers = new Map();
 
 fs.watchFile = function(filename, options, listener) {
-  handleError((filename = getPathFromURL(filename)));
+  handleError(filename = getPathFromURL(filename));
   nullCheck(filename);
   filename = pathModule.resolve(filename);
   var stat;
@@ -1523,10 +1686,10 @@ fs.watchFile = function(filename, options, listener) {
 };
 
 fs.unwatchFile = function(filename, listener) {
-  handleError((filename = getPathFromURL(filename)));
+  handleError(filename = getPathFromURL(filename));
   nullCheck(filename);
   filename = pathModule.resolve(filename);
-  var stat = statWatchers.get(filename);
+  const stat = statWatchers.get(filename);
 
   if (stat === undefined) return;
 
@@ -1601,7 +1764,7 @@ fs.realpathSync = function realpathSync(p, options) {
   nullCheck(p);
   p = pathModule.resolve(p);
 
-  const cache = options[internalFS.realpathCacheKey];
+  const cache = options[realpathCacheKey];
   const maybeCachedResult = cache && cache.get(p);
   if (maybeCachedResult) {
     return maybeCachedResult;
@@ -1722,13 +1885,11 @@ fs.realpath = function realpath(p, options, callback) {
   else
     options = getOptions(options, emptyObj);
   if (typeof p !== 'string') {
-    if (handleError((p = getPathFromURL(p)), callback))
-      return;
+    handleError(p = getPathFromURL(p));
     if (typeof p !== 'string')
       p += '';
   }
-  if (!nullCheck(p, callback))
-    return;
+  nullCheck(p);
   p = pathModule.resolve(p);
 
   const seenLinks = Object.create(null);
@@ -1860,11 +2021,9 @@ fs.mkdtemp = function(prefix, options, callback) {
                                'string',
                                prefix);
   }
-  if (!nullCheck(prefix, callback)) {
-    return;
-  }
+  nullCheck(prefix);
 
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = callback;
 
   binding.mkdtemp(prefix + 'XXXXXX', options.encoding, req);
@@ -1900,19 +2059,23 @@ fs.copyFile = function(src, dest, flags, callback) {
 
   src = getPathFromURL(src);
 
-  if (handleError(src, callback))
-    return;
+  handleError(src);
+  nullCheck(src);
 
-  if (!nullCheck(src, callback))
-    return;
+  if (typeof src !== 'string' && !Buffer.isBuffer(src)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                               ['string', 'Buffer', 'URL']);
+  }
 
   dest = getPathFromURL(dest);
 
-  if (handleError(dest, callback))
-    return;
+  handleError(dest);
+  nullCheck(dest);
 
-  if (!nullCheck(dest, callback))
-    return;
+  if (typeof dest !== 'string' && !Buffer.isBuffer(dest)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                               ['string', 'Buffer', 'URL']);
+  }
 
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);
@@ -1928,9 +2091,19 @@ fs.copyFileSync = function(src, dest, flags) {
   handleError(src);
   nullCheck(src);
 
+  if (typeof src !== 'string' && !Buffer.isBuffer(src)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                               ['string', 'Buffer', 'URL']);
+  }
+
   dest = getPathFromURL(dest);
   handleError(dest);
   nullCheck(dest);
+
+  if (typeof dest !== 'string' && !Buffer.isBuffer(dest)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                               ['string', 'Buffer', 'URL']);
+  }
 
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);
@@ -1965,7 +2138,7 @@ function ReadStream(path, options) {
 
   Readable.call(this, options);
 
-  handleError((this.path = getPathFromURL(path)));
+  handleError(this.path = getPathFromURL(path));
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
@@ -2142,7 +2315,7 @@ function WriteStream(path, options) {
 
   Writable.call(this, options);
 
-  handleError((this.path = getPathFromURL(path)));
+  handleError(this.path = getPathFromURL(path));
   this.fd = options.fd === undefined ? null : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
@@ -2283,11 +2456,19 @@ WriteStream.prototype.destroySoon = WriteStream.prototype.end;
 
 // SyncWriteStream is internal. DO NOT USE.
 // This undocumented API was never intended to be made public.
-var SyncWriteStream = internalFS.SyncWriteStream;
+var SyncWriteStream = _SyncWriteStream;
 Object.defineProperty(fs, 'SyncWriteStream', {
   configurable: true,
   get: internalUtil.deprecate(() => SyncWriteStream,
                               'fs.SyncWriteStream is deprecated.', 'DEP0061'),
   set: internalUtil.deprecate((val) => { SyncWriteStream = val; },
                               'fs.SyncWriteStream is deprecated.', 'DEP0061')
+});
+
+Object.defineProperty(fs, 'async', {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return require('internal/async/fs');
+  }
 });

--- a/lib/internal/async/fs.js
+++ b/lib/internal/async/fs.js
@@ -1,0 +1,947 @@
+'use strict';
+
+process.emitWarning(
+  'The promisified fs module is an experimental API.',
+  'ExperimentalWarning'
+);
+
+const {
+  F_OK,
+  O_SYMLINK,
+  O_WRONLY
+} = process.binding('constants').fs;
+
+const errors = require('internal/errors');
+
+const {
+  access: _access,
+  chmod: _chmod,
+  chown: _chown,
+  close: _close,
+  copyFile: _copyFile,
+  fchmod: _fchmod,
+  fchown: _fchown,
+  fdatasync: _fdatasync,
+  fstat: _fstat,
+  fsync: _fsync,
+  ftruncate: _ftruncate,
+  futimes: _futimes,
+  link: _link,
+  lstat: _lstat,
+  mkdir: _mkdir,
+  mkdtemp: _mkdtemp,
+  open: _open,
+  read: _read,
+  readdir: _readdir,
+  readlink: _readlink,
+  realpath: _realpath,
+  rename: _rename,
+  rmdir: _rmdir,
+  stat: _stat,
+  symlink: _symlink,
+  unlink: _unlink,
+  utimes: _utimes,
+  writeBuffer: _writeBuffer,
+  writeString: _writeString,
+  FSReqWrap
+} = process.binding('fs');
+
+const {
+  assertEncoding,
+  getOptions,
+  modeNum,
+  nullCheck,
+  preprocessSymlinkDestination,
+  statsFromValues,
+  stringToFlags,
+  stringToSymlinkType,
+  toUnixTimestamp
+} = require('internal/fs');
+
+const {
+  createPromise,
+  isUint8Array,
+  promiseResolve,
+  promiseReject
+} = process.binding('util');
+
+const {
+  _makeLong
+} = require('path');
+
+const {
+  getPathFromURL
+} = require('internal/url');
+
+const {
+  Buffer,
+  kMaxLength
+} = require('buffer');
+
+const kReadFileBufferLength = 8 * 1024;
+
+function handleError(val) {
+  if (val instanceof Error)
+    throw val;
+}
+
+function isFd(path) {
+  return (path >>> 0) === path;
+}
+
+function access(path, mode = F_OK) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+    if (!Number.isInteger(mode)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _access(_makeLong(path), mode, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function chmod(path, mode) {
+  const promise = createPromise();
+  try {
+    mode = modeNum(mode);
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+    if (!Number.isInteger(mode) || mode < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode',
+                                 'unsigned integer');
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _chmod(_makeLong(path), mode, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function chown(path, uid, gid) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    if (!Number.isInteger(uid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
+    }
+
+    if (!Number.isInteger(gid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _chown(_makeLong(path), uid, gid, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function close(fd) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _close(fd, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function copyFile(src, dest, flags = 0) {
+  const promise = createPromise();
+  try {
+    src = getPathFromURL(src);
+    handleError(src);
+    nullCheck(src);
+
+    if (typeof src !== 'string' && !Buffer.isBuffer(src)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    dest = getPathFromURL(dest);
+    handleError(dest);
+    nullCheck(dest);
+
+    if (typeof dest !== 'string' && !Buffer.isBuffer(dest)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    src = _makeLong(src);
+    dest = _makeLong(dest);
+    flags = flags | 0;
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _copyFile(src, dest, flags, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function fchmod(fd, mode) {
+  const promise = createPromise();
+  try {
+    mode = modeNum(mode);
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _fchmod(fd, mode, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function fchown(fd, uid, gid) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+
+    if (!Number.isInteger(uid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
+    }
+
+    if (!Number.isInteger(gid)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _fchown(fd, uid, gid, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function fdatasync(fd) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _fdatasync(fd, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function fsync(fd) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _fsync(fd, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function ftruncate(fd, len) {
+  const promise = createPromise();
+  try {
+    if (len == null)
+      len = 0;
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+
+    if (!Number.isInteger(len) || len < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len',
+                                 'unsigned integer');
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _ftruncate(fd, len, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function futimes(fd, atime, mtime) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+
+    atime = toUnixTimestamp(atime);
+    mtime = toUnixTimestamp(mtime);
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _futimes(fd, atime, mtime, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function open(path, flags, mode) {
+  const promise = createPromise();
+  try {
+    mode = modeNum(mode, 0o666);
+    flags = stringToFlags(flags);
+
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+
+    _open(_makeLong(path), flags, mode, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function link(existingPath, newPath) {
+  const promise = createPromise();
+  try {
+    handleError(existingPath = getPathFromURL(existingPath));
+    handleError(newPath = getPathFromURL(newPath));
+
+    nullCheck(existingPath);
+    nullCheck(newPath);
+
+    if (typeof existingPath !== 'string' && !Buffer.isBuffer(existingPath)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+
+    _link(_makeLong(existingPath),
+          _makeLong(newPath),
+          req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function mkdir(path, mode) {
+  const promise = createPromise();
+  try {
+    mode = modeNum(mode, 0o777);
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _mkdir(_makeLong(path), mode, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function mkdtemp(prefix, options) {
+  const promise = createPromise();
+  try {
+    options = getOptions(options, {});
+    if (!prefix || typeof prefix !== 'string') {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'prefix',
+                                 'string');
+    }
+    nullCheck(prefix);
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _mkdtemp(`${prefix}XXXXXX`, options.encoding, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function readdir(path, options) {
+  const promise = createPromise();
+  try {
+    options = getOptions(options, {});
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _readdir(_makeLong(path), options.encoding, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function readlink(path, options) {
+  const promise = createPromise();
+  try {
+    options = getOptions(options, {});
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _readlink(_makeLong(path), options.encoding, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function rename(oldPath, newPath) {
+  const promise = createPromise();
+  try {
+    handleError(oldPath = getPathFromURL(oldPath));
+    handleError(newPath = getPathFromURL(newPath));
+
+    nullCheck(oldPath);
+    nullCheck(newPath);
+
+    if (typeof oldPath !== 'string' && !Buffer.isBuffer(oldPath)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    if (typeof newPath !== 'string' && !Buffer.isBuffer(newPath)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+
+    _rename(_makeLong(oldPath),
+            _makeLong(newPath),
+            req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function rmdir(path) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _rmdir(_makeLong(path), req);
+  } catch (err) {
+    promiseReject(err);
+  }
+  return promise;
+}
+
+function symlink(target, path, type = 'file') {
+  const promise = createPromise();
+  try {
+    const _type = stringToSymlinkType(type);
+
+    handleError(target = getPathFromURL(target));
+    handleError(path = getPathFromURL(path));
+
+    nullCheck(target);
+    nullCheck(path);
+
+    if (typeof target !== 'string' && !Buffer.isBuffer(target)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+
+    _symlink(preprocessSymlinkDestination(target, type, path),
+             _makeLong(path),
+             _type,
+             req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function unlink(path) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _unlink(_makeLong(path), req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function utimes(path, atime, mtime) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    _utimes(_makeLong(path),
+            toUnixTimestamp(atime),
+            toUnixTimestamp(mtime),
+            req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function writeBuffer(fd, buffer, offset, length, position, req) {
+  if (typeof offset !== 'number')
+    offset = 0;
+  if (typeof length !== 'number')
+    length = buffer.length - offset;
+  if (typeof position !== 'number')
+    position = null;
+
+  if (offset > buffer.length)
+    throw new errors.RangeError('ERR_OUTOFBOUNDS', 'offset');
+  if (length > buffer.length)
+    throw new errors.RangeError('ERR_OUTOFBOUNDS', 'length');
+  if (offset + length < offset)
+    throw new errors.RangeError('ERR_OVERFLOW');
+
+  _writeBuffer(fd, buffer, offset, length, position, req);
+}
+
+function writeString(fd, str, position, encoding, req) {
+  assertEncoding(encoding);
+  if (typeof position !== 'number')
+    position = null;
+  _writeString(fd, `${str}`, position, encoding || 'utf8', req);
+}
+
+function write(fd, buffer, offsetOrPosition, lengthOrEncoding, position) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = promise;
+    req.buffer = buffer; // Retain a reference to buffer
+
+    if (isUint8Array(buffer)) {
+      writeBuffer(fd, buffer, offsetOrPosition,
+                  lengthOrEncoding, position, req);
+    } else {
+      writeString(fd, buffer, offsetOrPosition, lengthOrEncoding, req);
+    }
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+async function writeAll(fd, isUserFd, buffer, offset, length, position) {
+  try {
+    const written = await write(fd, buffer, offset, length, position);
+    if (written === length) {
+      if (!isUserFd)
+        await close(fd);
+    } else {
+      offset += written;
+      length -= written;
+      if (position !== null)
+        position += written;
+      await writeAll(fd, isUserFd, buffer, offset, length, position);
+    }
+    return written;
+  } catch (err) {
+    if (!isUserFd)
+      await close(fd);
+    throw err;
+  }
+}
+
+async function writeFd(fd, data, isUserFd, options, flag) {
+  const buffer = isUint8Array(data) ?
+    data : Buffer.from(`${data}`, options.encoding || 'utf8');
+  const position = /a/.test(flag) ? null : 0;
+  return await writeAll(fd, isUserFd, buffer, 0, buffer.length, position);
+}
+
+async function writeFile(path, data, options) {
+  options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'w' });
+  const flag = options.flag || 'w';
+
+  if (isFd(path)) {
+    return await writeFd(path, data, true, options, flag);
+  } else {
+    const fd = await open(path, flag, options, options.mode);
+    return await writeFd(fd, data, false, options, flag);
+  }
+}
+
+async function appendFile(path, data, options) {
+  options = getOptions(options, { encoding: 'utf8', mode: 0o666, flag: 'a' });
+  options = Object.assign({}, options);
+  if (!options.flag || isFd(path))
+    options.flag = 'a';
+  return await writeFile(path, data, options);
+}
+
+async function truncate(path, len = 0) {
+  if (typeof path === 'number')
+    return await ftruncate(path, len);
+
+  const fd = await open(path, 'r+');
+  try {
+    await ftruncate(fd, len);
+  } finally {
+    await close(fd);
+  }
+}
+
+function read(fd, buffer, offset, length, position) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    if (!isUint8Array(buffer)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                                 ['Buffer', 'Uint8Array']);
+    }
+    if (length === 0) {
+      promiseResolve(promise, { length: 0, buffer });
+      return promise;
+    }
+
+    function wrapper(err, len) {
+      if (err) {
+        promiseReject(promise, err);
+        return;
+      }
+      promiseResolve(promise, { length: len, buffer });
+    }
+
+    if (typeof offset !== 'number')
+      offset = 0;
+    if (typeof length !== 'number')
+      length = buffer.length;
+    if (typeof position !== 'number')
+      position = 0;
+
+    if (offset > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'offset');
+    if (length > buffer.length)
+      throw new errors.RangeError('ERR_OUTOFBOUNDS', 'length');
+
+    const req = new FSReqWrap();
+    req.oncomplete = wrapper;
+
+    _read(fd, buffer, offset, length, position, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function resolveWithStats(promise) {
+  return (err) => {
+    if (err) {
+      promiseReject(promise, err);
+      return;
+    }
+    promiseResolve(promise, statsFromValues());
+  };
+}
+
+function fstat(fd) {
+  const promise = createPromise();
+  try {
+    if (!Number.isInteger(fd) || fd < 0) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd',
+                                 'unsigned integer');
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = resolveWithStats(promise);
+    _fstat(fd, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function lstat(path) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = resolveWithStats(promise);
+    _lstat(_makeLong(path), req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+function stat(path) {
+  const promise = createPromise();
+  try {
+    handleError(path = getPathFromURL(path));
+    nullCheck(path);
+    if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                                 ['string', 'Buffer', 'URL']);
+    }
+    const req = new FSReqWrap();
+    req.oncomplete = resolveWithStats(promise);
+    _stat(_makeLong(path), req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+async function lchmod(path, mode) {
+  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  try {
+    await fchmod(fd, mode);
+  } finally {
+    await close(fd);
+  }
+}
+
+async function lchown(path, uid, gid) {
+  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  try {
+    await fchown(fd, uid, gid);
+  } finally {
+    await close(fd);
+  }
+}
+
+// This uses the fast libuv implementation, not the legacy one that
+// is in fs that we had to revert back to.
+function realpath(path, options) {
+  options = getOptions(options, { encoding: 'utf8' });
+
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const promise = createPromise();
+  const req = new FSReqWrap();
+  req.oncomplete = promise;
+  try {
+    _realpath(_makeLong(path), options.encoding, req);
+  } catch (err) {
+    promiseReject(promise, err);
+  }
+  return promise;
+}
+
+async function readFile(path, options) {
+  options = getOptions(options, { flag: 'r' });
+
+  handleError(path = getPathFromURL(path));
+  nullCheck(path);
+  if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  const fd = isFd(path) ?
+    path :
+    await open(_makeLong(path),
+               stringToFlags(options.flag || 'r'),
+               0o666);
+
+  try {
+    const stat = await fstat(fd);
+
+    const size = stat.isFile() ? stat.size : 0;
+
+    if (size > kMaxLength) {
+      throw new RangeError('File size is greater than possible Buffer: ' +
+                          `0x${kMaxLength.toString(16)} bytes`);
+    }
+
+    // Ok, so if size it known, allocate a buffer that big and read once.
+    // Otherwise, iterate until there is no more data to read, concat
+    // the buffers, and done!
+    let buffer;
+    if (size > 0) {
+      buffer = Buffer.allocUnsafeSlow(size);
+      await read(fd, buffer, 0, size);
+    } else {
+      // The size is not known, just read until there are no more bytes
+      const buffers = [];
+      let bytesRead = 0;
+      do {
+        const buf = Buffer.allocUnsafeSlow(kReadFileBufferLength);
+        bytesRead =
+          (await read(fd, buf, 0, kReadFileBufferLength, null)).length;
+        buffers.push(buf.slice(0, bytesRead));
+      } while (bytesRead > 0);
+      buffer = Buffer.concat(buffers);
+    }
+
+    if (options.encoding)
+      return buffer.toString(options.encoding);
+
+    return buffer;
+  } finally {
+    await close(fd);
+  }
+}
+
+module.exports = {
+  access,
+  appendFile,
+  chmod,
+  chown,
+  close,
+  copyFile,
+  fchmod,
+  fchown,
+  fdatasync,
+  fstat,
+  fsync,
+  ftruncate,
+  futimes,
+  open,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  read,
+  readdir,
+  readFile,
+  readlink,
+  realpath,
+  rename,
+  rmdir,
+  stat,
+  symlink,
+  truncate,
+  unlink,
+  utimes,
+  write,
+  writeFile
+};
+
+if (O_SYMLINK !== undefined) {
+  module.exports.lchmod = lchmod;
+  module.exports.lchown = lchown;
+}

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -236,6 +236,7 @@ E('ERR_INVALID_PROTOCOL', (protocol, expectedProtocol) =>
   `Protocol "${protocol}" not supported. Expected "${expectedProtocol}"`);
 E('ERR_INVALID_REPL_EVAL_CONFIG',
   'Cannot specify both "breakEvalOnSigint" and "eval" for REPL');
+E('ERR_INVALID_SYMLINK_TYPE', 'Invalid symlink type: %s');
 E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support Buffer, Uint8Array or string input: %s');
 E('ERR_INVALID_THIS', 'Value of "this" must be of type %s');
@@ -259,7 +260,9 @@ E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
 E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
+E('ERR_OUTOFBOUNDS', 'The "%s" argument is out of bounds');
 E('ERR_OUTOFMEMORY', 'Out of memory');
+E('ERR_OVERFLOW', 'Overflow error');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
 E('ERR_SERVER_ALREADY_LISTEN',

--- a/lib/internal/fs.js
+++ b/lib/internal/fs.js
@@ -5,6 +5,7 @@ const Writable = require('stream').Writable;
 const errors = require('internal/errors');
 const fs = require('fs');
 const util = require('util');
+const pathModule = require('path');
 
 const {
   O_APPEND,
@@ -14,8 +15,26 @@ const {
   O_RDWR,
   O_SYNC,
   O_TRUNC,
-  O_WRONLY
+  O_WRONLY,
+  S_IFDIR,
+  S_IFBLK,
+  S_IFREG,
+  S_IFCHR,
+  S_IFMT,
+  S_IFLNK,
+  S_IFIFO,
+  S_IFSOCK,
+  UV_FS_SYMLINK_DIR,
+  UV_FS_SYMLINK_JUNCTION
 } = process.binding('constants').fs;
+
+const {
+  getStatValues
+} = process.binding('fs');
+
+const statValues = getStatValues();
+
+const isWindows = process.platform === 'win32';
 
 function assertEncoding(encoding) {
   if (encoding && !Buffer.isEncoding(encoding)) {
@@ -23,8 +42,29 @@ function assertEncoding(encoding) {
   }
 }
 
-function stringToFlags(flags) {
-  if (typeof flags === 'number') {
+function stringToSymlinkType(type = 'file') {
+  if (type != null && typeof type !== 'string') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'type', 'string');
+  }
+  type = type || 'file';
+  var flags = 0;
+  switch (type) {
+    case 'dir':
+      flags |= UV_FS_SYMLINK_DIR;
+      break;
+    case 'junction':
+      flags |= UV_FS_SYMLINK_JUNCTION;
+      break;
+    case 'file':
+      break;
+    default:
+      throw new errors.TypeError('ERR_INVALID_SYMLINK_TYPE', type);
+  }
+  return flags;
+}
+
+function stringToFlags(flags, opt = false) {
+  if (Number.isSafeInteger(flags) && flags >= 0) {
     return flags;
   }
 
@@ -53,7 +93,12 @@ function stringToFlags(flags) {
     case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
   }
 
-  throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'flags', flags);
+  if (opt) {
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'flags', flags);
+  } else {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags',
+                               ['string', 'unsigned integer']);
+  }
 }
 
 // Temporary hack for process.stdout and process.stderr when piped to files.
@@ -95,9 +140,191 @@ SyncWriteStream.prototype.destroy = function() {
   return true;
 };
 
+function nullCheck(path, callback) {
+  if (('' + path).indexOf('\u0000') !== -1) {
+    const er = new errors.Error('ERR_INVALID_ARG_TYPE',
+                                'path',
+                                'string without null bytes',
+                                path);
+
+    if (typeof callback !== 'function')
+      throw er;
+    process.nextTick(callback, er);
+    return false;
+  }
+  return true;
+}
+
+function modeNum(m, def) {
+  if (typeof m === 'number')
+    return m;
+  if (typeof m === 'string')
+    return parseInt(m, 8);
+  if (def)
+    return modeNum(def);
+  return undefined;
+}
+
+// converts Date or number to a fractional UNIX timestamp
+function toUnixTimestamp(time) {
+  // eslint-disable-next-line eqeqeq
+  if (typeof time === 'string' && +time == time) {
+    return +time;
+  }
+  if (Number.isFinite(time)) {
+    if (time < 0) {
+      return Date.now() / 1000;
+    }
+    return time;
+  }
+  if (util.isDate(time)) {
+    // convert to 123.456 UNIX timestamp
+    return time.getTime() / 1000;
+  }
+  throw new errors.Error('ERR_INVALID_ARG_TYPE',
+                         'time',
+                         ['Date', 'time in seconds'],
+                         time);
+}
+
+function getOptions(options, defaultOptions) {
+  if (options === null || options === undefined ||
+      typeof options === 'function') {
+    return defaultOptions;
+  }
+
+  if (typeof options === 'string') {
+    defaultOptions = util._extend({}, defaultOptions);
+    defaultOptions.encoding = options;
+    options = defaultOptions;
+  } else if (typeof options !== 'object') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                               'options',
+                               ['string', 'object'],
+                               options);
+  }
+
+  if (options.encoding !== 'buffer')
+    assertEncoding(options.encoding);
+  return options;
+}
+
+function preprocessSymlinkDestination(path, type, linkPath) {
+  if (!isWindows) {
+    // No preprocessing is needed on Unix.
+    return path;
+  } else if (type === 'junction') {
+    // Junctions paths need to be absolute and \\?\-prefixed.
+    // A relative target is relative to the link's parent directory.
+    path = pathModule.resolve(linkPath, '..', path);
+    return pathModule._makeLong(path);
+  } else {
+    // Windows symlinks don't tolerate forward slashes.
+    return ('' + path).replace(/\//g, '\\');
+  }
+}
+
+// Constructor for file stats.
+function Stats(
+  dev,
+  mode,
+  nlink,
+  uid,
+  gid,
+  rdev,
+  blksize,
+  ino,
+  size,
+  blocks,
+  atim_msec,
+  mtim_msec,
+  ctim_msec,
+  birthtim_msec
+) {
+  this.dev = dev;
+  this.mode = mode;
+  this.nlink = nlink;
+  this.uid = uid;
+  this.gid = gid;
+  this.rdev = rdev;
+  this.blksize = blksize;
+  this.ino = ino;
+  this.size = size;
+  this.blocks = blocks;
+  this.atimeMs = atim_msec;
+  this.mtimeMs = mtim_msec;
+  this.ctimeMs = ctim_msec;
+  this.birthtimeMs = birthtim_msec;
+  this.atime = new Date(atim_msec + 0.5);
+  this.mtime = new Date(mtim_msec + 0.5);
+  this.ctime = new Date(ctim_msec + 0.5);
+  this.birthtime = new Date(birthtim_msec + 0.5);
+}
+
+Stats.prototype._checkModeProperty = function(property) {
+  return ((this.mode & S_IFMT) === property);
+};
+
+Stats.prototype.isDirectory = function() {
+  return this._checkModeProperty(S_IFDIR);
+};
+
+Stats.prototype.isFile = function() {
+  return this._checkModeProperty(S_IFREG);
+};
+
+Stats.prototype.isBlockDevice = function() {
+  return this._checkModeProperty(S_IFBLK);
+};
+
+Stats.prototype.isCharacterDevice = function() {
+  return this._checkModeProperty(S_IFCHR);
+};
+
+Stats.prototype.isSymbolicLink = function() {
+  return this._checkModeProperty(S_IFLNK);
+};
+
+Stats.prototype.isFIFO = function() {
+  return this._checkModeProperty(S_IFIFO);
+};
+
+Stats.prototype.isSocket = function() {
+  return this._checkModeProperty(S_IFSOCK);
+};
+
+function statsFromValues() {
+  return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
+                   statValues[4], statValues[5],
+                   statValues[6] < 0 ? undefined : statValues[6], statValues[7],
+                   statValues[8], statValues[9] < 0 ? undefined : statValues[9],
+                   statValues[10], statValues[11], statValues[12],
+                   statValues[13]);
+}
+
+function statsFromPrevValues() {
+  return new Stats(statValues[14], statValues[15], statValues[16],
+                   statValues[17], statValues[18], statValues[19],
+                   statValues[20] < 0 ? undefined : statValues[20],
+                   statValues[21], statValues[22],
+                   statValues[23] < 0 ? undefined : statValues[23],
+                   statValues[24], statValues[25], statValues[26],
+                   statValues[27]);
+}
+
 module.exports = {
   assertEncoding,
+  getOptions,
+  modeNum,
+  nullCheck,
+  preprocessSymlinkDestination,
+  statsFromValues,
+  statsFromPrevValues,
+  statValues,
   stringToFlags,
+  stringToSymlinkType,
+  Stats,
   SyncWriteStream,
+  toUnixTimestamp,
   realpathCacheKey: Symbol('realpathCacheKey')
 };

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -100,7 +100,11 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
   // History files are conventionally not readable by others:
   // https://github.com/nodejs/node/issues/3392
   // https://github.com/nodejs/node/pull/3394
-  fs.open(historyPath, 'a+', 0o0600, oninit);
+  try {
+    fs.open(historyPath, 'a+', 0o0600, oninit);
+  } catch (err) {
+    oninit(err);
+  }
 
   function oninit(err, hnd) {
     if (err) {

--- a/node.gyp
+++ b/node.gyp
@@ -76,6 +76,7 @@
       'lib/v8.js',
       'lib/vm.js',
       'lib/zlib.js',
+      'lib/internal/async/fs.js',
       'lib/internal/buffer.js',
       'lib/internal/child_process.js',
       'lib/internal/cluster/child.js',

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1164,6 +1164,14 @@ void DefineSystemConstants(Local<Object> target) {
 #ifdef X_OK
   NODE_DEFINE_CONSTANT(target, X_OK);
 #endif
+
+#ifdef UV_FS_SYMLINK_DIR
+  NODE_DEFINE_CONSTANT(target, UV_FS_SYMLINK_DIR);
+#endif
+
+#ifdef UV_FS_SYMLINK_JUNCTION
+  NODE_DEFINE_CONSTANT(target, UV_FS_SYMLINK_JUNCTION);
+#endif
 }
 
 void DefineCryptoConstants(Local<Object> target) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -97,7 +97,7 @@ class FSReqWrap: public ReqWrap<uv_fs_t> {
     Local<Value> promise =
         object()->Get(context, env->oncomplete_string()).ToLocalChecked();
     if (promise->IsPromise()) {
-      if (promise.As<Promise>()->State() != Promise::kPending) return;
+      CHECK_EQ(promise.As<Promise>()->State(), Promise::kPending);
       Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
       resolver->Resolve(context, arg).FromJust();
       return;
@@ -109,7 +109,7 @@ class FSReqWrap: public ReqWrap<uv_fs_t> {
       Local<Value> argv[2];
       argv[0] = Null(env->isolate());
       argv[1] = arg;
-      MakeCallback(env->oncomplete_string(), 2, argv);
+      MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
     }
   }
 
@@ -118,7 +118,7 @@ class FSReqWrap: public ReqWrap<uv_fs_t> {
     Local<Value> promise =
         object()->Get(context, env->oncomplete_string()).ToLocalChecked();
     if (promise->IsPromise()) {
-      if (promise.As<Promise>()->State() != Promise::kPending) return;
+      CHECK_EQ(promise.As<Promise>()->State(), Promise::kPending);
       Local<Promise::Resolver> resolver = promise.As<Promise::Resolver>();
       resolver->Reject(context, arg).FromJust();
       return;

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -81,9 +81,14 @@ fs.access(readOnlyFile, fs.W_OK, common.mustCall((err) => {
   }
 }));
 
-assert.throws(() => {
-  fs.access(100, fs.F_OK, common.mustNotCall());
-}, /^TypeError: path must be a string or Buffer$/);
+common.expectsError(
+  () => fs.access(100, fs.F_OK, common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "path" argument must be one of type string, Buffer, or URL'
+  }
+);
 
 common.expectsError(
   () => {

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -24,9 +24,14 @@ assert.doesNotThrow(() => {
   }));
 });
 
-assert.throws(() => {
-  fs.accessSync(true);
-}, /path must be a string or Buffer/);
+common.expectsError(
+  () => fs.accessSync(true),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "path" argument must be one of type string, Buffer, or URL'
+  }
+);
 
 const dir = Buffer.from(common.fixturesDir);
 fs.readdir(dir, 'hex', common.mustCall((err, hexList) => {

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -136,6 +136,38 @@ if (fs.lchmod) {
   }));
 }
 
+[1, {}, [], true, undefined, null].forEach((i) => {
+  common.expectsError(
+    () => fs.chmodSync(i, 0o664),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }
+  );
+
+  common.expectsError(
+    () => fs.chmod(i, 0o664, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }
+  );
+});
+
+[-1, {}, [], true, undefined, null, Infinity, 'foo'].forEach((i) => {
+  common.expectsError(
+    () => fs.chmod(__filename, i, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "mode" argument must be of type unsigned integer'
+    }
+  );
+  fs.chmodSync(__filename, 0o664);
+});
+
 
 process.on('exit', function() {
   assert.strictEqual(0, openCount);

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+['', {}, -1, true, Infinity, undefined, null].forEach((i) => {
+  common.expectsError(
+    () => fs.closeSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }
+  );
+
+  common.expectsError(
+    () => fs.close(i, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }
+  );
+});

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -69,9 +69,14 @@ common.expectsError(() => {
 });
 
 // Throws if the source path is not a string.
-assert.throws(() => {
-  fs.copyFileSync(null, dest);
-}, /^TypeError: src must be a string$/);
+common.expectsError(
+  () => fs.copyFileSync(null, dest),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "src" argument must be one of type string, Buffer, or URL'
+  }
+);
 
 // Throws if the source path is an invalid path.
 common.expectsError(() => {
@@ -84,9 +89,14 @@ common.expectsError(() => {
 });
 
 // Throws if the destination path is not a string.
-assert.throws(() => {
-  fs.copyFileSync(src, null);
-}, /^TypeError: dest must be a string$/);
+common.expectsError(
+  () => fs.copyFileSync(src, null),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "dest" argument must be one of type string, Buffer, or URL'
+  }
+);
 
 // Throws if the destination path is an invalid path.
 common.expectsError(() => {

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -34,7 +34,15 @@ fs.exists(`${f}-NO`, common.mustCall(function(y) {
   assert.strictEqual(y, false);
 }));
 
-fs.exists(new URL('https://foo'), common.mustCall(function(y) {
+common.expectsError(
+  () => fs.exists(new URL('https://foo'), common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }
+);
+fs.exists(new URL(`file://${f}-NO`), common.mustCall(function(y) {
   assert.strictEqual(y, false);
 }));
 

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -21,16 +21,38 @@ fs.link(srcPath, dstPath, common.mustCall(callback));
 
 // test error outputs
 
-assert.throws(
-  function() {
-    fs.link();
-  },
-  /src must be a string or Buffer/
+common.expectsError(
+  () => fs.linkSync(),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "src" argument must be one of type string, Buffer, or URL'
+  }
 );
 
-assert.throws(
-  function() {
-    fs.link('abc');
-  },
-  /dest must be a string or Buffer/
+common.expectsError(
+  () => fs.linkSync('abc'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "dest" argument must be one of type string, Buffer, or URL'
+  }
+);
+
+common.expectsError(
+  () => fs.link(undefined, undefined, common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "src" argument must be one of type string, Buffer, or URL'
+  }
+);
+
+common.expectsError(
+  () => fs.link('abc', undefined, common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "dest" argument must be one of type string, Buffer, or URL'
+  }
 );

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -60,21 +60,21 @@ assert.strictEqual(stringToFlags('xa+'), O_APPEND | O_CREAT | O_RDWR | O_EXCL);
   .forEach(function(flags) {
     common.expectsError(
       () => stringToFlags(flags),
-      { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
+      { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
     );
   });
 
 common.expectsError(
   () => stringToFlags({}),
-  { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
+  { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
 );
 
 common.expectsError(
   () => stringToFlags(true),
-  { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
+  { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
 );
 
 common.expectsError(
   () => stringToFlags(null),
-  { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
+  { code: 'ERR_INVALID_ARG_TYPE', type: TypeError }
 );

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -43,3 +43,40 @@ fs.open(__filename, 'r', common.mustCall((err) => {
 fs.open(__filename, 'rs', common.mustCall((err) => {
   assert.ifError(err);
 }));
+
+[-1, {}, [], null, undefined, Infinity, true].forEach((i) => {
+  common.expectsError(
+    () => fs.openSync(i, 'r'),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }
+  );
+  common.expectsError(
+    () => fs.open(i, 'r', common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }
+  );
+  common.expectsError(
+    () => fs.openSync(__filename, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message:
+        'The "flags" argument must be one of type string or unsigned integer'
+    }
+  );
+  common.expectsError(
+    () => fs.open(__filename, i, common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message:
+        'The "flags" argument must be one of type string or unsigned integer'
+    }
+  );
+});

--- a/test/parallel/test-fs-promise-access.js
+++ b/test/parallel/test-fs-promise-access.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const common = require('../common');
+const { async: fs, F_OK } = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+
+const goodurl = new URL(`file://${__filename}`);
+const badurl = new URL(`file://${__filename}-NO`);
+const nullurl = new URL(`file://${__filename}-%00NO`);
+const invalidurl = new URL(`http://${__filename}`);
+
+common.crashOnUnhandledRejection();
+
+// Access this file, known to exist. Must not fail.
+fs.access(__filename)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(goodurl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(__filename, F_OK)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(goodurl, F_OK)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(__dirname)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(__dirname, F_OK)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(`${__filename}-NO`)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, access '${__filename}-NO'`
+  }));
+
+fs.access(badurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, access '${__filename}-NO'`
+  }));
+
+fs.access(nullurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.access(invalidurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+fs.access(Buffer.from(__filename))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.access(Buffer.from(`${__filename}-NO`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, access '${__filename}-NO'`
+  }));
+
+[1, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  fs.access(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});
+
+[{}, [], Infinity, null, true].forEach((i) => {
+  fs.access(__filename, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "mode" argument must be of type integer'
+    }));
+});

--- a/test/parallel/test-fs-promise-chmod.js
+++ b/test/parallel/test-fs-promise-chmod.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+const mode = common.isWindows ? 0o600 : 0o644;
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+closeSync(openSync(file, 'w'));
+
+// fchmod
+async function test(file, mode) {
+  const fd = await fs.open(file, 'w');
+  await fs.fchmod(fd, mode);
+  await fs.close(fd);
+}
+
+test(file, mode)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, file, {}, [], Infinity, true].forEach((i) => {
+  fs.fchmod(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});
+
+// chmod
+const goodurl = new URL(`file://${file}`);
+const badurl = new URL(`file://${file}-NO`);
+const nullurl = new URL(`file://${file}-%00NO`);
+const invalidurl = new URL(`http://${file}`);
+
+fs.chmod(file, mode)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(Buffer.from(file), mode)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(file, mode.toString(8))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(Buffer.from(file), mode.toString(8))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(goodurl, mode)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(goodurl, mode.toString(8))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chmod(badurl, mode)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, chmod '${file}-NO'`
+  }));
+
+fs.chmod(nullurl, mode)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.chmod(invalidurl, mode)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[1, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  fs.chmod(i, mode)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});
+
+['', -1, null, {}, [], Infinity, true, '-1'].forEach((i) => {
+  fs.chmod(file, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "mode" argument must be of type unsigned integer'
+    }));
+});

--- a/test/parallel/test-fs-promise-chown.js
+++ b/test/parallel/test-fs-promise-chown.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const common = require('../common');
+if (common.isWindows)
+  common.skip('unsupported on windows');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+const uid = process.getuid();
+const gid = process.getgid();
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+closeSync(openSync(file, 'w'));
+
+// fchown
+
+async function test(file) {
+  const fd = await fs.open(file, 'w');
+
+  [file, {}, [], null, undefined, true, Infinity].forEach((i) => {
+    fs.fchown(fd, i, gid)
+      .then(common.mustNotCall())
+      .catch(common.expectsError({
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "uid" argument must be of type integer'
+      }));
+    fs.fchown(fd, uid, i)
+      .then(common.mustNotCall())
+      .catch(common.expectsError({
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "gid" argument must be of type integer'
+      }));
+  });
+
+  await fs.close(fd);
+}
+
+test(file)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, file, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  fs.fchown(i, uid, gid)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});
+
+// chown
+
+const goodurl = new URL(`file://${file}`);
+const badurl = new URL(`file://${file}-NO`);
+const nullurl = new URL(`file://${file}-%00NO`);
+const invalidurl = new URL(`http://${file}`);
+
+fs.chown(file, uid, gid)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chown(Buffer.from(file), uid, gid)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chown(goodurl, uid, gid)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.chown(badurl, uid, gid)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, chown '${file}-NO'`
+  }));
+
+fs.chown(nullurl, uid, gid)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.chown(invalidurl, uid, gid)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[1, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  fs.chown(i, uid, gid)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});
+
+['', null, {}, [], Infinity, true, '-1'].forEach((i) => {
+  fs.chown(file, i, gid)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "uid" argument must be of type integer'
+    }));
+});
+
+['', null, {}, [], Infinity, true, '-1'].forEach((i) => {
+  fs.chown(file, uid, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "gid" argument must be of type integer'
+    }));
+});

--- a/test/parallel/test-fs-promise-copyfile.js
+++ b/test/parallel/test-fs-promise-copyfile.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync,
+  constants
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+const { COPYFILE_EXCL, UV_FS_COPYFILE_EXCL } = constants;
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+const dest = path.join(common.tmpDir, 'b.js');
+closeSync(openSync(src, 'w'));
+
+const goodsrcurl = new URL(`file://${src}`);
+const badsrcurl = new URL(`file://${src}-NO`);
+const nullsrcurl = new URL(`file://${src}-%00NO`);
+const invalidsrcurl = new URL(`http://${src}`);
+
+const gooddesturl = new URL(`file://${dest}`);
+const nulldesturl = new URL(`file://${dest}-%00NO`);
+const invaliddesturl = new URL(`http://${dest}`);
+
+fs.copyFile(src, dest)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(src, dest, COPYFILE_EXCL)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'EEXIST',
+    type: Error,
+    message: `EEXIST: file already exists, copyfile '${src}' -> '${dest}'`
+  }));
+
+fs.copyFile(src, dest, UV_FS_COPYFILE_EXCL)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'EEXIST',
+    type: Error,
+    message: `EEXIST: file already exists, copyfile '${src}' -> '${dest}'`
+  }));
+
+fs.copyFile(Buffer.from(src), dest)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(src, Buffer.from(dest))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(goodsrcurl, dest)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(goodsrcurl, gooddesturl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(src, gooddesturl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(Buffer.from(src), gooddesturl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.copyFile(badsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message:
+      `ENOENT: no such file or directory, copyfile '${src}-NO' -> '${dest}'`
+  }));
+
+fs.copyFile(nullsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.copyFile(src, nulldesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.copyFile(invalidsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+fs.copyFile(src, invaliddesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[-1, {}, [], Infinity, true, null, undefined].forEach((i) => {
+  fs.copyFile(i, dest)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "src" argument must be one of type string, Buffer, or URL'
+    }));
+
+  fs.copyFile(src, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "dest" argument must be one of type string, Buffer, or URL'
+    }));
+});

--- a/test/parallel/test-fs-promise-fdatasync.js
+++ b/test/parallel/test-fs-promise-fdatasync.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+closeSync(openSync(file, 'w'));
+
+async function test(method, file) {
+  const fd = await fs.open(file, 'w');
+  await method(fd);
+}
+
+test(fs.fdatasync, file)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(fs.fsync, file)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, {}, [], '-1', null, undefined, Infinity].forEach((i) => {
+  fs.fdatasync(i)
+    .then(common.mustNotCall)
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+  fs.fsync(i)
+    .then(common.mustNotCall)
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});

--- a/test/parallel/test-fs-promise-ftruncate.js
+++ b/test/parallel/test-fs-promise-ftruncate.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const path = require('path');
+const {
+  Buffer
+} = require('buffer');
+const {
+  URL
+} = require('url');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+closeSync(openSync(file, 'w'));
+
+async function test(file, len) {
+  const fd = await fs.open(file, 'w');
+  try {
+    await fs.ftruncate(fd, len);
+  } finally {
+    await fs.close(fd);
+  }
+}
+
+async function test2(file, len) {
+  await fs.truncate(file, len);
+}
+
+test(file, 0)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(file, 1)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, {}, [], '-1', Infinity].forEach((i) => {
+  fs.ftruncate(i)
+    .then(common.mustNotCall)
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+
+  test(file, i)
+    .then(common.mustNotCall)
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "len" argument must be of type unsigned integer'
+    }));
+
+  test2(file, i)
+    .then(common.mustNotCall)
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "len" argument must be of type unsigned integer'
+    }));
+});
+
+test2(file, 0)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test2(Buffer.from(file), 0)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test2(new URL(`file://${file}`), 0)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());

--- a/test/parallel/test-fs-promise-link.js
+++ b/test/parallel/test-fs-promise-link.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+const dest = path.join(common.tmpDir, 'b.js');
+closeSync(openSync(src, 'w'));
+
+const goodsrcurl = new URL(`file://${src}`);
+const badsrcurl = new URL(`file://${src}-NO`);
+const nullsrcurl = new URL(`file://${src}-%00NO`);
+const invalidsrcurl = new URL(`http://${src}`);
+
+const gooddesturl = new URL(`file://${dest}-4`);
+const nulldesturl = new URL(`file://${dest}-%00NO`);
+const invaliddesturl = new URL(`http://${dest}`);
+
+async function test(src, dest) {
+  await fs.link(src, dest);
+  await fs.unlink(dest);
+}
+
+test(src, `${dest}-1`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(src), `${dest}-2`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(goodsrcurl, `${dest}-3`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(src, gooddesturl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(goodsrcurl, Buffer.from(`${dest}-5`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.link(badsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message:
+      `ENOENT: no such file or directory, link '${src}-NO' -> '${dest}'`
+  }));
+
+fs.link(nullsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.link(src, nulldesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.link(invalidsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+fs.link(src, invaliddesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[-1, {}, [], Infinity, true, null, undefined].forEach((i) => {
+  fs.unlink(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+
+  fs.link(i, dest)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "src" argument must be one of type string, Buffer, or URL'
+    }));
+
+  fs.link(src, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "dest" argument must be one of type string, Buffer, or URL'
+    }));
+});

--- a/test/parallel/test-fs-promise-mkdir.js
+++ b/test/parallel/test-fs-promise-mkdir.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const dir = path.join(common.tmpDir, 'foo');
+
+// mkdir
+const goodurl = new URL(`file://${dir}-2`);
+const nullurl = new URL(`file://${dir}-%00NO`);
+const invalidurl = new URL(`http://${dir}`);
+
+async function test(dir) {
+  await fs.mkdir(dir);
+  await fs.rmdir(dir);
+}
+
+test(dir)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(`${dir}-1`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(goodurl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(nullurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+test(invalidurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[1, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  test(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});

--- a/test/parallel/test-fs-promise-mkdtemp.js
+++ b/test/parallel/test-fs-promise-mkdtemp.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+fs.mkdtemp(`${common.tmpDir}-`)
+  .then(fs.rmdir)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.mkdtemp(`${common.tmpDir}-`, 'buffer')
+  .then(fs.rmdir)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.mkdtemp(`${common.tmpDir}-`, { encoding: 'buffer' })
+  .then(fs.rmdir)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, null, undefined, {}, [], Infinity, true].forEach((i) => {
+  fs.mkdtemp(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "prefix" argument must be of type string'
+    }));
+});

--- a/test/parallel/test-fs-promise-open-close.js
+++ b/test/parallel/test-fs-promise-open-close.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+//closeSync(openSync(file, 'w'));
+
+const goodurl = new URL(`file://${file}`);
+const badurl = new URL(`file://${file}-NO`);
+const nullurl = new URL(`file://${file}-%00NO`);
+const invalidurl = new URL(`http://${file}`);
+
+async function test(path, mode = 'w') {
+  await fs.close(await fs.open(path, mode));
+}
+
+test(file)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(file))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(goodurl)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(badurl, 'r')
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, open '${file}-NO'`
+  }));
+
+test(nullurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+test(invalidurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[1, {}, [], true, Infinity, null, undefined].forEach((i) => {
+  fs.open(i, 'w')
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});
+
+[-1, {}, [], true, Infinity, null, '-1'].forEach((i) => {
+  fs.open(file, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message:
+        'The "flags" argument must be one of type string or unsigned integer'
+    }));
+});
+
+['a', -1, '-1', {}, [], true, Infinity, null, undefined].forEach((i) => {
+  fs.close(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});

--- a/test/parallel/test-fs-promise-read-write-file.js
+++ b/test/parallel/test-fs-promise-read-write-file.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+const assert = require('assert');
+const {
+  Buffer
+} = require('buffer');
+const {
+  URL
+} = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+
+async function test(path, data) {
+  await fs.writeFile(path, data.slice(0, -2));
+  await fs.appendFile(path, data.slice(-2));
+  const content = await fs.readFile(path);
+  if (typeof data === 'string') {
+    assert.strictEqual(data, content.toString());
+  } else {
+    assert.deepStrictEqual(data, content);
+  }
+}
+
+test(src, 'testing')
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(`${src}-1`, Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(`${src}-2`), Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(new URL(`file://${src}-3`), Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());

--- a/test/parallel/test-fs-promise-read.js
+++ b/test/parallel/test-fs-promise-read.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  readFileSync
+} = require('fs');
+const assert = require('assert');
+const {
+  Buffer
+} = require('buffer');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const content = readFileSync(__filename, 'utf8');
+
+async function test(input) {
+  const fd = await fs.open(input, 'r');
+  try {
+    const stat = await fs.fstat(fd);
+    const buffer = Buffer.allocUnsafeSlow(stat.size);
+    await fs.read(fd, buffer);
+    assert.strictEqual(content, buffer.toString('utf8'));
+  } finally {
+    await fs.close(fd);
+  }
+}
+
+test(__filename)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());

--- a/test/parallel/test-fs-promise-readdir.js
+++ b/test/parallel/test-fs-promise-readdir.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+const {
+  Buffer
+} = require('buffer');
+const {
+  URL
+} = require('url');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+fs.readdir(common.fixturesDir)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.readdir(Buffer.from(common.fixturesDir))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.readdir(new URL(`file://${common.fixturesDir}`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.readdir(`${common.fixturesDir}-NO`)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message:
+      `ENOENT: no such file or directory, scandir '${common.fixturesDir}-NO'`
+  }));
+
+fs.readdir(Buffer.from(`${common.fixturesDir}-NO`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message:
+      `ENOENT: no such file or directory, scandir '${common.fixturesDir}-NO'`
+  }));
+
+fs.readdir(new URL(`file://${common.fixturesDir}-NO`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message:
+      `ENOENT: no such file or directory, scandir '${common.fixturesDir}-NO'`
+  }));
+
+fs.readdir(`${common.fixturesDir}-\u0000NO`)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.readdir(Buffer.from(`${common.fixturesDir}-\u0000NO`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type object'
+  }));
+
+fs.readdir(new URL(`file://${common.fixturesDir}-\u0000NO`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));

--- a/test/parallel/test-fs-promise-rename.js
+++ b/test/parallel/test-fs-promise-rename.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+const dest = path.join(common.tmpDir, 'b.js');
+closeSync(openSync(src, 'w'));
+
+const nullurl = new URL(`file://${src}-%00NO`);
+const invalidurl = new URL(`http://${src}`);
+
+async function test(s, d) {
+  closeSync(openSync(s, 'w'));
+  await fs.rename(s, d);
+}
+
+test(src, dest)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(`${src}-1`), `${dest}-1`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(`${src}-2`, Buffer.from(`${dest}-2`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(new URL(`file://${src}-3`), `${dest}-3`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(`${src}-4`, new URL(`file://${dest}-1`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.rename(nullurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.rename(src, nullurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.rename(invalidurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+fs.rename(src, invalidurl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));

--- a/test/parallel/test-fs-promise-stat.js
+++ b/test/parallel/test-fs-promise-stat.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  Stats
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const assert = require('assert');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+async function test(method, input, open = false) {
+  if (open) {
+    input = await fs.open(input, 'r');
+  }
+  try {
+    const stats = await method(input);
+    assert(stats instanceof Stats);
+  } finally {
+    if (open)
+      await fs.close(input);
+  }
+}
+
+test(fs.fstat, __filename, true);
+
+[-1, {}, [], Infinity, null, undefined, 'hello'].forEach((i) => {
+  fs.fstat(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});
+
+test(fs.stat, __filename)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(fs.stat, Buffer.from(__filename))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(fs.stat, new URL(`file://${__filename}`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(fs.stat, `${__filename}-NO`)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, stat '${__filename}-NO'`
+  }));
+
+test(fs.stat, `${__filename}-\u0000`)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+test(fs.stat, new URL(`file://${__filename}-%00`))
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+[-1, {}, [], Infinity, undefined, null, true].forEach((i) => {
+  test(fs.stat, i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});

--- a/test/parallel/test-fs-promise-symlinks.js
+++ b/test/parallel/test-fs-promise-symlinks.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const common = require('../common');
+if (!common.canCreateSymLink())
+  common.skip('insufficient privileges');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const assert = require('assert');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+const dest = path.join(common.tmpDir, 'b.js');
+closeSync(openSync(src, 'w'));
+
+const nullsrcurl = new URL(`file://${src}-%00NO`);
+const invalidsrcurl = new URL(`http://${src}`);
+
+const nulldesturl = new URL(`file://${dest}-%00NO`);
+const invaliddesturl = new URL(`http://${dest}`);
+
+async function test(s, d) {
+  await fs.symlink(s, d);
+  assert.strictEqual(src, await fs.readlink(d));
+  assert.strictEqual(src, await fs.realpath(d));
+}
+
+test(src, dest)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(src), `${dest}-1`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(src, Buffer.from(`${dest}-2`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(new URL(`file://${src}`), `${dest}-3`)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(src, new URL(`file://${dest}-4`))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(nullsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+test(invalidsrcurl, dest)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+test(src, nulldesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+test(src, invaliddesturl)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));

--- a/test/parallel/test-fs-promise-utimes.js
+++ b/test/parallel/test-fs-promise-utimes.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs,
+  closeSync,
+  openSync
+} = require('fs');
+const { Buffer } = require('buffer');
+const { URL } = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+const date = new Date();
+
+common.refreshTmpDir();
+
+const file = path.join(common.tmpDir, 'a.js');
+closeSync(openSync(file, 'w'));
+
+// futimes
+async function test(file) {
+  const fd = await fs.open(file, 'w');
+  await fs.futimes(fd, date, date);
+  await fs.close(fd);
+}
+
+test(file)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+[-1, file, {}, [], Infinity, true].forEach((i) => {
+  fs.fchmod(i)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type unsigned integer'
+    }));
+});
+
+// utimes
+const goodurl = new URL(`file://${file}`);
+const badurl = new URL(`file://${file}-NO`);
+const nullurl = new URL(`file://${file}-%00NO`);
+const invalidurl = new URL(`http://${file}`);
+
+fs.utimes(file, date, date)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(Buffer.from(file), date, date)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(goodurl, date, date)
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(file, date.valueOf(), date.valueOf())
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(Buffer.from(file), date.valueOf(), date.valueOf())
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(goodurl, date.valueOf(), date.valueOf())
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+fs.utimes(badurl, date, date)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ENOENT',
+    type: Error,
+    message: `ENOENT: no such file or directory, utime '${file}-NO'`
+  }));
+
+fs.utimes(nullurl, date, date)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error,
+    message: 'The "path" argument must be of type string without null bytes. ' +
+             'Received type string'
+  }));
+
+fs.utimes(invalidurl, date, date)
+  .then(common.mustNotCall())
+  .catch(common.expectsError({
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }));
+
+[1, {}, [], Infinity, null, undefined, true].forEach((i) => {
+  fs.utimes(i, date, date)
+    .then(common.mustNotCall())
+    .catch(common.expectsError({
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "path" argument must be one of type string, Buffer, or URL'
+    }));
+});

--- a/test/parallel/test-fs-promise-write.js
+++ b/test/parallel/test-fs-promise-write.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+const {
+  async: fs
+} = require('fs');
+const assert = require('assert');
+const {
+  Buffer
+} = require('buffer');
+const {
+  URL
+} = require('url');
+const path = require('path');
+
+common.crashOnUnhandledRejection();
+
+common.refreshTmpDir();
+
+const src = path.join(common.tmpDir, 'a.js');
+
+async function test(path, data) {
+  const fd = await fs.open(path, 'w+');
+  try {
+    await fs.write(fd, data);
+    const buffer = Buffer.allocUnsafeSlow(data.length);
+    await fs.read(fd, buffer);
+    if (typeof data === 'string') {
+      assert.strictEqual(data, buffer.toString());
+    } else {
+      assert.deepStrictEqual(data, buffer);
+    }
+  } finally {
+    await fs.close(fd);
+  }
+}
+
+test(src, 'testing')
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(`${src}-1`, Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(Buffer.from(`${src}-2`), Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());
+
+test(new URL(`file://${src}-3`), Buffer.from('testing'))
+  .then(common.mustCall())
+  .catch(common.mustNotCall());

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
@@ -9,14 +8,20 @@ const fd = fs.openSync(filepath, 'r');
 const expected = 'xyz\n';
 
 // Error must be thrown with string
-assert.throws(() => {
-  fs.read(fd,
-          expected.length,
-          0,
-          'utf-8',
-          common.mustNotCall());
-}, /^TypeError: Second argument needs to be a buffer$/);
+common.expectsError(
+  () => fs.read(fd, expected.length, 0, 'utf-8', common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+  }
+);
 
-assert.throws(() => {
-  fs.readSync(fd, expected.length, 0, 'utf-8');
-}, /^TypeError: Second argument needs to be a buffer$/);
+common.expectsError(
+  () => fs.readSync(fd, expected.length, 0, 'utf-8'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+  }
+);

--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -28,46 +28,55 @@ fs.readFile(url, common.mustCall((err, data) => {
 
 // Check that using a non file:// URL reports an error
 const httpUrl = new URL('http://example.org');
-fs.readFile(httpUrl, common.expectsError({
-  code: 'ERR_INVALID_URL_SCHEME',
-  type: TypeError,
-  message: 'The URL must be of scheme file'
-}));
+common.expectsError(
+  () => fs.readFile(httpUrl, common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_URL_SCHEME',
+    type: TypeError,
+    message: 'The URL must be of scheme file'
+  }
+);
 
 // pct-encoded characters in the path will be decoded and checked
-fs.readFile(new URL('file:///c:/tmp/%00test'), common.mustCall((err) => {
-  common.expectsError(
-    () => {
-      throw err;
-    },
-    {
-      code: 'ERR_INVALID_ARG_TYPE',
-      type: Error
-    });
-}));
+common.expectsError(
+  () => fs.readFile(new URL('file:///c:/tmp/%00test'), common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: Error
+  }
+);
 
 if (common.isWindows) {
   // encoded back and forward slashes are not permitted on windows
   ['%2f', '%2F', '%5c', '%5C'].forEach((i) => {
-    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.expectsError({
-      code: 'ERR_INVALID_FILE_URL_PATH',
-      type: TypeError,
-      message: 'File URL path must not include encoded \\ or / characters'
-    }));
+    common.expectsError(
+      () => fs.readFile(new URL(`file:///c:/tmp/${i}`), common.mustNotCall()),
+      {
+        code: 'ERR_INVALID_FILE_URL_PATH',
+        type: TypeError,
+        message: 'File URL path must not include encoded \\ or / characters'
+      }
+    );
   });
 } else {
   // encoded forward slashes are not permitted on other platforms
   ['%2f', '%2F'].forEach((i) => {
-    fs.readFile(new URL(`file:///c:/tmp/${i}`), common.expectsError({
-      code: 'ERR_INVALID_FILE_URL_PATH',
-      type: TypeError,
-      message: 'File URL path must not include encoded / characters'
-    }));
+    common.expectsError(
+      () => fs.readFile(new URL(`file:///c:/tmp/${i}`), common.mustNotCall()),
+      {
+        code: 'ERR_INVALID_FILE_URL_PATH',
+        type: TypeError,
+        message: 'File URL path must not include encoded / characters'
+      }
+    );
   });
 
-  fs.readFile(new URL('file://hostname/a/b/c'), common.expectsError({
-    code: 'ERR_INVALID_FILE_URL_HOST',
-    type: TypeError,
-    message: `File URL host must be "localhost" or empty on ${os.platform()}`
-  }));
+  common.expectsError(
+    () => fs.readFile(new URL('file://hostname/a/b/c'), common.mustNotCall()),
+    {
+      code: 'ERR_INVALID_FILE_URL_HOST',
+      type: TypeError,
+      message: `File URL host must be "localhost" or empty on ${os.platform()}`
+    }
+  );
 }


### PR DESCRIPTION
Introduces an experimental promises API for the fs module. The API is accessible via `fs.async`, e.g.

This is intended to land as *Experimental*.

```js
const { async:fs } = require('fs');

fs.access('.')
  .then(console.log)
  .catch(console.error);
```

Most fs functions are supported. There are some variations from
the base fs module (for instance, `fs.async.realpath()` uses the
faster libuv realpath implementation rather than the slower js
implementation.

This does not yet include documentation updates.

Semver-major because this makes substantive changes to error handling in the existing `fs` module.

Benchmarks are included. For instance,

access
```
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-access.js
fs/promises-access.js method="legacy" n=200000: 280,078.9048933864
fs/promises-access.js method="promisify" n=200000: 69,310.04884236863
fs/promises-access.js method="promise" n=200000: 240,928.00098102028
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-access.js
fs/promises-access.js method="legacy" n=200000: 236,062.80841465757
fs/promises-access.js method="promisify" n=200000: 82,258.05538216804
fs/promises-access.js method="promise" n=200000: 192,776.68164314007
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-access.js
fs/promises-access.js method="legacy" n=200000: 112,929.07886994253
fs/promises-access.js method="promisify" n=200000: 136,272.83764802708
fs/promises-access.js method="promise" n=200000: 169,612.60194223037
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-access.js
fs/promises-access.js method="legacy" n=200000: 163,294.66290369138
fs/promises-access.js method="promisify" n=200000: 119,130.69228308211
fs/promises-access.js method="promise" n=200000: 185,855.53426089959
```

copyFile
```
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 282,755.1240812897
fs/promises-copyfile.js method="promisify" n=20000: 166,754.91197646034
fs/promises-copyfile.js method="promise" n=20000: 101,068.59267154362
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 264,452.6619289267
fs/promises-copyfile.js method="promisify" n=20000: 84,065.33716046945
fs/promises-copyfile.js method="promise" n=20000: 100,486.89215315646
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 270,616.2934281645
fs/promises-copyfile.js method="promisify" n=20000: 156,420.93141688287
fs/promises-copyfile.js method="promise" n=20000: 103,760.93116221747
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 251,781.945806882
fs/promises-copyfile.js method="promisify" n=20000: 118,330.0739314469
fs/promises-copyfile.js method="promise" n=20000: 266,315.20161791815
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 106,352.46687950206
fs/promises-copyfile.js method="promisify" n=20000: 120,297.63535689937
fs/promises-copyfile.js method="promise" n=20000: 260,925.24326093044
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 283,371.8168790678
fs/promises-copyfile.js method="promisify" n=20000: 154,272.6477009993
fs/promises-copyfile.js method="promise" n=20000: 177,795.42772743877
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 116,029.27694807078
fs/promises-copyfile.js method="promisify" n=20000: 154,155.65571356818
fs/promises-copyfile.js method="promise" n=20000: 92,732.89058694763
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 286,576.9026610743
fs/promises-copyfile.js method="promisify" n=20000: 69,093.89846983271
fs/promises-copyfile.js method="promise" n=20000: 83,583.96891906712
james@ubuntu:~/node/node$ ./node --no-warnings benchmark/fs/promises-copyfile.js
fs/promises-copyfile.js method="legacy" n=20000: 123,446.49834316899
fs/promises-copyfile.js method="promisify" n=20000: 157,543.37448739127
fs/promises-copyfile.js method="promise" n=20000: 150,655.3488844555
```

As illustrated by the benchmarks, the promise versions *can* be faster than the traditional callbacks, but the results are inconsistent. This appears largely to do with gc (there are a lot of promise objects created that need to be cleaned up).

Having the Promise version does not obsolete the callback version, as the creation and management of the promise objects can be fairly expensive.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
