### PR TITLE
stream: migrate stream errors to internal/errors

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -1040,11 +1040,6 @@ function copyFromBuffer(n, list) {
 function endReadable(stream) {
   var state = stream._readableState;
 
-  // If we get here before consuming all the bytes, then that is a
-  // bug in node.  Should never happen.
-  if (state.length > 0)
-    throw new Error('"endReadable()" called on non-empty stream');
-
   if (!state.endEmitted) {
     state.ended = true;
     process.nextTick(endReadableNT, state, stream);

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -157,7 +157,7 @@ Transform.prototype.push = function(chunk, encoding) {
 // an error, then that'll put the hurt on the whole operation.  If you
 // never call cb(), then you'll never get another chunk.
 Transform.prototype._transform = function(chunk, encoding, cb) {
-  throw new Error('_transform() is not implemented');
+  throw new errors.Error('ERR_METHOD_NOT_IMPLEMENTED', '_transform');
 };
 
 Transform.prototype._write = function(chunk, encoding, cb) {

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -33,6 +33,7 @@ const internalUtil = require('internal/util');
 const Stream = require('stream');
 const Buffer = require('buffer').Buffer;
 const destroyImpl = require('internal/streams/destroy');
+const errors = require('internal/errors');
 
 util.inherits(Writable, Stream);
 
@@ -319,7 +320,7 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
   if (typeof encoding === 'string')
     encoding = encoding.toLowerCase();
   if (!Buffer.isEncoding(encoding))
-    throw new TypeError('Unknown encoding: ' + encoding);
+    throw new errors.TypeError('ERR_UNKNOWN_ENCODING', encoding);
   this._writableState.defaultEncoding = encoding;
   return this;
 };

--- a/test/parallel/test-stream-transform-constructor-set-methods.js
+++ b/test/parallel/test-stream-transform-constructor-set-methods.js
@@ -27,10 +27,13 @@ const t2 = new Transform({});
 t.end(Buffer.from('blerg'));
 t.resume();
 
-assert.throws(() => {
+common.expectsError(() => {
   t2.end(Buffer.from('blerg'));
-}, /^Error: _transform\(\) is not implemented$/);
-
+}, {
+  type: Error,
+  code: 'ERR_METHOD_NOT_IMPLEMENTED',
+  message: 'The _transform method is not implemented'
+});
 
 process.on('exit', () => {
   assert.strictEqual(t._transform, _transform);

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
@@ -55,13 +55,17 @@ MyWritable.prototype._write = function(chunk, encoding, callback) {
   m.end();
 }());
 
-assert.throws(function changeDefaultEncodingToInvalidValue() {
+common.expectsError(function changeDefaultEncodingToInvalidValue() {
   const m = new MyWritable(function(isBuffer, type, enc) {
   }, { decodeStrings: false });
   m.setDefaultEncoding({});
   m.write('bar');
   m.end();
-}, /^TypeError: Unknown encoding: \[object Object\]$/);
+}, {
+  type: TypeError,
+  code: 'ERR_UNKNOWN_ENCODING',
+  message: 'Unknown encoding: [object Object]'
+});
 
 (function checkVairableCaseEncoding() {
   const m = new MyWritable(function(isBuffer, type, enc) {


### PR DESCRIPTION
I removed some dead code and migrated the rest of the stream errors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream