### PR TITLE
http2: assortment of small adjustments and clean-up

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -145,8 +145,9 @@ function emit(self, ...args) {
 // the block of headers on.
 function onSessionHeaders(id, cat, flags, headers) {
   const owner = this[kOwner];
+  const type = owner[kType];
   _unrefActive(owner);
-  debug(`[${sessionName(owner[kType])}] headers were received on ` +
+  debug(`[${sessionName(type)}] headers were received on ` +
         `stream ${id}: ${cat}`);
   const streams = owner[kState].streams;
 
@@ -158,7 +159,7 @@ function onSessionHeaders(id, cat, flags, headers) {
 
   if (stream === undefined) {
     // owner[kType] can be only one of two possible values
-    if (owner[kType] === NGHTTP2_SESSION_SERVER) {
+    if (type === NGHTTP2_SESSION_SERVER) {
       stream = new ServerHttp2Stream(owner, id,
                                      { readable: !endOfStream },
                                      obj);
@@ -193,7 +194,7 @@ function onSessionHeaders(id, cat, flags, headers) {
     } else {
       event = endOfStream ? 'trailers' : 'headers';
     }
-    debug(`[${sessionName(owner[kType])}] emitting stream '${event}' event`);
+    debug(`[${sessionName(type)}] emitting stream '${event}' event`);
     process.nextTick(emit, stream, event, obj, flags, headers);
   }
   if (endOfStream) {
@@ -405,7 +406,6 @@ function requestOnConnect(headers, options) {
   const streams = session[kState].streams;
 
   validatePriorityOptions(options);
-  const handle = session[kHandle];
 
   const headersList = mapToHeaders(headers);
   if (!Array.isArray(headersList)) {
@@ -424,11 +424,11 @@ function requestOnConnect(headers, options) {
 
   // ret will be either the reserved stream ID (if positive)
   // or an error code (if negative)
-  const ret = handle.submitRequest(headersList,
-                                   streamOptions,
-                                   options.parent | 0,
-                                   options.weight | 0,
-                                   !!options.exclusive);
+  const ret = session[kHandle].submitRequest(headersList,
+                                             streamOptions,
+                                             options.parent | 0,
+                                             options.weight | 0,
+                                             !!options.exclusive);
 
   // In an error condition, one of three possible response codes will be
   // possible:
@@ -551,13 +551,13 @@ function setupHandle(session, socket, type, options) {
 
 // Submits a SETTINGS frame to be sent to the remote peer.
 function submitSettings(settings) {
-  debug(`[${sessionName(this[kType])}] submitting actual settings`);
+  const type = this[kType];
+  debug(`[${sessionName(type)}] submitting actual settings`);
   _unrefActive(this);
   this[kLocalSettings] = undefined;
 
   updateSettingsBuffer(settings);
-  const handle = this[kHandle];
-  const ret = handle.submitSettings();
+  const ret = this[kHandle].submitSettings();
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
@@ -571,24 +571,22 @@ function submitSettings(settings) {
         process.nextTick(emit, this, 'error', err);
       }
   }
-  debug(`[${sessionName(this[kType])}] settings complete`);
+  debug(`[${sessionName(type)}] settings complete`);
 }
 
 // Submits a PRIORITY frame to be sent to the remote peer
 // Note: If the silent option is true, the change will be made
 // locally with no PRIORITY frame sent.
 function submitPriority(stream, options) {
-  debug(`[${sessionName(this[kType])}] submitting actual priority`);
+  const type = this[kType];
+  debug(`[${sessionName(type)}] submitting actual priority`);
   _unrefActive(this);
 
-  const handle = this[kHandle];
-  const ret =
-    handle.submitPriority(
-      stream[kID],
-      options.parent | 0,
-      options.weight | 0,
-      !!options.exclusive,
-      !!options.silent);
+  const ret = this[kHandle].submitPriority(stream[kID],
+                                           options.parent | 0,
+                                           options.weight | 0,
+                                           !!options.exclusive,
+                                           !!options.silent);
 
   let err;
   switch (ret) {
@@ -603,17 +601,16 @@ function submitPriority(stream, options) {
         process.nextTick(emit, stream, 'error', err);
       }
   }
-  debug(`[${sessionName(this[kType])}] priority complete`);
+  debug(`[${sessionName(type)}] priority complete`);
 }
 
 // Submit an RST-STREAM frame to be sent to the remote peer.
 // This will cause the Http2Stream to be closed.
 function submitRstStream(stream, code) {
-  debug(`[${sessionName(this[kType])}] submit actual rststream`);
+  const type = this[kType];
+  debug(`[${sessionName(type)}] submit actual rststream`);
   _unrefActive(this);
-  const id = stream[kID];
-  const handle = this[kHandle];
-  const ret = handle.submitRstStream(id, code);
+  const ret = this[kHandle].submitRstStream(stream[kID], code);
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
@@ -629,7 +626,7 @@ function submitRstStream(stream, code) {
       }
       stream.destroy();
   }
-  debug(`[${sessionName(this[kType])}] rststream complete`);
+  debug(`[${sessionName(type)}] rststream complete`);
 }
 
 function doShutdown(self, options) {
@@ -654,13 +651,12 @@ function doShutdown(self, options) {
 
 // Submit a graceful or immediate shutdown request for the Http2Session.
 function submitShutdown(options) {
-  debug(`[${sessionName(this[kType])}] submitting actual shutdown request`);
-  const handle = this[kHandle];
   const type = this[kType];
+  debug(`[${sessionName(type)}] submitting actual shutdown request`);
   if (type === NGHTTP2_SESSION_SERVER &&
       options.graceful === true) {
     // first send a shutdown notice
-    handle.submitShutdownNotice();
+    this[kHandle].submitShutdownNotice();
     // then, on flip of the event loop, do the actual shutdown
     setImmediate(doShutdown, this, options);
   } else {
@@ -827,7 +823,8 @@ class Http2Session extends EventEmitter {
 
   // Submits a SETTINGS frame to be sent to the remote peer.
   settings(settings) {
-    if (this[kState].destroyed || this[kState].destroying)
+    const state = this[kState];
+    if (state.destroyed || state.destroying)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
     // Validate the input first
@@ -855,14 +852,14 @@ class Http2Session extends EventEmitter {
       err.actual = settings.enablePush;
       throw err;
     }
-    if (this[kState].pendingAck === this[kState].maxPendingAck) {
+    if (state.pendingAck === state.maxPendingAck) {
       throw new errors.Error('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
                              this[kState].pendingAck);
     }
     debug(`[${sessionName(this[kType])}] sending settings`);
 
-    this[kState].pendingAck++;
-    if (this[kState].connecting) {
+    state.pendingAck++;
+    if (state.connecting) {
       debug(`[${sessionName(this[kType])}] session still connecting, ` +
             'queue settings');
       this.once('connect', submitSettings.bind(this, settings));
@@ -873,7 +870,8 @@ class Http2Session extends EventEmitter {
 
   // Submits a PRIORITY frame to be sent to the remote peer.
   priority(stream, options) {
-    if (this[kState].destroyed || this[kState].destroying)
+    const state = this[kState];
+    if (state.destroyed || state.destroying)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
     if (!(stream instanceof Http2Stream)) {
@@ -885,11 +883,12 @@ class Http2Session extends EventEmitter {
     options = Object.assign(Object.create(null), options);
     validatePriorityOptions(options);
 
+    const id = stream[kID];
     debug(`[${sessionName(this[kType])}] sending priority for stream ` +
-          `${stream[kID]}`);
+          `${id}`);
 
     // A stream cannot be made to depend on itself
-    if (options.parent === stream[kID]) {
+    if (options.parent === id) {
       debug(`[${sessionName(this[kType])}] session still connecting. queue ` +
             'priority');
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
@@ -897,7 +896,7 @@ class Http2Session extends EventEmitter {
                                  options.parent);
     }
 
-    if (stream[kID] === undefined) {
+    if (id === undefined) {
       stream.once('ready', submitPriority.bind(this, stream, options));
       return;
     }
@@ -924,19 +923,21 @@ class Http2Session extends EventEmitter {
                                  'number');
     }
 
-    if (this[kState].rst) {
+    const state = stream[kState];
+    if (state.rst) {
       // rst has already been called, do not call again,
       // skip straight to destroy
       stream.destroy();
       return;
     }
-    stream[kState].rst = true;
-    stream[kState].rstCode = code;
+    state.rst = true;
+    state.rstCode = code;
 
+    const id = stream[kID];
     debug(`[${sessionName(this[kType])}] initiating rststream for stream ` +
-          `${stream[kID]}: ${code}`);
+          `${id}: ${code}`);
 
-    if (stream[kID] === undefined) {
+    if (id === undefined) {
       debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'rststream');
       stream.once('ready', submitRstStream.bind(this, stream, code));
@@ -976,10 +977,11 @@ class Http2Session extends EventEmitter {
   // Graceful or immediate shutdown of the Http2Session. Graceful shutdown
   // is only supported on the server-side
   shutdown(options, callback) {
-    if (this[kState].destroyed || this[kState].destroying)
+    const state = this[kState];
+    if (state.destroyed || state.destroying)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
-    if (this[kState].shutdown || this[kState].shuttingDown)
+    if (state.shutdown || state.shuttingDown)
       return;
 
     const type = this[kType];
@@ -1019,21 +1021,21 @@ class Http2Session extends EventEmitter {
                                  options.lastStreamID);
     }
 
-    debug(`[${sessionName(this[kType])}] initiating shutdown`);
-    this[kState].shuttingDown = true;
+    debug(`[${sessionName(type)}] initiating shutdown`);
+    state.shuttingDown = true;
 
     if (callback) {
       this.on('shutdown', callback);
     }
 
-    if (this[kState].connecting) {
-      debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
+    if (state.connecting) {
+      debug(`[${sessionName(type)}] session still connecting, queue ` +
             'shutdown');
       this.once('connect', submitShutdown.bind(this, options));
       return;
     }
 
-    debug(`[${sessionName(this[kType])}] sending shutdown`);
+    debug(`[${sessionName(type)}] sending shutdown`);
     submitShutdown.call(this, options);
   }
 
@@ -1062,7 +1064,8 @@ class ClientHttp2Session extends Http2Session {
   // Submits a new HTTP2 request to the connected peer. Returns the
   // associated Http2Stream instance.
   request(headers, options) {
-    if (this[kState].destroyed || this[kState].destroying)
+    const state = this[kState];
+    if (state.destroyed || state.destroying)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
     debug(`[${sessionName(this[kType])}] initiating request`);
     _unrefActive(this);
@@ -1121,7 +1124,7 @@ class ClientHttp2Session extends Http2Session {
     if (options.endStream)
       stream.end();
 
-    if (this[kState].connecting) {
+    if (state.connecting) {
       debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'stream init');
       stream.on('connect', onConnect);
@@ -1438,7 +1441,7 @@ class Http2Stream extends Duplex {
     debug(`[${sessionName(session[kType])}] sending rstStream for stream ` +
           `${this[kID]}: ${code}`);
     _unrefActive(this);
-    this[kSession].rstStream(this, code);
+    session.rstStream(this, code);
   }
 
   rstWithNoError() {
@@ -1479,7 +1482,7 @@ class Http2Stream extends Duplex {
     debug(`[${sessionName(session[kType])}] sending priority for stream ` +
           `${this[kID]}`);
     _unrefActive(this);
-    this[kSession].priority(this, options);
+    session.priority(this, options);
   }
 
   // Called by this.destroy().
@@ -1507,7 +1510,6 @@ class Http2Stream extends Duplex {
 
 function continueStreamDestroy(self, err, callback) {
   const session = self[kSession];
-  const handle = session[kHandle];
   const state = self[kState];
 
   debug(`[${sessionName(session[kType])}] destroying stream ${self[kID]}`);
@@ -1527,7 +1529,7 @@ function continueStreamDestroy(self, err, callback) {
   // Unenroll the timer
   self.setTimeout(0);
 
-  setImmediate(finishStreamDestroy, self, handle);
+  setImmediate(finishStreamDestroy, self, session[kHandle]);
 
   // RST code 8 not emitted as an error as its used by clients to signify
   // abort and is already covered by aborted event, also allows more
@@ -1579,9 +1581,8 @@ function processRespondWithFD(fd, headers, offset = 0, length = -1,
   // Close the writable side of the stream
   this.end();
 
-  const handle = session[kHandle];
-  const ret =
-    handle.submitFile(this[kID], fd, headers, offset, length, streamOptions);
+  const ret = session[kHandle].submitFile(this[kID], fd, headers,
+                                          offset, length, streamOptions);
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
@@ -1749,9 +1750,8 @@ class ServerHttp2Stream extends Http2Stream {
     _unrefActive(this);
     const state = session[kState];
     const streams = state.streams;
-    const handle = session[kHandle];
 
-    if (!this[kSession].remoteSettings.enablePush)
+    if (!session.remoteSettings.enablePush)
       throw new errors.Error('ERR_HTTP2_PUSH_DISABLED');
 
     if (typeof options === 'function') {
@@ -1792,7 +1792,9 @@ class ServerHttp2Stream extends Http2Stream {
 
     const streamOptions = options.endStream ? STREAM_OPTION_EMPTY_PAYLOAD : 0;
 
-    const ret = handle.submitPushPromise(this[kID], headersList, streamOptions);
+    const ret = session[kHandle].submitPushPromise(this[kID],
+                                                   headersList,
+                                                   streamOptions);
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
@@ -1886,9 +1888,9 @@ class ServerHttp2Stream extends Http2Stream {
     if (options.endStream)
       this.end();
 
-    const handle = session[kHandle];
-    const ret =
-      handle.submitResponse(this[kID], headersList, streamOptions);
+    const ret = session[kHandle].submitResponse(this[kID],
+                                                headersList,
+                                                streamOptions);
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
@@ -2078,7 +2080,6 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     _unrefActive(this);
-    const handle = this[kSession][kHandle];
 
     const headersList = mapToHeaders(headers,
                                      assertValidPseudoHeaderResponse);
@@ -2086,13 +2087,12 @@ class ServerHttp2Stream extends Http2Stream {
       throw headersList;
     }
 
-    const ret =
-      handle.sendHeaders(this[kID], headersList);
+    const ret = session[kHandle].sendHeaders(this[kID], headersList);
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(emit, this[kSession], 'error', err);
+        process.nextTick(emit, session, 'error', err);
         break;
       default:
         if (ret < 0) {
@@ -2159,12 +2159,13 @@ Object.defineProperty(Http2Session.prototype, 'setTimeout', setTimeout);
 // Set as a replacement for socket.prototype.destroy upon the
 // establishment of a new connection.
 function socketDestroy(error) {
-  const type = this[kSession][kType];
+  const session = this[kSession];
+  const type = session[kType];
   debug(`[${sessionName(type)}] socket destroy called`);
   delete this[kServer];
   // destroy the session first so that it will stop trying to
   // send data while we close the socket.
-  this[kSession].destroy();
+  session.destroy();
   this.destroy = this[kDestroySocket];
   debug(`[${sessionName(type)}] destroying the socket`);
   this.destroy(error);
@@ -2212,12 +2213,13 @@ function sessionOnError(error) {
 // When a Socket emits an error, forward it to the session as a
 // socketError; failing that, remove the listener and call destroy
 function socketOnError(error) {
-  const type = this[kSession] && this[kSession][kType];
+  const session = this[kSession];
+  const type = session && session[kType];
   debug(`[${sessionName(type)}] server socket error: ${error.message}`);
   if (kRenegTest.test(error.message))
     return this.destroy();
-  if (this[kSession] !== undefined &&
-      this[kSession].emit('socketError', error, this))
+  if (session !== undefined &&
+      session.emit('socketError', error, this))
     return;
   this.removeListener('error', socketOnError);
   this.destroy(error);
@@ -2244,8 +2246,9 @@ function sessionOnSocketError(error, socket) {
 function sessionOnTimeout() {
   debug('session timeout');
   process.nextTick(() => {
+    const state = this[kState];
     // if destroyed or destryoing, do nothing
-    if (this[kState].destroyed || this[kState].destroying)
+    if (state.destroyed || state.destroying)
       return;
     const server = this[kServer];
     const socket = this[kSocket];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -881,14 +881,14 @@ class Http2Session extends EventEmitter {
 
     // A stream cannot be made to depend on itself
     if (options.parent === id) {
-      debug(`[${sessionName(this[kType])}] session still connecting. queue ` +
-            'priority');
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
                                  'parent',
                                  options.parent);
     }
 
     if (id === undefined) {
+      debug(`[${sessionName(this[kType])}] session still connecting. queue ` +
+            'priority');
       stream.once('ready', submitPriority.bind(this, stream, options));
       return;
     }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1211,7 +1211,7 @@ function streamOnResume() {
   if (session && !state.reading) {
     state.reading = true;
     assert(session[kHandle].streamReadStart(this[kID]) === undefined,
-           'HTTP/2 Stream #{this[kID]} does not exist. Please report this as ' +
+           `HTTP/2 Stream ${this[kID]} does not exist. Please report this as ` +
            'a bug in Node.js');
   }
 }
@@ -1419,7 +1419,7 @@ class Http2Stream extends Duplex {
       return;
     state.reading = true;
     assert(this[kSession][kHandle].streamReadStart(this[kID]) === undefined,
-           'HTTP/2 Stream #{this[kID]} does not exist. Please report this as ' +
+           `HTTP/2 Stream ${this[kID]} does not exist. Please report this as ` +
            'a bug in Node.js');
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -218,13 +218,8 @@ function onSessionTrailers(id) {
   assert(stream !== undefined,
          'Internal HTTP/2 Failure. Stream does not exist. Please ' +
          'report this as a bug in Node.js');
-  const getTrailers = stream[kState].getTrailers;
-  // We should not have been able to get here at all if getTrailers
-  // was not a function, and there's no code that could have changed
-  // it between there and here.
-  assert.strictEqual(typeof getTrailers, 'function');
   const trailers = Object.create(null);
-  getTrailers.call(stream, trailers);
+  stream[kState].getTrailers.call(stream, trailers);
   const headersList = mapToHeaders(trailers, assertValidPseudoHeaderTrailer);
   if (!Array.isArray(headersList)) {
     process.nextTick(emit, stream, 'error', headersList);
@@ -382,9 +377,6 @@ function onGoawayData(code, lastStreamID, buf) {
 // maxPayloadLen. The method must return a numeric value within the range
 // frameLen <= n <= maxPayloadLen.
 function onSelectPadding(fn) {
-  assert(typeof fn === 'function',
-         'options.selectPadding must be a function. Please report this as a ' +
-         'bug in Node.js');
   return function getPadding() {
     debug('fetching padding for frame');
     const frameLen = paddingBuffer[PADDING_BUF_FRAME_LENGTH];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1497,8 +1497,7 @@ class Http2Stream extends Duplex {
     }
 
     const server = session[kServer];
-
-    if (err && server) {
+    if (server !== undefined && err) {
       server.emit('streamError', err, this);
     }
 
@@ -1515,10 +1514,10 @@ function continueStreamDestroy(self, err, callback) {
 
   // Submit RST-STREAM frame if one hasn't been sent already and the
   // stream hasn't closed normally...
-  if (!state.rst && !session.destroyed) {
-    const code =
-      err instanceof Error ?
-        NGHTTP2_INTERNAL_ERROR : NGHTTP2_NO_ERROR;
+  const rst = state.rst;
+  let code = state.rstCode;
+  if (!rst && !session.destroyed) {
+    code = err instanceof Error ? NGHTTP2_INTERNAL_ERROR : NGHTTP2_NO_ERROR;
     session.rstStream(self, code);
   }
 
@@ -1530,13 +1529,10 @@ function continueStreamDestroy(self, err, callback) {
 
   setImmediate(finishStreamDestroy, self, handle);
 
-  // All done
-  const rst = state.rst;
-  const code = rst ? state.rstCode : NGHTTP2_NO_ERROR;
   // RST code 8 not emitted as an error as its used by clients to signify
   // abort and is already covered by aborted event, also allows more
   // seamless compatibility with http1
-  if (!err && code !== NGHTTP2_NO_ERROR && code !== NGHTTP2_CANCEL) {
+  if (code !== NGHTTP2_NO_ERROR && code !== NGHTTP2_CANCEL && !err) {
     err = new errors.Error('ERR_HTTP2_STREAM_ERROR', code);
   }
   callback(err);
@@ -1546,8 +1542,7 @@ function continueStreamDestroy(self, err, callback) {
 
 function finishStreamDestroy(self, handle) {
   const id = self[kID];
-  const session = self[kSession];
-  session[kState].streams.delete(id);
+  self[kSession][kState].streams.delete(id);
   delete self[kSession];
   if (handle !== undefined)
     handle.destroyStream(id);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2264,16 +2264,14 @@ function connectionListener(socket) {
   const options = this[kOptions] || {};
 
   if (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1') {
-    if (options.allowHTTP1 === true) {
-      // Fallback to HTTP/1.1
+    // Fallback to HTTP/1.1
+    if (options.allowHTTP1 === true)
       return httpConnectionListener.call(this, socket);
-    } else if (this.emit('unknownProtocol', socket)) {
-      // Let event handler deal with the socket
+    // Let event handler deal with the socket
+    if (this.emit('unknownProtocol', socket))
       return;
-    } else {
-      // Reject non-HTTP/2 client
-      return socket.destroy();
-    }
+    // Reject non-HTTP/2 client
+    return socket.destroy();
   }
 
   socket.on('error', socketOnError);


### PR DESCRIPTION
Because of the speed at which http2 core has been evolving, there's been some accumulation of little quirks and inconsistencies: unused variables, unnecessary variables, strings that should be template strings, etc. This just takes care of some general cleanup and should hopefully — among other things — improve readability a bit.

(Amusingly there's a tiny 2% bump on the http2 headers benchmarks.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2