### PR TITLE
Make test match others in repository

### DIFF
--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -10,5 +10,4 @@ const buffer = new ArrayBuffer(128);
 const template = Reflect.construct(DataView, [buffer]);
 
 const theDataview = test_dataview.CreateDataView(template);
-assert.ok(theDataview instanceof DataView,
-          'The new variable should be of type Dataview');
+assert.ok(theDataview instanceof DataView);

--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -10,4 +10,4 @@ const buffer = new ArrayBuffer(128);
 const template = Reflect.construct(DataView, [buffer]);
 
 const theDataview = test_dataview.CreateDataView(template);
-assert.ok(`Expect ${theDataview} to be a DataView`);
+assert.ok(theDataview instanceof DataView, `Expect ${theDataview} to be a DataView`);

--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -10,4 +10,4 @@ const buffer = new ArrayBuffer(128);
 const template = Reflect.construct(DataView, [buffer]);
 
 const theDataview = test_dataview.CreateDataView(template);
-assert.ok(theDataview instanceof DataView);
+assert.ok(`Expect ${theDataview} to be a DataView`);

--- a/test/addons-napi/test_dataview/test.js
+++ b/test/addons-napi/test_dataview/test.js
@@ -10,4 +10,5 @@ const buffer = new ArrayBuffer(128);
 const template = Reflect.construct(DataView, [buffer]);
 
 const theDataview = test_dataview.CreateDataView(template);
-assert.ok(theDataview instanceof DataView, `Expect ${theDataview} to be a DataView`);
+assert.ok(theDataview instanceof DataView,
+          `Expect ${theDataview} to be a DataView`);


### PR DESCRIPTION
Working on our first commit in Node. The task was to review `assert.ok` and determine if the string literal made sense or not. After reviewing other tests in nearby directories, we determined that removing the message would better match the repository.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dataview
