### PR TITLE
replacing common.fixturesDir with usage of the common.fixtures module

### DIFF
--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const { fixturesDir } = require('../common/fixtures');
 const http2 = require('http2');
 const path = require('path');
 const fs = require('fs');
@@ -29,7 +30,7 @@ const types = {
   symbol: Symbol('test')
 };
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = path.resolve(fixturesDir, 'elipses.txt');
 const fd = fs.openSync(fname, 'r');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -3,9 +3,8 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const { fixturesDir } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 const http2 = require('http2');
-const path = require('path');
 const fs = require('fs');
 
 const {
@@ -30,7 +29,7 @@ const types = {
   symbol: Symbol('test')
 };
 
-const fname = path.resolve(fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 const fd = fs.openSync(fname, 'r');
 
 const server = http2.createServer();


### PR DESCRIPTION
Replacing `common.fixturesDir` with usage of the `common.fixtures` module

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
na
