### PR TITLE
module: Set dynamic import callback

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ lib/internal/v8.js
 lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*
+test/es-module/test-esm-dynamic-import.js
 test/fixtures
 test/message/esm_display_syntax_error.mjs
 tools/eslint

--- a/lib/internal/loader/Loader.js
+++ b/lib/internal/loader/Loader.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const { getURLFromFilePath } = require('internal/url');
+const path = require('path');
+const { getURLFromFilePath, URL } = require('internal/url');
 
-const { createDynamicModule } = require('internal/loader/ModuleWrap');
+const {
+  createDynamicModule,
+  setImportModuleDynamicallyCallback
+} = require('internal/loader/ModuleWrap');
 
 const ModuleMap = require('internal/loader/ModuleMap');
 const ModuleJob = require('internal/loader/ModuleJob');
@@ -22,6 +26,13 @@ function getURLStringForCwd() {
     }
     throw e;
   }
+}
+
+function normalizeReferrerURL(referrer) {
+  if (typeof referrer === 'string' && path.isAbsolute(referrer)) {
+    return getURLFromFilePath(referrer).href;
+  }
+  return new URL(referrer).href;
 }
 
 /* A Loader instance is used as the main entry point for loading ES modules.
@@ -128,6 +139,12 @@ class Loader {
     const job = await this.getModuleJob(specifier, parentURL);
     const module = await job.run();
     return module.namespace();
+  }
+
+  static registerImportDynamicallyCallback(loader) {
+    setImportModuleDynamicallyCallback(async (referrer, specifier) => {
+      return loader.import(specifier, normalizeReferrerURL(referrer));
+    });
   }
 }
 Loader.validFormats = ['esm', 'cjs', 'builtin', 'addon', 'json', 'dynamic'];

--- a/lib/internal/loader/ModuleWrap.js
+++ b/lib/internal/loader/ModuleWrap.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { ModuleWrap } = internalBinding('module_wrap');
+const {
+  ModuleWrap,
+  setImportModuleDynamicallyCallback
+} = internalBinding('module_wrap');
 const debug = require('util').debuglog('esm');
 const ArrayJoin = Function.call.bind(Array.prototype.join);
 const ArrayMap = Function.call.bind(Array.prototype.map);
@@ -59,5 +62,6 @@ const createDynamicModule = (exports, url = '', evaluate) => {
 
 module.exports = {
   createDynamicModule,
+  setImportModuleDynamicallyCallback,
   ModuleWrap
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -472,6 +472,7 @@ Module._load = function(request, parent, isMain) {
           ESMLoader.hook(hooks);
         }
       }
+      Loader.registerImportDynamicallyCallback(ESMLoader);
       await ESMLoader.import(getURLFromFilePath(request).pathname);
     })()
     .catch((e) => {

--- a/src/env.h
+++ b/src/env.h
@@ -332,6 +332,7 @@ class ModuleWrap;
   V(vm_parsing_context_symbol, v8::Symbol)                                    \
   V(url_constructor_function, v8::Function)                                   \
   V(write_wrap_constructor_function, v8::Function)                            \
+  V(host_import_module_dynamically_callback, v8::Function)                    \
 
 class Environment;
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -558,6 +558,62 @@ void ModuleWrap::Resolve(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(result.FromJust().ToObject(env));
 }
 
+static MaybeLocal<Promise> ImportModuleDynamically(
+    Local<Context> context,
+    Local<v8::ScriptOrModule> referrer,
+    Local<String> specifier) {
+  Isolate* iso = context->GetIsolate();
+  Environment* env = Environment::GetCurrent(context);
+  v8::EscapableHandleScope handle_scope(iso);
+
+  if (env->context() != context) {
+    auto maybe_resolver = Promise::Resolver::New(context);
+    Local<Promise::Resolver> resolver;
+    if (maybe_resolver.ToLocal(&resolver)) {
+      // TODO(jkrems): Turn into proper error object w/ code
+      Local<Value> error = v8::Exception::Error(
+        OneByteString(iso, "import() called outside of main context"));
+      if (resolver->Reject(context, error).IsJust()) {
+        return handle_scope.Escape(resolver.As<Promise>());
+      }
+    }
+    return MaybeLocal<Promise>();
+  }
+
+  Local<Function> import_callback =
+    env->host_import_module_dynamically_callback();
+  Local<Value> import_args[] = {
+    referrer->GetResourceName(),
+    Local<Value>(specifier)
+  };
+  MaybeLocal<Value> maybe_result = import_callback->Call(context,
+                                                         v8::Undefined(iso),
+                                                         2,
+                                                         import_args);
+
+  Local<Value> result;
+  if (maybe_result.ToLocal(&result)) {
+    return handle_scope.Escape(result.As<Promise>());
+  }
+  return MaybeLocal<Promise>();
+}
+
+void ModuleWrap::SetImportModuleDynamicallyCallback(
+    const FunctionCallbackInfo<Value>& args) {
+  Isolate* iso = args.GetIsolate();
+  Environment* env = Environment::GetCurrent(args);
+  HandleScope handle_scope(iso);
+  if (!args[0]->IsFunction()) {
+    env->ThrowError("first argument is not a function");
+    return;
+  }
+
+  Local<Function> import_callback = args[0].As<Function>();
+  env->set_host_import_module_dynamically_callback(import_callback);
+
+  iso->SetHostImportModuleDynamicallyCallback(ImportModuleDynamically);
+}
+
 void ModuleWrap::Initialize(Local<Object> target,
                             Local<Value> unused,
                             Local<Context> context) {
@@ -575,6 +631,9 @@ void ModuleWrap::Initialize(Local<Object> target,
 
   target->Set(FIXED_ONE_BYTE_STRING(isolate, "ModuleWrap"), tpl->GetFunction());
   env->SetMethod(target, "resolve", node::loader::ModuleWrap::Resolve);
+  env->SetMethod(target,
+                 "setImportModuleDynamicallyCallback",
+                 node::loader::ModuleWrap::SetImportModuleDynamicallyCallback);
 }
 
 }  // namespace loader

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -39,6 +39,8 @@ class ModuleWrap : public BaseObject {
   static void GetUrl(v8::Local<v8::String> property,
                      const v8::PropertyCallbackInfo<v8::Value>& info);
   static void Resolve(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetImportModuleDynamicallyCallback(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static v8::MaybeLocal<v8::Module> ResolveCallback(
       v8::Local<v8::Context> context,
       v8::Local<v8::String> specifier,

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -1,0 +1,113 @@
+// Flags: --experimental-modules --harmony-dynamic-import
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { URL } = require('url');
+const vm = require('vm');
+
+common.crashOnUnhandledRejection();
+
+const relativePath = './test-esm-ok.mjs';
+const absolutePath = require.resolve('./test-esm-ok.mjs');
+const targetURL = new URL('file:///');
+targetURL.pathname = absolutePath;
+
+function expectErrorProperty(result, propertyKey, value) {
+  Promise.resolve(result)
+    .catch(common.mustCall(error => {
+      assert.equal(error[propertyKey], value);
+    }));
+}
+
+function expectMissingModuleError(result) {
+  expectErrorProperty(result, 'code', 'MODULE_NOT_FOUND');
+}
+
+function expectInvalidUrlError(result) {
+  expectErrorProperty(result, 'code', 'ERR_INVALID_URL');
+}
+
+function expectInvalidReferrerError(result) {
+  expectErrorProperty(result, 'code', 'ERR_INVALID_URL');
+}
+
+function expectInvalidProtocolError(result) {
+  expectErrorProperty(result, 'code', 'ERR_INVALID_PROTOCOL');
+}
+
+function expectInvalidContextError(result) {
+  expectErrorProperty(result,
+    'message', 'import() called outside of main context');
+}
+
+function expectOkNamespace(result) {
+  Promise.resolve(result)
+    .then(common.mustCall(ns => {
+      // Can't deepStrictEqual because ns isn't a normal object
+      assert.deepEqual(ns, { default: true });
+    }));
+}
+
+function expectFsNamespace(result) {
+  Promise.resolve(result)
+    .then(common.mustCall(ns => {
+      assert.equal(typeof ns.default.writeFile, 'function');
+    }));
+}
+
+// For direct use of import expressions inside of CJS or ES modules, including
+// via eval, all kinds of specifiers should work without issue.
+(function testScriptOrModuleImport() {
+  // Importing another file, both direct & via eval
+  // expectOkNamespace(import(relativePath));
+  expectOkNamespace(eval.call(null, `import("${relativePath}")`));
+  expectOkNamespace(eval(`import("${relativePath}")`));
+  expectOkNamespace(eval.call(null, `import("${targetURL}")`));
+
+  // Importing a built-in, both direct & via eval
+  expectFsNamespace(import("fs"));
+  expectFsNamespace(eval('import("fs")'));
+  expectFsNamespace(eval.call(null, 'import("fs")'));
+
+  expectMissingModuleError(import("./not-an-existing-module.mjs"));
+  // TODO(jkrems): Right now this doesn't hit a protocol error because the
+  // module resolution step already rejects it. These arguably should be
+  // protocol errors.
+  expectMissingModuleError(import("node:fs"));
+  expectMissingModuleError(import('http://example.com/foo.js'));
+})();
+
+// vm.runInThisContext:
+// * Supports built-ins, always
+// * Supports imports if the script has a known defined origin
+(function testRunInThisContext() {
+  // Succeeds because it's got an valid base url
+  expectFsNamespace(vm.runInThisContext(`import("fs")`, {
+    filename: __filename,
+  }));
+  expectOkNamespace(vm.runInThisContext(`import("${relativePath}")`, {
+    filename: __filename,
+  }));
+  // Rejects because it's got an invalid referrer URL.
+  // TODO(jkrems): Arguably the first two (built-in + absolute URL) could work
+  // with some additional effort.
+  expectInvalidReferrerError(vm.runInThisContext('import("fs")'));
+  expectInvalidReferrerError(vm.runInThisContext(`import("${targetURL}")`));
+  expectInvalidReferrerError(vm.runInThisContext(`import("${relativePath}")`));
+})();
+
+// vm.runInNewContext is currently completely unsupported, pending well-defined
+// semantics for per-context/realm module maps in node.
+(function testRunInNewContext() {
+  // Rejects because it's running in the wrong context
+  expectInvalidContextError(
+    vm.runInNewContext(`import("${targetURL}")`, undefined, {
+      filename: __filename,
+    })
+  );
+
+  // Rejects because it's running in the wrong context
+  expectInvalidContextError(vm.runInNewContext(`import("fs")`, undefined, {
+    filename: __filename,
+  }));
+})();


### PR DESCRIPTION
This is an initial implementation to support dynamic import in
both scripts and modules. It's off by default since support for
dynamic import is still flagged in V8. Without setting the V8 flag,
this code won't be executed.

Because of missing support in the V8 APIs, we can't support
importing into the proper context yet. Without further changes this
might allow code to break out of the context it's running in.

/cc @bmeck 

#### TODO

- [x] Add test case to ensure import from "random contexts" is ignored
- [x] ~~Clean error handling when calling `import()` before the callback is set up~~ (can't think of a scenario where this might happen)
- [x] Cleanup code for handling import from CommonJS scripts
- [x] ~~Potentially add explicit error handling for failing import handler call~~ (just preventing a crash for now)
- [x] Ensure behavior matches browsers where appropriate (e.g. eval & friends)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module