### PR TITLE
test: replace common.fixturesDir with common.fixtures

### DIFF
--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -5,15 +5,14 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const fixtures = require('../common/fixtures');
+
 const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
 const tls = require('tls');
 const h2 = require('http2');
 
 function loadKey(keyname) {
-  return fs.readFileSync(
-    path.join(common.fixturesDir, 'keys', keyname), 'binary');
+  return fixtures.readKey(keyname, 'binary');
 }
 
 function onStream(stream, headers) {


### PR DESCRIPTION
**Action->** Replaced `common.fixturesDir` in `test-http2-create-client-secure-session.js` with `common.fixtures` module

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
