### PR TITLE
doc: update fs.utimes{,Sync} changelog

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2339,6 +2339,10 @@ and `fs.unwatchFile()` when possible.
 <!-- YAML
 added: v0.4.2
 changes:
+   - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11919
+    description: `NaN`, `Infinity`, and `-Infinity` are no longer valid time
+                 specifiers.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using `file:`
@@ -2371,6 +2375,10 @@ The `atime` and `mtime` arguments follow these rules:
 <!-- YAML
 added: v0.4.2
 changes:
+  - version: v8.0.0
+    pr-url: https://github.com/nodejs/node/pull/11919
+    description: `NaN`, `Infinity`, and `-Infinity` are no longer valid time
+                 specifiers.
   - version: v7.6.0
     pr-url: https://github.com/nodejs/node/pull/10739
     description: The `path` parameter can be a WHATWG `URL` object using `file:`


### PR DESCRIPTION
Specify that `NaN`, `Infinity`, and `-Infinity` are no longer valid
values for the `atime` and `mtime` arguments.

Fixes: https://github.com/nodejs/node/issues/15453

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc