### PR TITLE
repl: remove unused err argument

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1025,9 +1025,7 @@ function complete(line, callback) {
 
   // Will be called when all completionGroups are in place
   // Useful for async autocompletion
-  function completionGroupsLoaded(err) {
-    if (err) throw err;
-
+  function completionGroupsLoaded() {
     // Filter, sort (within each group), uniq and merge the completion groups.
     if (completionGroups.length && filter) {
       var newCompletionGroups = [];


### PR DESCRIPTION
Not used by any callers in `lib/repl.js`, and is not public API.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl
