### PR TITLE
src: correct typo in trace_event header

### DIFF
--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -30,7 +30,7 @@ enum CategoryGroupEnabledFlags {
   kEnabledForETWExport_CategoryGroupEnabledFlags = 1 << 3,
 };
 
-// By default, const char* asrgument values are assumed to have long-lived scope
+// By default, const char* argument values are assumed to have long-lived scope
 // and will not be copied. Use this macro to force a const char* to be copied.
 #define TRACE_STR_COPY(str) node::tracing::TraceStringWithCopy(str)
 


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src