### PR TITLE
test: replace literal error message with template string in parallel …

### DIFF
--- a/test/parallel/test-cluster-server-restart-rr.js
+++ b/test/parallel/test-cluster-server-restart-rr.js
@@ -10,15 +10,31 @@ if (cluster.isMaster) {
   worker1.on('listening', common.mustCall(() => {
     const worker2 = cluster.fork();
     worker2.on('exit', (code, signal) => {
-      assert.strictEqual(code, 0, 'worker2 did not exit normally');
-      assert.strictEqual(signal, null, 'worker2 did not exit normally');
+      assert.strictEqual(
+        code,
+        0,
+        `worker${worker2.id} did not exit normally. Exit with code: ${code}`
+      );
+      assert.strictEqual(
+        signal,
+        null,
+        `worker${worker2.id} did not exit normally. Exit with signal: ${signal}`
+      );
       worker1.disconnect();
     });
   }));
 
   worker1.on('exit', common.mustCall((code, signal) => {
-    assert.strictEqual(code, 0, 'worker1 did not exit normally');
-    assert.strictEqual(signal, null, 'worker1 did not exit normally');
+    assert.strictEqual(
+      code,
+      0,
+      `worker${worker1.id} did not exit normally. Exit with code: ${code}`
+    );
+    assert.strictEqual(
+      signal,
+      null,
+      `worker${worker1.id} did not exit normally. Exit with code: ${signal}`
+    );
   }));
 } else {
   const net = require('net');


### PR DESCRIPTION
…cluster tests

Improved error messages by using template strings to remove hardcoding and additional data to the messages.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test