### PR TITLE
test: change usage from common.fixturesDir to fixturesDir

### DIFF
--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixturesDir = require('../common/fixtures').fixturesDir;
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -30,8 +31,8 @@ const https = require('https');
 const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fs.readFileSync(`${fixturesDir}/keys/agent1-key.pem`),
+  cert: fs.readFileSync(`${fixturesDir}/keys/agent1-cert.pem`)
 };
 
 const tests = 2;

--- a/test/parallel/test-https-simple.js
+++ b/test/parallel/test-https-simple.js
@@ -21,18 +21,17 @@
 
 'use strict';
 const common = require('../common');
-const fixturesDir = require('../common/fixtures').fixturesDir;
+const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(`${fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const tests = 2;


### PR DESCRIPTION
Now use the common.fixtures module directly to reference fixturesDir, bypassing common module.