### PR TITLE
src: clear async id stack if bootstrap throws

### DIFF
--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+
+if (process.argv[2] === 'async') {
+  async function fn() {
+    fn();
+    throw new Error();
+  }
+  (async function() { await fn(); })();
+  // While the above should error, just in case it dosn't the script shouldn't
+  // fork itself indefinitely so return early.
+  return;
+}
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const ret = spawnSync(process.execPath, [__filename, 'async']);
+assert.strictEqual(ret.status, 0);
+assert.ok(!/async.*hook/i.test(ret.stderr.toString('utf8', 0, 1024)));


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src

##### Notes

If bootstrap throws and if ids are added to the async id stack and if
the exception wasn't handled by the fatal exception handler then the
`AsyncCallbackScope` destructor will cause the `AsyncHooks::pop_ids()` stack
check to fail. Causing the application to crash. So clear the async id
stack manually.

This is only possible if the user: 1) manually calls `MakeCallback()` or
2) uses async await in the top level. Which will cause `_tickCallback()`
to fire before bootstrap finishes executing.

The following example shows how the application can fail due to
exceeding the maximum call stack while using `async` `await`:

    async function fn() {
      fn();
      throw new Error();
    }
    (async function() { await fn(); })();

If this occurs during bootstrap then the application will pring the
following warning a number of times then exit with a status of 0:

    (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: *): Error

Here's the same recursive call done after enabling a new `AsyncHook()` the
following will print instead of the above warning and exit with a
non-zero code (currently it's 7 because of how `node::FatalException`
assigns error codes based on where the failure happened):

    script.js:25
    async function fn() {
                     ^
    RangeError: Maximum call stack size exceeded
        at <anonymous>
        at fn (script.js:25:18)
        at fn (script.js:26:3)
        ....

This has to do with how Promises lazily enable `PromiseHook` if an
`AsyncHook()` is enabled. Whether these need to be made uniform is outside
the scope of this commit

Fixes: https://github.com/nodejs/node/issues/15448

Note: Still need to add my own test