### PR TITLE
fs: account for buffer alloc failure in readFile

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -474,7 +474,11 @@ function readFileAfterStat(err) {
     return context.close(err);
   }
 
-  context.buffer = Buffer.allocUnsafeSlow(size);
+  try {
+    context.buffer = Buffer.allocUnsafeSlow(size);
+  } catch (err) {
+    return context.close(err);
+  }
   context.read();
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -521,23 +521,13 @@ function readFileAfterClose(err) {
     else
       buffer = context.buffer;
 
-    if (context.encoding) {
-      return tryToString(buffer, context.encoding, callback);
-    }
+    if (context.encoding)
+      buffer = buffer.toString(context.encoding);
   } catch (err) {
     return callback(err);
   }
 
   callback(null, buffer);
-}
-
-function tryToString(buf, encoding, callback) {
-  try {
-    buf = buf.toString(encoding);
-  } catch (err) {
-    return callback(err);
-  }
-  callback(null, buf);
 }
 
 function tryStatSync(fd, isUserFd) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -513,15 +513,19 @@ function readFileAfterClose(err) {
   if (context.err || err)
     return callback(context.err || err);
 
-  if (context.size === 0)
-    buffer = Buffer.concat(context.buffers, context.pos);
-  else if (context.pos < context.size)
-    buffer = context.buffer.slice(0, context.pos);
-  else
-    buffer = context.buffer;
+  try {
+    if (context.size === 0)
+      buffer = Buffer.concat(context.buffers, context.pos);
+    else if (context.pos < context.size)
+      buffer = context.buffer.slice(0, context.pos);
+    else
+      buffer = context.buffer;
 
-  if (context.encoding) {
-    return tryToString(buffer, context.encoding, callback);
+    if (context.encoding) {
+      return tryToString(buffer, context.encoding, callback);
+    }
+  } catch (err) {
+    return callback(err);
   }
 
   callback(null, buffer);

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -29,7 +29,8 @@ stream.on('finish', common.mustCall(function() {
   // make sure that the toString does not throw an error
   fs.readFile(file, 'utf8', common.mustCall(function(err, buf) {
     assert.ok(err instanceof Error);
-    assert.strictEqual('"toString()" failed', err.message);
+    assert(/^(Array buffer allocation failed|"toString\(\)" failed)$/
+             .test(err.message));
     assert.strictEqual(buf, undefined);
   }));
 }));


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/15362

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

fs