### PR TITLE
build: make gyp user defined variables lowercase

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -44,29 +44,29 @@
 
     'conditions': [
       ['GENERATOR=="ninja"', {
-        'OBJ_DIR': '<(PRODUCT_DIR)/obj',
-        'V8_BASE': '<(PRODUCT_DIR)/obj/deps/v8/src/libv8_base.a',
+        'obj_dir': '<(PRODUCT_DIR)/obj',
+        'v8_base': '<(PRODUCT_DIR)/obj/deps/v8/src/libv8_base.a',
        }, {
-         'OBJ_DIR%': '<(PRODUCT_DIR)/obj.target',
-         'V8_BASE%': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
+         'obj_dir%': '<(PRODUCT_DIR)/obj.target',
+         'v8_base%': '<(PRODUCT_DIR)/obj.target/deps/v8/src/libv8_base.a',
       }],
       ['OS == "win"', {
         'os_posix': 0,
         'v8_postmortem_support%': 'false',
-        'OBJ_DIR': '<(PRODUCT_DIR)/obj',
-        'V8_BASE': '<(PRODUCT_DIR)/lib/v8_libbase.lib',
+        'obj_dir': '<(PRODUCT_DIR)/obj',
+        'v8_base': '<(PRODUCT_DIR)/lib/v8_libbase.lib',
       }, {
         'os_posix': 1,
         'v8_postmortem_support%': 'true',
       }],
       ['OS== "mac"', {
-        'OBJ_DIR%': '<(PRODUCT_DIR)/obj.target',
-        'V8_BASE': '<(PRODUCT_DIR)/libv8_base.a',
+        'obj_dir%': '<(PRODUCT_DIR)/obj.target',
+        'v8_base': '<(PRODUCT_DIR)/libv8_base.a',
       }],
       ['openssl_fips != ""', {
-        'OPENSSL_PRODUCT': '<(STATIC_LIB_PREFIX)crypto<(STATIC_LIB_SUFFIX)',
+        'openssl_product': '<(STATIC_LIB_PREFIX)crypto<(STATIC_LIB_SUFFIX)',
       }, {
-        'OPENSSL_PRODUCT': '<(STATIC_LIB_PREFIX)openssl<(STATIC_LIB_SUFFIX)',
+        'openssl_product': '<(STATIC_LIB_PREFIX)openssl<(STATIC_LIB_SUFFIX)',
       }],
       ['OS=="mac"', {
         'clang%': 1,

--- a/node.gyp
+++ b/node.gyp
@@ -234,7 +234,7 @@
           'conditions': [
             ['OS in "linux freebsd openbsd solaris android"', {
               'ldflags': [
-                '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
+                '-Wl,--whole-archive,<(obj_dir)/<(STATIC_LIB_PREFIX)'
                     '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
                 '-Wl,--no-whole-archive',
               ],
@@ -772,10 +772,10 @@
             {
               'action_name': 'node_dtrace_provider_o',
               'inputs': [
-                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace.o',
+                '<(obj_dir)/<(node_lib_target_name)/src/node_dtrace.o',
               ],
               'outputs': [
-                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace_provider.o'
+                '<(obj_dir)/<(node_lib_target_name)/src/node_dtrace_provider.o'
               ],
               'action': [ 'dtrace', '-G', '-xnolibs', '-s', 'src/node_provider.d',
                 '<@(_inputs)', '-o', '<@(_outputs)' ]
@@ -807,7 +807,7 @@
             {
               'action_name': 'node_dtrace_ustack_constants',
               'inputs': [
-                '<(V8_BASE)'
+                '<(v8_base)'
               ],
               'outputs': [
                 '<(SHARED_INTERMEDIATE_DIR)/v8constants.h'
@@ -825,7 +825,7 @@
                 '<(SHARED_INTERMEDIATE_DIR)/v8constants.h'
               ],
               'outputs': [
-                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace_ustack.o'
+                '<(obj_dir)/<(node_lib_target_name)/src/node_dtrace_ustack.o'
               ],
               'conditions': [
                 [ 'target_arch=="ia32" or target_arch=="arm"', {
@@ -915,32 +915,32 @@
       ],
 
       'variables': {
-        'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src',
-        'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/gen',
-        'OBJ_TRACING_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src/tracing',
-        'OBJ_SUFFIX': 'o',
-        'OBJ_SEPARATOR': '/',
+        'obj_path': '<(obj_dir)/<(node_lib_target_name)/src',
+        'obj_gen_path': '<(obj_dir)/<(node_lib_target_name)/gen',
+        'obj_tracing_path': '<(obj_dir)/<(node_lib_target_name)/src/tracing',
+        'obj_suffix': 'o',
+        'obj_separator': '/',
         'conditions': [
           ['OS=="win"', {
-            'OBJ_SUFFIX': 'obj',
+            'obj_suffix': 'obj',
           }],
           ['GENERATOR=="ninja"', {
-            'OBJ_PATH': '<(OBJ_DIR)/src',
-            'OBJ_GEN_PATH': '<(OBJ_DIR)/gen',
-            'OBJ_TRACING_PATH': '<(OBJ_DIR)/src/tracing',
-            'OBJ_SEPARATOR': '/<(node_lib_target_name).',
+            'obj_path': '<(obj_dir)/src',
+            'obj_gen_path': '<(obj_dir)/gen',
+            'obj_tracing_path': '<(obj_dir)/src/tracing',
+            'obj_separator': '/<(node_lib_target_name).',
           }, {
             'conditions': [
               ['OS=="win"', {
-                'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
-                'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
-                'OBJ_TRACING_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
+                'obj_path': '<(obj_dir)/<(node_lib_target_name)',
+                'obj_gen_path': '<(obj_dir)/<(node_lib_target_name)',
+                'obj_tracing_path': '<(obj_dir)/<(node_lib_target_name)',
               }],
               ['OS=="aix"', {
-                'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src',
-                'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/gen',
-                'OBJ_TRACING_PATH':
-                  '<(OBJ_DIR)/<(node_lib_target_name)/src/tracing',
+                'obj_path': '<(obj_dir)/<(node_lib_target_name)/src',
+                'obj_gen_path': '<(obj_dir)/<(node_lib_target_name)/gen',
+                'obj_tracing_path':
+                  '<(obj_dir)/<(node_lib_target_name)/src/tracing',
               }],
             ]}
           ]
@@ -974,26 +974,26 @@
       ],
 
       'libraries': [
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)async_wrap.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)handle_wrap.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)env.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_buffer.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_debug_options.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_i18n.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_perf.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_platform.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_url.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)util.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)string_bytes.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)string_search.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)stream_base.<(OBJ_SUFFIX)',
-        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_constants.<(OBJ_SUFFIX)',
-        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)agent.<(OBJ_SUFFIX)',
-        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_buffer.<(OBJ_SUFFIX)',
-        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_writer.<(OBJ_SUFFIX)',
-        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)trace_event.<(OBJ_SUFFIX)',
-        '<(OBJ_GEN_PATH)<(OBJ_SEPARATOR)node_javascript.<(OBJ_SUFFIX)',
+        '<(obj_path)<(obj_separator)async_wrap.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)handle_wrap.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)env.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_buffer.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_debug_options.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_i18n.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_perf.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_platform.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_url.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)util.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)string_bytes.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)string_search.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)stream_base.<(obj_suffix)',
+        '<(obj_path)<(obj_separator)node_constants.<(obj_suffix)',
+        '<(obj_tracing_path)<(obj_separator)agent.<(obj_suffix)',
+        '<(obj_tracing_path)<(obj_separator)node_trace_buffer.<(obj_suffix)',
+        '<(obj_tracing_path)<(obj_separator)node_trace_writer.<(obj_suffix)',
+        '<(obj_tracing_path)<(obj_separator)trace_event.<(obj_suffix)',
+        '<(obj_gen_path)<(obj_separator)node_javascript.<(obj_suffix)',
       ],
 
       'conditions': [
@@ -1001,10 +1001,10 @@
           'conditions': [
             ['node_target_type!="static_library"', {
               'libraries': [
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_crypto.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_crypto_bio.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_crypto_clienthello.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)tls_wrap.<(OBJ_SUFFIX)',
+                '<(obj_path)<(obj_separator)node_crypto.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)node_crypto_bio.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)node_crypto_clienthello.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)tls_wrap.<(obj_suffix)',
               ],
             }],
           ],
@@ -1015,9 +1015,9 @@
         [ 'node_use_perfctr=="true"', {
           'defines': [ 'HAVE_PERFCTR=1' ],
           'libraries': [
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_counters.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)'
-              'node_win32_perfctr_provider.<(OBJ_SUFFIX)',
+            '<(obj_path)<(obj_separator)node_counters.<(obj_suffix)',
+            '<(obj_path)<(obj_separator)'
+              'node_win32_perfctr_provider.<(obj_suffix)',
           ],
         }],
         ['v8_enable_inspector==1', {
@@ -1028,11 +1028,11 @@
           'conditions': [
             ['node_target_type!="static_library"', {
               'libraries': [
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)inspector_agent.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)inspector_io.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)inspector_js_api.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)inspector_socket.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)inspector_socket_server.<(OBJ_SUFFIX)',
+                '<(obj_path)<(obj_separator)inspector_agent.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)inspector_io.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)inspector_js_api.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)inspector_socket.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)inspector_socket_server.<(obj_suffix)',
               ],
             }],
           ],
@@ -1042,19 +1042,19 @@
         }],
         [ 'node_use_dtrace=="true" and node_target_type!="static_library"', {
           'libraries': [
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_dtrace.<(OBJ_SUFFIX)',
+            '<(obj_path)<(obj_separator)node_dtrace.<(obj_suffix)',
           ],
           'conditions': [
             ['OS!="mac" and OS!="linux"', {
               'libraries': [
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_dtrace_provider.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_dtrace_ustack.<(OBJ_SUFFIX)',
+                '<(obj_path)<(obj_separator)node_dtrace_provider.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)node_dtrace_ustack.<(obj_suffix)',
               ]
             }],
             ['OS=="linux"', {
               'libraries': [
-                '<(SHARED_INTERMEDIATE_DIR)<(OBJ_SEPARATOR)'
-                  'node_dtrace_provider.<(OBJ_SUFFIX)',
+                '<(SHARED_INTERMEDIATE_DIR)<(obj_separator)'
+                  'node_dtrace_provider.<(obj_suffix)',
               ]
             }],
           ],
@@ -1062,22 +1062,22 @@
           'conditions': [
             [ 'node_use_etw=="true" and OS=="win"', {
               'libraries': [
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_dtrace.<(OBJ_SUFFIX)',
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)'
-                  'node_win32_etw_provider.<(OBJ_SUFFIX)',
+                '<(obj_path)<(obj_separator)node_dtrace.<(obj_suffix)',
+                '<(obj_path)<(obj_separator)'
+                  'node_win32_etw_provider.<(obj_suffix)',
               ],
             }]
           ]
         }],
         [ 'OS=="win" and node_target_type!="static_library"', {
           'libraries': [
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)backtrace_win32.<(OBJ_SUFFIX)',
+            '<(obj_path)<(obj_separator)backtrace_win32.<(obj_suffix)',
           ],
         }, {
           'conditions': [
             ['node_target_type!="static_library"', {
               'libraries': [
-                '<(OBJ_PATH)<(OBJ_SEPARATOR)backtrace_posix.<(OBJ_SUFFIX)',
+                '<(obj_path)<(obj_separator)backtrace_posix.<(obj_suffix)',
               ],
             }],
           ],

--- a/node.gypi
+++ b/node.gypi
@@ -99,7 +99,7 @@
         [ 'force_load=="true"', {
           'xcode_settings': {
             'OTHER_LDFLAGS': [
-              '-Wl,-force_load,<(V8_BASE)',
+              '-Wl,-force_load,<(v8_base)',
             ],
           },
         }],
@@ -154,7 +154,7 @@
             {
               'action_name': 'expfile',
               'inputs': [
-                '<(OBJ_DIR)'
+                '<(obj_dir)'
               ],
               'outputs': [
                 '<(PRODUCT_DIR)/node.exp'
@@ -186,13 +186,13 @@
     [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
         ' and coverage=="false" and force_load=="true"', {
       'ldflags': [ '-Wl,-z,noexecstack',
-                   '-Wl,--whole-archive <(V8_BASE)',
+                   '-Wl,--whole-archive <(v8_base)',
                    '-Wl,--no-whole-archive' ]
     }],
     [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
         ' and coverage=="true" and force_load=="true"', {
       'ldflags': [ '-Wl,-z,noexecstack',
-                   '-Wl,--whole-archive <(V8_BASE)',
+                   '-Wl,--whole-archive <(v8_base)',
                    '-Wl,--no-whole-archive',
                    '--coverage',
                    '-g',
@@ -237,15 +237,15 @@
             [ 'force_load=="true"', {
               'xcode_settings': {
                 'OTHER_LDFLAGS': [
-                  '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
+                  '-Wl,-force_load,<(PRODUCT_DIR)/<(openssl_product)',
                 ],
               },
               'conditions': [
                 ['OS in "linux freebsd" and node_shared=="false"', {
                   'ldflags': [
                     '-Wl,--whole-archive,'
-                        '<(OBJ_DIR)/deps/openssl/'
-                        '<(OPENSSL_PRODUCT)',
+                        '<(obj_dir)/deps/openssl/'
+                        '<(openssl_product)',
                     '-Wl,--no-whole-archive',
                   ],
                 }],

--- a/test/addons/openssl-client-cert-engine/binding.gyp
+++ b/test/addons/openssl-client-cert-engine/binding.gyp
@@ -14,7 +14,7 @@
           'include_dirs': ['../../../deps/openssl/openssl/include'],
           'link_settings': {
             'libraries': [
-              '../../../../out/<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)'
+              '../../../../out/<(PRODUCT_DIR)/<(openssl_product)'
             ]
           },
         }]


### PR DESCRIPTION
I mistakenly introduced user defined variables using uppercase
characters, reading the gyp documentation they state:
"Predefined variables. By convention, these are named with
CAPITAL_LETTERS. Predefined variables are set automatically by GYP"
and also "By convention, user-defined variables are named with
lowercase_letters."

This commit renames the user defined variables to lowercase to follow
the above mentioned convention.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build