### PR TITLE
test: improve assert message in test-dh-regr

### DIFF
--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -36,9 +36,14 @@ for (let i = 0; i < 2000; i++) {
   a.generateKeys();
   b.generateKeys();
 
+  const aSecret = a.computeSecret(b.getPublicKey());
+  const bSecret = b.computeSecret(a.getPublicKey());
+
   assert.deepStrictEqual(
-    a.computeSecret(b.getPublicKey()),
-    b.computeSecret(a.getPublicKey()),
-    'secrets should be equal!'
+    aSecret,
+    bSecret,
+    'Secrets should be equal.\n' +
+    `aSecret: ${aSecret.toString('base64')}\n` +
+    `bSecret: ${bSecret.toString('base64')}`
   );
 }


### PR DESCRIPTION
Part of the Node Interactive Code and Learn.

My task suggested improving the assert message in test-dh-regr as it currently doesn't print the failing values. To make the output readable I specified 'base64' as the encoding and print the secrets on test failure.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
