### PR TITLE
errors: refactor `invalidArgType()`

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -309,7 +309,7 @@ function invalidArgType(name, expected, actual) {
 
   // determiner: 'must be' or 'must not be'
   let determiner;
-  if (expected.includes('not ')) {
+  if (typeof expected === 'string' && expected.startsWith('not ')) {
     determiner = 'must not be';
     expected = expected.split('not ')[1];
   } else {
@@ -320,7 +320,7 @@ function invalidArgType(name, expected, actual) {
   if (Array.isArray(name)) {
     var names = name.map((val) => `"${val}"`).join(', ');
     msg = `The ${names} arguments ${determiner} ${oneOf(expected, 'type')}`;
-  } else if (name.includes(' argument')) {
+  } else if (name.endsWith(' argument')) {
     // for the case like 'first argument'
     msg = `The ${name} ${determiner} ${oneOf(expected, 'type')}`;
   } else {


### PR DESCRIPTION
`invalidArgType()` uses `includes()` in two places where `startsWith()`
and `endsWith()` are more appropriate (at least in my opinion). Switch
to those more specific functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors