### PR TITLE
src: remove empty comment in node_http2.h

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -309,7 +309,6 @@ class Http2Options {
 
 static const size_t kAllocBufferSize = 64 * 1024;
 
-////
 typedef uint32_t(*get_setting)(nghttp2_session* session,
                                nghttp2_settings_id id);
 

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -3021,7 +3021,7 @@ def CheckComment(line, filename, linenum, next_line_start, error):
       # If the comment contains an alphanumeric character, there
       # should be a space somewhere between it and the // unless
       # it's a /// or //! Doxygen comment.
-      if (Match(r'//[^ ]*\w', comment) and
+      if (Match(r'(?://[^ ]*\w)|(?:////\s*$)', comment) and
           not Match(r'(///|//\!)(\s+|$)', comment)):
         error(filename, linenum, 'whitespace/comments', 4,
               'Should have a space between // and comment')


### PR DESCRIPTION
This commit removes an "empty" comment in node_http2.h that I don't
think was intentional and as far as I can tell not a doxygen comment or
anything like that.

This was not picked up by the cpp linter so a suggestion has also been
added to the CheckComment function to detect these in the future.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, tools