### PR TITLE
src: do not add .domain to promises in VM contexts

### DIFF
--- a/doc/api/domain.md
+++ b/doc/api/domain.md
@@ -1,6 +1,12 @@
 # Domain
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Any `Promise`s created in VM contexts no longer have a
+                 `.domain` property. Their handlers are still executed in the
+                 proper domain, however, and `Promise`s created in the main
+                 context still possess a `.domain` property.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/12489
     description: Handlers for `Promise`s are now invoked in the domain in which

--- a/src/env.h
+++ b/src/env.h
@@ -93,6 +93,7 @@ class ModuleWrap;
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(processed_private_symbol, "node:processed")                               \
   V(selected_npn_buffer_private_symbol, "node:selectedNpnBuffer")             \
+  V(domain_private_symbol, "node:domain")                                     \
 
 // Strings are per-isolate primitives but Environment proxies them
 // for the sake of convenience.  Strings should be ASCII-only.

--- a/src/node.cc
+++ b/src/node.cc
@@ -1156,8 +1156,19 @@ bool ShouldAbortOnUncaughtException(Isolate* isolate) {
 }
 
 
+Local<Value> GetDomainProperty(Environment* env, Local<Object> object) {
+  Local<Value> domain_v =
+      object->GetPrivate(env->context(), env->domain_private_symbol())
+          .ToLocalChecked();
+  if (domain_v->IsObject()) {
+    return domain_v;
+  }
+  return object->Get(env->context(), env->domain_string()).ToLocalChecked();
+}
+
+
 void DomainEnter(Environment* env, Local<Object> object) {
-  Local<Value> domain_v = object->Get(env->domain_string());
+  Local<Value> domain_v = GetDomainProperty(env, object);
   if (domain_v->IsObject()) {
     Local<Object> domain = domain_v.As<Object>();
     Local<Value> enter_v = domain->Get(env->enter_string());
@@ -1172,7 +1183,7 @@ void DomainEnter(Environment* env, Local<Object> object) {
 
 
 void DomainExit(Environment* env, v8::Local<v8::Object> object) {
-  Local<Value> domain_v = object->Get(env->domain_string());
+  Local<Value> domain_v = GetDomainProperty(env, object);
   if (domain_v->IsObject()) {
     Local<Object> domain = domain_v.As<Object>();
     Local<Value> exit_v = domain->Get(env->exit_string());
@@ -1194,10 +1205,16 @@ void DomainPromiseHook(PromiseHookType type,
   Local<Context> context = env->context();
 
   if (type == PromiseHookType::kInit && env->in_domain()) {
-    promise->Set(context,
-                 env->domain_string(),
-                 env->domain_array()->Get(context,
-                                          0).ToLocalChecked()).FromJust();
+    Local<Value> domain_obj =
+        env->domain_array()->Get(context, 0).ToLocalChecked();
+    if (promise->CreationContext() == context) {
+      promise->Set(context, env->domain_string(), domain_obj).FromJust();
+    } else {
+      // Do not expose object from another context publicly in promises created
+      // in non-main contexts.
+      promise->SetPrivate(context, env->domain_private_symbol(), domain_obj)
+          .FromJust();
+    }
     return;
   }
 

--- a/test/parallel/test-domain-promise.js
+++ b/test/parallel/test-domain-promise.js
@@ -31,9 +31,13 @@ common.crashOnUnhandledRejection();
   const d = domain.create();
 
   d.run(common.mustCall(() => {
-    vm.runInNewContext(`Promise.resolve().then(common.mustCall(() => {
-      assert.strictEqual(process.domain, d);
-    }));`, { common, assert, process, d });
+    vm.runInNewContext(`
+      const promise = Promise.resolve();
+      assert.strictEqual(promise.domain, undefined);
+      promise.then(common.mustCall(() => {
+        assert.strictEqual(process.domain, d);
+      }));
+    `, { common, assert, process, d });
   }));
 }
 


### PR DESCRIPTION
The promises are still tracked, and their handlers will still execute in the correct domain. The creation domain is now simply hidden, in order to prevent objects from outside from leaking into a VM context.

Fixes (and see more context at): https://github.com/nodejs/node/issues/15673

This is technically a breaking change, as it removes a property from created Promise objects under certain circumstances. However, I would argue that this should be landed as semver-patch, for the following reasons:

- This feature breaks the contract of the VM module that, if one doesn't pass in any objects from the outside, the VM context is fully independent. In other words, it can be a bug of security implications *despite the fact that we advertise VM module as not a full sandbox*, which is duly noted both in [documentation](https://nodejs.org/api/vm.html#vm_vm_executing_javascript) and by @bnoordhuis in https://github.com/nodejs/node/issues/15673#issuecomment-333084637.
- The core feature of domains -- preserving information across async boundaries -- is still available even after this PR.
- Domain support for promises was introduced in v8.0.0, which means that most of the ecosystem probably have not yet started using the `.domain` property on promises.
- Even if they have, the presence of `.domain` on Promises is inconsistent at best. Right now, the property exists only if it was created in a running domain, which means that modules that do not have control over domains (i.e. pretty much all modules except for the very core of a program) cannot depend on the presence of this property.
- However, once v8.x goes LTS, this behavior will be near impossible to change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src