### PR TITLE
Replace common.fixtureDir with common.fixtures module

### DIFF
--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -21,10 +21,11 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const filepath = path.join(common.fixturesDir, 'x.txt');
+const filepath = path.join(fixtures.fixturesDir, 'x.txt');
 const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -56,10 +56,10 @@ try {
 } catch (e) {
   gh1140Exception = e;
   assert.ok(/expected-filename/.test(e.stack),
-            'expected appearance of filename in Error stack');
+            `expected appearance of filename in Error stack: ${e.stack}` );
 }
 assert.ok(gh1140Exception,
-          'expected exception from runInContext signature test');
+          `expected exception from runInContext signature test: ${gh1140Exception}`);
 
 // GH-558, non-context argument segfaults / raises assertion
 const nonContextualSandboxErrorMsg =
@@ -100,7 +100,7 @@ assert.throws(() => {
   });
 }, (err) => {
   return /expected-filename\.js:33:130/.test(err.stack);
-}, 'Expected appearance of proper offset in Error stack');
+}, `Expected appearance of proper offset in Error stack: ${err.stack}`);
 
 // https://github.com/nodejs/node/issues/6158
 ctx = new Proxy({}, {});

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -50,16 +50,16 @@ assert.throws(() => {
 
 // Issue GH-1140:
 // Test runInContext signature
-let gh1140Exception;
+let gh1140Exp;
 try {
   vm.runInContext('throw new Error()', context, 'expected-filename.js');
 } catch (e) {
-  gh1140Exception = e;
+  gh1140Exp = e;
   assert.ok(/expected-filename/.test(e.stack),
-            `expected appearance of filename in Error stack: ${e.stack}` );
+            `expected appearance of filename in Error stack: ${e.stack}`);
 }
-assert.ok(gh1140Exception,
-          `expected exception from runInContext signature test: ${gh1140Exception}`);
+assert.ok(gh1140Exp,
+          `expected exception from runInContext signature test: ${gh1140Exp}`);
 
 // GH-558, non-context argument segfaults / raises assertion
 const nonContextualSandboxErrorMsg =
@@ -92,6 +92,7 @@ assert.strictEqual(script.runInContext(ctx), false);
 
 // Error on the first line of a module should
 // have the correct line and column number
+let assertErrStack = null;
 assert.throws(() => {
   vm.runInContext('throw new Error()', context, {
     filename: 'expected-filename.js',
@@ -99,8 +100,9 @@ assert.throws(() => {
     columnOffset: 123
   });
 }, (err) => {
+  assertErrStack = err.stack;
   return /expected-filename\.js:33:130/.test(err.stack);
-}, `Expected appearance of proper offset in Error stack: ${err.stack}`);
+}, `expected appearance of proper offset in Error stack: ${assertErrStack}`);
 
 // https://github.com/nodejs/node/issues/6158
 ctx = new Proxy({}, {});


### PR DESCRIPTION
In tests/paraller/test-fs-read.js replaced common.fixturesDir with usage of the common.fixtures module.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test