### PR TITLE
module: Fix bug for undefined CJS dependency loading from loader hook file

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -431,7 +431,8 @@ Module._load = function(request, parent, isMain) {
         ESMLoader = new Loader();
         const userLoader = process.binding('config').userLoader;
         if (userLoader) {
-          const hooks = await new Loader().import(userLoader);
+          const hooks = await ESMLoader.import(userLoader);
+          ESMLoader = new Loader();
           ESMLoader.hook(hooks);
         }
       }

--- a/test/es-module/test-esm-loader-dependency.mjs
+++ b/test/es-module/test-esm-loader-dependency.mjs
@@ -1,0 +1,5 @@
+// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-with-dep.mjs
+/* eslint-disable required-modules */
+import './test-esm-ok.mjs';
+
+// We just test that this module doesn't fail loading

--- a/test/fixtures/es-module-loaders/loader-dep.js
+++ b/test/fixtures/es-module-loaders/loader-dep.js
@@ -1,0 +1,1 @@
+exports.format = 'esm';

--- a/test/fixtures/es-module-loaders/loader-with-dep.mjs
+++ b/test/fixtures/es-module-loaders/loader-with-dep.mjs
@@ -1,0 +1,7 @@
+import dep from './loader-dep.js';
+export function resolve (specifier, base, defaultResolve) {
+  return {
+    url: defaultResolve(specifier, base).url,
+    format: dep.format
+  };
+}


### PR DESCRIPTION
It can be useful to load dependencies as part of the loader hook definition file. This fixes a bug where `import x from 'x'` would always return `x` as `undefined` if the import was made in a loader hooks definition module.

A parallel change to the CJS loading injection process which happens in https://github.com/nodejs/node/blob/master/lib/module.js#L521 meant that the CJS module wasn't being injected into the correct loader instance, which is corrected here with a test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
esmodules