### PR TITLE
http2: remove unused onTimeout, add timeout tests

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2138,23 +2138,8 @@ const setTimeout = {
     return this;
   }
 };
-
-const onTimeout = {
-  configurable: false,
-  enumerable: false,
-  value: function() {
-    process.nextTick(emit.bind(this, 'timeout'));
-  }
-};
-
-Object.defineProperties(Http2Stream.prototype, {
-  setTimeout,
-  onTimeout
-});
-Object.defineProperties(Http2Session.prototype, {
-  setTimeout,
-  onTimeout
-});
+Object.defineProperty(Http2Stream.prototype, 'setTimeout', setTimeout);
+Object.defineProperty(Http2Session.prototype, 'setTimeout', setTimeout);
 
 // --------------------------------------------------------------------
 

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -54,7 +54,7 @@ assert.doesNotThrow(() => {
     if (client)
       client.end();
   }));
-  server.setTimeout(common.platformTimeout(1000));
+  server.setTimeout(common.platformTimeout(1000), common.mustCall());
   server.listen(0, common.mustCall(() => {
     const port = server.address().port;
     client = net.connect(port, common.mustCall());
@@ -70,7 +70,7 @@ assert.doesNotThrow(() => {
     if (client)
       client.end();
   }));
-  server.setTimeout(common.platformTimeout(1000));
+  server.setTimeout(common.platformTimeout(1000), common.mustCall());
   server.listen(0, common.mustCall(() => {
     const port = server.address().port;
     client = tls.connect({

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -14,6 +14,32 @@ server.on('stream', common.mustCall((stream) => {
     stream.respond({ ':status': 200 });
     stream.end('hello world');
   }));
+
+  // check that expected errors are thrown with wrong args
+  common.expectsError(
+    () => stream.setTimeout('100'),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "msecs" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => stream.setTimeout(0, Symbol('test')),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: 'Callback must be a function'
+    }
+  );
+  common.expectsError(
+    () => stream.setTimeout(100, {}),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: 'Callback must be a function'
+    }
+  );
 }));
 server.listen(0);
 


### PR DESCRIPTION
This PR removes unused `onTimeout` method which should be `_onTimeout` (and that one already exists). I've also expanded existing tests for timeouts to test for supplied arguments.

Thanks for any and all reviews/feedback!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test