### PR TITLE
test: updated exiting worker to throw with content of code or signal

### DIFF
--- a/test/parallel/test-cluster-send-deadlock.js
+++ b/test/parallel/test-cluster-send-deadlock.js
@@ -31,8 +31,8 @@ const net = require('net');
 if (cluster.isMaster) {
   const worker = cluster.fork();
   worker.on('exit', function(code, signal) {
-    assert.strictEqual(code, 0, 'Worker exited with an error code');
-    assert(!signal, 'Worker exited by a signal');
+    assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
+    assert(!signal, `Worker exited by a signal: ${signal}`);
     server.close();
   });
 


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test

##### Is a gif ok?
![giphy](https://user-images.githubusercontent.com/6353499/31289947-935bf29c-aa7f-11e7-93c2-bbc13370b173.gif)

That's how we do PRs in my house