### PR TITLE
src: remove unused using in node_trace_writer.h

### DIFF
--- a/src/tracing/node_trace_writer.h
+++ b/src/tracing/node_trace_writer.h
@@ -13,7 +13,6 @@ namespace tracing {
 
 using v8::platform::tracing::TraceObject;
 using v8::platform::tracing::TraceWriter;
-using v8::platform::tracing::TracingController;
 
 class NodeTraceWriter : public TraceWriter {
  public:


### PR DESCRIPTION
There is an unnecessary using TracingController in node_trace_writer.h
and this commit removes it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src