### PR TITLE
doc: fix inconsistent documentation of server.listen()

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -841,85 +841,9 @@ added: v0.1.90
 
 Stops the server from accepting new connections.  See [`net.Server.close()`][].
 
-### server.listen(handle[, callback])
-<!-- YAML
-added: v0.5.10
--->
+### server.listen()
 
-* `handle` {Object}
-* `callback` {Function}
-
-The `handle` object can be set to either a server or socket (anything
-with an underlying `_handle` member), or a `{fd: <n>}` object.
-
-This will cause the server to accept connections on the specified
-handle, but it is presumed that the file descriptor or handle has
-already been bound to a port or domain socket.
-
-Listening on a file descriptor is not supported on Windows.
-
-This function is asynchronous. `callback` will be added as a listener for the
-[`'listening'`][] event. See also [`net.Server.listen()`][].
-
-Returns `server`.
-
-*Note*: The `server.listen()` method can be called again if and only if there was an error
-during the first `server.listen()` call or `server.close()` has been called.
-Otherwise, an `ERR_SERVER_ALREADY_LISTEN` error will be thrown.
-
-### server.listen(path[, callback])
-<!-- YAML
-added: v0.1.90
--->
-
-* `path` {string}
-* `callback` {Function}
-
-Start a UNIX socket server listening for connections on the given `path`.
-
-This function is asynchronous. `callback` will be added as a listener for the
-[`'listening'`][] event.  See also [`net.Server.listen(path)`][].
-
-*Note*: The `server.listen()` method can be called again if and only if there was an error
-during the first `server.listen()` call or `server.close()` has been called.
-Otherwise, an `ERR_SERVER_ALREADY_LISTEN` error will be thrown.
-
-### server.listen([port][, hostname][, backlog][, callback])
-<!-- YAML
-added: v0.1.90
--->
-
-* `port` {number}
-* `hostname` {string}
-* `backlog` {number}
-* `callback` {Function}
-
-Begin accepting connections on the specified `port` and `hostname`. If the
-`hostname` is omitted, the server will accept connections on the
-[unspecified IPv6 address][] (`::`) when IPv6 is available, or the
-[unspecified IPv4 address][] (`0.0.0.0`) otherwise.
-
-*Note*: In most operating systems, listening to the
-[unspecified IPv6 address][] (`::`) may cause the `net.Server` to also listen on
-the [unspecified IPv4 address][] (`0.0.0.0`).
-
-Omit the port argument, or use a port value of `0`, to have the operating system
-assign a random port, which can be retrieved by using `server.address().port`
-after the `'listening'` event has been emitted.
-
-To listen to a unix socket, supply a filename instead of port and hostname.
-
-`backlog` is the maximum length of the queue of pending connections.
-The actual length will be determined by the OS through sysctl settings such as
-`tcp_max_syn_backlog` and `somaxconn` on linux. The default value of this
-parameter is 511 (not 512).
-
-This function is asynchronous. `callback` will be added as a listener for the
-[`'listening'`][] event.  See also [`net.Server.listen(port)`][].
-
-*Note*: The `server.listen()` method can be called again if and only if there was an error
-during the first `server.listen()` call or `server.close()` has been called.
-Otherwise, an `ERR_SERVER_ALREADY_LISTEN` error will be thrown.
+Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ### server.listening
 <!-- YAML
