### PR TITLE
[WIP] tools: use clang-format to format C++ code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,111 @@
+# # Defines the Google C++ style for automatic reformatting.
+# # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     79
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 20
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+# ...
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !.mailmap
 !.nycrc
 !.remarkrc
+!.clang-format
 
 core
 vgcore.*

--- a/Makefile
+++ b/Makefile
@@ -949,6 +949,18 @@ bench: bench-net bench-http bench-fs bench-tls
 
 bench-ci: bench
 
+CLANG_FORMAT = $(NODE) ./node_modules/.bin/clang-format -style=file -i
+
+format:
+	mkdir -p node_modules
+	if [ ! -d node_modules/clang-format ]; then \
+			./node ./deps/npm install clang-format --no-save --no-package-lock; fi
+	$(CLANG_FORMAT) --glob=src/**/*.cc
+	$(CLANG_FORMAT) --glob=src/**/*.h
+	# $(CLANG_FORMAT) --glob=test/**/*.cc
+	# $(CLANG_FORMAT) --glob=test/**/*.c
+	# $(CLANG_FORMAT) --glob=test/**/*.h
+
 lint-md-clean:
 	$(RM) -r tools/remark-cli/node_modules
 	$(RM) -r tools/remark-preset-lint-node/node_modules

--- a/src/node_root_certs.h
+++ b/src/node_root_certs.h
@@ -1,3 +1,4 @@
+// clang-format off
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 /* GlobalSign Root CA */
@@ -3944,3 +3945,4 @@
 "8W0jq5Rm+K37DwhuJi1/FwcJsoz7UMCflo3Ptv0AnVoUmr8CRPXBwp8iXqIPoeM=\n"
 "-----END CERTIFICATE-----\n",
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+// clang-format on


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

I think we have discussed briefly about this during the collaboration summit @BridgeAR @Fishrock123   This is just an attempt to see how everybody feels about using an automatic formatting tool to reduce style inconsistencies and nits in PRs. We use [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) in [llnode](https://github.com/nodejs/llnode) and v8 uses it as well so this sounds like a good candidate.

* The first commit just initializes the`.clang-format` file based on Google styles (since previously we use `cpplint.py` that lints C++ code using the Google style guide). We have our own "extensions" to the style guide (e.g. the ones being added in https://github.com/nodejs/node/pull/16090) so we need to work out more rules in the `.clang-format` based on our needs.
  * If we want more granular control over the rules we can do a `clang-format -style=google -dump-config > .clang-format` and start from that as well.
  * This PR is first about seeing if there are any concerns on the idea of using a auto-formatting tool at all. And the rules will kinda depend on what https://github.com/nodejs/node/pull/16090 comes down to.
* The second commit formats every `.cc` under `src` with the initalized `.clang-format` (`clang-format -style=file -i src/**/*.cc`)
* I am using [the clang-format npm module](https://www.npmjs.com/package/clang-format) with pre-built binaries maintained by the Angular team, though `clang-format` can be obtained by compiling from the clang source code as well. Also you can get a python wrapper if you happen to have `depot_tools` and a V8/Chromium checkout on your machine. I am not sure whether we should bundle it in the codebase like what we do with eslint, but definitely doesn't hurt to add some commands to the Makefile (maybe along with `eslint --fix`).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, tools