### PR TITLE
test: Z lib const descriptive failure messages

### DIFF
--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -4,14 +4,15 @@ const assert = require('assert');
 
 const zlib = require('zlib');
 
-assert.strictEqual(zlib.constants.Z_OK, 0, 'Z_OK should be 0');
+assert.strictEqual(zlib.constants.Z_OK, 0, `Expected Z_OK to be 0; got ${zlib.constants.Z_OK}`);
 zlib.constants.Z_OK = 1;
-assert.strictEqual(zlib.constants.Z_OK, 0, 'Z_OK should be 0');
+assert.strictEqual(zlib.constants.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.constants.Z_OK}`);
 
-assert.strictEqual(zlib.codes.Z_OK, 0, 'Z_OK should be 0');
+assert.strictEqual(zlib.codes.Z_OK, 0, `Expected Z_OK to be 0; got ${zlib.codes.Z_OK}`);
 zlib.codes.Z_OK = 1;
-assert.strictEqual(zlib.codes.Z_OK, 0, 'zlib.codes.Z_OK should be 0');
+assert.strictEqual(zlib.codes.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
 zlib.codes = { Z_OK: 1 };
-assert.strictEqual(zlib.codes.Z_OK, 0, 'zlib.codes.Z_OK should be 0');
+assert.strictEqual(zlib.codes.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
 
-assert.ok(Object.isFrozen(zlib.codes), 'zlib.codes should be frozen');
+assert.ok(Object.isFrozen(zlib.codes),
+  `Expected zlib.codes to be frozen, but Object.isFrozen returned ${Object.isFrozen(zlib.codes)}`);

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -4,15 +4,20 @@ const assert = require('assert');
 
 const zlib = require('zlib');
 
-assert.strictEqual(zlib.constants.Z_OK, 0, `Expected Z_OK to be 0; got ${zlib.constants.Z_OK}`);
+assert.strictEqual(zlib.constants.Z_OK, 0,
+          `Expected Z_OK to be 0; got ${zlib.constants.Z_OK}`);
 zlib.constants.Z_OK = 1;
-assert.strictEqual(zlib.constants.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.constants.Z_OK}`);
+assert.strictEqual(zlib.constants.Z_OK, 0,
+          `Z_OK should be immutable. Expected to get 0, got ${zlib.constants.Z_OK}`);
 
-assert.strictEqual(zlib.codes.Z_OK, 0, `Expected Z_OK to be 0; got ${zlib.codes.Z_OK}`);
+assert.strictEqual(zlib.codes.Z_OK, 0,
+          `Expected Z_OK to be 0; got ${zlib.codes.Z_OK}`);
 zlib.codes.Z_OK = 1;
-assert.strictEqual(zlib.codes.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
+assert.strictEqual(zlib.codes.Z_OK, 0,
+          `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
 zlib.codes = { Z_OK: 1 };
-assert.strictEqual(zlib.codes.Z_OK, 0, `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
+assert.strictEqual(zlib.codes.Z_OK, 0,
+          `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
 
 assert.ok(Object.isFrozen(zlib.codes),
-  `Expected zlib.codes to be frozen, but Object.isFrozen returned ${Object.isFrozen(zlib.codes)}`);
+          `Expected zlib.codes to be frozen, but Object.isFrozen returned ${Object.isFrozen(zlib.codes)}`);

--- a/test/parallel/test-zlib-const.js
+++ b/test/parallel/test-zlib-const.js
@@ -5,19 +5,34 @@ const assert = require('assert');
 const zlib = require('zlib');
 
 assert.strictEqual(zlib.constants.Z_OK, 0,
-          `Expected Z_OK to be 0; got ${zlib.constants.Z_OK}`);
+                   [
+                     'Expected Z_OK to be 0;',
+                     `got ${zlib.constants.Z_OK}`
+                   ].join(' '));
 zlib.constants.Z_OK = 1;
 assert.strictEqual(zlib.constants.Z_OK, 0,
-          `Z_OK should be immutable. Expected to get 0, got ${zlib.constants.Z_OK}`);
+                   [
+                     'Z_OK should be immutable.',
+                     `Expected to get 0, got ${zlib.constants.Z_OK}`
+                   ].join(' '));
 
 assert.strictEqual(zlib.codes.Z_OK, 0,
-          `Expected Z_OK to be 0; got ${zlib.codes.Z_OK}`);
+                   `Expected Z_OK to be 0; got ${zlib.codes.Z_OK}`);
 zlib.codes.Z_OK = 1;
 assert.strictEqual(zlib.codes.Z_OK, 0,
-          `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
+                   [
+                     'Z_OK should be immutable.',
+                     `Expected to get 0, got ${zlib.codes.Z_OK}`
+                   ].join(' '));
 zlib.codes = { Z_OK: 1 };
 assert.strictEqual(zlib.codes.Z_OK, 0,
-          `Z_OK should be immutable. Expected to get 0, got ${zlib.codes.Z_OK}`);
+                   [
+                     'Z_OK should be immutable.',
+                     `Expected to get 0, got ${zlib.codes.Z_OK}`
+                   ].join(' '));
 
 assert.ok(Object.isFrozen(zlib.codes),
-          `Expected zlib.codes to be frozen, but Object.isFrozen returned ${Object.isFrozen(zlib.codes)}`);
+          [
+            'Expected zlib.codes to be frozen, but Object.isFrozen',
+            `returned ${Object.isFrozen(zlib.codes)}`
+          ].join(' '));


### PR DESCRIPTION
More informative failure messages for ZLib constants tests. Using template literals to output the actual value in addition to expected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test