### PR TITLE
lib: improve the usage of TypeError[INVALID_ARG_TYPE]

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -105,7 +105,7 @@ function ClientRequest(options, cb) {
     // when createConnection is provided.
   } else if (typeof agent.addRequest !== 'function') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'Agent option',
-                               ['Agent-like object', 'undefined', 'false']);
+                               ['Agent-like Object', 'undefined', 'false']);
   }
   this.agent = agent;
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -650,7 +650,7 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
 
   if (!fromEnd && typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
-                               ['string', 'buffer']);
+                               ['string', 'Buffer']);
   }
 
 
@@ -748,7 +748,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   if (chunk) {
     if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'first argument',
-                                 ['string', 'buffer']);
+                                 ['string', 'Buffer']);
     }
     if (!this._header) {
       if (typeof chunk === 'string')

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -845,7 +845,7 @@ function Server(options, listener) {
   } else if (options == null || typeof options === 'object') {
     options = options || {};
   } else {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
   }
 
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -166,7 +166,7 @@ function innerThrows(shouldThrow, block, expected, message) {
   var details = '';
 
   if (typeof block !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'function',
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
                                block);
   }
 

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -199,7 +199,7 @@ Buffer.from = function from(value, encodingOrOffset, length) {
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE',
       'first argument',
-      ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object'],
+      ['string', 'Buffer', 'ArrayBuffer', 'Array', 'Array-like Object'],
       value
     );
   }
@@ -226,7 +226,7 @@ Buffer.from = function from(value, encodingOrOffset, length) {
   throw new errors.TypeError(
     'ERR_INVALID_ARG_TYPE',
     'first argument',
-    ['string', 'buffer', 'arrayBuffer', 'array', 'array-like object'],
+    ['string', 'Buffer', 'ArrayBuffer', 'Array', 'Array-like Object'],
     value
   );
 };
@@ -429,7 +429,7 @@ Buffer.isBuffer = function isBuffer(b) {
 Buffer.compare = function compare(a, b) {
   if (!isUint8Array(a) || !isUint8Array(b)) {
     throw new errors.TypeError(
-      'ERR_INVALID_ARG_TYPE', ['buf1', 'buf2'], ['buffer', 'uint8Array']
+      'ERR_INVALID_ARG_TYPE', ['buf1', 'buf2'], ['Buffer', 'Uint8Array']
     );
   }
 
@@ -448,7 +448,7 @@ Buffer.isEncoding = function isEncoding(encoding) {
 Buffer[kIsEncodingSymbol] = Buffer.isEncoding;
 
 const kConcatErr = new errors.TypeError(
-  'ERR_INVALID_ARG_TYPE', 'list', ['array', 'buffer', 'uint8Array']
+  'ERR_INVALID_ARG_TYPE', 'list', ['Array', 'Buffer', 'Uint8Array']
 );
 
 Buffer.concat = function concat(list, length) {
@@ -509,7 +509,7 @@ function byteLength(string, encoding) {
 
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE', 'string',
-      ['string', 'buffer', 'arrayBuffer'], string
+      ['string', 'Buffer', 'ArrayBuffer'], string
     );
   }
 
@@ -671,7 +671,7 @@ Buffer.prototype.equals = function equals(b) {
   if (!isUint8Array(b)) {
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE', 'otherBuffer',
-      ['buffer', 'uint8Array'], b
+      ['Buffer', 'Uint8Array'], b
     );
   }
   if (this === b)
@@ -700,7 +700,7 @@ Buffer.prototype.compare = function compare(target,
   if (!isUint8Array(target)) {
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE', 'target',
-      ['buffer', 'uint8Array'], target
+      ['Buffer', 'Uint8Array'], target
     );
   }
   if (arguments.length === 1)
@@ -783,7 +783,7 @@ function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
 
   throw new errors.TypeError(
     'ERR_INVALID_ARG_TYPE', 'value',
-    ['string', 'buffer', 'uint8Array'], val
+    ['string', 'Buffer', 'Uint8Array'], val
   );
 }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -63,7 +63,7 @@ function newHandle(type, lookup) {
   if (lookup === undefined)
     lookup = dns.lookup;
   else if (typeof lookup !== 'function')
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'lookup', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'lookup', 'Function');
 
   if (type === 'udp4') {
     const handle = new UDP();

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -133,7 +133,7 @@ function lookup(hostname, options, callback) {
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'hostname',
-                               ['string', 'falsey'], hostname);
+                               ['string', 'falsy'], hostname);
   } else if (typeof options === 'function') {
     callback = options;
     family = 0;

--- a/lib/events.js
+++ b/lib/events.js
@@ -243,7 +243,7 @@ function _addListener(target, type, listener, prepend) {
 
   if (typeof listener !== 'function') {
     const errors = lazyErrors();
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'Function');
   }
 
   events = target._events;
@@ -344,7 +344,7 @@ function _onceWrap(target, type, listener) {
 EventEmitter.prototype.once = function once(type, listener) {
   if (typeof listener !== 'function') {
     const errors = lazyErrors();
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener', 'Function');
   }
   this.on(type, _onceWrap(this, type, listener));
   return this;
@@ -355,7 +355,7 @@ EventEmitter.prototype.prependOnceListener =
       if (typeof listener !== 'function') {
         const errors = lazyErrors();
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener',
-                                   'function');
+                                   'Function');
       }
       this.prependListener(type, _onceWrap(this, type, listener));
       return this;
@@ -369,7 +369,7 @@ EventEmitter.prototype.removeListener =
       if (typeof listener !== 'function') {
         const errors = lazyErrors();
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'listener',
-                                   'function');
+                                   'Function');
       }
 
       events = this._events;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -86,7 +86,7 @@ function getOptions(options, defaultOptions) {
   } else if (typeof options !== 'object') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'options',
