### PR TITLE
test: reduce run time for string_decoder benchmark

### DIFF
--- a/test/parallel/test-benchmark-string_decoder.js
+++ b/test/parallel/test-benchmark-string_decoder.js
@@ -4,4 +4,7 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('string_decoder', ['n=1']);
+runBenchmark('string_decoder', ['chunk=16',
+                                'encoding=utf8',
+                                'inlen=32',
+                                'n=1']);


### PR DESCRIPTION
test-benchmark-string_decoder was timing out in CI. Reduce the run time
by sending appropriate options such that each benchmark file only runs
one combination of options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark string_decoder