### PR TITLE
doc: add parentheses to refreshTmpDir()

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -317,10 +317,10 @@ Port tests are running on.
 
 Logs '1..0 # Skipped: ' + `msg`
 
-### refreshTmpDir
+### refreshTmpDir()
 * return [&lt;String>]
 
-Deletes the 'tmp' dir and recreates it
+Deletes the testing 'tmp' directory and recreates it.
 
 ### restoreStderr()
 


### PR DESCRIPTION
`common.refreshTmpDir()` is a function. Add parentheses to make that
explicit. Also copy edit the descriptive sentence.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc test