### PR TITLE
deps: cherry-pick 0353a1e from upstream V8

### DIFF
--- a/deps/v8/src/regexp/jsregexp.cc
+++ b/deps/v8/src/regexp/jsregexp.cc
@@ -1115,7 +1115,7 @@ RegExpEngine::CompilationResult RegExpCompiler::Assemble(
   Handle<HeapObject> code = macro_assembler_->GetCode(pattern);
   isolate->IncreaseTotalRegexpCodeGenerated(code->Size());
   work_list_ = NULL;
-#ifdef ENABLE_DISASSEMBLER
+#if defined(ENABLE_DISASSEMBLER) && !defined(V8_INTERPRETED_REGEXP)
   if (FLAG_print_code) {
     CodeTracer::Scope trace_scope(isolate->GetCodeTracer());
     OFStream os(trace_scope.file());


### PR DESCRIPTION
Original commit message:

    Avoid disassembling Interpreted Regexp code

    I found that v8 will crash when --print-code is turned on while Regexp
    is interpreted. It crashes when trying to print Relocation info during
    Disassembly. It should probably avoid printing out disassembly when the
    Code object is a bytecode regexp.

    Bug:
    Change-Id: I35b531cb03996a303248652871452266c78fee38
    Reviewed-on: https://chromium-review.googlesource.com/642127
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Commit-Queue: Jaideep Bajwa <bjaideep@ca.ibm.com>
    Cr-Commit-Position: refs/heads/master@{#47718}

This is the same as https://github.com/nodejs/node/pull/15287 for `master`, as the [merge request](https://bugs.chromium.org/p/v8/issues/detail?id=6835) was only accepted for V8 6.2.
/cc @nodejs/v8 @jBarz 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
V8