### PR TITLE
Function Inline

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -213,9 +213,26 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   if (valueOf !== null && valueOf !== undefined && valueOf !== value)
     return Buffer.from(valueOf, encodingOrOffset, length);
 
-  var b = fromObject(value);
-  if (b)
+  if (isUint8Array(value)) {
+    const b = allocate(value.length);
+
+    if (b.length === 0)
+      return b;
+
+    _copy(value, b, 0, 0, value.length);
     return b;
+  }
+
+  if (value.length !== undefined || isAnyArrayBuffer(value.buffer)) {
+    if (typeof value.length !== 'number' || value.length !== value.length) {
+      return new FastBuffer();
+    }
+    return fromArrayLike(value);
+  }
+
+  if (value.type === 'Buffer' && Array.isArray(value.data)) {
+    return fromArrayLike(value.data);
+  }
 
   if (typeof value[Symbol.toPrimitive] === 'function') {
     return Buffer.from(value[Symbol.toPrimitive]('string'),
@@ -394,30 +411,6 @@ function fromArrayBuffer(obj, byteOffset, length) {
 
   return new FastBuffer(obj, byteOffset, length);
 }
-
-function fromObject(obj) {
-  if (isUint8Array(obj)) {
-    const b = allocate(obj.length);
-
-    if (b.length === 0)
-      return b;
-
-    _copy(obj, b, 0, 0, obj.length);
-    return b;
-  }
-
-  if (obj.length !== undefined || isAnyArrayBuffer(obj.buffer)) {
-    if (typeof obj.length !== 'number' || obj.length !== obj.length) {
-      return new FastBuffer();
-    }
-    return fromArrayLike(obj);
-  }
-
-  if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
-    return fromArrayLike(obj.data);
-  }
-}
-
 
 // Static methods
 


### PR DESCRIPTION
The  `var b = fromObject(value);` function call in `buffer.js` line 215 is only used once. A suggestion was put forth to make it an INLINE function. This is a PR to that effect.


- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
buffer.js

Benchmark:

![screen shot 2017-10-07 at 10 36 27 am](https://user-images.githubusercontent.com/3332246/31310343-6fd8e3ee-ab4b-11e7-9004-6cd84a46192e.png)
