### PR TITLE
test: add failing vm tests to known_issues

### DIFF
--- a/test/known_issues/test-vm-ownkeys.js
+++ b/test/known_issues/test-vm-ownkeys.js
@@ -1,0 +1,28 @@
+'use strict';
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+const sym1 = Symbol('1');
+const sym2 = Symbol('2');
+const sandbox = {
+  a: true,
+  [sym1]: true
+};
+Object.defineProperty(sandbox, 'b', { value: true });
+Object.defineProperty(sandbox, sym2, { value: true });
+
+const ctx = vm.createContext(sandbox);
+
+// Sanity check
+// Please uncomment these when the test is no longer broken
+// assert.deepStrictEqual(Reflect.ownKeys(sandbox), ['a', 'b', sym1, sym2]);
+// assert.deepStrictEqual(Object.getOwnPropertyNames(sandbox), ['a', 'b']);
+// assert.deepStrictEqual(Object.getOwnPropertySymbols(sandbox), [sym1, sym2]);
+
+const nativeKeys = vm.runInNewContext('Reflect.ownKeys(this);');
+const ownKeys = vm.runInContext('Reflect.ownKeys(this);', ctx);
+const restKeys = ownKeys.filter((key) => !nativeKeys.includes(key));
+// this should not fail
+assert.deepStrictEqual(Array.from(restKeys), ['a', 'b', sym1, sym2]);

--- a/test/known_issues/test-vm-ownpropertynames.js
+++ b/test/known_issues/test-vm-ownpropertynames.js
@@ -1,0 +1,28 @@
+'use strict';
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+const sym1 = Symbol('1');
+const sym2 = Symbol('2');
+const sandbox = {
+  a: true,
+  [sym1]: true
+};
+Object.defineProperty(sandbox, 'b', { value: true });
+Object.defineProperty(sandbox, sym2, { value: true });
+
+const ctx = vm.createContext(sandbox);
+
+// Sanity check
+// Please uncomment these when the test is no longer broken
+// assert.deepStrictEqual(Reflect.ownKeys(sandbox), ['a', 'b', sym1, sym2]);
+// assert.deepStrictEqual(Object.getOwnPropertyNames(sandbox), ['a', 'b']);
+// assert.deepStrictEqual(Object.getOwnPropertySymbols(sandbox), [sym1, sym2]);
+
+const nativeNames = vm.runInNewContext('Object.getOwnPropertyNames(this);');
+const ownNames = vm.runInContext('Object.getOwnPropertyNames(this);', ctx);
+const restNames = ownNames.filter((name) => !nativeNames.includes(name));
+// this should not fail
+assert.deepStrictEqual(Array.from(restNames), ['a', 'b']);

--- a/test/known_issues/test-vm-ownpropertysymbols.js
+++ b/test/known_issues/test-vm-ownpropertysymbols.js
@@ -1,0 +1,28 @@
+'use strict';
+
+require('../common');
+const vm = require('vm');
+const assert = require('assert');
+
+const sym1 = Symbol('1');
+const sym2 = Symbol('2');
+const sandbox = {
+  a: true,
+  [sym1]: true
+};
+Object.defineProperty(sandbox, 'b', { value: true });
+Object.defineProperty(sandbox, sym2, { value: true });
+
+const ctx = vm.createContext(sandbox);
+
+// Sanity check
+// Please uncomment these when the test is no longer broken
+// assert.deepStrictEqual(Reflect.ownKeys(sandbox), ['a', 'b', sym1, sym2]);
+// assert.deepStrictEqual(Object.getOwnPropertyNames(sandbox), ['a', 'b']);
+// assert.deepStrictEqual(Object.getOwnPropertySymbols(sandbox), [sym1, sym2]);
+
+const nativeSym = vm.runInNewContext('Object.getOwnPropertySymbols(this);');
+const ownSym = vm.runInContext('Object.getOwnPropertySymbols(this);', ctx);
+const restSym = ownSym.filter((sym) => !nativeSym.includes(sym));
+// this should not fail
+assert.deepStrictEqual(Array.from(restSym), [sym1, sym2]);


### PR DESCRIPTION
Currently, `Reflect.ownKeys(this)`, when run in a sandbox, fails to
retrieve Symbol and non-enumerable values.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
vm