### PR TITLE
build,win: include addons-napi in linter

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -468,7 +468,7 @@ goto lint-cpp
 
 :lint-cpp
 if not defined lint_cpp goto lint-js
-call :run-lint-cpp src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
+call :run-lint-cpp src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\addons-napi\*.cc test\addons-napi\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
 call :run-python tools/check-imports.py
 goto lint-js
 
@@ -500,6 +500,9 @@ echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.h"
 if %errorlevel% equ 0 goto exit
 
 echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.cc"
+if %errorlevel% equ 0 goto exit
+
+echo %1 | findstr /c:"test\\addons-napi\common.h"
 if %errorlevel% equ 0 goto exit
 
 set "localcppfilelist=%localcppfilelist% %1"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -502,7 +502,7 @@ if %errorlevel% equ 0 goto exit
 echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.cc"
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /c:"test\\addons-napi\common.h"
+echo %1 | findstr /c:"test\\addons-napi\\common.h"
 if %errorlevel% equ 0 goto exit
 
 set "localcppfilelist=%localcppfilelist% %1"


### PR DESCRIPTION
Currently test/addons-napi files are not being included in the lint
processing. This commit adds them.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, windows