### PR TITLE
Tweak esignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ lib/internal/v8_prof_polyfill.js
 lib/punycode.js
 test/addons/??_*
 test/fixtures
-test/tmp*
 tools/eslint
 tools/icu
 node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,10 +1,10 @@
 lib/internal/v8_prof_polyfill.js
 lib/punycode.js
-test/addons/??_*/
+test/addons/??_*
 test/fixtures
-test/tmp*/
+test/tmp*
 tools/eslint
 tools/icu
 node_modules
-benchmark/tmp/
+benchmark/tmp
 doc/**/*.js

--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,15 @@ uninstall:
 
 clean:
 	$(RM) -r out/Makefile $(NODE_EXE) $(NODE_G_EXE) out/$(BUILDTYPE)/$(NODE_EXE) \
-                out/$(BUILDTYPE)/node.exp
+		out/$(BUILDTYPE)/node.exp
 	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' -o -name '*.d' | xargs $(RM) -r; fi
 	$(RM) -r node_modules
 	@if [ -d deps/icu ]; then echo deleting deps/icu; $(RM) -r deps/icu; fi
 	$(RM) test.tap
+	# Next one is legacy remove this at some point
+	$(RM) -r test/tmp*
+	$(RM) -r test/.tmp*
+	$(MAKE) test-addons-clean
 
 distclean:
 	$(RM) -r out

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -38,7 +38,9 @@ const noop = () => {};
 
 exports.fixturesDir = fixturesDir;
 
-exports.tmpDirName = 'tmp';
+// Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
+// gets tools to ignore it by default or by simple rules, especially eslint.
+exports.tmpDirName = '.tmp';
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -541,7 +541,7 @@ echo Failed to create vc project files.
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [test/test-ci/test-all/test-uv/test-internet/test-pummel/test-simple/test-message/test-async-hooks/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [clean] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vs2015/vs2017] [download-all] [enable-vtune] [lint/lint-ci] [no-NODE-OPTIONS] [link-module path-to-module]
+echo vcbuild.bat [debug/release] [msi] [test/test-ci/test-all/test-uv/test-internet/test-pummel/test-simple/test-message/test-async-hooks/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [noprojgen] [small-icu/full-icu/without-intl] [nobuild] [sign] [x86/x64] [vs2015/vs2017] [download-all] [enable-vtune] [lint/lint-ci] [no-NODE-OPTIONS] [link-module path-to-module]
 echo Examples:
 echo   vcbuild.bat                          : builds release build
 echo   vcbuild.bat debug                    : builds debug build


### PR DESCRIPTION
Fixes issue with unicode paths not being ignored by `eslint`
https://github.com/nodejs/node/commit/b485bc476c14ad0972f2b91cd2117217ae87e9c5 solves what https://github.com/nodejs/node/pull/16010 tried to acomplish
The second commit solves it at the root

Refs: https://github.com/nodejs/node/pull/16010
Refs: https://github.com/nodejs/node/issues/16278
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools,test
