### PR TITLE
Replaced common.fixturesDir with usage of common.fixtures module

### DIFF
--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -24,6 +24,7 @@
 
 /* eslint-disable strict */
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
 const path = require('path');
@@ -40,7 +41,7 @@ assert.strictEqual(baseBar, // eslint-disable-line no-undef
                    'bar',
                    'global.x -> x in base level not working');
 
-const mod = require(path.join(common.fixturesDir, 'global', 'plain'));
+const mod = require(path.join(fixtures.fixturesDir, 'global', 'plain'));
 const fooBar = mod.fooBar;
 
 assert.strictEqual(fooBar.foo, 'foo', 'x -> global.x in sub level not working');


### PR DESCRIPTION
First-time contribution during Node.js Interactive:

In `test/parallel/test-global.js`, replace `common.fixturesDir` with usage of the `common.fixtures` module (see https://github.com/nodejs/node/tree/master/test/common#fixtures-module).

