### PR TITLE
test: add tests for ERR_HTTP2_FRAME_ERROR

### DIFF
--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -297,6 +297,14 @@ assert.strictEqual(
   errors.message('ERR_HTTP2_HEADER_REQUIRED', ['test']),
   'The test header is required');
 
+// Test ERR_HTTP2_FRAME_ERROR
+assert.strictEqual(
+  errors.message('ERR_HTTP2_FRAME_ERROR', ['foo', 'bar', 'baz']),
+  'Error sending frame type foo for stream baz with code bar');
+assert.strictEqual(
+  errors.message('ERR_HTTP2_FRAME_ERROR', ['foo', 'bar']),
+  'Error sending frame type foo with code bar');
+
 // Test error messages for async_hooks
 assert.strictEqual(
   errors.message('ERR_ASYNC_CALLBACK', ['init']),


### PR DESCRIPTION
This should finally bring the coverage to 100% for branches, too 😄 

<img width="600" alt="internal/errors coverage" src="https://user-images.githubusercontent.com/11021586/31357999-bd38cccc-acf8-11e7-80f0-0458a2cb2d9e.png">


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
`test`
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
