### PR TITLE
deps: define BUILDING_NGHTTP2 during nghttp2 build

### DIFF
--- a/deps/nghttp2/nghttp2.gyp
+++ b/deps/nghttp2/nghttp2.gyp
@@ -9,13 +9,16 @@
       'target_name': 'nghttp2',
       'type': 'static_library',
       'include_dirs': ['lib/includes'],
+      'defines': [
+        'BUILDING_NGHTTP2',
+        'NGHTTP2_STATICLIB',
+      ],
       'conditions': [
         ['OS=="win"', {
           'defines': [
             'WIN32',
             '_WINDOWS',
             'HAVE_CONFIG_H',
-            'NGHTTP2_STATICLIB',
           ],
           'msvs_settings': {
             'VCCLCompilerTool': {
@@ -28,6 +31,7 @@
         }]
       ],
       'direct_dependent_settings': {
+        'defines': [ 'NGHTTP2_STATICLIB' ],
         'include_dirs': [ 'lib/includes' ]
       },
       'sources': [

--- a/node.gyp
+++ b/node.gyp
@@ -301,8 +301,6 @@
         'NODE_WANT_INTERNALS=1',
         # Warn when using deprecated V8 APIs.
         'V8_DEPRECATION_WARNINGS=1',
-        # We're using the nghttp2 static lib
-        'NGHTTP2_STATICLIB'
       ],
     },
     {


### PR DESCRIPTION
Define BUILDING_NGHTTP2 in order that NGHTTP2_EXTERN is properly defined
when building the nghttp2 static library.

Move NGHTTP2_STATICLIB out of node.gyp because it is a property of the
nghttp2 static library, not the node executable.

CI: https://ci.nodejs.org/job/node-test-pull-request/10159/
