### PR TITLE
test: remove `common.PORT` from test-tlswrap

### DIFF
--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -25,7 +25,7 @@ const server = tls
   })
   .on('listening', common.mustCall(onlistening))
   .on('secureConnection', common.mustCall(onsecureConnection))
-  .listen(common.PORT);
+  .listen(0);
 
 let svr, client;
 function onlistening() {
@@ -33,7 +33,7 @@ function onlistening() {
   // Creating client and connecting it to server
   //
   tls
-    .connect(common.PORT, { rejectUnauthorized: false })
+    .connect(server.address().port, { rejectUnauthorized: false })
     .on('secureConnect', common.mustCall(onsecureConnect));
 
   const as = hooks.activitiesOfTypes('TLSWRAP');


### PR DESCRIPTION
`test/async-hooks/test/test-tslwrap.js` uses `common.PORT` but
async-hooks tests are run in parallel. Another test using port 0 could
result in a port collision. Remove `common.PORT` from the test.

Refs: https://github.com/nodejs/node/issues/14404#issuecomment-333672346

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test