### PR TITLE
docs: reorder steps for first timers

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -88,16 +88,6 @@ On macOS you will need to install the `Xcode Command Line Tools` by running
 installed, you can find them under the menu `Xcode -> Open Developer Tool ->
 More Developer Tools...`. This step will install `clang`, `clang++`, and
 `make`.
-* You may want to setup [firewall rules](tools/macosx-firewall.sh)
-to avoid popups asking to accept incoming network connections when running tests:
-
-If the path to your build directory contains a space, the build will likely fail.
-
-```console
-$ sudo ./tools/macosx-firewall.sh
-```
-Running this script will add rules for the executable `node` in the out
-directory and the symbolic `node` link in the project's root directory.
 
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo
@@ -119,6 +109,17 @@ for more information.
 
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
 and not a newer version.
+
+* On macOS you may want to setup [firewall rules](tools/macosx-firewall.sh)
+to avoid popups asking to accept incoming network connections when running tests:
+
+If the path to your build directory contains a space, the build will likely fail.
+
+```console
+$ sudo ./tools/macosx-firewall.sh
+```
+Running this script will add rules for the executable `node` in the out
+directory and the symbolic `node` link in the project's root directory.
 
 To run the tests:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -89,6 +89,8 @@ installed, you can find them under the menu `Xcode -> Open Developer Tool ->
 More Developer Tools...`. This step will install `clang`, `clang++`, and
 `make`.
 
+If the path to your build directory contains a space, the build will likely fail.
+
 On FreeBSD and OpenBSD, you may also need:
 * libexecinfo
 
@@ -112,8 +114,6 @@ and not a newer version.
 
 * On macOS you may want to setup [firewall rules](tools/macosx-firewall.sh)
 to avoid popups asking to accept incoming network connections when running tests:
-
-If the path to your build directory contains a space, the build will likely fail.
 
 ```console
 $ sudo ./tools/macosx-firewall.sh


### PR DESCRIPTION
found at node interactive code and learn.
when you have never built, running macosx-firewall.sh gives errors as
/out does not exist. reordering this after the build step in the doc
will remove that error. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc