### PR TITLE
Refactor the message pass to the assert module in Test cluster setup master

### DIFF
--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
@@ -38,7 +38,7 @@ if (cluster.isWorker) {
   };
 
   const totalWorkers = 2;
-  let onlineWorkers = 0;
+  let settings;
 
   // Setup master
   cluster.setupMaster({
@@ -49,7 +49,7 @@ if (cluster.isWorker) {
   cluster.once('setup', function() {
     checks.setupEvent = true;
 
-    const settings = cluster.settings;
+    settings = cluster.settings;
     if (settings &&
         settings.args && settings.args[0] === 'custom argument' &&
         settings.silent === true &&
@@ -58,25 +58,19 @@ if (cluster.isWorker) {
     }
   });
 
-  let correctIn = 0;
+  let correctInput = 0;
 
-  cluster.on('online', function lisenter(worker) {
-
-    onlineWorkers++;
+  cluster.on('online', common.mustCall(function listener(worker) {
 
     worker.once('message', function(data) {
-      correctIn += (data === 'custom argument' ? 1 : 0);
-      if (correctIn === totalWorkers) {
+      correctInput += (data === 'custom argument' ? 1 : 0);
+      if (correctInput === totalWorkers) {
         checks.args = true;
       }
       worker.kill();
     });
 
-    // All workers are online
-    if (onlineWorkers === totalWorkers) {
-      checks.workers = true;
-    }
-  });
+  }, totalWorkers));
 
   // Start all workers
   cluster.fork();
@@ -84,11 +78,14 @@ if (cluster.isWorker) {
 
   // Check all values
   process.once('exit', function() {
-    assert.ok(checks.workers, 'Not all workers went online');
-    assert.ok(checks.args, 'The arguments was noy send to the worker');
+    const argsMsg = `The arguments was not send for one or more worker.
+                       There was  ${correctInput} worker that receive argument,
+                       ${totalWorkers} were expected`;
+    assert.ok(checks.args, argsMsg);
     assert.ok(checks.setupEvent, 'The setup event was never emitted');
-    const m = 'The settingsObject do not have correct properties';
-    assert.ok(checks.settingsObject, m);
+    const settingObjectMsg = `The settingsObject do not have correct properties :
+                              ${JSON.stringify(settings)}`;
+    assert.ok(checks.settingsObject, settingObjectMsg);
   });
 
 }

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -78,13 +78,15 @@ if (cluster.isWorker) {
 
   // Check all values
   process.once('exit', function() {
-    const argsMsg = `The arguments was not send for one or more worker.
-                       There was  ${correctInput} worker that receive
-                       argument, ${totalWorkers} were expected`;
+    const argsMsg = 'Arguments was not send for one or more worker. ' +
+                    `${correctInput} workers receive argument, ` +
+                    `but ${totalWorkers} were expected.`;
     assert.ok(checks.args, argsMsg);
+
     assert.ok(checks.setupEvent, 'The setup event was never emitted');
-    const settingObjectMsg = `The settingsObject do not have correct
-                              properties : ${JSON.stringify(settings)}`;
+
+    const settingObjectMsg = 'The settingsObject do not have correct ' +
+                             `properties : ${JSON.stringify(settings)}`;
     assert.ok(checks.settingsObject, settingObjectMsg);
   });
 

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -79,12 +79,12 @@ if (cluster.isWorker) {
   // Check all values
   process.once('exit', function() {
     const argsMsg = `The arguments was not send for one or more worker.
-                       There was  ${correctInput} worker that receive argument,
-                       ${totalWorkers} were expected`;
+                       There was  ${correctInput} worker that receive
+                       argument, ${totalWorkers} were expected`;
     assert.ok(checks.args, argsMsg);
     assert.ok(checks.setupEvent, 'The setup event was never emitted');
-    const settingObjectMsg = `The settingsObject do not have correct properties :
-                              ${JSON.stringify(settings)}`;
+    const settingObjectMsg = `The settingsObject do not have correct
+                              properties : ${JSON.stringify(settings)}`;
     assert.ok(checks.settingsObject, settingObjectMsg);
   });
 

--- a/test/parallel/test-cluster-setup-master.js
+++ b/test/parallel/test-cluster-setup-master.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
 
@@ -38,7 +38,7 @@ if (cluster.isWorker) {
   };
 
   const totalWorkers = 2;
-  let settings;
+  let onlineWorkers = 0;
 
   // Setup master
   cluster.setupMaster({
@@ -49,7 +49,7 @@ if (cluster.isWorker) {
   cluster.once('setup', function() {
     checks.setupEvent = true;
 
-    settings = cluster.settings;
+    const settings = cluster.settings;
     if (settings &&
         settings.args && settings.args[0] === 'custom argument' &&
         settings.silent === true &&
@@ -58,19 +58,25 @@ if (cluster.isWorker) {
     }
   });
 
-  let correctInput = 0;
+  let correctIn = 0;
 
-  cluster.on('online', common.mustCall(function listener(worker) {
+  cluster.on('online', function lisenter(worker) {
+
+    onlineWorkers++;
 
     worker.once('message', function(data) {
-      correctInput += (data === 'custom argument' ? 1 : 0);
-      if (correctInput === totalWorkers) {
+      correctIn += (data === 'custom argument' ? 1 : 0);
+      if (correctIn === totalWorkers) {
         checks.args = true;
       }
       worker.kill();
     });
 
-  }, totalWorkers));
+    // All workers are online
+    if (onlineWorkers === totalWorkers) {
+      checks.workers = true;
+    }
+  });
 
   // Start all workers
   cluster.fork();
@@ -78,14 +84,11 @@ if (cluster.isWorker) {
 
   // Check all values
   process.once('exit', function() {
-    const argsMsg = `The arguments was not send for one or more worker.
-                       There was  ${correctInput} worker that receive argument,
-                       ${totalWorkers} were expected`;
-    assert.ok(checks.args, argsMsg);
+    assert.ok(checks.workers, 'Not all workers went online');
+    assert.ok(checks.args, 'The arguments was noy send to the worker');
     assert.ok(checks.setupEvent, 'The setup event was never emitted');
-    const settingObjectMsg = `The settingsObject do not have correct properties :
-                              ${JSON.stringify(settings)}`;
-    assert.ok(checks.settingsObject, settingObjectMsg);
+    const m = 'The settingsObject do not have correct properties';
+    assert.ok(checks.settingsObject, m);
   });
 
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
In test/parallel/test-cluster-setup-master.js,  a refactoring was done on the message pass to the assert module.  Template literal was add in some case to give more information.  Also, one assert was remove because the test was optimize by adding the "must call method" from common. Rather than incrementing a variable each time a worker go online and then assert that this number is equal to totalWorker. We specify that the callback after the worker get online are call totalWorker times with the "mustcall" method from common.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x]  Commit message follows [commit guidelines]
- [x]  git fetch, rebase with upstream/master

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- None
