### PR TITLE
test: handle blank shells in test-os.js

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -208,7 +208,11 @@ if (common.isWindows) {
 } else {
   is.number(pwd.uid);
   is.number(pwd.gid);
-  assert.ok(pwd.shell.includes(path.sep));
+  assert.strictEqual(typeof pwd.shell, 'string');
+  // It's possible for /etc/passwd to leave the user's shell blank.
+  if (pwd.shell.length > 0) {
+    assert(pwd.shell.includes(path.sep));
+  }
   assert.strictEqual(pwd.uid, pwdBuf.uid);
   assert.strictEqual(pwd.gid, pwdBuf.gid);
   assert.strictEqual(pwd.shell, pwdBuf.shell.toString('utf8'));


### PR DESCRIPTION
The shell in /etc/passwd can be blank, in which case the user is given
the default shell. Handle this by only checking the shell contains a
path separator if the string isn't empty.

Fixes: https://github.com/nodejs/node/issues/15684

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test