### PR TITLE
test: more AsyncWrap constructor args validation tests

### DIFF
--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -7,7 +7,8 @@ const assert = require('assert');
 const async_hooks = require('async_hooks');
 
 for (const badArg of [0, 1, false, true, null, 'hello']) {
-  for (const field of ['init', 'before', 'after', 'destroy', 'promiseResolve']) {
+  const hookNames = ['init', 'before', 'after', 'destroy', 'promiseResolve'];
+  for (const field of hookNames) {
     assert.throws(() => {
       async_hooks.createHook({ [field]: badArg });
     }, common.expectsError({

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const async_hooks = require('async_hooks');
 
 for (const badArg of [0, 1, false, true, null, 'hello']) {
-  for (const field of ['init', 'before', 'after', 'destroy']) {
+  for (const field of ['init', 'before', 'after', 'destroy', 'promiseResolve']) {
     assert.throws(() => {
       async_hooks.createHook({ [field]: badArg });
     }, common.expectsError({


### PR DESCRIPTION
Fixes a line of uncovered code in the AsyncWrap class's constructor.
Specifically this covers validtion of the 'promiseResolve' argument.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test