### PR TITLE
doc: add UV_THREADPOOL_SIZE link definition

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -711,5 +711,6 @@ Decompress a chunk of data with [Unzip][].
 [Inflate]: #zlib_class_zlib_inflate
 [Memory Usage Tuning]: #zlib_memory_usage_tuning
 [Unzip]: #zlib_class_zlib_unzip
+[`UV_THREADPOOL_SIZE`]: cli.html#cli_uv_threadpool_size_size
 [options]: #zlib_class_options
 [zlib documentation]: http://zlib.net/manual.html#Constants


### PR DESCRIPTION
Currently is rendered as "see the [UV_THREADPOOL_SIZE][] documentation",

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
