### PR TITLE
src: use maybe versions of methods

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -496,11 +496,11 @@ bool Agent::StartIoThread(bool wait_for_connect) {
 
   v8::Isolate* isolate = parent_env_->isolate();
   HandleScope handle_scope(isolate);
+  auto context = parent_env_->context();
 
   // Enable tracking of async stack traces
   if (!enable_async_hook_function_.IsEmpty()) {
     Local<Function> enable_fn = enable_async_hook_function_.Get(isolate);
-    auto context = parent_env_->context();
     auto result = enable_fn->Call(context, Undefined(isolate), 0, nullptr);
     if (result.IsEmpty()) {
       FatalError(
@@ -512,14 +512,15 @@ bool Agent::StartIoThread(bool wait_for_connect) {
   // Send message to enable debug in workers
   Local<Object> process_object = parent_env_->process_object();
   Local<Value> emit_fn =
-      process_object->Get(FIXED_ONE_BYTE_STRING(isolate, "emit"));
+    process_object->Get(context, FIXED_ONE_BYTE_STRING(isolate, "emit"))
+      .ToLocalChecked();
   // In case the thread started early during the startup
   if (!emit_fn->IsFunction())
     return true;
 
   Local<Object> message = Object::New(isolate);
-  message->Set(FIXED_ONE_BYTE_STRING(isolate, "cmd"),
-               FIXED_ONE_BYTE_STRING(isolate, "NODE_DEBUG_ENABLED"));
+  message->Set(context, FIXED_ONE_BYTE_STRING(isolate, "cmd"),
+               FIXED_ONE_BYTE_STRING(isolate, "NODE_DEBUG_ENABLED")).FromJust();
   Local<Value> argv[] = {
     FIXED_ONE_BYTE_STRING(isolate, "internalMessage"),
     message

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -284,7 +284,7 @@ void Open(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (args.Length() > 2 && args[2]->IsBoolean()) {
-    wait_for_connect =  args[2]->BooleanValue();
+    wait_for_connect = args[2]->BooleanValue(env->context()).FromJust();
   }
 
   agent->StartIoThread(wait_for_connect);


### PR DESCRIPTION
Invoke newer "maybe" versions of methods for which the old versions have been deprecated, throughout inspector_agent.cc.

Tests exist in test-inspector.js and are passing. If these tests are not sufficiently relevant let me now where I might begin supplying more specific coverage.

Affected core subsystems: inspector.

Implements #15864.