### PR TITLE
http2: use common.fixtures.fixturesDir in 304 tests

### DIFF
--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');
@@ -12,7 +13,7 @@ const {
   HTTP2_HEADER_STATUS
 } = http2.constants;
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = path.resolve(fixtures.fixturesDir, 'elipses.txt');
 
 const server = http2.createServer();
 server.on('stream', (stream) => {

--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -6,14 +6,13 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const http2 = require('http2');
 const assert = require('assert');
-const path = require('path');
 
 const {
   HTTP2_HEADER_CONTENT_TYPE,
   HTTP2_HEADER_STATUS
 } = http2.constants;
 
-const fname = path.resolve(fixtures.fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 
 const server = http2.createServer();
 server.on('stream', (stream) => {


### PR DESCRIPTION
replace common.fixturesDir with common.fixtures.fixturesDir

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2
