### PR TITLE
test: replace common.fixturesDir with common.fixtures module

### DIFF
--- a/test/parallel/test-tls-key-mismatch.js
+++ b/test/parallel/test-tls-key-mismatch.js
@@ -25,15 +25,16 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const fixtures = require('../common/fixtures');
+
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 const errorMessageRegex =
   /^Error: error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch$/;
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem')
 };
 
 assert.throws(function() {


### PR DESCRIPTION
**Action->** Replaced `common.fixturesDir` in `test-tls-key-mismatch.js` with `common.fixtures` module
 
_Pushed as part of Node.js Interactive 2017 Code n Learn!_

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
