### PR TITLE
test: upgrade from common.fixturesDir to common.fixtures.path

### DIFF
--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -3,16 +3,16 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
 const http2 = require('http2');
 const assert = require('assert');
-const path = require('path');
 
 const {
   HTTP2_HEADER_CONTENT_TYPE,
   HTTP2_HEADER_STATUS
 } = http2.constants;
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 
 const server = http2.createServer();
 server.on('stream', (stream) => {


### PR DESCRIPTION
The common/fixtures module provides convenience methods for working with files in the test/fixtures directory.

##### Checklist

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