-                               ['string', 'object'],
+                               ['string', 'Object'],
                                options);
   }
 
@@ -1209,7 +1209,7 @@ function toUnixTimestamp(time) {
   }
   throw new errors.Error('ERR_INVALID_ARG_TYPE',
                          'time',
-                         ['Date', 'time in seconds'],
+                         ['Date', 'Time in seconds'],
                          time);
 }
 
@@ -1513,7 +1513,7 @@ fs.watchFile = function(filename, options, listener) {
   if (typeof listener !== 'function') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'listener',
-                               'function',
+                               'Function',
                                listener);
   }
 
@@ -1922,7 +1922,7 @@ fs.copyFile = function(src, dest, flags, callback) {
     callback = flags;
     flags = 0;
   } else if (typeof callback !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'callback', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'callback', 'Function');
   }
 
   src = getPathFromURL(src);

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -56,7 +56,7 @@ class Session extends EventEmitter {
     }
     if (params && typeof params !== 'object') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                                 'params', 'object', params);
+                                 'params', 'Object', params);
     }
     if (callback && typeof callback !== 'function') {
       throw new errors.TypeError('ERR_INVALID_CALLBACK');

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -273,7 +273,7 @@ ChildProcess.prototype.spawn = function(options) {
   var i;
 
   if (options === null || typeof options !== 'object') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object',
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object',
                                options);
   }
 
@@ -594,7 +594,7 @@ function setupChannel(target, channel) {
       options = undefined;
     } else if (options !== undefined &&
                (options === null || typeof options !== 'object')) {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object',
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object',
                                  options);
     }
 

--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -345,7 +345,7 @@ function makeTextDecoderICU() {
     constructor(encoding = 'utf-8', options = {}) {
       encoding = `${encoding}`;
       if (typeof options !== 'object')
-        throw new errors.Error('ERR_INVALID_ARG_TYPE', 'options', 'object');
+        throw new errors.Error('ERR_INVALID_ARG_TYPE', 'options', 'Object');
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined)
@@ -378,7 +378,7 @@ function makeTextDecoderICU() {
                                    ['ArrayBuffer', 'ArrayBufferView']);
       }
       if (typeof options !== 'object') {
-        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
       }
 
       var flags = 0;
