### PR TITLE
test: update test-buffer-alloc to use template literals

### DIFF
--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -310,12 +310,12 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores whitespace
-  const expectedWhite = `${expected.slice(0, 60)}
-                         ${expected.slice(60, 120)}
-                         ${expected.slice(120, 180)}
-                         ${expected.slice(180, 240)}
-                         ${expected.slice(240, 300)}
-                         ${expected.slice(300, 360)}`;
+  const expectedWhite = `${expected.slice(0, 60)} \n` +
+                        `${expected.slice(60, 120)} \n` +
+                        `${expected.slice(120, 180)} \n` +
+                        `${expected.slice(180, 240)} \n` +
+                        `${expected.slice(240, 300)}\n` +
+                        `${expected.slice(300, 360)}\n`;
   b = Buffer.allocUnsafe(1024);
   bytesWritten = b.write(expectedWhite, 0, 'base64');
   assert.strictEqual(quote.length, bytesWritten);

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -310,12 +310,12 @@ assert.strictEqual('TWFu', (Buffer.from('Man')).toString('base64'));
   assert.strictEqual(quote, b.toString('ascii', 0, quote.length));
 
   // check that the base64 decoder ignores whitespace
-  const expectedWhite = expected.slice(0, 60) + ' \n' +
-                        expected.slice(60, 120) + ' \n' +
-                        expected.slice(120, 180) + ' \n' +
-                        expected.slice(180, 240) + ' \n' +
-                        expected.slice(240, 300) + '\n' +
-                        expected.slice(300, 360) + '\n';
+  const expectedWhite = `${expected.slice(0, 60)}
+                         ${expected.slice(60, 120)}
+                         ${expected.slice(120, 180)}
+                         ${expected.slice(180, 240)}
+                         ${expected.slice(240, 300)}
+                         ${expected.slice(300, 360)}`;
   b = Buffer.allocUnsafe(1024);
   bytesWritten = b.write(expectedWhite, 0, 'base64');
   assert.strictEqual(quote.length, bytesWritten);


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tests
