### PR TITLE
test: fix flaky test-benchmark-buffer

### DIFF
--- a/test/sequential/test-benchmark-buffer.js
+++ b/test/sequential/test-benchmark-buffer.js
@@ -20,5 +20,5 @@ runBenchmark('buffers',
                'source=array',
                'type=',
                'withTotalLength=0'
-
-             ]);
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Allow zero operations for short buffer benchmark tests.

Should fix flaky CI as seen in https://ci.nodejs.org/job/node-test-commit-linux/13297/nodes=ubuntu1604-32/console:

```console
    buffers/buffer_zero.js
    /home/iojs/build/workspace/node-test-commit-linux/nodes/ubuntu1604-32/benchmark/common.js:202
          throw new Error('insufficient clock precision for short benchmark');
          ^
    
    Error: insufficient clock precision for short benchmark
        at Benchmark.end (/home/iojs/build/workspace/node-test-commit-linux/nodes/ubuntu1604-32/benchmark/common.js:202:13)
        at main (/home/iojs/build/workspace/node-test-commit-linux/nodes/ubuntu1604-32/benchmark/buffers/buffer_zero.js:22:9)
        at Benchmark.process.nextTick (/home/iojs/build/workspace/node-test-commit-linux/nodes/ubuntu1604-32/benchmark/common.js:34:28)
        at _combinedTickCallback (internal/process/next_tick.js:131:7)
        at process._tickCallback (internal/process/next_tick.js:180:9)
        at Function.Module.runMain (module.js:644:11)
        at startup (bootstrap_node.js:187:16)
        at bootstrap_node.js:605:3
    assert.js:45
      throw new errors.AssertionError({
      ^
    
    AssertionError [ERR_ASSERTION]: 1 === 0
        at ChildProcess.child.on (/home/iojs/build/workspace/node-test-commit-linux/nodes/ubuntu1604-32/test/common/benchmark.js:25:12)
        at emitTwo (events.js:136:13)
        at ChildProcess.emit (events.js:227:7)
        at Process.ChildProcess._handle.onexit (internal/child_process.js:209:12)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark buffer