### PR TITLE
doc: truncate 'close' event descriptions for fs.ReadStream and fs.WriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -279,8 +279,7 @@ added: v0.1.93
 added: v0.1.93
 -->
 
-Emitted when the `ReadStream`'s underlying file descriptor has been closed
-using the `fs.close()` method.
+Emitted when the `ReadStream`'s underlying file descriptor has been closed.
 
 ### Event: 'open'
 <!-- YAML
@@ -398,8 +397,7 @@ added: v0.1.93
 added: v0.1.93
 -->
 
-Emitted when the `WriteStream`'s underlying file descriptor has been closed
-using the `fs.close()` method.
+Emitted when the `WriteStream`'s underlying file descriptor has been closed.
 
 ### Event: 'open'
 <!-- YAML


### PR DESCRIPTION
Per suggestion from @mscdex in PR #15790

##### Checklist
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

---

As with PR #15790, I tried to follow the commit message guidelines but I couldn't think any of good message that was 50 characters or less.  If anyone has recommendations, I'd be happy to update it.