### PR TITLE
buffer: runtime-deprecate Buffer(num) by default

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -133,11 +133,8 @@ const bufferWarning = 'The Buffer() and new Buffer() constructors are not ' +
                       'Buffer.allocUnsafe(), or Buffer.from() construction ' +
                       'methods instead.';
 
-function showFlaggedDeprecation() {
+function showDeprecation() {
   if (bufferWarn) {
-    // This is a *pending* deprecation warning. It is not emitted by
-    // default unless the --pending-deprecation command-line flag is
-    // used or the NODE_PENDING_DEPRECATION=1 env var is set.
     process.emitWarning(bufferWarning, 'DeprecationWarning', 'DEP0005');
     bufferWarn = false;
   }
@@ -145,23 +142,21 @@ function showFlaggedDeprecation() {
 
 const doFlaggedDeprecation =
   pendingDeprecation ?
-    showFlaggedDeprecation :
+    showDeprecation :
     function() {};
 
 /**
- * The Buffer() constructor is deprecated in documentation and should not be
- * used moving forward. Rather, developers should use one of the three new
- * factory APIs: Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on
- * their specific needs. There is no runtime deprecation because of the extent
- * to which the Buffer constructor is used in the ecosystem currently -- a
- * runtime deprecation would introduce too much breakage at this time. It's not
- * likely that the Buffer constructors would ever actually be removed.
+ * The Buffer() constructor is deprecated and should not be used moving forward.
+ * Rather, developers should use one of the three new factory APIs:
+ * Buffer.from(), Buffer.allocUnsafe() or Buffer.alloc() based on their specific
+ * needs. It's not likely that the Buffer constructors would ever actually be
+ * removed.
  * Deprecation Code: DEP0005
  **/
 function Buffer(arg, encodingOrOffset, length) {
-  doFlaggedDeprecation();
   // Common case.
   if (typeof arg === 'number') {
+    showDeprecation();
     if (typeof encodingOrOffset === 'string') {
       throw new errors.TypeError(
         'ERR_INVALID_ARG_TYPE', 'string', 'string', arg
@@ -169,6 +164,7 @@ function Buffer(arg, encodingOrOffset, length) {
     }
     return Buffer.alloc(arg);
   }
+  doFlaggedDeprecation();
   return Buffer.from(arg, encodingOrOffset, length);
 }
 

--- a/test/parallel/test-buffer-deprecation.js
+++ b/test/parallel/test-buffer-deprecation.js
@@ -1,4 +1,4 @@
-// Flags: --pending-deprecation --no-warnings
+// Flags: --no-warnings
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-buffer-nodep-map.js
+++ b/test/parallel/test-buffer-nodep-map.js
@@ -1,12 +1,12 @@
-// Flags: --no-warnings --pending-deprecation
+// Flags: --no-warnings
 'use strict';
 
 const common = require('../common');
 
 process.on('warning', common.mustNotCall('A warning should not be emitted'));
 
-// With the --pending-deprecation flag, the deprecation warning for
-// new Buffer() should not be emitted when Uint8Array methods are called.
+// The deprecation warning for new Buffer() should not be emitted when
+// Uint8Array methods are called.
 
 Buffer.from('abc').map((i) => i);
 Buffer.from('abc').filter((i) => i);


### PR DESCRIPTION
This is a "light" version of #15346 that only prints the warning by default when `[new ]Buffer(num)` is used, as suggested by @BridgeAR in https://github.com/nodejs/node/pull/15346#issuecomment-331557738.

Most reasons for runtime deprecation by default as listed in #15346 still apply here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer