### PR TITLE
test: http2 connectionListener reject client

### DIFF
--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -110,9 +110,9 @@ function onSession(session) {
     common.mustCall(onRequest)
   );
 
-  server.on('unknownProtocol', common.mustCall((socket) => {
+  server.once('unknownProtocol', common.mustCall((socket) => {
     socket.destroy();
-  }, 2));
+  }));
 
   server.listen(0);
 


### PR DESCRIPTION
This code change modifies connectionListener tests to cover a test case where `this.emit('unknownProtocol', socket)` returns false

https://github.com/nodejs/node/blob/e0122299cf4ee7d97ca826a8f68eb799a5a56fe7/lib/internal/http2/core.js#L2284-L2287

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2