### PR TITLE
doc: clarify os.cpus() returns logical CPU cores

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -58,7 +58,7 @@ added: v0.3.3
 * Returns: {Array}
 
 The `os.cpus()` method returns an array of objects containing information about
-each CPU/core installed.
+each logical CPU core.
 
 The properties included on each object include:
 


### PR DESCRIPTION
Original text implied it returns physical cpu cores. This is misleading as `os.cpus().length` is often used to get the CPU core count in Node.js. In reality that will return the thread count which may not be what the user intended.

Fixes: https://github.com/nodejs/node/issues/16279