### PR TITLE
http2: fix compiler errors in debug statements

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -138,42 +138,45 @@ void PackSettings(const FunctionCallbackInfo<Value>& args) {
 
   if (flags & (1 << IDX_SETTINGS_HEADER_TABLE_SIZE)) {
     DEBUG_HTTP2("Setting header table size: %d\n",
-                buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_HEADER_TABLE_SIZE,
                        buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_CONCURRENT_STREAMS)) {
     DEBUG_HTTP2("Setting max concurrent streams: %d\n",
-                buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
                        buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_FRAME_SIZE)) {
     DEBUG_HTTP2("Setting max frame size: %d\n",
-                buffer[IDX_SETTINGS_MAX_FRAME_SIZE]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_MAX_FRAME_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_FRAME_SIZE,
                        buffer[IDX_SETTINGS_MAX_FRAME_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_INITIAL_WINDOW_SIZE)) {
     DEBUG_HTTP2("Setting initial window size: %d\n",
-                buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
                        buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
     DEBUG_HTTP2("Setting max header list size: %d\n",
-                buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
                        buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_ENABLE_PUSH)) {
     DEBUG_HTTP2("Setting enable push: %d\n",
-                buffer[IDX_SETTINGS_ENABLE_PUSH]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_ENABLE_PUSH]));
     entries.push_back({NGHTTP2_SETTINGS_ENABLE_PUSH,
                        buffer[IDX_SETTINGS_ENABLE_PUSH]});
   }
@@ -403,42 +406,45 @@ void Http2Session::SubmitSettings(const FunctionCallbackInfo<Value>& args) {
 
   if (flags & (1 << IDX_SETTINGS_HEADER_TABLE_SIZE)) {
     DEBUG_HTTP2("Setting header table size: %d\n",
-                buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_HEADER_TABLE_SIZE,
                        buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_CONCURRENT_STREAMS)) {
     DEBUG_HTTP2("Setting max concurrent streams: %d\n",
-                buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS,
                        buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_FRAME_SIZE)) {
     DEBUG_HTTP2("Setting max frame size: %d\n",
-                buffer[IDX_SETTINGS_MAX_FRAME_SIZE]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_MAX_FRAME_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_FRAME_SIZE,
                        buffer[IDX_SETTINGS_MAX_FRAME_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_INITIAL_WINDOW_SIZE)) {
     DEBUG_HTTP2("Setting initial window size: %d\n",
-                buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
                        buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
     DEBUG_HTTP2("Setting max header list size: %d\n",
-                buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]);
+                static_cast<uint32_t>(
+                    buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]));
     entries.push_back({NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
                        buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE]});
   }
 
   if (flags & (1 << IDX_SETTINGS_ENABLE_PUSH)) {
     DEBUG_HTTP2("Setting enable push: %d\n",
-                buffer[IDX_SETTINGS_ENABLE_PUSH]);
+                static_cast<uint32_t>(buffer[IDX_SETTINGS_ENABLE_PUSH]));
     entries.push_back({NGHTTP2_SETTINGS_ENABLE_PUSH,
                        buffer[IDX_SETTINGS_ENABLE_PUSH]});
   }


### PR DESCRIPTION
When compiling with `--debug-http2` flag, compiler complains about passing wrong type of argument to `DEBUG_HTTP2`. I'm not certain if this is something about my system or if I'm missing something here since no one else has noticed... then again maybe I'm the only one using `--debug-http2` at this moment.

```
../src/node_http2.cc:141:17: error: cannot pass object of non-trivial type 'node::AliasedBuffer<unsigned int,
      v8::Uint32Array>::Reference' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
                buffer[IDX_SETTINGS_HEADER_TABLE_SIZE]);
```

This fixes the issue by casting to `uint32_t`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2