### PR TITLE
test: removed string literal on assert.strictEqual

### DIFF
--- a/test/parallel/test-tls-pfx-gh-5100-regr.js
+++ b/test/parallel/test-tls-pfx-gh-5100-regr.js
@@ -19,8 +19,7 @@ const server = tls.createServer({
 }, common.mustCall(function(c) {
   assert.strictEqual(
     c.authorizationError,
-    null,
-    'authorizationError must be null'
+    null
   );
   c.end();
 })).listen(0, function() {


### PR DESCRIPTION
removed string literal argument to function call strictEqual
so that default error message is printed


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test