### PR TITLE
meta: provide a two-week review period for semver-major

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -78,8 +78,8 @@ elevated for review by the TSC. This does not necessarily mean that the
 PR must be put onto the TSC meeting agenda. If multiple TSC members
 approve (`LGTM`) the PR and no Collaborators oppose the PR, it can be
 landed. Where there is disagreement among TSC members or objections
-from one or more Collaborators, `semver-major` pull requests should be
-put on the TSC meeting agenda.
+from one or more Collaborators, `semver-major` pull requests must be
+tagged `tsc-review`.
 
 All bugfixes require a test case which demonstrates the defect. The
 test should *fail* before the change, and *pass* after the change.
@@ -184,7 +184,11 @@ breaking changes are made.
 ### Breaking Changes
 
 Backwards-incompatible changes may land on the master branch at any time after
-sufficient review by collaborators and approval of at least two TSC members.
+sufficient review by collaborators and after either:
+
+* Approval from at least two TSC members, or
+* Two weeks have passed since the pull request was tagged `tsc-review` and there
+  are no explicit objections.
 
 Examples of breaking changes include, but are not necessarily limited to,
 removal or redefinition of existing API arguments, changing return values


### PR DESCRIPTION
Allow semver-major pull requests to land after two weeks of
review if there are no explicitly objections, even if there
are not two TSC members signing off.

The reasons are fairly straightforward: the internal/errors conversion has taken a lot longer than it really needed to take because of delays in getting TSC members to actually review the PRs.  This PR allows semver-major's to land after two weeks of review if there is signoff from collaborators, even if there are not two TSC members signing off.

If there are objections, it goes to a vote, as things currently happen.

ping @mcollina  

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
