### PR TITLE
test: remove `common.fixturesDir`

### DIFF
--- a/test/parallel/test-dsa-fips-invalid-key.js
+++ b/test/parallel/test-dsa-fips-invalid-key.js
@@ -1,16 +1,16 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
+
 if (!common.hasFipsCrypto)
   common.skip('node compiled without FIPS OpenSSL.');
 
 const assert = require('assert');
 const crypto = require('crypto');
-const fs = require('fs');
 
 const input = 'hello';
 
-const dsapri = fs.readFileSync(
-  `${common.fixturesDir}/keys/dsa_private_1025.pem`);
+const dsapri = fixtures.readKey('dsa_private_1025.pem');
 const sign = crypto.createSign('SHA1');
 sign.update(input);
 


### PR DESCRIPTION
Replace `common.fixturesDir` with usage of the `common.fixtures` module

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)