### PR TITLE
module: allow loading files with % in the name

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1377,8 +1377,14 @@ function getPathFromURL(path) {
   return isWindows ? getPathFromURLWin32(path) : getPathFromURLPosix(path);
 }
 
+// We percent-encode % character when converting from file path to URL,
+// as this is the only character that won't be percent encoded by
+// default URL percent encoding when pathname is set.
+const percentRegEx = /%/g;
 function getURLFromFilePath(filepath) {
   const tmp = new URL('file://');
+  if (filepath.includes('%'))
+    filepath = filepath.replace(percentRegEx, '%25');
   tmp.pathname = filepath;
   return tmp;
 }

--- a/test/es-module/test-esm-double-encoding-native%20.js
+++ b/test/es-module/test-esm-double-encoding-native%20.js
@@ -1,0 +1,7 @@
+'use strict';
+require('../common');
+
+// Trivial test to assert we can load files with `%` in their pathname.
+// Imported by `test-esm-double-encoding.mjs`.
+
+module.exports = 42;

--- a/test/es-module/test-esm-double-encoding.mjs
+++ b/test/es-module/test-esm-double-encoding.mjs
@@ -1,0 +1,6 @@
+// Flags: --experimental-modules
+import '../common';
+
+// Assert we can import files with `%` in their pathname.
+
+import './test-esm-double-encoding-native%2520.js';


### PR DESCRIPTION
Because the module resolver applies percent decoding due to being URL-based for browser alignment, files with % characters in them cannot be loaded. For example a file at an actual path "x%20.js" gets decoded to the incorrect path "x .js".

We can support this if we carefully ensure that double encoding is supported of the form "x%2520.js" (just as is supported in browser module specifiers).

In order to make this work, a small fix to the URL filepath -> URL conversion code is needed, which is included here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
url, esmodules