### PR TITLE
Replace methods used in the example code

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2383,12 +2383,12 @@ Examples:
 ```js
 const buf = Buffer.allocUnsafe(6);
 
-buf.writeUIntBE(0x1234567890ab, 0, 6);
+buf.writeIntBE(0x1234567890ab, 0, 6);
 
 // Prints: <Buffer 12 34 56 78 90 ab>
 console.log(buf);
 
-buf.writeUIntLE(0x1234567890ab, 0, 6);
+buf.writeIntLE(0x1234567890ab, 0, 6);
 
 // Prints: <Buffer ab 90 78 56 34 12>
 console.log(buf);


### PR DESCRIPTION
Methods `buf.writeUIntLE()` and `buf.writeUIntBE()` were used in the example code for the section of the methods `writeIntLE()` and `writeIntBE()` instead of the latter.