### PR TITLE
improve message for test-domain-http-server failure cases to include actual value

### DIFF
--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -109,7 +109,7 @@ function next() {
 }
 
 process.on('exit', function() {
-  assert.strictEqual(serverCaught, 2);
-  assert.strictEqual(clientCaught, 2);
+  assert.strictEqual(serverCaught, 2, `Expected value was 2, but actual value was ${serverCaught}`);
+  assert.strictEqual(clientCaught, 2, `Expected value was 2, but actual value was ${clientCaught}`);
   console.log('ok');
 });

--- a/test/parallel/test-domain-http-server.js
+++ b/test/parallel/test-domain-http-server.js
@@ -51,7 +51,7 @@ const server = http.createServer(function(req, res) {
     const data = JSON.stringify(objects[req.url.replace(/[^a-z]/g, '')]);
 
     // this line will throw if you pick an unknown key
-    assert.notStrictEqual(data, undefined, 'Data should not be undefined');
+    assert.notStrictEqual(data, undefined);
 
     res.writeHead(200);
     res.end(data);
@@ -109,7 +109,7 @@ function next() {
 }
 
 process.on('exit', function() {
-  assert.strictEqual(serverCaught, 2, `Expected value was 2, but actual value was ${serverCaught}`);
-  assert.strictEqual(clientCaught, 2, `Expected value was 2, but actual value was ${clientCaught}`);
+  assert.strictEqual(serverCaught, 2);
+  assert.strictEqual(clientCaught, 2);
   console.log('ok');
 });


### PR DESCRIPTION
improve assert failure message in parallel/test-domain-http-server failure cases to include actual value with more meaningufl message

##### Checklist\
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines]

##### Affected core subsystem(s)
test
