### PR TITLE
test: replace common.fixturesDir

### DIFF
--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -21,17 +21,17 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tls = require('tls');
-const fs = require('fs');
 const net = require('net');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`)
+  key: fixtures.readSync('/keys/agent2-key.pem'),
+  cert: fixtures.readSync('/keys/agent2-cert.pem')
 };
 
 const server = tls.createServer(options, common.mustNotCall());

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -30,8 +30,8 @@ const tls = require('tls');
 const net = require('net');
 
 const options = {
-  key: fixtures.readSync('/keys/agent2-key.pem'),
-  cert: fixtures.readSync('/keys/agent2-cert.pem')
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem')
 };
 
 const server = tls.createServer(options, common.mustNotCall());


### PR DESCRIPTION
In test/parallel/test-tls-junk-closes-server.js, replaced
common.fixtruesDir with usage of the common.fixtrues module.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test