### PR TITLE
deps: cherry-pick f4a2b7f3 from V8 upstream.

### DIFF
--- a/deps/v8/src/inspector/v8-inspector-impl.cc
+++ b/deps/v8/src/inspector/v8-inspector-impl.cc
@@ -286,18 +286,22 @@ std::unique_ptr<V8StackTrace> V8InspectorImpl::captureStackTrace(
 
 void V8InspectorImpl::asyncTaskScheduled(const StringView& taskName, void* task,
                                          bool recurring) {
+  if (!task) return;
   m_debugger->asyncTaskScheduled(taskName, task, recurring);
 }
 
 void V8InspectorImpl::asyncTaskCanceled(void* task) {
+  if (!task) return;
   m_debugger->asyncTaskCanceled(task);
 }
 
 void V8InspectorImpl::asyncTaskStarted(void* task) {
+  if (!task) return;
   m_debugger->asyncTaskStarted(task);
 }
 
 void V8InspectorImpl::asyncTaskFinished(void* task) {
+  if (!task) return;
   m_debugger->asyncTaskFinished(task);
 }
 


### PR DESCRIPTION
Also requested backport to v8 6.1 and 6.2.

Bug: https://bugs.chromium.org/p/v8/issues/detail?id=6902
Merge request for 6.1: https://chromium-review.googlesource.com/c/v8/v8/+/706213
Merge request for 6.2: https://chromium-review.googlesource.com/c/v8/v8/+/706199 

Original commit message:

    should ignore asyncTask* with null

    In V8Debugger code we don't expect task_id == null, e.g.
    asyncTaskStartedForStepping will trigger debug break on null as task_id.
    Let's filter task_id == null out.

    This issue is originally filed in Node.js:
    https://github.com/nodejs/node/issues/15464

    R=dgozman@chromium.org

    Bug: none
    Cq-Include-Trybots: master.tryserver.blink:linux_trusty_blink_rel
    Change-Id: Icc9f96105b3c91ee1b102d545a7817f7ee93394c
    Reviewed-on: https://chromium-review.googlesource.com/695808
    Reviewed-by: Dmitry Gozman <dgozman@chromium.org>
    Commit-Queue: Aleksey Kozyatinskiy <kozyatinskiy@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#48265}

Fixes #15464 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
V8