### PR TITLE
doc: fix paragraph line-height issue

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -211,6 +211,7 @@ abbr {
 p {
   text-rendering: optimizeLegibility;
   margin: 0 0 1.125rem 0;
+  line-height: 1.5;
 }
 
 #apicontent > *:last-child {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

Fix a line-height issue introduced in #15660 where paragraphs containing `<code>` blocks would have unequal line heights.

Fixes: https://github.com/nodejs/nodejs.org/issues/1399

##### Before

![](https://i.imgur.com/Glkihyt.png)

##### After

![](https://i.imgur.com/VbLjrkM.png)