### PR TITLE
aix,test: skip test due to file size limit

### DIFF
--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -8,7 +8,10 @@ if (!common.enoughTestMem)
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const cp = require('child_process');
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
+if (common.isAIX && Number(cp.execSync('ulimit -f')) < kStringMaxLength)
+  common.skip('intensive toString tests due to file size confinements');
 
 common.refreshTmpDir();
 

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
 const kStringMaxLength = process.binding('buffer').kStringMaxLength;
-if (common.isAIX && Number(cp.execSync('ulimit -f')) < kStringMaxLength)
+if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');
 
 common.refreshTmpDir();


### PR DESCRIPTION
The test requires a file size limit that is greater than the string
size limit. Some aix machines might not meet this criteria so in
which case we should skip the test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
