### PR TITLE
async_hooks: fix pointer exception

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -274,7 +274,6 @@ PromiseWrap* PromiseWrap::New(Environment* env,
                              Number::New(env->isolate(),
                                          parent_wrap->get_async_id()));
   }
-  CHECK_EQ(promise->GetAlignedPointerFromInternalField(0), nullptr);
   promise->SetInternalField(0, object);
   return new PromiseWrap(env, object, silent);
 }


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks: previously, if you tried to resolve a promise from the `init` handler you would get a `FATAL ERROR: v8::Object::GetAlignedPointerFromInternalField() Not a Smi` exception.

Here is an example to reproduce the original issue:

```js
'use strict';

const { createHook } = require('async_hooks');
const { promiseResolve } = process.binding('util');

let isCalled;
const init = function (asyncId, type, triggerId, resource) {
  if (type === 'PROMISE' && !isCalled) {
    isCalled = true;
    promiseResolve(resource.promise, 'result');
  }
};

const asyncHook = createHook({ init });

const func = () => {
  return new Promise((resolve, reject) => {
    setImmediate(() => {
      throw new Error()
    });
  });
};

const main = async () => {
  asyncHook.enable();
  try {
    await func();
  } catch (ex) {
    console.log('caught exception');
  }
  asyncHook.disable();
}

main();
```

This resulted in:

```
$ node async.js
FATAL ERROR: v8::Object::GetAlignedPointerFromInternalField() Not a Smi
 1: node::Abort() [node]
 2: node::FatalException(v8::Isolate*, v8::Local<v8::Value>, v8::Local<v8::Message>) [node]
 3: v8::Object::SlowGetAlignedPointerFromInternalField(int) [node]
 4: node::PromiseWrap::New(node::Environment*, v8::Local<v8::Promise>, node::PromiseWrap*, bool) [node]
 5: node::PromiseHook(v8::PromiseHookType, v8::Local<v8::Promise>, v8::Local<v8::Value>, void*) [node]
 6: node::Environment::EnvPromiseHook(v8::PromiseHookType, v8::Local<v8::Promise>, v8::Local<v8::Value>) [node]
 7: v8::internal::Runtime_PromiseHookResolve(int, v8::internal::Object**, v8::internal::Isolate*) [node]
 8: 0x33630c38463d
 9: 0x33630c4083a0
Abort trap: 6
```