### PR TITLE
doc: fix link in the test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@ For a detailed guide on how to write tests in this
 directory, see [the guide on writing tests](../doc/guides/writing-tests.md).
 
 On how to run tests in this directory, see
-[the contributing guide](../CONTRIBUTING.md#step-5-test).
+[the contributing guide](../CONTRIBUTING.md#step-6-test).
 
 ## Test Directories
 


### PR DESCRIPTION
It seems the link must point to `[Step 6: Test](#step-6-test)`: 

https://github.com/nodejs/node/blob/93985ef83cf3b7e10c6199776a20b5ea3f93bf4d/CONTRIBUTING.md#L33-L35

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
