### PR TITLE
meta: note re author check in COLLABORATOR_GUIDE

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -452,6 +452,15 @@ Check number of commits and commit messages
 $ git log upstream/master...master
 ```
 
+If you land somebody else's PR (especially a first-time contributor's PR),
+please make sure that a username and an email in the log match the ones
+in the author's GitHub account. Otherwise, the commits will not be properly
+associated with the author's account, and the first-time contributor
+will not be promoted to Contributor once their first commit is landed.
+If in doubt, please contact the author before landing, then abort and reapply
+the patch if the author has changed their username and email
+and amended the PR commit.
+
 If there are multiple commits that relate to the same feature or
 one with a feature and separate with a test for that feature,
 you'll need to use `squash` or `fixup`:


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, meta

I still feel uneasy about [this](https://github.com/nodejs/node/pull/16339#issuecomment-338240029) incident (see also https://github.com/nodejs/node/pull/16339#issuecomment-338263556: the author still is not promoted), so I am trying to add a note for a lander side as well, something like the https://github.com/nodejs/node/pull/16340 has done for the authors' side. I hope this is not an overcaution.

Please, correct my wording if necessary.

I wish I had compared this data yesterday:

![1](https://user-images.githubusercontent.com/10393198/31852222-c9b0ade8-b67c-11e7-840d-7e67d72806ed.png)

![2](https://user-images.githubusercontent.com/10393198/31852223-c9cd0ac4-b67c-11e7-9281-858aa5fae56f.png)

I am sorry, @hyades.