### PR TITLE
test: make addresses of internet tests configurable

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -10,6 +10,7 @@ This directory contains modules used to test the Node.js implementation.
 * [DNS module](#dns-module)
 * [Duplex pair helper](#duplex-pair-helper)
 * [Fixtures module](#fixtures-module)
+* [Internet module](#internet-module)
 * [WPT module](#wpt-module)
 
 ## Benchmark Module
@@ -497,6 +498,40 @@ Returns the result of
 
 Returns the result of
 `fs.readFileSync(path.join(fixtures.fixturesDir, 'keys', arg), 'enc')`.
+
+## Internet Module
+
+The `common/internet` module provides utilities for working with
+internet-related tests.
+
+### internet.addresses
+
+* [&lt;Object>]
+  * `INET_HOST` [&lt;String>] A generic host that has registered common
+    DNS records, supports both IPv4 and IPv6, and provides basic HTTP/HTTPS
+    services
+  * `INET4_HOST` [&lt;String>] A host that provides IPv4 services
+  * `INET6_HOST` [&lt;String>] A host that provides IPv6 services
+  * `INET4_IP` [&lt;String>] An accessible IPv4 IP, defaults to the
+    Google Public DNS IPv4 address
+  * `INET6_IP` [&lt;String>] An accessible IPv6 IP, defaults to the
+    Google Public DNS IPv6 address
+  * `INVALID_HOST` [&lt;String>] An invalid host that cannot be resolved
+  * `MX_HOST` [&lt;String>] A host with MX records registered
+  * `SRV_HOST` [&lt;String>] A host with SRV records registered
+  * `PTR_HOST` [&lt;String>] A host with PTR records registered
+  * `NAPTR_HOST` [&lt;String>] A host with NAPTR records registered
+  * `SOA_HOST` [&lt;String>] A host with SOA records registered
+  * `CNAME_HOST` [&lt;String>] A host with CNAME records registered
+  * `NS_HOST` [&lt;String>] A host with NS records registered
+  * `TXT_HOST` [&lt;String>] A host with TXT records registered
+  * `DNS4_SERVER` [&lt;String>] An accessible IPv4 DNS server
+  * `DNS6_SERVER` [&lt;String>] An accessible IPv6 DNS server
+
+A set of addresses for internet-related tests. All properties are configurable
+via `NODE_TEST_*` environment variables. For example, to configure
+`internet.addresses.INET_HOST`, set the environment
+vairable `NODE_TEST_INET_HOST` to a specified host.
 
 ## WPT Module
 

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -287,4 +287,6 @@ function writeDNSPacket(parsed) {
   }));
 }
 
-module.exports = { types, classes, writeDNSPacket, parseDNSPacket };
+module.exports = {
+  types, classes, writeDNSPacket, parseDNSPacket
+};

--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -1,0 +1,54 @@
+/* eslint-disable required-modules */
+'use strict';
+
+// Utilities for internet-related tests
+
+const addresses = {
+  // A generic host that has registered common DNS records,
+  // supports both IPv4 and IPv6, and provides basic HTTP/HTTPS services
+  INET_HOST: 'nodejs.org',
+  // A host that provides IPv4 services
+  INET4_HOST: 'nodejs.org',
+  // A host that provides IPv6 services
+  INET6_HOST: 'nodejs.org',
+  // An accessible IPv4 IP,
+  // defaults to the Google Public DNS IPv4 address
+  INET4_IP: '8.8.8.8',
+  // An accessible IPv6 IP,
+  // defaults to the Google Public DNS IPv6 address
+  INET6_IP: '2001:4860:4860::8888',
+  // An invalid host that cannot be resolved
+  // See https://tools.ietf.org/html/rfc2606#section-2
+  INVALID_HOST: 'something.invalid',
+  // A host with MX records registered
+  MX_HOST: 'nodejs.org',
+  // A host with SRV records registered
+  SRV_HOST: '_jabber._tcp.google.com',
+  // A host with PTR records registered
+  PTR_HOST: '8.8.8.8.in-addr.arpa',
+  // A host with NAPTR records registered
+  NAPTR_HOST: 'sip2sip.info',
+  // A host with SOA records registered
+  SOA_HOST: 'nodejs.org',
+  // A host with CNAME records registered
+  CNAME_HOST: 'blog.nodejs.org',
+  // A host with NS records registered
+  NS_HOST: 'nodejs.org',
+  // A host with TXT records registered
+  TXT_HOST: 'nodejs.org',
+  // An accessible IPv4 DNS server
+  DNS4_SERVER: '8.8.8.8',
+  // An accessible IPv4 DNS server
+  DNS6_SERVER: '2001:4860:4860::8888'
+};
+
+for (const key of Object.keys(addresses)) {
+  const envName = `NODE_TEST_${key}`;
+  if (process.env[envName]) {
+    addresses[key] = process.env[envName];
+  }
+}
+
+module.exports = {
+  addresses
+};

--- a/test/internet/test-dns-cares-domains.js
+++ b/test/internet/test-dns-cares-domains.js
@@ -1,5 +1,6 @@
 'use strict';
-require('../common');
+const common = require('../common');
+const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dns = require('dns');
 const domain = require('domain');
@@ -20,8 +21,8 @@ const methods = [
 methods.forEach(function(method) {
   const d = domain.create();
   d.run(function() {
-    dns[method]('google.com', function() {
+    dns[method](addresses.INET_HOST, common.mustCall(() => {
       assert.strictEqual(process.domain, d, `${method} retains domain`);
-    });
+    }));
   });
 });

--- a/test/internet/test-dns-ipv4.js
+++ b/test/internet/test-dns-ipv4.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
@@ -38,68 +39,72 @@ function checkWrap(req) {
 }
 
 TEST(function test_resolve4(done) {
-  const req = dns.resolve4('www.google.com',
-                           common.mustCall((err, ips) => {
-                             assert.ifError(err);
+  const req = dns.resolve4(
+    addresses.INET4_HOST,
+    common.mustCall((err, ips) => {
+      assert.ifError(err);
 
-                             assert.ok(ips.length > 0);
+      assert.ok(ips.length > 0);
 
-                             for (let i = 0; i < ips.length; i++) {
-                               assert.ok(isIPv4(ips[i]));
-                             }
+      for (let i = 0; i < ips.length; i++) {
+        assert.ok(isIPv4(ips[i]));
+      }
 
-                             done();
-                           }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_reverse_ipv4(done) {
-  const req = dns.reverse('8.8.8.8',
-                          common.mustCall((err, domains) => {
-                            assert.ifError(err);
+  const req = dns.reverse(
+    addresses.INET4_IP,
+    common.mustCall((err, domains) => {
+      assert.ifError(err);
 
-                            assert.ok(domains.length > 0);
+      assert.ok(domains.length > 0);
 
-                            for (let i = 0; i < domains.length; i++) {
-                              assert.ok(domains[i]);
-                              assert.ok(typeof domains[i] === 'string');
-                            }
+      for (let i = 0; i < domains.length; i++) {
+        assert.ok(domains[i]);
+        assert.ok(typeof domains[i] === 'string');
+      }
 
-                            done();
-                          }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_lookup_ipv4_explicit(done) {
-  const req = dns.lookup('www.google.com', 4,
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
-                           assert.ok(net.isIPv4(ip));
-                           assert.strictEqual(family, 4);
+  const req = dns.lookup(
+    addresses.INET4_HOST, 4,
+    common.mustCall((err, ip, family) => {
+      assert.ifError(err);
+      assert.ok(net.isIPv4(ip));
+      assert.strictEqual(family, 4);
 
-                           done();
-                         }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_lookup_ipv4_implicit(done) {
-  const req = dns.lookup('www.google.com',
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
-                           assert.ok(net.isIPv4(ip));
-                           assert.strictEqual(family, 4);
+  const req = dns.lookup(
+    addresses.INET4_HOST,
+    common.mustCall((err, ip, family) => {
+      assert.ifError(err);
+      assert.ok(net.isIPv4(ip));
+      assert.strictEqual(family, 4);
 
-                           done();
-                         }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_lookup_ipv4_explicit_object(done) {
-  const req = dns.lookup('www.google.com', {
+  const req = dns.lookup(addresses.INET4_HOST, {
     family: 4
   }, common.mustCall((err, ip, family) => {
     assert.ifError(err);
@@ -113,7 +118,7 @@ TEST(function test_lookup_ipv4_explicit_object(done) {
 });
 
 TEST(function test_lookup_ipv4_hint_addrconfig(done) {
-  const req = dns.lookup('www.google.com', {
+  const req = dns.lookup(addresses.INET4_HOST, {
     hints: dns.ADDRCONFIG
   }, common.mustCall((err, ip, family) => {
     assert.ifError(err);
@@ -154,7 +159,7 @@ TEST(function test_lookup_localhost_ipv4(done) {
 
 TEST(function test_lookup_all_ipv4(done) {
   const req = dns.lookup(
-    'www.google.com',
+    addresses.INET4_HOST,
     { all: true, family: 4 },
     common.mustCall((err, ips) => {
       assert.ifError(err);

--- a/test/internet/test-dns-ipv6.js
+++ b/test/internet/test-dns-ipv6.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 if (!common.hasIPv6)
   common.skip('this test, no IPv6 support');
 
@@ -38,53 +39,57 @@ function checkWrap(req) {
 }
 
 TEST(function test_resolve6(done) {
-  const req = dns.resolve6('ipv6.google.com',
-                           common.mustCall((err, ips) => {
-                             assert.ifError(err);
+  const req = dns.resolve6(
+    addresses.INET6_HOST,
+    common.mustCall((err, ips) => {
+      assert.ifError(err);
 
-                             assert.ok(ips.length > 0);
+      assert.ok(ips.length > 0);
 
-                             for (let i = 0; i < ips.length; i++)
-                               assert.ok(isIPv6(ips[i]));
+      for (let i = 0; i < ips.length; i++)
+        assert.ok(isIPv6(ips[i]));
 
-                             done();
-                           }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_reverse_ipv6(done) {
-  const req = dns.reverse('2001:4860:4860::8888',
-                          common.mustCall((err, domains) => {
-                            assert.ifError(err);
+  const req = dns.reverse(
+    addresses.INET6_IP,
+    common.mustCall((err, domains) => {
+      assert.ifError(err);
 
-                            assert.ok(domains.length > 0);
+      assert.ok(domains.length > 0);
 
-                            for (let i = 0; i < domains.length; i++)
-                              assert.ok(typeof domains[i] === 'string');
+      for (let i = 0; i < domains.length; i++)
+        assert.ok(typeof domains[i] === 'string');
 
-                            done();
-                          }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_lookup_ipv6_explicit(done) {
-  const req = dns.lookup('ipv6.google.com', 6,
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
-                           assert.ok(isIPv6(ip));
-                           assert.strictEqual(family, 6);
+  const req = dns.lookup(
+    addresses.INET6_HOST,
+    6,
+    common.mustCall((err, ip, family) => {
+      assert.ifError(err);
+      assert.ok(isIPv6(ip));
+      assert.strictEqual(family, 6);
 
-                           done();
-                         }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 /* This ends up just being too problematic to test
 TEST(function test_lookup_ipv6_implicit(done) {
-  var req = dns.lookup('ipv6.google.com', function(err, ip, family) {
+  var req = dns.lookup(addresses.INET6_HOST, function(err, ip, family) {
     assert.ifError(err);
     assert.ok(net.isIPv6(ip));
     assert.strictEqual(family, 6);
@@ -97,7 +102,7 @@ TEST(function test_lookup_ipv6_implicit(done) {
 */
 
 TEST(function test_lookup_ipv6_explicit_object(done) {
-  const req = dns.lookup('ipv6.google.com', {
+  const req = dns.lookup(addresses.INET6_HOST, {
     family: 6
   }, common.mustCall((err, ip, family) => {
     assert.ifError(err);
@@ -111,7 +116,7 @@ TEST(function test_lookup_ipv6_explicit_object(done) {
 });
 
 TEST(function test_lookup_ipv6_hint(done) {
-  const req = dns.lookup('www.google.com', {
+  const req = dns.lookup(addresses.INET6_HOST, {
     family: 6,
     hints: dns.V4MAPPED
   }, common.mustCall((err, ip, family) => {
@@ -120,7 +125,7 @@ TEST(function test_lookup_ipv6_hint(done) {
       if (common.isFreeBSD) {
         assert(err instanceof Error);
         assert.strictEqual(err.code, 'EAI_BADFLAGS');
-        assert.strictEqual(err.hostname, 'www.google.com');
+        assert.strictEqual(err.hostname, addresses.INET_HOST);
         assert.ok(/getaddrinfo EAI_BADFLAGS/.test(err.message));
         done();
         return;
@@ -139,21 +144,22 @@ TEST(function test_lookup_ipv6_hint(done) {
 });
 
 TEST(function test_lookup_ip_ipv6(done) {
-  const req = dns.lookup('::1',
-                         common.mustCall((err, ip, family) => {
-                           assert.ifError(err);
-                           assert.ok(isIPv6(ip));
-                           assert.strictEqual(family, 6);
+  const req = dns.lookup(
+    '::1',
+    common.mustCall((err, ip, family) => {
+      assert.ifError(err);
+      assert.ok(isIPv6(ip));
+      assert.strictEqual(family, 6);
 
-                           done();
-                         }));
+      done();
+    }));
 
   checkWrap(req);
 });
 
 TEST(function test_lookup_all_ipv6(done) {
   const req = dns.lookup(
-    'www.google.com',
+    addresses.INET6_HOST,
     { all: true, family: 6 },
     common.mustCall((err, ips) => {
       assert.ifError(err);

--- a/test/internet/test-dns-setserver-in-callback-of-resolve4.js
+++ b/test/internet/test-dns-setserver-in-callback-of-resolve4.js
@@ -5,8 +5,11 @@
 // a crash or not. If it doesn't crash, the test succeeded.
 
 const common = require('../common');
+const { addresses } = require('../common/internet');
 const dns = require('dns');
 
-dns.resolve4('google.com', common.mustCall(function(/* err, nameServers */) {
-  dns.setServers([ '8.8.8.8' ]);
-}));
+dns.resolve4(
+  addresses.INET4_HOST,
+  common.mustCall(function(/* err, nameServers */) {
+    dns.setServers([ addresses.DNS4_SERVER ]);
+  }));

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dns = require('dns');
 const net = require('net');
@@ -74,7 +75,9 @@ TEST(function test_reverse_bogus(done) {
 });
 
 TEST(function test_resolve4_ttl(done) {
-  const req = dns.resolve4('google.com', { ttl: true }, function(err, result) {
+  const req = dns.resolve4(addresses.INET4_HOST, {
+    ttl: true
+  }, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -95,7 +98,9 @@ TEST(function test_resolve4_ttl(done) {
 });
 
 TEST(function test_resolve6_ttl(done) {
-  const req = dns.resolve6('google.com', { ttl: true }, function(err, result) {
+  const req = dns.resolve6(addresses.INET6_HOST, {
+    ttl: true
+  }, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -116,7 +121,7 @@ TEST(function test_resolve6_ttl(done) {
 });
 
 TEST(function test_resolveMx(done) {
-  const req = dns.resolveMx('gmail.com', function(err, result) {
+  const req = dns.resolveMx(addresses.MX_HOST, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -138,7 +143,7 @@ TEST(function test_resolveMx(done) {
 });
 
 TEST(function test_resolveMx_failure(done) {
-  const req = dns.resolveMx('something.invalid', function(err, result) {
+  const req = dns.resolveMx(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -151,7 +156,7 @@ TEST(function test_resolveMx_failure(done) {
 });
 
 TEST(function test_resolveNs(done) {
-  const req = dns.resolveNs('rackspace.com', function(err, names) {
+  const req = dns.resolveNs(addresses.NS_HOST, function(err, names) {
     assert.ifError(err);
     assert.ok(names.length > 0);
 
@@ -168,7 +173,7 @@ TEST(function test_resolveNs(done) {
 });
 
 TEST(function test_resolveNs_failure(done) {
-  const req = dns.resolveNs('something.invalid', function(err, result) {
+  const req = dns.resolveNs(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -181,7 +186,7 @@ TEST(function test_resolveNs_failure(done) {
 });
 
 TEST(function test_resolveSrv(done) {
-  const req = dns.resolveSrv('_jabber._tcp.google.com', function(err, result) {
+  const req = dns.resolveSrv(addresses.SRV_HOST, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -205,7 +210,7 @@ TEST(function test_resolveSrv(done) {
 });
 
 TEST(function test_resolveSrv_failure(done) {
-  const req = dns.resolveSrv('something.invalid', function(err, result) {
+  const req = dns.resolveSrv(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -218,7 +223,7 @@ TEST(function test_resolveSrv_failure(done) {
 });
 
 TEST(function test_resolvePtr(done) {
-  const req = dns.resolvePtr('8.8.8.8.in-addr.arpa', function(err, result) {
+  const req = dns.resolvePtr(addresses.PTR_HOST, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -235,7 +240,7 @@ TEST(function test_resolvePtr(done) {
 });
 
 TEST(function test_resolvePtr_failure(done) {
-  const req = dns.resolvePtr('something.invalid', function(err, result) {
+  const req = dns.resolvePtr(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -248,7 +253,7 @@ TEST(function test_resolvePtr_failure(done) {
 });
 
 TEST(function test_resolveNaptr(done) {
-  const req = dns.resolveNaptr('sip2sip.info', function(err, result) {
+  const req = dns.resolveNaptr(addresses.NAPTR_HOST, function(err, result) {
     assert.ifError(err);
     assert.ok(result.length > 0);
 
@@ -272,7 +277,7 @@ TEST(function test_resolveNaptr(done) {
 });
 
 TEST(function test_resolveNaptr_failure(done) {
-  const req = dns.resolveNaptr('something.invalid', function(err, result) {
+  const req = dns.resolveNaptr(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -285,7 +290,7 @@ TEST(function test_resolveNaptr_failure(done) {
 });
 
 TEST(function test_resolveSoa(done) {
-  const req = dns.resolveSoa('nodejs.org', function(err, result) {
+  const req = dns.resolveSoa(addresses.SOA_HOST, function(err, result) {
     assert.ifError(err);
     assert.ok(result);
     assert.strictEqual(typeof result, 'object');
@@ -318,7 +323,7 @@ TEST(function test_resolveSoa(done) {
 });
 
 TEST(function test_resolveSoa_failure(done) {
-  const req = dns.resolveSoa('something.invalid', function(err, result) {
+  const req = dns.resolveSoa(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -331,7 +336,7 @@ TEST(function test_resolveSoa_failure(done) {
 });
 
 TEST(function test_resolveCname(done) {
-  const req = dns.resolveCname('www.microsoft.com', function(err, names) {
+  const req = dns.resolveCname(addresses.CNAME_HOST, function(err, names) {
     assert.ifError(err);
     assert.ok(names.length > 0);
 
@@ -348,7 +353,7 @@ TEST(function test_resolveCname(done) {
 });
 
 TEST(function test_resolveCname_failure(done) {
-  const req = dns.resolveCname('something.invalid', function(err, result) {
+  const req = dns.resolveCname(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -362,7 +367,7 @@ TEST(function test_resolveCname_failure(done) {
 
 
 TEST(function test_resolveTxt(done) {
-  const req = dns.resolveTxt('google.com', function(err, records) {
+  const req = dns.resolveTxt(addresses.TXT_HOST, function(err, records) {
     assert.ifError(err);
     assert.strictEqual(records.length, 1);
     assert.ok(util.isArray(records[0]));
@@ -374,7 +379,7 @@ TEST(function test_resolveTxt(done) {
 });
 
 TEST(function test_resolveTxt_failure(done) {
-  const req = dns.resolveTxt('something.invalid', function(err, result) {
+  const req = dns.resolveTxt(addresses.INVALID_HOST, function(err, result) {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, 'ENOTFOUND');
 
@@ -388,12 +393,12 @@ TEST(function test_resolveTxt_failure(done) {
 
 
 TEST(function test_lookup_failure(done) {
-  const req = dns.lookup('this.hostname.is.invalid', 4, (err, ip, family) => {
+  const req = dns.lookup(addresses.INVALID_HOST, 4, (err, ip, family) => {
     assert.ok(err instanceof Error);
     assert.strictEqual(err.errno, dns.NOTFOUND);
     assert.strictEqual(err.errno, 'ENOTFOUND');
     assert.ok(!/ENOENT/.test(err.message));
-    assert.ok(err.message.includes('this.hostname.is.invalid'));
+    assert.ok(err.message.includes(addresses.INVALID_HOST));
 
     done();
   });
@@ -461,7 +466,9 @@ TEST(function test_lookup_null_all(done) {
 
 
 TEST(function test_lookup_all_mixed(done) {
-  const req = dns.lookup('www.google.com', { all: true }, function(err, ips) {
+  const req = dns.lookup(addresses.INET_HOST, {
+    all: true
+  }, function(err, ips) {
     assert.ifError(err);
     assert.ok(Array.isArray(ips));
     assert.ok(ips.length > 0);
@@ -511,11 +518,11 @@ TEST(function test_reverse_failure(done) {
 
 
 TEST(function test_lookup_failure(done) {
-  const req = dns.lookup('this.hostname.is.invalid', (err) => {
+  const req = dns.lookup(addresses.INVALID_HOST, (err) => {
     assert(err instanceof Error);
     assert.strictEqual(err.code, 'ENOTFOUND');  // Silly error code...
-    assert.strictEqual(err.hostname, 'this.hostname.is.invalid');
-    assert.ok(err.message.includes('this.hostname.is.invalid'));
+    assert.strictEqual(err.hostname, addresses.INVALID_HOST);
+    assert.ok(err.message.includes(addresses.INVALID_HOST));
 
     done();
   });
@@ -525,7 +532,7 @@ TEST(function test_lookup_failure(done) {
 
 
 TEST(function test_resolve_failure(done) {
-  const req = dns.resolve4('this.hostname.is.invalid', (err) => {
+  const req = dns.resolve4(addresses.INVALID_HOST, (err) => {
     assert(err instanceof Error);
 
     switch (err.code) {
@@ -537,8 +544,8 @@ TEST(function test_resolve_failure(done) {
         break;
     }
 
-    assert.strictEqual(err.hostname, 'this.hostname.is.invalid');
-    assert.ok(err.message.includes('this.hostname.is.invalid'));
+    assert.strictEqual(err.hostname, addresses.INVALID_HOST);
+    assert.ok(err.message.includes(addresses.INVALID_HOST));
 
     done();
   });
@@ -549,15 +556,16 @@ TEST(function test_resolve_failure(done) {
 
 let getaddrinfoCallbackCalled = false;
 
-console.log('looking up nodejs.org...');
+console.log(`looking up ${addresses.INET4_HOST}..`);
 
 const cares = process.binding('cares_wrap');
 const req = new cares.GetAddrInfoReqWrap();
-cares.getaddrinfo(req, 'nodejs.org', 4, /* hints */ 0, /* verbatim */ true);
+cares.getaddrinfo(req, addresses.INET4_HOST, 4,
+  /* hints */ 0, /* verbatim */ true);
 
 req.oncomplete = function(err, domains) {
   assert.strictEqual(err, 0);
-  console.log('nodejs.org = ', domains);
+  console.log(`${addresses.INET4_HOST} = ${domains}`);
   assert.ok(Array.isArray(domains));
   assert.ok(domains.length >= 1);
   assert.strictEqual(typeof domains[0], 'string');
@@ -572,10 +580,14 @@ process.on('exit', function() {
 });
 
 
-assert.doesNotThrow(() => dns.lookup('nodejs.org', 6, common.mustCall()));
+assert.doesNotThrow(() =>
+  dns.lookup(addresses.INET6_HOST, 6, common.mustCall()));
 
-assert.doesNotThrow(() => dns.lookup('nodejs.org', {}, common.mustCall()));
+assert.doesNotThrow(() =>
+  dns.lookup(addresses.INET_HOST, {}, common.mustCall()));
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', '0', common.mustCall()));
+assert.doesNotThrow(() =>
+  dns.lookupService('0.0.0.0', '0', common.mustCall()));
 
-assert.doesNotThrow(() => dns.lookupService('0.0.0.0', 0, common.mustCall()));
+assert.doesNotThrow(() =>
+  dns.lookupService('0.0.0.0', 0, common.mustCall()));

--- a/test/internet/test-http-https-default-ports.js
+++ b/test/internet/test-http-https-default-ports.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -29,10 +30,10 @@ const https = require('https');
 
 const http = require('http');
 
-https.get('https://www.google.com/', common.mustCall(function(res) {
+https.get(`https://${addresses.INET_HOST}/`, common.mustCall(function(res) {
   res.resume();
 }));
 
-http.get('http://www.google.com/', common.mustCall(function(res) {
+http.get(`http://${addresses.INET_HOST}/`, common.mustCall(function(res) {
   res.resume();
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This PR makes the addresses used by the internet tests configurable (via `NODE_TEST_*` environment variables), so it's easier to verify them within a firewall.

Also this moves most `google.com` references to `nodejs.org`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
