### PR TITLE
build: set disable_glibcxx_debug flag

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -31,6 +31,10 @@
     # Don't bake anything extra into the snapshot.
     'v8_use_external_startup_data%': 0,
 
+    # Some STL containers (e.g. std::vector) do not preserve ABI compatibility
+    # between debug and non-debug mode.
+    'disable_glibcxx_debug': 1,
+
     # Don't use ICU data file (icudtl.dat) from V8, we use our own.
     'icu_use_data_file_flag%': 0,
 


### PR DESCRIPTION
This breaks a few tests when Node is built in debug mode, because V8 is built with `-D_GLIBCXX_DEBUG=1` and Node is built without, which makes e.g. `std::vector` ABI-incompatible between the two.

`./node_g test/parallel/test-cli-node-options.js` if you want to try it. :)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

build