### PR TITLE
Chore: use template literal in error message

### DIFF
--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -89,6 +89,6 @@ function next(er, input) {
       break;
 
     default:
-      throw new Error('Invalid format: ' + format);
+      throw new Error(`Invalid format: ${format}`);
   }
 }


### PR DESCRIPTION
##### Description
- First PR: Replace string concatentation in https://github.com/nodejs/node/blob/master/tools/doc/generate.js with template literal

##### Checklist
- [x] `make -j4 test` (UNIX)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
- tools
