### PR TITLE
test: fix test-esm-addons

### DIFF
--- a/test/addons/hello-world-esm/binding.cc
+++ b/test/addons/hello-world-esm/binding.cc
@@ -1,0 +1,13 @@
+#include <node.h>
+#include <v8.h>
+
+void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  args.GetReturnValue().Set(v8::String::NewFromUtf8(isolate, "world"));
+}
+
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/hello-world-esm/binding.gyp
+++ b/test/addons/hello-world-esm/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'defines': [ 'V8_DEPRECATION_WARNINGS=1' ],
+      'sources': [ 'binding.cc' ]
+    }
+  ]
+}

--- a/test/addons/hello-world-esm/test.js
+++ b/test/addons/hello-world-esm/test.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../../common');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { copyFileSync } = require('fs');
+const { join } = require('path');
+
+const buildDir = join(__dirname, 'build');
+
+copyFileSync(join(buildDir, common.buildType, 'binding.node'),
+             join(buildDir, 'binding.node'));
+
+const result = spawnSync(process.execPath,
+                         ['--experimental-modules', `${__dirname}/test.mjs`]);
+
+assert.ifError(result.error);
+// TODO: Uncomment this once ESM is no longer experimental.
+// assert.strictEqual(result.stderr.toString().trim(), '');
+assert.strictEqual(result.stdout.toString().trim(), 'binding.hello() = world');

--- a/test/addons/hello-world-esm/test.mjs
+++ b/test/addons/hello-world-esm/test.mjs
@@ -1,7 +1,6 @@
-// Flags: --experimental-modules
 /* eslint-disable required-modules */
 
 import assert from 'assert';
-import binding from '../addons/hello-world/build/Release/binding.node';
+import binding from './build/binding.node';
 assert.strictEqual(binding.hello(), 'world');
 console.log('binding.hello() =', binding.hello());


### PR DESCRIPTION
Move test-esm-addons to test/addons/hello-world-esm.

Test should now work properly on CI machines where `addons` are not
always built at the expected relative path from the es-modules tests.

Test should now work in Debug builds.

Fixes: https://github.com/nodejs/node/issues/16155

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test 