### PR TITLE
fs: change concatenation to template literal

### DIFF
--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -42,7 +42,7 @@ assert.throws(() => {
 
 // Throws if the source does not exist.
 assert.throws(() => {
-  fs.copyFileSync(src + '__does_not_exist', dest, COPYFILE_EXCL);
+  fs.copyFileSync(`${src}__does_not_exist`, dest, COPYFILE_EXCL);
 }, /^Error: ENOENT: no such file or directory, copyfile/);
 
 // Copies asynchronously.


### PR DESCRIPTION

Changed test/parallel/test-fs-copyfile.js

[x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
