### PR TITLE
Make tests engine agnostic

### DIFF
--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -34,7 +34,9 @@ try {
   assert.strictEqual(
     SlowBuffer(buffer.kMaxLength).length, buffer.kMaxLength);
 } catch (e) {
-  assert.strictEqual(e.message, 'Array buffer allocation failed');
+  // Don't match on message as it is from the JavaScript engine. V8 and
+  // ChakraCore provide different messages.
+  assert.strictEqual(e.name, 'RangeError');
 }
 
 // should work with number-coercible values

--- a/test/parallel/test-cli-syntax.js
+++ b/test/parallel/test-cli-syntax.js
@@ -13,7 +13,9 @@ const syntaxArgs = [
   ['--check']
 ];
 
-const syntaxErrorRE = /^SyntaxError: Unexpected identifier$/m;
+// Match on the name of the `Error` but not the message as it is different
+// depending on the JavaScript engine.
+const syntaxErrorRE = /^SyntaxError: \b/m;
 const notFoundRE = /^Error: Cannot find module/m;
 
 // test good syntax with and without shebang

--- a/test/parallel/test-console-count.js
+++ b/test/parallel/test-console-count.js
@@ -54,10 +54,12 @@ assert.strictEqual(buf, 'default: 2\n');
 
 process.stdout.write = stdoutWrite;
 
-// Symbol labels do not work
+// Symbol labels do not work. Only check that the `Error` is a `TypeError`. Do
+// not check the message because it is different depending on the JavaScript
+// engine.
 assert.throws(
   () => console.count(Symbol('test')),
-  /^TypeError: Cannot convert a Symbol value to a string$/);
+  TypeError);
 assert.throws(
   () => console.countReset(Symbol('test')),
-  /^TypeError: Cannot convert a Symbol value to a string$/);
+  TypeError);

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -42,10 +42,12 @@ assert.doesNotThrow(function() {
   console.timeEnd('label');
 });
 
+// Check that the `Error` is a `TypeError` but do not check the message as it
+// will be different in different JavaScript engines.
 assert.throws(() => console.time(Symbol('test')),
-              /^TypeError: Cannot convert a Symbol value to a string$/);
+              TypeError);
 assert.throws(() => console.timeEnd(Symbol('test')),
-              /^TypeError: Cannot convert a Symbol value to a string$/);
+              TypeError);
 
 
 // an Object with a custom .inspect() function

--- a/test/parallel/test-error-reporting.js
+++ b/test/parallel/test-error-reporting.js
@@ -32,17 +32,14 @@ function errExec(script, callback) {
     assert.ok(err);
 
     // More than one line of error output.
-    assert.ok(stderr.split('\n').length > 2);
-
-    // Assert the script is mentioned in error output.
-    assert.ok(stderr.includes(script));
+    assert.ok(stderr.split('\n').length);
 
     // Proxy the args for more tests.
     callback(err, stdout, stderr);
   });
 }
 
-const syntaxErrorMessage = /SyntaxError/;
+const syntaxErrorMessage = /\bSyntaxError\b/;
 
 
 // Simple throw error
@@ -65,7 +62,6 @@ errExec('throws_error3.js', common.mustCall(function(err, stdout, stderr) {
 
 // throw ILLEGAL error
 errExec('throws_error4.js', common.mustCall(function(err, stdout, stderr) {
-  assert.ok(/\/\*\*/.test(stderr));
   assert.ok(syntaxErrorMessage.test(stderr));
 }));
 

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -96,11 +96,14 @@ assert.throws(() => {
   message: 'The first argument must be one of type string or buffer'
 }));
 
-// addTrailers
+// addTrailers()
+// The `Error` comes from the JavaScript engine so confirm that it is a
+// `TypeError` but do not check the message. It will be different in different
+// JavaScript engines.
 assert.throws(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.addTrailers();
-}, /^TypeError: Cannot convert undefined or null to object$/);
+}, TypeError);
 
 assert.throws(() => {
   const outgoingMessage = new OutgoingMessage();

--- a/test/parallel/test-internal-util-decorate-error-stack.js
+++ b/test/parallel/test-internal-util-decorate-error-stack.js
@@ -24,11 +24,16 @@ const obj = {};
 decorateErrorStack(obj);
 assert.strictEqual(obj.stack, undefined);
 
-// Verify that the stack is decorated when possible
+// Verify that the stack is decorated when possible.
 function checkStack(stack) {
-  const matches = stack.match(/var foo bar;/g);
-  assert.strictEqual(Array.isArray(matches), true);
-  assert.strictEqual(matches.length, 1);
+  // Matching only on a minimal piece of the stack because the string will vary
+  // greatly depending on the JavaScript engine. V8 includes `;` because it
+  // displays the line of code (`var foo bar;`) that is causing a problem.
+  // ChakraCore does not display the line of code but includes `;` in the phrase
+  // `Expected ';' `.
+  assert.ok(/;/g.test(stack));
+  // Test that it's a multiline string.
+  assert.ok(/\n/g.test(stack));
 }
 let err;
 const badSyntaxPath =

--- a/test/parallel/test-os-eol.js
+++ b/test/parallel/test-os-eol.js
@@ -8,12 +8,9 @@ const eol = common.isWindows ? '\r\n' : '\n';
 
 assert.strictEqual(os.EOL, eol);
 
-common.expectsError(function() {
-  os.EOL = 123;
-}, {
-  type: TypeError,
-  message: /^Cannot assign to read only property 'EOL' of object '#<Object>'$/
-});
+// Test that the `Error` is a `TypeError` but do not check the message as it
+// varies between different JavaScript engines.
+assert.throws(function() { os.EOL = 123; }, TypeError);
 
 const foo = 'foo';
 Object.defineProperties(os, {

--- a/test/parallel/test-process-env-symbols.js
+++ b/test/parallel/test-process-env-symbols.js
@@ -3,20 +3,23 @@ require('../common');
 
 const assert = require('assert');
 const symbol = Symbol('sym');
-const errRegExp = /^TypeError: Cannot convert a Symbol value to a string$/;
 
 // Verify that getting via a symbol key returns undefined.
 assert.strictEqual(process.env[symbol], undefined);
 
 // Verify that assigning via a symbol key throws.
+// The message depends on the JavaScript engine and so will be different between
+// different JavaScript engines. Confirm that the `Error` is a `TypeError` only.
 assert.throws(() => {
   process.env[symbol] = 42;
-}, errRegExp);
+}, TypeError);
 
 // Verify that assigning a symbol value throws.
+// The message depends on the JavaScript engine and so will be different between
+// different JavaScript engines. Confirm that the `Error` is a `TypeError` only.
 assert.throws(() => {
   process.env.foo = symbol;
-}, errRegExp);
+}, TypeError);
 
 // Verify that using a symbol with the in operator returns false.
 assert.strictEqual(symbol in process.env, false);

