### PR TITLE
test: http2 priority stream depends on itself

### DIFF
--- a/test/parallel/test-http2-priority-parent-self.js
+++ b/test/parallel/test-http2-priority-parent-self.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const h2 = require('http2');
+
+const server = h2.createServer();
+const invalidOptValueError = (value) => ({
+  type: TypeError,
+  code: 'ERR_INVALID_OPT_VALUE',
+  message: `The value "${value}" is invalid for option "parent"`
+});
+
+// we use the lower-level API here
+server.on('stream', common.mustCall((stream) => {
+  common.expectsError(
+    () => stream.priority({
+      parent: stream.id,
+      weight: 1,
+      exclusive: false
+    }),
+    invalidOptValueError(stream.id)
+  );
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('hello world');
+}));
+
+server.listen(0, common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({ ':path': '/' });
+
+  req.on(
+    'ready',
+    () => common.expectsError(
+      () => req.priority({
+        parent: req.id,
+        weight: 1,
+        exclusive: false
+      }),
+      invalidOptValueError(req.id)
+    )
+  );
+
+  req.on('response', common.mustCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));


### PR DESCRIPTION
This commit add test case where priority() throws ERR_INVALID_OPT_VALUE when stream depends on itself https://github.com/nodejs/node/blob/411695e1d26565c7498992be19731bbea6b6aa58/lib/internal/http2/core.js#L893-L899

Refs: https://github.com/nodejs/node/issues/14985

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2