### PR TITLE
http2: Http2Stream server shutdown setting shuttingDown=true after validating options

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -983,9 +983,6 @@ class Http2Session extends EventEmitter {
     if (this[kState].shutdown || this[kState].shuttingDown)
       return;
 
-    debug(`[${sessionName(this[kType])}] initiating shutdown`);
-    this[kState].shuttingDown = true;
-
     const type = this[kType];
 
     if (typeof options === 'function') {
@@ -1022,6 +1019,9 @@ class Http2Session extends EventEmitter {
                                  'lastStreamID',
                                  options.lastStreamID);
     }
+
+    debug(`[${sessionName(this[kType])}] initiating shutdown`);
+    this[kState].shuttingDown = true;
 
     if (callback) {
       this.on('shutdown', callback);

--- a/test/parallel/test-http2-server-shutdown-options-errors.js
+++ b/test/parallel/test-http2-server-shutdown-options-errors.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+const optionsToTest = {
+  opaqueData: 'Uint8Array',
+  graceful: 'boolean',
+  errorCode: 'number',
+  lastStreamID: 'number'
+};
+
+const types = {
+  boolean: true,
+  number: 1,
+  object: {},
+  array: [],
+  null: null,
+  Uint8Array: Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5])
+};
+
+server.on(
+  'stream',
+  common.mustCall((stream) => {
+    Object.keys(optionsToTest).forEach((option) => {
+      Object.keys(types).forEach((type) => {
+        if (type === optionsToTest[option]) {
+          return;
+        }
+        common.expectsError(
+          () =>
+            stream.session.shutdown(
+              { [option]: types[type] },
+              common.mustNotCall()
+            ),
+          {
+            type: TypeError,
+            code: 'ERR_INVALID_OPT_VALUE',
+            message: `The value "${String(types[type])}" is invalid ` +
+            `for option "${option}"`
+          }
+        );
+      });
+    });
+    stream.session.destroy();
+  })
+);
+
+server.listen(
+  0,
+  common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.resume();
+    req.on('end', common.mustCall(() => server.close()));
+  })
+);


### PR DESCRIPTION
In shutdown(), shuttingDown was set to true before validating options.
If invalid options are passed, error was thrown and server remained in
shuttingDown state. This code change fixes it.

Refs: #14985
Fixes: #15666

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2, test
