### PR TITLE
🎨 test: include expected result in error messages

### DIFF
--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -124,10 +124,10 @@ testData.forEach((item) => {
           // an analytics id is provided. Should not be present by default
           if (includeAnalytics) {
             assert(actual.includes(scriptDomain),
-                   'Google Analytics script was not present, but it should be');
+                   `Google Analytics script was not present in "${actual}"`);
           } else {
             assert.strictEqual(actual.includes(scriptDomain), false,
-                               'Google Analytics script was present, but it should not be');
+                               `Google Analytics script was present in "${actual}"`);
           }
         }));
     }));

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -115,6 +115,7 @@ testData.forEach((item) => {
           assert.ifError(err);
 
           const actual = output.replace(spaces, '');
+          const scriptDomain = 'google-analytics.com'
           // Assert that the input stripped of all whitespace contains the
           // expected list
           assert(actual.includes(expected));
@@ -122,11 +123,11 @@ testData.forEach((item) => {
           // Testing the insertion of Google Analytics script when
           // an analytics id is provided. Should not be present by default
           if (includeAnalytics) {
-            assert(actual.includes('google-analytics.com'),
-                   'Google Analytics script was not present');
+            assert(actual.includes(scriptDomain),
+                   'Google Analytics script was not present, but it should be');
           } else {
-            assert.strictEqual(actual.includes('google-analytics.com'), false,
-                               'Google Analytics script was present');
+            assert.strictEqual(actual.includes(scriptDomain), false,
+                               'Google Analytics script was present, but it should not be');
           }
         }));
     }));

--- a/test/doctool/test-doctool-html.js
+++ b/test/doctool/test-doctool-html.js
@@ -115,7 +115,7 @@ testData.forEach((item) => {
           assert.ifError(err);
 
           const actual = output.replace(spaces, '');
-          const scriptDomain = 'google-analytics.com'
+          const scriptDomain = 'google-analytics.com';
           // Assert that the input stripped of all whitespace contains the
           // expected list
           assert(actual.includes(expected));
@@ -127,7 +127,8 @@ testData.forEach((item) => {
                    `Google Analytics script was not present in "${actual}"`);
           } else {
             assert.strictEqual(actual.includes(scriptDomain), false,
-                               `Google Analytics script was present in "${actual}"`);
+                               'Google Analytics script was present in ' +
+                               `"${actual}"`);
           }
         }));
     }));


### PR DESCRIPTION
The script being tested for is expected to be present only if the analytics id is provided. To improve user experience, the error message indicates whether the script is expected to be present or not.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
