### PR TITLE
doc: update style guide for markdown extension

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -6,8 +6,6 @@
     topic the document will describe (e.g., `child_process`).
   * Filenames should be **lowercase**.
   * Some files, such as top-level markdown files, are exceptions.
-  * Older files may use the `.markdown` extension. These may be ported to `.md`
-    at will. **Prefer `.md` for all new documents.**
 * Documents should be word-wrapped at 80 characters.
 * The formatting described in `.editorconfig` is preferred.
   * A [plugin][] is available for some editors to automatically apply these


### PR DESCRIPTION
There are no longer files in the repository that use the `.markdown`
extension so remove mention of them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc