### PR TITLE
repl: deprecate REPLServer.prototype.memory

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -728,6 +728,15 @@ Type: Runtime
 deprecated. Please use `fs.ftruncate()` or `fs.ftruncateSync()` to work with
 file descriptors.
 
+<a id="DEP00XX"></a>
+### DEP00XX: REPLServer.prototype.memory()
+
+Type: Runtime
+
+`REPLServer.prototype.memory()` is a function only necessary for the
+internal mechanics of the `REPLServer` itself, and is therefore not
+necessary in user space.
+
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -460,7 +460,7 @@ function REPLServer(prompt,
         self.line = prefix;
         self.cursor = prefix.length;
       }
-      self.memory(cmd);
+      _memory.call(self, cmd);
       return;
     }
 
@@ -493,7 +493,7 @@ function REPLServer(prompt,
 
     function finish(e, ret) {
       debug('finish', e, ret);
-      self.memory(cmd);
+      _memory.call(self, cmd);
 
       if (e && !self[kBufferedCommandSymbol] && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
@@ -1113,9 +1113,13 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   this.commands[keyword] = cmd;
 };
 
-REPLServer.prototype.memory = function memory(cmd) {
-  var self = this;
+REPLServer.prototype.memory = util.deprecate(
+  _memory,
+  'REPLServer.memory() is deprecated',
+  'DEP00XX');
 
+function _memory(cmd) {
+  const self = this;
   self.lines = self.lines || [];
   self.lines.level = self.lines.level || [];
 
@@ -1185,7 +1189,7 @@ REPLServer.prototype.memory = function memory(cmd) {
   } else {
     self.lines.level = [];
   }
-};
+}
 
 function addStandardGlobals(completionGroups, filter) {
   // Global object properties

--- a/test/parallel/test-repl-memory-deprecation.js
+++ b/test/parallel/test-repl-memory-deprecation.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+
+testMemory();
+
+function testMemory() {
+  const server = repl.start({ prompt: '> ' });
+  const warn = 'REPLServer.memory() is deprecated';
+
+  common.expectWarning('DeprecationWarning', warn);
+  assert.strictEqual(server.memory(), undefined);
+  server.close();
+}


### PR DESCRIPTION
This method is only useful for the internal mechanics of the REPLServer
and does not need to be exposed in user space. It was previously not
documented, so I believe a Runtime deprecation makes sense.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl, doc
