### PR TITLE
test: replaced common.fixturesDir usage with common.fixtures module

### DIFF
--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -1,6 +1,7 @@
 // Flags: --expose_internals
 'use strict';
-const common = require('../common');
+require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const internalUtil = require('internal/util');
 const binding = process.binding('util');
@@ -32,7 +33,7 @@ function checkStack(stack) {
 }
 let err;
 const badSyntaxPath =
-    path.join(common.fixturesDir, 'syntax', 'bad_syntax')
+    path.join(fixtures.fixturesDir, 'syntax', 'bad_syntax')
         .replace(/\\/g, '\\\\');
 
 try {

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -6,7 +6,6 @@ const assert = require('assert');
 const internalUtil = require('internal/util');
 const binding = process.binding('util');
 const spawnSync = require('child_process').spawnSync;
-const path = require('path');
 
 const kArrowMessagePrivateSymbolIndex = binding['arrow_message_private_symbol'];
 const kDecoratedPrivateSymbolIndex = binding['decorated_private_symbol'];
@@ -33,7 +32,7 @@ function checkStack(stack) {
 }
 let err;
 const badSyntaxPath =
-    path.join(fixtures.fixturesDir, 'syntax', 'bad_syntax')
+    fixtures.path('syntax', 'bad_syntax')
         .replace(/\\/g, '\\\\');
 
 try {


### PR DESCRIPTION
Removes the usage of common.fixturesDir and replaces with common.fixtures module
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test