### PR TITLE
test: cleanup test-buffer-sharedarraybuffer test suite

### DIFF
--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -16,15 +16,15 @@ arr2[1] = 4000;
 const arr_buf = Buffer.from(arr1.buffer);
 const ar_buf = Buffer.from(arr2.buffer);
 
-assert.deepStrictEqual(arr_buf, ar_buf, 0);
+assert.deepStrictEqual(arr_buf, ar_buf);
 
 arr1[1] = 6000;
 arr2[1] = 6000;
 
-assert.deepStrictEqual(arr_buf, ar_buf, 0);
+assert.deepStrictEqual(arr_buf, ar_buf);
 
 // Checks for calling Buffer.byteLength on a SharedArrayBuffer
 
-assert.strictEqual(Buffer.byteLength(sab), sab.byteLength, 0);
+assert.strictEqual(Buffer.byteLength(sab), sab.byteLength);
 
 assert.doesNotThrow(() => Buffer.from({ buffer: sab }));


### PR DESCRIPTION
Removed third argument `0` from calls to `assert.deepStrictEqual`. The default messages for assertion errors provide enough context so no custom messages are needed. In addition the `0` passed as a message actually didn't do anything.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
