### PR TITLE
util: allow to disable only custom inspect "named" method

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -313,9 +313,13 @@ changes:
   * `colors` {boolean} If `true`, the output will be styled with ANSI color
     codes. Defaults to `false`. Colors are customizable, see
     [Customizing `util.inspect` colors][].
-  * `customInspect` {boolean} If `false`, then custom `inspect(depth, opts)`
-    functions exported on the `object` being inspected will not be called.
-    Defaults to `true`.
+  * `customInspect` {boolean} If `false`, then custom functions exported
+    by the `object` being inspected, either with the `inspect` name or with
+    the `inspect.custom` Symbol, will not be called to generate it's
+    inspected value. Defaults to `true`.
+  * `customInspectMethod` {boolean} If `false`, then the  custom inspect
+    method exported by `inspect` name on the `object` being inspected will
+    not be called. Defaults to `true`.
   * `showProxy` {boolean} If `true`, then objects and functions that are
     `Proxy` objects will be introspected to show their `target` and `handler`
     objects. Defaults to `false`.

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,6 +62,7 @@ const inspectDefaultOptions = Object.seal({
   depth: 2,
   colors: false,
   customInspect: true,
+  customInspectMethod: true,
   showProxy: false,
   maxArrayLength: 100,
   breakLength: 60
@@ -296,6 +297,7 @@ function inspect(obj, opts) {
     depth: inspectDefaultOptions.depth,
     colors: inspectDefaultOptions.colors,
     customInspect: inspectDefaultOptions.customInspect,
+    customInspectMethod: inspectDefaultOptions.customInspectMethod,
     showProxy: inspectDefaultOptions.showProxy,
     maxArrayLength: inspectDefaultOptions.maxArrayLength,
     breakLength: inspectDefaultOptions.breakLength,
@@ -420,7 +422,10 @@ function formatValue(ctx, value, recurseTimes, ln) {
   // Provide a hook for user-specified inspect functions.
   // Check that value is an object with an inspect function on it
   if (ctx.customInspect) {
-    const maybeCustomInspect = value[customInspectSymbol] || value.inspect;
+    let maybeCustomInspect = value[customInspectSymbol];
+    if (!maybeCustomInspect && ctx.customInspectMethod && 'inspect' in value) {
+      maybeCustomInspect = value.inspect;
+    }
 
     if (typeof maybeCustomInspect === 'function' &&
         // Filter out the util module, its inspect function is special

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -681,6 +681,16 @@ assert.doesNotThrow(() => {
     true
   );
 
+  // "customInspectMethod" option can disable calling inspect() on objects
+  assert.strictEqual(
+    util.inspect(subject, { customInspectMethod: false }).includes('123'),
+    false
+  );
+  assert.strictEqual(
+    util.inspect(subject, { customInspectMethod: false }).includes('inspect'),
+    true
+  );
+
   // custom inspect() functions should be able to return other Objects
   subject.inspect = () => ({ foo: 'bar' });
 
@@ -704,6 +714,12 @@ assert.doesNotThrow(() => {
   assert.strictEqual(
     util.inspect(subject, { customInspect: false }).includes('123'),
     false
+  );
+
+  // "customInspectMethod: false" should not override the Symbol
+  assert.strictEqual(
+    util.inspect(subject, { customInspectMethod: false }).includes('123'),
+    true
   );
 
   // a custom [util.inspect.custom]() should be able to return other Objects


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/15549
Refs: https://github.com/nodejs/node/pull/15631

This add a switch that allows disabling just the "named" custom inspect method.
Except for the immediate benefit, this also allows future deprecation by defaulting to `false` and warning only on changing the default. Or allowing to turn this off so that deprecation warning will not be emitted.

CI: https://ci.nodejs.org/job/node-test-pull-request/10791/
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util
