### PR TITLE
https: refactor to use http internals

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -25,8 +25,13 @@ require('internal/util').assertCrypto();
 
 const tls = require('tls');
 const url = require('url');
-const http = require('http');
 const util = require('util');
+const { Agent: HttpAgent } = require('_http_agent');
+const {
+  Server: HttpServer,
+  _connectionListener
+} = require('_http_server');
+const { ClientRequest } = require('_http_client');
 const { inherits } = util;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
@@ -52,7 +57,7 @@ function Server(opts, requestListener) {
     opts.ALPNProtocols = ['http/1.1'];
   }
 
-  tls.Server.call(this, opts, http._connectionListener);
+  tls.Server.call(this, opts, _connectionListener);
 
   this.httpAllowHalfOpen = false;
 
@@ -69,13 +74,12 @@ function Server(opts, requestListener) {
   this.keepAliveTimeout = 5000;
 }
 inherits(Server, tls.Server);
-exports.Server = Server;
 
-Server.prototype.setTimeout = http.Server.prototype.setTimeout;
+Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 
-exports.createServer = function createServer(opts, requestListener) {
+function createServer(opts, requestListener) {
   return new Server(opts, requestListener);
-};
+}
 
 
 // HTTPS agents.
@@ -130,7 +134,7 @@ function Agent(options) {
   if (!(this instanceof Agent))
     return new Agent(options);
 
-  http.Agent.call(this, options);
+  HttpAgent.call(this, options);
   this.defaultPort = 443;
   this.protocol = 'https:';
   this.maxCachedSessions = this.options.maxCachedSessions;
@@ -142,11 +146,11 @@ function Agent(options) {
     list: []
   };
 }
-inherits(Agent, http.Agent);
+inherits(Agent, HttpAgent);
 Agent.prototype.createConnection = createConnection;
 
 Agent.prototype.getName = function getName(options) {
-  var name = http.Agent.prototype.getName.call(this, options);
+  var name = HttpAgent.prototype.getName.call(this, options);
 
   name += ':';
   if (options.ca)
@@ -220,10 +224,7 @@ Agent.prototype._evictSession = function _evictSession(key) {
 
 const globalAgent = new Agent();
 
-exports.globalAgent = globalAgent;
-exports.Agent = Agent;
-
-exports.request = function request(options, cb) {
+function request(options, cb) {
   if (typeof options === 'string') {
     options = url.parse(options);
     if (!options.hostname) {
@@ -237,11 +238,20 @@ exports.request = function request(options, cb) {
     options = util._extend({}, options);
   }
   options._defaultAgent = globalAgent;
-  return http.request(options, cb);
-};
+  return new ClientRequest(options, cb);
+}
 
-exports.get = function get(options, cb) {
-  var req = exports.request(options, cb);
+function get(options, cb) {
+  const req = request(options, cb);
   req.end();
   return req;
+}
+
+module.exports = {
+  Agent,
+  globalAgent,
+  Server,
+  createServer,
+  get,
+  request
 };


### PR DESCRIPTION
Rather than using `http`, use `_http_client`, etc. directly.

Also moving all the exports to the bottom, in line with most of the rest
of the codebase.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
https