### PR TITLE
test: fix flaky test-crypto-classes.js

### DIFF
--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -25,6 +25,7 @@ const TEST_CASES = {
 if (!common.hasFipsCrypto) {
   TEST_CASES.Cipher = ['aes192', 'secret'];
   TEST_CASES.Decipher = ['aes192', 'secret'];
+  TEST_CASES.DiffieHellman = [256];
 }
 
 for (const [clazz, args] of Object.entries(TEST_CASES)) {


### PR DESCRIPTION
On non-FIPS, we can instantiate DiffieHellman with 256 instead of 1024.
This should be quite a bit faster, and therefore prevent the timeouts.

Fixes: https://github.com/nodejs/node/issues/15655

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
