### PR TITLE
[v6.x fix] lib: fix zlib async callback after close

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1102,7 +1102,11 @@ rapidly.
 In line with OpenSSL's recommendation to use pbkdf2 instead of
 [`EVP_BytesToKey`][] it is recommended that developers derive a key and IV on
 their own using [`crypto.pbkdf2()`][] and to use [`crypto.createCipheriv()`][]
-to create the `Cipher` object.
+to create the `Cipher` object. Users should not use ciphers with counter mode
+(e.g. CTR, GCM or CCM) in `crypto.createCipher()`. A warning is emitted when
+they are used in order to avoid the risk of IV reuse that causes
+vulnerabilities. For the case when IV is reused in GCM, see [Nonce-Disrespecting
+Adversaries][] for details.
 
 ### crypto.createCipheriv(algorithm, key, iv)
 
@@ -2024,6 +2028,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
 [NIST SP 800-132]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 [OpenSSL cipher list format]: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT
+[Nonce-Disrespecting Adversaries]: https://github.com/nonce-disrespect/nonce-disrespect
 [OpenSSL's SPKAC implementation]: https://www.openssl.org/docs/man1.0.2/apps/spkac.html
 [publicly trusted list of CAs]: https://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt
 [RFC 2412]: https://www.rfc-editor.org/rfc/rfc2412.txt

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -77,110 +77,6 @@ exports.writer = util.inspect;
 
 exports._builtinLibs = internalModule.builtinLibs;
 
-
-const BLOCK_SCOPED_ERROR = 'Block-scoped declarations (let, const, function, ' +
-                           'class) not yet supported outside strict mode';
-
-
-class LineParser {
-
-  constructor() {
-    this.reset();
-  }
-
-  reset() {
-    this._literal = null;
-    this.shouldFail = false;
-    this.blockComment = false;
-    this.regExpLiteral = false;
-    this.prevTokenChar = null;
-  }
-
-  parseLine(line) {
-    var previous = null;
-    this.shouldFail = false;
-    const wasWithinStrLiteral = this._literal !== null;
-
-    for (const current of line) {
-      if (previous === '\\') {
-        // valid escaping, skip processing. previous doesn't matter anymore
-        previous = null;
-        continue;
-      }
-
-      if (!this._literal) {
-        if (this.regExpLiteral && current === '/') {
-          this.regExpLiteral = false;
-          previous = null;
-          continue;
-        }
-        if (previous === '*' && current === '/') {
-          if (this.blockComment) {
-            this.blockComment = false;
-            previous = null;
-            continue;
-          } else {
-            this.shouldFail = true;
-            break;
-          }
-        }
-
-        // ignore rest of the line if `current` and `previous` are `/`s
-        if (previous === current && previous === '/' && !this.blockComment) {
-          break;
-        }
-
-        if (previous === '/') {
-          if (current === '*') {
-            this.blockComment = true;
-          } else if (
-            // Distinguish between a division operator and the start of a regex
-            // by examining the non-whitespace character that precedes the /
-            [null, '(', '[', '{', '}', ';'].includes(this.prevTokenChar)
-          ) {
-            this.regExpLiteral = true;
-          }
-          previous = null;
-        }
-      }
-
-      if (this.blockComment || this.regExpLiteral) continue;
-
-      if (current === this._literal) {
-        this._literal = null;
-      } else if (current === '\'' || current === '"') {
-        this._literal = this._literal || current;
-      }
-
-      if (current.trim() && current !== '/') this.prevTokenChar = current;
-
-      previous = current;
-    }
-
-    const isWithinStrLiteral = this._literal !== null;
-
-    if (!wasWithinStrLiteral && !isWithinStrLiteral) {
-      // Current line has nothing to do with String literals, trim both ends
-      line = line.trim();
-    } else if (wasWithinStrLiteral && !isWithinStrLiteral) {
-      // was part of a string literal, but it is over now, trim only the end
-      line = line.trimRight();
-    } else if (isWithinStrLiteral && !wasWithinStrLiteral) {
-      // was not part of a string literal, but it is now, trim only the start
-      line = line.trimLeft();
-    }
-
-    const lastChar = line.charAt(line.length - 1);
-
-    this.shouldFail = this.shouldFail ||
-                      ((!this._literal && lastChar === '\\') ||
-                      (this._literal && lastChar !== '\\'));
-
-    return line;
-  }
-}
-
-
 function REPLServer(prompt,
                     stream,
                     eval_,
@@ -232,8 +128,6 @@ function REPLServer(prompt,
   self.breakEvalOnSigint = !!breakEvalOnSigint;
   self.editorMode = false;
 
-  self._inTemplateLiteral = false;
-
   // just for backwards compat, see github.com/joyent/node/pull/7127
   self.rli = this;
 
@@ -245,69 +139,48 @@ function REPLServer(prompt,
 
   eval_ = eval_ || defaultEval;
 
-  function preprocess(code) {
-    let cmd = code;
-    if (/^\s*\{/.test(cmd) && /\}\s*$/.test(cmd)) {
+  function defaultEval(code, context, file, cb) {
+    var err, result, script, wrappedErr;
+    var wrappedCmd = false;
+    var input = code;
+
+    if (/^\s*\{/.test(code) && /\}\s*$/.test(code)) {
       // It's confusing for `{ a : 1 }` to be interpreted as a block
       // statement rather than an object literal.  So, we first try
       // to wrap it in parentheses, so that it will be interpreted as
       // an expression.
-      cmd = `(${cmd})`;
-      self.wrappedCmd = true;
-    } else {
-      // Mitigate https://github.com/nodejs/node/issues/548
-      cmd = cmd.replace(
-        /^\s*function(?:\s*(\*)\s*|\s+)([^(]+)/,
-        (_, genStar, name) => `var ${name} = function ${genStar || ''}${name}`
-      );
+      code = `(${code.trim()})\n`;
+      wrappedCmd = true;
     }
-    // Append a \n so that it will be either
-    // terminated, or continued onto the next expression if it's an
-    // unexpected end of input.
-    return `${cmd}\n`;
-  }
 
-  function defaultEval(code, context, file, cb) {
-    // Remove trailing new line
-    code = code.replace(/\n$/, '');
-    code = preprocess(code);
-
-    var err, result, retry = false, input = code, wrappedErr;
     // first, create the Script object to check the syntax
-
     if (code === '\n')
       return cb(null);
 
     while (true) {
       try {
         if (!/^\s*$/.test(code) &&
-            (self.replMode === exports.REPL_MODE_STRICT || retry)) {
+            (self.replMode === exports.REPL_MODE_STRICT)) {
           // "void 0" keeps the repl from returning "use strict" as the
           // result value for let/const statements.
           code = `'use strict'; void 0;\n${code}`;
         }
-        var script = vm.createScript(code, {
+        script = vm.createScript(code, {
           filename: file,
           displayErrors: true
         });
       } catch (e) {
         debug('parse error %j', code, e);
-        if (self.replMode === exports.REPL_MODE_MAGIC &&
-            e.message === BLOCK_SCOPED_ERROR &&
-            !retry || self.wrappedCmd) {
-          if (self.wrappedCmd) {
-            self.wrappedCmd = false;
-            // unwrap and try again
-            code = `${input.substring(1, input.length - 2)}\n`;
-            wrappedErr = e;
-          } else {
-            retry = true;
-          }
+        if (wrappedCmd) {
+          wrappedCmd = false;
+          // unwrap and try again
+          code = input;
+          wrappedErr = e;
           continue;
         }
         // preserve original error for wrapped command
         const error = wrappedErr || e;
-        if (isRecoverableError(error, self))
+        if (isRecoverableError(error, code))
           err = new Recoverable(error);
         else
           err = error;
@@ -394,7 +267,6 @@ function REPLServer(prompt,
                                 (_, pre, line) => pre + (line - 1));
     }
     top.outputStream.write((e.stack || e) + '\n');
-    top.lineParser.reset();
     top.bufferedCommand = '';
     top.lines.level = [];
     top.displayPrompt();
@@ -421,7 +293,6 @@ function REPLServer(prompt,
   self.outputStream = output;
 
   self.resetContext();
-  self.lineParser = new LineParser();
   self.bufferedCommand = '';
   self.lines.level = [];
 
@@ -485,7 +356,6 @@ function REPLServer(prompt,
       sawSIGINT = false;
     }
 
-    self.lineParser.reset();
     self.bufferedCommand = '';
     self.lines.level = [];
     self.displayPrompt();
@@ -493,6 +363,7 @@ function REPLServer(prompt,
 
   self.on('line', function(cmd) {
     debug('line %j', cmd);
+    cmd = cmd || '';
     sawSIGINT = false;
 
     if (self.editorMode) {
@@ -510,24 +381,28 @@ function REPLServer(prompt,
       return;
     }
 
-    // leading whitespaces in template literals should not be trimmed.
-    if (self._inTemplateLiteral) {
-      self._inTemplateLiteral = false;
-    } else {
-      cmd = self.lineParser.parseLine(cmd);
-    }
+    // Check REPL keywords and empty lines against a trimmed line input.
+    const trimmedCmd = cmd.trim();
 
     // Check to see if a REPL keyword was used. If it returns true,
     // display next prompt and return.
-    if (cmd && cmd.charAt(0) === '.' && cmd.charAt(1) !== '.' &&
-        isNaN(parseFloat(cmd))) {
-      const matches = cmd.match(/^\.([^\s]+)\s*(.*)$/);
-      const keyword = matches && matches[1];
-      const rest = matches && matches[2];
-      if (self.parseREPLKeyword(keyword, rest) === true) {
-        return;
-      } else if (!self.bufferedCommand) {
-        self.outputStream.write('Invalid REPL keyword\n');
+    if (trimmedCmd) {
+      if (trimmedCmd.charAt(0) === '.' && isNaN(parseFloat(trimmedCmd))) {
+        const matches = trimmedCmd.match(/^\.([^\s]+)\s*(.*)$/);
+        const keyword = matches && matches[1];
+        const rest = matches && matches[2];
+        if (self.parseREPLKeyword(keyword, rest) === true) {
+          return;
+        }
+        if (!self.bufferedCommand) {
+          self.outputStream.write('Invalid REPL keyword\n');
+          finish(null);
+          return;
+        }
+      }
+    } else {
+      // Print a new line when hitting enter.
+      if (!self.bufferedCommand) {
         finish(null);
         return;
       }
@@ -542,12 +417,10 @@ function REPLServer(prompt,
       debug('finish', e, ret);
       self.memory(cmd);
 
-      self.wrappedCmd = false;
       if (e && !self.bufferedCommand && cmd.trim().startsWith('npm ')) {
         self.outputStream.write('npm should be run outside of the ' +
                                 'node repl, in your normal shell.\n' +
                                 '(Press Control-D to exit.)\n');
-        self.lineParser.reset();
         self.bufferedCommand = '';
         self.displayPrompt();
         return;
@@ -555,8 +428,7 @@ function REPLServer(prompt,
 
       // If error was SyntaxError and not JSON.parse error
       if (e) {
-        if (e instanceof Recoverable && !self.lineParser.shouldFail &&
-            !sawCtrlD) {
+        if (e instanceof Recoverable && !sawCtrlD) {
           // Start buffering data like that:
           // {
           // ...  x: 1
@@ -570,7 +442,6 @@ function REPLServer(prompt,
       }
 
       // Clear buffer if no SyntaxErrors
-      self.lineParser.reset();
       self.bufferedCommand = '';
       sawCtrlD = false;
 
@@ -1232,7 +1103,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
     action: function() {
-      this.lineParser.reset();
       this.bufferedCommand = '';
       this.displayPrompt();
     }
@@ -1247,7 +1117,6 @@ function defineDefaultCommands(repl) {
   repl.defineCommand('clear', {
     help: clearMessage,
     action: function() {
-      this.lineParser.reset();
       this.bufferedCommand = '';
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
@@ -1367,20 +1236,13 @@ REPLServer.prototype.convertToContext = function(cmd) {
   return cmd;
 };
 
-function bailOnIllegalToken(parser) {
-  return parser._literal === null &&
-         !parser.blockComment &&
-         !parser.regExpLiteral;
-}
-
 // If the error is that we've unexpectedly ended the input,
 // then let the user try to recover by adding more input.
-function isRecoverableError(e, self) {
+function isRecoverableError(e, code) {
   if (e && e.name === 'SyntaxError') {
     var message = e.message;
     if (message === 'Unterminated template literal' ||
         message === 'Missing } in template expression') {
-      self._inTemplateLiteral = true;
       return true;
     }
 
@@ -1390,9 +1252,79 @@ function isRecoverableError(e, self) {
       return true;
 
     if (message === 'Invalid or unexpected token')
-      return !bailOnIllegalToken(self.lineParser);
+      return isCodeRecoverable(code);
   }
   return false;
+}
+
+// Check whether a code snippet should be forced to fail in the REPL.
+function isCodeRecoverable(code) {
+  var current, previous, stringLiteral;
+  var isBlockComment = false;
+  var isSingleComment = false;
+  var isRegExpLiteral = false;
+  var lastChar = code.charAt(code.length - 2);
+  var prevTokenChar = null;
+
+  for (var i = 0; i < code.length; i++) {
+    previous = current;
+    current = code[i];
+
+    if (previous === '\\' && (stringLiteral || isRegExpLiteral)) {
+      current = null;
+      continue;
+    }
+
+    if (stringLiteral) {
+      if (stringLiteral === current) {
+        stringLiteral = null;
+      }
+      continue;
+    } else {
+      if (isRegExpLiteral && current === '/') {
+        isRegExpLiteral = false;
+        continue;
+      }
+
+      if (isBlockComment && previous === '*' && current === '/') {
+        isBlockComment = false;
+        continue;
+      }
+
+      if (isSingleComment && current === '\n') {
+        isSingleComment = false;
+        continue;
+      }
+
+      if (isBlockComment || isRegExpLiteral || isSingleComment) continue;
+
+      if (current === '/' && previous === '/') {
+        isSingleComment = true;
+        continue;
+      }
+
+      if (previous === '/') {
+        if (current === '*') {
+          isBlockComment = true;
+        } else if (
+          // Distinguish between a division operator and the start of a regex
+          // by examining the non-whitespace character that precedes the /
+          [null, '(', '[', '{', '}', ';'].includes(prevTokenChar)
+        ) {
+          isRegExpLiteral = true;
+        }
+        continue;
+      }
+
+      if (current.trim()) prevTokenChar = current;
+    }
+
+    if (current === '\'' || current === '"') {
+      stringLiteral = current;
+    }
+  }
+
+  return stringLiteral ? lastChar === '\\' : isBlockComment;
 }
 
 function Recoverable(err) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -595,7 +595,7 @@ Zlib.prototype._processChunk = function(chunk, flushFlag, cb) {
       this.callback = null;
     }
 
-    if (self._hadError)
+    if (self._hadError || !self._handle)
       return;
 
     var have = availOutBefore - availOutAfter;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3362,10 +3362,7 @@ void CipherBase::Init(const char* cipher_type,
   if (mode == EVP_CIPH_WRAP_MODE)
     EVP_CIPHER_CTX_set_flags(&ctx_, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 
-  if (!EVP_CIPHER_CTX_set_key_length(&ctx_, key_len)) {
-    EVP_CIPHER_CTX_cleanup(&ctx_);
-    return env()->ThrowError("Invalid key length");
-  }
+  CHECK_EQ(1, EVP_CIPHER_CTX_set_key_length(&ctx_, key_len));
 
   EVP_CipherInit_ex(&ctx_,
                     nullptr,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3359,6 +3359,9 @@ void CipherBase::Init(const char* cipher_type,
                        cipher_type);
   }
 
+  if (mode == EVP_CIPH_WRAP_MODE)
+    EVP_CIPHER_CTX_set_flags(&ctx_, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
   if (!EVP_CIPHER_CTX_set_key_length(&ctx_, key_len)) {
     EVP_CIPHER_CTX_cleanup(&ctx_);
     return env()->ThrowError("Invalid key length");
@@ -3406,13 +3409,18 @@ void CipherBase::InitIv(const char* cipher_type,
   }
 
   const int expected_iv_len = EVP_CIPHER_iv_length(cipher_);
-  const bool is_gcm_mode = (EVP_CIPH_GCM_MODE == EVP_CIPHER_mode(cipher_));
+  const int mode = EVP_CIPHER_mode(cipher_);
+  const bool is_gcm_mode = (EVP_CIPH_GCM_MODE == mode);
 
   if (is_gcm_mode == false && iv_len != expected_iv_len) {
     return env()->ThrowError("Invalid IV length");
   }
 
   EVP_CIPHER_CTX_init(&ctx_);
+
+  if (mode == EVP_CIPH_WRAP_MODE)
+    EVP_CIPHER_CTX_set_flags(&ctx_, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
   const bool encrypt = (kind_ == kCipher);
   EVP_CipherInit_ex(&ctx_, cipher_, nullptr, nullptr, nullptr, encrypt);
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3351,6 +3351,14 @@ void CipherBase::Init(const char* cipher_type,
   EVP_CIPHER_CTX_init(&ctx_);
   const bool encrypt = (kind_ == kCipher);
   EVP_CipherInit_ex(&ctx_, cipher_, nullptr, nullptr, nullptr, encrypt);
+
+  int mode = EVP_CIPHER_CTX_mode(&ctx_);
+  if (encrypt && (mode == EVP_CIPH_CTR_MODE || mode == EVP_CIPH_GCM_MODE ||
+      mode == EVP_CIPH_CCM_MODE)) {
+    ProcessEmitWarning(env(), "Use Cipheriv for counter mode of %s",
+                       cipher_type);
+  }
+
   if (!EVP_CIPHER_CTX_set_key_length(&ctx_, key_len)) {
     EVP_CIPHER_CTX_cleanup(&ctx_);
     return env()->ThrowError("Invalid key length");

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -509,12 +509,33 @@ function testCipher4(key, iv) {
                      'encryption and decryption with key and iv');
 }
 
+
+function testCipher5(key, iv) {
+  // Test encryption and decryption with explicit key with aes128-wrap
+  const plaintext =
+      '32|RmVZZkFUVmpRRkp0TmJaUm56ZU9qcnJkaXNNWVNpTTU*|iXmckfRWZBGWWELw' +
+      'eCBsThSsfUHLeRe0KCsK8ooHgxie0zOINpXxfZi/oNG7uq9JWFVCk70gfzQH8ZUJ' +
+      'jAfaFg**';
+  const cipher = crypto.createCipher('id-aes128-wrap', key);
+  let ciph = cipher.update(plaintext, 'utf8', 'buffer');
+  ciph = Buffer.concat([ciph, cipher.final('buffer')]);
+
+  const decipher = crypto.createDecipher('id-aes128-wrap', key);
+  let txt = decipher.update(ciph, 'buffer', 'utf8');
+  txt += decipher.final('utf8');
+
+  assert.strictEqual(txt, plaintext,
+                     'encryption and decryption with key');
+}
+
 if (!common.hasFipsCrypto) {
   testCipher1('MySecretKey123');
   testCipher1(Buffer.from('MySecretKey123'));
 
   testCipher2('0123456789abcdef');
   testCipher2(Buffer.from('0123456789abcdef'));
+
+  testCipher5(Buffer.from('0123456789abcd0123456789'));
 }
 
 testCipher3('0123456789abcd0123456789', '12345678');

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -148,3 +148,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
   assert.strictEqual(decipher.setAuthTag(tagbuf), decipher);
   assert.strictEqual(decipher.setAAD(aadbuf), decipher);
 }
+
+// https://github.com/nodejs/node/issues/13801
+common.expectWarning('Warning', 'Use Cipheriv for counter mode of aes-256-gcm');
+crypto.createCipher('aes-256-gcm', '0123456789');

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -55,11 +55,35 @@ function testCipher2(key, iv) {
   assert.strictEqual(txt, plaintext, 'encryption/decryption with key and iv');
 }
 
+
+function testCipher3(key, iv) {
+  // Test encryption and decryption with explicit key and iv.
+  // AES Key Wrap test vector comes from RFC3394
+  const plaintext = Buffer.from('00112233445566778899AABBCCDDEEFF', 'hex');
+
+  const cipher = crypto.createCipheriv('id-aes128-wrap', key, iv);
+  let ciph = cipher.update(plaintext, 'utf8', 'buffer');
+  ciph = Buffer.concat([ciph, cipher.final('buffer')]);
+  const ciph2 = Buffer.from('1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5',
+                            'hex');
+  assert(ciph.equals(ciph2));
+  const decipher = crypto.createDecipheriv('id-aes128-wrap', key, iv);
+  let deciph = decipher.update(ciph, 'buffer');
+  deciph = Buffer.concat([deciph, decipher.final()]);
+
+  assert(deciph.equals(plaintext), 'encryption/decryption with key and iv');
+}
+
 testCipher1('0123456789abcd0123456789', '12345678');
 testCipher1('0123456789abcd0123456789', Buffer.from('12345678'));
 testCipher1(Buffer.from('0123456789abcd0123456789'), '12345678');
 testCipher1(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
 testCipher2(Buffer.from('0123456789abcd0123456789'), Buffer.from('12345678'));
+
+if (!common.hasFipsCrypto) {
+  testCipher3(Buffer.from('000102030405060708090A0B0C0D0E0F', 'hex'),
+              Buffer.from('A6A6A6A6A6A6A6A6', 'hex'));
+}
 
 // Zero-sized IV should be accepted in ECB mode.
 crypto.createCipheriv('aes-128-ecb', Buffer.alloc(16), Buffer.alloc(0));

--- a/test/parallel/test-repl-multi-line-templates.js
+++ b/test/parallel/test-repl-multi-line-templates.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const stream = require('stream');
+
+const inputStream = new stream.PassThrough();
+const outputStream = new stream.PassThrough();
+outputStream.accum = '';
+
+outputStream.on('data', (data) => {
+  outputStream.accum += data;
+});
+
+const r = repl.start({
+  input: inputStream,
+  output: outputStream,
+  useColors: false,
+  terminal: false,
+  prompt: ''
+});
+
+r.write('const str = `tacos \\\nfoobar`');
+assert.strictEqual(r.output.accum, '... ');

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -386,14 +386,15 @@ function error_test() {
 
     {
       client: client_unix, send: '(function() {\nif (false) {} /bar"/;\n}())',
-      expect: `${prompt_multiline}${prompt_multiline}undefined\n${prompt_unix}`
+      expect: prompt_multiline + prompt_multiline + 'undefined\n' + prompt_unix
     },
-    // Do not parse `...[]` as a REPL keyword
-    { client: client_unix, send: '...[]\n',
-      expect: `${prompt_multiline}` },
-    // bring back the repl to prompt
-    { client: client_unix, send: '.break',
-      expect: `${prompt_unix}` }
+
+    // Newline within template string maintains whitespace.
+    { client: client_unix, send: '`foo \n`',
+      expect: prompt_multiline + '\'foo \\n\'\n' + prompt_unix },
+    // Whitespace is not evaluated.
+    { client: client_unix, send: ' \t  \n',
+      expect: prompt_unix }
   ]);
 }
 


### PR DESCRIPTION
A minimal change that will fix #15625. There are no test cases for this, as I have not been able to find a way to trigger this without actually running a busy system in production. The fix is also minimal because I have been able to verify in production that this fixes the issue, by using code like `stream._hadError = true; stream.close()`. The fix is for 6.x only, as the code has been heavily rewritten in 8.x and does not contain this bug anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
zlib