### PR TITLE
Replacing use of common.fixturesDir with usage of common.fixtures mod…

### DIFF
--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -7,15 +7,14 @@ if (!common.hasCrypto)
 
 const https = require('https');
 const crypto = require('crypto');
-
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
-const ca = fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`);
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const clientSessions = {};
 let serverRequests = 0;


### PR DESCRIPTION
Replacing use of common.fixturesDir with usage of common.fixtures module in test-https-agent-session-reuse.js

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test