### PR TITLE
assert: add alwaysUseStrict flag

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -7,6 +7,17 @@
 The `assert` module provides a simple set of assertion tests that can be used to
 test invariants.
 
+## assert.alwaysUseStrict
+<!-- YAML
+added: REPLACEME
+-->
+
+A boolean that, if set to true, indicates if `assert.equal`, `assert.notEqual`,
+`assert.deepEqual` and `assert.notDeepEqual` use strict comparison or not.
+
+*Note*: Using this flag is only meant for end users and not for userland
+libraries!
+
 ## assert(value[, message])
 <!-- YAML
 added: v0.5.9

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -33,6 +33,9 @@ const { propertyIsEnumerable } = Object.prototype;
 
 const assert = module.exports = ok;
 
+// If set to true, all functions will use strict comparison
+assert.alwaysUseStrict = false;
+
 // All of the following functions must throw an AssertionError
 // when a corresponding condition is not met, with a message that
 // may be undefined if not provided. All assertion methods provide
@@ -85,22 +88,30 @@ assert.ok = ok;
 // The equality assertion tests shallow, coercive equality with ==.
 /* eslint-disable no-restricted-properties */
 assert.equal = function equal(actual, expected, message) {
+  if (assert.alwaysUseStrict) {
+    if (actual !== expected)
+      innerFail(actual, expected, message, '===', equal);
   // eslint-disable-next-line eqeqeq
-  if (actual != expected) innerFail(actual, expected, message, '==', equal);
+  } else if (actual != expected) {
+    innerFail(actual, expected, message, '==', equal);
+  }
 };
 
 // The non-equality assertion tests for whether two objects are not
 // equal with !=.
 assert.notEqual = function notEqual(actual, expected, message) {
+  if (assert.alwaysUseStrict) {
+    if (actual === expected)
+      innerFail(actual, expected, message, '!==', notEqual);
   // eslint-disable-next-line eqeqeq
-  if (actual == expected) {
+  } else if (actual == expected) {
     innerFail(actual, expected, message, '!=', notEqual);
   }
 };
 
 // The equivalence assertion tests a deep equality relation.
 assert.deepEqual = function deepEqual(actual, expected, message) {
-  if (!innerDeepEqual(actual, expected, false)) {
+  if (!innerDeepEqual(actual, expected, assert.alwaysUseStrict)) {
     innerFail(actual, expected, message, 'deepEqual', deepEqual);
   }
 };
@@ -608,7 +619,7 @@ function objEquiv(a, b, strict, keys, memos) {
 
 // The non-equivalence assertion tests for any deep inequality.
 assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
-  if (innerDeepEqual(actual, expected, false)) {
+  if (innerDeepEqual(actual, expected, assert.alwaysUseStrict)) {
     innerFail(actual, expected, message, 'notDeepEqual', notDeepEqual);
   }
 };

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -752,3 +752,14 @@ common.expectsError(
     message: /^'Error: foo' === 'Error: foobar'$/
   }
 );
+
+// Test `alwaysUseStrict`
+assert.alwaysUseStrict = true;
+/* eslint-disable no-restricted-properties */
+assert.throws(() => assert.equal(1, true), assert.AssertionError);
+assert.notEqual(0, false);
+assert.throws(() => assert.deepEqual(1, true), assert.AssertionError);
+assert.notDeepEqual(0, false);
+assert.alwaysUseStrict = false;
+assert.equal(1, true);
+/* eslint-enable no-restricted-properties */


### PR DESCRIPTION
This enables strict comparison for the "non strict" assert as e.g. assert.equal or assert.deepEqual.

I thought what the best way would be to get rid of the loose equal comparisons in assert without deprecating them. I personally prefer the "non strict" name a lot over the strict name but these functions should not be used at all.

This is a first step towards getting more users to use strict comparison. It is only meant for users and not for libraries, as it would otherwise manipulate user code.

A alternative would be to deprecate all loose equal functions.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert