### PR TITLE
[v6.x backport] doc: add links to alternative versions of doc

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -1,5 +1,7 @@
 # C/C++ Addons
 
+<!--introduced_in=v0.10.0-->
+
 Node.js Addons are dynamically-linked shared objects, written in C or C++, that
 can be loaded into Node.js using the [`require()`][require] function, and used
 just as if they were an ordinary Node.js module. They are used primarily to

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1,5 +1,7 @@
 # Assert
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `assert` module provides a simple set of assertion tests that can be used to

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1,5 +1,7 @@
 # Buffer
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 Prior to the introduction of [`TypedArray`] in ECMAScript 2015 (ES6), the

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1,5 +1,7 @@
 # Child Process
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `child_process` module provides the ability to spawn child processes in

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1,5 +1,6 @@
 # Command Line Options
 
+<!--introduced_in=v5.9.1-->
 <!--type=misc-->
 
 Node.js comes with a variety of CLI options. These options expose built-in

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -1,5 +1,7 @@
 # Cluster
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 A single instance of Node.js runs in a single thread. To take advantage of

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -1,5 +1,7 @@
 # Console
 
+<!--introduced_in=v0.10.13-->
+
 > Stability: 2 - Stable
 
 The `console` module provides a simple debugging console that is similar to the

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1,5 +1,7 @@
 # Crypto
 
+<!--introduced_in=v0.3.6-->
+
 > Stability: 2 - Stable
 
 The `crypto` module provides cryptographic functionality that includes a set of

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -1,5 +1,7 @@
 # Debugger
 
+<!--introduced_in=v0.9.12-->
+
 > Stability: 2 - Stable
 
 <!-- type=misc -->

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -1,5 +1,7 @@
 # UDP / Datagram Sockets
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!-- name=dgram -->

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1,5 +1,7 @@
 # DNS
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `dns` module contains functions belonging to two different categories:

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -1,5 +1,6 @@
 # About this Documentation
 
+<!--introduced_in=v0.10.0-->
 <!-- type=misc -->
 
 The goal of this documentation is to comprehensively explain the Node.js

--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -1,5 +1,7 @@
 # Domain
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 0 - Deprecated
 
 **This module is pending deprecation**. Once a replacement API has been

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1,5 +1,6 @@
 # Errors
 
+<!--introduced_in=v4.0.0-->
 <!--type=misc-->
 
 Applications running in Node.js will generally experience four categories of

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1,5 +1,7 @@
 # Events
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--type=module-->

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1,5 +1,7 @@
 # File System
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=fs-->

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1,5 +1,6 @@
 # Global Objects
 
+<!--introduced_in=v0.10.0-->
 <!-- type=misc -->
 
 These objects are available in all modules. Some of these objects aren't

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1,5 +1,7 @@
 # HTTP
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 To use the HTTP server and client one must `require('http')`.

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -1,5 +1,7 @@
 # HTTPS
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1,5 +1,7 @@
 # Modules
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=module-->

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1,5 +1,7 @@
 # Net
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `net` module provides you with an asynchronous network wrapper. It contains

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -1,5 +1,7 @@
 # OS
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `os` module provides a number of operating system-related utility methods.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -1,5 +1,7 @@
 # Path
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `path` module provides utilities for working with file and directory paths.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1,5 +1,6 @@
 # Process
 
+<!-- introduced_in=v0.10.0 -->
 <!-- type=global -->
 
 The `process` object is a `global` that provides information about, and control

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -1,5 +1,7 @@
 # Punycode
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 0 - Deprecated
 
 **The version of the punycode module bundled in Node.js is being deprecated**.

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -1,5 +1,7 @@
 # Query String
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=querystring-->

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -1,5 +1,7 @@
 # Readline
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `readline` module provides an interface for reading data from a [Readable][]

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1,5 +1,7 @@
 # REPL
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `repl` module provides a Read-Eval-Print-Loop (REPL) implementation that

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1,5 +1,7 @@
 # Stream
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 A stream is an abstract interface for working with streaming data in Node.js.

--- a/doc/api/string_decoder.md
+++ b/doc/api/string_decoder.md
@@ -1,5 +1,7 @@
 # String Decoder
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `string_decoder` module provides an API for decoding `Buffer` objects into

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -1,5 +1,6 @@
 # Usage
 
