### PR TITLE
test: normalize fixtures use

### DIFF
--- a/test/parallel/test-fs-read-stream-resume.js
+++ b/test/parallel/test-fs-read-stream-resume.js
@@ -20,13 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
 const fs = require('fs');
-const path = require('path');
 
-const file = path.join(common.fixturesDir, 'x.txt');
+const file = fixtures.path('x.txt');
 let data = '';
 let first = true;
 


### PR DESCRIPTION
This commit replaces the use of `common.fixturesDir` with `common.fixtures` & `fixtures.path` in `test-fs-read-stream-resume.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
