### PR TITLE
test: replace fixturesDir to use fixtures module

### DIFF
--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 if (!common.canCreateSymLink())
   common.skip('insufficient privileges');
 
@@ -34,7 +35,7 @@ let fileTime;
 common.refreshTmpDir();
 
 // test creating and reading symbolic link
-const linkData = path.join(common.fixturesDir, '/cycles/root.js');
+const linkData = fixtures.path('/cycles/root.js');
 const linkPath = path.join(common.tmpDir, 'symlink1.js');
 
 fs.symlink(linkData, linkPath, common.mustCall(function(err) {


### PR DESCRIPTION
Change usage of fixturesDir to be from the common.fixtures module instead of common.
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
##### Affected core subsystem(s)
test
