### PR TITLE
test: http2 add timeout no callback test case

### DIFF
--- a/test/parallel/test-http2-server-settimeout-no-callback.js
+++ b/test/parallel/test-http2-server-settimeout-no-callback.js
@@ -4,38 +4,39 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const http2 = require('http2');
 
 // Verify that setTimeout callback verifications work correctly
+const verifyCallbacks = (server) => {
+  const testTimeout = 10;
+  const notFunctions = [true, 1, {}, [], null, 'test'];
+  const invalidCallBackError = {
+    type: TypeError,
+    code: 'ERR_INVALID_CALLBACK',
+    message: 'Callback must be a function'
+  };
 
+  notFunctions.forEach((notFunction) =>
+    common.expectsError(
+      () => server.setTimeout(testTimeout, notFunction),
+      invalidCallBackError
+    )
+  );
+
+  // No callback
+  const returnedVal = server.setTimeout(testTimeout);
+  assert.strictEqual(returnedVal.timeout, testTimeout);
+};
+
+// Test with server
 {
   const server = http2.createServer();
-  common.expectsError(
-    () => server.setTimeout(10, 'test'),
-    {
-      code: 'ERR_INVALID_CALLBACK',
-      type: TypeError
-    });
-  common.expectsError(
-    () => server.setTimeout(10, 1),
-    {
-      code: 'ERR_INVALID_CALLBACK',
-      type: TypeError
-    });
+  verifyCallbacks(server);
 }
 
+// Test with secure server
 {
-  const server = http2.createSecureServer({});
-  common.expectsError(
-    () => server.setTimeout(10, 'test'),
-    {
-      code: 'ERR_INVALID_CALLBACK',
-      type: TypeError
-    });
-  common.expectsError(
-    () => server.setTimeout(10, 1),
-    {
-      code: 'ERR_INVALID_CALLBACK',
-      type: TypeError
-    });
+  const secureServer = http2.createSecureServer({});
+  verifyCallbacks(secureServer);
 }


### PR DESCRIPTION
This code change adds a test case where `server.setTimeout` is called without a callback
Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
