### PR TITLE
build, windows: ignore C4251 & C4275

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -205,7 +205,12 @@
         # Disable "warning C4267: conversion from 'size_t' to 'int',
         # possible loss of data".  Many originate from our dependencies
         # and their sheer number drowns out other, more legitimate warnings.
-        'DisableSpecificWarnings': ['4267'],
+        #
+        # Disable "warning C4251: 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'"
+        # Many V8 method do not comply with the requirements to be dll exported,
+        # which result in this warning reported several 1000s times.
+        # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
+        'DisableSpecificWarnings': ['4267', '4251'],
         'WarnAsError': 'false',
       },
       'VCLibrarianTool': {
@@ -238,7 +243,7 @@
         'SuppressStartupBanner': 'true',
       },
     },
-    'msvs_disabled_warnings': [4351, 4355, 4800],
+    'msvs_disabled_warnings': [4351, 4355, 4800 ],
     'conditions': [
       ['asan == 1 and OS != "mac"', {
         'cflags+': [

--- a/common.gypi
+++ b/common.gypi
@@ -207,10 +207,12 @@
         # and their sheer number drowns out other, more legitimate warnings.
         #
         # Disable "warning C4251: 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'"
+        # Disable "warning C4275: non - DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'"
         # Many V8 method do not comply with the requirements to be dll exported,
-        # which result in this warning reported several 1000s times.
+        # which result in these warnings reported several 1000s times.
         # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
-        'DisableSpecificWarnings': ['4267', '4251'],
+        # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
+        'DisableSpecificWarnings': ['4267', '4251', '4275'],
         'WarnAsError': 'false',
       },
       'VCLibrarianTool': {

--- a/common.gypi
+++ b/common.gypi
@@ -205,14 +205,7 @@
         # Disable "warning C4267: conversion from 'size_t' to 'int',
         # possible loss of data".  Many originate from our dependencies
         # and their sheer number drowns out other, more legitimate warnings.
-        #
-        # Disable "warning C4251: 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'"
-        # Disable "warning C4275: non - DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'"
-        # Many V8 method do not comply with the requirements to be dll exported,
-        # which result in these warnings reported several 1000s times.
-        # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
-        # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
-        'DisableSpecificWarnings': ['4267', '4251', '4275'],
+        'DisableSpecificWarnings': ['4267'],
         'WarnAsError': 'false',
       },
       'VCLibrarianTool': {
@@ -286,7 +279,6 @@
           '_CRT_NONSTDC_NO_DEPRECATE',
           # Make sure the STL doesn't try to use exceptions
           '_HAS_EXCEPTIONS=0',
-          'BUILDING_V8_SHARED=1',
           'BUILDING_UV_SHARED=1',
         ],
       }],


### PR DESCRIPTION
* ignore C4251 "mismatched dll-interface"
* ignore C4275 "bad inheritance dll-interface"

Many V8 methods do not comply with the requirements to be DLL-exportable,
which results in these warnings reported several 1000s times during build.

CI: https://ci.nodejs.org/job/node-test-commit/12552/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build,windows
