### PR TITLE
Enable explicit `.m.js` intent for ESM

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -19,11 +19,13 @@ and implementation is ready. Error messages are still being polished.
 The `--experimental-modules` flag can be used to enable features for loading
 ESM modules.
 
-Once this has been set, files ending with `.mjs` will be able to be loaded
+Once this has been set, files ending with `.mjs` or `.m.js` will be able to be loaded
 as ES Modules.
 
 ```sh
 node --experimental-modules my-app.mjs
+
+node --experimental-modules other-app.m.js
 ```
 
 ## Features
@@ -41,6 +43,7 @@ points into ESM graphs at run time.
 | Feature | Reason |
 | --- | --- |
 | `require('./foo.mjs')` | ES Modules have differing resolution and timing, use language standard `import()` |
+| `require('./foo.m.js')` | same as above, use language standard `import()` |
 | `import()` | pending newer V8 release used in Node.js |
 | `import.meta` | pending V8 implementation |
 | Loader Hooks | pending Node.js EP creation/consensus |

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -114,7 +114,8 @@ exports.resolve = (specifier, parentURL) => {
     case '.node':
       return { url: `${url}`, format: 'addon' };
     case '.js':
-      return { url: `${url}`, format: 'cjs' };
+      const format = url.pathname.slice(-5) === '.m.js' ? 'esm' : 'cjs';
+      return { url: `${url}`, format };
     default:
       throw new errors.Error('ERR_UNKNOWN_FILE_EXTENSION',
                              internalURLModule.getPathFromURL(url));

--- a/lib/module.js
+++ b/lib/module.js
@@ -611,6 +611,9 @@ Module.prototype._compile = function(content, filename) {
 
 // Native extension for .js
 Module._extensions['.js'] = function(module, filename) {
+  if (experimentalModules && filename.slice(-5) === '.m.js') {
+    return Module._extensions['.mjs'](module, filename);
+  }
   var content = fs.readFileSync(filename, 'utf8');
   module._compile(internalModule.stripBOM(content), filename);
 };

--- a/test/es-module/test-es-m-basic-imports.mjs
+++ b/test/es-module/test-es-m-basic-imports.mjs
@@ -1,0 +1,5 @@
+// Flags: --experimental-modules
+import assert from 'assert';
+import ok from './test-esm-ok.m.js';
+
+assert(ok === true);

--- a/test/es-module/test-es-m-failing-require.js
+++ b/test/es-module/test-es-m-failing-require.js
@@ -1,0 +1,9 @@
+// Flags: --experimental-modules
+const assert = require('assert');
+
+try {
+  require('./test-esm-ok.m.js');
+  assert(false);
+} catch(error) {
+  assert(/es\s*m(?:odule)?|\.m\.?js/i.test(error.message));
+}

--- a/test/es-module/test-esm-ok.m.js
+++ b/test/es-module/test-esm-ok.m.js
@@ -1,0 +1,5 @@
+// Flags: --experimental-modules
+/* eslint-disable required-modules */
+
+const isJs = true;
+export default isJs;


### PR DESCRIPTION
As discussed in the [.mjs extension trade-offs](https://github.com/nodejs/node-eps/issues/57#issuecomment-336254657) post, it would be great if NodeJS could provide a way to explicitly opt-in as ESM, without needing to use a different extension.

### Goal
The purpose of this PR is to enable a universal convention for ESM that would work out of the box in both browsers and other JavaScript environment including SpiderMonkey and JSC.

If the file is imported with a fully qualified path name, and such path name uses the `.m.js` convention, the format will be ESM and it will throw if such file does not respect such format.

### Please consider this PR

The current NodeJS diversion from the rest of the JavaScript environments is alarming for various reasons and consistency, as well as code reliability, is currently potentially compromised, as described in details in [this blog post](https://codeburst.io/the-javascript-modules-limbo-585eedbb182e).

If there is anything else I could do in order to land this PR while ESM is still behind an experimental flag, please let me know, thank you.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
