### PR TITLE
tests: remove literal message from assert.strictEqual() calls

### DIFF
--- a/test/parallel/test-zlib-flush-drain.js
+++ b/test/parallel/test-zlib-flush-drain.js
@@ -38,13 +38,11 @@ deflater.on('drain', function() {
 
 process.once('exit', function() {
   assert.strictEqual(
-    beforeFlush, true,
-    'before calling flush, writable stream should need to drain');
+    beforeFlush, true);
   assert.strictEqual(
-    afterFlush, false,
-    'after calling flush, writable stream should not need to drain');
+    afterFlush, false);
   assert.strictEqual(
-    drainCount, 1, 'the deflater should have emitted a single drain event');
+    drainCount, 1);
   assert.strictEqual(
-    flushCount, 2, 'flush should be called twice');
+    flushCount, 2);
 });


### PR DESCRIPTION
Assertions will now print the values that caused the assertions to fail.
 