### PR TITLE
[v6.x backport] repl: force editorMode in .load

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1301,15 +1301,16 @@ function defineDefaultCommands(repl) {
       try {
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {
-          var self = this;
+          this.editorMode = true;
+          REPLServer.super_.prototype.setPrompt.call(this, '');
           var data = fs.readFileSync(file, 'utf8');
           var lines = data.split('\n');
-          this.displayPrompt();
-          lines.forEach(function(line) {
-            if (line) {
-              self.write(line + '\n');
-            }
-          });
+          for (var n = 0; n < lines.length; n++) {
+            if (lines[n])
+              this.write(`${lines[n]}\n`);
+          }
+          this.turnOffEditorMode();
+          this.write('\n');
         } else {
           this.outputStream.write('Failed to load:' + file +
                                   ' is not a valid file\n');

--- a/test/fixtures/repl-load-multiline.js
+++ b/test/fixtures/repl-load-multiline.js
@@ -1,0 +1,6 @@
+const getLunch = () =>
+  placeOrder('tacos')
+    .then(eat);
+
+const placeOrder = (order) => Promise.resolve(order);
+const eat = (food) => '<nom nom nom>';

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -1,0 +1,39 @@
+'use strict';
+const common = require('../common');
+const path = require('path');
+const fixtures = common.fixturesDir;
+const assert = require('assert');
+const repl = require('repl');
+
+const command = `.load ${path.join(fixtures, 'repl-load-multiline.js')}`;
+const terminalCode = '\u001b[1G\u001b[0J \u001b[1G';
+const terminalCodeRegex = new RegExp(terminalCode.replace(/\[/g, '\\['), 'g');
+
+const expected = `${command}
+const getLunch = () =>
+  placeOrder('tacos')
+    .then(eat);
+const placeOrder = (order) => Promise.resolve(order);
+const eat = (food) => '<nom nom nom>';
+
+undefined
+`;
+
+let accum = '';
+
+const inputStream = new common.ArrayStream();
+const outputStream = new common.ArrayStream();
+
+outputStream.write = (data) => accum += data.replace('\r', '');
+
+const r = repl.start({
+  prompt: '',
+  input: inputStream,
+  output: outputStream,
+  terminal: true,
+  useColors: false
+});
+
+r.write(`${command}\n`);
+assert.strictEqual(accum.replace(terminalCodeRegex, ''), expected);
+r.close();


### PR DESCRIPTION
The `.load` command would fail with any file that contains
multiline `.` operator expressions. This was particularly
noticeable when chaining promises or multi-line arrow
expressions.

This change Forces the REPL to be in `editorMode` while loading
a file from disk using the `.load` command.

Original PR: https://github.com/nodejs/node/pull/14861

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl
