### PR TITLE
test: added fs benchmark

### DIFF
--- a/benchmark/fs/bench-realpath.js
+++ b/benchmark/fs/bench-realpath.js
@@ -8,21 +8,21 @@ const relative_path = path.relative(__dirname, '../../lib/');
 
 const bench = common.createBenchmark(main, {
   n: [1e4],
-  type: ['relative', 'resolved'],
+  pathType: ['relative', 'resolved'],
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  const type = conf.type;
+  const pathType = conf.pathType;
 
   bench.start();
-  if (type === 'relative')
+  if (pathType === 'relative')
     relativePath(n);
-  else if (type === 'resolved')
+  else if (pathType === 'resolved')
     resolvedPath(n);
   else
-    throw new Error(`unknown "type": ${type}`);
+    throw new Error(`unknown "pathType": ${pathType}`);
 }
 
 function relativePath(n) {

--- a/benchmark/fs/bench-realpathSync.js
+++ b/benchmark/fs/bench-realpathSync.js
@@ -10,21 +10,21 @@ const relative_path = path.relative(__dirname, '../../lib/');
 
 const bench = common.createBenchmark(main, {
   n: [1e4],
-  type: ['relative', 'resolved'],
+  pathType: ['relative', 'resolved'],
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  const type = conf.type;
+  const pathType = conf.pathType;
 
   bench.start();
-  if (type === 'relative')
+  if (pathType === 'relative')
     relativePath(n);
-  else if (type === 'resolved')
+  else if (pathType === 'resolved')
     resolvedPath(n);
   else
-    throw new Error(`unknown "type": ${type}`);
+    throw new Error(`unknown "pathType": ${pathType}`);
   bench.end(n);
 }
 

--- a/benchmark/fs/bench-stat.js
+++ b/benchmark/fs/bench-stat.js
@@ -5,15 +5,15 @@ const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
   n: [20e4],
-  kind: ['fstat', 'lstat', 'stat']
+  statType: ['fstat', 'lstat', 'stat']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  const kind = conf.kind;
+  const statType = conf.statType;
   var arg;
-  if (kind === 'fstat')
+  if (statType === 'fstat')
     arg = fs.openSync(__filename, 'r');
   else
     arg = __filename;
@@ -22,12 +22,12 @@ function main(conf) {
   (function r(cntr, fn) {
     if (cntr-- <= 0) {
       bench.end(n);
-      if (kind === 'fstat')
+      if (statType === 'fstat')
         fs.closeSync(arg);
       return;
     }
     fn(arg, function() {
       r(cntr, fn);
     });
-  }(n, fs[kind]));
+  }(n, fs[statType]));
 }

--- a/benchmark/fs/bench-statSync.js
+++ b/benchmark/fs/bench-statSync.js
@@ -5,15 +5,17 @@ const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
   n: [1e6],
-  kind: ['fstatSync', 'lstatSync', 'statSync']
+  statSyncType: ['fstatSync', 'lstatSync', 'statSync']
 });
 
 
 function main(conf) {
   const n = conf.n >>> 0;
-  const kind = conf.kind;
-  const arg = (kind === 'fstatSync' ? fs.openSync(__filename, 'r') : __dirname);
-  const fn = fs[conf.kind];
+  const statSyncType = conf.statSyncType;
+  const arg = (statSyncType === 'fstatSync' ?
+    fs.openSync(__filename, 'r') :
+    __dirname);
+  const fn = fs[statSyncType];
 
   bench.start();
   for (var i = 0; i < n; i++) {
@@ -21,6 +23,6 @@ function main(conf) {
   }
   bench.end(n);
 
-  if (kind === 'fstat')
+  if (statSyncType === 'fstat')
     fs.closeSync(arg);
 }

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -5,19 +5,20 @@ const path = require('path');
 const common = require('../common.js');
 const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
 const fs = require('fs');
-const filesize = 1000 * 1024 * 1024;
 const assert = require('assert');
 
-var type, encoding, size;
+let type, encoding, size, filesize;
 
 const bench = common.createBenchmark(main, {
   type: ['buf', 'asc', 'utf'],
+  filesize: [1000 * 1024 * 1024],
   size: [1024, 4096, 65535, 1024 * 1024]
 });
 
 function main(conf) {
   type = conf.type;
   size = +conf.size;
+  filesize = conf.filesize;
 
   switch (type) {
     case 'buf':

--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -7,20 +7,20 @@ const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
 const fs = require('fs');
 const assert = require('assert');
 
-let type, encoding, size, filesize;
+let encodingType, encoding, size, filesize;
 
 const bench = common.createBenchmark(main, {
-  type: ['buf', 'asc', 'utf'],
+  encodingType: ['buf', 'asc', 'utf'],
   filesize: [1000 * 1024 * 1024],
   size: [1024, 4096, 65535, 1024 * 1024]
 });
 
 function main(conf) {
-  type = conf.type;
+  encodingType = conf.encodingType;
   size = +conf.size;
   filesize = conf.filesize;
 
-  switch (type) {
+  switch (encodingType) {
     case 'buf':
       encoding = null;
       break;
@@ -31,7 +31,7 @@ function main(conf) {
       encoding = 'utf8';
       break;
     default:
-      throw new Error('invalid type');
+      throw new Error(`invalid encodingType: ${encodingType}`);
   }
 
   makeFile(runTest);

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -8,18 +8,18 @@ const fs = require('fs');
 
 const bench = common.createBenchmark(main, {
   dur: [5],
-  type: ['buf', 'asc', 'utf'],
+  encodingType: ['buf', 'asc', 'utf'],
   size: [2, 1024, 65535, 1024 * 1024]
 });
 
 function main(conf) {
   const dur = +conf.dur;
-  const type = conf.type;
+  const encodingType = conf.encodingType;
   const size = +conf.size;
   var encoding;
 
   var chunk;
-  switch (type) {
+  switch (encodingType) {
     case 'buf':
       chunk = Buffer.alloc(size, 'b');
       break;
@@ -32,7 +32,7 @@ function main(conf) {
       encoding = 'utf8';
       break;
     default:
-      throw new Error('invalid type');
+      throw new Error(`invalid encodingType: ${encodingType}`);
   }
 
   try { fs.unlinkSync(filename); } catch (e) {}

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../common');
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('fs', [
+  'n=1',
+  'size=1',
+  'dur=1',
+  'filesize=1024'
+]);

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -7,5 +7,11 @@ runBenchmark('fs', [
   'n=1',
   'size=1',
   'dur=1',
+  'len=1024',
+  'concurrent=1',
+  'pathType=relative',
+  'statType=fstat',
+  'statSyncType=fstatSync',
+  'encodingType=buf',
   'filesize=1024'
 ]);


### PR DESCRIPTION
Had to make the `filesize` configurable for the `read-stream-throughput` benchmark since the default was quite large and ended up causing the test to timeout.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)