### PR TITLE
doc: public keys don't accept passphrases

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1709,43 +1709,43 @@ Encrypts `buffer` with `privateKey`.
 `privateKey` can be an object or a string. If `privateKey` is a string, it is
 treated as the key with no passphrase and will use `RSA_PKCS1_PADDING`.
 
-### crypto.publicDecrypt(publicKey, buffer)
+### crypto.publicDecrypt(key, buffer)
 <!-- YAML
 added: v1.1.0
 -->
-- `publicKey` {Object | string}
-  - `key` {string} A PEM encoded public key.
-  - `passphrase` {string} An optional passphrase for the public key.
+- `key` {Object | string}
+  - `key` {string} A PEM encoded public or private key.
+  - `passphrase` {string} An optional passphrase for the private key.
   - `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING` or
     `RSA_PKCS1_PADDING`.
 - `buffer` {Buffer | TypedArray | DataView}
 
-Decrypts `buffer` with `publicKey`.
+Decrypts `buffer` with `key`.
 
-`publicKey` can be an object or a string. If `publicKey` is a string, it is
-treated as the key with no passphrase and will use `RSA_PKCS1_PADDING`.
+`key` can be an object or a string. If `key` is a string, it is treated as
+the key with no passphrase and will use `RSA_PKCS1_PADDING`.
 
 Because RSA public keys can be derived from private keys, a private key may
 be passed instead of a public key.
 
-### crypto.publicEncrypt(publicKey, buffer)
+### crypto.publicEncrypt(key, buffer)
 <!-- YAML
 added: v0.11.14
 -->
-- `publicKey` {Object | string}
-  - `key` {string} A PEM encoded public key.
-  - `passphrase` {string} An optional passphrase for the public key.
+- `key` {Object | string}
+  - `key` {string} A PEM encoded public or private key.
+  - `passphrase` {string} An optional passphrase for the private key.
   - `padding` {crypto.constants} An optional padding value defined in
     `crypto.constants`, which may be: `crypto.constants.RSA_NO_PADDING`,
     `RSA_PKCS1_PADDING`, or `crypto.constants.RSA_PKCS1_OAEP_PADDING`.
 - `buffer` {Buffer | TypedArray | DataView}
 
-Encrypts the content of `buffer` with `publicKey` and returns a new
+Encrypts the content of `buffer` with `key` and returns a new
 [`Buffer`][] with encrypted content.
 
-`publicKey` can be an object or a string. If `publicKey` is a string, it is
-treated as the key with no passphrase and will use `RSA_PKCS1_OAEP_PADDING`.
+`key` can be an object or a string. If `key` is a string, it is treated as
+the key with no passphrase and will use `RSA_PKCS1_OAEP_PADDING`.
 
 Because RSA public keys can be derived from private keys, a private key may
 be passed instead of a public key.


### PR DESCRIPTION
While `crypto.publicDecrypt()` and `crypto.publicEncrypt()` do accept a
`passphrase` option, the C++ code simply ignores it because OpenSSL does
not support it for public keys.  Undocument the option.

Refs: https://github.com/nodejs/node/pull/16038