### PR TITLE
test: Http2Stream destroy server before shutdown

### DIFF
--- a/test/parallel/test-http2-server-destroy-before-shutdown.js
+++ b/test/parallel/test-http2-server-destroy-before-shutdown.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+// Test that ERR_HTTP2_INVALID_SESSION is thrown when a stream is destroyed
+// before calling stream.session.shutdown
+server.on('stream', common.mustCall((stream) => {
+  stream.session.destroy();
+  common.expectsError(
+    () => stream.session.shutdown(),
+    {
+      type: Error,
+      code: 'ERR_HTTP2_INVALID_SESSION',
+      message: 'The session has been destroyed'
+    }
+  );
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request();
+  req.resume();
+  req.on('end', common.mustCall(() => server.close()));
+}));


### PR DESCRIPTION
This PR includes a test case for the handling of `stream.session.shutdown()` when session is already destroyed.
This is my first PR in node, will add more tests for http2 after getting this reviewed/merged.

Refs: #14985

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
