### PR TITLE
[8.x] http2: expose http2 by default, add NODE_NO_HTTP2

### DIFF
--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -6,7 +6,7 @@ const PORT = common.PORT;
 const bench = common.createBenchmark(main, {
   n: [1e3],
   nheaders: [0, 10, 100, 1000],
-}, { flags: ['--expose-http2', '--no-warnings'] });
+}, { flags: ['--no-warnings'] });
 
 function main(conf) {
   const n = +conf.n;

--- a/benchmark/http2/respond-with-fd.js
+++ b/benchmark/http2/respond-with-fd.js
@@ -11,7 +11,7 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 10000, 100000, 1000000],
   streams: [100, 200, 1000],
   clients: [1, 2]
-}, { flags: ['--expose-http2', '--no-warnings'] });
+}, { flags: ['--no-warnings'] });
 
 function main(conf) {
 

--- a/benchmark/http2/simple.js
+++ b/benchmark/http2/simple.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
   requests: [100, 1000, 10000, 100000],
   streams: [100, 200, 1000],
   clients: [1, 2]
-}, { flags: ['--expose-http2', '--no-warnings'] });
+}, { flags: ['--no-warnings'] });
 
 function main(conf) {
   const n = +conf.requests;

--- a/benchmark/http2/write.js
+++ b/benchmark/http2/write.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   streams: [100, 200, 1000],
   length: [64 * 1024, 128 * 1024, 256 * 1024, 1024 * 1024],
   size: [100000]
-}, { flags: ['--expose-http2', '--no-warnings'] });
+}, { flags: ['--no-warnings'] });
 
 function main(conf) {
   const m = +conf.streams;

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -432,6 +432,13 @@ added: v7.5.0
 
 When set to `1`, process warnings are silenced.
 
+### `NODE_NO_HTTP2=1`
+<!-- YAML
+added: REPLACEME
+-->
+
+When set to `1`, the `http2` module is suppressed.
+
 ### `NODE_OPTIONS=options...`
 <!-- YAML
 added: v8.0.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -9,9 +9,6 @@ can be accessed using:
 const http2 = require('http2');
 ```
 
-*Note*: Node.js must be launched with the `--expose-http2` command line flag
-in order to use the `'http2'` module.
-
 ## Core API
 
 The Core API provides a low-level interface designed specifically around

--- a/doc/node.1
+++ b/doc/node.1
@@ -131,10 +131,6 @@ Emit pending deprecation warnings.
 Silence all process warnings (including deprecations).
 
 .TP
-.BR \-\-expose\-http2
-Enable the experimental `'http2'` module.
-
-.TP
 .BR \-\-napi\-modules
 Enable loading native modules compiled with the ABI-stable Node.js API (N-API)
 (experimental).
@@ -279,6 +275,10 @@ with small\-icu support.
 .TP
 .BR NODE_NO_WARNINGS =\fI1\fR
 When set to \fI1\fR, process warnings are silenced.
+
+.TP
+.BR NODE_NO_HTTP2 =\fI1\fR
+When set to \fI1\fR, the http2 module is suppressed.
 
 .TP
 .BR NODE_OPTIONS =\fIoptions...\fR

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-data-end.js
+++ b/test/parallel/test-http2-client-data-end.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-onconnect-errors.js
+++ b/test/parallel/test-http2-client-onconnect-errors.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const {

--- a/test/parallel/test-http2-client-priority-before-connect.js
+++ b/test/parallel/test-http2-client-priority-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-promisify-connect.js
+++ b/test/parallel/test-http2-client-promisify-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-shutdown-before-connect.js
+++ b/test/parallel/test-http2-client-shutdown-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-socket-destroy.js
+++ b/test/parallel/test-http2-client-socket-destroy.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-unescaped-path.js
+++ b/test/parallel/test-http2-client-unescaped-path.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 // Verifies that uploading data from a client works

--- a/test/parallel/test-http2-client-write-before-connect.js
+++ b/test/parallel/test-http2-client-write-before-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-errors.js
+++ b/test/parallel/test-http2-compat-errors.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2 --expose-internals
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-expect-continue-check.js
+++ b/test/parallel/test-http2-compat-expect-continue-check.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-expect-continue.js
+++ b/test/parallel/test-http2-compat-expect-continue.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-expect-handling.js
+++ b/test/parallel/test-http2-compat-expect-handling.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-method-connect.js
+++ b/test/parallel/test-http2-compat-method-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-end.js
+++ b/test/parallel/test-http2-compat-serverrequest-end.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-pause.js
+++ b/test/parallel/test-http2-compat-serverrequest-pause.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-settimeout.js
+++ b/test/parallel/test-http2-compat-serverrequest-settimeout.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-trailers.js
+++ b/test/parallel/test-http2-compat-serverrequest-trailers.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-close.js
+++ b/test/parallel/test-http2-compat-serverresponse-close.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2 --expose-internals
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-destroy.js
+++ b/test/parallel/test-http2-compat-serverresponse-destroy.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-drain.js
+++ b/test/parallel/test-http2-compat-serverresponse-drain.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const {

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-settimeout.js
+++ b/test/parallel/test-http2-compat-serverresponse-settimeout.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-trailers.js
+++ b/test/parallel/test-http2-compat-serverresponse-trailers.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
+++ b/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const { mustCall,

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-connect.js
+++ b/test/parallel/test-http2-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const { mustCall, hasCrypto, skip, expectsError } = require('../common');

--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 // Tests http2.connect()

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -1,4 +1,3 @@
-// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-createwritereq.js
+++ b/test/parallel/test-http2-createwritereq.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-date-header.js
+++ b/test/parallel/test-http2-date-header.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-dont-override.js
+++ b/test/parallel/test-http2-dont-override.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-head-request.js
+++ b/test/parallel/test-http2-head-request.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-methods.js
+++ b/test/parallel/test-http2-methods.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-misused-pseudoheaders.js
+++ b/test/parallel/test-http2-misused-pseudoheaders.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-multi-content-length.js
+++ b/test/parallel/test-http2-multi-content-length.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-multiheaders-raw.js
+++ b/test/parallel/test-http2-multiheaders-raw.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-multiplex.js
+++ b/test/parallel/test-http2-multiplex.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Tests opening 100 concurrent simultaneous uploading streams over a single

--- a/test/parallel/test-http2-noflag.js
+++ b/test/parallel/test-http2-noflag.js
@@ -1,8 +1,0 @@
-// The --expose-http2 flag is not set
-'use strict';
-
-require('../common');
-const assert = require('assert');
-
-assert.throws(() => require('http2'), // eslint-disable-line crypto-check
-              /^Error: Cannot find module 'http2'$/);

--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-padding-callback.js
+++ b/test/parallel/test-http2-padding-callback.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-request-response-proto.js
+++ b/test/parallel/test-http2-request-response-proto.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-404.js
+++ b/test/parallel/test-http2-respond-file-404.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-compat.js
+++ b/test/parallel/test-http2-respond-file-compat.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-error-dir.js
+++ b/test/parallel/test-http2-respond-file-error-dir.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-fd-range.js
+++ b/test/parallel/test-http2-respond-file-fd-range.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Tests the ability to minimally request a byte range with respondWithFD

--- a/test/parallel/test-http2-respond-file-fd.js
+++ b/test/parallel/test-http2-respond-file-fd.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-push.js
+++ b/test/parallel/test-http2-respond-file-push.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file-range.js
+++ b/test/parallel/test-http2-respond-file-range.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-respond-no-data.js
+++ b/test/parallel/test-http2-respond-no-data.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-response-splitting.js
+++ b/test/parallel/test-http2-response-splitting.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Response splitting is no longer an issue with HTTP/2. The underlying

--- a/test/parallel/test-http2-serve-file.js
+++ b/test/parallel/test-http2-serve-file.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-additional.js
+++ b/test/parallel/test-http2-server-destroy-before-additional.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-priority.js
+++ b/test/parallel/test-http2-server-destroy-before-priority.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-push.js
+++ b/test/parallel/test-http2-server-destroy-before-push.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-respond.js
+++ b/test/parallel/test-http2-server-destroy-before-respond.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-rst.js
+++ b/test/parallel/test-http2-server-destroy-before-rst.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-state.js
+++ b/test/parallel/test-http2-server-destroy-before-state.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-write.js
+++ b/test/parallel/test-http2-server-destroy-before-write.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-errors.js
+++ b/test/parallel/test-http2-server-errors.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2 --expose-internals
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-disabled.js
+++ b/test/parallel/test-http2-server-push-disabled.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-stream-errors-args.js
+++ b/test/parallel/test-http2-server-push-stream-errors-args.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-stream-errors.js
+++ b/test/parallel/test-http2-server-push-stream-errors.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-stream-head.js
+++ b/test/parallel/test-http2-server-push-stream-head.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-settimeout-no-callback.js
+++ b/test/parallel/test-http2-server-settimeout-no-callback.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-socket-destroy.js
+++ b/test/parallel/test-http2-server-socket-destroy.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-socketerror.js
+++ b/test/parallel/test-http2-server-socketerror.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Tests the basic operation of creating a plaintext or TLS

--- a/test/parallel/test-http2-server-timeout.js
+++ b/test/parallel/test-http2-server-timeout.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-session-stream-state.js
+++ b/test/parallel/test-http2-session-stream-state.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-single-headers.js
+++ b/test/parallel/test-http2-single-headers.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-status-code-invalid.js
+++ b/test/parallel/test-http2-status-code-invalid.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-status-code.js
+++ b/test/parallel/test-http2-status-code.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-stream-client.js
+++ b/test/parallel/test-http2-stream-client.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Tests that attempting to send too many non-acknowledged

--- a/test/parallel/test-http2-trailers.js
+++ b/test/parallel/test-http2-trailers.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --expose-http2
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --expose-http2
+// Flags: --expose-internals
 'use strict';
 
 // Tests the internal utility function that is used to prepare headers

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // This test ensures that servers are able to send data independent of window

--- a/test/parallel/test-http2-withflag.js
+++ b/test/parallel/test-http2-withflag.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-write-callbacks.js
+++ b/test/parallel/test-http2-write-callbacks.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 // Verifies that write callbacks are called

--- a/test/parallel/test-http2-write-empty-string.js
+++ b/test/parallel/test-http2-write-empty-string.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-zero-length-write.js
+++ b/test/parallel/test-http2-zero-length-write.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');

--- a/test/sequential/test-http2-session-timeout.js
+++ b/test/sequential/test-http2-session-timeout.js
@@ -1,4 +1,4 @@
-// Flags: --expose-http2
+// 
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
Make `--expose-http2` a non-op,
Expose http2 by default.
Add `NODE_NO_HTTP2=1` to suppress http2

Note that this flips the default in v8.x, turning http2 always on. For anyone currently using the http2 userland module, they would need to set the `NODE_NO_HTTP2=1` environment variable to avoid breaking.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2