### PR TITLE
test: remove --harmony-sharedarraybuffer usage

### DIFF
--- a/test/parallel/test-buffer-sharedarraybuffer.js
+++ b/test/parallel/test-buffer-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-util-format-shared-arraybuffer.js
+++ b/test/parallel/test-util-format-shared-arraybuffer.js
@@ -1,5 +1,3 @@
-// Flags: --harmony_sharedarraybuffer
-
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-v8-serdes-sharedarraybuffer.js
+++ b/test/parallel/test-v8-serdes-sharedarraybuffer.js
@@ -1,6 +1,5 @@
 /*global SharedArrayBuffer*/
 'use strict';
-// Flags: --harmony-sharedarraybuffer
 
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
This flag has been enabled by default since v8 6.2.81.

Refs: https://github.com/v8/v8/commit/7662e0634c3a057fa5d746912ee5af76e285c274

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test