### PR TITLE
assert: display better error message for assertion

### DIFF
--- a/test/parallel/test-zlib-random-byte-pipes.js
+++ b/test/parallel/test-zlib-random-byte-pipes.js
@@ -150,5 +150,5 @@ const gunz = zlib.createGunzip();
 inp.pipe(gzip).pipe(gunz).pipe(out);
 
 out.on('data', common.mustCall((c) => {
-  assert.strictEqual(c, inp._hash, 'hashes should match');
+  assert.strictEqual(c, inp._hash, `Hash '${c}' equals '${inp._hash}'.`);
 }));


### PR DESCRIPTION
This commit makes understanding assertion failures easier by
displaying the values that failed the assertion.


Changes the error message from

> 
> ➜  node git:(fixTestMsg) ✗ tools/test.py parallel/test-zlib-random-byte-pipes.js
> === release test-zlib-random-byte-pipes ===
> Path: parallel/test-zlib-random-byte-pipes
> assert.js:45
>   throw new errors.AssertionError({
>   ^
> 
> AssertionError [ERR_ASSERTION]: hashes should match
>     at HashStream.out.on.common.mustCall (/Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js:154:10)
>     at HashStream.<anonymous> (/Users/dempser/code/node/test/common/index.js:517:15)
>     at emitOne (events.js:115:13)
>     at HashStream.emit (events.js:210:7)
>     at HashStream.end (/Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js:139:10)
>     at Gunzip.onend (_stream_readable.js:596:10)
>     at Object.onceWrapper (events.js:314:30)
>     at emitNone (events.js:110:20)
>     at Gunzip.emit (events.js:207:7)
>     at endReadableNT (_stream_readable.js:1052:12)
> Command: out/Release/node /Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js
> [00:00|% 100|+   0|-   1]: Done

to

> ➜  node git:(fixTestMsg) tools/test.py parallel/test-zlib-random-byte-pipes.js
> === release test-zlib-random-byte-pipes ===
> Path: parallel/test-zlib-random-byte-pipes
> assert.js:45
>   throw new errors.AssertionError({
>   ^
> 
>
> 
> AssertionError [ERR_ASSERTION]: Hash 'some non hash' equals '4663ea81710e8f7941232a9f46a99e11118f336d'.
>     at HashStream.out.on.common.mustCall (/Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js:154:10)
>     at HashStream.<anonymous> (/Users/dempser/code/node/test/common/index.js:517:15)
>     at emitOne (events.js:115:13)
>     at HashStream.emit (events.js:210:7)
>     at HashStream.end (/Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js:139:10)
>     at Gunzip.onend (_stream_readable.js:596:10)
>     at Object.onceWrapper (events.js:314:30)
>     at emitNone (events.js:110:20)
>     at Gunzip.emit (events.js:207:7)
>     at endReadableNT (_stream_readable.js:1052:12)
> Command: out/Release/node /Users/dempser/code/node/test/parallel/test-zlib-random-byte-pipes.js
> [00:00|% 100|+   0|-   1]: Done
> 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
