### PR TITLE
docs: fix: correctly use `public key` instead of `private key`

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1714,8 +1714,8 @@ treated as the key with no passphrase and will use `RSA_PKCS1_PADDING`.
 added: v1.1.0
 -->
 - `publicKey` {Object | string}
-  - `key` {string} A PEM encoded private key.
-  - `passphrase` {string} An optional passphrase for the private key.
+  - `key` {string} A PEM encoded public key.
+  - `passphrase` {string} An optional passphrase for the public key.
   - `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING` or
     `RSA_PKCS1_PADDING`.
@@ -1734,8 +1734,8 @@ be passed instead of a public key.
 added: v0.11.14
 -->
 - `publicKey` {Object | string}
-  - `key` {string} A PEM encoded private key.
-  - `passphrase` {string} An optional passphrase for the private key.
+  - `key` {string} A PEM encoded public key.
+  - `passphrase` {string} An optional passphrase for the public key.
   - `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING`,
     `RSA_PKCS1_PADDING`, or `crypto.constants.RSA_PKCS1_OAEP_PADDING`.


### PR DESCRIPTION
Fixes #13633

Although, as docs mention, private keys can be used instead of
public keys, I presume that these parameter explanations
should be corrected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
