### PR TITLE
doc: explain common.restore* functions

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -323,11 +323,13 @@ Deletes the 'tmp' dir and recreates it
 
 ### restoreStderr()
 
-Restore the original `process.stderr.write`.
+Restore the original `process.stderr.write`. Used to restore `stderr` to its
+original state after calling [`common.hijackStdErr()`][].
 
 ### restoreStdout()
 
-Restore the original `process.stdout.write`.
+Restore the original `process.stdout.write`. Used to restore `stdout` to its
+original state after calling [`common.hijackStdOut()`][].
 
 ### rootDir
 * return [&lt;String>]
@@ -456,4 +458,6 @@ implementation with tests from
 [&lt;Object>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [&lt;RegExp>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 [&lt;String>]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type
+[`common.hijackStdErr()`]: #hijackstderrlistener
+[`common.hijackStdOut()`]: #hijackstdoutlistener
 [internationalization]: https://github.com/nodejs/node/wiki/Intl


### PR DESCRIPTION
Explain that `common.restoreStderr()` and `common.restoreStdout()` are
for use with `common.hijackStderr()` and `common.hijackStdout()`
respectively.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc test