### PR TITLE
test: replaced fixturesDir with fixtures module

### DIFF
--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const http2 = require('http2');
 const assert = require('assert');
-const path = require('path');
 const fs = require('fs');
 
 const {
@@ -15,7 +14,7 @@ const {
   HTTP2_HEADER_LAST_MODIFIED
 } = http2.constants;
 
-const fname = path.resolve(fixtures.fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 const data = fs.readFileSync(fname);
 const stat = fs.statSync(fname);
 

--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
 const http2 = require('http2');
 const assert = require('assert');
 const path = require('path');
@@ -14,7 +15,7 @@ const {
   HTTP2_HEADER_LAST_MODIFIED
 } = http2.constants;
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = path.resolve(fixtures.fixturesDir, 'elipses.txt');
 const data = fs.readFileSync(fname);
 const stat = fs.statSync(fname);
 


### PR DESCRIPTION
This was an assigned task at Node.js Interactive North America 2017.
This replaced the fixturesDir exported by the common module with
the fixtures.path() function on the fixtures module. 

The now superfluous import of path was removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
