### PR TITLE
test: replacing common.fixturesDir in test-require-exceptions.js

### DIFF
--- a/test/parallel/test-require-exceptions.js
+++ b/test/parallel/test-require-exceptions.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fixtures = require ('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 // A module with an error in it should throw
 assert.throws(function() {

--- a/test/parallel/test-require-exceptions.js
+++ b/test/parallel/test-require-exceptions.js
@@ -22,15 +22,16 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const fixtures = require ('../common/fixtures');
 
 // A module with an error in it should throw
 assert.throws(function() {
-  require(`${common.fixturesDir}/throws_error`);
+  require(fixtures.path('/throws_error'));
 }, /^Error: blah$/);
 
 // Requiring the same module again should throw as well
 assert.throws(function() {
-  require(`${common.fixturesDir}/throws_error`);
+  require(fixtures.path('/throws_error'));
 }, /^Error: blah$/);
 
 // Requiring a module that does not exist should throw an
@@ -43,7 +44,7 @@ assertModuleNotFound('/module-require/not-found/trailingSlash');
 
 function assertModuleNotFound(path) {
   assert.throws(function() {
-    require(common.fixturesDir + path);
+    require(fixtures.path(path));
   }, function(e) {
     assert.strictEqual(e.code, 'MODULE_NOT_FOUND');
     return true;
@@ -51,5 +52,5 @@ function assertModuleNotFound(path) {
 }
 
 function assertExists(fixture) {
-  assert(common.fileExists(common.fixturesDir + fixture));
+  assert(common.fileExists(fixtures.path(fixture)));
 }


### PR DESCRIPTION
Using common.fixtures module instead of common.fixturesDir based on task at Nodejs code and learn at Node.js Interactive 2017 in Vancouver.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
