### PR TITLE
test: update fixturesDir to fixtures.readKey in test-https-agent-servername.js

### DIFF
--- a/test/parallel/test-https-agent-servername.js
+++ b/test/parallel/test-https-agent-servername.js
@@ -5,12 +5,12 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const https = require('https');
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`),
-  ca:  fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+  ca:  fixtures.readKey('ca1-cert.pem')
 };
 
 


### PR DESCRIPTION
Update usage of `fixturesDir` to `fixtures.readKey` in `test-https-agent-servername.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test