### PR TITLE
n-api,test: use module name macro

### DIFF
--- a/test/addons-napi/test_constructor/test_constructor_name.c
+++ b/test/addons-napi/test_constructor/test_constructor_name.c
@@ -20,4 +20,4 @@ napi_value Init(napi_env env, napi_value exports) {
   return cons;
 }
 
-NAPI_MODULE(addon, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)


### PR DESCRIPTION
test_constructor_name.c should use NODE_GYP_MODULE_NAME.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api,test