### PR TITLE
 test: replace common.fixturesDir with the fixtures module 

### DIFF
--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fixturesModule = require('../common/fixtures');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -31,7 +32,7 @@ const assert = require('assert');
 const hostExpect = 'localhost';
 const fs = require('fs');
 const path = require('path');
-const fixtures = path.join(common.fixturesDir, 'keys');
+const fixtures = path.join(fixturesModule.fixturesDir, 'keys');
 const options = {
   key: fs.readFileSync(`${fixtures}/agent1-key.pem`),
   cert: fs.readFileSync(`${fixtures}/agent1-cert.pem`)


### PR DESCRIPTION
Replace common.fixturesDir with use of the common.fixtures module

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to []. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master

##### Subsystem
test