### PR TITLE
[WIP] repl: don't use lineParser for Recoverable errors

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -77,110 +77,6 @@ exports.writer = util.inspect;
 
 exports._builtinLibs = internalModule.builtinLibs;
 
-
-const BLOCK_SCOPED_ERROR = 'Block-scoped declarations (let, const, function, ' +
-                           'class) not yet supported outside strict mode';
-
-
-class LineParser {
-
-  constructor() {
-    this.reset();
-  }
-
-  reset() {
-    this._literal = null;
-    this.shouldFail = false;
-    this.blockComment = false;
-    this.regExpLiteral = false;
-    this.prevTokenChar = null;
-  }
-
-  parseLine(line) {
-    var previous = null;
-    this.shouldFail = false;
-    const wasWithinStrLiteral = this._literal !== null;
-
-    for (const current of line) {
-      if (previous === '\\') {
-        // valid escaping, skip processing. previous doesn't matter anymore
-        previous = null;
-        continue;
-      }
-
-      if (!this._literal) {
-        if (this.regExpLiteral && current === '/') {
-          this.regExpLiteral = false;
-          previous = null;
-          continue;
-        }
-        if (previous === '*' && current === '/') {
-          if (this.blockComment) {
-            this.blockComment = false;
-            previous = null;
-            continue;
-          } else {
-            this.shouldFail = true;
-            break;
-          }
-        }
-
-        // ignore rest of the line if `current` and `previous` are `/`s
-        if (previous === current && previous === '/' && !this.blockComment) {
-          break;
-        }
-
-        if (previous === '/') {
-          if (current === '*') {
-            this.blockComment = true;
-          } else if (
-            // Distinguish between a division operator and the start of a regex
-            // by examining the non-whitespace character that precedes the /
-            [null, '(', '[', '{', '}', ';'].includes(this.prevTokenChar)
-          ) {
-            this.regExpLiteral = true;
-          }
-          previous = null;
-        }
-      }
-
-      if (this.blockComment || this.regExpLiteral) continue;
-
-      if (current === this._literal) {
-        this._literal = null;
-      } else if (current === '\'' || current === '"') {
-        this._literal = this._literal || current;
-      }
-
-      if (current.trim() && current !== '/') this.prevTokenChar = current;
-
-      previous = current;
-    }
-
-    const isWithinStrLiteral = this._literal !== null;
-
-    if (!wasWithinStrLiteral && !isWithinStrLiteral) {
-      // Current line has nothing to do with String literals, trim both ends
-      line = line.trim();
-    } else if (wasWithinStrLiteral && !isWithinStrLiteral) {
-      // was part of a string literal, but it is over now, trim only the end
-      line = line.trimRight();
-    } else if (isWithinStrLiteral && !wasWithinStrLiteral) {
-      // was not part of a string literal, but it is now, trim only the start
-      line = line.trimLeft();
-    }
-
-    const lastChar = line.charAt(line.length - 1);
-
-    this.shouldFail = this.shouldFail ||
-                      ((!this._literal && lastChar === '\\') ||
-                      (this._literal && lastChar !== '\\'));
-
-    return line;
-  }
-}
-
-
 function REPLServer(prompt,
                     stream,
                     eval_,
@@ -232,8 +128,6 @@ function REPLServer(prompt,
   self.breakEvalOnSigint = !!breakEvalOnSigint;
   self.editorMode = false;
 
-  self._inTemplateLiteral = false;
-
   // just for backwards compat, see github.com/joyent/node/pull/7127
   self.rli = this;
 
@@ -245,69 +139,48 @@ function REPLServer(prompt,
 
   eval_ = eval_ || defaultEval;
 
-  function preprocess(code) {
-    let cmd = code;
-    if (/^\s*\{/.test(cmd) && /\}\s*$/.test(cmd)) {
+  function defaultEval(code, context, file, cb) {
+    var err, result, script, wrappedErr;
+    var wrappedCmd = false;
+    var input = code;
+
+    if (/^\s*\{/.test(code) && /\}\s*$/.test(code)) {
       // It's confusing for `{ a : 1 }` to be interpreted as a block
       // statement rather than an object literal.  So, we first try
       // to wrap it in parentheses, so that it will be interpreted as
       // an expression.
-      cmd = `(${cmd})`;
-      self.wrappedCmd = true;
-    } else {
-      // Mitigate https://github.com/nodejs/node/issues/548
-      cmd = cmd.replace(
-        /^\s*function(?:\s*(\*)\s*|\s+)([^(]+)/,
-        (_, genStar, name) => `var ${name} = function ${genStar || ''}${name}`
-      );
+      code = `(${code.trim()})\n`;
+      wrappedCmd = true;
     }
-    // Append a \n so that it will be either
-    // terminated, or continued onto the next expression if it's an
-    // unexpected end of input.
-    return `${cmd}\n`;
-  }
 
-  function defaultEval(code, context, file, cb) {
-    // Remove trailing new line
-    code = code.replace(/\n$/, '');
-    code = preprocess(code);
-
-    var err, result, retry = false, input = code, wrappedErr;
     // first, create the Script object to check the syntax
-
     if (code === '\n')
       return cb(null);
 
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
-            (self.replMode === exports.REPL_MODE_STRICT || retry)) {
+            (self.replMode === exports.REPL_MODE_STRICT)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
           code = `'use strict'; void 0;\n${code}`;
         }
-        var script = vm.createScript(code, {
+        script = vm.createScript(code, {
           filename: file,
           displayErrors: true
         });
       } catch (e) {
         debug('parse error %j', code, e);
-        if (self.replMode === exports.REPL_MODE_MAGIC &&
-            e.message === BLOCK_SCOPED_ERROR &&
-            !retry || self.wrappedCmd) {
-          if (self.wrappedCmd) {
-            self.wrappedCmd = false;
-            // unwrap and try again
-            code = `${input.substring(1, input.length - 2)}\n`;
-            wrappedErr = e;
-          } else {
-            retry = true;
-          }
+        if (wrappedCmd) {
+          wrappedCmd = false;
+          // unwrap and try again
+          code = input;
+          wrappedErr = e;
           continue;
         }
         // preserve original error for wrapped command
         const error = wrappedErr || e;
-        if (isRecoverableError(error, self))
+        if (isRecoverableError(error, code))
           err = new Recoverable(error);
         else
           err = error;
@@ -394,7 +267,6 @@ function REPLServer(prompt,
                                 (_, pre, line) => pre + (line - 1));
     }
     top.outputStream.write((e.stack || e) + '\n');
-    top.lineParser.reset();
     top.bufferedCommand = '';
     top.lines.level = [];
     top.displayPrompt();
@@ -421,7 +293,6 @@ function REPLServer(prompt,
   self.outputStream = output;
 
   self.resetContext();
-  self.lineParser = new LineParser();
   self.bufferedCommand = '';
   self.lines.level = [];
 
@@ -485,7 +356,6 @@ function REPLServer(prompt,
       sawSIGINT = false;
     }
 
-    self.lineParser.reset();
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
@@ -493,6 +363,7 @@ function REPLServer(prompt,
 
   self.on('line', function(cmd) {
     debug('line %j', cmd);
+    cmd = cmd || '';
     sawSIGINT = false;
 
     if (self.editorMode) {
@@ -510,24 +381,28 @@ function REPLServer(prompt,
       return;
     }
 
-    // leading whitespaces in template literals should not be trimmed.
-    if (self._inTemplateLiteral) {
-      self._inTemplateLiteral = false;
-    } else {
-      cmd = self.lineParser.parseLine(cmd);
-    }
+    // Check REPL keywords and empty lines against a trimmed line input.
+    const trimmedCmd = cmd.trim();
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && cmd.charAt(1) !== '.' &&
-        isNaN(parseFloat(cmd))) {
-      const matches = cmd.match(/^\.([^\s]+)\s*(.*)$/);
-      const keyword = matches && matches[1];
-      const rest = matches && matches[2];
-      if (self.parseREPLKeyword(keyword, rest) === true) {
-        return;
-      } else if (!self.bufferedCommand) {
-        self.outputStream.write('Invalid REPL keyword\n');
+    if (trimmedCmd) {
+      if (trimmedCmd.charAt(0) === '.' && isNaN(parseFloat(trimmedCmd))) {
+        const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
+        const keyword = matches && matches[1];
+        const rest = matches && matches[2];
+        if (self.parseREPLKeyword(keyword, rest) === true) {
+          return;
+        }
+        if (!self.bufferedCommand) {
+          self.outputStream.write('Invalid REPL keyword\n');
+          finish(null);
+          return;
+        }
+      }
+    } else {
+      // Print a new line when hitting enter.
+      if (!self.bufferedCommand) {
         finish(null);
         return;
       }
@@ -542,12 +417,10 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
-      self.wrappedCmd = false;
       if (e && !self.bufferedCommand && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
-        self.lineParser.reset();
         self.bufferedCommand = '';
         self.displayPrompt();
         return;
@@ -555,8 +428,7 @@ function REPLServer(prompt,
 
       // If error was SyntaxError and not JSON.parse error
       if (e) {
-        if (e instanceof Recoverable && !self.lineParser.shouldFail &&
-            !sawCtrlD) {
+        if (e instanceof Recoverable && !sawCtrlD) {
           // Start buffering data like that:
           // {
           // ...  x: 1
@@ -570,7 +442,6 @@ function REPLServer(prompt,
       }
 
       // Clear buffer if no SyntaxErrors
-      self.lineParser.reset();
       self.bufferedCommand = '';
       sawCtrlD = false;
 
@@ -1232,7 +1103,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {
-      this.lineParser.reset();
       this.bufferedCommand = '';
       this.displayPrompt();
     }
@@ -1247,7 +1117,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('clear', {
     help: clearMessage,
     action: function() {
-      this.lineParser.reset();
       this.bufferedCommand = '';
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
@@ -1366,20 +1235,13 @@ REPLServer.prototype.convertToContext = function(cmd) {
   return cmd;
 };
 
-function bailOnIllegalToken(parser) {
-  return parser._literal === null &&
-         !parser.blockComment &&
-         !parser.regExpLiteral;
-}
-
 // If the error is that we've unexpectedly ended the input,
 // then let the user try to recover by adding more input.
-function isRecoverableError(e, self) {
+function isRecoverableError(e, code) {
   if (e && e.name === 'SyntaxError') {
     var message = e.message;
     if (message === 'Unterminated template literal' ||
         message === 'Missing } in template expression') {
-      self._inTemplateLiteral = true;
       return true;
     }
 
@@ -1389,9 +1251,79 @@ function isRecoverableError(e, self) {
       return true;
 
     if (message === 'Invalid or unexpected token')
-      return !bailOnIllegalToken(self.lineParser);
+      return isCodeRecoverable(code);
   }
   return false;
+}
+
+// Check whether a code snippet should be forced to fail in the REPL.
+function isCodeRecoverable(code) {
+  var current, previous, stringLiteral;
+  var isBlockComment = false;
+  var isSingleComment = false;
+  var isRegExpLiteral = false;
+  var lastChar = code.charAt(code.length - 2);
+  var prevTokenChar = null;
+
+  for (var i = 0; i < code.length; i++) {
+    previous = current;
+    current = code[i];
+
+    if (previous === '\\' && (stringLiteral || isRegExpLiteral)) {
+      current = null;
+      continue;
+    }
+
+    if (stringLiteral) {
+      if (stringLiteral === current) {
+        stringLiteral = null;
+      }
+      continue;
+    } else {
+      if (isRegExpLiteral && current === '/') {
+        isRegExpLiteral = false;
+        continue;
+      }
+
+      if (isBlockComment && previous === '*' && current === '/') {
+        isBlockComment = false;
+        continue;
+      }
+
+      if (isSingleComment && current === '\n') {
+        isSingleComment = false;
+        continue;
+      }
+
+      if (isBlockComment || isRegExpLiteral || isSingleComment) continue;
+
+      if (current === '/' && previous === '/') {
+        isSingleComment = true;
+        continue;
+      }
+
+      if (previous === '/') {
+        if (current === '*') {
+          isBlockComment = true;
+        } else if (
+          // Distinguish between a division operator and the start of a regex
+          // by examining the non-whitespace character that precedes the /
+          [null, '(', '[', '{', '}', ';'].includes(prevTokenChar)
+        ) {
+          isRegExpLiteral = true;
+        }
+        continue;
+      }
+
+      if (current.trim()) prevTokenChar = current;
+    }
+
+    if (current === '\'' || current === '"') {
+      stringLiteral = current;
+    }
+  }
+
+  return stringLiteral ? lastChar === '\\' : isBlockComment;
 }
 
 function Recoverable(err) {

--- a/test/parallel/test-repl-multi-line-templates.js
+++ b/test/parallel/test-repl-multi-line-templates.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const stream = require('stream');
+
+const inputStream = new stream.PassThrough();
+const outputStream = new stream.PassThrough();
+outputStream.accum = '';
+
+outputStream.on('data', (data) => {
+  outputStream.accum += data;
+});
+
+const r = repl.start({
+  input: inputStream,
+  output: outputStream,
+  useColors: false,
+  terminal: false,
+  prompt: ''
+});
+
+r.write('const str = `tacos \\\nfoobar`');
+assert.strictEqual(r.output.accum, '... ');

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -386,14 +386,15 @@ function error_test() {
 
     {
       client: client_unix, send: '(function() {\nif (false) {} /bar"/;\n}())',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${prompt_unix}`
+      expect: prompt_multiline + prompt_multiline + 'undefined\n' + prompt_unix
     },
-    // Do not parse `...[]` as a REPL keyword
-    { client: client_unix, send: '...[]\n',
-      expect: `${prompt_multiline}` },
-    // bring back the repl to prompt
-    { client: client_unix, send: '.break',
-      expect: `${prompt_unix}` }
+
+    // Newline within template string maintains whitespace.
+    { client: client_unix, send: '`foo \n`',
+      expect: prompt_multiline + '\'foo \\n\'\n' + prompt_unix },
+    // Whitespace is not evaluated.
+    { client: client_unix, send: ' \t  \n',
+      expect: prompt_unix }
   ]);
 }
 


### PR DESCRIPTION
Removing the REPL's `lineParser.shouldFail` checks resolves the issue below and does not cause any regressions in the test suite. It appears that when `editorMode` was backported to the 6.x branch, the `LineParser` failure checks were not removed.

Fixes: https://github.com/nodejs/node/issues/15704
Ref: https://github.com/nodejs/node/commit/39d9afe279e9d66f983bc06294cb38243e54d637
Ref: https://github.com/nodejs/node/commit/4875aa2aa20445ca754dc46db381e02b4f42a486

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl
