### PR TITLE
crypto: make createXYZ inlineable

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -79,23 +79,69 @@ const {
 } = require('internal/crypto/util');
 const Certificate = require('internal/crypto/certificate');
 
+// These helper functions are needed because the constructors can
+// use new, in which case V8 cannot inline the recursive constructor call
+function createHash(algorithm, options) {
+  return new Hash(algorithm, options);
+}
+
+function createCipher(cipher, password, options) {
+  return new Cipher(cipher, password, options);
+}
+
+function createCipheriv(cipher, key, iv, options) {
+  return new Cipheriv(cipher, key, iv, options);
+}
+
+function createDecipher(cipher, password, options) {
+  return new Decipher(cipher, password, options);
+}
+
+function createDecipheriv(cipher, key, iv, options) {
+  return new Decipheriv(cipher, key, iv, options);
+}
+
+function createDiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
+  return new DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding);
+}
+
+function createDiffieHellmanGroup(name) {
+  return new DiffieHellmanGroup(name);
+}
+
+function createECDH(curve) {
+  return new ECDH(curve);
+}
+
+function createHmac(hmac, key, options) {
+  return new Hmac(hmac, key, options);
+}
+
+function createSign(algorithm, options) {
+  return new Sign(algorithm, options);
+}
+
+function createVerify(algorithm, options) {
+  return new Verify(algorithm, options);
+}
+
 module.exports = exports = {
   // Methods
   _toBuf: toBuf,
-  createCipher: Cipher,
-  createCipheriv: Cipheriv,
-  createDecipher: Decipher,
-  createDecipheriv: Decipheriv,
-  createDiffieHellman: DiffieHellman,
-  createDiffieHellmanGroup: DiffieHellmanGroup,
-  createECDH: ECDH,
-  createHash: Hash,
-  createHmac: Hmac,
-  createSign: Sign,
-  createVerify: Verify,
+  createCipher,
+  createCipheriv,
+  createDecipher,
+  createDecipheriv,
+  createDiffieHellman,
+  createDiffieHellmanGroup,
+  createECDH,
+  createHash,
+  createHmac,
+  createSign,
+  createVerify,
   getCiphers,
   getCurves,
-  getDiffieHellman: DiffieHellmanGroup,
+  getDiffieHellman: createDiffieHellmanGroup,
   getHashes,
   pbkdf2,
   pbkdf2Sync,


### PR DESCRIPTION
This commit increase by around 10% hot code paths that are hitting
createXYZ functions. Before this change the createXYZ called the XYZ
constructor without new.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

crypto