### PR TITLE
Replaced https-socket-options test using fixtures

### DIFF
--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -30,8 +31,8 @@ const fs = require('fs');
 const http = require('http');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readSync(`/keys/agent1-key.pem`),
+  cert: fixtures.readSync(`/keys/agent1-cert.pem`)
 };
 
 const body = 'hello world\n';

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -21,13 +21,12 @@
 
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const fixtures = require('../common/fixtures');
 const https = require('https');
-const fs = require('fs');
 const http = require('http');
 
 const options = {

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -31,8 +31,8 @@ const fs = require('fs');
 const http = require('http');
 
 const options = {
-  key: fixtures.readSync(`/keys/agent1-key.pem`),
-  cert: fixtures.readSync(`/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('git stagent1-cert.pem')
 };
 
 const body = 'hello world\n';

--- a/test/parallel/test-https-socket-options.js
+++ b/test/parallel/test-https-socket-options.js
@@ -32,7 +32,7 @@ const http = require('http');
 
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
-  cert: fixtures.readKey('git stagent1-cert.pem')
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const body = 'hello world\n';


### PR DESCRIPTION
NINA 2017 Code and Learn session for first time contributors.  This
touched test/parallel/test-https-socket-options.js to replace
common.fixturesDir

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
