### PR TITLE
test: replace common.fixturesDir with usage of common.fixtures

### DIFF
--- a/test/parallel/test-tls-ecdh.js
+++ b/test/parallel/test-tls-ecdh.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -32,11 +33,10 @@ const assert = require('assert');
 const tls = require('tls');
 
 const exec = require('child_process').exec;
-const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem'),
   ciphers: '-ALL:ECDHE-RSA-AES128-SHA256',
   ecdhCurve: 'prime256v1'
 };


### PR DESCRIPTION
`test/parallel/test-tls-ecdh.js` was loading fixture keys using
`common.fixturesDir`. Now it's using `fixtures.readKey` instead

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test