### PR TITLE
test: change fixturesDir to fixtures.path

### DIFF
--- a/test/parallel/test-fs-read-stream-throw-type-error.js
+++ b/test/parallel/test-fs-read-stream-throw-type-error.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
-const path = require('path');
 
-const example = path.join(common.fixturesDir, 'x.txt');
+const example = fixtures.path('x.txt');
 
 assert.doesNotThrow(function() {
   fs.createReadStream(example, undefined);


### PR DESCRIPTION
This commit replaces common.fixturesPath with the usage of common.fixtures

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
None
