### PR TITLE
test: removed string from assert message arg

### DIFF
--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -45,7 +45,7 @@ const out = fs.createWriteStream(outputFile);
 inp.pipe(gunzip).pipe(out);
 out.on('close', common.mustCall(() => {
   const actual = fs.readFileSync(outputFile);
-  assert.strictEqual(actual.length, expect.length, 'length should match');
+  assert.strictEqual(actual.length, expect.length);
   for (let i = 0, l = actual.length; i < l; i++) {
     assert.strictEqual(actual[i], expect[i], `byte[${i}]`);
   }


### PR DESCRIPTION
Assert message removed so the method can use its default message (which will display the values).
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