@@ -417,7 +417,7 @@ function makeTextDecoderJS() {
     constructor(encoding = 'utf-8', options = {}) {
       encoding = `${encoding}`;
       if (typeof options !== 'object')
-        throw new errors.Error('ERR_INVALID_ARG_TYPE', 'options', 'object');
+        throw new errors.Error('ERR_INVALID_ARG_TYPE', 'options', 'Object');
 
       const enc = getEncodingFromLabel(encoding);
       if (enc === undefined || !hasConverter(enc))
@@ -452,7 +452,7 @@ function makeTextDecoderJS() {
                                    ['ArrayBuffer', 'ArrayBufferView']);
       }
       if (typeof options !== 'object') {
-        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
       }
 
       if (this[kFlags] & CONVERTER_FLAGS_FLUSH) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -133,7 +133,7 @@ class SystemError extends makeNodeError(Error) {
 class AssertionError extends Error {
   constructor(options) {
     if (typeof options !== 'object' || options === null) {
-      throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+      throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
     }
     var { actual, expected, message, operator, stackStartFunction } = options;
     if (message) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2484,7 +2484,7 @@ function connect(authority, options, listener) {
   if (typeof authority === 'string')
     authority = new URL(authority);
 
-  assertIsObject(authority, 'authority', ['string', 'object', 'URL']);
+  assertIsObject(authority, 'authority', ['string', 'Object', 'URL']);
 
   debug(`connecting to ${authority}`);
 
@@ -2539,7 +2539,7 @@ function createSecureServer(options, handler) {
   if (options == null || typeof options !== 'object') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'options',
-                               'object');
+                               'Object');
   }
   debug('creating http2secureserver');
   return new Http2SecureServer(options, handler);

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -465,7 +465,7 @@ class NghttpError extends Error {
   }
 }
 
-function assertIsObject(value, name, types = 'object') {
+function assertIsObject(value, name, types = 'Object') {
   if (value !== undefined &&
       (value === null ||
        typeof value !== 'object' ||

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -28,12 +28,12 @@ function setup_cpuUsage() {
     if (prevValue) {
       if (!previousValueIsValid(prevValue.user)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                                   'preValue.user', 'Number');
+                                   'preValue.user', 'number');
       }
 
       if (!previousValueIsValid(prevValue.system)) {
         throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                                   'preValue.system', 'Number');
+                                   'preValue.system', 'number');
       }
     }
 
@@ -154,7 +154,7 @@ function setupKillAndExit() {
 
     // eslint-disable-next-line eqeqeq
     if (pid != (pid | 0)) {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pid', 'Number');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'pid', 'number');
     }
 
     // preserve null signal

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -372,7 +372,7 @@ Object.defineProperties(URL.prototype, {
     // eslint-disable-next-line func-name-matching
     value: function format(options) {
       if (options && typeof options !== 'object')
-        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
       options = util._extend({
         fragment: true,
         unicode: false,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -208,14 +208,14 @@ const kCustomPromisifyArgsSymbol = Symbol('customPromisifyArgs');
 
 function promisify(original) {
   if (typeof original !== 'function')
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'Function');
 
   if (original[kCustomPromisifiedSymbol]) {
     const fn = original[kCustomPromisifiedSymbol];
     if (typeof fn !== 'function') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                  'util.promisify.custom',
-                                 'function',
+                                 'Function',
                                  fn);
     }
     Object.defineProperty(fn, kCustomPromisifiedSymbol, {

--- a/lib/net.js
+++ b/lib/net.js
@@ -1080,7 +1080,7 @@ function lookupAndConnect(self, options) {
   if (options.lookup && typeof options.lookup !== 'function')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'options.lookup',
-                               'function',
+                               'Function',
                                options.lookup);
 
   var dnsopts = {
@@ -1225,7 +1225,7 @@ function Server(options, connectionListener) {
   } else {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'options',
-                               'object',
+                               'Object',
                                options);
   }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1111,7 +1111,7 @@ REPLServer.prototype.defineCommand = function(keyword, cmd) {
   } else if (typeof cmd.action !== 'function') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                'action',
-                               'function',
+                               'Function',
                                cmd.action);
   }
   this.commands[keyword] = cmd;

--- a/lib/url.js
+++ b/lib/url.js
@@ -556,7 +556,7 @@ function urlFormat(urlObject, options) {
     urlObject = urlParse(urlObject);
   } else if (typeof urlObject !== 'object' || urlObject === null) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'urlObject',
-                               ['object', 'string'], urlObject);
+                               ['Object', 'string'], urlObject);
   } else if (!(urlObject instanceof Url)) {
     var format = urlObject[formatSymbol];
     return format ?

--- a/lib/util.js
+++ b/lib/util.js
@@ -335,7 +335,7 @@ Object.defineProperty(inspect, 'defaultOptions', {
   },
   set(options) {
     if (options === null || typeof options !== 'object') {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'object');
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
     }
     Object.assign(inspectDefaultOptions, options);
     return inspectDefaultOptions;
@@ -970,14 +970,14 @@ function log() {
 function inherits(ctor, superCtor) {
 
   if (ctor === undefined || ctor === null)
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ctor', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'ctor', 'Function');
 
   if (superCtor === undefined || superCtor === null)
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor', 'function');
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor', 'Function');
 
   if (superCtor.prototype === undefined) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'superCtor.prototype',
-                               'function');
+                               'Function');
   }
   ctor.super_ = superCtor;
   Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
@@ -1080,7 +1080,7 @@ function callbackify(original) {
     throw new errors.TypeError(
       'ERR_INVALID_ARG_TYPE',
       'original',
-      'function');
+      'Function');
   }
 
   // We DO NOT return the promise as it gives the user a false sense that
@@ -1092,7 +1092,7 @@ function callbackify(original) {
       throw new errors.TypeError(
         'ERR_INVALID_ARG_TYPE',
         'last argument',
-        'function');
+        'Function');
     }
     const cb = (...args) => { Reflect.apply(maybeCb, this, args); };
     // In true node style we process the callback on `nextTick` with all the

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -689,8 +689,8 @@ try {
       common.expectsError({
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
-        message: 'The "block" argument must be of type function. Received ' +
-                 `type ${typeName(block)}`
+        message: 'The "block" argument must be of type Function. Received ' +
+                 'type ' + typeName(block)
       })(e);
     }
 
@@ -732,7 +732,7 @@ assert.throws(() => {
 {
   // bad args to AssertionError constructor should throw TypeError
   const args = [1, true, false, '', null, Infinity, Symbol('test'), undefined];
-  const re = /^The "options" argument must be of type object$/;
+  const re = /^The "options" argument must be of type Object$/;
   args.forEach((input) => {
     assert.throws(
       () => new assert.AssertionError(input),

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -934,8 +934,8 @@ assert.throws(() => Buffer.allocUnsafe(10).copy(),
               /TypeError: argument should be a Buffer/);
 
 const regErrorMsg =
-  new RegExp('The first argument must be one of type string, buffer, ' +
-             'arrayBuffer, array, or array-like object\\.');
+  new RegExp('The first argument must be one of type string, Buffer, ' +
+             'ArrayBuffer, Array, or Array-like Object\\.');
 
 assert.throws(() => Buffer.from(), regErrorMsg);
 assert.throws(() => Buffer.from(null), regErrorMsg);

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -17,7 +17,7 @@ const vm = require('vm');
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "string" argument must be one of type string, ' +
-               `buffer, or arrayBuffer. Received type ${typeof args[0]}`
+               `Buffer, or ArrayBuffer. Received type ${typeof args[0]}`
     }
   );
 });

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -70,5 +70,5 @@ assert.throws(() => a.compare(), common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "target" argument must be one of ' +
-           'type buffer or uint8Array. Received type undefined'
+           'type Buffer or Uint8Array. Received type undefined'
 }));

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -32,7 +32,7 @@ const errMsg = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "buf1", "buf2" arguments must be one of ' +
-             'type buffer or uint8Array'
+             'type Buffer or Uint8Array'
 }, 2);
 assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
 
@@ -42,5 +42,5 @@ assert.throws(() => Buffer.alloc(1).compare('abc'), common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "target" argument must be one of ' +
-           'type buffer or uint8Array. Received type string'
+           'type Buffer or Uint8Array. Received type string'
 }));

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -58,7 +58,7 @@ function assertWrongList(value) {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "list" argument must be one of type ' +
-             'array, buffer, or uint8Array'
+             'Array, Buffer, or Uint8Array'
   }));
 }
 

