### PR TITLE
benchmark: remove writing to benchmark directory

### DIFF
--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const common = require('../common.js');
 
-const tmpDirectory = path.join(__dirname, '..', 'tmp');
-const benchmarkDirectory = path.join(tmpDirectory, 'nodejs-benchmark-module');
+const { refreshTmpDir, tmpDir } = require('../../test/common');
+const benchmarkDirectory = path.join(tmpDir, 'nodejs-benchmark-module');
 
 const bench = common.createBenchmark(main, {
   thousands: [50],
@@ -15,8 +15,7 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const n = +conf.thousands * 1e3;
 
-  rmrf(tmpDirectory);
-  try { fs.mkdirSync(tmpDirectory); } catch (e) {}
+  refreshTmpDir();
   try { fs.mkdirSync(benchmarkDirectory); } catch (e) {}
 
   for (var i = 0; i <= n; i++) {
@@ -36,7 +35,7 @@ function main(conf) {
   else
     measureDir(n, conf.useCache === 'true');
 
-  rmrf(tmpDirectory);
+  refreshTmpDir();
 }
 
 function measureFull(n, useCache) {
@@ -65,22 +64,4 @@ function measureDir(n, useCache) {
     require(`${benchmarkDirectory}${i}`);
   }
   bench.end(n / 1e3);
-}
-
-function rmrf(location) {
-  try {
-    const things = fs.readdirSync(location);
-    things.forEach(function(thing) {
-      var cur = path.join(location, thing),
-        isDirectory = fs.statSync(cur).isDirectory();
-      if (isDirectory) {
-        rmrf(cur);
-        return;
-      }
-      fs.unlinkSync(cur);
-    });
-    fs.rmdirSync(location);
-  } catch (err) {
-    // Ignore error
-  }
 }


### PR DESCRIPTION
A benchmark for module loading creates a temporary directory in the
benchmark directory. Re-use the test common module to put the tmp
directory in test instead. This was causing intermittent test failures
because run.js (invoked by benchmark tests, mulitple of which could be
running at once) throws if a subdirectory of benchmark disappears at
just the wrong time.

There are other possible solutions than repurposing the `test/common`
module but two arguments for doing it this way are:

* There is already another benchmark file that does this
  (`http_server_for_chunky_client.js`) so the dependency already exists
  in the benchmarks.
* This also eliminates a re-implementation of rimraf in the benchmark
  code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark