### PR TITLE
src: operator[] checks bounds in debug mode

### DIFF
--- a/src/string_search.h
+++ b/src/string_search.h
@@ -44,7 +44,9 @@ class Vector {
 
   // Access individual vector elements - checks bounds in debug mode.
   T& operator[](size_t index) const {
+#ifdef DEBUG
     CHECK(index < length_);
+#endif
     return start_[is_forward_ ? index : (length_ - index - 1)];
   }
 


### PR DESCRIPTION
operator[] restrict check bounds to debug mode

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src