@@ -1963,6 +1887,7 @@ const req = http.request(options, (res) => {
 [`net.Server.listen(path)`]: net.html#net_server_listen_path_backlog_callback
 [`net.Server.listen(port)`]: net.html#net_server_listen_port_host_backlog_callback
 [`net.Server`]: net.html#net_class_net_server
+[`server.listen()`]: net.html#net_server_listen
 [`net.Socket`]: net.html#net_class_net_socket
 [`net.createConnection()`]: net.html#net_net_createconnection_options_connectlistener
 [`removeHeader(name)`]: #http_request_removeheader_name

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -843,7 +843,8 @@ Stops the server from accepting new connections.  See [`net.Server.close()`][].
 
 ### server.listen()
 
-Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
+Starts the HTTP server listening for connections.
+This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ### server.listening
 <!-- YAML

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -23,6 +23,18 @@ added: v0.3.4
 This class is a subclass of `tls.Server` and emits events same as
 [`http.Server`][]. See [`http.Server`][] for more information.
 
+### server.close([callback])
+<!-- YAML
+added: v0.1.90
+-->
+- `callback` {Function}
+
+See [`http.close()`][] for details.
+
+### server.listen()
+
+Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
+
 ### server.setTimeout([msecs][, callback])
 <!-- YAML
 added: v0.11.2
@@ -89,18 +101,6 @@ https.createServer(options, (req, res) => {
   res.end('hello world\n');
 }).listen(8000);
 ```
-
-### server.close([callback])
-<!-- YAML
-added: v0.1.90
--->
-- `callback` {Function}
-
-See [`http.close()`][] for details.
-
-### server.listen()
-
-Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ## https.get(options[, callback])
 <!-- YAML

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -33,7 +33,8 @@ See [`http.close()`][] for details.
 
 ### server.listen()
 
-Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
+Starts the HTTPS server listening for encrypted connections.
+This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ### server.setTimeout([msecs][, callback])
 <!-- YAML

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -29,7 +29,7 @@ added: v0.1.90
 -->
 - `callback` {Function}
 
-See [`http.close()`][] for details.
+See [`server.close()`][`http.close()`] from the HTTP module for details.
 
 ### server.listen()
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -98,21 +98,9 @@ added: v0.1.90
 
 See [`http.close()`][] for details.
 
-### server.listen(handle[, callback])
-- `handle` {Object}
-- `callback` {Function}
+### server.listen()
 
-### server.listen(path[, callback])
-- `path` {string}
-- `callback` {Function}
-
-### server.listen([port][, host][, backlog][, callback])
-- `port` {number}
-- `hostname` {string}
-- `backlog` {number}
-- `callback` {Function}
-
-See [`http.listen()`][] for details.
+Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ## https.get(options[, callback])
 <!-- YAML
@@ -261,6 +249,8 @@ const req = https.request(options, (res) => {
 
 [`Agent`]: #https_class_https_agent
 [`URL`]: url.html#url_the_whatwg_url_api
+[`net.Server`]: net.html#net_class_net_server
+[`server.listen()`]: net.html#net_server_listen
 [`http.Agent`]: http.html#http_class_http_agent
 [`http.Server#keepAliveTimeout`]: http.html#http_server_keepalivetimeout
 [`http.Server#setTimeout()`]: http.html#http_server_settimeout_msecs_callback

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -410,7 +410,8 @@ encryption/decryption of the [TLS Session Tickets][]
 
 ### server.listen()
 
-Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
+Starts the server listening for encrypted connections.
+This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ### server.setTicketKeys(keys)
 <!-- YAML

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -408,27 +408,9 @@ added: v3.0.0
 Returns a `Buffer` instance holding the keys currently used for
 encryption/decryption of the [TLS Session Tickets][]
 
-### server.listen(port[, hostname][, callback])
-<!-- YAML
-added: v0.3.2
--->
+### server.listen()
 
-* `port` {number} The TCP/IP port on which to begin listening for connections.
-  A value of `0` (zero) will assign a random port.
-* `hostname` {string} The hostname, IPv4, or IPv6 address on which to begin
-  listening for connections. If `undefined`, the server will accept connections
-  on any IPv6 address (`::`) when IPv6 is available, or any IPv4 address
-  (`0.0.0.0`) otherwise.
-* `callback` {Function} A callback function to be invoked when the server has
-  begun listening on the `port` and `hostname`.
-
-The `server.listen()` methods instructs the server to begin accepting
-connections on the specified `port` and `hostname`.
-
-This function operates asynchronously. If the `callback` is given, it will be
-called when the server has started listening.
-
-See [`net.Server`][] for more information.
+Start a server listening for connections. This method is identical to [`server.listen()`][] from [`net.Server`][].
 
 ### server.setTicketKeys(keys)
 <!-- YAML
@@ -1290,6 +1272,7 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [`crypto.getCurves()`]: crypto.html#crypto_crypto_getcurves
 [`net.Server.address()`]: net.html#net_server_address
 [`net.Server`]: net.html#net_class_net_server
+[`server.listen()`]: net.html#net_server_listen
 [`net.Socket`]: net.html#net_class_net_socket
 [`server.getConnections()`]: net.html#net_server_getconnections_callback
 [`tls.DEFAULT_ECDH_CURVE`]: #tls_tls_default_ecdh_curve


### PR DESCRIPTION
First commit:
The `net`, `tls`, `http` and `https` module have the same
`server.listen()` method, but have a different documenation.
Changed to a consistent link to the documentation of the `net` module.

Fixes #11915

Second commit:
The `https.createServer()` function is above some `https.Server`
methods. Move `server.close()` and `server.listen()` to the correct
position.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->