### PR TITLE
test: http2 emitGoAway post shutdown pre destroy

### DIFF
--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -29,6 +29,8 @@ server.listen(0, () => {
     assert.deepStrictEqual(code, 1);
     assert.deepStrictEqual(lastStreamID, 0);
     assert.deepStrictEqual(data, buf);
+    // Call shutdown() here so that emitGoaway calls destroy()
+    client.shutdown();
     server.close();
   }));
   const req = client.request({ ':path': '/' });


### PR DESCRIPTION
This commit tests use case when emitGoAway is called when client is
shutting down but is not destroyed https://github.com/nodejs/node/blob/411695e1d26565c7498992be19731bbea6b6aa58/lib/internal/http2/core.js#L368-L370

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
