### PR TITLE
test: replace common.fixturesDir with usage of the common.fixtures

### DIFF
--- a/test/parallel/test-https-close.js
+++ b/test/parallel/test-https-close.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -7,8 +8,8 @@ const fs = require('fs');
 const https = require('https');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const connections = {};


### PR DESCRIPTION
Replaces usage of common.fixturesDir with common.fixtures module in test/parallel/test-https-close.js

Node.js Interactive 2017 Code & Learn workshop

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
`test`
