### PR TITLE
test: replace usage of common.fixturesDir by using common.fixtures

### DIFF
--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -1,12 +1,12 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
 const exec = require('child_process').exec;
-const join = require('path').join;
 
 const nodePath = process.argv[0];
-const script = join(common.fixturesDir, 'print-10-lines.js');
+const script = fixtures.path('print-10-lines.js');
 
 const cmd = `"${nodePath}" "${script}" | head -2`;
 


### PR DESCRIPTION
Replace usage of common.fixturesDir by using common.fixtures module

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
tests
