### PR TITLE
crypto: migrate Certificate to internal/errors

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -64,11 +64,12 @@ console.log(challenge.toString('utf8'));
 // Prints: the challenge as a UTF8 string
 ```
 
-### Certificate.exportPublicKey(spkac)
+### Certificate.exportPublicKey(spkac[, encoding])
 <!-- YAML
 added: REPLACEME
 -->
 - `spkac` {string | Buffer | TypedArray | DataView}
+- `encoding` {string}
 - Returns {Buffer} The public key component of the `spkac` data structure,
 which includes a public key and a challenge.
 

--- a/lib/internal/crypto/certificate.js
+++ b/lib/internal/crypto/certificate.js
@@ -6,20 +6,37 @@ const {
   certVerifySpkac
 } = process.binding('crypto');
 
+const errors = require('internal/errors');
+const { isArrayBufferView } = require('internal/util/types');
+
 const {
   toBuf
 } = require('internal/crypto/util');
 
-function verifySpkac(object) {
-  return certVerifySpkac(object);
+function verifySpkac(spkac) {
+  if (!isArrayBufferView(spkac)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'spkac',
+                               ['Buffer', 'TypedArray', 'DataView']);
+  }
+  return certVerifySpkac(spkac);
 }
 
-function exportPublicKey(object, encoding) {
-  return certExportPublicKey(toBuf(object, encoding));
+function exportPublicKey(spkac, encoding) {
+  spkac = toBuf(spkac, encoding);
+  if (!isArrayBufferView(spkac)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'spkac',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+  return certExportPublicKey(spkac);
 }
 
-function exportChallenge(object, encoding) {
-  return certExportChallenge(toBuf(object, encoding));
+function exportChallenge(spkac, encoding) {
+  spkac = toBuf(spkac, encoding);
+  if (!isArrayBufferView(spkac)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'spkac',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+  return certExportChallenge(spkac);
 }
 
 // For backwards compatibility reasons, this cannot be converted into a

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5819,11 +5819,6 @@ void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   bool i = false;
 
-  if (args.Length() < 1)
-    return env->ThrowTypeError("Data argument is mandatory");
-
-  THROW_AND_RETURN_IF_NOT_BUFFER(args[0], "Data");
-
   size_t length = Buffer::Length(args[0]);
   if (length == 0)
     return args.GetReturnValue().Set(i);
@@ -5881,11 +5876,6 @@ char* ExportPublicKey(const char* data, int len, size_t* size) {
 void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 1)
-    return env->ThrowTypeError("Public key argument is mandatory");
-
-  THROW_AND_RETURN_IF_NOT_BUFFER(args[0], "Public key");
-
   size_t length = Buffer::Length(args[0]);
   if (length == 0)
     return args.GetReturnValue().SetEmptyString();
@@ -5921,11 +5911,6 @@ const char* ExportChallenge(const char* data, int len) {
 
 void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-
-  if (args.Length() < 1)
-    return env->ThrowTypeError("Challenge argument is mandatory");
-
-  THROW_AND_RETURN_IF_NOT_BUFFER(args[0], "Challenge");
 
   size_t len = Buffer::Length(args[0]);
   if (len == 0)

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -80,3 +80,37 @@ function stripLineEndings(obj) {
 
 // direct call Certificate() should return instance
 assert(Certificate() instanceof Certificate);
+
+[1, {}, [], Infinity, true, 'test', undefined, null].forEach((i) => {
+  common.expectsError(
+    () => Certificate.verifySpkac(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "spkac" argument must be one of type Buffer, TypedArray, ' +
+               'or DataView'
+    }
+  );
+});
+
+[1, {}, [], Infinity, true, undefined, null].forEach((i) => {
+  common.expectsError(
+    () => Certificate.exportPublicKey(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "spkac" argument must be one of type string, Buffer,' +
+               ' TypedArray, or DataView'
+    }
+  );
+
+  common.expectsError(
+    () => Certificate.exportChallenge(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "spkac" argument must be one of type string, Buffer,' +
+               ' TypedArray, or DataView'
+    }
+  );
+});


### PR DESCRIPTION
Move argument type checking to js, use internal/errors
Improve docs and tests

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto