### PR TITLE
replacing common with fixtures for cmd string building

### DIFF
--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -21,9 +21,9 @@
 
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const exec = require('child_process').exec;
+const fixtures = require('../common/fixtures');
 
 function errExec(script, callback) {
   const cmd = `"${process.argv[0]}" "${fixtures.path(script)}"`;

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -24,11 +24,9 @@ const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const exec = require('child_process').exec;
-const path = require('path');
 
 function errExec(script, callback) {
-  const cmd = `"${process.argv[0]}" ` +
-    `"${path.join(fixtures.fixturesDir, script)}"`;
+  const cmd = `"${process.argv[0]}" "${fixtures.path(script)}"`;
   return exec(cmd, function(err, stdout, stderr) {
     // There was some error
     assert.ok(err);

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -21,12 +21,14 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const exec = require('child_process').exec;
 const path = require('path');
 
 function errExec(script, callback) {
-  const cmd = `"${process.argv[0]}" "${path.join(common.fixturesDir, script)}"`;
+  const cmd = `"${process.argv[0]}" ` +
+    `"${path.join(fixtures.fixturesDir, script)}"`;
   return exec(cmd, function(err, stdout, stderr) {
     // There was some error
     assert.ok(err);


### PR DESCRIPTION
Replaced the common module with the fixtures module for use when building the cmd string in test-error-reporting

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
