### PR TITLE
test: updated test-http-get-pipeline-problem.js to use fixtures module

### DIFF
--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -24,6 +24,7 @@
 // after http.globalAgent.maxSockets number of files.
 // See https://groups.google.com/forum/#!topic/nodejs-dev/V5fB69hFa9o
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const http = require('http');
 const fs = require('fs');
@@ -32,7 +33,7 @@ http.globalAgent.maxSockets = 1;
 
 common.refreshTmpDir();
 
-const image = fs.readFileSync(`${common.fixturesDir}/person.jpg`);
+const image = fixtures.readSync('/person.jpg');
 
 console.log(`image.length = ${image.length}`);
 


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/15842. Ping @NigelKibodeaux 

Instead of using common.fixturesDir, uses the fixtures module

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test http