### PR TITLE
test: update test to use fixtures module

### DIFF
--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -5,9 +5,8 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 const h2 = require('http2');
-const path = require('path');
 const url = require('url');
 const URL = url.URL;
 
@@ -51,8 +50,8 @@ const URL = url.URL;
 {
 
   const options = {
-    key: fs.readFileSync(path.join(common.fixturesDir, 'keys/agent3-key.pem')),
-    cert: fs.readFileSync(path.join(common.fixturesDir, 'keys/agent3-cert.pem'))
+    key: fixtures.readKey('agent3-key.pem'),
+    cert: fixtures.readKey('agent3-cert.pem')
   };
 
   const server = h2.createSecureServer(options);


### PR DESCRIPTION
Updated the test-http2-create-client-connect tests to
use the test fixures module instead of the common
module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test