+<!--introduced_in=v0.10.0-->
 <!--type=misc-->
 
 `node [options] [v8 options] [script.js | -e "script"] [arguments]`

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -1,5 +1,7 @@
 # Timers
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `timer` module exposes a global API for scheduling functions to

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1,5 +1,7 @@
 # TLS (SSL)
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `tls` module provides an implementation of the Transport Layer Security

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -1,5 +1,7 @@
 # TTY
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `tty` module provides the `tty.ReadStream` and `tty.WriteStream` classes.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1,5 +1,7 @@
 # URL
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `url` module provides utilities for URL resolution and parsing. It can be

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1,5 +1,7 @@
 # Util
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `util` module is primarily designed to support the needs of Node.js' own

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1,5 +1,7 @@
 # V8
 
+<!--introduced_in=v4.0.0-->
+
 The `v8` module exposes APIs that are specific to the version of [V8][]
 built into the Node.js binary. It can be accessed using:
 

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1,5 +1,7 @@
 # VM (Executing JavaScript)
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 <!--name=vm-->

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -1,5 +1,7 @@
 # Zlib
 
+<!--introduced_in=v0.10.0-->
+
 > Stability: 2 - Stable
 
 The `zlib` module provides compression functionality implemented using Gzip and

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -81,6 +81,61 @@ em code {
 
 #gtoc {
   font-size: .8em;
+  margin-bottom: 1em;
+}
+
+#gtoc ul {
+  list-style: none;
+  margin-left: 0;
+}
+
+#gtoc li {
+  display: inline;
+}
+
+li.version-picker {
+  position: relative;
+}
+
+li.version-picker:hover > ol {
+  display: block;
+}
+
+li.version-picker a span {
+  font-size: .7em;
+}
+
+ol.version-picker {
+  background: #fff;
+  border: 1px #43853d solid;
+  border-radius: 2px;
+  display: none;
+  list-style: none;
+  position: absolute;
+  right: -2px;
+  width: 101%;
+}
+
+#gtoc ol.version-picker li {
+  display: block;
+}
+
+ol.version-picker li a {
+  border-radius: 0;
+  display: block;
+  margin: 0;
+  padding: .1em;
+  padding-left: 1em;
+}
+
+ol.version-picker li:first-child a {
+  border-top-right-radius: 1px;
+  border-top-left-radius: 1px;
+}
+
+ol.version-picker li:last-child a {
+  border-bottom-right-radius: 1px;
+  border-bottom-left-radius: 1px;
 }
 
 .line {
@@ -495,6 +550,9 @@ th > *:last-child, td > *:last-child {
 @media only screen and (max-width: 1024px) and (orientation: portrait) {
   #content {
     font-size: 3.5em;
+  }
+  #gtoc {
+    font-size: 0.6em;
   }
 }
 

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -91,6 +91,15 @@ em code {
 
 #gtoc li {
   display: inline;
+  border-right: 1px #000 solid;
+  margin-right: 0.4em;
+  padding-right: 0.4em;
+}
+
+#gtoc li:last-child {
+  border-right: none;
+  margin-right: 0;
+  padding-right: 0;
 }
 
 li.version-picker {
@@ -118,6 +127,9 @@ ol.version-picker {
 
 #gtoc ol.version-picker li {
   display: block;
+  border-right: 0;
+  margin-right: 0;
+  width: 100%;
 }
 
 ol.version-picker li a {

--- a/doc/template.html
+++ b/doc/template.html
@@ -23,11 +23,21 @@
       <header>
         <h1>Node.js __VERSION__ Documentation</h1>
         <div id="gtoc">
-          <p>
-            <a href="index.html" name="toc">Index</a> |
-            <a href="all.html">View on single page</a> |
-            <a href="__FILENAME__.json">View as JSON</a>
-          </p>
+          <ul>
+            <li>
+              <a href="index.html" name="toc">Index</a> |
+            </li>
+            <li>
+              <a href="all.html">View on single page</a> |
+            </li>
+            <li>
+              <a href="__FILENAME__.json">View as JSON</a> |
+            </li>
+            <li class="version-picker">
+              <a href="#">View another version <span>&#x25bc;</span></a>
+              __ALTDOCS__
+            </li>
+          </ul>
         </div>
         <hr>
       </header>

--- a/doc/template.html
+++ b/doc/template.html
@@ -25,18 +25,15 @@
         <div id="gtoc">
           <ul>
             <li>
-              <a href="index.html" name="toc">Index</a> |
+              <a href="index.html" name="toc">Index</a>
             </li>
             <li>
-              <a href="all.html">View on single page</a> |
+              <a href="all.html">View on single page</a>
             </li>
             <li>
-              <a href="__FILENAME__.json">View as JSON</a> |
+              <a href="__FILENAME__.json">View as JSON</a>
             </li>
-            <li class="version-picker">
-              <a href="#">View another version <span>&#x25bc;</span></a>
-              __ALTDOCS__
-            </li>
+            __ALTDOCS__
           </ul>
         </div>
         <hr>

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -10,6 +10,7 @@ const typeParser = require('./type-parser.js');
 module.exports = toHTML;
 
 const STABILITY_TEXT_REG_EXP = /(.*:)\s*(\d)([\s\S]*)/;
+const DOC_CREATED_REG_EXP = /<!--\s*introduced_in\s*=\s*v([0-9]+)\.([0-9]+)\.([0-9]+)\s*-->/;
 
 // customized heading without id attribute
 var renderer = new marked.Renderer();
@@ -31,6 +32,8 @@ var gtocPath = path.resolve(path.join(
 ));
 var gtocLoading = null;
 var gtocData = null;
+var docCreated = null;
+var nodeVersion = null;
 
 /**
  * opts: input, filename, template, nodeVersion.
@@ -38,6 +41,8 @@ var gtocData = null;
 function toHTML(opts, cb) {
   var template = opts.template;
   var nodeVersion = opts.nodeVersion || process.version;
+
+  docCreated = opts.input.match(DOC_CREATED_REG_EXP);
 
   if (gtocData) {
     return onGtocLoaded();
@@ -136,6 +141,8 @@ function render(opts, cb) {
       );
     }
 
+    template = template.replace(/__ALTDOCS__/, altDocs(filename));
+
     // content has to be the last thing we do with
     // the lexed tokens, because it's destructive.
     const content = marked.parser(lexed);
@@ -165,6 +172,50 @@ function analyticsScript(analytics) {
 // replace placeholders in text tokens
 function replaceInText(text) {
   return linkJsTypeDocs(linkManPages(text));
+}
+
+function altDocs(filename) {
+  let html = '';
+
+  if (!docCreated) {
+    console.error(`Failed to add alternative version links to ${filename}`);
+    return html;
+  }
+
+  function lte(v) {
+    const ns = v.num.split('.');
+    if (docCreated[1] > +ns[0])
+      return false;
+    if (docCreated[1] < +ns[0])
+      return true;
+    return docCreated[2] <= +ns[1];
+  }
+
+  const versions = [
+    { num: '8.x' },
+    { num: '7.x' },
+    { num: '6.x', lts: true },
+    { num: '5.x' },
+    { num: '4.x', lts: true },
+    { num: '0.12.x' },
+    { num: '0.10.x' }
+  ];
+
+  const host = 'https://nodejs.org';
+  const href = (v) => `${host}/docs/latest-v${v.num}/api/${filename}.html`;
+
+  function li(v, i) {
+    let html = `<li><a href="${href(v)}">${v.num}`;
+
+    if (v.lts)
+      html += ' <b>LTS</b>';
+
+    return html + '</a></li>';
+  }
+
+  const lis = (vs) => vs.filter(lte).map(li).join('\n');
+
+  return `<ol class="version-picker">${lis(versions)}</ol>`;
 }
 
 // handle general body-text replacements

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -33,7 +33,6 @@ var gtocPath = path.resolve(path.join(
 var gtocLoading = null;
 var gtocData = null;
 var docCreated = null;
-var nodeVersion = null;
 
 /**
  * opts: input, filename, template, nodeVersion.
@@ -211,9 +210,17 @@ function altDocs(filename) {
     return html + '</a></li>';
   }
 
-  const lis = (vs) => vs.filter(lte).map(li).join('\n');
+  const lis = versions.filter(lte).map(li).join('\n');
 
-  return `<ol class="version-picker">${lis(versions)}</ol>`;
+  if (!lis.length)
+    return '';
+
+  return `
+    <li class="version-picker">
+      <a href="#">View another version <span>&#x25bc;</span></a>
+      <ol class="version-picker">${lis}</ol>
+    </li>
+  `;
 }
 
 // handle general body-text replacements

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -175,11 +175,9 @@ function replaceInText(text) {
 }
 
 function altDocs(filename) {
-  let html = '';
-
   if (!docCreated) {
     console.error(`Failed to add alternative version links to ${filename}`);
-    return html;
+    return '';
   }
 
   function lte(v) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This will make it easier to switch between the current "live" release docs 
at nodejs.org and LTS versions, by adding a drop down with links to other 
versions of the same page.

Original pr: https://github.com/nodejs/node/pull/10958

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, tools
