### PR TITLE
[v8.x backport] crypto: expose ECDH class

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -67,7 +67,6 @@ function toBuf(str, encoding) {
 }
 exports._toBuf = toBuf;
 
-
 const assert = require('assert');
 const StringDecoder = require('string_decoder').StringDecoder;
 
@@ -559,16 +558,15 @@ DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
 };
 
 
+exports.createECDH = exports.ECDH = ECDH;
 function ECDH(curve) {
+  if (!(this instanceof ECDH))
+    return new ECDH(curve);
   if (typeof curve !== 'string')
     throw new TypeError('"curve" argument should be a string');
 
   this._handle = new binding.ECDH(curve);
 }
-
-exports.createECDH = function createECDH(curve) {
-  return new ECDH(curve);
-};
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
 ECDH.prototype.setPrivateKey = DiffieHellman.prototype.setPrivateKey;

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -18,6 +18,7 @@ const TEST_CASES = {
   'Verify': ['RSA-SHA1'],
   'DiffieHellman': [1024],
   'DiffieHellmanGroup': ['modp5'],
+  'ECDH': ['prime256v1'],
   'Credentials': []
 };
 

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -1,0 +1,31 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+  return;
+}
+const crypto = require('crypto');
+
+// 'ClassName' : ['args', 'for', 'constructor']
+const TEST_CASES = {
+  'Hash': ['sha1'],
+  'Hmac': ['sha1', 'Node'],
+  'Cipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
+  'Decipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
+  'Sign': ['RSA-SHA1'],
+  'Verify': ['RSA-SHA1'],
+  'DiffieHellman': [1024],
+  'DiffieHellmanGroup': ['modp5'],
+  'Credentials': []
+};
+
+if (!common.hasFipsCrypto) {
+  TEST_CASES.Cipher = ['aes192', 'secret'];
+  TEST_CASES.Decipher = ['aes192', 'secret'];
+}
+
+for (const [clazz, args] of Object.entries(TEST_CASES)) {
+  assert(crypto[`create${clazz}`](...args) instanceof crypto[clazz]);
+}

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -25,6 +25,7 @@ const TEST_CASES = {
 if (!common.hasFipsCrypto) {
   TEST_CASES.Cipher = ['aes192', 'secret'];
   TEST_CASES.Decipher = ['aes192', 'secret'];
+  TEST_CASES.DiffieHellman = [256];
 }
 
 for (const [clazz, args] of Object.entries(TEST_CASES)) {


### PR DESCRIPTION
Backport of #8188 and #15662 for v8.x. Should also land cleanly on v6.x.

Note that the non-test commit in #8188 is rewritten so as to be back-portable.

/cc @MylesBorins 