### PR TITLE
win, test: escape script filename on Windows

### DIFF
--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -139,7 +139,10 @@ child.exec(`${nodejs} --use-strict -p process.execArgv`,
 
 // Regression test for https://github.com/nodejs/node/issues/3574.
 {
-  const emptyFile = fixtures.path('empty.js');
+  let emptyFile = fixtures.path('empty.js');
+  if (common.isWindows) {
+    emptyFile = emptyFile.replace(/\\/g, '\\\\');
+  }
 
   child.exec(`${nodejs} -e 'require("child_process").fork("${emptyFile}")'`,
              common.mustCall((err, stdout, stderr) => {


### PR DESCRIPTION
Escape backslashes in script filename on Windows in `test-cli-eval.js`.

Fixes: https://github.com/nodejs/node/issues/16057 and https://github.com/nodejs/node/issues/16023

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
