### PR TITLE
Update buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1421,7 +1421,7 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`.
+* `byteOffset` {integer} Where to end searching in `buf`.
   **Default:** [`buf.length`]` - 1`
 * `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`


### PR DESCRIPTION
The `byteOffset` parameter of the `buf.lastIndexOf(value[, byteOffset][, encoding])` method should be described as `Where to end searching in buf.` rather than `Where to begin searching in buf.` since it is pretty misleading.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
