### PR TITLE
Test https eof for eom

### DIFF
--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -35,7 +35,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const https = require('https');
 const tls = require('tls');
-const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
 const options = {

--- a/test/parallel/test-https-eof-for-eom.js
+++ b/test/parallel/test-https-eof-for-eom.js
@@ -36,10 +36,11 @@ const assert = require('assert');
 const https = require('https');
 const tls = require('tls');
 const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 


### PR DESCRIPTION
Upgraded test-https-eof-for-eom to use the `common.fixtures` model. Removed the unused `fs` module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Test