### PR TITLE
doc,test: minor improvements to O_DSYNC

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2806,12 +2806,13 @@ The following constants are meant for use with `fs.open()`.
   </tr>
   <tr>
     <td><code>O_SYNC</code></td>
-    <td>Flag indicating that the file is opened for synchronous I/O.</td>
+    <td>Flag indicating that the file is opened for synchronized I/O with write
+    operations waiting for file integrity.</td>
   </tr>
   <tr>
     <td><code>O_DSYNC</code></td>
-    <td>Flag indicating that the file is opened for synchronous I/O
-    with write operations waiting for data integrity.</td>
+    <td>Flag indicating that the file is opened for synchronized I/O with write
+    operations waiting for data integrity.</td>
   </tr>
   <tr>
     <td><code>O_SYMLINK</code></td>

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -81,10 +81,10 @@ common.expectsError(
   { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
 );
 
-if (common.isLinux === true) {
+if (common.isLinux) {
   const file = fixtures.path('a.js');
 
-  fs.open(file, O_DSYNC, common.mustCall(function(err, fd) {
+  fs.open(file, O_DSYNC, common.mustCall((err, fd) => {
     assert.ifError(err);
   }));
 }

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -84,7 +84,5 @@ common.expectsError(
 if (common.isLinux) {
   const file = fixtures.path('a.js');
 
-  fs.open(file, O_DSYNC, common.mustCall((err, fd) => {
-    assert.ifError(err);
-  }));
+  fs.open(file, O_DSYNC, common.mustCall(assert.ifError));
 }


### PR DESCRIPTION
`synchronous` is misleading here, it should be `synchronized`. Also simplified the test.

Refs: https://github.com/nodejs/node/pull/15451

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs, doc, test