### PR TITLE
tools: prohibit notDeepEqual usage

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -57,6 +57,9 @@ rules:
       property: deepEqual
       message: Use assert.deepStrictEqual().
     - object: assert
+      property: notDeepEqual
+      message: Use assert.notDeepStrictEqual().
+    - object: assert
       property: equal
       message: Use assert.strictEqual() rather than assert.equal().
     - object: assert

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -101,18 +101,18 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
     innerFail(actual, expected, message, 'deepEqual', deepEqual);
   }
 };
-/* eslint-enable */
-
-assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
-  if (!isDeepStrictEqual(actual, expected)) {
-    innerFail(actual, expected, message, 'deepStrictEqual', deepStrictEqual);
-  }
-};
 
 // The non-equivalence assertion tests for any deep inequality.
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
   if (isDeepEqual(actual, expected)) {
     innerFail(actual, expected, message, 'notDeepEqual', notDeepEqual);
+  }
+};
+/* eslint-enable */
+
+assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
+  if (!isDeepStrictEqual(actual, expected)) {
+    innerFail(actual, expected, message, 'deepStrictEqual', deepStrictEqual);
   }
 };
 


### PR DESCRIPTION
Seems like this slipped through sometime earlier.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools