### PR TITLE
build: ignore empty folders in test-addons-napi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,8 @@ test/addons/.buildstamp: config.gypi \
 	test/addons/.docbuildstamp
 #	Cannot use $(wildcard test/addons/*/) here, it's evaluated before
 #	embedded addons have been generated from the documentation.
-#	Ignore folders without binding.gyp (#14843)
+#	Ignore folders without binding.gyp
+#	(https://github.com/nodejs/node/issues/14843)
 	@for dirname in test/addons/*/; do \
 		if [ ! -f "$$PWD/$${dirname}binding.gyp" ]; then \
 			continue; fi ; \
@@ -322,7 +323,11 @@ test/addons-napi/.buildstamp: config.gypi \
 	src/node_api.h src/node_api_types.h
 #	Cannot use $(wildcard test/addons-napi/*/) here, it's evaluated before
 #	embedded addons have been generated from the documentation.
+#	Ignore folders without binding.gyp
+#	(https://github.com/nodejs/node/issues/14843)
 	@for dirname in test/addons-napi/*/; do \
+		if [ ! -f "$$PWD/$${dirname}binding.gyp" ]; then \
+			continue; fi ; \
 		printf "\nBuilding addon $$PWD/$$dirname\n" ; \
 		env MAKEFLAGS="-j1" $(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp \
 		        --loglevel=$(LOGLEVEL) rebuild \


### PR DESCRIPTION
The same as https://github.com/nodejs/node/pull/16031 except for N-API addons.

Fixes: https://github.com/nodejs/node/issues/13521

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

build