### PR TITLE
n-api: make more symbols local

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -198,19 +198,23 @@ class EscapableHandleScopeWrapper {
   bool escape_called_;
 };
 
+static
 napi_handle_scope JsHandleScopeFromV8HandleScope(HandleScopeWrapper* s) {
   return reinterpret_cast<napi_handle_scope>(s);
 }
 
+static
 HandleScopeWrapper* V8HandleScopeFromJsHandleScope(napi_handle_scope s) {
   return reinterpret_cast<HandleScopeWrapper*>(s);
 }
 
+static
 napi_escapable_handle_scope JsEscapableHandleScopeFromV8EscapableHandleScope(
     EscapableHandleScopeWrapper* s) {
   return reinterpret_cast<napi_escapable_handle_scope>(s);
 }
 
+static
 EscapableHandleScopeWrapper*
 V8EscapableHandleScopeFromJsEscapableHandleScope(
     napi_escapable_handle_scope s) {
@@ -224,18 +228,22 @@ V8EscapableHandleScopeFromJsEscapableHandleScope(
 static_assert(sizeof(v8::Local<v8::Value>) == sizeof(napi_value),
   "Cannot convert between v8::Local<v8::Value> and napi_value");
 
+static
 napi_deferred JsDeferredFromV8Persistent(v8::Persistent<v8::Value>* local) {
   return reinterpret_cast<napi_deferred>(local);
 }
 
+static
 v8::Persistent<v8::Value>* V8PersistentFromJsDeferred(napi_deferred local) {
   return reinterpret_cast<v8::Persistent<v8::Value>*>(local);
 }
 
+static
 napi_value JsValueFromV8LocalValue(v8::Local<v8::Value> local) {
   return reinterpret_cast<napi_value>(*local);
 }
 
+static
 v8::Local<v8::Value> V8LocalValueFromJsValue(napi_value v) {
   v8::Local<v8::Value> local;
   memcpy(&local, &v, sizeof(v));
@@ -634,6 +642,7 @@ class SetterCallbackWrapper
 
 // Creates an object to be made available to the static function callback
 // wrapper, used to retrieve the native callback function and data pointer.
+static
 v8::Local<v8::Object> CreateFunctionCallbackData(napi_env env,
                                                  napi_callback cb,
                                                  void* data) {
@@ -659,6 +668,7 @@ v8::Local<v8::Object> CreateFunctionCallbackData(napi_env env,
 // Creates an object to be made available to the static getter/setter
 // callback wrapper, used to retrieve the native getter/setter callback
 // function and data pointer.
+static
 v8::Local<v8::Object> CreateAccessorCallbackData(napi_env env,
                                                  napi_callback getter,
                                                  napi_callback setter,
@@ -701,6 +711,7 @@ const char napi_wrap_name[] = "N-API Wrapper";
 // Search the object's prototype chain for the wrapper object. Usually the
 // wrapper would be the first in the chain, but it is OK for other objects to
 // be inserted in the prototype chain.
+static
 bool FindWrapper(v8::Local<v8::Object> obj,
                  v8::Local<v8::Object>* result = nullptr,
                  v8::Local<v8::Object>* parent = nullptr) {
@@ -734,6 +745,7 @@ static void DeleteEnv(napi_env env, void* data, void* hint) {
   delete env;
 }
 
+static
 napi_env GetEnv(v8::Local<v8::Context> context) {
   napi_env result;
 
@@ -769,6 +781,7 @@ napi_env GetEnv(v8::Local<v8::Context> context) {
   return result;
 }
 
+static
 napi_status Unwrap(napi_env env,
                    napi_value js_object,
                    void** result,
@@ -792,6 +805,7 @@ napi_status Unwrap(napi_env env,
   return napi_ok;
 }
 
+static
 napi_status ConcludeDeferred(napi_env env,
                              napi_deferred deferred,
                              napi_value result,
@@ -851,12 +865,8 @@ void napi_module_register_cb(v8::Local<v8::Object> exports,
 
 // Registers a NAPI module.
 void napi_module_register(napi_module* mod) {
-  int module_version = -1;
-#ifdef EXTERNAL_NAPI
-  module_version = NODE_MODULE_VERSION;
-#endif  // EXTERNAL_NAPI
   node::node_module* nm = new node::node_module {
-    module_version,
+    -1,
     mod->nm_flags,
     nullptr,
     mod->nm_filename,
@@ -870,6 +880,7 @@ void napi_module_register(napi_module* mod) {
 }
 
 // Warning: Keep in-sync with napi_status enum
+static
 const char* error_messages[] = {nullptr,
                                 "Invalid argument",
                                 "An object was expected",
@@ -1206,10 +1217,10 @@ napi_status napi_delete_property(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-NAPI_EXTERN napi_status napi_has_own_property(napi_env env,
-                                              napi_value object,
-                                              napi_value key,
-                                              bool* result) {
+napi_status napi_has_own_property(napi_env env,
+                                  napi_value object,
+                                  napi_value key,
+                                  bool* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, key);
 
@@ -3224,6 +3235,7 @@ napi_status napi_adjust_external_memory(napi_env env,
   return napi_clear_last_error(env);
 }
 
+namespace {
 namespace uvimpl {
 
 static napi_status ConvertUVErrorCode(int code) {
@@ -3322,6 +3334,7 @@ class Work : public node::AsyncResource {
 };
 
 }  // end of namespace uvimpl
+}  // end of anonymous namespace
 
 #define CALL_UV(env, condition)                                         \
   do {                                                                  \
@@ -3404,9 +3417,9 @@ napi_status napi_cancel_async_work(napi_env env, napi_async_work work) {
   return napi_clear_last_error(env);
 }
 
-NAPI_EXTERN napi_status napi_create_promise(napi_env env,
-                                            napi_deferred* deferred,
-                                            napi_value* promise) {
+napi_status napi_create_promise(napi_env env,
+                                napi_deferred* deferred,
+                                napi_value* promise) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, deferred);
   CHECK_ARG(env, promise);
@@ -3423,21 +3436,21 @@ NAPI_EXTERN napi_status napi_create_promise(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-NAPI_EXTERN napi_status napi_resolve_deferred(napi_env env,
-                                              napi_deferred deferred,
-                                              napi_value resolution) {
+napi_status napi_resolve_deferred(napi_env env,
+                                  napi_deferred deferred,
+                                  napi_value resolution) {
   return v8impl::ConcludeDeferred(env, deferred, resolution, true);
 }
 
-NAPI_EXTERN napi_status napi_reject_deferred(napi_env env,
-                                             napi_deferred deferred,
-                                             napi_value resolution) {
+napi_status napi_reject_deferred(napi_env env,
+                                 napi_deferred deferred,
+                                 napi_value resolution) {
   return v8impl::ConcludeDeferred(env, deferred, resolution, false);
 }
 
-NAPI_EXTERN napi_status napi_is_promise(napi_env env,
-                                        napi_value promise,
-                                        bool* is_promise) {
+napi_status napi_is_promise(napi_env env,
+                            napi_value promise,
+                            bool* is_promise) {
   CHECK_ENV(env);
   CHECK_ARG(env, promise);
   CHECK_ARG(env, is_promise);
@@ -3447,9 +3460,9 @@ NAPI_EXTERN napi_status napi_is_promise(napi_env env,
   return napi_clear_last_error(env);
 }
 
-NAPI_EXTERN napi_status napi_run_script(napi_env env,
-                                        napi_value script,
-                                        napi_value* result) {
+napi_status napi_run_script(napi_env env,
+                            napi_value script,
+                            napi_value* result) {
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, script);
   CHECK_ARG(env, result);


### PR DESCRIPTION
* namespaced functions such as v8impl::JsHandleScopeFromV8HandleScope
  become part of Node's public symbols unless they are declared static.
* the class uvimpl::Work needs to be enclosed in an anonymous namespace
  else it, too becomes part of Node's public symbols.
* allow NAPI_EXTERN to be defined on the compiler's command line.
* remove references to EXTERNAL_NAPI.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
n-api