### PR TITLE
build,win: enable lint option to run "standalone"

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -129,6 +129,10 @@ goto next-arg
 
 :args-done
 
+if "%*"=="lint" (
+  goto lint-cpp
+)
+
 if defined build_release (
   set config=Release
   set package=1
@@ -480,12 +484,12 @@ setlocal enabledelayedexpansion
 for /f "tokens=*" %%G in ('dir /b /s /a %*') do (
   set relpath=%%G
   set relpath=!relpath:*%~dp0=!
-  call :add-to-list !relpath!
+  call :add-to-list !relpath! > nul
 )
 ( endlocal
   set cppfilelist=%localcppfilelist%
 )
-call :run-python tools/cpplint.py %cppfilelist%
+call :run-python tools/cpplint.py %cppfilelist% > nul
 goto exit
 
 :add-to-list
@@ -538,6 +542,7 @@ echo   vcbuild.bat test                     : builds debug build and runs tests
 echo   vcbuild.bat build-release            : builds the release distribution as used by nodejs.org
 echo   vcbuild.bat enable-vtune             : builds nodejs with Intel VTune profiling support to profile JavaScript
 echo   vcbuild.bat link-module my_module.js : bundles my_module as built-in module
+echo   vcbuild.bat lint                     : runs the C++ and JavaScript linter
 goto exit
 
 :run-python


### PR DESCRIPTION
This commit adds support to run the linter without running any other
targets. This commit also makes the lint task a little more quite and
more inline with the output on other operating systems.
Below is an example of running (with a lint error to show that it is not
so quite that errors are hidden):
```console
C:\Users\danbev\working\node>vcbuild.bat lint
running lint-cpp 'src\*.c src\*.cc src\*.h test\addons\*.cc
test\addons\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc
tools\icu\*.cc tools\icu\*.h'
src\env.h:24:  Should have a space between // and comment
[whitespace/comments] [4]
Total errors found: 1
"C:\Python27\python.exe" tools/check-imports.py
running lint-js
```

The help message now looks like:
```console
C:\Users\danbev\working\node>vcbuild.bat /?
vcbuild.bat [debug/release] [msi] [test/test-ci/test-all/test-uv/
test-inspector/test-internet/test-pummel/test-simple/test-message/
test-async-hooks/test-v8/test-v8-intl/test-v8-benchmarks/
test-v8-all] [clean] [noprojgen] [small-icu/full-icu/without-intl]
[nobuild] [sign] [x86/x64] [vs2015/vs2017] [download-all]
[enable-vtune] [lint/lint-ci] [no-NODE-OPTIONS]
[link-module path-to-module]
Examples:
  vcbuild.bat                          : builds release build
  vcbuild.bat debug                    : builds debug build
  vcbuild.bat release msi              : builds release build and MSI installer package
  vcbuild.bat test                     : builds debug build and runs tests
  vcbuild.bat build-release            : builds the release distribution as used by nodejs.org
  vcbuild.bat enable-vtune             : builds nodejs with Intel VTune profiling support to profile JavaScript
  vcbuild.bat link-module my_module.js : bundles my_module as built-in module
  vcbuild.bat lint                     : runs the C++ and JavaScript linter
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, windows