### PR TITLE
doc: replace undocumented encoding aliases

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1224,7 +1224,7 @@ Example
 const Socket = require('net').Socket;
 const instance = new Socket();
 
-instance.setEncoding('utf-8');
+instance.setEncoding('utf8');
 ```
 
 <a id="ERR_TLS_CERT_ALTNAME_INVALID"></a>

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1284,7 +1284,7 @@ If the file previously was shorter than `len` bytes, it is extended, and the
 extended part is filled with null bytes ('\0'). For example,
 
 ```js
-console.log(fs.readFileSync('temp.txt', 'utf-8'));
+console.log(fs.readFileSync('temp.txt', 'utf8'));
 // Prints: Node.js
 
 // get the file descriptor of the file to be truncated


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc

Currently, we support `utf-8` as an alias for `utf8`, but [it is not documented](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings). We document this for [`util.TextDecoder`](https://nodejs.org/api/util.html#util_encodings_supported_without_icu) API, but it seems to be a different API. So maybe we can fix this fragments for consistency.
