### PR TITLE
src: use more appropriate context-entered check

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1366,7 +1366,7 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
 
   HandleScope handle_scope(env->isolate());
   // If you hit this assertion, you forgot to enter the v8::Context first.
-  CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
+  CHECK_EQ(Environment::GetCurrent(env->isolate()), env);
 
   if (env->using_domains() && !object_.IsEmpty()) {
     DomainEnter(env, object_);

--- a/test/inspector/test-scriptparsed-context.js
+++ b/test/inspector/test-scriptparsed-context.js
@@ -37,6 +37,8 @@ const script = `
 
   vm.runInNewContext('Array', {});
   debugger;
+
+  vm.runInNewContext('debugger', {});
 `;
 
 async function getContext(session) {
@@ -91,6 +93,12 @@ async function runTests() {
   const thirdContext = await getContext(session);
   await checkScriptContext(session, thirdContext);
   await session.waitForBreakOnLine(33, '[eval]');
+
+  console.error('[test]', 'vm.runInNewContext can contain debugger statements');
+  await session.send({ 'method': 'Debugger.resume' });
+  const fourthContext = await getContext(session);
+  await checkScriptContext(session, fourthContext);
+  await session.waitForBreakOnLine(0, 'evalmachine.<anonymous>');
 
   await session.runToCompletion();
   assert.strictEqual(0, (await instance.expectShutdown()).exitCode);


### PR DESCRIPTION
Make the context check in `MakeCallback` match what the comment says
(and what actually makes sense).

Fixes: https://github.com/nodejs/node/issues/15672
Ref: https://github.com/nodejs/node/pull/15428
Ref: f27b5e4bdaafc73a830a0451ee3c641b8bcd08fe

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src