### PR TITLE
docs: clarify usage cli options -e,-p on windows

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -53,10 +53,9 @@ changes:
 Evaluate the following argument as JavaScript. The modules which are
 predefined in the REPL can also be used in `script`.
 
-*Note*: Please use double quote for the `script`, although it does not matter
-on the Linux that you use double quote or a single quote, on the Windows it
-makes a difference. On the Windows a single quote will not work correctly
-because Windows shell traditionally uses double quote as the quote char.
+*Note*: On Windows, using `cmd.exe` a single quote will not work correctly
+because it only recognizes double `"` for quoting. In Powershell or
+Git bash, both `'` and `"` are usable.
 
 
 ### `-p`, `--print "script"`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -53,6 +53,10 @@ changes:
 Evaluate the following argument as JavaScript. The modules which are
 predefined in the REPL can also be used in `script`.
 
+*Note*: Please use double quote for the `script`, although it does not matter
+on the Linux that you use double quote or a single quote, on the Windows it
+makes a difference. On the Windows a single quote will not work correctly
+because Windows shell traditionally uses double quote as the quote char.
 
 ### `-p`, `--print "script"`
 <!-- YAML
@@ -64,7 +68,6 @@ changes:
 -->
 
 Identical to `-e` but prints the result.
-
 
 ### `-c`, `--check`
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -58,6 +58,7 @@ on the Linux that you use double quote or a single quote, on the Windows it
 makes a difference. On the Windows a single quote will not work correctly
 because Windows shell traditionally uses double quote as the quote char.
 
+
 ### `-p`, `--print "script"`
 <!-- YAML
 added: v0.6.4
@@ -68,6 +69,7 @@ changes:
 -->
 
 Identical to `-e` but prints the result.
+
 
 ### `-c`, `--check`
 <!-- YAML


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/15522

I open previously Pull Request (https://github.com/nodejs/node/pull/15543), but I decided to close it because I messed a little with a git rebase... I'm sorry for this, but it seams I need to practice more with git..

About the change. So I put note about using double quote for the `script` only under option `-e`, because description under `-p` refers to option `-e` so if the user would like to know the whole meaning about option `-p` will read description under `-e` with this new note.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc