### PR TITLE
doc: how to decode buffers extending from Writable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1510,6 +1510,39 @@ class MyWritable extends Writable {
 }
 ```
 
+#### Decoding buffers in a Writable Stream
+
+Decoding buffers is a common task, for instance, when using transformers whose
+input is a string. This is not a trivial process when using multi-byte
+characters encoding. Implement it within [Writable][] implies some performance
+regressions. The following is an example of how to achieve that extending
+[Writable][].
+
+```js
+const { Writable } = require('stream')
+const { StringDecoder } = require('string_decoder')
+
+class StringWritable extends Writable {
+  constructor (options) {
+    super(options)
+    const state = this._writableState
+    this._decoder = new StringDecoder(state.defaultEncoding)
+    this._data = ''
+  }
+  _write (chunk, encoding, callback) {
+    if (encoding === 'buffer') {
+      chunk = this._decoder.write(chunk)
+    }
+    this._data += chunk
+    callback()
+  }
+  _final (callback) {
+    this._data += this._decoder.end()
+    callback()
+  }
+}
+```
+
 ### Implementing a Readable Stream
 
 The `stream.Readable` class is extended to implement a [Readable][] stream.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1526,17 +1526,17 @@ class StringWritable extends Writable {
     super(options);
     const state = this._writableState;
     this._decoder = new StringDecoder(state.defaultEncoding);
-    this._data = '';
+    this.data = '';
   }
   _write(chunk, encoding, callback) {
     if (encoding === 'buffer') {
       chunk = this._decoder.write(chunk);
     }
-    this._data += chunk;
+    this.data += chunk;
     callback();
   }
   _final(callback) {
-    this._data += this._decoder.end();
+    this.data += this._decoder.end();
     callback();
   }
 }
@@ -1548,7 +1548,7 @@ w.write('currency: ');
 w.write(euro[0]);
 w.end(euro[1]);
 
-console.log(w._data); // currency: €
+console.log(w.data); // currency: €
 ```
 
 ### Implementing a Readable Stream

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1514,9 +1514,8 @@ class MyWritable extends Writable {
 
 Decoding buffers is a common task, for instance, when using transformers whose
 input is a string. This is not a trivial process when using multi-byte
-characters encoding. Implement it within [Writable][] implies some performance
-regressions. The following is an example of how to achieve that extending
-[Writable][].
+characters encoding, such as UTF-8. The following example shows how to decode
+multi-byte strings using `StringDecoder` and [Writable][].
 
 ```js
 const { Writable } = require('stream');
@@ -1541,6 +1540,15 @@ class StringWritable extends Writable {
     callback();
   }
 }
+
+const euro = [[0xE2, 0x82], [0xAC]].map(Buffer.from);
+const w = new StringWritable();
+
+w.write('currency: ');
+w.write(euro[0]);
+w.end(euro[1]);
+
+console.log(w._data); // currency: €
 ```
 
 ### Implementing a Readable Stream

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -1519,26 +1519,26 @@ regressions. The following is an example of how to achieve that extending
 [Writable][].
 
 ```js
-const { Writable } = require('stream')
-const { StringDecoder } = require('string_decoder')
+const { Writable } = require('stream');
+const { StringDecoder } = require('string_decoder');
 
 class StringWritable extends Writable {
-  constructor (options) {
-    super(options)
-    const state = this._writableState
-    this._decoder = new StringDecoder(state.defaultEncoding)
-    this._data = ''
+  constructor(options) {
+    super(options);
+    const state = this._writableState;
+    this._decoder = new StringDecoder(state.defaultEncoding);
+    this._data = '';
   }
-  _write (chunk, encoding, callback) {
+  _write(chunk, encoding, callback) {
     if (encoding === 'buffer') {
-      chunk = this._decoder.write(chunk)
+      chunk = this._decoder.write(chunk);
     }
-    this._data += chunk
-    callback()
+    this._data += chunk;
+    callback();
   }
-  _final (callback) {
-    this._data += this._decoder.end()
-    callback()
+  _final(callback) {
+    this._data += this._decoder.end();
+    callback();
   }
 }
 ```


### PR DESCRIPTION
Improved stream documentation with an example of how to decode buffers
to strings within a custom Writable.

Fixes: https://github.com/nodejs/node/issues/15369

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
