### PR TITLE
test: defer abort with setTimeout

### DIFF
--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -7,29 +7,36 @@ const { get, createServer } = require('http');
 // res.writable should not be set to false after it has finished sending
 // Ref: https://github.com/nodejs/node/issues/15029
 
+let internal;
 let external;
-
-// Http server
-const internal = createServer((req, res) => {
-  res.writeHead(200);
-  setImmediate(common.mustCall(() => {
-    external.abort();
-    res.end('Hello World\n');
-  }));
-}).listen(0);
 
 // Proxy server
 const server = createServer(common.mustCall((req, res) => {
   get(`http://127.0.0.1:${internal.address().port}`, common.mustCall((inner) => {
-    res.on('close', common.mustCall(() => {
+    const listener = common.mustCall(() => {
       assert.strictEqual(res.writable, true);
-    }));
+    });
+
+    // on CentOS 5, 'finish' is emitted
+    res.on('finish', listener);
+    // everywhere else, 'close' is emitted
+    res.on('close', listener);
+
     inner.pipe(res);
   }));
 })).listen(0, () => {
-  external = get(`http://127.0.0.1:${server.address().port}`);
-  external.on('error', common.mustCall((err) => {
-    server.close();
-    internal.close();
-  }));
+  // Http server
+  internal = createServer((req, res) => {
+    res.writeHead(200);
+    setImmediate(common.mustCall(() => {
+      external.abort();
+      res.end('Hello World\n');
+    }));
+  }).listen(0, () => {
+    external = get(`http://127.0.0.1:${server.address().port}`);
+    external.on('error', common.mustCall((err) => {
+      server.close();
+      internal.close();
+    }));
+  });
 });


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/15404
Fixes: https://github.com/nodejs/node/issues/15505

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http