### PR TITLE
test: refactor test-internal-errors

### DIFF
--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -12,36 +12,45 @@ function invalidKey(key) {
 errors.E('TEST_ERROR_1', 'Error for testing purposes: %s');
 errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`);
 
-const err1 = new errors.Error('TEST_ERROR_1', 'test');
-const err2 = new errors.TypeError('TEST_ERROR_1', 'test');
-const err3 = new errors.RangeError('TEST_ERROR_1', 'test');
-const err4 = new errors.Error('TEST_ERROR_2', 'abc', 'xyz');
-const err5 = new errors.Error('TEST_ERROR_1');
+{
+  const err = new errors.Error('TEST_ERROR_1', 'test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+  assert.strictEqual(err.message, 'Error for testing purposes: test');
+  assert.strictEqual(err.code, 'TEST_ERROR_1');
+}
 
-assert(err1 instanceof Error);
-assert.strictEqual(err1.name, 'Error [TEST_ERROR_1]');
-assert.strictEqual(err1.message, 'Error for testing purposes: test');
-assert.strictEqual(err1.code, 'TEST_ERROR_1');
+{
+  const err = new errors.TypeError('TEST_ERROR_1', 'test');
+  assert(err instanceof TypeError);
+  assert.strictEqual(err.name, 'TypeError [TEST_ERROR_1]');
+  assert.strictEqual(err.message, 'Error for testing purposes: test');
+  assert.strictEqual(err.code, 'TEST_ERROR_1');
+}
 
-assert(err2 instanceof TypeError);
-assert.strictEqual(err2.name, 'TypeError [TEST_ERROR_1]');
-assert.strictEqual(err2.message, 'Error for testing purposes: test');
-assert.strictEqual(err2.code, 'TEST_ERROR_1');
+{
+  const err = new errors.RangeError('TEST_ERROR_1', 'test');
+  assert(err instanceof RangeError);
+  assert.strictEqual(err.name, 'RangeError [TEST_ERROR_1]');
+  assert.strictEqual(err.message, 'Error for testing purposes: test');
+  assert.strictEqual(err.code, 'TEST_ERROR_1');
+}
 
-assert(err3 instanceof RangeError);
-assert.strictEqual(err3.name, 'RangeError [TEST_ERROR_1]');
-assert.strictEqual(err3.message, 'Error for testing purposes: test');
-assert.strictEqual(err3.code, 'TEST_ERROR_1');
+{
+  const err = new errors.Error('TEST_ERROR_2', 'abc', 'xyz');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error [TEST_ERROR_2]');
+  assert.strictEqual(err.message, 'abc xyz');
+  assert.strictEqual(err.code, 'TEST_ERROR_2');
+}
 
-assert(err4 instanceof Error);
-assert.strictEqual(err4.name, 'Error [TEST_ERROR_2]');
-assert.strictEqual(err4.message, 'abc xyz');
-assert.strictEqual(err4.code, 'TEST_ERROR_2');
-
-assert(err5 instanceof Error);
-assert.strictEqual(err5.name, 'Error [TEST_ERROR_1]');
-assert.strictEqual(err5.message, 'Error for testing purposes: %s');
-assert.strictEqual(err5.code, 'TEST_ERROR_1');
+{
+  const err = new errors.Error('TEST_ERROR_1');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error [TEST_ERROR_1]');
+  assert.strictEqual(err.message, 'Error for testing purposes: %s');
+  assert.strictEqual(err.code, 'TEST_ERROR_1');
+}
 
 assert.throws(
   () => new errors.Error('TEST_FOO_KEY'),


### PR DESCRIPTION
Use block-scoping rather than `err1`, `err2`, etc.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test