### PR TITLE
fs: remove no-longer-relevant comment

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -621,10 +621,6 @@ fs.readFileSync = function(path, options) {
   return buffer;
 };
 
-
-// Yes, the follow could be easily DRYed up but I provide the explicit
-// list to make the arguments clear.
-
 fs.close = function(fd, callback) {
   var req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);


### PR DESCRIPTION
The comment suggests that the subsequent code could by DRYed up, due to
simply passing arguments along. However, in the commits since then, this
no longer appears to apply, and so the comment is now confusing with
respect to the current code.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs