### PR TITLE
src,etw: fix event 9 on 64 bit Windows

### DIFF
--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -27,12 +27,6 @@
 #include "node_win32_etw_provider.h"
 #include "node_etw_provider.h"
 
-#if defined(_WIN64)
-# define ETW_WRITE_INTPTR_DATA ETW_WRITE_INT64_DATA
-#else
-# define ETW_WRITE_INTPTR_DATA ETW_WRITE_INT32_DATA
-#endif
-
 namespace node {
 
 // From node_win32_etw_provider.cc
@@ -100,7 +94,7 @@ extern int events_enabled;
     ETW_WRITE_ADDRESS_DATA(descriptors, &context);                            \
     ETW_WRITE_ADDRESS_DATA(descriptors + 1, &startAddr);                      \
     ETW_WRITE_INT64_DATA(descriptors + 2, &size);                             \
-    ETW_WRITE_INTPTR_DATA(descriptors + 3, &id);                              \
+    ETW_WRITE_INT32_DATA(descriptors + 3, &id);                               \
     ETW_WRITE_INT16_DATA(descriptors + 4, &flags);                            \
     ETW_WRITE_INT16_DATA(descriptors + 5, &rangeId);                          \
     ETW_WRITE_INT64_DATA(descriptors + 6, &sourceId);                         \
@@ -253,7 +247,11 @@ void NODE_V8SYMBOL_ADD(LPCSTR symbol,
     }
     void* context = nullptr;
     INT64 size = (INT64)len;
-    INT_PTR id = (INT_PTR)addr1;
+#if defined(_WIN64)
+    INT32 id = 0;
+#else
+    INT32 id = (INT32)addr1;
+#endif
     INT16 flags = 0;
     INT16 rangeid = 1;
     INT32 col = 1;

--- a/src/node_win32_etw_provider-inl.h
+++ b/src/node_win32_etw_provider-inl.h
@@ -247,11 +247,7 @@ void NODE_V8SYMBOL_ADD(LPCSTR symbol,
     }
     void* context = nullptr;
     INT64 size = (INT64)len;
-#if defined(_WIN64)
-    INT32 id = 0;
-#else
     INT32 id = (INT32)addr1;
-#endif
     INT16 flags = 0;
     INT16 rangeid = 1;
     INT32 col = 1;


### PR DESCRIPTION
The event manifest specifies the [MethodID field as a 32 bit integer](https://github.com/nodejs/node/blob/3888a576ac83239d8d3d2fc985e7ea1856dac83e/src/res/node_etw_provider.man#L79). The 32 bit node executable publishes this correctly, but the 64 bit executable publishes a 64 bit integer, making the event undecodable.

This fix makes the event decodable again by publishing it as 0 in 64 bit systems. This way the manifest is not changed, so this fix is semver-patch and can be backported to LTS. Note there are already other dummy values on this event and the address is already published correctly as a pointer in another field. In the future, this should probably be changed to a meaningful value provided by the engine in use.

cc @nodejs/platform-windows 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src, etw.