### PR TITLE
util: adding a unit test to cover invalid code check in util.deprecate method

### DIFF
--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const common = require("../common");
+const assert = require("assert");
+const util = require("util");
+
+[1, true, false, null, {}].forEach(notString => {
+  common.expectsError(
+    () => {
+      util.deprecate(() => {}, "message", 123);
+    },
+    {
+      code: "ERR_INVALID_ARG_TYPE",
+      type: global.TypeError,
+      message: `The "code" argument must be of type string`
+    }
+  );
+});


### PR DESCRIPTION
Added a simple unit test that checks for assertion being thrown if code argument within util.deprecate method call is not a valid string (or undefined). This was a test gap as observed in the coverage file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util.deprecate