### PR TITLE
Fix race condition bug in test, and show assertion failure values

### DIFF
--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -4,12 +4,10 @@ const common = require('../../common');
 const test_promise = require(`./build/${common.buildType}/test_promise`);
 const assert = require('assert');
 
-let promise;
-
 // A resolution
 {
-  let expected_result = 42;
-  promise = test_promise.createPromise();
+  const expected_result = 42;
+  const promise = test_promise.createPromise();
   promise.then(
     common.mustCall(function(result) {
       assert.strictEqual(result, expected_result,
@@ -21,8 +19,8 @@ let promise;
 
 // A rejection
 {
-  let expected_result = 'It\'s not you, it\'s me.';
-  promise = test_promise.createPromise();
+  const expected_result = 'It\'s not you, it\'s me.';
+  const promise = test_promise.createPromise();
   promise.then(
     common.mustNotCall(),
     common.mustCall(function(result) {
@@ -33,7 +31,7 @@ let promise;
 }
 
 // Chaining
-promise = test_promise.createPromise();
+const promise = test_promise.createPromise();
 promise.then(
   common.mustCall(function(result) {
     assert.strictEqual(result, 'chained answer',

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -4,29 +4,33 @@ const common = require('../../common');
 const test_promise = require(`./build/${common.buildType}/test_promise`);
 const assert = require('assert');
 
-let expected_result, promise;
+let promise;
 
 // A resolution
-expected_result = 42;
-promise = test_promise.createPromise();
-promise.then(
-  common.mustCall(function(result) {
-    assert.strictEqual(result, expected_result,
-                       'promise resolved as expected');
-  }),
-  common.mustNotCall());
-test_promise.concludeCurrentPromise(expected_result, true);
+{
+  let expected_result = 42;
+  promise = test_promise.createPromise();
+  promise.then(
+    common.mustCall(function(result) {
+      assert.strictEqual(result, expected_result,
+                         `promise resolved as expected, received ${result}`);
+    }),
+    common.mustNotCall());
+  test_promise.concludeCurrentPromise(expected_result, true);
+}
 
 // A rejection
-expected_result = 'It\'s not you, it\'s me.';
-promise = test_promise.createPromise();
-promise.then(
-  common.mustNotCall(),
-  common.mustCall(function(result) {
-    assert.strictEqual(result, expected_result,
-                       'promise rejected as expected');
-  }));
-test_promise.concludeCurrentPromise(expected_result, false);
+{
+  let expected_result = 'It\'s not you, it\'s me.';
+  promise = test_promise.createPromise();
+  promise.then(
+    common.mustNotCall(),
+    common.mustCall(function(result) {
+      assert.strictEqual(result, expected_result,
+                         `promise rejected as expected, received ${result}`);
+    }));
+  test_promise.concludeCurrentPromise(expected_result, false);
+}
 
 // Chaining
 promise = test_promise.createPromise();

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -42,23 +42,16 @@ promise.then(
   common.mustNotCall());
 test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
 
-assert.strictEqual(test_promise.isPromise(promise), true,
-                   'natively created promise is recognized as a promise');
+assert.strictEqual(test_promise.isPromise(promise), true);
 
-assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true,
-                   'Promise created with JS is recognized as a promise');
+assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true);
 
-assert.strictEqual(test_promise.isPromise(2.4), false,
-                   'Number is recognized as not a promise');
+assert.strictEqual(test_promise.isPromise(2.4), false);
 
-assert.strictEqual(test_promise.isPromise('I promise!'), false,
-                   'String is recognized as not a promise');
+assert.strictEqual(test_promise.isPromise('I promise!'), false);
 
-assert.strictEqual(test_promise.isPromise(undefined), false,
-                   'undefined is recognized as not a promise');
+assert.strictEqual(test_promise.isPromise(undefined), false);
 
-assert.strictEqual(test_promise.isPromise(null), false,
-                   'null is recognized as not a promise');
+assert.strictEqual(test_promise.isPromise(null), false);
 
-assert.strictEqual(test_promise.isPromise({}), false,
-                   'an object is recognized as not a promise');
+assert.strictEqual(test_promise.isPromise({}), false);

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -43,15 +43,9 @@ promise.then(
 test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
 
 assert.strictEqual(test_promise.isPromise(promise), true);
-
 assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true);
-
 assert.strictEqual(test_promise.isPromise(2.4), false);
-
 assert.strictEqual(test_promise.isPromise('I promise!'), false);
-
 assert.strictEqual(test_promise.isPromise(undefined), false);
-
 assert.strictEqual(test_promise.isPromise(null), false);
-
 assert.strictEqual(test_promise.isPromise({}), false);


### PR DESCRIPTION
Two changes:
1. Fixed a bug in the test where the expected_result was caught in a race condition with the first two tests using promises.
2. Cosmetic fixes for the test by removing the strings, making the assert return failure values.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
