### PR TITLE
Replaced string concats with template literals

### DIFF
--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -16,7 +16,7 @@ const glob = require('./eslint/node_modules/glob');
 const cwd = process.cwd();
 const cliOptions = {
   rulePaths: rulesDirs,
-  extensions: extensions
+  extensions: extensions,
 };
 
 // Check if we should fix errors that are fixable
@@ -46,12 +46,14 @@ if (cluster.isMaster) {
   var i;
 
   // Check if spreading work among all cores/cpus
-  if (process.argv.indexOf('-J') !== -1) numCPUs = totalCPUs;
+  if (process.argv.indexOf('-J') !== -1)
+    numCPUs = totalCPUs;
 
   // Check if spreading work among an explicit number of cores/cpus
   i = process.argv.indexOf('-j');
   if (i !== -1) {
-    if (!process.argv[i + 1]) throw new Error('Missing parallel job count');
+    if (!process.argv[i + 1])
+      throw new Error('Missing parallel job count');
     numCPUs = parseInt(process.argv[i + 1], 10);
     if (!isFinite(numCPUs) || numCPUs <= 0)
       throw new Error('Bad parallel job count');
@@ -60,10 +62,12 @@ if (cluster.isMaster) {
   // Check for custom ESLint report formatter
   i = process.argv.indexOf('-f');
   if (i !== -1) {
-    if (!process.argv[i + 1]) throw new Error('Missing format name');
+    if (!process.argv[i + 1])
+      throw new Error('Missing format name');
     const format = process.argv[i + 1];
     formatter = cli.getFormatter(format);
-    if (!formatter) throw new Error('Invalid format name');
+    if (!formatter)
+      throw new Error('Invalid format name');
     // Automatically disable progress display
     showProgress = false;
     // Tell worker to send all results, not just linter errors
@@ -76,9 +80,11 @@ if (cluster.isMaster) {
   // Check if outputting ESLint report to a file instead of stdout
   i = process.argv.indexOf('-o');
   if (i !== -1) {
-    if (!process.argv[i + 1]) throw new Error('Missing output filename');
+    if (!process.argv[i + 1])
+      throw new Error('Missing output filename');
     var outPath = process.argv[i + 1];
-    if (!path.isAbsolute(outPath)) outPath = path.join(cwd, outPath);
+    if (!path.isAbsolute(outPath))
+      outPath = path.join(cwd, outPath);
     fd = fs.openSync(outPath, 'w');
     outFn = function(str) {
       fs.writeSync(fd, str, 'utf8');
@@ -108,7 +114,8 @@ if (cluster.isMaster) {
     paths.push(process.argv[i]);
   }
 
-  if (paths.length === 0) return;
+  if (paths.length === 0)
+    return;
   totalPaths = paths.length;
 
   if (showProgress) {
@@ -136,10 +143,7 @@ if (cluster.isMaster) {
   });
 
   for (i = 0; i < numCPUs; ++i)
-    cluster
-      .fork()
-      .on('message', onWorkerMessage)
-      .on('exit', onWorkerExit);
+    cluster.fork().on('message', onWorkerMessage).on('exit', onWorkerExit);
 
   function onWorkerMessage(results) {
     if (typeof results !== 'number') {
@@ -160,7 +164,8 @@ if (cluster.isMaster) {
   }
 
   function onWorkerExit(code, signal) {
-    if (code !== 0 || signal) process.exit(2);
+    if (code !== 0 || signal)
+      process.exit(2);
   }
 
   function sendWork(worker) {
@@ -170,11 +175,13 @@ if (cluster.isMaster) {
       while (paths.length) {
         var dir = paths.shift();
         curPath = dir;
-        if (dir.indexOf('/') > 0) dir = path.join(cwd, dir);
+        if (dir.indexOf('/') > 0)
+          dir = path.join(cwd, dir);
         const patterns = cli.resolveFileGlobPatterns([dir]);
         dir = path.resolve(patterns[0]);
         files = glob.sync(dir, globOptions);
-        if (files.length) break;
+        if (files.length)
+          break;
       }
       if ((!files || !files.length) && !paths.length) {
         // We exhausted all input paths and thus have nothing left to do, so end
@@ -199,7 +206,8 @@ if (cluster.isMaster) {
   }
 
   function printProgress() {
-    if (!showProgress) return;
+    if (!showProgress)
+      return;
 
     // Clear line
     outFn(`\r ${' '.repeat(lastLineLen)}\r`);
@@ -216,7 +224,8 @@ if (cluster.isMaster) {
     var line = `[${mins}:${secs}|%${pct}|+${passed}|-${failed}]: ${curPath}`;
 
     // Truncate line like cpplint does in case it gets too long
-    if (line.length > 75) line = `${line.slice(0, 75)}...`;
+    if (line.length > 75)
+      line = `${line.slice(0, 75)}...`;
 
     // Store the line length so we know how much to erase the next time around
     lastLineLen = line.length;
@@ -226,7 +235,8 @@ if (cluster.isMaster) {
 
   function padString(str, len, chr) {
     str = `${str}`;
-    if (str.length >= len) return str;
+    if (str.length >= len)
+      return str;
     return chr.repeat(len - str.length) + str;
   }
 } else {
@@ -239,7 +249,8 @@ if (cluster.isMaster) {
       const report = cli.executeOnFiles(files);
 
       // If we were asked to fix the fixable issues, do so.
-      if (cliOptions.fix) CLIEngine.outputFixes(report);
+      if (cliOptions.fix)
+        CLIEngine.outputFixes(report);
 
       if (config.sendAll) {
         // Return both success and error results

--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -139,7 +139,8 @@ if (cluster.isMaster) {
       printProgress();
       outFn('\r\n');
     }
-    if (code === 0) process.exit(failures ? 1 : 0);
+    if (code === 0)
+      process.exit(failures ? 1 : 0);
   });
 
   for (i = 0; i < numCPUs; ++i)

--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -20,7 +20,8 @@ const cliOptions = {
 };
 
 // Check if we should fix errors that are fixable
-if (process.argv.indexOf('-F') !== -1) cliOptions.fix = true;
+if (process.argv.indexOf('-F') !== -1)
+  cliOptions.fix = true;
 
 const cli = new CLIEngine(cliOptions);
 
@@ -209,7 +210,7 @@ if (cluster.isMaster) {
     const secs = padString(elapsed % 60, 2, '0');
     const passed = padString(successes, 6, ' ');
     const failed = padString(failures, 6, ' ');
-    var pct = Math.ceil((totalPaths - paths.length) / totalPaths * 100);
+    var pct = Math.ceil(((totalPaths - paths.length) / totalPaths) * 100);
     pct = padString(pct, 3, ' ');
 
     var line = `[${mins}:${secs}|%${pct}|+${passed}|-${failed}]: ${curPath}`;

--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -16,12 +16,11 @@ const glob = require('./eslint/node_modules/glob');
 const cwd = process.cwd();
 const cliOptions = {
   rulePaths: rulesDirs,
-  extensions: extensions,
+  extensions: extensions
 };
 
 // Check if we should fix errors that are fixable
-if (process.argv.indexOf('-F') !== -1)
-  cliOptions.fix = true;
+if (process.argv.indexOf('-F') !== -1) cliOptions.fix = true;
 
 const cli = new CLIEngine(cliOptions);
 
@@ -46,14 +45,12 @@ if (cluster.isMaster) {
   var i;
 
   // Check if spreading work among all cores/cpus
-  if (process.argv.indexOf('-J') !== -1)
-    numCPUs = totalCPUs;
+  if (process.argv.indexOf('-J') !== -1) numCPUs = totalCPUs;
 
   // Check if spreading work among an explicit number of cores/cpus
   i = process.argv.indexOf('-j');
   if (i !== -1) {
-    if (!process.argv[i + 1])
-      throw new Error('Missing parallel job count');
+    if (!process.argv[i + 1]) throw new Error('Missing parallel job count');
     numCPUs = parseInt(process.argv[i + 1], 10);
     if (!isFinite(numCPUs) || numCPUs <= 0)
       throw new Error('Bad parallel job count');
@@ -62,12 +59,10 @@ if (cluster.isMaster) {
   // Check for custom ESLint report formatter
   i = process.argv.indexOf('-f');
   if (i !== -1) {
-    if (!process.argv[i + 1])
-      throw new Error('Missing format name');
+    if (!process.argv[i + 1]) throw new Error('Missing format name');
     const format = process.argv[i + 1];
     formatter = cli.getFormatter(format);
-    if (!formatter)
-      throw new Error('Invalid format name');
+    if (!formatter) throw new Error('Invalid format name');
     // Automatically disable progress display
     showProgress = false;
     // Tell worker to send all results, not just linter errors
@@ -80,11 +75,9 @@ if (cluster.isMaster) {
   // Check if outputting ESLint report to a file instead of stdout
   i = process.argv.indexOf('-o');
   if (i !== -1) {
-    if (!process.argv[i + 1])
-      throw new Error('Missing output filename');
+    if (!process.argv[i + 1]) throw new Error('Missing output filename');
     var outPath = process.argv[i + 1];
-    if (!path.isAbsolute(outPath))
-      outPath = path.join(cwd, outPath);
+    if (!path.isAbsolute(outPath)) outPath = path.join(cwd, outPath);
     fd = fs.openSync(outPath, 'w');
     outFn = function(str) {
       fs.writeSync(fd, str, 'utf8');
@@ -114,8 +107,7 @@ if (cluster.isMaster) {
     paths.push(process.argv[i]);
   }
 
-  if (paths.length === 0)
-    return;
+  if (paths.length === 0) return;
   totalPaths = paths.length;
 
   if (showProgress) {
@@ -139,12 +131,14 @@ if (cluster.isMaster) {
       printProgress();
       outFn('\r\n');
     }
-    if (code === 0)
-      process.exit(failures ? 1 : 0);
+    if (code === 0) process.exit(failures ? 1 : 0);
   });
 
   for (i = 0; i < numCPUs; ++i)
-    cluster.fork().on('message', onWorkerMessage).on('exit', onWorkerExit);
+    cluster
+      .fork()
+      .on('message', onWorkerMessage)
+      .on('exit', onWorkerExit);
 
   function onWorkerMessage(results) {
     if (typeof results !== 'number') {
@@ -155,7 +149,7 @@ if (cluster.isMaster) {
       } else {
         failures += results.length;
       }
-      outFn(formatter(results) + '\r\n');
+      outFn(`${formatter(results)}\r\n`);
       printProgress();
     } else {
       successes += results;
@@ -165,8 +159,7 @@ if (cluster.isMaster) {
   }
 
   function onWorkerExit(code, signal) {
-    if (code !== 0 || signal)
-      process.exit(2);
+    if (code !== 0 || signal) process.exit(2);
   }
 
   function sendWork(worker) {
@@ -176,13 +169,11 @@ if (cluster.isMaster) {
       while (paths.length) {
         var dir = paths.shift();
         curPath = dir;
-        if (dir.indexOf('/') > 0)
-          dir = path.join(cwd, dir);
+        if (dir.indexOf('/') > 0) dir = path.join(cwd, dir);
         const patterns = cli.resolveFileGlobPatterns([dir]);
         dir = path.resolve(patterns[0]);
         files = glob.sync(dir, globOptions);
-        if (files.length)
-          break;
+        if (files.length) break;
       }
       if ((!files || !files.length) && !paths.length) {
         // We exhausted all input paths and thus have nothing left to do, so end
@@ -207,11 +198,10 @@ if (cluster.isMaster) {
   }
 
   function printProgress() {
-    if (!showProgress)
-      return;
+    if (!showProgress) return;
 
     // Clear line
-    outFn('\r' + ' '.repeat(lastLineLen) + '\r');
+    outFn(`\r ${' '.repeat(lastLineLen)}\r`);
 
     // Calculate and format the data for displaying
     const elapsed = process.hrtime(startTime)[0];
@@ -219,14 +209,13 @@ if (cluster.isMaster) {
     const secs = padString(elapsed % 60, 2, '0');
     const passed = padString(successes, 6, ' ');
     const failed = padString(failures, 6, ' ');
-    var pct = Math.ceil(((totalPaths - paths.length) / totalPaths) * 100);
+    var pct = Math.ceil((totalPaths - paths.length) / totalPaths * 100);
     pct = padString(pct, 3, ' ');
 
     var line = `[${mins}:${secs}|%${pct}|+${passed}|-${failed}]: ${curPath}`;
 
     // Truncate line like cpplint does in case it gets too long
-    if (line.length > 75)
-      line = line.slice(0, 75) + '...';
+    if (line.length > 75) line = `${line.slice(0, 75)}...`;
 
     // Store the line length so we know how much to erase the next time around
     lastLineLen = line.length;
@@ -235,9 +224,8 @@ if (cluster.isMaster) {
   }
 
   function padString(str, len, chr) {
-    str = '' + str;
-    if (str.length >= len)
-      return str;
+    str = `${str}`;
+    if (str.length >= len) return str;
     return chr.repeat(len - str.length) + str;
   }
 } else {
@@ -250,8 +238,7 @@ if (cluster.isMaster) {
       const report = cli.executeOnFiles(files);
 
       // If we were asked to fix the fixable issues, do so.
-      if (cliOptions.fix)
-        CLIEngine.outputFixes(report);
+      if (cliOptions.fix) CLIEngine.outputFixes(report);
 
       if (config.sendAll) {
         // Return both success and error results


### PR DESCRIPTION
Replaced string concatenation in `tools/lint-js.js` with template literals.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Tools