### PR TITLE
test: add missing assert.throws()

### DIFF
--- a/test/parallel/test-dgram-multicast-set-interface.js
+++ b/test/parallel/test-dgram-multicast-set-interface.js
@@ -33,11 +33,14 @@ const dgram = require('dgram');
   socket.bind(0);
   socket.on('listening', common.mustCall(() => {
     // Try to set with an invalid interfaceAddress (wrong address class)
+    //
+    // This operation succeeds on some platforms, throws `EINVAL` on some
+    // platforms, and throws `ENOPROTOOPT` on others. This is unpleasant, but
+    // we should at least test for it.
     try {
       socket.setMulticastInterface('::');
-      throw new Error('Not detected.');
     } catch (e) {
-      console.error(`setMulticastInterface: wrong family error is: ${e}`);
+      assert(e.code === 'EINVAL' || e.code === 'ENOPROTOOPT');
     }
 
     socket.close();


### PR DESCRIPTION
This commit replaces a `try...catch` in `test/parallel/test-dgram-multicast-set-interface.js` with `assert.throws()`. The existing implementation wasn't actually verifying that a synchronous exception is thrown.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test