### PR TITLE
Replaced assert.strictEqual() error messages with template literals

### DIFF
--- a/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/parallel/test-cluster-send-handle-twice.js
@@ -35,8 +35,8 @@ if (cluster.isMaster) {
   for (let i = 0; i < workers.toStart; ++i) {
     const worker = cluster.fork();
     worker.on('exit', common.mustCall(function(code, signal) {
-      assert.strictEqual(code, 0, 'Worker exited with an error code');
-      assert.strictEqual(signal, null, 'Worker exited by a signal');
+      assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
+      assert.strictEqual(signal, null, `Worker exited by a signal: ${signal}`);
     }));
   }
 } else {


### PR DESCRIPTION
Pull request from Code & Learn!
-----------------
In `test/parallel/test-cluster-send-handle-twice.js`, there are calls to the `strictEqual` method in the `assert` module. Literals were being passed into the message argument and the values of the error messages were not being printed. Two strictEqual messages have been changed to template literals that now include the `code` and `signal` values in the error messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
