### PR TITLE
test: expand http2 util test coverage for headers

### DIFF
--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -11,7 +11,8 @@ const server = h2.createServer();
 
 const setCookie = [
   'a=b',
-  'c=d; Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly'
+  'c=d; Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly',
+  'e=f'
 ];
 
 // we use the lower-level API here

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -261,4 +261,10 @@ const regex =
   })(mapToHeaders({ [name]: 'abc' }));
 });
 
+common.expectsError({
+  code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
+  message: regex
+})(mapToHeaders({ [HTTP2_HEADER_TE]: ['abc'] }));
+
 assert(!(mapToHeaders({ te: 'trailers' }) instanceof Error));
+assert(!(mapToHeaders({ te: ['trailers'] }) instanceof Error));


### PR DESCRIPTION
This PR expands existing test cases to hit some additional branches of `toHeaderObject` and `mapToHeaders`.

Thanks in advance for the reviews & any feedback!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test