### PR TITLE
test: use fake http benchmarker to avoid timeout

### DIFF
--- a/test/parallel/test-benchmark-cluster.js
+++ b/test/parallel/test-benchmark-cluster.js
@@ -4,4 +4,11 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('cluster', ['n=1', 'payload=string', 'sendsPerBroadcast=1']);
+runBenchmark('cluster', [
+  'benchmarker=test-double',
+  'n=1',
+  'payload=string',
+  'sendsPerBroadcast=1',
+  'c=50',
+  'len=16'
+]);


### PR DESCRIPTION
Without this, I was consistently encountering a timeout which caused problems with sequential tests that were also using `common.PORT` at the same time.

CI: https://ci.nodejs.org/job/node-test-pull-request/10373/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* test