--- a/test/parallel/test-querystring-escape.js
+++ b/test/parallel/test-querystring-escape.js
@@ -28,12 +28,14 @@ assert.strictEqual(
   'test'
 );
 
-// toString is not callable, must throw an error
-assert.throws(() => qs.escape({ toString: 5 }),
-              /^TypeError: Cannot convert object to primitive value$/);
+// `toString` is not callable, must throw an error.
+// Error message will vary between different JavaScript engines, so only check
+// that it is a `TypeError`.
+assert.throws(() => qs.escape({ toString: 5 }), TypeError);
 
-// should use valueOf instead of non-callable toString
+// Should use valueOf instead of non-callable toString.
 assert.strictEqual(qs.escape({ toString: 5, valueOf: () => 'test' }), 'test');
 
-assert.throws(() => qs.escape(Symbol('test')),
-              /^TypeError: Cannot convert a Symbol value to a string$/);
+// Error message will vary between different JavaScript engines, so only check
+// that it is a `TypeError`.
+assert.throws(() => qs.escape(Symbol('test')), TypeError);

--- a/test/parallel/test-repl-harmony.js
+++ b/test/parallel/test-repl-harmony.js
@@ -28,7 +28,9 @@ const args = ['-i'];
 const child = spawn(process.execPath, args);
 
 const input = '(function(){"use strict"; const y=1;y=2})()\n';
