### PR TITLE
test: reduce run time for misc benchmark tests

### DIFF
--- a/benchmark/misc/console.js
+++ b/benchmark/misc/console.js
@@ -93,6 +93,8 @@ function runUsingArgumentsAndApply(n, concat) {
 function main(conf) {
   const n = +conf.n;
   switch (conf.method) {
+    // '' is a default case for tests
+    case '':
     case 'restAndSpread':
       runUsingRestAndSpread(n, conf.concat);
       break;

--- a/benchmark/misc/object-property-bench.js
+++ b/benchmark/misc/object-property-bench.js
@@ -63,6 +63,8 @@ function main(conf) {
   const n = +conf.millions * 1e6;
 
   switch (conf.method) {
+    // '' is a default case for tests
+    case '':
     case 'property':
       runProperty(n);
       break;

--- a/benchmark/misc/punycode.js
+++ b/benchmark/misc/punycode.js
@@ -63,6 +63,8 @@ function main(conf) {
   const n = +conf.n;
   const val = conf.val;
   switch (conf.method) {
+    // '' is a default case for tests
+    case '':
     case 'punycode':
       runPunycode(n, val);
       break;

--- a/test/parallel/test-benchmark-misc.js
+++ b/test/parallel/test-benchmark-misc.js
@@ -5,9 +5,10 @@ require('../common');
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('misc', [
-  'n=1',
-  'val=magyarország.icom.museum',
+  'concat=0',
+  'method=',
   'millions=.000001',
+  'n=1',
   'type=extend',
-  'concat=0'
+  'val=magyarország.icom.museum'
 ]);


### PR DESCRIPTION
Run only one benchmark for each benchmark file tested by
test-benchmark-misc.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark