### PR TITLE
build: do not include deleted directory

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -181,7 +181,6 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/uv/src/ares',
         '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
         'deps/nghttp2/lib/includes'
       ],


### PR DESCRIPTION
`deps/uv/src/ares` hasn't existed since libuv/libuv@41b1265af8329131154539cb0d1eda57758b62be
(mid 2012).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build