### PR TITLE
test: make use of common/fixtures.fixturesDir

### DIFF
--- a/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
+++ b/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -10,7 +11,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 
 const BENCHMARK_FUNC_PATH =
-  `${common.fixturesDir}/crypto-timing-safe-equal-benchmark-func`;
+  `${fixtures.fixturesDir}/crypto-timing-safe-equal-benchmark-func`;
 function runOneBenchmark(...args) {
   const benchmarkFunc = require(BENCHMARK_FUNC_PATH);
   const result = benchmarkFunc(...args);

--- a/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
+++ b/test/pummel/test-crypto-timing-safe-equal-benchmarks.js
@@ -1,12 +1,12 @@
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 if (!common.enoughTestMem)
   common.skip('memory-intensive test');
 
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const crypto = require('crypto');
 


### PR DESCRIPTION
The common/fixtures module provides convenience methods for working with
files in the test/fixtures directory. Make use of the `fixturesDir`
value from module rather than value from common.

- Replace `common.fixtures` with `fixtures.fixturesDir`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
