### PR TITLE
module: add builtinModules

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -817,6 +817,28 @@ The `module.require` method provides a way to load a module as if
 `module` is typically *only* available within a specific module's code, it must
 be explicitly exported in order to be used.
 
+## The `Module` Object
+
+<!-- YAML
+added: v0.3.7
+-->
+
+* {Object}
+
+Provides general utility methods when interacting with instances of
+`Module` -- the `module` variable often seen in file modules. Accessed
+via `require('module')`.
+
+### module.builtinModules
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string[]}
+
+A list of  the names of all modules provided by Node.js. Can be used to verify
+if a module is maintained by a third-party module or not.
+
 [`__dirname`]: #modules_dirname
 [`__filename`]: #modules_filename
 [`Error`]: errors.html#errors_class_error

--- a/lib/module.js
+++ b/lib/module.js
@@ -74,6 +74,12 @@ function Module(id, parent) {
 }
 module.exports = Module;
 
+const builtinModules = Object.keys(NativeModule._source)
+  .filter(NativeModule.nonInternalExists);
+
+Object.freeze(builtinModules);
+Module.builtinModules = builtinModules;
+
 Module._cache = Object.create(null);
 Module._pathCache = Object.create(null);
 Module._extensions = Object.create(null);

--- a/test/parallel/test-module-builtin.js
+++ b/test/parallel/test-module-builtin.js
@@ -1,0 +1,14 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { builtinModules } = require('module');
+
+// Includes modules in lib/ (even deprecated ones)
+assert(builtinModules.includes('http'));
+assert(builtinModules.includes('sys'));
+
+// Does not include internal modules
+assert.deepStrictEqual(
+  builtinModules.filter((mod) => { return mod.startsWith('internal/'); }),
+  []
+);

--- a/test/parallel/test-module-builtin.js
+++ b/test/parallel/test-module-builtin.js
@@ -9,6 +9,6 @@ assert(builtinModules.includes('sys'));
 
 // Does not include internal modules
 assert.deepStrictEqual(
-  builtinModules.filter((mod) => { return mod.startsWith('internal/'); }),
+  builtinModules.filter((mod) => mod.startsWith('internal/')),
   []
 );


### PR DESCRIPTION
Provides list of all builtin modules in Node.

Includes modules of all types:
- prefixed (ex: _tls_common)
- deprecated (ex: sys)
- regular (ex: vm)

**Refs: #3307**

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added --> where should this be documented? The Modules API guide contains things about user modules, not about `require('module')`'s API
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
module

cc @Fishrock123 @Trott 