### PR TITLE
test: In test/parallel/test-https-drain.js, use fixtures.fixturesDir

### DIFF
--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -29,11 +29,10 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const https = require('https');
 const fs = require('fs');
-const path = require('path');
 
 const options = {
-  key: fs.readFileSync(path.join(fixtures.fixturesDir, 'test_key.pem')),
-  cert: fs.readFileSync(path.join(fixtures.fixturesDir, 'test_cert.pem'))
+  key: fs.readFileSync(fixtures.path('test_key.pem')),
+  cert: fs.readFileSync(fixtures.path('test_cert.pem'))
 };
 
 const bufSize = 1024 * 1024;

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -21,6 +21,8 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -30,8 +32,8 @@ const fs = require('fs');
 const path = require('path');
 
 const options = {
-  key: fs.readFileSync(path.join(common.fixturesDir, 'test_key.pem')),
-  cert: fs.readFileSync(path.join(common.fixturesDir, 'test_cert.pem'))
+  key: fs.readFileSync(path.join(fixtures.fixturesDir, 'test_key.pem')),
+  cert: fs.readFileSync(path.join(fixtures.fixturesDir, 'test_cert.pem'))
 };
 
 const bufSize = 1024 * 1024;

--- a/test/parallel/test-https-drain.js
+++ b/test/parallel/test-https-drain.js
@@ -28,11 +28,10 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(fixtures.path('test_key.pem')),
-  cert: fs.readFileSync(fixtures.path('test_cert.pem'))
+  key: fixtures.readSync('test_key.pem'),
+  cert: fixtures.readSync('test_cert.pem')
 };
 
 const bufSize = 1024 * 1024;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This is a task at Node.js Interactive 2017 Code & Learn. The task reads:

> In test/parallel/test-https-drain.js, replace `common.fixturesDir` with usage of `common.fixtures` module (see https://github.com/nodejs/node/tree/master/test/common#fixtures-module)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- test