### PR TITLE
test: replace common.fixturesDir with fixtures.

### DIFF
--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -1,13 +1,14 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 const firstEncoding = 'base64';
 const secondEncoding = 'latin1';
 
-const examplePath = path.join(common.fixturesDir, 'x.txt');
+const examplePath = fixtures.path('x.txt');
 const dummyPath = path.join(common.tmpDir, 'x.txt');
 
 common.refreshTmpDir();


### PR DESCRIPTION
Replaces the use of `common.fixturesDir` with the generic `fixtures`
mechanism.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

- test
