### PR TITLE
test: use template literals in test-string-decoder

### DIFF
--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -165,7 +165,7 @@ function test(encoding, input, expected, singleSequence) {
     if (output !== expected) {
       const message =
         `Expected "${unicodeEscape(expected)}", ` +
-        `but got "${unicodeEscape(output)}"\n ` +
+        `but got "${unicodeEscape(output)}"\n` +
         `input: ${input.toString('hex').match(hexNumberRE)}\n` +
         `Write sequence: ${JSON.stringify(sequence)}\n` +
         `Full Decoder State: ${inspect(decoder)}`;

--- a/test/parallel/test-string-decoder.js
+++ b/test/parallel/test-string-decoder.js
@@ -164,11 +164,11 @@ function test(encoding, input, expected, singleSequence) {
     output += decoder.end();
     if (output !== expected) {
       const message =
-        'Expected "' + unicodeEscape(expected) + '", ' +
-        'but got "' + unicodeEscape(output) + '"\n' +
-        'input: ' + input.toString('hex').match(hexNumberRE) + '\n' +
-        'Write sequence: ' + JSON.stringify(sequence) + '\n' +
-        'Full Decoder State: ' + inspect(decoder);
+        `Expected "${unicodeEscape(expected)}", ` +
+        `but got "${unicodeEscape(output)}"\n ` +
+        `input: ${input.toString('hex').match(hexNumberRE)}\n` +
+        `Write sequence: ${JSON.stringify(sequence)}\n` +
+        `Full Decoder State: ${inspect(decoder)}`;
       assert.fail(output, expected, message);
     }
   });


### PR DESCRIPTION
`test/parallel/test-string-decoder.js` used to use string concatenation
this was migrated to use template literals. When concatenation
involved a newline we kept string concatenation, or to keep below 80
charters per line.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test