### PR TITLE
[v6.x backport] http: eliminate capture of ClientRequest in Agent

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -206,37 +206,41 @@ Agent.prototype.createSocket = function(req, options, cb) {
     }
     self.sockets[name].push(s);
     debug('sockets', name, self.sockets[name].length);
-
-    function onFree() {
-      self.emit('free', s, options);
-    }
-    s.on('free', onFree);
-
-    function onClose(err) {
-      debug('CLIENT socket onClose');
-      // This is the only place where sockets get removed from the Agent.
-      // If you want to remove a socket from the pool, just close it.
-      // All socket errors end in a close event anyway.
-      self.removeSocket(s, options);
-    }
-    s.on('close', onClose);
-
-    function onRemove() {
-      // We need this function for cases like HTTP 'upgrade'
-      // (defined by WebSockets) where we need to remove a socket from the
-      // pool because it'll be locked up indefinitely
-      debug('CLIENT socket onRemove');
-      self.removeSocket(s, options);
-      s.removeListener('close', onClose);
-      s.removeListener('free', onFree);
-      s.removeListener('agentRemove', onRemove);
-    }
-    s.on('agentRemove', onRemove);
+    installListeners(self, s, options);
     cb(null, s);
   }
 };
 
-Agent.prototype.removeSocket = function(s, options) {
+function installListeners(agent, s, options) {
+  function onFree() {
+    debug('CLIENT socket onFree');
+    agent.emit('free', s, options);
+  }
+  s.on('free', onFree);
+
+  function onClose(err) {
+    debug('CLIENT socket onClose');
+    // This is the only place where sockets get removed from the Agent.
+    // If you want to remove a socket from the pool, just close it.
+    // All socket errors end in a close event anyway.
+    agent.removeSocket(s, options);
+  }
+  s.on('close', onClose);
+
+  function onRemove() {
+    // We need this function for cases like HTTP 'upgrade'
+    // (defined by WebSockets) where we need to remove a socket from the
+    // pool because it'll be locked up indefinitely
+    debug('CLIENT socket onRemove');
+    agent.removeSocket(s, options);
+    s.removeListener('close', onClose);
+    s.removeListener('free', onFree);
+    s.removeListener('agentRemove', onRemove);
+  }
+  s.on('agentRemove', onRemove);
+}
+
+Agent.prototype.removeSocket = function removeSocket(s, options) {
   var name = this.getName(options);
   debug('removeSocket', name, 'writable:', s.writable);
   var sets = [this.sockets];


### PR DESCRIPTION
Keepalive sockets that are returned to the agent's freesocket pool were
previously capturing a reference to the ClientRequest that initiated the
request.

This commit eliminates that by moving the installation of the socket
listeners to a different function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
