### PR TITLE
console,doc: add inspector console object

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -417,6 +417,26 @@ added: v0.1.100
 
 The `console.warn()` function is an alias for [`console.error()`][].
 
+### console.inspector
+<!-- YAML
+added: REPLACEME
+-->
+
+V8 contexts provide a `console` global object, but by default it is only useful
+for sending console messages to attached inspectors. This is provided as the
+`inspector` property of the global `console` object (but not of other instances
+of `Console`).
+
+For example, to send a log message, `'hello'` to an attached inspector console:
+
+```js
+console.inspector.log('hello');
+// 'hello' appears in inspector console, but not in node's stdout
+```
+
+When an inspector is connected, logging methods on the global `console` object
+will also send messages to the inspector console.
+
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -344,11 +344,7 @@
                                              wrappedConsole[key],
                                              config);
     }
-    for (const key of Object.keys(originalConsole)) {
-      if (wrappedConsole.hasOwnProperty(key))
-        continue;
-      wrappedConsole[key] = originalConsole[key];
-    }
+    wrappedConsole.inspector = originalConsole;
   }
 
   function setupProcessFatal() {

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const vm = require('vm');
 
 assert.ok(process.stdout.writable);
 assert.ok(process.stderr.writable);
@@ -187,3 +188,16 @@ common.hijackStderr(common.mustCall(function(data) {
     assert.strictEqual(data.includes('no such label'), true);
   });
 }));
+
+const pristineConsole = vm.runInNewContext('this.console');
+for (const name in console.inspector) {
+
+  // No inspector-only functions are available on the global console
+  if (name in console) {
+    assert.notStrictEqual(console[name], console.inspector[name]);
+  }
+
+  // console.inspector should be the same as a pristine console object from a v8
+  // context.
+  assert(name in pristineConsole);
+}


### PR DESCRIPTION
Remove undocumented (and unusable without inspector) methods from
the global `console` object.

Rather than having the undocumented methods on the global `console`, these
methods are now available on the `console.inspector` object.

Fixes: https://github.com/nodejs/node/issues/12675

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console, doc