### PR TITLE
Revert "url: const-ify APIs, and pass URL by ref"

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -323,7 +323,7 @@ struct file_check {
   bool failed = true;
   uv_file file = -1;
 };
-inline const struct file_check check_file(const URL& search,
+inline const struct file_check check_file(URL search,
                                           bool close = false,
                                           bool allow_dir = false) {
   struct file_check ret;
@@ -349,7 +349,7 @@ inline const struct file_check check_file(const URL& search,
   if (close) uv_fs_close(nullptr, &fs_req, fd, nullptr);
   return ret;
 }
-URL resolve_extensions(const URL& search, bool check_exact = true) {
+URL resolve_extensions(URL search, bool check_exact = true) {
   if (check_exact) {
     auto check = check_file(search, true);
     if (!check.failed) {
@@ -365,10 +365,10 @@ URL resolve_extensions(const URL& search, bool check_exact = true) {
   }
   return URL("");
 }
-inline URL resolve_index(const URL& search) {
+inline URL resolve_index(URL search) {
   return resolve_extensions(URL("index", &search), false);
 }
-URL resolve_main(const URL& search) {
+URL resolve_main(URL search) {
   URL pkg("package.json", &search);
   auto check = check_file(pkg);
   if (!check.failed) {
@@ -402,7 +402,7 @@ URL resolve_main(const URL& search) {
   }
   return URL("");
 }
-URL resolve_module(std::string specifier, const URL* base) {
+URL resolve_module(std::string specifier, URL* base) {
   URL parent(".", base);
   URL dir("");
   do {
@@ -427,7 +427,7 @@ URL resolve_module(std::string specifier, const URL* base) {
   return URL("");
 }
 
-URL resolve_directory(const URL& search, bool read_pkg_json) {
+URL resolve_directory(URL search, bool read_pkg_json) {
   if (read_pkg_json) {
     auto main = resolve_main(search);
     if (!(main.flags() & URL_FLAGS_FAILED)) return main;
@@ -438,7 +438,7 @@ URL resolve_directory(const URL& search, bool read_pkg_json) {
 }  // anonymous namespace
 
 
-URL Resolve(std::string specifier, const URL* base, bool read_pkg_json) {
+URL Resolve(std::string specifier, URL* base, bool read_pkg_json) {
   URL pure_url(specifier);
   if (!(pure_url.flags() & URL_FLAGS_FAILED)) {
     return pure_url;

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -13,7 +13,7 @@
 namespace node {
 namespace loader {
 
-node::url::URL Resolve(std::string specifier, const node::url::URL* base,
+node::url::URL Resolve(std::string specifier, node::url::URL* base,
                        bool read_pkg_json = false);
 
 class ModuleWrap : public BaseObject {

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2081,7 +2081,7 @@ static void DomainToUnicode(const FunctionCallbackInfo<Value>& args) {
                           v8::NewStringType::kNormal).ToLocalChecked());
 }
 
-std::string URL::ToFilePath() const {
+std::string URL::ToFilePath() {
   if (context_.scheme != "file:") {
     return "";
   }
@@ -2102,7 +2102,7 @@ std::string URL::ToFilePath() const {
   }
 #endif
   std::string decoded_path;
-  for (const std::string& part : context_.path) {
+  for (std::string& part : context_.path) {
     std::string decoded;
     PercentDecode(part.c_str(), part.length(), &decoded);
     for (char& ch : decoded) {

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -154,7 +154,7 @@ class URL {
     return context_.fragment;
   }
 
-  std::string path() const {
+  std::string path() {
     std::string ret;
     for (auto i = context_.path.begin(); i != context_.path.end(); i++) {
       ret += '/';
@@ -165,7 +165,7 @@ class URL {
 
   // Get the path of the file: URL in a format consumable by native file system
   // APIs. Returns an empty string if something went wrong.
-  std::string ToFilePath() const;
+  std::string ToFilePath();
 
   const Local<Value> ToObject(Environment* env) const;
 


### PR DESCRIPTION
This reverts commit af6af08482d2e7a4e20990bd67743e81a6be881c.

Ref https://github.com/nodejs/node/pull/15615#issuecomment-333435350

This results in build errors on Windows and it is now to late to rebase to get rid of this commit.
To have one option of solving this fast I open this revert. 
@sam-github or anyone else - if there is a nicer fix that could land fast as well, I think that would be the preferred way instead.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url