### PR TITLE
deps: V8: cherry-pick 163d360 from upstream

### DIFF
--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -1814,7 +1814,11 @@ void Heap::Scavenge() {
   ArrayBufferTracker::FreeDeadInNewSpace(this);
 
   RememberedSet<OLD_TO_NEW>::IterateMemoryChunks(this, [](MemoryChunk* chunk) {
-    RememberedSet<OLD_TO_NEW>::PreFreeEmptyBuckets(chunk);
+    if (chunk->SweepingDone()) {
+      RememberedSet<OLD_TO_NEW>::FreeEmptyBuckets(chunk);
+    } else {
+      RememberedSet<OLD_TO_NEW>::PreFreeEmptyBuckets(chunk);
+    }
   });
 
   // Update how much has survived scavenge.

--- a/deps/v8/src/heap/remembered-set.h
+++ b/deps/v8/src/heap/remembered-set.h
@@ -150,6 +150,19 @@ class RememberedSet : public AllStatic {
     }
   }
 
+  static int NumberOfPreFreedEmptyBuckets(MemoryChunk* chunk) {
+    DCHECK(type == OLD_TO_NEW);
+    int result = 0;
+    SlotSet* slots = chunk->slot_set<type>();
+    if (slots != nullptr) {
+      size_t pages = (chunk->size() + Page::kPageSize - 1) / Page::kPageSize;
+      for (size_t page = 0; page < pages; page++) {
+        result += slots[page].NumberOfPreFreedEmptyBuckets();
+      }
+    }
+    return result;
+  }
+
   static void PreFreeEmptyBuckets(MemoryChunk* chunk) {
     DCHECK(type == OLD_TO_NEW);
     SlotSet* slots = chunk->slot_set<type>();
@@ -157,6 +170,18 @@ class RememberedSet : public AllStatic {
       size_t pages = (chunk->size() + Page::kPageSize - 1) / Page::kPageSize;
       for (size_t page = 0; page < pages; page++) {
         slots[page].PreFreeEmptyBuckets();
+      }
+    }
+  }
+
+  static void FreeEmptyBuckets(MemoryChunk* chunk) {
+    DCHECK(type == OLD_TO_NEW);
+    SlotSet* slots = chunk->slot_set<type>();
+    if (slots != nullptr) {
+      size_t pages = (chunk->size() + Page::kPageSize - 1) / Page::kPageSize;
+      for (size_t page = 0; page < pages; page++) {
+        slots[page].FreeEmptyBuckets();
+        slots[page].FreeToBeFreedBuckets();
       }
     }
   }

--- a/deps/v8/src/heap/spaces.cc
+++ b/deps/v8/src/heap/spaces.cc
@@ -3308,6 +3308,7 @@ void LargeObjectSpace::ClearMarkingStateOfLiveObjects() {
       Marking::MarkWhite(
           ObjectMarking::MarkBitFrom(obj, MarkingState::Internal(obj)));
       MemoryChunk* chunk = MemoryChunk::FromAddress(obj->address());
+      RememberedSet<OLD_TO_NEW>::FreeEmptyBuckets(chunk);
       chunk->ResetProgressBar();
       MarkingState::Internal(chunk).SetLiveBytes(0);
     }


### PR DESCRIPTION
Fixes a [memory leak](https://bugs.chromium.org/p/v8/issues/detail?id=6800) in V8 affecting `8.x` and `master`. `v8-version.h` was not bumped as 6.1 is still stable.

```
Original commit message
  [heap] Fix memory leak in the remembered set.

  Empty slot set buckets can leak in the following scenarios.

  Scenario 1 (large object space):
  1) A large array is allocated in the large object space.
  2) The array is filled with old->new references, which allocates new
    slot set buckets.
  3) The references are overwritten with smis or old space pointers, which
    make the slots set buckets empty.
  4) Garbage collection (scavenge or mark-compact) iterates the slots set
    of the array and pre-frees the empty buckets.
  5) Steps 2-4 repeated many times and leak arbitary many empty buckets.
  The fix to free empty buckets for large object space in mark-compact.

  Scenario 2 (no mark-compact):
  1) A small array is allocated in the old space.
  2) The array is filled with old->new references, which allocates new
    slot set buckets.
  3) The references are overwritten with smis or old space pointers, which
    make the slots set buckets empty.
  4) Scavenge iterates the slots set of the array and pre-frees the empty
    buckets.
  5) Steps 2-4 repeated many times and leak arbitary many empty buckets.
  The fix to free empty buckets for swept pages in scavenger.

  Bug: v8:6800
  TBR: mlippautz@chromium.org
  Change-Id: I48d94870f5acf4f6208858271886911c895a9126
  Reviewed-on: https://chromium-review.googlesource.com/668442
  Reviewed-by: Ulan Degenbaev <ulan@chromium.org>
  Commit-Queue: Ulan Degenbaev <ulan@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#48041}
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:v8

/cc @nodejs/v8 

CI: https://ci.nodejs.org/job/node-test-pull-request/10324/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/937/