### PR TITLE
HTTP/2 createServer() options to pass custom Request and Response classes

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1714,6 +1714,14 @@ changes:
   * `Http1ServerResponse` {http.ServerResponse} Specifies the ServerResponse
     class to used for HTTP/1 fallback. Useful for extending the original
     `http.ServerResponse`. **Default:** `http.ServerResponse`
+  * `Http2ServerRequest` {http2.Http2ServerRequest} Specifies the
+    Http2ServerRequest class to use.
+    Useful for extending the original `Http2ServerRequest`.
+    **Default:** `Http2ServerRequest`
+  * `Http2ServerResponse` {htt2.Http2ServerResponse} Specifies the
+    Http2ServerResponse class to use.
+    Useful for extending the original `Http2ServerResponse`.
+    **Default:** `Http2ServerResponse`
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -661,11 +661,11 @@ class Http2ServerResponse extends Stream {
   }
 }
 
-function onServerStream(stream, headers, flags, rawHeaders) {
+function onServerStream(ServerRequest, ServerResponse,
+                        stream, headers, flags, rawHeaders) {
   const server = this;
-  const request = new Http2ServerRequest(stream, headers, undefined,
-                                         rawHeaders);
-  const response = new Http2ServerResponse(stream);
+  const request = new ServerRequest(stream, headers, undefined, rawHeaders);
+  const response = new ServerResponse(stream);
 
   // Check for the CONNECT method
   const method = headers[HTTP2_HEADER_METHOD];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2498,6 +2498,10 @@ function initializeOptions(options) {
   options.Http1ServerResponse = options.Http1ServerResponse ||
     http.ServerResponse;
 
+  options.Http2ServerRequest = options.Http2ServerRequest ||
+                                       Http2ServerRequest;
+  options.Http2ServerResponse = options.Http2ServerResponse ||
+                                        Http2ServerResponse;
   return options;
 }
 
@@ -2563,7 +2567,11 @@ class Http2Server extends NETServer {
 function setupCompat(ev) {
   if (ev === 'request') {
     this.removeListener('newListener', setupCompat);
-    this.on('stream', onServerStream);
+    this.on('stream', onServerStream.bind(
+      this,
+      this[kOptions].Http2ServerRequest,
+      this[kOptions].Http2ServerResponse)
+    );
   }
 }
 

--- a/test/parallel/test-http2-options-server-request.js
+++ b/test/parallel/test-http2-options-server-request.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+class MyServerRequest extends h2.Http2ServerRequest {
+  getUserAgent() {
+    return this.headers['user-agent'] || 'unknown';
+  }
+}
+
+const server = h2.createServer({
+  Http2ServerRequest: MyServerRequest
+}, (req, res) => {
+  assert.strictEqual(req.getUserAgent(), 'node-test');
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end();
+});
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({
+    ':path': '/',
+    'User-Agent': 'node-test'
+  });
+
+  req.on('response', common.mustCall());
+
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+}));

--- a/test/parallel/test-http2-options-server-response.js
+++ b/test/parallel/test-http2-options-server-response.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+class MyServerResponse extends h2.Http2ServerResponse {
+  status(code) {
+    return this.writeHead(code, { 'Content-Type': 'text/plain' });
+  }
+}
+
+const server = h2.createServer({
+  Http2ServerResponse: MyServerResponse
+}, (req, res) => {
+  res.status(200);
+  res.end();
+});
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustCall());
+
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+}));


### PR DESCRIPTION
### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

### Affected core subsystem(s)

 - http2

### Motivation

Provide a simple and performant way to extend the original `Http2ServerRequest` and `Http2ServerResponse` classes in web frameworks like `express` or `restify` without messing with the original Response and Request handlers in Node core or overwriting the prototypes at every request. 

**Current solutions for inheritance**:

