### PR TITLE
deps: cherry-pick 37a3a15c3 from V8 upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.3',
+    'v8_embedder_string': '-node.4',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/lookup.h
+++ b/deps/v8/src/lookup.h
@@ -22,7 +22,7 @@ class V8_EXPORT_PRIVATE LookupIterator final BASE_EMBEDDED {
     kInterceptor = 1 << 0,
     kPrototypeChain = 1 << 1,
 
-    // Convience combinations of bits.
+    // Convenience combinations of bits.
     OWN_SKIP_INTERCEPTOR = 0,
     OWN = kInterceptor,
     PROTOTYPE_CHAIN_SKIP_INTERCEPTOR = kPrototypeChain,

--- a/deps/v8/test/cctest/test-api-interceptors.cc
+++ b/deps/v8/test/cctest/test-api-interceptors.cc
@@ -716,20 +716,21 @@ bool define_was_called_in_order = false;
 void GetterCallbackOrder(Local<Name> property,
                          const v8::PropertyCallbackInfo<v8::Value>& info) {
   get_was_called_in_order = true;
-  CHECK(define_was_called_in_order);
+  CHECK(!define_was_called_in_order);
   info.GetReturnValue().Set(property);
 }
 
 void DefinerCallbackOrder(Local<Name> property,
                           const v8::PropertyDescriptor& desc,
                           const v8::PropertyCallbackInfo<v8::Value>& info) {
-  CHECK(!get_was_called_in_order);  // Define called before get.
+  // Get called before DefineProperty because we query the descriptor first.
+  CHECK(get_was_called_in_order);
   define_was_called_in_order = true;
 }
 
 }  // namespace
 
-// Check that definer callback is called before getter callback.
+// Check that getter callback is called before definer callback.
 THREADED_TEST(DefinerCallbackGetAndDefine) {
   v8::HandleScope scope(CcTest::isolate());
   v8::Local<v8::FunctionTemplate> templ =


### PR DESCRIPTION
This is a backport of a fix for some V8 interceptor functions. I'd like to back port this so we can [fix the vm module](https://github.com/nodejs/node/pull/16293) in Node 9. What do you think? Or should we wait until V8 64 lands regularly? 

Original commit message:
  [api] Intercept DefineProperty after Descriptor query

  Analog to other interceptors, intercept the DefineProperty
  call only after obtaining the property descriptor.

  This behavior allows us to mirror calls on a sandboxed object
  as it is needed in Node. See for example
  https://github.com/nodejs/node/pull/13265

  Bug:
  Change-Id: I73b8f8908d13473939b37fb6727858d0bee6bda3
  Reviewed-on: https://chromium-review.googlesource.com/725295
  Reviewed-by: Andreas Haas <ahaas@chromium.org>
  Commit-Queue: Franziska Hinkelmann <franzih@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#48683}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
(https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps