### PR TITLE
inspector: migrate to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -885,6 +885,31 @@ Used when `http2.connect()` is passed a URL that uses any protocol other than
 
 Used when a given index is out of the accepted range (e.g. negative offsets).
 
+<a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
+### ERR_INSPECTOR_ALREADY_CONNECTED
+
+When using the `inspector` module, the `ERR_INSPECTOR_ALREADY_CONNECTED` error
+code is used when an attempt is made to connect when the inspector is already
+connected.
+
+<a id="ERR_INSPECTOR_CLOSED"></a>
+### ERR_INSPECTOR_CLOSED
+
+When using the `inspector` module, the `ERR_INSPECTOR_CLOSED` error code is
+used when an attempt is made to use the inspector after the session has
+already closed.
+
+<a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
+### ERR_INSPECTOR_NOT_AVAILABLE
+
+Used to identify when the `inspector` module is not available for use.
+
+<a id="ERR_INSPECTOR_NOT_CONNECTED"></a>
+### ERR_INSPECTOR_NOT_CONNECTED
+
+When using the `inspector` module, the `ERR_INSPECTOR_NOT_CONNECTED` error code
+is used when an attempt is made to use the inspector before it is connected.
+
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const EventEmitter = require('events');
+const errors = require('internal/errors');
 const util = require('util');
 const { Connection, open, url } = process.binding('inspector');
 
 if (!Connection)
-  throw new Error('Inspector is not available');
+  throw new errors.Error('ERR_INSPECTOR_NOT_AVAILABLE');
 
 const connectionSymbol = Symbol('connectionProperty');
 const messageCallbacksSymbol = Symbol('messageCallbacks');
@@ -22,7 +23,7 @@ class Session extends EventEmitter {
 
   connect() {
     if (this[connectionSymbol])
-      throw new Error('Already connected');
+      throw new errors.Error('ERR_INSPECTOR_ALREADY_CONNECTED');
     this[connectionSymbol] =
         new Connection((message) => this[onMessageSymbol](message));
   }
@@ -46,24 +47,23 @@ class Session extends EventEmitter {
 
   post(method, params, callback) {
     if (typeof method !== 'string') {
-      throw new TypeError(
-        `"method" must be a string, got ${typeof method} instead`);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'method', 'string', method);
     }
     if (!callback && util.isFunction(params)) {
       callback = params;
       params = null;
     }
     if (params && typeof params !== 'object') {
-      throw new TypeError(
-        `"params" must be an object, got ${typeof params} instead`);
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'params', 'object', params);
     }
     if (callback && typeof callback !== 'function') {
-      throw new TypeError(
-        `"callback" must be a function, got ${typeof callback} instead`);
+      throw new errors.TypeError('ERR_INVALID_CALLBACK');
     }
 
     if (!this[connectionSymbol]) {
-      throw new Error('Session is not connected');
+      throw new errors.Error('ERR_INSPECTOR_NOT_CONNECTED');
     }
     const id = this[nextIdSymbol]++;
     const message = { id, method };
@@ -83,7 +83,7 @@ class Session extends EventEmitter {
     this[connectionSymbol] = null;
     const remainingCallbacks = this[messageCallbacksSymbol].values();
     for (const callback of remainingCallbacks) {
-      process.nextTick(callback, new Error('Session was closed'));
+      process.nextTick(callback, new errors.Error('ERR_INSPECTOR_CLOSED'));
     }
     this[messageCallbacksSymbol].clear();
     this[nextIdSymbol] = 1;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -236,7 +236,7 @@ E('ERR_HTTP_INVALID_STATUS_CODE',
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding');
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
-E('ERR_INSPECTOR_ALREADY_CONNECTED', 'Already connected');
+E('ERR_INSPECTOR_ALREADY_CONNECTED', 'The inspector is already connected');
 E('ERR_INSPECTOR_CLOSED', 'Session was closed');
 E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
 E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -236,6 +236,10 @@ E('ERR_HTTP_INVALID_STATUS_CODE',
 E('ERR_HTTP_TRAILER_INVALID',
   'Trailers are invalid with this transfer encoding');
 E('ERR_INDEX_OUT_OF_RANGE', 'Index out of range');
+E('ERR_INSPECTOR_ALREADY_CONNECTED', 'Already connected');
+E('ERR_INSPECTOR_CLOSED', 'Session was closed');
+E('ERR_INSPECTOR_NOT_AVAILABLE', 'Inspector is not available');
+E('ERR_INSPECTOR_NOT_CONNECTED', 'Session is not connected');
 E('ERR_INVALID_ARG_TYPE', invalidArgType);
 E('ERR_INVALID_ARG_VALUE',
   (name, value) => {

--- a/test/parallel/test-inspector-module.js
+++ b/test/parallel/test-inspector-module.js
@@ -54,7 +54,7 @@ common.expectsError(
   {
     code: 'ERR_INSPECTOR_ALREADY_CONNECTED',
     type: Error,
-    message: 'Already connected'
+    message: 'The inspector is already connected'
   }
 );
 

--- a/test/parallel/test-inspector-module.js
+++ b/test/parallel/test-inspector-module.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { Session } = require('inspector');
+
+const session = new Session();
+
+common.expectsError(
+  () => session.post('Runtime.evaluate', { expression: '2 + 2' }),
+  {
+    code: 'ERR_INSPECTOR_NOT_CONNECTED',
+    type: Error,
+    message: 'Session is not connected'
+  }
+);
+
+assert.doesNotThrow(() => session.connect());
+
+assert.doesNotThrow(
+  () => session.post('Runtime.evaluate', { expression: '2 + 2' }));
+
+[1, {}, [], true, Infinity, undefined].forEach((i) => {
+  common.expectsError(
+    () => session.post(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message:
+        'The "method" argument must be of type string. ' +
+        `Received type ${typeof i}`
+    }
+  );
+});
+
+[1, true, Infinity].forEach((i) => {
+  common.expectsError(
+    () => session.post('test', i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message:
+        'The "params" argument must be of type object. ' +
+        `Received type ${typeof i}`
+    }
+  );
+});
+
+common.expectsError(
+  () => session.connect(),
+  {
+    code: 'ERR_INSPECTOR_ALREADY_CONNECTED',
+    type: Error,
+    message: 'Already connected'
+  }
+);
+
+assert.doesNotThrow(() => session.disconnect());
+assert.doesNotThrow(() => session.disconnect());


### PR DESCRIPTION
migrate to internal/errors

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
inspector,errors