### PR TITLE
deps: v8: fix potential segfault in profiler

### DIFF
--- a/deps/v8/src/profiler/sampling-heap-profiler.h
+++ b/deps/v8/src/profiler/sampling-heap-profiler.h
@@ -172,8 +172,11 @@ class SamplingAllocationObserver : public AllocationObserver {
   void Step(int bytes_allocated, Address soon_object, size_t size) override {
     USE(heap_);
     DCHECK(heap_->gc_state() == Heap::NOT_IN_GC);
-    DCHECK(soon_object);
-    profiler_->SampleObject(soon_object, size);
+    if (soon_object) {
+      // TODO(ofrobots): it would be better to sample the next object rather
+      // than skipping this sample epoch if soon_object happens to be null.
+      profiler_->SampleObject(soon_object, size);
+    }
   }
 
   intptr_t GetNextStepSize() override { return GetNextSampleInterval(rate_); }


### PR DESCRIPTION
This change fixes a potential segfault in the sampling heap profiler.
This landed as part of a larger change upstream (https://github.com/v8/v8/commit/ec952aaa68b12e8448c123b5252efa3afa440ceb). This is the minimal
backport that avoids the segfault.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps: v8

CI: https://ci.nodejs.org/job/node-test-pull-request/10165/
V8-CI: https://ci.nodejs.org/job/node-test-commit-v8-linux/918/