### PR TITLE
src: move node_trace_writer/buffer.h to agent.cc

### DIFF
--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -2,6 +2,8 @@
 
 #include <sstream>
 #include <string>
+#include "tracing/node_trace_buffer.h"
+#include "tracing/node_trace_writer.h"
 
 #include "env-inl.h"
 

--- a/src/tracing/agent.h
+++ b/src/tracing/agent.h
@@ -1,14 +1,15 @@
 #ifndef SRC_TRACING_AGENT_H_
 #define SRC_TRACING_AGENT_H_
 
+#include "libplatform/v8-tracing.h"
 #include "node_platform.h"
-#include "tracing/node_trace_buffer.h"
-#include "tracing/node_trace_writer.h"
 #include "uv.h"
 #include "v8.h"
 
 namespace node {
 namespace tracing {
+
+using v8::platform::tracing::TracingController;
 
 class Agent {
  public:


### PR DESCRIPTION
The headers node_trace_writer.h and node_trace_buffer.h are not used in
agent.h but are more of an implementation detail of agent.cc.

This commit suggests moving the inclusion of these headers to agent.cc.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src