### PR TITLE
test: replaced common.fixturesDir usage in http2-respond-file-push test

### DIFF
--- a/test/parallel/test-http2-respond-file-push.js
+++ b/test/parallel/test-http2-respond-file-push.js
@@ -3,6 +3,9 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');
@@ -14,7 +17,7 @@ const {
   HTTP2_HEADER_LAST_MODIFIED
 } = http2.constants;
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 const data = fs.readFileSync(fname);
 const stat = fs.statSync(fname);
 const fd = fs.openSync(fname, 'r');


### PR DESCRIPTION
Replaces the usage of `common.fixturesDir` with `fixtures.path`. I didn't bother using `fixtures.readFileSync` since the file name was needed for `fs.statSync` and `fs.openSync`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
