### PR TITLE
test: replacing common.fixturesDir with common.fixtures module for te…

### DIFF
--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -6,7 +6,6 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 
 let nconns = 0;
 
@@ -22,8 +21,8 @@ process.on('exit', function() {
 function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
   const soptions = {
     secureProtocol: SSL_Method,
-    key: fs.readFileSync(fixtures.path('/keys/agent2-key.pem')),
-    cert: fs.readFileSync(fixtures.path('/keys/agent2-cert.pem')),
+    key: fixtures.readKey('agent2-key.pem'),
+    cert: fixtures.readKey('agent2-cert.pem'),
     ciphers: 'AES256-SHA256:AES128-GCM-SHA256:AES128-SHA256:' +
              'ECDHE-RSA-AES128-GCM-SHA256',
     honorCipherOrder: !!honorCipherOrder

--- a/test/parallel/test-tls-honorcipherorder.js
+++ b/test/parallel/test-tls-honorcipherorder.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
@@ -21,8 +22,8 @@ process.on('exit', function() {
 function test(honorCipherOrder, clientCipher, expectedCipher, cb) {
   const soptions = {
     secureProtocol: SSL_Method,
-    key: fs.readFileSync(`${common.fixturesDir}/keys/agent2-key.pem`),
-    cert: fs.readFileSync(`${common.fixturesDir}/keys/agent2-cert.pem`),
+    key: fs.readFileSync(fixtures.path('/keys/agent2-key.pem')),
+    cert: fs.readFileSync(fixtures.path('/keys/agent2-cert.pem')),
     ciphers: 'AES256-SHA256:AES128-GCM-SHA256:AES128-SHA256:' +
              'ECDHE-RSA-AES128-GCM-SHA256',
     honorCipherOrder: !!honorCipherOrder


### PR DESCRIPTION
…st-tls-honorcipherorder.js

as part of Node.js Interactive 2017, Vancouver BC, Canada

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
