### PR TITLE
doc: fix incorrect vm.createContext usage

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -117,7 +117,7 @@ const sandbox = {
 
 const script = new vm.Script('count += 1; name = "kitty";');
 
-const context = new vm.createContext(sandbox);
+const context = vm.createContext(sandbox);
 for (let i = 0; i < 10; ++i) {
   script.runInContext(context);
 }


### PR DESCRIPTION
In code example `vm.createContext` called with new operator by mistake.
It is not a constructor.