### PR TITLE
test: Enable specifying flaky tests on fips

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1427,6 +1427,9 @@ def BuildOptions():
   result.add_option('--abort-on-timeout',
       help='Send SIGABRT instead of SIGTERM to kill processes that time out',
       default=False, action="store_true", dest="abort_on_timeout")
+  result.add_option("--type",
+      help="Type of build (simple, fips)",
+      default=None)
   return result
 
 
@@ -1576,6 +1579,21 @@ def ArgsToTestPaths(test_root, args, suites):
   return paths
 
 
+def get_env_type(vm, options_type):
+  if options_type is not None:
+    env_type = options_type
+  else:
+    if "fips" in subprocess.check_output([vm, "-p",
+                                          "process.versions.openssl"]):
+      env_type = "fips"
+    # NOTE(nikhil): "simple" is the default value for var 'env_type' and should
+    # be set last if no if/elif matches. If you plan to add more values, use
+    # 'elif' above.
+    else:
+      env_type = "simple"
+  return env_type
+
+
 def Main():
   parser = BuildOptions()
   (options, args) = parser.parse_args()
@@ -1659,6 +1677,7 @@ def Main():
           'mode': mode,
           'system': utils.GuessOS(),
           'arch': vmArch,
+          'type': get_env_type(vm, options.type),
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list


### PR DESCRIPTION
Adds a way to mark a specified test as 'flaky' on fips compliant
systems.

Earlier, the ``tools/test.py`` script supported only 'mode',
'system' and 'arch' for test environment specification. This limits the
ability to specify the behavior of tests and setting pre-determined
behavior of the same on other types of systems. As an example, the
feature request below indicates the need to specify certain tests as
'flaky' on fips compliant systems. It hints at future possibility of a
shared library, which in turn may need a specifier for running tests.

This commit introduces a new item in the ``env`` dict, called ``type``
which defaults to ``simple`` type. It also adds an optional command
line argument ``--type``, which inputs strings. Current functionality
extends to setting ``simple`` or ``fips`` for this ``type`` variable.
However, extending it to further uses is rather simple by adding "if"
conditions at appropriate places in the ``tools/test.py`` script.

Fixes: https://github.com/nodejs/node/issues/14746

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

* build
* doc
* test