### PR TITLE
http: disallow two-byte characters in URL path

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -41,33 +41,7 @@ const { outHeadersKey } = require('internal/http');
 const { nextTick } = require('internal/process/next_tick');
 const errors = require('internal/errors');
 
-// The actual list of disallowed characters in regexp form is more like:
-//    /[^A-Za-z0-9\-._~!$&'()*+,;=/:@]/
-// with an additional rule for ignoring percentage-escaped characters, but
-// that's a) hard to capture in a regular expression that performs well, and
-// b) possibly too restrictive for real-world usage. So instead we restrict the
-// filter to just control characters, spaces and two-byte characters.
-//
-// This function is used in the case of small paths, where manual character code
-// checks can greatly outperform the equivalent regexp (tested in V8 5.4).
-function isInvalidPath(s) {
-  var i = 0;
-  if (s.charCodeAt(0) <= 32 || s.charCodeAt(0) > 0xFF) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(1) <= 32 || s.charCodeAt(1) > 0xFF) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(2) <= 32 || s.charCodeAt(2) > 0xFF) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(3) <= 32 || s.charCodeAt(3) > 0xFF) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(4) <= 32 || s.charCodeAt(4) > 0xFF) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(5) <= 32 || s.charCodeAt(5) > 0xFF) return true;
-  ++i;
-  for (; i < s.length; ++i)
-    if (s.charCodeAt(i) <= 32 || s.charCodeAt(i) > 0xFF) return true;
-  return false;
-}
+const INVALID_PATH_REGEX = /[\u0000-\u0020\u0100-\uffff]/;
 
 function validateHost(host, name) {
   if (host != null && typeof host !== 'string') {
@@ -117,13 +91,7 @@ function ClientRequest(options, cb) {
   var path;
   if (options.path) {
     path = String(options.path);
-    var invalidPath;
-    if (path.length <= 39) { // Determined experimentally in V8 5.4
-      invalidPath = isInvalidPath(path);
-    } else {
-      invalidPath = /[\u0000-\u0020\u0100-\uffff]/.test(path);
-    }
-    if (invalidPath)
+    if (INVALID_PATH_REGEX.test(path))
       throw new errors.TypeError('ERR_UNESCAPED_CHARACTERS', 'Request path');
   }
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -52,20 +52,20 @@ const errors = require('internal/errors');
 // checks can greatly outperform the equivalent regexp (tested in V8 5.4).
 function isInvalidPath(s) {
   var i = 0;
-  if (s.charCodeAt(0) <= 32) return true;
+  if (s.charCodeAt(0) <= 32 || s.charCodeAt(0) > 0xFF) return true;
   if (++i >= s.length) return false;
-  if (s.charCodeAt(1) <= 32) return true;
+  if (s.charCodeAt(1) <= 32 || s.charCodeAt(1) > 0xFF) return true;
   if (++i >= s.length) return false;
-  if (s.charCodeAt(2) <= 32) return true;
+  if (s.charCodeAt(2) <= 32 || s.charCodeAt(2) > 0xFF) return true;
   if (++i >= s.length) return false;
-  if (s.charCodeAt(3) <= 32) return true;
+  if (s.charCodeAt(3) <= 32 || s.charCodeAt(3) > 0xFF) return true;
   if (++i >= s.length) return false;
-  if (s.charCodeAt(4) <= 32) return true;
+  if (s.charCodeAt(4) <= 32 || s.charCodeAt(4) > 0xFF) return true;
   if (++i >= s.length) return false;
-  if (s.charCodeAt(5) <= 32) return true;
+  if (s.charCodeAt(5) <= 32 || s.charCodeAt(5) > 0xFF) return true;
   ++i;
   for (; i < s.length; ++i)
-    if (s.charCodeAt(i) <= 32) return true;
+    if (s.charCodeAt(i) <= 32 || s.charCodeAt(i) > 0xFF) return true;
   return false;
 }
 
@@ -121,7 +121,7 @@ function ClientRequest(options, cb) {
     if (path.length <= 39) { // Determined experimentally in V8 5.4
       invalidPath = isInvalidPath(path);
     } else {
-      invalidPath = /[\u0000-\u0020]/.test(path);
+      invalidPath = /[\u0000-\u0020\u0100-\uffff]/.test(path);
     }
     if (invalidPath)
       throw new errors.TypeError('ERR_UNESCAPED_CHARACTERS', 'Request path');

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -46,7 +46,7 @@ const errors = require('internal/errors');
 // with an additional rule for ignoring percentage-escaped characters, but
 // that's a) hard to capture in a regular expression that performs well, and
 // b) possibly too restrictive for real-world usage. So instead we restrict the
-// filter to just control characters and spaces.
+// filter to just control characters, spaces and two-byte characters.
 //
 // This function is used in the case of small paths, where manual character code
 // checks can greatly outperform the equivalent regexp (tested in V8 5.4).

--- a/test/parallel/test-http-client-invalid-path.js
+++ b/test/parallel/test-http-client-invalid-path.js
@@ -1,24 +1,3 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 const common = require('../common');
 const http = require('http');

--- a/test/parallel/test-http-client-invalid-path.js
+++ b/test/parallel/test-http-client-invalid-path.js
@@ -1,0 +1,33 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const http = require('http');
+
+common.expectsError(() => {
+  http.request({
+    path: '/thisisinvalid\uffe2'
+  }).end();
+}, {
+  code: 'ERR_UNESCAPED_CHARACTERS',
+  type: TypeError
+});


### PR DESCRIPTION
This commit changes node's handling of two-byte characters in the path component
of an http URL. Previously, node would just strip the higher byte when
generating the request. So this code:

```
http.request({host: "example.com", port: "80", "/\uFF2e"})
```

would request `http://example.com/.` (`.` is the character for the byte `0x2e`).

This is not useful and can in some cases allow filter evasion. With this
change, the code generates `ERR_UNESCAPED_CHARACTERS`, just like space and
control characters already did.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http