### PR TITLE
http2: allow port 80 in http2.connect

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2413,7 +2413,8 @@ function connect(authority, options, listener) {
   debug(`connecting to ${authority}`);
 
   const protocol = authority.protocol || options.protocol || 'https:';
-  const port = '' + (authority.port !== '' ? authority.port : 443);
+  const port = '' + (authority.port !== '' ?
+    authority.port : (authority.protocol === 'http:' ? 80 : 443));
   const host = authority.hostname || authority.host || 'localhost';
 
   let socket;

--- a/test/parallel/test-http2-client-port-80.js
+++ b/test/parallel/test-http2-client-port-80.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const net = require('net');
+
+// Verifies that port 80 gets set as expected
+
+const connect = net.connect;
+net.connect = common.mustCall((...args) => {
+  assert.strictEqual(args[0], '80');
+  return connect(...args);
+});
+
+const client = http2.connect('http://localhost:80');
+client.destroy();


### PR DESCRIPTION
Due to how WHATWG-URL parser works, port numbers are omitted if they are the default port for a scheme. This meant that `http2.connect` could not create connections on port 80 with http scheme. Fix this bug by detecting `http:` scheme and setting port to 80.

Fixes: https://github.com/nodejs/node/issues/14304

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test