### PR TITLE
test: use common.fixtures module in test-https-agent-session-eviction

### DIFF
--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -1,18 +1,18 @@
 'use strict';
 
 const common = require('../common');
+const { readKey } = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
 const https = require('https');
-const fs = require('fs');
 const SSL_OP_NO_TICKET = require('crypto').constants.SSL_OP_NO_TICKET;
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
+  key: readKey('agent1-key.pem'),
+  cert: readKey('agent1-cert.pem'),
   secureOptions: SSL_OP_NO_TICKET
 };
 


### PR DESCRIPTION
Update [test/parallel/test-https-agent-session-eviction.js](https://github.com/nodejs/node/blob/master/test/parallel/test-https-agent-session-eviction.js#L14-L15) to use common.fixtures module's [readKey](https://github.com/nodejs/node/blob/master/test/common/fixtures.js#L27) method.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
~- [ ] tests and/or benchmarks are included~
~- [ ] documentation is changed or added~
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
None
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
