### PR TITLE
test: Http2Stream redundant call to shutdown and call passing only callback

### DIFF
--- a/test/parallel/test-http2-server-shutdown-redundant.js
+++ b/test/parallel/test-http2-server-shutdown-redundant.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+// Test blank return when a stream.session.shutdown is called twice
+// Also tests stream.session.shutdown with just a callback function (no options)
+server.on('stream', common.mustCall((stream) => {
+  stream.session.shutdown(common.mustCall(() => {
+    assert.strictEqual(
+      stream.session.shutdown(common.mustNotCall()),
+      undefined
+    );
+  }));
+  stream.session.shutdown(common.mustNotCall());
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request();
+  req.resume();
+  req.on('end', common.mustCall(() => server.close()));
+}));


### PR DESCRIPTION
This PR includes test cases for the handling of:
- redundant call of `stream.session.shutdown()`
- calling `stream.session.shutdown()` with only callback (no options)

Refs: #14985

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
