### PR TITLE
timers: cleanup extraneous property on Immediates

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -727,8 +727,6 @@ function processImmediate() {
     if (domain)
       domain.enter();
 
-    immediate._callback = immediate._onImmediate;
-
     // Save next in case `clearImmediate(immediate)` is called from callback
     var next = immediate._idleNext;
 
@@ -764,8 +762,8 @@ function tryOnImmediate(immediate, oldTail) {
     runCallback(immediate);
     threw = false;
   } finally {
-    // clearImmediate checks _callback === null for kDestroy hooks.
-    immediate._callback = null;
+    // clearImmediate checks _onImmediate === null for kDestroy hooks.
+    immediate._onImmediate = null;
     if (!threw)
       emitAfter(immediate[async_id_symbol]);
     if (async_hook_fields[kDestroy] > 0 && !immediate._destroyed) {
@@ -794,21 +792,21 @@ function tryOnImmediate(immediate, oldTail) {
 function runCallback(timer) {
   const argv = timer._argv;
   const argc = argv ? argv.length : 0;
-  if (typeof timer._callback !== 'function')
-    return promiseResolve(timer._callback, argv[0]);
+  if (typeof timer._onImmediate !== 'function')
+    return promiseResolve(timer._onImmediate, argv[0]);
   switch (argc) {
     // fast-path callbacks with 0-3 arguments
     case 0:
-      return timer._callback();
+      return timer._onImmediate();
     case 1:
-      return timer._callback(argv[0]);
+      return timer._onImmediate(argv[0]);
     case 2:
-      return timer._callback(argv[0], argv[1]);
+      return timer._onImmediate(argv[0], argv[1]);
     case 3:
-      return timer._callback(argv[0], argv[1], argv[2]);
+      return timer._onImmediate(argv[0], argv[1], argv[2]);
     // more than 3 arguments run slower with .apply
     default:
-      return Function.prototype.apply.call(timer._callback, timer, argv);
+      return Function.prototype.apply.call(timer._onImmediate, timer, argv);
   }
 }
 
@@ -818,7 +816,7 @@ function Immediate() {
   // so have caller annotate the object (node v6.0.0, v8 5.0.71.35)
   this._idleNext = null;
   this._idlePrev = null;
-  this._callback = null;
+  this._onImmediate = null;
   this._argv = null;
   this._onImmediate = null;
   this._destroyed = false;
@@ -869,7 +867,6 @@ exports.setImmediate = setImmediate;
 function createImmediate(args, callback) {
   // declaring it `const immediate` causes v6.0.0 to deoptimize this function
   var immediate = new Immediate();
-  immediate._callback = callback;
   immediate._argv = args;
   immediate._onImmediate = callback;
 
@@ -888,7 +885,7 @@ exports.clearImmediate = function(immediate) {
   if (!immediate) return;
 
   if (async_hook_fields[kDestroy] > 0 &&
-      immediate._callback !== null &&
+      immediate._onImmediate !== null &&
       !immediate._destroyed) {
     emitDestroy(immediate[async_id_symbol]);
     immediate._destroyed = true;

--- a/test/message/unhandled_promise_trace_warnings.out
+++ b/test/message/unhandled_promise_trace_warnings.out
@@ -22,7 +22,7 @@
     at rejectionHandled (internal/process/promises.js:*)
     at *
     at Promise.catch *
-    at Immediate.setImmediate [as _onImmediate] (*test*message*unhandled_promise_trace_warnings.js:*)
+    at Immediate.setImmediate (*test*message*unhandled_promise_trace_warnings.js:*)
     at *
     at *
     at *


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/10205
I'd like to have this in 9.0.0.

/cc @nodejs/tsc @Fishrock123 