### PR TITLE
n-api: make changes for source compatibility

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -455,7 +455,7 @@ class CallbackWrapper {
   CallbackWrapper(napi_value this_arg, size_t args_length, void* data)
       : _this(this_arg), _args_length(args_length), _data(data) {}
 
-  virtual napi_value NewTarget() = 0;
+  virtual napi_value GetNewTarget() = 0;
   virtual void Args(napi_value* buffer, size_t bufferlength) = 0;
   virtual void SetReturnValue(napi_value value) = 0;
 
@@ -484,7 +484,7 @@ class CallbackWrapperBase : public CallbackWrapper {
                 ->Value();
   }
 
-  napi_value NewTarget() override { return nullptr; }
+  napi_value GetNewTarget() override { return nullptr; }
 
  protected:
   void InvokeCallback() {
@@ -532,7 +532,7 @@ class FunctionCallbackWrapper
       const v8::FunctionCallbackInfo<v8::Value>& cbinfo)
       : CallbackWrapperBase(cbinfo, cbinfo.Length()) {}
 
-  napi_value NewTarget() override {
+  napi_value GetNewTarget() override {
     if (_cbinfo.IsConstructCall()) {
       return v8impl::JsValueFromV8LocalValue(_cbinfo.NewTarget());
     } else {
@@ -854,8 +854,12 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
 
 // Registers a NAPI module.
 void napi_module_register(napi_module* mod) {
+  int module_version = -1;
+#ifdef EXTERNAL_NAPI
+  module_version = NODE_MODULE_VERSION;
+#endif  // EXTERNAL_NAPI
   node::node_module* nm = new node::node_module {
-    -1,
+    module_version,
     mod->nm_flags,
     nullptr,
     mod->nm_filename,
@@ -1908,7 +1912,7 @@ napi_status napi_get_new_target(napi_env env,
   v8impl::CallbackWrapper* info =
       reinterpret_cast<v8impl::CallbackWrapper*>(cbinfo);
 
-  *result = info->NewTarget();
+  *result = info->GetNewTarget();
   return napi_clear_last_error(env);
 }
 
@@ -3335,7 +3339,7 @@ class Work : public node::AsyncResource {
                 void* data = nullptr)
     : AsyncResource(env->isolate,
                     async_resource,
-                    async_resource_name),
+                    *v8::String::Utf8Value(async_resource_name)),
     _env(env),
     _data(data),
     _execute(execute),


### PR DESCRIPTION
These changes are necessary in order to retain source compatibility
with older versions of node.

The removal of `module_version` from `napi_module_register()` is
reverted from the flag removal PR, because it should not have been a
part of it.

`CallbackWrapper::NewTarget()` is renamed to
`CallbackWrapper::GetNewTarget()` to distinguish it from V8's native
method, thus allowing for a macro which reduces `NewTarget()` to
`This()` on V8 versions where it was not yet available.

`AsyncResource` is constructed with a C string rather than a V8 string
because the former is available on all versions of node.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api