### PR TITLE
Improve HTTP2 documentation.

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -30,8 +30,8 @@ const http2 = require('http2');
 const fs = require('fs');
 
 const server = http2.createSecureServer({
-  key: fs.readFileSync("test/fixtures/keys/agent2-key.pem"),
-  cert: fs.readFileSync("test/fixtures/keys/agent2-cert.pem"),
+  key: fs.readFileSync("localhost-privkey.pem"),
+  cert: fs.readFileSync("localhost-cert.pem")
 });
 server.on('error', (err) => console.error(err));
 server.on('socketError', (err) => console.error(err));
@@ -48,13 +48,22 @@ server.on('stream', (stream, headers) => {
 server.listen(8443);
 ```
 
+To generate the certificate and key for this example, run:
+
+```bash
+openssl req -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -x509 -keyout localhost-privkey.pem -out localhost-cert.pem
+```
+
 ### Client-side example
 
 The following illustrates an HTTP/2 client:
 
 ```js
 var http2 = require('http2');
-const client = http2.connect('https://localhost');
+var fs = require('fs');
+const client = http2.connect('https://localhost:8443', {
+  ca: fs.readFileSync("localhost-cert.pem")
+});
 client.on('socketError', (err) => console.error(err))
 client.on('error', (err) => console.error(err))
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -16,14 +16,25 @@ support for HTTP/2 protocol features. It is specifically *not* designed for
 compatibility with the existing [HTTP/1][] module API. However,
 the [Compatibility API][] is.
 
+The `http2` Core API is much more symmetric between client and server than the
+`http` API. For instance, most events, like `error` and `socketError`, can be
+emitted either by client-side code or server-side code.
+
+### Server-side example
+
 The following illustrates a simple, plain-text HTTP/2 server using the
 Core API:
 
 ```js
 const http2 = require('http2');
+const fs = require('fs');
 
-// Create a plain-text HTTP/2 server
-const server = http2.createServer();
+const server = http2.createSecureServer({
+  key: fs.readFileSync("test/fixtures/keys/agent2-key.pem"),
+  cert: fs.readFileSync("test/fixtures/keys/agent2-cert.pem"),
+});
+server.on('error', (err) => console.error(err));
+server.on('socketError', (err) => console.error(err));
 
 server.on('stream', (stream, headers) => {
   // stream is a Duplex
@@ -34,34 +45,34 @@ server.on('stream', (stream, headers) => {
   stream.end('<h1>Hello World</h1>');
 });
 
-server.listen(80);
+server.listen(8443);
 ```
 
-Note that the above example is an HTTP/2 server that does not support SSL.
-This is significant as most browsers support HTTP/2 only with SSL.
-To make the above server be able to serve content to browsers,
-replace `http2.createServer()` with
-`http2.createSecureServer({key: /* your SSL key */, cert: /* your SSL cert */})`.
+### Client-side example
 
 The following illustrates an HTTP/2 client:
 
 ```js
-const http2 = require('http2');
+var http2 = require('http2');
+const client = http2.connect('https://localhost');
+client.on('socketError', (err) => console.error(err))
+client.on('error', (err) => console.error(err))
 
-const client = http2.connect('http://localhost:80');
-
-// req is a Duplex
 const req = client.request({ ':path': '/' });
 
-req.on('response', (headers) => {
-  console.log(headers[':status']);
-  console.log(headers['date']);
+req.on('response', (headers, flags) => {
+  for (var name in headers) {
+    console.log(name + ": " + headers[name]);
+  }
 });
 
-let data = '';
-req.setEncoding('utf8');
-req.on('data', (d) => data += d);
-req.on('end', () => client.destroy());
+let data = []
+req.on('data', (d) => data.push(d));
+req.on('end', () => {
+  console.log();
+  console.log(Buffer.concat(data).toString('utf8'));
+  client.destroy()
+});
 req.end();
 ```
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -51,7 +51,8 @@ server.listen(8443);
 To generate the certificate and key for this example, run:
 
 ```bash
-openssl req -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -x509 -keyout localhost-privkey.pem -out localhost-cert.pem
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
+  -keyout localhost-privkey.pem -out localhost-cert.pem
 ```
 
 ### Client-side example
@@ -59,8 +60,8 @@ openssl req -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -x509 -keyout 
 The following illustrates an HTTP/2 client:
 
 ```js
-var http2 = require('http2');
-var fs = require('fs');
+const http2 = require('http2');
+const fs = require('fs');
 const client = http2.connect('https://localhost:8443', {
   ca: fs.readFileSync("localhost-cert.pem")
 });
@@ -70,7 +71,7 @@ client.on('error', (err) => console.error(err))
 const req = client.request({ ':path': '/' });
 
 req.on('response', (headers, flags) => {
-  for (var name in headers) {
+  for (const name in headers) {
     console.log(name + ": " + headers[name]);
   }
 });

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -76,11 +76,12 @@ req.on('response', (headers, flags) => {
   }
 });
 
-let data = []
-req.on('data', (d) => data.push(d));
+req.setEncoding('utf8');
+let rawData = '';
+req.on('data', (chunk) => { rawData += chunk; });
 req.on('end', () => {
   console.log();
-  console.log(Buffer.concat(data).toString('utf8'));
+  console.log(rawData);
   client.destroy()
 });
 req.end();


### PR DESCRIPTION
Provide section headings for server-side and client side examples.
Add error handling and TLS to server-side example, following example of `https`.
Add error handling, TLS, more efficient Buffer usage, and header printing to
client example.

Fixes #16345 /cc @apapirovski 