### PR TITLE
build: use bin path override if no python is found in PATH

### DIFF
--- a/configure
+++ b/configure
@@ -1357,7 +1357,9 @@ def get_bin_override():
   # sys.executable. This directory will be prefixed to the PATH, so that
   # other tools that shell out to `python` will use the appropriate python
 
-  if os.path.realpath(which('python')) == os.path.realpath(sys.executable):
+  which_python = which('python')
+  if (which_python and 
+      os.path.realpath(which_python) == os.path.realpath(sys.executable)):
     return
 
   bin_override = os.path.abspath('out/tools/bin')


### PR DESCRIPTION
On systems with no "python" in the PATH, e.g. when building with poudriere on FreeBSD, we should always create a python symlink in get_bin_override(). Otherwise, configure fails with the following error:

```
Traceback (most recent call last):
  File "./configure", line 1461, in <module>
    bin_override = get_bin_override()
  File "./configure", line 1360, in get_bin_override
    if os.path.realpath(which('python')) == os.path.realpath(sys.executable):
  File "/usr/local/lib/python2.7/posixpath.py", line 375, in realpath
    path, ok = _joinrealpath('', filename, {})
  File "/usr/local/lib/python2.7/posixpath.py", line 381, in _joinrealpath
    if isabs(rest):
  File "/usr/local/lib/python2.7/posixpath.py", line 54, in isabs
    return s.startswith('/')
AttributeError: 'NoneType' object has no attribute 'startswith'
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build