-const expectOut = /^> TypeError: Assignment to constant variable\.\n/;
+// This message will vary based on JavaScript engine, so don't check the message
+// contents beyond confirming that the `Error` is a `TypeError`.
+const expectOut = /^> TypeError: /;
 
 child.stderr.setEncoding('utf8');
 child.stderr.on('data', function(c) {

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -11,7 +11,12 @@ process.on('exit', () => {
 });
 
 common.ArrayStream.prototype.write = function(output) {
-  if (/var foo bar;/.test(output))
+  // Matching only on a minimal piece of the stack because the string will vary
+  // greatly depending on the JavaScript engine. V8 includes `;` because it
+  // displays the line of code (`var foo bar;`) that is causing a problem.
+  // ChakraCore does not display the line of code but includes `;` in the phrase
+  // `Expected ';' `.
+  if (/;/.test(output))
     found = true;
 };
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -72,7 +72,7 @@ function clean_up() {
 function strict_mode_error_test() {
   send_expect([
     { client: client_unix, send: 'ref = 1',
-      expect: /^ReferenceError:\sref\sis\snot\sdefined\nnode via Unix socket> $/ },
+      expect: /^ReferenceError:\s/ },
   ]);
 }
 
@@ -143,7 +143,7 @@ function error_test() {
       expect: prompt_unix },
     // But passing the same string to eval() should throw
     { client: client_unix, send: 'eval("function test_func() {")',
-      expect: /^SyntaxError: Unexpected end of input/ },
+      expect: /^SyntaxError: / },
     // Can handle multiline template literals
     { client: client_unix, send: '`io.js',
       expect: prompt_multiline },
@@ -172,51 +172,48 @@ function error_test() {
     // invalid input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{invalid: \\\'json\\\'}\');',
-      expect: /^SyntaxError: Unexpected token i/ },
+      expect: /^SyntaxError: / },
     // end of input to JSON.parse error is special case of syntax error,
     // should throw
     { client: client_unix, send: 'JSON.parse(\'066\');',
-      expect: /^SyntaxError: Unexpected number/ },
+      expect: /^SyntaxError: / },
     // should throw
     { client: client_unix, send: 'JSON.parse(\'{\');',
-      expect: /^SyntaxError: Unexpected end of JSON input/ },
+      expect: /^SyntaxError: / },
     // invalid RegExps are a special case of syntax error,
     // should throw
     { client: client_unix, send: '/(/;',
-      expect: /^SyntaxError: Invalid regular expression:/ },
+      expect: /^SyntaxError: / },
     // invalid RegExp modifiers are a special case of syntax error,
     // should throw (GH-4012)
     { client: client_unix, send: 'new RegExp("foo", "wrong modifier");',
-      expect: /^SyntaxError: Invalid flags supplied to RegExp constructor/ },
+      expect: /^SyntaxError: / },
     // strict mode syntax errors should be caught (GH-5178)
     { client: client_unix,
       send: '(function() { "use strict"; return 0755; })()',
-      expect: /\bSyntaxError: Octal literals are not allowed in strict mode/ },
+      expect: /\bSyntaxError: / },
     {
       client: client_unix,
       send: '(function(a, a, b) { "use strict"; return a + b + c; })()',
-      expect:
-        /\bSyntaxError: Duplicate parameter name not allowed in this context/
+      expect: /\bSyntaxError: /
     },
     {
       client: client_unix,
       send: '(function() { "use strict"; with (this) {} })()',
-      expect: /\bSyntaxError: Strict mode code may not include a with statement/
+      expect: /\bSyntaxError: /
     },
     {
       client: client_unix,
       send: '(function() { "use strict"; var x; delete x; })()',
-      expect:
-        /\bSyntaxError: Delete of an unqualified identifier in strict mode/
+      expect: /\bSyntaxError: /
     },
     { client: client_unix,
       send: '(function() { "use strict"; eval = 17; })()',
-      expect: /\bSyntaxError: Unexpected eval or arguments in strict mode/ },
+      expect: /\bSyntaxError: / },
     {
       client: client_unix,
       send: '(function() { "use strict"; if (true) function f() { } })()',
-      expect:
-        /\bSyntaxError: In strict mode code, functions can only be declared at top level or inside a block\./
+      expect: /\bSyntaxError: /
     },
     // Named functions can be used:
     { client: client_unix, send: 'function blah() { return 1; }',
@@ -268,7 +265,7 @@ function error_test() {
       expect: `Invalid REPL keyword\n${prompt_unix}` },
     // fail when we are not inside a String and a line continuation is used
     { client: client_unix, send: '[] \\',
-      expect: /\bSyntaxError: Invalid or unexpected token/ },
+      expect: /\bSyntaxError: / },
     // do not fail when a String is created with line continuation
     { client: client_unix, send: '\'the\\\nfourth\\\neye\'',
       expect: `${prompt_multiline}${prompt_multiline}'thefourtheye'\n${

--- a/test/parallel/test-require-json.js
+++ b/test/parallel/test-require-json.js
@@ -28,7 +28,6 @@ try {
   require(fixtures.path('invalid.json'));
 } catch (err) {
   assert.ok(
-    /test[/\\]fixtures[/\\]invalid\.json: Unexpected string/.test(err.message),
-    `require() json error should include path - currently: ${err.message}`
-  );
+    /test[/\\]fixtures[/\\]invalid\.json: /.test(err.message),
+    `require() json error should include path: ${err.message}`);
 }

--- a/test/parallel/test-tls-external-accessor.js
+++ b/test/parallel/test-tls-external-accessor.js
@@ -11,12 +11,12 @@ const tls = require('tls');
 {
   const pctx = tls.createSecureContext().context;
   const cctx = Object.create(pctx);
-  assert.throws(() => cctx._external, /incompatible receiver/);
+  assert.throws(() => cctx._external, TypeError);
   pctx._external;
 }
 {
   const pctx = tls.createSecurePair().credentials.context;
   const cctx = Object.create(pctx);
-  assert.throws(() => cctx._external, /incompatible receiver/);
+  assert.throws(() => cctx._external, TypeError);
   pctx._external;
 }


### PR DESCRIPTION
We treat error message changes as breaking changes and therefore often test for exact error messages. However, this only applies to errors generated by Node.js core. For errors generated by V8, the TSC has determined that we do not consider it a breaking change when an error message changes.

We have a relatively easy way to find these errors in our tests because ChakraCore will often (usually? almost always?) need to modify such tests to match their error messages.

This PR changes several tests that node-chakracore needed to modify due to the overzealous error message checking (much of which I may have been responsible for either directly or indirectly, but hey, we all get to learn from our mistakes).

There are still more tests to be done, but this is a good start and reaction to this will inform the approach in the rest of the tests.

@nodejs/chakracore @nodejs/testing 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test