### PR TITLE
test: fix common.PIPE path bug

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -274,7 +274,7 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
   const localRelative = path.relative(process.cwd(), `${exports.tmpDir}/`);
   const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : localRelative;
   const pipeName = `node-test.${process.pid}.sock`;
-  exports.PIPE = pipePrefix + pipeName;
+  exports.PIPE = path.join(pipePrefix, pipeName);
 }
 
 {


### PR DESCRIPTION
`common.PIPE` is returning a path name in `test` rather than in the
`tmp` directory for each test. This is causing multiple test failures in
CI. Make the path name inside the temporary directories again. This way
the pipe is removed by `common.refreshTmpDir()` on POSIX.

The bug in `common.PIPE` was introduced in
c34ae48083b44f1da7be75c8d11abc9f3aa7ab19.

Fixes: https://github.com/nodejs/node/issues/16290
Fixes: https://github.com/nodejs/node/issues/16323

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test