### PR TITLE
doc: document resolve hook formats

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -129,10 +129,18 @@ argument to the resolver for easy compatibility workflows.
 
 In addition to returning the resolved file URL value, the resolve hook also
 returns a `format` property specifying the module format of the resolved
-module. This can be one of `"esm"`, `"cjs"`, `"json"`, `"builtin"` or
-`"addon"`.
+module. This can be one of the following:
 
-For example a dummy loader to load JavaScript restricted to browser resolution
+| `format` | Description |
+| --- | --- |
+| `"esm"` | Load a standard JavaScript module |
+| `"cjs"` | Load a node-style CommonJS module |
+| `"builtin"` | Load a node builtin CommonJS module |
+| `"json"` | Load a JSON file |
+| `"addon"` | Load a [C++ Addon][addons] |
+| `"dynamic"` | Use a [dynamic instantiate hook][] |
+
+For example, a dummy loader to load JavaScript restricted to browser resolution
 rules with only JS file extension and Node builtin modules support could
 be written:
 
@@ -206,3 +214,5 @@ then be called at the exact point of module evalutation order for that module
 in the import tree.
 
 [Node.js EP for ES Modules]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md
+[addons]: addons.html
+[dynamic instantiate hook]: #esm_dynamic_instantiate_hook


### PR DESCRIPTION
_Noticed `format: "dynamic"` was missing from the docs (it's mentioned later on)._

Add `"dynamic"` to the list of supported `format`s returned by a custom resolve hook.

Add a table describing the meaning of each `format`.

Refs: https://github.com/nodejs/node/pull/15445

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc

cc. @guybedford, @bmeck 