### PR TITLE
doc: exempt test/doc only changes from 48-hr rule

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -64,7 +64,8 @@ from other Collaborators. Leave at least 48 hours during the week and
 72 hours over weekends to account for international time differences
 and work schedules. Trivial changes (e.g. those which fix minor bugs
 or improve performance without affecting API or causing other
-wide-reaching impact) may be landed after a shorter delay.
+wide-reaching impact), and focused changes that affect only documentation
+and/or the test suite, may be landed after a shorter delay.
 
 For non-breaking changes, if there is no disagreement amongst
 Collaborators, a pull request may be landed given appropriate review.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -65,7 +65,8 @@ from other Collaborators. Leave at least 48 hours during the week and
 and work schedules. Trivial changes (e.g. those which fix minor bugs
 or improve performance without affecting API or causing other
 wide-reaching impact), and focused changes that affect only documentation
-and/or the test suite, may be landed after a shorter delay.
+and/or the test suite, may be landed after a shorter delay if they have
+multiple approvals.
 
 For non-breaking changes, if there is no disagreement amongst
 Collaborators, a pull request may be landed given appropriate review.


### PR DESCRIPTION
If a change affects only specific parts of the tests and or
documentation, and in particular not of the runtime code itself,
it should often be okay to land it early.

The primary goal of the 48-hour rule is to ensure that people
who are invested in certain parts of Node have a reasonable chance
to weigh in based on their usage of Node; if the API is not
touched in a change, that is arguably much less of an issue.

In particular, this:

- Should help avoid excessive nitpicking.
- Helps newcomers, since their first PRs often touch only those areas
  and a direct success is very motivating.
- Helps with the amount of pull requests created by events such a
  Code & Learn.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/tsc

I can’t be there but if you feel it’s worth pointing to this PR in today’s TSC meeting please do so :)