### PR TITLE
doc: add history for readline `crlfDelay` option

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -347,6 +347,12 @@ the current position of the cursor down.
 <!-- YAML
 added: v0.1.98
 changes:
+  - version: v8.3.0, 6.11.4
+    pr-url: https://github.com/nodejs/node/pull/13497
+    description: Remove max limit of `crlfDelay` option.
+  - version: v6.6.0
+    pr-url: https://github.com/nodejs/node/pull/8109
+    description: The `crlfDelay` option is supported now.
   - version: v6.3.0
     pr-url: https://github.com/nodejs/node/pull/7125
     description: The `prompt` option is supported now.


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, readline
