### PR TITLE
doc: include V8 commit URL in V8 backport guide

### DIFF
--- a/doc/guides/maintaining-V8.md
+++ b/doc/guides/maintaining-V8.md
@@ -196,7 +196,8 @@ Original commit message:
   Review-Url: https://codereview.chromium.org/2159683002
   Cr-Commit-Position: refs/heads/master@{#37833}
 
-PR-URL: <pr link>
+Refs: https://github.com/v8/v8/commit/a51f429772d1e796744244128c9feeab4c26a854
+PR-URL: https://github.com/nodejs/node/pull/7833
 ```
 * Open a PR against the `v6.x-staging` branch in the Node.js repo. Launch the normal and [V8-CI](https://ci.nodejs.org/job/node-test-commit-v8-linux/) using the Node.js CI system. We only needed to backport to `v6.x` as the other LTS branches weren't affected by this bug.
 


### PR DESCRIPTION
Use `Commit:` for the V8 commit, and `PR-URL:` for the Node PR URL.

Bikeshedding over `Commit:` welcome.

Refs: https://github.com/nodejs/node/pull/16053#issuecomment-334868621

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, v8

cc/ @nodejs/v8 