### PR TITLE
test: reduce test-benchmark-http iterations

### DIFF
--- a/test/sequential/test-benchmark-http.js
+++ b/test/sequential/test-benchmark-http.js
@@ -22,6 +22,7 @@ runBenchmark('http',
                'len=1',
                'method=write',
                'n=1',
-               'res=normal'
+               'res=normal',
+               'type=asc'
              ],
              { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Supply `type=asc` option in test-benchmark-http to reduce runs in all
benchmark files to one combination of options.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark http