### PR TITLE
build: correct minor typo in lttng help message

### DIFF
--- a/configure
+++ b/configure
@@ -357,7 +357,7 @@ parser.add_option('--with-dtrace',
 parser.add_option('--with-lttng',
     action='store_true',
     dest='with_lttng',
-    help='build with Lttng (Only available to Linux)')
+    help='build with Lttng (Only available on Linux)')
 
 parser.add_option('--with-etw',
     action='store_true',

--- a/configure
+++ b/configure
@@ -357,7 +357,7 @@ parser.add_option('--with-dtrace',
 parser.add_option('--with-lttng',
     action='store_true',
     dest='with_lttng',
-    help='build with Lttng (Only available on Linux)')
+    help='build with Lttng (Only supported on Linux)')
 
 parser.add_option('--with-etw',
     action='store_true',


### PR DESCRIPTION
Currently the help message when using --with-lttng looks like this:
```console
$ ./configure --help | grep 'with-lttng'
  --with-lttng          build with Lttng (Only available to Linux)
```
This commit makes the help message consistent with the error message
that is raised if --with-lttng is used on a non-Linux operating
system:
```console
$ ./configure --help | grep 'with-lttng'
  --with-lttng          build with Lttng (Only available on Linux)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build