### PR TITLE
doc: fix outdated code sample in n-api.md

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2349,7 +2349,7 @@ napi_status status = napi_status_generic_failure;
 
 // const obj = {};
 napi_value obj;
-status = napi_create_obj(env, &obj);
+status = napi_create_object(env, &obj);
 if (status != napi_ok) return status;
 
 // Create napi_values for 123 and 456
@@ -2360,9 +2360,9 @@ status = napi_create_int32(env, 456, &barValue);
 if (status != napi_ok) return status;
 
 // Set the properties
-napi_property_descriptors descriptors[] = {
-  { "foo", fooValue, 0, 0, 0, napi_default, 0 },
-  { "bar", barValue, 0, 0, 0, napi_default, 0 }
+napi_property_descriptor descriptors[] = {
+  { "foo", nullptr, 0, 0, 0, fooValue, napi_default, 0 },
+  { "bar", nullptr, 0, 0, 0, barValue, napi_default, 0 }
 }
 status = napi_define_properties(env,
                                 obj,


### PR DESCRIPTION
Code sample of napi_create_object and napi_property_descriptor were
not updated to latest API. Ran into this problem while migrating NAN projects to N-API.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
