### PR TITLE
test: check that this != new.target in addon

### DIFF
--- a/test/addons/new-target/binding.cc
+++ b/test/addons/new-target/binding.cc
@@ -3,7 +3,11 @@
 
 namespace {
 
-inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>&) {}
+inline void NewClass(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  // this != new.target since we are being invoked through super().
+  assert(args.IsConstructCall());
+  assert(!args.This()->StrictEquals(args.NewTarget()));
+}
 
 inline void Initialize(v8::Local<v8::Object> binding) {
   auto isolate = binding->GetIsolate();


### PR DESCRIPTION
Add two checks that are there for expository reasons as much as they are
sanity checks.

Refs: https://github.com/nodejs/node-addon-api/issues/142
CI: https://ci.nodejs.org/job/node-test-pull-request/10333/