### PR TITLE
test: replace usage of common.fixtures by common.fixturesDir

### DIFF
--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -6,6 +6,7 @@
 // opened and the contents are validated
 
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const fs = require('fs');
 const fork = require('child_process').fork;
 const path = require('path');
@@ -13,7 +14,7 @@ const assert = require('assert');
 
 common.refreshTmpDir();
 
-const warnmod = require.resolve(`${common.fixturesDir}/warnings.js`);
+const warnmod = fixtures.path('warnings.js');
 const warnpath = path.join(common.tmpDir, 'warnings.txt');
 
 fork(warnmod, { execArgv: [`--redirect-warnings=${warnpath}`] })


### PR DESCRIPTION
In test/parallel/test-process-redirect-warning.js replace usage of common.fixture by common.fixturesDir


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tests
