### PR TITLE
test: rewrite assert message

### DIFF
--- a/test/parallel/test-zlib-unzip-one-byte-chunks.js
+++ b/test/parallel/test-zlib-unzip-one-byte-chunks.js
@@ -17,7 +17,9 @@ const unzip = zlib.createUnzip()
   .on('data', (data) => resultBuffers.push(data))
   .on('finish', common.mustCall(() => {
     assert.deepStrictEqual(Buffer.concat(resultBuffers).toString(), 'abcdef',
-                           'result should match original string');
+                           `'${Buffer.concat(resultBuffers).toString()}' ` +
+                           'should match \'abcdef\' after ' +
+                           'zipping and unzipping');
   }));
 
 for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
`test/parallel/test-zlib-unzip-one-byte-chunks.js` uses a literal
string to describe the error if the string does not match itself
after zipping and unzipping. Changed to a more descriptive template
literal.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