- `express` uses [Object.setPrototypeOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) to [overwrite](https://github.com/expressjs/express/blob/a4bd4373b2c3b2521ee4c499cb8e90e98f78bfa5/lib/middleware/init.js#L35)` req` and `res` prototypes at every request

- `restify` extends the original Node Core [IncomingMessage](https://github.com/restify/node-restify/blob/master/lib/request.js#L19) and [ServerResponse](https://github.com/restify/node-restify/blob/master/lib/response.js#L20) Objects

`Object.setPrototypeOf:`

> **Warning:** Changing the [[Prototype]] of an object is, by the nature of how modern JavaScript engines optimize property accesses, a very slow operation, in every browser and JavaScript engine. The effects on performance of altering inheritance are subtle and far-flung, and are not limited to simply the time spent in obj.__proto__ = ... statement, but may extend to any code that has access to any object whose [[Prototype]] has been altered. If you care about performance you should avoid setting the [[Prototype]] of an object. Instead, create a new object with the desired [[Prototype]] using Object.create(). - [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf)

### How it works

```js
class MyServerRequest extends http2.Http2ServerRequest {
  getUserAgent() {
    return this.headers['user-agent'] || 'unknown';
  }
}

class MyServerResponse extends http2.Http2ServerResponse {
  status(code, contentType) {
    this.writeHead(code, { 'Content-Type': contentType });
  }
}

const server = http2.createServer({
  ServerRequest: MyServerRequest,
  ServerResponse: MyServerResponse
};
```

### Benchmark results

Continuously increasing concurrent and streams.  
See new benchmark in this PR.

```sh
./node benchmark/scatter.js --runs 30 --set benchmarker=h2load benchmark/http2/inheritance > scatter.csv
```

**Aggregated by requests:**

```sh
cat scatter.csv | Rscript benchmark/scatter.R --xaxis requests --category version --plot scatter-plot.png --log
```

X axis: total number of requests
Y axis: rate of operations

![scatter-plot-requests-2](https://user-images.githubusercontent.com/1764512/30763490-b61e7aa0-9fe6-11e7-933b-3b98b4e99e00.png)

```
aggregating variable: streams

 requests        version     rate confidence.interval
     5000       original 6157.151            46.30018
     5000         params 6118.722            52.94544
     5000 setPrototypeOf 6127.015            46.04977
    10000       original 7373.277            54.71278
    10000         params 7318.096            55.83396
    10000 setPrototypeOf 7363.882            46.79015
    20000       original 8003.976            53.02454
    20000         params 8237.659            48.35231
    20000 setPrototypeOf 7999.081            50.75252
    50000       original 7870.669            63.91681
    50000         params 8347.653            54.88024
    50000 setPrototypeOf 7838.831            62.77288
```


**Aggregated by streams:**

```sh
cat scatter.csv | Rscript benchmark/scatter.R --xaxis streams --category version --plot scatter-plot.png --log
```

X axis: concurrency level
Y axis: rate of operations

![scatter-plot-streams-2](https://user-images.githubusercontent.com/1764512/30763496-bcd6b84e-9fe6-11e7-8ed3-565f4cdef5bf.png)

```
aggregating variable: requests

 streams        version     rate confidence.interval
     100       original 7321.768            152.6445
     100         params 7506.819            164.8038
     100 setPrototypeOf 7317.199            143.0783
     500       original 7364.365            149.7678
     500         params 7566.271            174.6796
     500 setPrototypeOf 7385.408            143.0759
    1000       original 7372.903            140.9144
    1000         params 7518.531            172.2680
    1000 setPrototypeOf 7335.217            147.1282
    2500       original 7331.950            145.9298
    2500         params 7502.725            172.1327
    2500 setPrototypeOf 7320.819            157.1094
    5000       original 7385.907            145.3467
    5000         params 7492.245            174.1755
    5000 setPrototypeOf 7302.101            149.7285
   10000       original 7330.715            155.2385
   10000         params 7446.603            190.6992
   10000 setPrototypeOf 7332.468            145.8346
```

From the result, aggregated by `requests` number you can see that this new extension type *(passing custom classes as options)* is significantly faster for higher concurrency and request number.

### Related PR

- https://github.com/nodejs/node/pull/15752
