### PR TITLE
test: verify sending net.Server via cluster

### DIFF
--- a/test/parallel/test-cluster-send-net-server.js
+++ b/test/parallel/test-cluster-send-net-server.js
@@ -1,0 +1,28 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/15556
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isMaster) {
+  const subprocess = cluster.fork();
+  const server = net.createServer();
+
+  server.listen(0, common.mustCall(() => {
+    subprocess.send('server', server);
+  }));
+
+  subprocess.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    server.close();
+  }));
+} else {
+  process.on('message', common.mustCall((m, server) => {
+    assert.strictEqual(m, 'server');
+    assert(server instanceof net.Server);
+    assert.strictEqual(server._connectionKey, '-1:null:-1');
+    process.disconnect();
+  }));
+}


### PR DESCRIPTION
This test verifies that a `net.Server` instance can be sent via cluster workers.

This adds a regression test for #15556.

Fixes: https://github.com/nodejs/node/issues/15556
Refs: https://github.com/nodejs/node/pull/14221

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test