--- a/test/parallel/test-buffer-equals.js
+++ b/test/parallel/test-buffer-equals.js
@@ -20,6 +20,6 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "otherBuffer" argument must be one of type ' +
-    'buffer or uint8Array. Received type string'
+    'Buffer or Uint8Array. Received type string'
   }
 );

--- a/test/parallel/test-buffer-from.js
+++ b/test/parallel/test-buffer-from.js
@@ -46,8 +46,8 @@ deepStrictEqual(
   const err = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The first argument must be one of type string, buffer, ' +
-             'arrayBuffer, array, or array-like object. Received ' +
+    message: 'The first argument must be one of type string, Buffer, ' +
+             'ArrayBuffer, Array, or Array-like Object. Received ' +
              `type ${actualType}`
   });
   throws(() => Buffer.from(input), err);

--- a/test/parallel/test-buffer-includes.js
+++ b/test/parallel/test-buffer-includes.js
@@ -282,7 +282,7 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "value" argument must be one of type string, ' +
-               `buffer, or uint8Array. Received type ${typeof val}`
+               `Buffer, or Uint8Array. Received type ${typeof val}`
     }
   );
 });

--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -357,7 +357,7 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "value" argument must be one of type string, ' +
-               `buffer, or uint8Array. Received type ${typeof val}`
+               `Buffer, or Uint8Array. Received type ${typeof val}`
     }
   );
 });

