### PR TITLE
test: http2 util passing array in te header

### DIFF
--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -360,8 +360,7 @@ function isIllegalConnectionSpecificHeader(name, value) {
     case HTTP2_HEADER_TRANSFER_ENCODING:
       return true;
     case HTTP2_HEADER_TE:
-      const val = Array.isArray(value) ? value.join(', ') : value;
-      return val !== 'trailers';
+      return value !== 'trailers';
     default:
       return false;
   }

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -266,5 +266,10 @@ common.expectsError({
   message: regex
 })(mapToHeaders({ [HTTP2_HEADER_TE]: ['abc'] }));
 
+common.expectsError({
+  code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
+  message: regex
+})(mapToHeaders({ [HTTP2_HEADER_TE]: ['abc', 'trailers'] }));
+
 assert(!(mapToHeaders({ te: 'trailers' }) instanceof Error));
 assert(!(mapToHeaders({ te: ['trailers'] }) instanceof Error));


### PR DESCRIPTION
This adds a test case in which array with two values is passed to param value in isIllegalConnectionSpecificHeader: https://github.com/nodejs/node/blob/212de3c5ec429a580d2e79ce3c2516b93b52b8f5/lib/internal/http2/util.js#L363

Refs: https://github.com/nodejs/node/issues/14985

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test, http2
