### PR TITLE
src: do not include internals from node_buffer.h

### DIFF
--- a/src/node_buffer.h
+++ b/src/node_buffer.h
@@ -22,7 +22,8 @@
 #ifndef SRC_NODE_BUFFER_H_
 #define SRC_NODE_BUFFER_H_
 
-#include "node_internals.h"
+#include "node.h"
+#include "v8.h"
 
 namespace node {
 

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -1,10 +1,7 @@
-#include "node.h"
+#include "node_internals.h"
 #include "node_buffer.h"
 #include "base-object.h"
 #include "base-object-inl.h"
-#include "env.h"
-#include "env-inl.h"
-#include "v8.h"
 
 namespace node {
 

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -24,7 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "node.h"
+#include "node_internals.h"
 #include "node_buffer.h"
 
 namespace node {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -22,9 +22,8 @@
 #include "string_bytes.h"
 
 #include "base64.h"
-#include "node.h"
+#include "node_internals.h"
 #include "node_buffer.h"
-#include "v8.h"
 
 #include <limits.h>
 #include <string.h>  // memcpy


### PR DESCRIPTION
`node_buffer.h` is a public header, so it should not be using the `node_internals.h` internal header.

Ref: 290315ace7eed6eeeb300754dd68fc1af4d80c9b
Fixes: https://github.com/nodejs/node/issues/15552

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

addons