### PR TITLE
Add `closed` property to `OutgoingMessage`.

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -110,6 +110,11 @@ function OutgoingMessage() {
 }
 util.inherits(OutgoingMessage, Stream);
 
+Object.defineProperty(OutgoingMessage.prototype, 'closed', {
+  get: function() {
+    return this.finished === true || this.writable === false;
+  }
+});
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
   get: function() {


### PR DESCRIPTION
Similar to `HTTP2ServerResponse.closed`. This is an alternative to https://github.com/nodejs/node/commit/8589c70c85411c2dd0e02c021d926b1954c74696 which provides an API similar to h2 compat and won't break existing OSS projects.

Fixes #15523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->