### PR TITLE
url: using util._extend for improving profermace

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -170,7 +170,7 @@ class URLSearchParams {
       return ctx.stylize('[Object]', 'special');
 
     var separator = ', ';
-    var innerOpts = Object.assign({}, ctx);
+    var innerOpts = util._extend({}, ctx);
     if (recurseTimes !== null) {
       innerOpts.depth = recurseTimes - 1;
     }
@@ -373,7 +373,7 @@ Object.defineProperties(URL.prototype, {
     value: function format(options) {
       if (options && typeof options !== 'object')
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
-      options = Object.assign({
+      options = util._extend({
         fragment: true,
         unicode: false,
         search: true,
@@ -1244,7 +1244,7 @@ defineIDLClass(URLSearchParamsIteratorPrototype, 'URLSearchParamsIterator', {
     if (typeof recurseTimes === 'number' && recurseTimes < 0)
       return ctx.stylize('[Object]', 'special');
 
-    const innerOpts = Object.assign({}, ctx);
+    const innerOpts = util._extend({}, ctx);
     if (recurseTimes !== null) {
       innerOpts.depth = recurseTimes - 1;
     }


### PR DESCRIPTION
`Object.assign` is much slower than `util._extend` according to
the refs. This change is to convert the `Object.assign` to use
`util._extend` in url module for improving profermance.

Refs: https://github.com/nodejs/CTC/issues/62

Benchmark:
```
 url/url-resolve.js n=100000 path="down" href="auth"                                                     0.73 %            4.001573e-01
 url/url-resolve.js n=100000 path="down" href="dot"                                                     -0.28 %            8.223166e-01
 url/url-resolve.js n=100000 path="down" href="file"                                                     1.69 %            1.027301e-01
 url/url-resolve.js n=100000 path="down" href="idn"                                                      0.87 %            4.341655e-01
 url/url-resolve.js n=100000 path="down" href="javascript"                                               3.48 %          * 4.274686e-02
 url/url-resolve.js n=100000 path="down" href="long"                                                     1.36 %            1.400734e-01
 url/url-resolve.js n=100000 path="down" href="noscheme"                                                -2.57 %            7.697437e-02
 url/url-resolve.js n=100000 path="down" href="percent"                                                  0.73 %            5.244919e-01
 url/url-resolve.js n=100000 path="down" href="short"                                                    4.44 %        *** 3.820092e-04
 url/url-resolve.js n=100000 path="down" href="ws"                                                       1.59 %          * 2.243749e-02
 url/url-resolve.js n=100000 path="foo/bar" href="auth"                                                  1.94 %          * 4.641876e-02
 url/url-resolve.js n=100000 path="foo/bar" href="dot"                                                   5.24 %        *** 5.656288e-05
 url/url-resolve.js n=100000 path="foo/bar" href="file"                                                  2.64 %            9.331631e-02
 url/url-resolve.js n=100000 path="foo/bar" href="idn"                                                  -0.45 %            6.854409e-01
 url/url-resolve.js n=100000 path="foo/bar" href="javascript"                                           -1.07 %            5.415987e-01
 url/url-resolve.js n=100000 path="foo/bar" href="long"                                                  0.49 %            5.780417e-01
 url/url-resolve.js n=100000 path="foo/bar" href="noscheme"                                              5.08 %         ** 5.798221e-03
 url/url-resolve.js n=100000 path="foo/bar" href="percent"                                               0.04 %            9.816567e-01
 url/url-resolve.js n=100000 path="foo/bar" href="short"                                                 2.21 %            1.986360e-01
 url/url-resolve.js n=100000 path="foo/bar" href="ws"                                                    0.29 %            7.859900e-01
 url/url-resolve.js n=100000 path="sibling" href="auth"                                                  1.95 %          * 3.832157e-02
 url/url-resolve.js n=100000 path="sibling" href="dot"                                                   1.83 %            7.399938e-02
 url/url-resolve.js n=100000 path="sibling" href="file"                                                  2.44 %          * 3.722787e-02
 url/url-resolve.js n=100000 path="sibling" href="idn"                                                   0.83 %            3.692427e-01
 url/url-resolve.js n=100000 path="sibling" href="javascript"                                            0.09 %            9.523714e-01
 url/url-resolve.js n=100000 path="sibling" href="long"                                                  1.80 %            6.542290e-02
 url/url-resolve.js n=100000 path="sibling" href="noscheme"                                             -0.20 %            8.973654e-01
 url/url-resolve.js n=100000 path="sibling" href="percent"                                               0.57 %            6.611122e-01
 url/url-resolve.js n=100000 path="sibling" href="short"                                                 0.94 %            4.288303e-01
 url/url-resolve.js n=100000 path="sibling" href="ws"                                                    1.74 %          * 3.850364e-02
 url/url-resolve.js n=100000 path="up" href="auth"                                                       1.56 %            1.695226e-01
 url/url-resolve.js n=100000 path="up" href="dot"                                                        1.59 %            5.566368e-02
 url/url-resolve.js n=100000 path="up" href="file"                                                       0.03 %            9.810652e-01
 url/url-resolve.js n=100000 path="up" href="idn"                                                        0.58 %            4.708234e-01
 url/url-resolve.js n=100000 path="up" href="javascript"                                                 2.68 %          * 1.764476e-02
 url/url-resolve.js n=100000 path="up" href="long"                                                      -0.23 %            8.000201e-01
 url/url-resolve.js n=100000 path="up" href="noscheme"                                                   0.57 %            7.034992e-01
 url/url-resolve.js n=100000 path="up" href="percent"                                                    1.69 %            1.894380e-01
 url/url-resolve.js n=100000 path="up" href="short"                                                     -0.94 %            4.023246e-01
 url/url-resolve.js n=100000 path="up" href="ws"                                                         1.01 %            2.854117e-01
 url/url-resolve.js n=100000 path="withscheme" href="auth"                                               0.52 %            7.065682e-01
 url/url-resolve.js n=100000 path="withscheme" href="dot"                                                0.44 %            7.631471e-01
 url/url-resolve.js n=100000 path="withscheme" href="file"                                              -0.22 %            8.804126e-01
 url/url-resolve.js n=100000 path="withscheme" href="idn"                                                3.35 %          * 1.185270e-02
 url/url-resolve.js n=100000 path="withscheme" href="javascript"                                         0.01 %            9.954955e-01
 url/url-resolve.js n=100000 path="withscheme" href="long"                                               0.80 %            3.409249e-01
 url/url-resolve.js n=100000 path="withscheme" href="noscheme"                                          -0.60 %            7.459196e-01
 url/url-resolve.js n=100000 path="withscheme" href="percent"                                            0.83 %            6.370433e-01
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url