### PR TITLE
test: allow short benchmarks for tests

### DIFF
--- a/test/parallel/test-benchmark-path.js
+++ b/test/parallel/test-benchmark-path.js
@@ -11,4 +11,4 @@ runBenchmark('path',
                'pathext=',
                'paths=',
                'props='
-             ]);
+             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/parallel/test-benchmark-process.js
+++ b/test/parallel/test-benchmark-process.js
@@ -9,4 +9,4 @@ runBenchmark('process',
                'millions=0.000001',
                'n=1',
                'type=raw'
-             ]);
+             ], { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Enable short benchmarks for process and path benchmark tests. These have
been observed to fail in CI due to returning with zero operations
performed in the allotted time. We have a special environment variable
for other benchmark tests that can be set to make that allowable in
benchmarks. Set it for path and process.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark