### PR TITLE
test: allow for different nsswitch.conf settings

### DIFF
--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -33,7 +33,7 @@ function runTest() {
 
 dns.lookup('localhost', { family: 6, all: true }, (err, addresses) => {
   if (err) {
-    if (err.code === 'ENOTFOUND')
+    if (err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN')
       common.skip('localhost does not resolve to ::1');
 
     throw err;

--- a/test/parallel/test-net-better-error-messages-port-hostname.js
+++ b/test/parallel/test-net-better-error-messages-port-hostname.js
@@ -9,7 +9,13 @@ const c = net.createConnection(0, 'this.hostname.is.invalid');
 c.on('connect', common.mustNotCall());
 
 c.on('error', common.mustCall(function(e) {
-  assert.strictEqual(e.code, 'ENOTFOUND');
+  // If Name Service Switch is available on the operating system then it
+  // might be configured differently (/etc/nsswitch.conf).
+  // If the system is configured with no dns the error code will be EAI_AGAIN,
+  // but if there are more services after the dns entry, for example some
+  // linux distributions ship a myhostname service by default which would
+  // still produce the ENOTFOUND error.
+  assert.ok(e.code === 'ENOTFOUND' || e.code === 'EAI_AGAIN');
   assert.strictEqual(e.port, 0);
   assert.strictEqual(e.hostname, 'this.hostname.is.invalid');
 }));

--- a/test/parallel/test-net-connect-immediate-finish.js
+++ b/test/parallel/test-net-connect-immediate-finish.js
@@ -32,7 +32,13 @@ const client = net.connect({
 client.once('error', common.mustCall((err) => {
   assert(err);
   assert.strictEqual(err.code, err.errno);
-  assert.strictEqual(err.code, 'ENOTFOUND');
+  // If Name Service Switch is available on the operating system then it
+  // might be configured differently (/etc/nsswitch.conf).
+  // If the system is configured with no dns the error code will be EAI_AGAIN,
+  // but if there are more services after the dns entry, for example some
+  // linux distributions ship a myhostname service by default which would
+  // still produce the ENOTFOUND error.
+  assert.ok(err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN');
   assert.strictEqual(err.host, err.hostname);
   assert.strictEqual(err.host, 'this.hostname.is.invalid');
   assert.strictEqual(err.syscall, 'getaddrinfo');

--- a/test/parallel/test-tls-connect-address-family.js
+++ b/test/parallel/test-tls-connect-address-family.js
@@ -32,7 +32,7 @@ function runTest() {
 
 dns.lookup('localhost', { family: 6, all: true }, (err, addresses) => {
   if (err) {
-    if (err.code === 'ENOTFOUND')
+    if (err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN')
       common.skip('localhost does not resolve to ::1');
 
     throw err;


### PR DESCRIPTION
The motivation for this commit is that these two test fail on systems
that have different Name Service Switch configuration settings. A
concrete example of this is when using Red Hat Enterprise Linux (RHEL)
7.

If Name Service Switch is available on the operating system then it
might be configured differently (/etc/nsswitch.conf).
If the system is configured with no dns the error code will be
AI_AGAIN, but if there are more services after the dns entry, for
example some linux distributions skip a myhostname service by default
which would still produce the ENOTFOUND error.

This commit suggests checking for either ENOTFOUND or EAI_AGAIN to
accommodate systems like the ones described above. The references below
indicate that others have run, or are running, into this aswell.

Refs: https://github.com/nodejs/node/issues/12075
Refs: https://github.com/nodejs/help/issues/687


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test