### PR TITLE
doc: fix style bug on version link dropdown

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -129,6 +129,7 @@ ol.version-picker {
   display: block;
   border-right: 0;
   margin-right: 0;
+  width: 100%;
 }
 
 ol.version-picker li a {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I noticed a minor styling bug while working on https://github.com/nodejs/node/pull/15670 that this pr will fix.

__Before:__
<img width="543" alt="screen shot 2017-09-28 at 6 23 42 pm" src="https://user-images.githubusercontent.com/6627780/30997088-3c31676e-a47a-11e7-961a-a90391ae970e.png">

__After:__
<img width="535" alt="screen shot 2017-09-28 at 6 23 30 pm" src="https://user-images.githubusercontent.com/6627780/30997089-3ed83fe2-a47a-11e7-8e3e-a8fbb3935e26.png">

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc