### PR TITLE
Replace usage of `common.fixturesDir` with the `path` method from the fixtures module

### DIFF
--- a/test/parallel/test-https-agent-sockets-leak.js
+++ b/test/parallel/test-https-agent-sockets-leak.js
@@ -4,14 +4,14 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const fs = require('fs');
 const https = require('https');
 const assert = require('assert');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
-  ca: fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca: fixtures.readKey('ca1-cert.pem')
 };
 
 const server = https.Server(options, common.mustCall((req, res) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
Test

This commit was opened from the Node.JS interactive code & learn summit. It replaces a usage of common.fixturesDir with the fixtures module.
