### PR TITLE
test: mark big string tests flaky on freebsd

### DIFF
--- a/test/addons/addons.status
+++ b/test/addons/addons.status
@@ -1,0 +1,10 @@
+prefix addons
+
+# https://github.com/nodejs/node/issues/16354 - known flaky after the upgrade
+# to V8 6.2 in https://github.com/nodejs/node/pull/15362.  Most likely reason
+# is the increase of the maximum string length from 256 to 1024 MB, pushing
+# their execution times over the time limit.
+[$system==freebsd]
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-binary: FLAKY,PASS
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max-by-1-hex: FLAKY,PASS
+stringbytes-external-exceed-max/test-stringbytes-external-exceed-max: FLAKY,PASS

--- a/test/addons/testcfg.py
+++ b/test/addons/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.AddonTestConfiguration(context, root, 'addon')
+  return testpy.AddonTestConfiguration(context, root, 'addons')


### PR DESCRIPTION
Some of the addons/stringbytes-external-exceed-max tests are known flaky
after the upgrade to V8 6.2.  The most likely reason is the increase of
the maximum string length from 256 to 1024 MB, pushing their execution
times over the time limit.

Fixes: https://github.com/nodejs/node/issues/16354
Refs: https://github.com/nodejs/node/pull/15362
CI: https://ci.nodejs.org/job/node-test-pull-request/10887/