### PR TITLE
test: update test-fs-fsync to run from temp

### DIFF
--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -25,10 +25,16 @@ const assert = require('assert');
 const fixtures = require('../common/fixtures');
 
 const fs = require('fs');
+const path = require('path');
 
-const file = fixtures.path('a.js');
+const fileFixture = fixtures.path('a.js');
+const fileTemp = path.join(common.tmpDir, 'a.js');
 
-fs.open(file, 'a', 0o777, common.mustCall(function(err, fd) {
+// Copy fixtures to temp.
+common.refreshTmpDir();
+fs.copyFileSync(fileFixture, fileTemp);
+
+fs.open(fileFixture, 'a', 0o777, common.mustCall(function(err, fd) {
   assert.ifError(err);
 
   fs.fdatasyncSync(fd);


### PR DESCRIPTION
test: update test-fs-fsync to run from temp

We copy the "a.js" file fixture to a temp directory and then we open it with write access.
This makes sure we are only writing to the provided temp-dir and not in the fixture dir.
This is makes the test pass on system where temp is the only writable dir.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
