### PR TITLE
test: common.fixturesDir -> fixtures.path

### DIFF
--- a/test/parallel/test-https-timeout-server-2.js
+++ b/test/parallel/test-https-timeout-server-2.js
@@ -24,15 +24,15 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
 const https = require('https');
 const tls = require('tls');
-const fs = require('fs');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = https.createServer(options, common.mustNotCall());


### PR DESCRIPTION
Replaced `common.fixturesDir` with `fixtures.path` as part of Node Interactive 2017 workshop.

- [*] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [*] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
