### PR TITLE
doc, win: remove note about resize

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -90,15 +90,6 @@ process.stdout.on('resize', () => {
 });
 ```
 
-*Note*: On Windows resize events will be emitted only if stdin is unpaused
-(by a call to `resume()` or by adding a data listener) and in raw mode. It can
-also be triggered if a terminal control sequence that moves the cursor is
-written to the screen. Also, the resize event will only be signaled if the
-console screen buffer height was also changed. For example shrinking the
-console window height will not cause the resize event to be emitted. Increasing
-the console window height will only be registered when the new console window
-height is greater than the current console buffer size.
-
 ### writeStream.columns
 <!-- YAML
 added: v0.7.7


### PR DESCRIPTION
Libuv 1.15.0 improved console resize detection on Windows (https://github.com/libuv/libuv/pull/1408). This note is no longer needed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
docs
