### PR TITLE
url: fix port overflow checking

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1598,9 +1598,12 @@ void URL::Parse(const char* input,
                    special_back_slash) {
           if (buffer.size() > 0) {
             int port = 0;
-            for (size_t i = 0; i < buffer.size(); i++)
+            for (size_t i = 0; i < buffer.size(); i++) {
               port = port * 10 + buffer[i] - '0';
-            if (port < 0 || port > 0xffff) {
+              // prevent integer overflow
+              if (port > 0xffff) break;
+            }
+            if (port > 0xffff) {
               // TODO(TimothyGu): This hack is currently needed for the host
               // setter since it needs access to hostname if it is valid, and
               // if the FAILED flag is set the entire response to JS layer

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1598,11 +1598,9 @@ void URL::Parse(const char* input,
                    special_back_slash) {
           if (buffer.size() > 0) {
             unsigned port = 0;
-            for (size_t i = 0; i < buffer.size(); i++) {
+            // the condition port <= 0xffff prevents integer overflow
+            for (size_t i = 0; port <= 0xffff && i < buffer.size(); i++)
               port = port * 10 + buffer[i] - '0';
-              // prevent integer overflow
-              if (port > 0xffff) break;
-            }
             if (port > 0xffff) {
               // TODO(TimothyGu): This hack is currently needed for the host
               // setter since it needs access to hostname if it is valid, and

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1597,7 +1597,7 @@ void URL::Parse(const char* input,
                    ch == '#' ||
                    special_back_slash) {
           if (buffer.size() > 0) {
-            int port = 0;
+            unsigned port = 0;
             for (size_t i = 0; i < buffer.size(); i++) {
               port = port * 10 + buffer[i] - '0';
               // prevent integer overflow
@@ -1614,7 +1614,8 @@ void URL::Parse(const char* input,
                 url->flags |= URL_FLAGS_FAILED;
               return;
             }
-            url->port = NormalizePort(url->scheme, port);
+            // the port is valid
+            url->port = NormalizePort(url->scheme, static_cast<int>(port));
             buffer.clear();
           } else if (has_state_override) {
             // TODO(TimothyGu): Similar case as above.

--- a/test/fixtures/url-tests.js
+++ b/test/fixtures/url-tests.js
@@ -2,7 +2,7 @@
 
 /* The following tests are copied from WPT. Modifications to them should be
    upstreamed first. Refs:
-   https://github.com/w3c/web-platform-tests/blob/5d149f0/url/urltestdata.json
+   https://github.com/w3c/web-platform-tests/blob/11757f1/url/urltestdata.json
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 module.exports =
@@ -5809,6 +5809,24 @@ module.exports =
   {
     "input": "http://#",
     "base": "about:blank",
+    "failure": true
+  },
+  "Port overflow (2^32 + 81)",
+  {
+    "input": "http://f:4294967377/c",
+    "base": "http://example.org/",
+    "failure": true
+  },
+  "Port overflow (2^64 + 81)",
+  {
+    "input": "http://f:18446744073709551697/c",
+    "base": "http://example.org/",
+    "failure": true
+  },
+  "Port overflow (2^128 + 81)",
+  {
+    "input": "http://f:340282366920938463463374607431768211537/c",
+    "base": "http://example.org/",
     "failure": true
   },
   "# Non-special-URL path tests",

--- a/test/parallel/test-whatwg-url-parsing.js
+++ b/test/parallel/test-whatwg-url-parsing.js
@@ -26,7 +26,7 @@ const failureTests = tests.filter((test) => test.failure).concat([
 ]);
 
 const expectedError = common.expectsError(
-  { code: 'ERR_INVALID_URL', type: TypeError }, 110);
+  { code: 'ERR_INVALID_URL', type: TypeError }, failureTests.length);
 
 for (const test of failureTests) {
   assert.throws(


### PR DESCRIPTION
This patch adds `(port > 0xffff)` check after each digit in the loop and prevents integer overflow.

In the current implementation a result can be incorrect if an integer overflow occurs. For example:

```js
const URL = require('url').URL;
const url = new URL("http://example.com:4294967377/");
console.log(url.port);
// actual: 81
// expected: failure (TypeError)
```

Refs: https://github.com/w3c/web-platform-tests/pull/7602
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
url
