### PR TITLE
errors: make code property mutable

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -11,9 +11,8 @@
 const kCode = Symbol('code');
 const messages = new Map();
 
-const {
-  kMaxLength
-} = process.binding('buffer');
+const { kMaxLength } = process.binding('buffer');
+const { defineProperty } = Object;
 
 // Lazily loaded
 var util = null;
@@ -22,11 +21,36 @@ function makeNodeError(Base) {
   return class NodeError extends Base {
     constructor(key, ...args) {
       super(message(key, args));
-      this[kCode] = this.code = key;
-      Object.defineProperty(this, 'name', {
+      defineProperty(this, kCode, {
         configurable: true,
         enumerable: false,
-        value: `${super.name} [${this[kCode]}]`,
+        value: key,
+        writable: true
+      });
+    }
+
+    get name() {
+      return `${super.name} [${this[kCode]}]`;
+    }
+
+    set name(value) {
+      defineProperty(this, 'name', {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true
+      });
+    }
+
+    get code() {
+      return this[kCode];
+    }
+
+    set code(value) {
+      defineProperty(this, 'code', {
+        configurable: true,
+        enumerable: true,
+        value,
         writable: true
       });
     }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -22,15 +22,13 @@ function makeNodeError(Base) {
   return class NodeError extends Base {
     constructor(key, ...args) {
       super(message(key, args));
-      this[kCode] = key;
-    }
-
-    get name() {
-      return `${super.name} [${this[kCode]}]`;
-    }
-
-    get code() {
-      return this[kCode];
+      this[kCode] = this.code = key;
+      Object.defineProperty(this, 'name', {
+        configurable: true,
+        enumerable: false,
+        value: `${super.name} [${this[kCode]}]`,
+        writable: true
+      });
     }
   };
 }


### PR DESCRIPTION
Userland code can break if it depends on a mutable `code` property for
errors. Allow users to change the `code` property but do not propagate
changes to the error `name`.
    
Additionally, make `message` and `name` consistent with `Error` object
(non-enumerable). Test that `console.log()` and `.toString()` calls on
internal `Error` objects with mutated properties have analogous results
with the standard ECMAScript `Error` objects.
    
Fixes: https://github.com/nodejs/node/issues/15658

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors