### PR TITLE
util: use faster -0 check

### DIFF
--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -22,7 +22,8 @@ const bench = common.createBenchmark(main, {
     'Error',
     'Array',
     'TypedArray',
-    'TypedArray_extra'
+    'TypedArray_extra',
+    'Number'
   ],
   option: Object.keys(opts)
 });
@@ -91,6 +92,9 @@ function main({ method, n, option }) {
       obj.foo = 'bar';
       obj[Symbol('baz')] = 5;
       benchmark(n, obj, options);
+      break;
+    case 'Number':
+      benchmark(n, 0, options);
       break;
     default:
       throw new Error(`Unsupported method "${method}"`);

--- a/lib/util.js
+++ b/lib/util.js
@@ -615,8 +615,10 @@ function formatValue(ctx, value, recurseTimes, ln) {
 }
 
 function formatNumber(fn, value) {
-  // Format -0 as '-0'. Strict equality won't distinguish 0 from -0.
-  if (Object.is(value, -0))
+  // Format -0 as '-0'. A `value === -0` check won't distinguish 0 from -0.
+  // Using a division check is currently faster than `Object.is(value, -0)`
+  // as of V8 6.1.
+  if (1 / value === -Infinity)
     return fn('-0', 'number');
   return fn(`${value}`, 'number');
 }


### PR DESCRIPTION
Benchmark results:

```
                                                       improvement confidence      p.value
 util/inspect.js option="" method="Number" n=90000000     38.95 %        *** 5.305807e-54
```

CI: https://ci.nodejs.org/job/node-test-pull-request/10378/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

* util
