### PR TITLE
use fixtures

### DIFF
--- a/test/parallel/test-https-server-keep-alive-timeout.js
+++ b/test/parallel/test-https-server-keep-alive-timeout.js
@@ -13,8 +13,8 @@ const fs = require('fs');
 const tests = [];
 
 const serverOptions = {
-  key: fs.readFileSync(fixtures.path('/keys/agent1-key.pem')),
-  cert: fs.readFileSync(fixtures.path('/keys/agent1-cert.pem'))
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 function test(fn) {

--- a/test/parallel/test-https-server-keep-alive-timeout.js
+++ b/test/parallel/test-https-server-keep-alive-timeout.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -11,8 +13,8 @@ const fs = require('fs');
 const tests = [];
 
 const serverOptions = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fs.readFileSync(fixtures.path('/keys/agent1-key.pem')),
+  cert: fs.readFileSync(fixtures.path('/keys/agent1-cert.pem'))
 };
 
 function test(fn) {


### PR DESCRIPTION
src: use fixtures module

In test-https-server-keep-alive-timeout.js, replaced common.fixturesDir with use of the common.fixtures module as requested at nodejs interactive code & learn. Thanks!

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
