### PR TITLE
inspector: overhaul JS binding implementation

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -2,9 +2,9 @@
 
 const EventEmitter = require('events');
 const util = require('util');
-const { connect, open, url } = process.binding('inspector');
+const { Connection, open, url } = process.binding('inspector');
 
-if (!connect)
+if (!Connection)
   throw new Error('Inspector is not available');
 
 const connectionSymbol = Symbol('connectionProperty');
@@ -24,7 +24,7 @@ class Session extends EventEmitter {
     if (this[connectionSymbol])
       throw new Error('Already connected');
     this[connectionSymbol] =
-        connect((message) => this[onMessageSymbol](message));
+        new Connection((message) => this[onMessageSymbol](message));
   }
 
   [onMessageSymbol](message) {

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -83,6 +83,11 @@ const builtinLibs = [
   'stream', 'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ];
 
+if (typeof process.binding('inspector').connect === 'function') {
+  builtinLibs.push('inspector');
+  builtinLibs.sort();
+}
+
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).
   builtinLibs.forEach((name) => {

--- a/src/async-wrap.h
+++ b/src/async-wrap.h
@@ -71,9 +71,17 @@ namespace node {
 #define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 #endif  // HAVE_OPENSSL
 
+#if HAVE_INSPECTOR
+#define NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)                                \
+  V(INSPECTORJSBINDING)
+#else
+#define NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)
+#endif  // HAVE_INSPECTOR
+
 #define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
   NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                                     \
-  NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
+  NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)                                         \
+  NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)                                      \
 
 class Environment;
 

--- a/src/env.h
+++ b/src/env.h
@@ -89,7 +89,6 @@ class ModuleWrap;
   V(arrow_message_private_symbol, "node:arrowMessage")                        \
   V(contextify_context_private_symbol, "node:contextify:context")             \
   V(contextify_global_private_symbol, "node:contextify:global")               \
-  V(inspector_delegate_private_symbol, "node:inspector:delegate")             \
   V(decorated_private_symbol, "node:decorated")                               \
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(processed_private_symbol, "node:processed")                               \

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -1,6 +1,8 @@
 #include "inspector_agent.h"
 
 #include "inspector_io.h"
+#include "base-object.h"
+#include "base-object-inl.h"
 #include "node_internals.h"
 #include "v8-inspector.h"
 #include "v8-platform.h"
@@ -26,9 +28,9 @@ using node::FatalError;
 using v8::Array;
 using v8::Boolean;
 using v8::Context;
-using v8::External;
 using v8::Function;
 using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
@@ -191,143 +193,117 @@ static int StartDebugSignalHandler() {
 }
 #endif  // _WIN32
 
-class JsBindingsSessionDelegate : public InspectorSessionDelegate {
+class JSBindingsConnection : public AsyncWrap {
  public:
-  JsBindingsSessionDelegate(Environment* env,
-                            Local<Object> session,
-                            Local<Object> receiver,
-                            Local<Function> callback)
-                            : env_(env),
-                              session_(env->isolate(), session),
-                              receiver_(env->isolate(), receiver),
-                              callback_(env->isolate(), callback) {
-    session_.SetWeak(this, JsBindingsSessionDelegate::Release,
-                     v8::WeakCallbackType::kParameter);
+  class JSBindingsSessionDelegate : public InspectorSessionDelegate {
+   public:
+    JSBindingsSessionDelegate(Environment* env,
+                              JSBindingsConnection* connection)
+                              : env_(env),
+                                connection_(connection) {
+    }
+
+    bool WaitForFrontendMessageWhilePaused() override {
+      return false;
+    }
+
+    void SendMessageToFrontend(const v8_inspector::StringView& message)
+        override {
+      Isolate* isolate = env_->isolate();
+      v8::HandleScope handle_scope(isolate);
+      Context::Scope context_scope(env_->context());
+      MaybeLocal<String> v8string =
+          String::NewFromTwoByte(isolate, message.characters16(),
+                                 NewStringType::kNormal, message.length());
+      Local<Value> argument = v8string.ToLocalChecked().As<Value>();
+      connection_->OnMessage(argument);
+    }
+
+    void Disconnect() {
+      Agent* agent = env_->inspector_agent();
+      if (agent->delegate() == this)
+        agent->Disconnect();
+    }
+
+   private:
+    Environment* env_;
+    JSBindingsConnection* connection_;
+  };
+
+  JSBindingsConnection(Environment* env,
+                       Local<Object> wrap,
+                       Local<Function> callback)
+                       : AsyncWrap(env, wrap, PROVIDER_INSPECTORJSBINDING),
+                         delegate_(env, this),
+                         callback_(env->isolate(), callback) {
+    Wrap(wrap, this);
+
+    Agent* inspector = env->inspector_agent();
+    if (inspector->delegate() != nullptr) {
+      env->ThrowTypeError("Session is already attached");
+      return;
+    }
+    inspector->Connect(&delegate_);
   }
 
-  ~JsBindingsSessionDelegate() override {
-    session_.Reset();
-    receiver_.Reset();
+  ~JSBindingsConnection() override {
     callback_.Reset();
   }
 
-  bool WaitForFrontendMessageWhilePaused() override {
-    return false;
+  void OnMessage(Local<Value> value) {
+    MakeCallback(callback_.Get(env()->isolate()), 1, &value);
   }
 
-  void SendMessageToFrontend(const v8_inspector::StringView& message) override {
-    Isolate* isolate = env_->isolate();
-    v8::HandleScope handle_scope(isolate);
-    Context::Scope context_scope(env_->context());
-    MaybeLocal<String> v8string =
-        String::NewFromTwoByte(isolate, message.characters16(),
-                               NewStringType::kNormal, message.length());
-    Local<Value> argument = v8string.ToLocalChecked().As<Value>();
-    Local<Function> callback = callback_.Get(isolate);
-    Local<Object> receiver = receiver_.Get(isolate);
-    callback->Call(env_->context(), receiver, 1, &argument)
-        .FromMaybe(Local<Value>());
+  void CheckIsCurrent() {
+    Agent* inspector = env()->inspector_agent();
+    CHECK_EQ(&delegate_, inspector->delegate());
+  }
+
+  static void New(const FunctionCallbackInfo<Value>& info) {
+    Environment* env = Environment::GetCurrent(info);
+    if (!info[0]->IsFunction()) {
+      env->ThrowTypeError("Message callback is required");
+      return;
+    }
+    Local<Function> callback = info[0].As<Function>();
+    new JSBindingsConnection(env, info.This(), callback);
   }
 
   void Disconnect() {
-    Agent* agent = env_->inspector_agent();
-    if (agent->delegate() == this)
-      agent->Disconnect();
+    delegate_.Disconnect();
+    if (!persistent().IsEmpty()) {
+      ClearWrap(object());
+      persistent().Reset();
+    }
+    delete this;
   }
+
+  static void Disconnect(const FunctionCallbackInfo<Value>& info) {
+    JSBindingsConnection* session;
+    ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+    session->Disconnect();
+  }
+
+  static void Dispatch(const FunctionCallbackInfo<Value>& info) {
+    Environment* env = Environment::GetCurrent(info);
+    JSBindingsConnection* session;
+    ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+    if (!info[0]->IsString()) {
+      env->ThrowTypeError("Inspector message must be a string");
+      return;
+    }
+
+    session->CheckIsCurrent();
+    Agent* inspector = env->inspector_agent();
+    inspector->Dispatch(ToProtocolString(env->isolate(), info[0])->string());
+  }
+
+  size_t self_size() const override { return sizeof(*this); }
 
  private:
-  static void Release(
-      const v8::WeakCallbackInfo<JsBindingsSessionDelegate>& info) {
-    info.SetSecondPassCallback(ReleaseSecondPass);
-    info.GetParameter()->session_.Reset();
-  }
-
-  static void ReleaseSecondPass(
-      const v8::WeakCallbackInfo<JsBindingsSessionDelegate>& info) {
-    JsBindingsSessionDelegate* delegate = info.GetParameter();
-    delegate->Disconnect();
-    delete delegate;
-  }
-
-  Environment* env_;
-  Persistent<Object> session_;
-  Persistent<Object> receiver_;
+  JSBindingsSessionDelegate delegate_;
   Persistent<Function> callback_;
 };
-
-void SetDelegate(Environment* env, Local<Object> inspector,
-                 JsBindingsSessionDelegate* delegate) {
-  inspector->SetPrivate(env->context(),
-                        env->inspector_delegate_private_symbol(),
-                        v8::External::New(env->isolate(), delegate));
-}
-
-Maybe<JsBindingsSessionDelegate*> GetDelegate(
-    const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  Local<Value> delegate;
-  MaybeLocal<Value> maybe_delegate =
-      info.This()->GetPrivate(env->context(),
-                              env->inspector_delegate_private_symbol());
-
-  if (maybe_delegate.ToLocal(&delegate)) {
-    CHECK(delegate->IsExternal());
-    void* value = delegate.As<External>()->Value();
-    if (value != nullptr) {
-      return v8::Just(static_cast<JsBindingsSessionDelegate*>(value));
-    }
-  }
-  env->ThrowError("Inspector is not connected");
-  return v8::Nothing<JsBindingsSessionDelegate*>();
-}
-
-void Dispatch(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  if (!info[0]->IsString()) {
-    env->ThrowError("Inspector message must be a string");
-    return;
-  }
-  Maybe<JsBindingsSessionDelegate*> maybe_delegate = GetDelegate(info);
-  if (maybe_delegate.IsNothing())
-    return;
-  Agent* inspector = env->inspector_agent();
-  CHECK_EQ(maybe_delegate.ToChecked(), inspector->delegate());
-  inspector->Dispatch(ToProtocolString(env->isolate(), info[0])->string());
-}
-
-void Disconnect(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  Maybe<JsBindingsSessionDelegate*> delegate = GetDelegate(info);
-  if (delegate.IsNothing()) {
-    return;
-  }
-  delegate.ToChecked()->Disconnect();
-  SetDelegate(env, info.This(), nullptr);
-  delete delegate.ToChecked();
-}
-
-void ConnectJSBindingsSession(const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  if (!info[0]->IsFunction()) {
-    env->ThrowError("Message callback is required");
-    return;
-  }
-  Agent* inspector = env->inspector_agent();
-  if (inspector->delegate() != nullptr) {
-    env->ThrowError("Session is already attached");
-    return;
-  }
-  Local<Object> session = Object::New(env->isolate());
-  env->SetMethod(session, "dispatch", Dispatch);
-  env->SetMethod(session, "disconnect", Disconnect);
-  info.GetReturnValue().Set(session);
-
-  JsBindingsSessionDelegate* delegate =
-      new JsBindingsSessionDelegate(env, session, info.Holder(),
-                                    info[0].As<Function>());
-  inspector->Connect(delegate);
-  SetDelegate(env, session, delegate);
-}
 
 void InspectorConsoleCall(const v8::FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
@@ -973,7 +949,6 @@ void Agent::InitInspector(Local<Object> target, Local<Value> unused,
   env->SetMethod(target, "addCommandLineAPI", AddCommandLineAPI);
   if (agent->debug_options_.wait_for_connect())
     env->SetMethod(target, "callAndPauseOnStart", CallAndPauseOnStart);
-  env->SetMethod(target, "connect", ConnectJSBindingsSession);
   env->SetMethod(target, "open", Open);
   env->SetMethod(target, "url", Url);
 
@@ -987,6 +962,16 @@ void Agent::InitInspector(Local<Object> target, Local<Value> unused,
 
   env->SetMethod(target, "registerAsyncHook", RegisterAsyncHookWrapper);
   env->SetMethod(target, "isEnabled", IsEnabled);
+
+  auto conn_str = FIXED_ONE_BYTE_STRING(env->isolate(), "Connection");
+  Local<FunctionTemplate> tmpl =
+      env->NewFunctionTemplate(JSBindingsConnection::New);
+  tmpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tmpl->SetClassName(conn_str);
+  AsyncWrap::AddWrapMethods(env, tmpl);
+  env->SetProtoMethod(tmpl, "dispatch", JSBindingsConnection::Dispatch);
+  env->SetProtoMethod(tmpl, "disconnect", JSBindingsConnection::Disconnect);
+  target->Set(env->context(), conn_str, tmpl->GetFunction()).ToChecked();
 }
 
 void Agent::RequestIoThreadStart() {

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -273,3 +273,10 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
   handle.send(req, [Buffer.alloc(1)], 1, req.port, req.address, true);
   testInitialized(req, 'SendWrap');
 }
+
+if (process.config.variables.v8_enable_inspector !== 0) {
+  const binding = process.binding('inspector');
+  const handle = new binding.Connection(() => {});
+  testInitialized(handle, 'Connection');
+  handle.disconnect();
+}


### PR DESCRIPTION
The first two commits of this PR are identical to https://github.com/nodejs/node/pull/14710. However, the last two commits fixed the GC problem pointed out by @bnoordhuis in https://github.com/nodejs/node/pull/14710#pullrequestreview-56313341, and makes `Connection` an AsyncWrap for async hooks support.

With

```js
const sess = new inspector.Session();
sess.connect();
sess.post('Runtime.evaluate', {
  expression: 'Promise.resolve(3)',
  awaitPromise: true
}, (err, msg) => {
  console.log(msg);
});
```

and appropriate async hooks, whereas before this PR it looked like

```
PROMISE(4): trigger: 1 execution: 1
PROMISE(5): trigger: 4 execution: 1
PROMISE(6): trigger: 4 execution: 1
before:  5
{ result: { type: 'number', value: 3, description: '3' } }
  TickObject(7): trigger: 5 execution: 5
after:   5
before:  6
after:   6
before:  7
after:   7
destroy: 7
```

after it

```
INSPECTORJSBINDING(5): trigger: 1 execution: 1
PROMISE(6): trigger: 1 execution: 1
PROMISE(7): trigger: 6 execution: 1
PROMISE(8): trigger: 6 execution: 1
before:  7
  before:  5
{ result: { type: 'number', value: 3, description: '3' } }
    TickObject(9): trigger: 5 execution: 5
  after:   5
after:   7
before:  8
after:   8
before:  9
after:   9
destroy: 9
```

with proper instrumentation.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
inspector