### PR TITLE
test: replaces common.fixturesDir usage

### DIFF
--- a/test/parallel/test-repl-require.js
+++ b/test/parallel/test-repl-require.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const net = require('net');
 
-process.chdir(common.fixturesDir);
+process.chdir(fixtures.fixturesDir);
 const repl = require('repl');
 
 const server = net.createServer((conn) => {


### PR DESCRIPTION
##### Description

In `test/parallel/test-repl-require.js` replaces usage of `common.fixturesDir` with `common/fixtures`.

Part of **Node.js Interactive 2017** Code & Learn workshop 😊 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
`test`
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
