### PR TITLE
test: skip test if host is too slow

### DIFF
--- a/test/sequential/test-http-server-consumed-timeout.js
+++ b/test/sequential/test-http-server-consumed-timeout.js
@@ -15,7 +15,7 @@ const server = http.createServer((req, res) => {
 
   req.setTimeout(TIMEOUT, () => {
     if (!intervalWasInvoked)
-      common.skip('interval was not invoked quickly enough for test');
+      return common.skip('interval was not invoked quickly enough for test');
     common.fail('Request timeout should not fire');
   });
 
@@ -35,8 +35,8 @@ server.listen(0, common.mustCall(() => {
       // If machine is busy enough that the interval takes more than TIMEOUT ms
       // to be invoked, skip the test.
       const now = Date.now();
-      if (time < now - TIMEOUT)
-        common.skip('interval is not invoked quickly enough for test');
+      if (now - time > TIMEOUT)
+        return common.skip('interval is not invoked quickly enough for test');
       time = now;
       req.write('a');
     }, common.platformTimeout(25));

--- a/test/sequential/test-http-server-consumed-timeout.js
+++ b/test/sequential/test-http-server-consumed-timeout.js
@@ -35,7 +35,6 @@ server.listen(0, common.mustCall(() => {
       // If machine is busy enough that the interval takes more than TIMEOUT ms
       // to be invoked, skip the test.
       const now = Date.now();
-      console.log('diff is ' + (now - time));
       if (time < now - TIMEOUT)
         common.skip('interval is not invoked quickly enough for test');
       time = now;

--- a/test/sequential/test-http-server-consumed-timeout.js
+++ b/test/sequential/test-http-server-consumed-timeout.js
@@ -3,18 +3,26 @@
 const common = require('../common');
 const http = require('http');
 
+let time = Date.now();
+let intervalWasInvoked = false;
+const TIMEOUT = common.platformTimeout(200);
+
 const server = http.createServer((req, res) => {
   server.close();
 
   res.writeHead(200);
   res.flushHeaders();
 
-  req.setTimeout(common.platformTimeout(200),
-                 common.mustNotCall('Request timeout should not fire'));
+  req.setTimeout(TIMEOUT, () => {
+    if (!intervalWasInvoked)
+      common.skip('interval was not invoked quickly enough for test');
+    common.fail('Request timeout should not fire');
+  });
+
   req.resume();
-  req.once('end', common.mustCall(() => {
+  req.once('end', () => {
     res.end();
-  }));
+  });
 });
 
 server.listen(0, common.mustCall(() => {
@@ -23,12 +31,20 @@ server.listen(0, common.mustCall(() => {
     method: 'POST'
   }, (res) => {
     const interval = setInterval(() => {
+      intervalWasInvoked = true;
+      // If machine is busy enough that the interval takes more than TIMEOUT ms
+      // to be invoked, skip the test.
+      const now = Date.now();
+      console.log('diff is ' + (now - time));
+      if (time < now - TIMEOUT)
+        common.skip('interval is not invoked quickly enough for test');
+      time = now;
       req.write('a');
     }, common.platformTimeout(25));
     setTimeout(() => {
       clearInterval(interval);
       req.end();
-    }, common.platformTimeout(200));
+    }, TIMEOUT);
   });
   req.write('.');
 }));


### PR DESCRIPTION
test-http-server-consumed-timeout will fail if the host is sufficiently
loaded that a 25ms interval takes more than 200ms to be invoked. Skip
the test in that situation.

Fixes: https://github.com/nodejs/node/issues/14312

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test