### PR TITLE
test: use common.fixtures over common.fixturesDir

### DIFF
--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -21,12 +21,13 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
 // test creating and reading symbolic link
-const linkData = path.join(common.fixturesDir, 'cycles/');
+const linkData = path.join(fixtures.fixturesDir, 'cycles/');
 const linkPath = path.join(common.tmpDir, 'cycles_link');
 
 common.refreshTmpDir();

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -32,9 +32,6 @@ const linkPath = path.join(common.tmpDir, 'cycles_link');
 
 common.refreshTmpDir();
 
-console.log(`linkData: ${linkData}`);
-console.log(`linkPath: ${linkPath}`);
-
 fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   assert.ifError(err);
 

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -27,7 +27,7 @@ const path = require('path');
 const fs = require('fs');
 
 // test creating and reading symbolic link
-const linkData = path.join(fixtures.fixturesDir, 'cycles/');
+const linkData = fixtures.path('cycles/');
 const linkPath = path.join(common.tmpDir, 'cycles_link');
 
 common.refreshTmpDir();


### PR DESCRIPTION
Replace common.fixturesDir with usage of common.fixtures

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