--- a/test/parallel/test-child-process-constructor.js
+++ b/test/parallel/test-child-process-constructor.js
@@ -19,7 +19,7 @@ function typeName(value) {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "options" argument must be of type object. ' +
+      message: 'The "options" argument must be of type Object. ' +
                `Received type ${typeName(options)}`
     });
   });

--- a/test/parallel/test-dgram-custom-lookup.js
+++ b/test/parallel/test-dgram-custom-lookup.js
@@ -41,7 +41,7 @@ const dns = require('dns');
     }, common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "lookup" argument must be of type function'
+      message: 'The "lookup" argument must be of type Function'
     }));
   });
 }

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -12,7 +12,7 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: /^The "hostname" argument must be one of type string or falsey/
+  message: /^The "hostname" argument must be one of type string or falsy/
 }));
 
 assert.throws(() => {

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -123,7 +123,7 @@ assert.throws(() => {
   const errorReg = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: /^The "hostname" argument must be one of type string or falsey/
+    message: /^The "hostname" argument must be one of type string or falsy/
   }, 5);
 
   assert.throws(() => dns.lookup({}, common.mustNotCall()), errorReg);

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -92,5 +92,5 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type function'
+  message: 'The "listener" argument must be of type Function'
 });

--- a/test/parallel/test-event-emitter-once.js
+++ b/test/parallel/test-event-emitter-once.js
@@ -57,7 +57,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type function'
+  message: 'The "listener" argument must be of type Function'
 });
 
 {

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -26,7 +26,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type function'
+  message: 'The "listener" argument must be of type Function'
 });
 
 // Test fallback if prependListener is undefined.

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -151,7 +151,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "listener" argument must be of type function'
+  message: 'The "listener" argument must be of type Function'
 });
 
 {

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -66,7 +66,7 @@ common.expectsError(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "callback" argument must be of type function'
+  message: 'The "callback" argument must be of type Function'
 });
 
 // Throws if the source path is not a string.

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -53,7 +53,7 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "Agent option" argument must be one of type ' +
-                 'Agent-like object, undefined, or false'
+                 'Agent-like Object, undefined, or false'
       })
     );
   });

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -84,7 +84,7 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The first argument must be one of type string or buffer'
+  message: 'The first argument must be one of type string or Buffer'
 }));
 
 assert.throws(() => {
@@ -93,7 +93,7 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The first argument must be one of type string or buffer'
+  message: 'The first argument must be one of type string or Buffer'
 }));
 
 // addTrailers

--- a/test/parallel/test-http2-createsecureserver-nooptions.js
+++ b/test/parallel/test-http2-createsecureserver-nooptions.js
@@ -10,7 +10,7 @@ const invalidOptions = [() => {}, 1, 'test', null, undefined];
 const invalidArgTypeError = {
   type: TypeError,
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "options" argument must be of type object'
+  message: 'The "options" argument must be of type Object'
 };
 
 // Error if options are not passed to createSecureServer

