### PR TITLE
test: add test file name to common.PIPE

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -305,7 +305,9 @@ Platform normalizes timeout.
 ### PIPE
 * return [&lt;String>]
 
-Path to the test sock.
+Path to a process-unique named pipe (FIFO), either an FS node on POSIX,
+or a `\\.\pipe\` prefixed path on Windows, which is random each time
+`common` is required.
 
 ### PORT
 * return [&lt;Number>] default = `12346`

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -271,9 +271,17 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 });
 
 {
-  const localRelative = path.relative(process.cwd(), `${exports.tmpDir}/`);
-  const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : localRelative;
-  const pipeName = `node-test.${process.pid}.sock`;
+  let pipePrefix;
+  if (exports.isWindows) {
+    pipePrefix = '\\\\.\\pipe\\';
+  } else {
+    const localRelative = path.relative(process.cwd(), `${exports.tmpDir}`);
+    pipePrefix = localRelative + path.sep;
+  }
+
+  const randHex = Math.random().toString(16).slice(2);
+  const pipeName = `node-test.${randHex}.sock`;
+
   exports.PIPE = pipePrefix + pipeName;
 }
 

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -76,7 +76,7 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
       const handleName = `${prefix}-client-${socketCounter++}`;
       const err = handle.bind(handleName);
       if (err < 0) {
-        assert.faill(`${errname(err)} binding ${handleName}`);
+        assert.fail(`${errname(err)} binding ${handleName}`);
       }
       assert.notStrictEqual(handle.fd, -1);
       handleMap.set(index, handle);

--- a/test/parallel/test-net-connect-options-path.js
+++ b/test/parallel/test-net-connect-options-path.js
@@ -11,7 +11,7 @@ const CLIENT_VARIANTS = 12;
 
 // Test connect(path)
 {
-  const prefix = `${common.PIPE}-net-connect-options-path`;
+  const prefix = `${common.PIPE}`;
   const serverPath = `${prefix}-server`;
   let counter = 0;
   const server = net.createServer()

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -30,7 +30,7 @@ let counter = 0;
 
 // Avoid conflict with listen-path
 function randomPipePath() {
-  return `${common.PIPE}-listen-handle-${counter++}`;
+  return `${common.PIPE}.${counter++}`;
 }
 
 function randomHandle(type) {

--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -15,7 +15,7 @@ let counter = 0;
 
 // Avoid conflict with listen-handle
 function randomPipePath() {
-  return `${common.PIPE}-listen-path-${counter++}`;
+  return `${common.PIPE}.${counter++}`;
 }
 
 // Test listen(path)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test

There have been some flaky `EADDRINUSE` errors on the CI. The theory is, using pid to avoid conflicts might still not be enough. This PR adds the file name to the mix to reduce the conflict.

Refs: https://github.com/nodejs/node/issues/16290
Refs: https://github.com/nodejs/node/issues/16323
