### PR TITLE
Improved assert.ok error message

### DIFF
--- a/test/parallel/test-dgram-send-empty-array.js
+++ b/test/parallel/test-dgram-send-empty-array.js
@@ -14,7 +14,7 @@ let interval;
 
 client.on('message', common.mustCall(function onMessage(buf, info) {
   const expected = Buffer.alloc(0);
-  assert.ok(buf.equals(expected), 'message was received correctly');
+  assert.ok(buf.equals(expected), `Expected empty message but got ${buf}`);
   clearInterval(interval);
   client.close();
 }));

--- a/test/parallel/test-https-agent-session-reuse.js
+++ b/test/parallel/test-https-agent-session-reuse.js
@@ -7,15 +7,14 @@ if (!common.hasCrypto)
 
 const https = require('https');
 const crypto = require('crypto');
-
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
 const options = {
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
-const ca = fs.readFileSync(`${common.fixturesDir}/keys/ca1-cert.pem`);
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const clientSessions = {};
 let serverRequests = 0;


### PR DESCRIPTION
In test-dgram-send-empty-array.js, improved the message associated with the assert.ok to include the unexpected msg.  Previously, this error message appeared to be a 'positive' message which seems contrary to the intent of the message parameter of the assert.ok() function.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
