### PR TITLE
test: http2 stored settings returned when present

### DIFF
--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -22,8 +22,14 @@ function assertSettings(settings) {
 
 function onStream(stream, headers, flags) {
 
-  assertSettings(stream.session.localSettings);
-  assertSettings(stream.session.remoteSettings);
+  const localSettings = stream.session.localSettings;
+  const remoteSettings = stream.session.remoteSettings;
+  assertSettings(localSettings);
+  assertSettings(remoteSettings);
+
+  // Test that stored settings are returned when called for second time
+  assert.strictEqual(stream.session.localSettings, localSettings);
+  assert.strictEqual(stream.session.remoteSettings, remoteSettings);
 
   stream.respond({
     'content-type': 'text/html',


### PR DESCRIPTION
This PR adds test to confirm that stored settings are returned when they're available in Http2Stream

It covers following lines:
https://github.com/nodejs/node/blob/2f8ddb27340a5e7e914dc1160846d4822e6352a2/lib/internal/http2/core.js#L805-L806
https://github.com/nodejs/node/blob/2f8ddb27340a5e7e914dc1160846d4822e6352a2/lib/internal/http2/core.js#L820-L821

Refs: #14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2