### PR TITLE
clarify assertion failure

### DIFF
--- a/test/pummel/test-tls-connect-memleak.js
+++ b/test/pummel/test-tls-connect-memleak.js
@@ -33,7 +33,7 @@ const fixtures = require('../common/fixtures');
 assert.strictEqual(
   typeof global.gc,
   'function',
-  'Run this test with --expose-gc'
+  `Type of global.gc is not a function. Type: ${typeof global.gc}. Run this test with --expose-gc`
 );
 
 tls.createServer({


### PR DESCRIPTION
assertion failure messages should always give the actual and expected results.
