### PR TITLE
In tests/paraller/test-fs-read.js replaced common.fixturesDir with common.fixtures

### DIFF
--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -23,9 +23,7 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-// const path = require('path');
 const fs = require('fs');
-// const filepath = path.join(common.fixturesDir, 'x.txt');
 const filepath = fixtures.path('x.txt');
 const fd = fs.openSync(filepath, 'r');
 

--- a/test/parallel/test-fs-read.js
+++ b/test/parallel/test-fs-read.js
@@ -21,10 +21,12 @@
 
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const path = require('path');
+// const path = require('path');
 const fs = require('fs');
-const filepath = path.join(common.fixturesDir, 'x.txt');
+// const filepath = path.join(common.fixturesDir, 'x.txt');
+const filepath = fixtures.path('x.txt');
 const fd = fs.openSync(filepath, 'r');
 
 const expected = Buffer.from('xyz\n');


### PR DESCRIPTION
In test/paraller/test-fs-read.js replaced usage of common.fixturesDir with common.fixture
This is fix for pull request 15897 (used fixture.path).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test