### PR TITLE
tty,doc: add type-check to isatty

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -123,4 +123,5 @@ added: v0.5.8
 * `fd` {number} A numeric file descriptor
 
 The `tty.isatty()` method returns `true` if the given `fd` is associated with
-a TTY and `false` if is not.
+a TTY and `false` if it is not, including whenever `fd` is not a non-negative
+integer.

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -30,7 +30,7 @@ const errors = require('internal/errors');
 const readline = require('readline');
 
 exports.isatty = function(fd) {
-  return isTTY(fd);
+  return Number.isInteger(fd) && fd >= 0 && isTTY(fd);
 };
 
 

--- a/test/pseudo-tty/test-tty-isatty.js
+++ b/test/pseudo-tty/test-tty-isatty.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const { strictEqual } = require('assert');
+const { isatty } = require('tty');
+
+strictEqual(isatty(0), true, 'stdin reported to not be a tty, but it is');
+strictEqual(isatty(1), true, 'stdout reported to not be a tty, but it is');
+strictEqual(isatty(2), true, 'stderr reported to not be a tty, but it is');
+
+strictEqual(isatty(-1), false, '-1 reported to be a tty, but it is not');
+strictEqual(isatty(55555), false, '55555 reported to be a tty, but it is not');
+strictEqual(isatty(1.1), false, '1.1 reported to be a tty, but it is not');
+strictEqual(isatty('1'), false, '\'1\' reported to be a tty, but it is not');
+strictEqual(isatty({}), false, '{} reported to be a tty, but it is not');
+strictEqual(isatty(() => {}), false,
+            '() => {} reported to be a tty, but it is not');


### PR DESCRIPTION
Previously, various inputs other than non-negative integers would
produce incorrect results.

Added type-checking on input, returning false for anything other than
non-negative integers.

Also clarified in docs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tty, doc
