### PR TITLE
Add 'fixtures' property to common.js exports

### DIFF
--- a/test/parallel/test-fs-error-messages.js
+++ b/test/parallel/test-fs-error-messages.js
@@ -21,14 +21,15 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.fixturesDir, 'non-existent');
-const existingFile = path.join(common.fixturesDir, 'exit.js');
-const existingFile2 = path.join(common.fixturesDir, 'create-file.js');
-const existingDir = path.join(common.fixturesDir, 'empty');
-const existingDir2 = path.join(common.fixturesDir, 'keys');
+const fn = fixtures.path('non-existent');
+const existingFile = fixtures.path('exit.js');
+const existingFile2 = fixtures.path('create-file.js');
+const existingDir = fixtures.path('empty');
+const existingDir2 = fixtures.path('keys');
 
 // ASYNC_CALL
 


### PR DESCRIPTION
Two tasks are involved as part of this change:
1. Add 'fixtures' property to common.js.
2. Use the new 'fixtures' property of common.js in test-fs-error-messages.js instead of 'fixturesDir'

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

<!--Affected core subsystem(s)
 Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
