### PR TITLE
tty: fix 'resize' event regression

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -33,6 +33,7 @@
 
     const _process = NativeModule.require('internal/process');
     _process.setupConfig(NativeModule._source);
+    _process.setupSignalHandlers();
     NativeModule.require('internal/process/warning').setup();
     NativeModule.require('internal/process/next_tick').setup();
     NativeModule.require('internal/process/stdio').setup();
@@ -55,7 +56,6 @@
     _process.setup_cpuUsage();
     _process.setupMemoryUsage();
     _process.setupKillAndExit();
-    _process.setupSignalHandlers();
     if (global.__coverage__)
       NativeModule.require('internal/process/write-coverage').setup();
 

--- a/test/pseudo-tty/pseudo-tty.status
+++ b/test/pseudo-tty/pseudo-tty.status
@@ -3,3 +3,8 @@ prefix pseudo-tty
 [$system==aix]
 # being investigated under https://github.com/nodejs/node/issues/9728
 test-tty-wrap              : FAIL, PASS
+
+[$system==solaris]
+# https://github.com/nodejs/node/pull/16225 - `ioctl(fd, TIOCGWINSZ)` seems
+# to fail with EINVAL on SmartOS when `fd` is a pty from python's pty module.
+test-tty-stdout-resize     : FAIL, PASS

--- a/test/pseudo-tty/test-tty-stdout-resize.js
+++ b/test/pseudo-tty/test-tty-stdout-resize.js
@@ -1,0 +1,11 @@
+'use strict';
+const { mustCall } = require('../common');
+const { notStrictEqual } = require('assert');
+
+// tty.WriteStream#_refreshSize() only emits the 'resize' event when the
+// window dimensions change.  We cannot influence that from the script
+// but we can set the old values to something exceedingly unlikely.
+process.stdout.columns = 9001;
+process.stdout.on('resize', mustCall());
+process.kill(process.pid, 'SIGWINCH');
+setImmediate(mustCall(() => notStrictEqual(process.stdout.columns, 9001)));


### PR DESCRIPTION
It's not wholly clear what commit introduced the regression but between
v8.4.0 and v8.5.0 the 'resize' event stopped getting emitted when the
tty was resized.

The SIGWINCH event listener apparently was being installed before the
support code for `process.on('SIGWINCH', ...)` was.  Fix that by moving
said support code to real early in the bootstrap process.

Fixes: https://github.com/nodejs/node/issues/16194
CI: https://ci.nodejs.org/job/node-test-pull-request/10732/