### PR TITLE
Modified pipePrefix to using relative path verses full path. 

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -258,9 +258,12 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 });
 
 {
-  const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : `${exports.tmpDir}/`;
+  const localRelative = path.relative(process.cwd(), `${exports.tmpDir}/`);
+  const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : localRelative;
   const pipeName = `node-test.${process.pid}.sock`;
+
   exports.PIPE = pipePrefix + pipeName;
+
 }
 
 {


### PR DESCRIPTION
Modified pipePrefix because if full path character count is to long you will get an error about port.
Test was done by using the following based on my directory ./node /Users/appleman/GitRepositories/github/NodeInteractiveWorkShops/FridayCodeAndLearn/node/test/parallel/test-tls-net-connect-prefer-path.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] tests and/or benchmarks are included

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->