### PR TITLE
stream: fix disparity between buffer and the count

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -502,6 +502,7 @@ function clearBuffer(stream, state) {
       corkReq.finish = onCorkedFinish.bind(undefined, corkReq, state);
       state.corkedRequestsFree = corkReq;
     }
+    state.bufferedRequestCount = 0;
   } else {
     // Slow case, write chunks one-by-one
     while (entry) {
@@ -512,6 +513,7 @@ function clearBuffer(stream, state) {
 
       doWrite(stream, state, false, len, chunk, encoding, cb);
       entry = entry.next;
+      state.bufferedRequestCount--;
       // if we didn't call the onwrite immediately, then
       // it means that we need to wait until it does.
       // also, that means that the chunk and cb are currently
@@ -525,7 +527,6 @@ function clearBuffer(stream, state) {
       state.lastBufferedRequest = null;
   }
 
-  state.bufferedRequestCount = 0;
   state.bufferedRequest = entry;
   state.bufferProcessing = false;
 }

--- a/test/sequential/test-stream-writable-clear-buffer.js
+++ b/test/sequential/test-stream-writable-clear-buffer.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const Stream = require('stream');
+//this test ensures that the _writeableState.bufferedRequestCount and
+// the actual buffered request count are the same
+const assert = require('assert');
+
+class StreamWritable extends Stream.Writable {
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  //We need a timeout like on the original issue thread
+  //otherwise the code will never reach our test case
+  //this means this should go on the sequential folder.
+  _write(chunk, encoding, cb) {
+    setTimeout(cb, common.platformTimeout(10));
+  }
+}
+
+const testStream = new StreamWritable();
+testStream.cork();
+
+for (let i = 1; i <= 5; i++) {
+  testStream.write(i, function() {
+    assert.strictEqual(
+      testStream._writableState.bufferedRequestCount,
+      testStream._writableState.getBuffer().length,
+      'bufferedRequestCount variable is different from the actual length of' +
+      ' the buffer');
+  });
+}
+
+testStream.end();

--- a/test/sequential/test-stream-writable-clear-buffer.js
+++ b/test/sequential/test-stream-writable-clear-buffer.js
@@ -1,7 +1,7 @@
 'use strict';
 const common = require('../common');
 const Stream = require('stream');
-//this test ensures that the _writeableState.bufferedRequestCount and
+// This test ensures that the _writeableState.bufferedRequestCount and
 // the actual buffered request count are the same
 const assert = require('assert');
 
@@ -10,9 +10,9 @@ class StreamWritable extends Stream.Writable {
     super({ objectMode: true });
   }
 
-  //We need a timeout like on the original issue thread
-  //otherwise the code will never reach our test case
-  //this means this should go on the sequential folder.
+  // We need a timeout like on the original issue thread
+  // otherwise the code will never reach our test case
+  // this means this should go on the sequential folder.
   _write(chunk, encoding, cb) {
     setTimeout(cb, common.platformTimeout(10));
   }


### PR DESCRIPTION
This changes the disparity of bufferedRequestCount and the actual buffer
on file _stream_writable.js
Fixes: https://github.com/nodejs/node/issues/6758

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
Stream Writable
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Note: I introduced the test in the sequential subfolder because I couldn't think of another way to test that part of the code without using a timeout (like in the example of the issue thread).
