### PR TITLE
 test: replaced common.fixturesDir with fixtures.path

### DIFF
--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const child = require('child_process');
 const path = require('path');
@@ -62,7 +63,7 @@ if (common.isWindows) {
   // Test resolving the current Windows drive letter from a spawned process.
   // See https://github.com/nodejs/node/issues/7215
   const currentDriveLetter = path.parse(process.cwd()).root.substring(0, 2);
-  const resolveFixture = path.join(common.fixturesDir, 'path-resolve.js');
+  const resolveFixture = path.join(fixtures.fixturesDir, 'path-resolve.js');
   const spawnResult = child.spawnSync(
     process.argv[0], [resolveFixture, currentDriveLetter]);
   const resolvedPath = spawnResult.stdout.toString().trim();

--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -63,7 +63,7 @@ if (common.isWindows) {
   // Test resolving the current Windows drive letter from a spawned process.
   // See https://github.com/nodejs/node/issues/7215
   const currentDriveLetter = path.parse(process.cwd()).root.substring(0, 2);
-  const resolveFixture = path.join(fixtures.fixturesDir, 'path-resolve.js');
+  const resolveFixture = fixtures.path('path-resolve.js');
   const spawnResult = child.spawnSync(
     process.argv[0], [resolveFixture, currentDriveLetter]);
   const resolvedPath = spawnResult.stdout.toString().trim();


### PR DESCRIPTION
 test: replaced common.fixturesDir with fixtures.path

This was an assigned task at Node.js Interactive North America 2017.
This replaced the fixturesDir exported by the common module with
the fixtures.path on the common/fixtures module.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
