### PR TITLE
tls,doc: fix unallocated deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -661,8 +661,8 @@ Type: Runtime
 
 `REPLServer.parseREPLKeyword()` was removed from userland visibility.
 
-<a id="DEP00XX"></a>
-### DEP00XX: tls.parseCertString()
+<a id="DEP0076"></a>
+### DEP0076: tls.parseCertString()
 
 Type: Runtime
 

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -233,7 +233,7 @@ exports.parseCertString = internalUtil.deprecate(
   internalTLS.parseCertString,
   'tls.parseCertString() is deprecated. ' +
   'Please use querystring.parse() instead.',
-  'DEP00XX');
+  'DEP0076');
 
 // Public API
 exports.createSecureContext = require('_tls_common').createSecureContext;


### PR DESCRIPTION
Deprecation was landed using `DEP00XX` instead of a properly
allocated deprecation code.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tls,doc