### PR TITLE
util,errors: make display of errors consistent with browsers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -539,7 +539,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
       base = ` ${dateToISOString.call(value)}`;
     } else if (isError(value)) {
       // Make error with message first say the error
-      if (keyLength === 0)
+      if (keyLength === 0 || !ctx.showHidden)
         return formatError(value);
       base = ` ${formatError(value)}`;
     } else if (isAnyArrayBuffer(value)) {

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -323,13 +323,25 @@ assert.strictEqual(
 // `console.log()` results, which is the behavior of `Error` objects in the
 // browser. Note that `name` becomes enumerable after being assigned.
 {
+  let initialConsoleLog = '';
+  common.hijackStdout((data) => { initialConsoleLog += data; });
   const myError = new errors.Error('ERR_TLS_HANDSHAKE_TIMEOUT');
   assert.deepStrictEqual(Object.keys(myError), []);
   const initialToString = myError.toString();
+  console.log(myError);
+  assert.notStrictEqual(initialConsoleLog, '');
 
+  common.restoreStdout();
+
+  let subsequentConsoleLog = '';
+  common.hijackStdout((data) => { subsequentConsoleLog += data; });
   myError.name = 'Fhqwhgads';
   assert.deepStrictEqual(Object.keys(myError), ['name']);
   assert.notStrictEqual(myError.toString(), initialToString);
+  console.log(myError);
+  assert.strictEqual(subsequentConsoleLog, initialConsoleLog);
+
+  common.restoreStdout();
 }
 
 // Test that `message` is mutable and that changing it alters `toString()` but


### PR DESCRIPTION
In Chrome, adding or mutating properties does not change the output of
`Error` objects displayed via `console.log()` etc. This change
replicates that behavior in Node.js.

This is blocked until https://github.com/nodejs/node/pull/15694 lands as some of the changes depend on that PR. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util tests