### PR TITLE
n-api: add check for large strings

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -10,6 +10,7 @@
 
 #include <node_buffer.h>
 #include <node_object_wrap.h>
+#include <limits.h>  // INT_MAX
 #include <string.h>
 #include <algorithm>
 #include <cmath>
@@ -125,6 +126,9 @@ struct napi_env__ {
   do {                                                                   \
     static_assert(static_cast<int>(NAPI_AUTO_LENGTH) == -1,              \
                   "Casting NAPI_AUTO_LENGTH to int must result in -1");  \
+    RETURN_STATUS_IF_FALSE((env),                                        \
+        (len == NAPI_AUTO_LENGTH) || len <= INT_MAX,                     \
+        napi_generic_failure);                                           \
     auto str_maybe = v8::String::NewFromUtf8(                            \
         (env)->isolate, (str), v8::NewStringType::kInternalized,         \
         static_cast<int>(len));                                          \

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -128,7 +128,7 @@ struct napi_env__ {
                   "Casting NAPI_AUTO_LENGTH to int must result in -1");  \
     RETURN_STATUS_IF_FALSE((env),                                        \
         (len == NAPI_AUTO_LENGTH) || len <= INT_MAX,                     \
-        napi_generic_failure);                                           \
+        napi_invalid_arg);                                               \
     auto str_maybe = v8::String::NewFromUtf8(                            \
         (env)->isolate, (str), v8::NewStringType::kInternalized,         \
         static_cast<int>(len));                                          \
@@ -870,7 +870,7 @@ void napi_module_register(napi_module* mod) {
 
 // Warning: Keep in-sync with napi_status enum
 const char* error_messages[] = {nullptr,
-                                "Invalid pointer passed as argument",
+                                "Invalid argument",
                                 "An object was expected",
                                 "A string was expected",
                                 "A string or symbol was expected",

--- a/test/addons-napi/test_string/test.js
+++ b/test/addons-napi/test_string/test.js
@@ -69,3 +69,7 @@ assert.strictEqual(test_string.TestUtf8Insufficient(str6), str6.slice(0, 1));
 assert.strictEqual(test_string.TestUtf16Insufficient(str6), str6.slice(0, 3));
 assert.strictEqual(test_string.Utf16Length(str6), 5);
 assert.strictEqual(test_string.Utf8Length(str6), 14);
+
+assert.throws(() => {
+  test_string.TestLargeUtf8()
+}, /^Error: Unknown failure$/);

--- a/test/addons-napi/test_string/test.js
+++ b/test/addons-napi/test_string/test.js
@@ -71,5 +71,5 @@ assert.strictEqual(test_string.Utf16Length(str6), 5);
 assert.strictEqual(test_string.Utf8Length(str6), 14);
 
 assert.throws(() => {
-  test_string.TestLargeUtf8()
-}, /^Error: Unknown failure$/);
+  test_string.TestLargeUtf8();
+}, /^Error: Invalid argument$/);

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -201,6 +201,13 @@ napi_value Utf8Length(napi_env env, napi_callback_info info) {
   return output;
 }
 
+napi_value TestLargeUtf8(napi_env env, napi_callback_info info) {
+  napi_value output;
+  NAPI_CALL(env, napi_create_string_utf8(env, "", 4294967296 + 1, &output));
+
+  return output;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
     DECLARE_NAPI_PROPERTY("TestLatin1", TestLatin1),
@@ -211,6 +218,7 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("TestUtf16Insufficient", TestUtf16Insufficient),
     DECLARE_NAPI_PROPERTY("Utf16Length", Utf16Length),
     DECLARE_NAPI_PROPERTY("Utf8Length", Utf8Length),
+    DECLARE_NAPI_PROPERTY("TestLargeUtf8", TestLargeUtf8),
   };
 
   NAPI_CALL(env, napi_define_properties(

--- a/test/addons-napi/test_string/test_string.c
+++ b/test/addons-napi/test_string/test_string.c
@@ -1,3 +1,4 @@
+#include <limits.h>  // INT_MAX
 #include <node_api.h>
 #include "../common.h"
 
@@ -203,7 +204,13 @@ napi_value Utf8Length(napi_env env, napi_callback_info info) {
 
 napi_value TestLargeUtf8(napi_env env, napi_callback_info info) {
   napi_value output;
-  NAPI_CALL(env, napi_create_string_utf8(env, "", 4294967296 + 1, &output));
+  if (SIZE_MAX > INT_MAX) { 
+    NAPI_CALL(env, napi_create_string_utf8(env, "", ((size_t)INT_MAX) + 1, &output));
+  } else {
+    // just throw the expected error as there is nothing to test
+    // in this case since we can't overflow
+    NAPI_CALL(env, napi_throw_error(env, NULL, "Invalid argument"));
+  }
 
   return output;
 }


### PR DESCRIPTION
n-api uses size_t for the size of strings when specifying
string lengths.  V8 only supports a size of int.  Add
a check so that an error will be returned if the user
passes in a string with a size larger than will fit into
an int.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api