### PR TITLE
test: replace common.fixturesDir with fixtures.fixturesDir

### DIFF
--- a/test/parallel/test-fs-whatwg-url.js
+++ b/test/parallel/test-fs-whatwg-url.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
@@ -15,7 +16,7 @@ function pathToFileURL(p) {
   return new URL(`file://${p}`);
 }
 
-const p = path.resolve(common.fixturesDir, 'a.js');
+const p = path.resolve(fixtures.fixturesDir, 'a.js');
 const url = pathToFileURL(p);
 
 assert(url instanceof URL);


### PR DESCRIPTION
Replacing the usage of common.fixturesDir with fixtures.fixturesDir in ```test/parallel/test-fs-whatwg-url.js```.
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test