### PR TITLE
Fixing to use common.fixtures module

### DIFF
--- a/test/sequential/test-process-warnings.js
+++ b/test/sequential/test-process-warnings.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const execFile = require('child_process').execFile;
-const warnmod = require.resolve(`${common.fixturesDir}/warnings.js`);
+const warnmod = require.resolve(fixtures.path('warnings.js'));
 const node = process.execPath;
 
 const normal = [warnmod];


### PR DESCRIPTION
Fixing test to use common.fixtures module in test/sequential/test-process-warnings.js at the Code & Learn in Vancouver 2017.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test 