### PR TITLE
util: adding a unit test to cover invalid code check in util.deprecate method

### DIFF
--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const common = require('../common');
+const util = require('util');
+
+[1, true, false, null, {}].forEach((notString) => {
+  common.expectsError(() => util.deprecate(() => {}, 'message', notString), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "code" argument must be of type string'
+  });
+});


### PR DESCRIPTION
Added a unit test that verifies assertion if util.deprecate is called with a non-string code parameter.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util.deprecate
