### PR TITLE
test: skip process-kill-null if cat unavailable

### DIFF
--- a/test/parallel/test-process-kill-null.js
+++ b/test/parallel/test-process-kill-null.js
@@ -20,11 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const spawn = require('child_process').spawn;
 
 const cat = spawn('cat');
+if (cat.pid === undefined) {
+  common.skip('cat not available');
+}
 let called;
 
 assert.ok(process.kill(cat.pid, 0));


### PR DESCRIPTION
If the cat command is not available test-process-kill-null.js will
report the following error:
```console
internal/process.js:160
      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pid', 'Number');
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "pid" argument must be of type Number
    at process.kill (internal/process.js:160:13)
    at Object.<anonymous> (C:\working\node\test\parallel\test-process-kill-null.js:31:19)
    at Module._compile (module.js:604:30)
    at Object.Module._extensions..js (module.js:615:10)
    at Module.load (module.js:523:32)
    at tryModuleLoad (module.js:486:12)
    at Function.Module._load (module.js:478:3)
    at Function.Module.runMain (module.js:645:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:605:3
```
I'm not sure if I have my windows environment configured correctly (I'm
using Windows 10 Pro) but I get this error. The CI servers don't report
it but perhaps they have some configuration that I don't. I wanted to
raise this to be sure.

This commit suggests to skip this test if the cat command is not
available on the operating system.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, windows