### PR TITLE
build: use local node-gyp for benchmark addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,14 @@ test-valgrind: all
 test-check-deopts: all
 	$(PYTHON) tools/test.py --mode=release --check-deopts parallel sequential -J
 
+benchmark/misc/function_call/build/Release/binding.node: all \
+		benchmark/misc/function_call/binding.cc \
+		benchmark/misc/function_call/binding.gyp
+	$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
+		--python="$(PYTHON)" \
+		--directory="$(shell pwd)/benchmark/misc/function_call" \
+		--nodedir="$(shell pwd)"
+
 # Implicitly depends on $(NODE_EXE).  We don't depend on it explicitly because
 # it always triggers a rebuild due to it being a .PHONY rule.  See the comment
 # near the build-addons rule for more background.
@@ -904,8 +912,7 @@ bench-http: all
 bench-fs: all
 	@$(NODE) benchmark/run.js fs
 
-bench-misc: all
-	@$(MAKE) -C benchmark/misc/function_call/
+bench-misc: benchmark/misc/function_call/build/Release/binding.node
 	@$(NODE) benchmark/run.js misc
 
 bench-array: all

--- a/Makefile
+++ b/Makefile
@@ -965,6 +965,7 @@ LINT_CPP_EXCLUDE += $(wildcard test/addons-napi/??_*/*.cc test/addons-napi/??_*/
 LINT_CPP_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
 
 LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
+	benchmark/misc/function_call/binding.cc \
 	src/*.c \
 	src/*.cc \
 	src/*.h \

--- a/benchmark/misc/function_call/Makefile
+++ b/benchmark/misc/function_call/Makefile
@@ -1,2 +1,0 @@
-binding:
-	node-gyp rebuild --nodedir=../../..

--- a/benchmark/misc/function_call/binding.cc
+++ b/benchmark/misc/function_call/binding.cc
@@ -1,17 +1,14 @@
 #include <v8.h>
 #include <node.h>
 
-using namespace v8;
-
 static int c = 0;
 
-void Hello(const FunctionCallbackInfo<Value>& args) {
+void Hello(const v8::FunctionCallbackInfo<v8::Value>& args) {
   args.GetReturnValue().Set(c++);
 }
 
-extern "C" void init (Local<Object> target) {
-  HandleScope scope(Isolate::GetCurrent());
+void Initialize(v8::Local<v8::Object> target) {
   NODE_SET_METHOD(target, "hello", Hello);
 }
 
-NODE_MODULE(NODE_GYP_MODULE_NAME, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)


### PR DESCRIPTION
Move the logic for building the benchmark/misc/function_call to
the top-level Makefile and use our local copy of node-gyp.

Fixes: #16154 (cc @joyeecheung)