### PR TITLE
test: switch to use common.fixtures.readKey

### DIFF
--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -33,7 +34,7 @@ const fs = require('fs');
 const path = require('path');
 
 function file(fname) {
-  return path.resolve(common.fixturesDir, 'keys', fname);
+  return path.resolve(fixtures.fixturesDir, 'keys', fname);
 }
 
 function read(fname) {

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -30,15 +30,9 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
-const path = require('path');
-
-function file(fname) {
-  return path.resolve(fixtures.fixturesDir, 'keys', fname);
-}
 
 function read(fname) {
-  return fs.readFileSync(file(fname));
+  return fixtures.readKey(fname);
 }
 
 // key1 is signed by ca1.


### PR DESCRIPTION
switch from common.fixturesDir to common.fixtures.readKey in test-https-strict.js

PR-URL: https://github.com/nodejs/node/pull/15814
Refs: code-and-learn 2017 node.js interactive
Reviewed-By: @benjamingr, @UnrememberMe, @cjihrig, @tniessen, @richardlau