### PR TITLE
buffer: convert `buffer.transcode` to use internal/errors

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1562,7 +1562,8 @@ if (process.binding('config').hasIntl) {
   // Buffer instance.
   transcode = function transcode(source, fromEncoding, toEncoding) {
     if (!isUint8Array(source))
-      throw new TypeError('"source" argument must be a Buffer or Uint8Array');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'source',
+                                 ['Buffer', 'Uint8Array'], source);
     if (source.length === 0) return Buffer.alloc(0);
 
     fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -41,9 +41,14 @@ for (const test in tests) {
                      utf8_to_ucs2.toString('ucs2'));
 }
 
-assert.throws(
+common.expectsError(
   () => buffer.transcode(null, 'utf8', 'ascii'),
-  /^TypeError: "source" argument must be a Buffer or Uint8Array$/
+  {
+    type: TypeError,
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "source" argument must be one of type Buffer ' +
+             'or Uint8Array. Received type null'
+  }
 );
 
 assert.throws(


### PR DESCRIPTION
`buffer.transcode` is still using raw TypeError. This change is to convert it to use `internal/errors`.

Ref: https://github.com/nodejs/node/issues/11273

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
buffer
