### PR TITLE
process: add isExiting

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1208,6 +1208,17 @@ console.log(process.getgroups());         // [ 27, 30, 46, 1000 ]
 *Note*: This function is only available on POSIX platforms (i.e. not Windows
 or Android).
 
+## process.isExiting
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+This read-only boolean indicates if the process is currently exiting. That is,
+when the `exit` event has been fired and no further scheduled asynchronous code
+will run.
+
 ## process.kill(pid[, signal])
 <!-- YAML
 added: v0.0.6

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -10,6 +10,7 @@
 (function(process) {
   let internalBinding;
   const exceptionHandlerState = { captureFn: null };
+  let _process;
 
   function startup() {
     const EventEmitter = NativeModule.require('events');
@@ -33,7 +34,8 @@
 
     setupGlobalVariables();
 
-    const _process = NativeModule.require('internal/process');
+    _process = NativeModule.require('internal/process');
+    _process.setIsExiting(false);
     _process.setupConfig(NativeModule._source);
     _process.setupSignalHandlers();
     _process.setupUncaughtExceptionCapture(exceptionHandlerState);
@@ -302,7 +304,6 @@
 
     global.Buffer = NativeModule.require('buffer').Buffer;
     process.domain = null;
-    process._exiting = false;
   }
 
   function setupGlobalTimeouts() {
@@ -391,8 +392,8 @@
       // since that means that we'll exit the process, emit the 'exit' event
       if (!caught) {
         try {
-          if (!process._exiting) {
-            process._exiting = true;
+          if (!process.isExiting) {
+            _process.setIsExiting(true);
             process.emit('exit', 1);
           }
         } catch (er) {

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -3,6 +3,11 @@
 const errors = require('internal/errors');
 const util = require('util');
 const constants = process.binding('constants').os.signals;
+const {
+  getHiddenValue,
+  setHiddenValue,
+  is_exiting_private_symbol: kIsExitingSymbol
+} = process.binding('util');
 
 const assert = process.assert = function(x, msg) {
   if (!x) throw new errors.Error('ERR_ASSERTION', msg || 'assertion error');
@@ -138,12 +143,24 @@ function setupConfig(_source) {
 
 function setupKillAndExit() {
 
+  Object.defineProperty(process, 'isExiting', {
+    enumerable: true,
+    configurable: false,
+    get: getIsExiting
+  });
+
+  Object.defineProperty(process, '_exiting', {
+    enumerable: true,
+    configurable: false,
+    get: getIsExiting
+  });
+
   process.exit = function(code) {
     if (code || code === 0)
       process.exitCode = code;
 
-    if (!process._exiting) {
-      process._exiting = true;
+    if (!process.isExiting) {
+      setIsExiting(true);
       process.emit('exit', process.exitCode || 0);
     }
     process.reallyExit(process.exitCode || 0);
@@ -247,7 +264,6 @@ function setupRawDebug() {
   };
 }
 
-
 function setupUncaughtExceptionCapture(exceptionHandlerState) {
   // This is a typed array for faster communication with JS.
   const shouldAbortOnUncaughtToggle = process._shouldAbortOnUncaughtToggle;
@@ -275,6 +291,14 @@ function setupUncaughtExceptionCapture(exceptionHandlerState) {
   };
 }
 
+function setIsExiting(isExiting) {
+  setHiddenValue(process, kIsExitingSymbol, isExiting);
+}
+
+function getIsExiting() {
+  return getHiddenValue(process, kIsExitingSymbol);
+}
+
 module.exports = {
   setup_performance,
   setup_cpuUsage,
@@ -285,5 +309,7 @@ module.exports = {
   setupSignalHandlers,
   setupChannel,
   setupRawDebug,
-  setupUncaughtExceptionCapture
+  setupUncaughtExceptionCapture,
+  setIsExiting,
+  getIsExiting
 };

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -188,7 +188,7 @@ function setupNextTick() {
     if (typeof callback !== 'function')
       throw new errors.TypeError('ERR_INVALID_CALLBACK');
 
-    if (process._exiting)
+    if (process.isExiting)
       return;
 
     var args;
@@ -221,7 +221,7 @@ function setupNextTick() {
     // CHECK(Number.isSafeInteger(triggerAsyncId) || triggerAsyncId === null)
     // CHECK(triggerAsyncId > 0 || triggerAsyncId === null)
 
-    if (process._exiting)
+    if (process.isExiting)
       return;
 
     var args;

--- a/src/env.h
+++ b/src/env.h
@@ -90,6 +90,7 @@ class ModuleWrap;
   V(contextify_context_private_symbol, "node:contextify:context")             \
   V(contextify_global_private_symbol, "node:contextify:global")               \
   V(decorated_private_symbol, "node:decorated")                               \
+  V(is_exiting_private_symbol, "node:isExiting")                              \
   V(npn_buffer_private_symbol, "node:npnBuffer")                              \
   V(selected_npn_buffer_private_symbol, "node:selectedNpnBuffer")             \
   V(domain_private_symbol, "node:domain")                                     \
@@ -145,7 +146,6 @@ class ModuleWrap;
   V(errno_string, "errno")                                                    \
   V(error_string, "error")                                                    \
   V(events_string, "_events")                                                 \
-  V(exiting_string, "_exiting")                                               \
   V(exit_code_string, "exitCode")                                             \
   V(exit_string, "exit")                                                      \
   V(expire_string, "expire")                                                  \

--- a/src/node.cc
+++ b/src/node.cc
@@ -4294,7 +4294,9 @@ int EmitExit(Environment* env) {
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
   Local<Object> process_object = env->process_object();
-  process_object->Set(env->exiting_string(), True(env->isolate()));
+  process_object->SetPrivate(env->context(),
+                             env->is_exiting_private_symbol(),
+                             True(env->isolate()));
 
   Local<String> exitCode = env->exit_code_string();
   int code = process_object->Get(exitCode)->Int32Value();

--- a/test/parallel/test-next-tick-when-exiting.js
+++ b/test/parallel/test-next-tick-when-exiting.js
@@ -3,8 +3,14 @@
 require('../common');
 const assert = require('assert');
 
+const isExitingDesc = Object.getOwnPropertyDescriptor(process, 'isExiting');
+assert.ok(!('set' in isExitingDesc));
+assert.ok('get' in isExitingDesc);
+assert.strictEqual(isExitingDesc.configurable, false);
+assert.strictEqual(isExitingDesc.enumerable, true);
+
 process.on('exit', () => {
-  assert.strictEqual(process._exiting, true, 'process._exiting was not set!');
+  assert.strictEqual(process.isExiting, true, 'process.isExiting was not set!');
 
   process.nextTick(() => {
     assert.fail('process is exiting, should not be called.');


### PR DESCRIPTION
This replaces the previously undocumented `_exiting` property with a
read-only property giving the same information. Setting the property is
restricted to internals, to prevent tampering. Tampering could affect
nextTick behavior, for example.

Twitter thread for context: https://twitter.com/bengl/status/922361992379166721

It may or may not make sense to keep `_exiting` around as an alias, if there's userland code using it. That's easy enough to do if reviewers would like that.

/cc @addaleax @Trott 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
process