### PR TITLE
src: fixup node_platform blocking task drain

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -86,8 +86,9 @@ static void RunForegroundTask(uv_timer_t* handle) {
 }
 
 void NodePlatform::DrainBackgroundTasks() {
-  while (FlushForegroundTasksInternal())
+  do {
     background_tasks_.BlockingDrain();
+  } while (FlushForegroundTasksInternal());
 }
 
 bool NodePlatform::FlushForegroundTasksInternal() {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/15428 was supposed to account for upcoming changes in V8 upstream, but while addressing review comments a bug was introduced; `DrainBackgroundTasks()` should always at least perform one blocking drain on the background task queue.

Ref: https://github.com/nodejs/node/pull/15428
Ref: f27b5e4bdaafc73a830a0451ee3c641b8bcd08fe

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

src/node_platform

@hashseed @nodejs/v8