### PR TITLE
module: fix regression in main ESM loading

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -421,35 +421,14 @@ Module._load = function(request, parent, isMain) {
     debug('Module._load REQUEST %s parent: %s', request, parent.id);
   }
 
-  var filename = null;
+  var filename = Module._resolveFilename(request, parent, isMain);
 
-  if (isMain) {
-    let err;
-    try {
-      filename = Module._resolveFilename(request, parent, isMain);
-    } catch (e) {
-      // try to keep stack
-      e.stack;
-      err = e;
-    }
-    if (experimentalModules) {
-      if (filename === null || /\.mjs$/.test(filename)) {
-        try {
-          ESMLoader.import(getURLFromFilePath(filename).href).catch((e) => {
-            console.error(e);
-            process.exit(1);
-          });
-          return;
-        } catch (e) {
-          // well, it isn't ESM
-        }
-      }
-    }
-    if (err) {
-      throw err;
-    }
-  } else {
-    filename = Module._resolveFilename(request, parent, isMain);
+  if (isMain && experimentalModules && /\.mjs$/.test(filename)) {
+    ESMLoader.import(getURLFromFilePath(filename).href).catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+    return;
   }
 
   var cachedModule = Module._cache[filename];

--- a/test/parallel/test-module-main-fail.js
+++ b/test/parallel/test-module-main-fail.js
@@ -1,28 +1,22 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const child_process = require('child_process');
-const { promisify } = require('util');
-const execFile = promisify(child_process.execFile);
-
-common.crashOnUnhandledRejection();
+const { execFileSync } = require('child_process');
 
 const entryPoints = ['iDoNotExist', 'iDoNotExist.js', 'iDoNotExist.mjs'];
 const flags = [[], ['--experimental-modules']];
 const node = process.argv[0];
 
-(async () => {
-  for (const args of flags) {
-    for (const entryPoint of entryPoints) {
-      try {
-        await execFile(node, args.concat(entryPoint));
-      } catch (e) {
-        assert.strictEqual(e.stdout, '');
-        assert(e.stderr.match(/Error: Cannot find module/));
-        continue;
-      }
-      throw new Error('Executing node with inexistent entry point should ' +
-                      `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+for (const args of flags) {
+  for (const entryPoint of entryPoints) {
+    try {
+      execFileSync(node, args.concat(entryPoint), { stdio: 'pipe' });
+    } catch (e) {
+      assert.strictEqual(e.stdout.toString(), '');
+      assert(e.stderr.toString().match(/Error: Cannot find module/));
+      continue;
     }
+    assert.fail('Executing node with inexistent entry point should fail. ' +
+                `Entry point: ${entryPoint}, Flags: [${args}]`);
   }
-})();
+}

--- a/test/parallel/test-module-main-fail.js
+++ b/test/parallel/test-module-main-fail.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const { promisify } = require('util');
+const execFile = promisify(child_process.execFile);
+
+common.crashOnUnhandledRejection();
+
+const entryPoints = ['iDoNotExist', 'iDoNotExist.js', 'iDoNotExist.mjs'];
+const flags = [[], ['--experimental-modules']];
+const node = process.argv[0];
+
+(async () => {
+  for (const args of flags) {
+    for (const entryPoint of entryPoints) {
+      try {
+        await execFile(node, args.concat(entryPoint));
+      } catch (e) {
+        assert.strictEqual(e.stdout, '');
+        assert(e.stderr.match(/Error: Cannot find module/));
+        continue;
+      }
+      throw new Error('Executing node with inexistent entry point should ' +
+                      `fail. Entry point: ${entryPoint}, Flags: [${args}]`);
+    }
+  }
+})();


### PR DESCRIPTION
When the requested module cannot be resolved to a file, loading should
always fail, regardless of wether ESM is enabled or not.

Fixes: https://github.com/nodejs/node/issues/15732

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
