### PR TITLE
doc: fix 'close' event descriptions for fs.ReadStream and fs.WriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -182,7 +182,8 @@ added: v0.1.93
 
 * `fd` {integer} Integer file descriptor used by the ReadStream.
 
-Emitted when the ReadStream's file is opened.
+Emitted when the `ReadStream`'s underlying file descriptor has been closed
+using the `fs.close()` method.
 
 ### readStream.bytesRead
 <!-- YAML
@@ -296,7 +297,8 @@ added: v0.1.93
 
 * `fd` {integer} Integer file descriptor used by the WriteStream.
 
-Emitted when the WriteStream's file is opened.
+Emitted when the `WriteStream`'s underlying file descriptor has been closed
+using the `fs.close()` method.
 
 ### writeStream.bytesWritten
 <!-- YAML


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

---

I tried to follow the commit message guidelines but I couldn't think any of good message that was 50 characters or less.  If anyone has recommendations, I'd be happy to update it.

Situation: These changes seem to already be in place within the docs for `4.x` and `8.x` but are somehow missing from `6.x`. Seemed like an easy but necessary fix when I happened upon it in the docs the other day. :+1:
