### PR TITLE
test: replaced fixturesDir with fixtures module

### DIFF
--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -21,11 +21,12 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 
 if (common.isWindows) {
-  const file = path.join(common.fixturesDir, 'a.js');
+  const file = path.join(fixtures.fixturesDir, 'a.js');
   const resolvedFile = path.resolve(file);
 
   assert.strictEqual(`\\\\?\\${resolvedFile}`,


### PR DESCRIPTION
This was an assigned task at Node.js Interactive North America 2017.
This replaced the fixturesDir exported by the common module with
the fixturesDir on the common/fixtures module in the path-makelong test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
