### PR TITLE
src: change var name 'u'  in url.js line 97

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -94,9 +94,9 @@ const querystring = require('querystring');
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url instanceof Url) return url;
 
-  var u = new Url();
-  u.parse(url, parseQueryString, slashesDenoteHost);
-  return u;
+  var objUrl = new Url();
+  objUrl.parse(url, parseQueryString, slashesDenoteHost);
+  return objUrl;
 }
 
 Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -94,9 +94,9 @@ const querystring = require('querystring');
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url instanceof Url) return url;
 
-  var objUrl = new Url();
-  objUrl.parse(url, parseQueryString, slashesDenoteHost);
-  return objUrl;
+  var urlObject = new Url();
+  urlObject.parse(url, parseQueryString, slashesDenoteHost);
+  return urlObject;
 }
 
 Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {


### PR DESCRIPTION
I think using var name 'objUrl' is more clear then 'u'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url