### PR TITLE
inspector: not pass zero as task_id

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -620,18 +620,22 @@ class NodeInspectorClient : public V8InspectorClient {
   // Async stack traces instrumentation.
   void AsyncTaskScheduled(const StringView& task_name, void* task,
                           bool recurring) {
+    if (!task) return;
     client_->asyncTaskScheduled(task_name, task, recurring);
   }
 
   void AsyncTaskCanceled(void* task) {
+    if (!task) return;
     client_->asyncTaskCanceled(task);
   }
 
   void AsyncTaskStarted(void* task) {
+    if (!task) return;
     client_->asyncTaskStarted(task);
   }
 
   void AsyncTaskFinished(void* task) {
+    if (!task) return;
     client_->asyncTaskFinished(task);
   }
 


### PR DESCRIPTION
Inspector doesn't support zero as task_id. Node.js uses 0 at least
as microTasksTickObject async_id in next_tick.js.
We can ignore this task and not report it to asyncTask* API.

Fixes: https://github.com/nodejs/node/issues/15464

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
inspector
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
