### PR TITLE
doc: added note to fs.watchFile on previousStat

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -626,6 +626,19 @@ Any specified file descriptor has to have been opened for appending.
 *Note*: If a file descriptor is specified as the `file`, it will not be closed
 automatically.
 
+*Note:* When a file being watched by `fs.watchFile()` disappears and reappears,
+then the `previousStat` reported in the second callback event (the file's
+reappearance) will be the same as the `previousStat` of the first callback
+event (its disappearance).
+
+This happens when:
+- the file is deleted, followed by a restore
+- the file is renamed twice - the second time back to its original name
+
+In such cases the reappearance callback will not report the `previousStat` of
+the file with all zeroes. This is the correct and expected behavior for
+`uv_fs_poll_start()`, the libuv function that `fs.watchFile()` uses internally.
+
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
 added: v0.6.7

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2571,10 +2571,6 @@ This happens when:
 - the file is deleted, followed by a restore
 - the file is renamed twice - the second time back to its original name
 
-In such cases the reappearance callback will not report the `previousStat` of
-the file with all zeroes. This is the correct and expected behavior for
-`uv_fs_poll_start()`, the libuv function that `fs.watchFile()` uses internally.
-
 ## fs.write(fd, buffer[, offset[, length[, position]]], callback)
 <!-- YAML
 added: v0.0.2

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -626,19 +626,6 @@ Any specified file descriptor has to have been opened for appending.
 *Note*: If a file descriptor is specified as the `file`, it will not be closed
 automatically.
 
-*Note:* When a file being watched by `fs.watchFile()` disappears and reappears,
-then the `previousStat` reported in the second callback event (the file's
-reappearance) will be the same as the `previousStat` of the first callback
-event (its disappearance).
-
-This happens when:
-- the file is deleted, followed by a restore
-- the file is renamed twice - the second time back to its original name
-
-In such cases the reappearance callback will not report the `previousStat` of
-the file with all zeroes. This is the correct and expected behavior for
-`uv_fs_poll_start()`, the libuv function that `fs.watchFile()` uses internally.
-
 ## fs.appendFileSync(file, data[, options])
 <!-- YAML
 added: v0.6.7
@@ -2574,6 +2561,19 @@ v0.10.
 *Note*: [`fs.watch()`][] is more efficient than `fs.watchFile` and
 `fs.unwatchFile`. `fs.watch` should be used instead of `fs.watchFile` and
 `fs.unwatchFile` when possible.
+
+*Note:* When a file being watched by `fs.watchFile()` disappears and reappears,
+then the `previousStat` reported in the second callback event (the file's
+reappearance) will be the same as the `previousStat` of the first callback
+event (its disappearance).
+
+This happens when:
+- the file is deleted, followed by a restore
+- the file is renamed twice - the second time back to its original name
+
+In such cases the reappearance callback will not report the `previousStat` of
+the file with all zeroes. This is the correct and expected behavior for
+`uv_fs_poll_start()`, the libuv function that `fs.watchFile()` uses internally.
 
 ## fs.write(fd, buffer[, offset[, length[, position]]], callback)
 <!-- YAML


### PR DESCRIPTION
**Checklist:**

- [x] `make -j4 test` (UNIX) passes
- [x] documentation is updated as per [style guide](https://github.com/nodejs/node/blob/master/doc/STYLE_GUIDE.md)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

**Fixes:** #15364