### PR TITLE
build: call setlocal in vcbuild.bat

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -1,5 +1,7 @@
 @echo off
 
+setlocal EnableExtensions
+
 cd %~dp0
 
 if /i "%1"=="help" goto help


### PR DESCRIPTION
Currently the variables set in vcbuild.bat are mostly global and
escape/leak out into the calling process. For example, running
vcbuild.bat test and then echoing the config variable gives:
```console
vcbuild.bat test
...
echo %config%
Release
```
After this change the same command give:
```console
vcbuild.bat test
...
echo %config%
%config%
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build