### PR TITLE
doc: fix unassigned deprecation code

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -710,8 +710,8 @@ function for [`util.inspect()`][] is deprecated. Use [`util.inspect.custom`][]
 instead. For backwards compatibility with Node.js prior to version 6.4.0, both
 may be specified.
 
-<a id="DEP00XX"></a>
-### DEP00XX: path.\_makeLong()
+<a id="DEP0080"></a>
+### DEP0080: path.\_makeLong()
 
 Type: Documentation-only
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1629,7 +1629,7 @@ const posix = {
 posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
-// Legacy internal API, docs-only deprecated: DEP00XX
+// Legacy internal API, docs-only deprecated: DEP0080
 win32._makeLong = win32.toNamespacedPath;
 posix._makeLong = posix.toNamespacedPath;
 


### PR DESCRIPTION
Forgot to assign the deprecation code when landing 1f8d527e94ad97e7db14d18406fe0e12983358cb

this really shouldn't need to wait the 48 hours to land.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

docs