### PR TITLE
test: http2 ERR_INVALID_ARG_TYPE tests

### DIFF
--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -6,39 +6,17 @@ if (!common.hasCrypto)
 
 const http2 = require('http2');
 
+const invalidOptions = [() => {}, 1, 'test', null, undefined];
+const invalidArgTypeError = {
+  type: TypeError,
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: 'The "options" argument must be of type object'
+};
+
 // Error if options are not passed to createSecureServer
-
-common.expectsError(
-  () => http2.createSecureServer(),
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
-
-common.expectsError(
-  () => http2.createSecureServer(() => {}),
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
-
-common.expectsError(
-  () => http2.createSecureServer(1),
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
-
-common.expectsError(
-  () => http2.createSecureServer('test'),
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
-
-common.expectsError(
-  () => http2.createSecureServer(null),
-  {
-    code: 'ERR_INVALID_ARG_TYPE',
-    type: TypeError
-  });
+invalidOptions.forEach((invalidOption) =>
+  common.expectsError(
+    () => http2.createSecureServer(invalidOption),
+    invalidArgTypeError
+  )
+);

--- a/test/parallel/test-http2-invalidargtypes-errors.js
+++ b/test/parallel/test-http2-invalidargtypes-errors.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+
+const server = http2.createServer();
+
+server.on(
+  'stream',
+  common.mustCall((stream) => {
+    const invalidArgTypeError = (param, type) => ({
+      type: TypeError,
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: `The "${param}" argument must be of type ${type}`
+    });
+    common.expectsError(
+      () => stream.session.priority(undefined, {}),
+      invalidArgTypeError('stream', 'Http2Stream')
+    );
+    common.expectsError(
+      () => stream.session.rstStream(undefined),
+      invalidArgTypeError('stream', 'Http2Stream')
+    );
+    common.expectsError(
+      () => stream.session.rstStream(stream, 'string'),
+      invalidArgTypeError('code', 'number')
+    );
+    stream.session.destroy();
+  })
+);
+
+server.listen(
+  0,
+  common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.resume();
+    req.on('end', common.mustCall(() => server.close()));
+    req.end();
+  })
+);


### PR DESCRIPTION
This PR adds unit tests for testing ERR_INVALID_ARG_TYPE errors in priority() and rstStream()

Refs: #14985 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
