### PR TITLE
errors: replace `.split()` with `.replace()`

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -311,7 +311,7 @@ function invalidArgType(name, expected, actual) {
   let determiner;
   if (expected.includes('not ')) {
     determiner = 'must not be';
-    expected = expected.split('not ')[1];
+    expected = expected.replace(/^not /, '');
   } else {
     determiner = 'must be';
   }


### PR DESCRIPTION
Replace a somewhat idiosyncratic use of `split()` to remove a prefix
with `replace()`. (A case could be made for `slice()` as well but I
think this is more readable.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors