### PR TITLE
wrap_js_stream: adding test for readStop

### DIFF
--- a/test/parallel/test-wrap-js-stream-read-stop.js
+++ b/test/parallel/test-wrap-js-stream-read-stop.js
@@ -1,0 +1,42 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const WrapStream = require('internal/wrap_js_stream');
+const Stream = require('stream');
+
+class FakeStream extends Stream {
+  constructor() {
+    super();
+    this._paused = false;
+  }
+
+  pause() {
+    this._paused = true;
+  }
+
+  resume() {
+    this._paused = false;
+  }
+
+  isPaused() {
+    return this._paused;
+  }
+}
+
+const fakeStreamObj = new FakeStream();
+const wrappedStream = new WrapStream(fakeStreamObj);
+
+// Resume by wrapped stream upon construction
+assert.strictEqual(fakeStreamObj.isPaused(), false);
+
+fakeStreamObj.pause();
+
+assert.strictEqual(fakeStreamObj.isPaused(), true);
+
+fakeStreamObj.resume();
+
+assert.strictEqual(wrappedStream.readStop(), 0);
+
+assert.strictEqual(fakeStreamObj.isPaused(), true);


### PR DESCRIPTION
Adding a test for wrap_js_stream readStop method that was skipped in coverage

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
wrap_js_stream