### PR TITLE
test: replace common.fixturesDir usage in test-fs-copyfile

### DIFF
--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -1,9 +1,10 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const src = path.join(common.fixturesDir, 'a.js');
+const src = fixtures.path('a.js');
 const dest = path.join(common.tmpDir, 'copyfile.out');
 const { COPYFILE_EXCL, UV_FS_COPYFILE_EXCL } = fs.constants;
 


### PR DESCRIPTION
Replace usage of common.fixturesDir with common/fixtures.path in test-fs-copyfile

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test