### PR TITLE
test: fixed crypto from binary test

### DIFF
--- a/test/parallel/test-crypto-from-binary.js
+++ b/test/parallel/test-crypto-from-binary.js
@@ -54,12 +54,12 @@ const b = Buffer.from(ucs2_control + ucs2_control, 'ucs2');
     .update(datum1.toString('base64'), 'base64')
     .digest('hex');
   const hash1_direct = crypto.createHash('sha1').update(datum1).digest('hex');
-  assert.strictEqual(hash1_direct, hash1_converted, 'should hash the same.');
+  assert.strictEqual(hash1_direct, hash1_converted);
 
   const datum2 = b;
   const hash2_converted = crypto.createHash('sha1')
     .update(datum2.toString('base64'), 'base64')
     .digest('hex');
   const hash2_direct = crypto.createHash('sha1').update(datum2).digest('hex');
-  assert.strictEqual(hash2_direct, hash2_converted, 'should hash the same.');
+  assert.strictEqual(hash2_direct, hash2_converted);
 }


### PR DESCRIPTION
removed string literal argument to function call strictEqual
so that default error message is printed

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
