### PR TITLE
process: Send signal name to signal handlers

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -350,6 +350,9 @@ Signal events will be emitted when the Node.js process receives a signal. Please
 refer to signal(7) for a listing of standard POSIX signal names such as
 `SIGINT`, `SIGHUP`, etc.
 
+The signal handler will receive the signal's name (`'SIGINT'`,
+ `'SIGTERM'`, etc.) as the first argument.
+
 The name of each event will be the uppercase common name for the signal (e.g.
 `'SIGINT'` for `SIGINT` signals).
 
@@ -362,6 +365,14 @@ process.stdin.resume();
 process.on('SIGINT', () => {
   console.log('Received SIGINT.  Press Control-D to exit.');
 });
+
+// Using a single function to handle multiple signals
+function handle(signal) {
+  console.log(`Received ${signal}`);
+}
+
+process.on('SIGINT', handle);
+process.on('SIGTERM', handle);
 ```
 
 *Note*: An easy way to send the `SIGINT` signal is with `<Ctrl>-C` in most

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -198,7 +198,7 @@ function setupSignalHandlers() {
 
       wrap.unref();
 
-      wrap.onsignal = function() { process.emit(type); };
+      wrap.onsignal = function() { process.emit(type, type); };
 
       const signum = constants[type];
       const err = wrap.start(signum);

--- a/test/parallel/test-signal-args.js
+++ b/test/parallel/test-signal-args.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+if (common.isWindows) {
+  common.skip('Sending signals with process.kill is not supported on Windows');
+}
+
+process.once('SIGINT', common.mustCall((signal) => {
+  assert.strictEqual(signal, 'SIGINT');
+}));
+
+process.kill(process.pid, 'SIGINT');
+
+process.once('SIGTERM', common.mustCall((signal) => {
+  assert.strictEqual(signal, 'SIGTERM');
+}));
+
+process.kill(process.pid, 'SIGTERM');
+
+// Prevent Node.js from exiting due to empty event loop before signal handlers
+// are fired
+setImmediate(() => {});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process

##### Description

Allow the signal handler to receive the signal code that triggered the handler.

This is useful in situations where you have one common signal handler to gracefully exit a Node.js process (ie. one handler for `SIGINT` and `SIGTERM`) **and** you still want to know exactly which signal was used to stop the process.


###### Before

```js
function shutdown(signal) {
  // Clean up resources
  console.log(`Quit - received ${signal}`)
}

process.once('SIGTERM', () => shutdown('SIGTERM'))
process.once('SIGINT', () => shutdown('SIGINT'))
```

###### After

```js
function shutdown(signal) {
  // Clean up resources
  console.log(`Quit - received ${signal}`)
}

process.once('SIGTERM', shutdown)
process.once('SIGINT', shutdown)
```