--- a/test/parallel/test-http2-misc-util.js
+++ b/test/parallel/test-http2-misc-util.js
@@ -35,7 +35,7 @@ common.expectsError(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "test" argument must be of type object'
+    message: 'The "test" argument must be of type Object'
   });
 
 common.expectsError(

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -15,7 +15,7 @@ const {
   new Date(),
   new (class Foo {})()
 ].forEach((i) => {
-  assert.doesNotThrow(() => assertIsObject(i, 'foo', 'object'));
+  assert.doesNotThrow(() => assertIsObject(i, 'foo', 'Object'));
 });
 
 [
@@ -27,10 +27,10 @@ const {
   [],
   [{}]
 ].forEach((i) => {
-  assert.throws(() => assertIsObject(i, 'foo', 'object'),
+  assert.throws(() => assertIsObject(i, 'foo', 'Object'),
                 common.expectsError({
                   code: 'ERR_INVALID_ARG_TYPE',
-                  message: /^The "foo" argument must be of type object$/
+                  message: /^The "foo" argument must be of type Object$/
                 }));
 });
 

--- a/test/parallel/test-process-cpuUsage.js
+++ b/test/parallel/test-process-cpuUsage.js
@@ -34,13 +34,13 @@ for (let i = 0; i < 10; i++) {
 const invalidUserArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "preValue.user" property must be of type Number'
+  message: 'The "preValue.user" property must be of type number'
 }, 8);
 
 const invalidSystemArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "preValue.system" property must be of type Number'
+  message: 'The "preValue.system" property must be of type number'
 }, 2);
 
 

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -41,7 +41,7 @@ const assert = require('assert');
 const invalidPidArgument = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "pid" argument must be of type Number'
+  message: 'The "pid" argument must be of type number'
 }, 6);
 
 assert.throws(function() { process.kill('SIGTERM'); },

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -43,7 +43,7 @@ assert.throws(() => tls.createServer('this is not valid'),
               common.expectsError({
                 code: 'ERR_INVALID_ARG_TYPE',
                 type: TypeError,
-                message: 'The "options" argument must be of type object'
+                message: 'The "options" argument must be of type Object'
               })
 );
 

--- a/test/parallel/test-url-format-invalid-input.js
+++ b/test/parallel/test-url-format-invalid-input.js
@@ -17,7 +17,7 @@ for (const [urlObject, type] of throwsObjsAndReportTypes) {
   const error = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "urlObject" argument must be one of type object or string. ' +
+    message: 'The "urlObject" argument must be one of type Object or string. ' +
              `Received type ${type}`
   });
   assert.throws(function() { url.format(urlObject); }, error);

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -24,7 +24,7 @@ assert.strictEqual(
   const expectedErr = common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type object'
+    message: 'The "options" argument must be of type Object'
   }, 4);
   assert.throws(() => url.format(myURL, true), expectedErr);
   assert.throws(() => url.format(myURL, 1), expectedErr);

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -234,7 +234,7 @@ const values = [
     }, common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "original" argument must be of type function'
+      message: 'The "original" argument must be of type Function'
     }));
   });
 }
@@ -255,7 +255,7 @@ const values = [
     }, common.expectsError({
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The last argument must be of type function'
+      message: 'The last argument must be of type Function'
     }));
   });
 }

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -6,7 +6,7 @@ const inherits = require('util').inherits;
 const errCheck = common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor" argument must be of type function'
+  message: 'The "superCtor" argument must be of type Function'
 });
 
 // super constructor
@@ -85,7 +85,7 @@ assert.throws(function() {
 }, common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "superCtor.prototype" property must be of type function'
+  message: 'The "superCtor.prototype" property must be of type Function'
 })
 );
 assert.throws(function() {
@@ -96,6 +96,6 @@ assert.throws(function() {
 }, common.expectsError({
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-  message: 'The "ctor" argument must be of type function'
+  message: 'The "ctor" argument must be of type Function'
 })
 );

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1136,7 +1136,7 @@ if (typeof Symbol !== 'undefined') {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type object'
+    message: 'The "options" argument must be of type Object'
   })
   );
 
@@ -1145,7 +1145,7 @@ if (typeof Symbol !== 'undefined') {
   }, common.expectsError({
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
-    message: 'The "options" argument must be of type object'
+    message: 'The "options" argument must be of type Object'
   })
   );
 }

--- a/test/sequential/test-inspector-module.js
+++ b/test/sequential/test-inspector-module.js
@@ -43,7 +43,7 @@ assert.doesNotThrow(
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message:
-        'The "params" argument must be of type object. ' +
+        'The "params" argument must be of type Object. ' +
         `Received type ${typeof i}`
     }
   );


### PR DESCRIPTION
The initials of `expected` in `TypeError[ERR_INVALID_ARG_TYPE]` are inconsistent.

This PR is to:
- Unify the initial usage of `TypeError[INVALID_ARG_TYPE]`
- Add an argument check before construct an error
- Revise some inappropriate usage of `INVALID_ARG_TYPE`

Fixes: https://github.com/nodejs/node/issues/16383

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib