### PR TITLE
lib: pass internalBinding more implicitly

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -197,3 +197,4 @@ globals:
   LTTNG_HTTP_SERVER_RESPONSE: false
   LTTNG_NET_SERVER_CONNECTION: false
   LTTNG_NET_STREAM_END: false
+  internalBinding: false

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -8,6 +8,7 @@
 'use strict';
 
 (function(process) {
+  let internalBinding;
 
   function startup() {
     const EventEmitter = NativeModule.require('events');
@@ -19,6 +20,9 @@
     EventEmitter.call(process);
 
     setupProcessObject();
+
+    internalBinding = process._internalBinding;
+    delete process._internalBinding;
 
     // do this good and early, since it handles errors.
     setupProcessFatal();
@@ -574,7 +578,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname) { ',
+    '(function (exports, require, module, internalBinding) {',
     '\n});'
   ];
 
@@ -590,7 +594,7 @@
         lineOffset: 0,
         displayErrors: true
       });
-      fn(this.exports, NativeModule.require, this, this.filename);
+      fn(this.exports, NativeModule.require, this, internalBinding);
 
       this.loaded = true;
     } finally {

--- a/lib/internal/loader/ModuleWrap.js
+++ b/lib/internal/loader/ModuleWrap.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { ModuleWrap } =
-    require('internal/process').internalBinding('module_wrap');
+const { ModuleWrap } = internalBinding('module_wrap');
 const debug = require('util').debuglog('esm');
 const ArrayJoin = Function.call.bind(Array.prototype.join);
 const ArrayMap = Function.call.bind(Array.prototype.map);

--- a/lib/internal/loader/search.js
+++ b/lib/internal/loader/search.js
@@ -3,7 +3,7 @@
 const { URL } = require('url');
 const CJSmodule = require('module');
 const errors = require('internal/errors');
-const { resolve } = require('internal/process').internalBinding('module_wrap');
+const { resolve } = internalBinding('module_wrap');
 
 module.exports = (target, base) => {
   if (base === undefined) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -4,9 +4,6 @@ const errors = require('internal/errors');
 const util = require('util');
 const constants = process.binding('constants').os.signals;
 
-const internalBinding = process._internalBinding;
-delete process._internalBinding;
-
 const assert = process.assert = function(x, msg) {
   if (!x) throw new errors.Error('ERR_ASSERTION', msg || 'assertion error');
 };
@@ -259,6 +256,5 @@ module.exports = {
   setupKillAndExit,
   setupSignalHandlers,
   setupChannel,
-  setupRawDebug,
-  internalBinding
+  setupRawDebug
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -78,8 +78,14 @@ Module._extensions = Object.create(null);
 var modulePaths = [];
 Module.globalPaths = [];
 
-Module.wrapper = NativeModule.wrapper;
-Module.wrap = NativeModule.wrap;
+Module.wrap = function(script) {
+  return Module.wrapper[0] + script + Module.wrapper[1];
+};
+
+Module.wrapper = [
+  '(function (exports, require, module, __filename, __dirname) { ',
+  '\n});'
+];
 
 const debug = util.debuglog('module');
 


### PR DESCRIPTION
Modify passing of the `internalBinding` function so that it’s easier for core modules to adopt, and also not even accessible through `--expose-internals`.

This also splits the module wrapper into a separate version for internal bindings and for CJS modules, which seems like a good idea given the different semantics.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

lib