### PR TITLE
test: pass process.env to child processes

### DIFF
--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -91,11 +91,11 @@ class TestDoubleBenchmarker {
   create(options) {
     const child = child_process.fork(this.executable, {
       silent: true,
-      env: {
+      env: Object.assign({}, process.env, {
         duration: options.duration,
         connections: options.connections,
         path: `http://127.0.0.1:${options.port}${options.path}`
-      }
+      })
     });
     return child;
   }

--- a/benchmark/_http-benchmarkers.js
+++ b/benchmark/_http-benchmarkers.js
@@ -92,9 +92,7 @@ class TestDoubleBenchmarker {
     const child = child_process.fork(this.executable, {
       silent: true,
       env: Object.assign({}, process.env, {
-        duration: options.duration,
-        connections: options.connections,
-        path: `http://127.0.0.1:${options.port}${options.path}`
+        test_url: `http://127.0.0.1:${options.port}${options.path}`
       })
     });
     return child;

--- a/benchmark/_test-double-benchmarker.js
+++ b/benchmark/_test-double-benchmarker.js
@@ -2,6 +2,6 @@
 
 const http = require('http');
 
-http.get(process.env.path, function() {
+http.get(process.env.test_url, function() {
   console.log(JSON.stringify({ throughput: 1 }));
 });

--- a/test/parallel/test-child-process-fork-no-shell.js
+++ b/test/parallel/test-child-process-fork-no-shell.js
@@ -8,7 +8,7 @@ const expected = common.isWindows ? '%foo%' : '$foo';
 if (process.argv[2] === undefined) {
   const child = cp.fork(__filename, [expected], {
     shell: true,
-    env: { foo: 'bar' }
+    env: Object.assign({}, process.env, { foo: 'bar' })
   });
 
   child.on('exit', common.mustCall((code, signal) => {

--- a/test/sequential/test-inspector-port-cluster.js
+++ b/test/sequential/test-inspector-port-cluster.js
@@ -311,11 +311,11 @@ function workerProcessMain() {
 function spawnMaster({ execArgv, workers, clusterSettings = {} }) {
   return new Promise((resolve) => {
     childProcess.fork(__filename, {
-      env: {
+      env: Object.assign({}, process.env, {
         workers: JSON.stringify(workers),
         clusterSettings: JSON.stringify(clusterSettings),
         testProcess: true
-      },
+      }),
       execArgv
     }).on('exit', common.mustCall((code, signal) => {
       checkExitCode(code, signal);


### PR DESCRIPTION
Primarily for testing when using `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`, these are a few newer instances that have been added since someone last tried to do this. Found while testing OpenSSL 1.1.0 dynamic linking for #16130.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

test