### PR TITLE
doc: support multidimensional arrays in type links

### DIFF
--- a/tools/doc/type-parser.js
+++ b/tools/doc/type-parser.js
@@ -58,6 +58,8 @@ const typeMap = {
   'URLSearchParams': 'url.html#url_class_urlsearchparams'
 };
 
+const arrayPart = /(?:\[])+$/;
+
 module.exports = {
   toLink: function(typeInput) {
     const typeLinks = [];
@@ -69,12 +71,10 @@ module.exports = {
       if (typeText) {
         let typeUrl = null;
 
-        // To support type[], we store the full string and use
-        // the bracket-less version to lookup the type URL
+        // To support type[], type[][] etc., we store the full string
+        // and use the bracket-less version to lookup the type URL
         const typeTextFull = typeText;
-        if (/\[]$/.test(typeText)) {
-          typeText = typeText.slice(0, -2);
-        }
+        typeText = typeText.replace(arrayPart, '');
 
         const primitive = jsPrimitives[typeText.toLowerCase()];
 


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, tools

Currently, we have at least one multidimensional array in type signature: see `records` parameter in https://nodejs.org/api/dns.html#dns_dns_resolvetxt_hostname_callback

Our type parser does not linkify these signatures properly. This PR tries to fix this.
