### PR TITLE
test: http2 rstStream duplicate call

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -925,7 +925,7 @@ class Http2Session extends EventEmitter {
                                  'number');
     }
 
-    if (this[kState].rst) {
+    if (stream[kState].rst) {
       // rst has already been called, do not call again,
       // skip straight to destroy
       stream.destroy();


### PR DESCRIPTION
This commit fixes an issue with rstStream() which checked incorrect value of rst. It also adds a test case for this fix https://github.com/nodejs/node/blob/411695e1d26565c7498992be19731bbea6b6aa58/lib/internal/http2/core.js#L928-L933

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
