### PR TITLE
tty: require readline at top of file

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -28,6 +28,7 @@ const isTTY = process.binding('tty_wrap').isTTY;
 const inherits = util.inherits;
 const errnoException = util._errnoException;
 const errors = require('internal/errors');
+const readline = require('readline');
 
 exports.isatty = function(fd) {
   return isTTY(fd);
@@ -117,16 +118,16 @@ WriteStream.prototype._refreshSize = function() {
 
 // backwards-compat
 WriteStream.prototype.cursorTo = function(x, y) {
-  require('readline').cursorTo(this, x, y);
+  readline.cursorTo(this, x, y);
 };
 WriteStream.prototype.moveCursor = function(dx, dy) {
-  require('readline').moveCursor(this, dx, dy);
+  readline.moveCursor(this, dx, dy);
 };
 WriteStream.prototype.clearLine = function(dir) {
-  require('readline').clearLine(this, dir);
+  readline.clearLine(this, dir);
 };
 WriteStream.prototype.clearScreenDown = function() {
-  require('readline').clearScreenDown(this);
+  readline.clearScreenDown(this);
 };
 WriteStream.prototype.getWindowSize = function() {
   return [this.columns, this.rows];


### PR DESCRIPTION
No need to require it on each of those function calls.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tty