### PR TITLE
test: replace fixturesDir with fixtures module

### DIFF
--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -21,11 +21,11 @@
 
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const https = require('https');
 

--- a/test/parallel/test-https-agent.js
+++ b/test/parallel/test-https-agent.js
@@ -21,16 +21,17 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 


### PR DESCRIPTION
Task assigned at Node Interactive code and learn.
Removes the usage of common.fixturesDir and 
replaces it with the usage of the common.fixtures module. 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test