### PR TITLE
test: update test-timers-block-eventloop.js

### DIFF
--- a/test/sequential/test-timers-block-eventloop.js
+++ b/test/sequential/test-timers-block-eventloop.js
@@ -2,21 +2,23 @@
 
 const common = require('../common');
 const fs = require('fs');
+const commonTimeout = common.platformTimeout;
 
 const t1 = setInterval(() => {
-  common.busyLoop(12);
-}, 10);
+  common.busyLoop(commonTimeout(12));
+}, common.platformTimeout(10));
 
 const t2 = setInterval(() => {
-  common.busyLoop(15);
-}, 10);
+  common.busyLoop(commonTimeout(15));
+}, commonTimeout(10));
 
-const t3 = setTimeout(common.mustNotCall('eventloop blocked!'), 100);
+const t3 =
+  setTimeout(common.mustNotCall('eventloop blocked!'), commonTimeout(200));
 
 setTimeout(function() {
-  fs.stat('./nonexistent.txt', (err, stats) => {
+  fs.stat('/dev/nonexistent', (err, stats) => {
     clearInterval(t1);
     clearInterval(t2);
     clearTimeout(t3);
   });
-}, 50);
+}, commonTimeout(50));


### PR DESCRIPTION
When CPU is busy, the above sequential case fails occasionally,
expand the timeout value to fix it.

Fixes: https://github.com/nodejs/node/issues/16310

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
