### PR TITLE
test: fix lint error

### DIFF
--- a/test/parallel/test-tls-net-connect-prefer-path.js
+++ b/test/parallel/test-tls-net-connect-prefer-path.js
@@ -12,7 +12,6 @@ common.refreshTmpDir();
 
 const tls = require('tls');
 const net = require('net');
-const fs = require('fs');
 const assert = require('assert');
 
 function libName(lib) {


### PR DESCRIPTION
Fix lint error introduced 03550a5c1e. Unused module `fs` is removed.

Refs: https://github.com/nodejs/node/pull/15832#issuecomment-335808467

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test