### PR TITLE
perf_hooks: remove docs for unimplemented API

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -135,16 +135,6 @@ the Performance Timeline or any of the timestamp properties provided by the
 `PerformanceNodeTiming` class. If the named `endMark` does not exist, an
 error will be thrown.
 
-### performance.nodeFrame
-<!-- YAML
-added: v8.5.0
--->
-
-* {PerformanceFrame}
-
-An instance of the `PerformanceFrame` class that provides performance metrics
-for the event loop.
-
 ### performance.nodeTiming
 <!-- YAML
 added: v8.5.0
@@ -267,37 +257,6 @@ The value may be one of:
 * `perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR`
 * `perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL`
 * `perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB`
-
-## Class: PerformanceNodeFrame extends PerformanceEntry
-<!-- YAML
-added: v8.5.0
--->
-
-Provides timing details for the Node.js event loop.
-
-### performanceNodeFrame.frameCheck
-
-The high resolution timestamp when `uv_check_t` processing occurred on the
-current loop.
-
-### performanceNodeFrame.frameCount
-
-The total number of event loop iterations (iterated when `uv_idle_t`
-processing occurrs).
-
-### performanceNodeFrame.frameIdle
-
-The high resolution timestamp when `uv_idle_t` processing occurred on the
-current loop.
-
-### performanceNodeFrame.framesPerSecond
-
-The number of event loop iterations per second.
-
-### performanceNodeFrame.framePrepare
-
-The high resolution timestamp when `uv_prepare_t` processing occurred on the
-current loop.
 
 ## Class: PerformanceNodeTiming extends PerformanceEntry
 <!-- YAML


### PR DESCRIPTION
The node frame (aka loop) timing API did not land, it depends on
https://github.com/libuv/libuv/pull/1489 which is still a WIP.

See: https://github.com/nodejs/node/pull/14680#discussion_r140605664

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
