### PR TITLE
tools: rename unused variale in more pythonic way

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1661,7 +1661,7 @@ def Main():
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list
-        (cases, unused_rules, all_outcomes) = (
+        (cases, unused_rules, _) = (
             config.ClassifyTests(test_list, env))
         if globally_unused_rules is None:
           globally_unused_rules = set(unused_rules)


### PR DESCRIPTION
The 'Main' function in tools/test.py file was using a variable named
``all_outcomes`` to store a value not being used. It is a best practice
to name unused variables, often return values of functions/methods (as
in this case) as ``_`` [1]. This just helps keep the code a bit cleaner and
avoid any silly mistakes.

Refs: [1] https://stackoverflow.com/a/5477153

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
NA