### PR TITLE
child_process: fix memory leak in .fork()

### DIFF
--- a/lib/internal/socket_list.js
+++ b/lib/internal/socket_list.js
@@ -10,6 +10,7 @@ class SocketListSend extends EventEmitter {
     super();
     this.key = key;
     this.child = child;
+    child.once('exit', () => this.emit('exit', this));
   }
 
   _request(msg, cmd, callback) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1665,6 +1665,10 @@ Server.prototype.listenFD = internalUtil.deprecate(function(fd, type) {
 Server.prototype._setupWorker = function(socketList) {
   this._usingWorkers = true;
   this._workers.push(socketList);
+  socketList.once('exit', (socketList) => {
+    const index = this._workers.indexOf(socketList);
+    this._workers.splice(index, 1);
+  });
 };
 
 Server.prototype.ref = function() {

--- a/test/parallel/test-child-process-fork-net2.js
+++ b/test/parallel/test-child-process-fork-net2.js
@@ -156,6 +156,7 @@ if (process.argv[2] === 'child') {
   }
 
   process.on('exit', function() {
+    assert.strictEqual(server._workers.length, 0);
     assert.strictEqual(disconnected, count);
     assert.strictEqual(connected, count);
   });


### PR DESCRIPTION
Entries in the `net.Server#_workers` array that is used to track handles
sent from the master to workers were not deleted when a worker exited,
resulting in a slow but inexorable memory leak.

Fixes: https://github.com/nodejs/node/issues/15651
CI: https://ci.nodejs.org/job/node-test-pull-request/10332/