### PR TITLE
doc: move Code of Conduct to admin repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,8 @@
 # Code of Conduct
 
 The Node.js Code of Conduct document has moved to
-https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md. Please update
+https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md. Please update
 links to this document accordingly.
+
+The Node.js Moderation policy can be found at
+https://github.com/nodejs/admin/blob/master/Moderation-Policy.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -853,7 +853,7 @@ By making a contribution to this project, I certify that:
 [benchmark results]: ./doc/guides/writing-and-running-benchmarks.md
 [Building guide]: ./BUILDING.md
 [CI (Continuous Integration) test run]: #ci-testing
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [guide for writing tests in Node.js]: ./doc/guides/writing-tests.md
 [https://ci.nodejs.org/]: https://ci.nodejs.org/
 [IRC in the #node-dev channel]: https://webchat.freenode.net?channels=node-dev&uio=d4

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Information on the current Node.js Working Groups can be found in the
 [Website]: https://nodejs.org/en/
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Help]: https://github.com/nodejs/help
-[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
+[Node.js Moderation Policy]: https://github.com/nodejs/admin/blob/master/Moderation-Policy.md
 [#node.js on chat.freenode.net]: https://webchat.freenode.net?channels=node.js&uio=d4
 [#node-dev on chat.freenode.net]: https://webchat.freenode.net?channels=node-dev&uio=d4
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
This will require https://github.com/nodejs/admin/pull/25 and
https://github.com/nodejs/TSC/pull/395 to land first