### PR TITLE
aix, test: prolong debugged child process

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -9,7 +9,6 @@ prefix sequential
 [$system==win32]
 test-inspector-bindings               : PASS, FLAKY
 test-inspector-debug-end              : PASS, FLAKY
-test-inspector-stop-profile-after-done: PASS, FLAKY
 
 [$system==linux]
 
@@ -20,4 +19,3 @@ test-inspector-stop-profile-after-done: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
-test-inspector-stop-profile-after-done: PASS, FLAKY

--- a/test/sequential/test-inspector-stop-profile-after-done.js
+++ b/test/sequential/test-inspector-stop-profile-after-done.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const { NodeInstance } = require('../common/inspector-helper.js');
 
 async function runTests() {
-  const child = new NodeInstance(['--inspect=0'],
+  const child = new NodeInstance(['--inspect-brk=0'],
                                  `let c = 0;
                                   const interval = setInterval(() => {
                                    console.log(new Object());


### PR DESCRIPTION
On AIX, there is a possibility that the child process is done before the parent debugger can connect to it. So prolong the child process by factor of 2.

Fixes: https://github.com/nodejs/node/issues/14897

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
