### PR TITLE
n-api: use module name macro

### DIFF
--- a/test/addons-napi/test_warning/test_warning.c
+++ b/test/addons-napi/test_warning/test_warning.c
@@ -8,4 +8,4 @@ napi_value Init(napi_env env, napi_value exports) {
   return result;
 }
 
-NAPI_MODULE(test_warning, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_warning/test_warning2.c
+++ b/test/addons-napi/test_warning/test_warning2.c
@@ -8,4 +8,4 @@ napi_value Init(napi_env env, napi_value exports) {
   return result;
 }
 
-NAPI_MODULE(test_warning2, Init)
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -68,4 +68,4 @@ void Initialize(v8::Local<v8::Object> exports) {
 
 }  // namespace
 
-NODE_MODULE(binding, Initialize)
+NODE_MODULE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/dlopen-ping-pong/binding.cc
+++ b/test/addons/dlopen-ping-pong/binding.cc
@@ -41,7 +41,7 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "ping", Ping);
 }
 
-NODE_MODULE(binding, init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)
 
 }  // anonymous namespace
 

--- a/test/addons/node-module-version/binding.cc
+++ b/test/addons/node-module-version/binding.cc
@@ -12,4 +12,4 @@ inline void Initialize(v8::Local<v8::Object> exports,
 
 }
 
-NODE_MODULE_CONTEXT_AWARE(binding, Initialize)
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/openssl-binding/binding.cc
+++ b/test/addons/openssl-binding/binding.cc
@@ -29,4 +29,4 @@ inline void Initialize(v8::Local<v8::Object> exports,
 
 }  // anonymous namespace
 
-NODE_MODULE_CONTEXT_AWARE(binding, Initialize)
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/zlib-binding/binding.cc
+++ b/test/addons/zlib-binding/binding.cc
@@ -52,4 +52,4 @@ inline void Initialize(v8::Local<v8::Object> exports,
 
 }  // anonymous namespace
 
-NODE_MODULE_CONTEXT_AWARE(binding, Initialize)
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/gc/binding.cc
+++ b/test/gc/binding.cc
@@ -77,4 +77,4 @@ inline void Initialize(v8::Local<v8::Object> exports,
 
 }  // anonymous namespace
 
-NODE_MODULE_CONTEXT_AWARE(binding, Initialize)
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)


### PR DESCRIPTION
Update tests to use module name macro

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api, test