### PR TITLE
[v8.x backport] src: pass context to Get() operations for child processes

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -127,6 +127,10 @@ exec('"my script.cmd" a b', (err, stdout, stderr) => {
 ### child_process.exec(command[, options][, callback])
 <!-- YAML
 added: v0.1.90
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
 -->
 
 * `command` {string} The command to run, with space-separated arguments.
@@ -144,6 +148,8 @@ added: v0.1.90
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * `callback` {Function} called with the output when process terminates.
   * `error` {Error}
   * `stdout` {string|Buffer}
@@ -237,6 +243,10 @@ lsExample();
 ### child_process.execFile(file[, args][, options][, callback])
 <!-- YAML
 added: v0.1.91
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
 -->
 
 * `file` {string} The name or path of the executable file to run.
@@ -252,6 +262,8 @@ added: v0.1.91
   * `killSignal` {string|integer} **Default:** `'SIGTERM'`
   * `uid` {number} Sets the user identity of the process (see setuid(2)).
   * `gid` {number} Sets the group identity of the process (see setgid(2)).
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * `callback` {Function} Called with the output when process terminates.
   * `error` {Error}
   * `stdout` {string|Buffer}
@@ -363,6 +375,9 @@ supported by `child_process.fork()` and will be ignored if set.
 <!-- YAML
 added: v0.1.90
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
   - version: v6.4.0
     pr-url: https://github.com/nodejs/node/pull/7696
     description: The `argv0` option is supported now.
@@ -389,6 +404,8 @@ changes:
     `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell Requirements][] and
     [Default Windows Shell][]. **Default:** `false` (no shell).
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {ChildProcess}
 
 The `child_process.spawn()` method spawns a new process using the given
@@ -648,6 +665,9 @@ configuration at startup.
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/10653
     description: The `input` option can now be a `Uint8Array`.
@@ -677,6 +697,8 @@ changes:
     stderr. **Default:** `200*1024` If exceeded, the child process is terminated.
     See caveat at [`maxBuffer` and Unicode][].
   * `encoding` {string} The encoding used for all stdio inputs and outputs. **Default:** `'buffer'`
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {Buffer|string} The stdout from the command.
 
 The `child_process.execFileSync()` method is generally identical to
@@ -697,6 +719,9 @@ throw an [`Error`][] that will include the full result of the underlying
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/10653
     description: The `input` option can now be a `Uint8Array`.
@@ -726,6 +751,8 @@ changes:
     See caveat at [`maxBuffer` and Unicode][].
   * `encoding` {string} The encoding used for all stdio inputs and outputs.
     **Default:** `'buffer'`
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {Buffer|string} The stdout from the command.
 
 The `child_process.execSync()` method is generally identical to
@@ -748,6 +775,9 @@ execution.
 <!-- YAML
 added: v0.11.12
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/15380
+    description: The `windowsHide` option is supported now.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/10653
     description: The `input` option can now be a `Uint8Array`.
@@ -783,6 +813,8 @@ changes:
     `'/bin/sh'` on UNIX, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell Requirements][] and
     [Default Windows Shell][]. **Default:** `false` (no shell).
+  * `windowsHide` {boolean} Hide the subprocess console window that would
+    normally be created on Windows systems. **Default:** `false`.
 * Returns: {Object}
   * `pid` {number} Pid of the child process.
   * `output` {Array} Array of results from stdio output.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -212,6 +212,7 @@ exports.execFile = function(file /*, args, options, callback*/) {
     gid: options.gid,
     uid: options.uid,
     shell: options.shell,
+    windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments
   });
 
@@ -428,6 +429,12 @@ function normalizeSpawnArguments(file, args, options) {
     throw new TypeError('"argv0" must be a string');
   }
 
+  // Validate windowsHide, if present.
+  if (options.windowsHide != null &&
+      typeof options.windowsHide !== 'boolean') {
+    throw new TypeError('"windowsHide" must be a boolean');
+  }
+
   // Validate windowsVerbatimArguments, if present.
   if (options.windowsVerbatimArguments != null &&
       typeof options.windowsVerbatimArguments !== 'boolean') {
@@ -493,6 +500,7 @@ var spawn = exports.spawn = function(/*file, args, options*/) {
     file: opts.file,
     args: opts.args,
     cwd: options.cwd,
+    windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!options.windowsVerbatimArguments,
     detached: !!options.detached,
     envPairs: opts.envPairs,

--- a/src/env.h
+++ b/src/env.h
@@ -287,6 +287,7 @@ class ModuleWrap;
   V(verify_error_string, "verifyError")                                       \
   V(version_string, "version")                                                \
   V(weight_string, "weight")                                                  \
+  V(windows_hide_string, "windowsHide")                                       \
   V(windows_verbatim_arguments_string, "windowsVerbatimArguments")            \
   V(wrap_string, "wrap")                                                      \
   V(writable_string, "writable")                                              \

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -211,6 +211,13 @@ class ProcessWrap : public HandleWrap {
     // options.stdio
     ParseStdioOptions(env, js_options, &options);
 
+    // options.windowsHide
+    Local<String> windows_hide_key = env->windows_hide_string();
+
+    if (js_options->Get(windows_hide_key)->IsTrue()) {
+      options.flags |= UV_PROCESS_WINDOWS_HIDE;
+    }
+
     // options.windows_verbatim_arguments
     Local<String> windows_verbatim_arguments_key =
         env->windows_verbatim_arguments_string();

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -777,6 +777,11 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
   if (js_options->Get(env()->detached_string())->BooleanValue())
     uv_process_options_.flags |= UV_PROCESS_DETACHED;
 
+  Local<String> win_hide = env()->windows_hide_string();
+
+  if (js_options->Get(win_hide)->BooleanValue())
+    uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE;
+
   Local<String> wba = env()->windows_verbatim_arguments_string();
 
   if (js_options->Get(wba)->BooleanValue())

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -663,39 +663,47 @@ void SyncProcessRunner::SetPipeError(int pipe_error) {
 
 Local<Object> SyncProcessRunner::BuildResultObject() {
   EscapableHandleScope scope(env()->isolate());
+  Local<Context> context = env()->context();
 
   Local<Object> js_result = Object::New(env()->isolate());
 
   if (GetError() != 0) {
-    js_result->Set(env()->error_string(),
-                   Integer::New(env()->isolate(), GetError()));
+    js_result->Set(context, env()->error_string(),
+                   Integer::New(env()->isolate(), GetError())).FromJust();
   }
 
   if (exit_status_ >= 0) {
     if (term_signal_ > 0) {
-      js_result->Set(env()->status_string(), Null(env()->isolate()));
+      js_result->Set(context, env()->status_string(),
+                     Null(env()->isolate())).FromJust();
     } else {
-      js_result->Set(env()->status_string(),
-          Number::New(env()->isolate(), static_cast<double>(exit_status_)));
+      js_result->Set(context, env()->status_string(),
+                     Number::New(env()->isolate(),
+                                 static_cast<double>(exit_status_))).FromJust();
     }
   } else {
     // If exit_status_ < 0 the process was never started because of some error.
-    js_result->Set(env()->status_string(), Null(env()->isolate()));
+    js_result->Set(context, env()->status_string(),
+                   Null(env()->isolate())).FromJust();
   }
 
   if (term_signal_ > 0)
-    js_result->Set(env()->signal_string(),
-        String::NewFromUtf8(env()->isolate(), signo_string(term_signal_)));
+    js_result->Set(context, env()->signal_string(),
+                   String::NewFromUtf8(env()->isolate(),
+                                       signo_string(term_signal_))).FromJust();
   else
-    js_result->Set(env()->signal_string(), Null(env()->isolate()));
+    js_result->Set(context, env()->signal_string(),
+                   Null(env()->isolate())).FromJust();
 
   if (exit_status_ >= 0)
-    js_result->Set(env()->output_string(), BuildOutputArray());
+    js_result->Set(context, env()->output_string(),
+                   BuildOutputArray()).FromJust();
   else
-    js_result->Set(env()->output_string(), Null(env()->isolate()));
+    js_result->Set(context, env()->output_string(),
+                   Null(env()->isolate())).FromJust();
 
-  js_result->Set(env()->pid_string(),
-                 Number::New(env()->isolate(), uv_process_.pid));
+  js_result->Set(context, env()->pid_string(),
+                 Number::New(env()->isolate(), uv_process_.pid)).FromJust();
 
   return scope.Escape(js_result);
 }
@@ -706,14 +714,15 @@ Local<Array> SyncProcessRunner::BuildOutputArray() {
   CHECK_NE(stdio_pipes_, nullptr);
 
   EscapableHandleScope scope(env()->isolate());
+  Local<Context> context = env()->context();
   Local<Array> js_output = Array::New(env()->isolate(), stdio_count_);
 
   for (uint32_t i = 0; i < stdio_count_; i++) {
     SyncProcessStdioPipe* h = stdio_pipes_[i];
     if (h != nullptr && h->writable())
-      js_output->Set(i, h->GetOutputAsBuffer(env()));
+      js_output->Set(context, i, h->GetOutputAsBuffer(env())).FromJust();
     else
-      js_output->Set(i, Null(env()->isolate()));
+      js_output->Set(context, i, Null(env()->isolate())).FromJust();
   }
 
   return scope.Escape(js_output);
@@ -727,22 +736,25 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
   if (!js_value->IsObject())
     return UV_EINVAL;
 
+  Local<Context> context = env()->context();
   Local<Object> js_options = js_value.As<Object>();
 
-  Local<Value> js_file = js_options->Get(env()->file_string());
+  Local<Value> js_file =
+      js_options->Get(context, env()->file_string()).ToLocalChecked();
   r = CopyJsString(js_file, &file_buffer_);
   if (r < 0)
     return r;
   uv_process_options_.file = file_buffer_;
 
-  Local<Value> js_args = js_options->Get(env()->args_string());
+  Local<Value> js_args =
+      js_options->Get(context, env()->args_string()).ToLocalChecked();
   r = CopyJsStringArray(js_args, &args_buffer_);
   if (r < 0)
     return r;
   uv_process_options_.args = reinterpret_cast<char**>(args_buffer_);
 
-
-  Local<Value> js_cwd = js_options->Get(env()->cwd_string());
+  Local<Value> js_cwd =
+      js_options->Get(context, env()->cwd_string()).ToLocalChecked();
   if (IsSet(js_cwd)) {
     r = CopyJsString(js_cwd, &cwd_buffer_);
     if (r < 0)
@@ -750,7 +762,8 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
     uv_process_options_.cwd = cwd_buffer_;
   }
 
-  Local<Value> js_env_pairs = js_options->Get(env()->env_pairs_string());
+  Local<Value> js_env_pairs =
+      js_options->Get(context, env()->env_pairs_string()).ToLocalChecked();
   if (IsSet(js_env_pairs)) {
     r = CopyJsStringArray(js_env_pairs, &env_buffer_);
     if (r < 0)
@@ -758,55 +771,65 @@ int SyncProcessRunner::ParseOptions(Local<Value> js_value) {
 
     uv_process_options_.env = reinterpret_cast<char**>(env_buffer_);
   }
-  Local<Value> js_uid = js_options->Get(env()->uid_string());
+  Local<Value> js_uid =
+      js_options->Get(context, env()->uid_string()).ToLocalChecked();
   if (IsSet(js_uid)) {
     CHECK(js_uid->IsInt32());
-    const int32_t uid = js_uid->Int32Value(env()->context()).FromJust();
+    const int32_t uid = js_uid->Int32Value(context).FromJust();
     uv_process_options_.uid = static_cast<uv_uid_t>(uid);
     uv_process_options_.flags |= UV_PROCESS_SETUID;
   }
 
-  Local<Value> js_gid = js_options->Get(env()->gid_string());
+  Local<Value> js_gid =
+      js_options->Get(context, env()->gid_string()).ToLocalChecked();
   if (IsSet(js_gid)) {
     CHECK(js_gid->IsInt32());
-    const int32_t gid = js_gid->Int32Value(env()->context()).FromJust();
+    const int32_t gid = js_gid->Int32Value(context).FromJust();
     uv_process_options_.gid = static_cast<uv_gid_t>(gid);
     uv_process_options_.flags |= UV_PROCESS_SETGID;
   }
 
-  if (js_options->Get(env()->detached_string())->BooleanValue())
+  Local<Value> js_detached =
+      js_options->Get(context, env()->detached_string()).ToLocalChecked();
+  if (js_detached->BooleanValue(context).FromJust())
     uv_process_options_.flags |= UV_PROCESS_DETACHED;
 
-  Local<String> win_hide = env()->windows_hide_string();
-
-  if (js_options->Get(win_hide)->BooleanValue())
+  Local<Value> js_win_hide =
+      js_options->Get(context, env()->windows_hide_string()).ToLocalChecked();
+  if (js_win_hide->BooleanValue(context).FromJust())
     uv_process_options_.flags |= UV_PROCESS_WINDOWS_HIDE;
 
-  Local<String> wba = env()->windows_verbatim_arguments_string();
+  Local<Value> js_wva =
+      js_options->Get(context, env()->windows_verbatim_arguments_string())
+          .ToLocalChecked();
 
-  if (js_options->Get(wba)->BooleanValue())
+  if (js_wva->BooleanValue(context).FromJust())
     uv_process_options_.flags |= UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
 
-  Local<Value> js_timeout = js_options->Get(env()->timeout_string());
+  Local<Value> js_timeout =
+      js_options->Get(context, env()->timeout_string()).ToLocalChecked();
   if (IsSet(js_timeout)) {
     CHECK(js_timeout->IsNumber());
-    int64_t timeout = js_timeout->IntegerValue();
+    int64_t timeout = js_timeout->IntegerValue(context).FromJust();
     timeout_ = static_cast<uint64_t>(timeout);
   }
 
-  Local<Value> js_max_buffer = js_options->Get(env()->max_buffer_string());
+  Local<Value> js_max_buffer =
+      js_options->Get(context, env()->max_buffer_string()).ToLocalChecked();
   if (IsSet(js_max_buffer)) {
     CHECK(js_max_buffer->IsNumber());
-    max_buffer_ = js_max_buffer->NumberValue();
+    max_buffer_ = js_max_buffer->NumberValue(context).FromJust();
   }
 
-  Local<Value> js_kill_signal = js_options->Get(env()->kill_signal_string());
+  Local<Value> js_kill_signal =
+      js_options->Get(context, env()->kill_signal_string()).ToLocalChecked();
   if (IsSet(js_kill_signal)) {
     CHECK(js_kill_signal->IsInt32());
-    kill_signal_ = js_kill_signal->Int32Value();
+    kill_signal_ = js_kill_signal->Int32Value(context).FromJust();
   }
 
-  Local<Value> js_stdio = js_options->Get(env()->stdio_string());
+  Local<Value> js_stdio =
+      js_options->Get(context, env()->stdio_string()).ToLocalChecked();
   r = ParseStdioOptions(js_stdio);
   if (r < 0)
     return r;
@@ -822,6 +845,7 @@ int SyncProcessRunner::ParseStdioOptions(Local<Value> js_value) {
   if (!js_value->IsArray())
     return UV_EINVAL;
 
+  Local<Context> context = env()->context();
   js_stdio_options = js_value.As<Array>();
 
   stdio_count_ = js_stdio_options->Length();
@@ -831,7 +855,8 @@ int SyncProcessRunner::ParseStdioOptions(Local<Value> js_value) {
   stdio_pipes_initialized_ = true;
 
   for (uint32_t i = 0; i < stdio_count_; i++) {
-    Local<Value> js_stdio_option = js_stdio_options->Get(i);
+    Local<Value> js_stdio_option =
+        js_stdio_options->Get(context, i).ToLocalChecked();
 
     if (!js_stdio_option->IsObject())
       return UV_EINVAL;
@@ -850,7 +875,9 @@ int SyncProcessRunner::ParseStdioOptions(Local<Value> js_value) {
 
 int SyncProcessRunner::ParseStdioOption(int child_fd,
                                         Local<Object> js_stdio_option) {
-  Local<Value> js_type = js_stdio_option->Get(env()->type_string());
+  Local<Context> context = env()->context();
+  Local<Value> js_type =
+      js_stdio_option->Get(context, env()->type_string()).ToLocalChecked();
 
   if (js_type->StrictEquals(env()->ignore_string())) {
     return AddStdioIgnore(child_fd);
@@ -859,13 +886,17 @@ int SyncProcessRunner::ParseStdioOption(int child_fd,
     Local<String> rs = env()->readable_string();
     Local<String> ws = env()->writable_string();
 
-    bool readable = js_stdio_option->Get(rs)->BooleanValue();
-    bool writable = js_stdio_option->Get(ws)->BooleanValue();
+    bool readable = js_stdio_option->Get(context, rs)
+        .ToLocalChecked()->BooleanValue(context).FromJust();
+    bool writable =
+        js_stdio_option->Get(context, ws)
+        .ToLocalChecked()->BooleanValue(context).FromJust();
 
     uv_buf_t buf = uv_buf_init(nullptr, 0);
 
     if (readable) {
-      Local<Value> input = js_stdio_option->Get(env()->input_string());
+      Local<Value> input =
+          js_stdio_option->Get(context, env()->input_string()).ToLocalChecked();
       if (Buffer::HasInstance(input)) {
         buf = uv_buf_init(Buffer::Data(input),
                           static_cast<unsigned int>(Buffer::Length(input)));
@@ -881,7 +912,8 @@ int SyncProcessRunner::ParseStdioOption(int child_fd,
 
   } else if (js_type->StrictEquals(env()->inherit_string()) ||
              js_type->StrictEquals(env()->fd_string())) {
-    int inherit_fd = js_stdio_option->Get(env()->fd_string())->Int32Value();
+    int inherit_fd = js_stdio_option->Get(context, env()->fd_string())
+        .ToLocalChecked()->Int32Value(context).FromJust();
     return AddStdioInheritFD(child_fd, inherit_fd);
 
   } else {
@@ -981,14 +1013,17 @@ int SyncProcessRunner::CopyJsStringArray(Local<Value> js_value,
   if (!js_value->IsArray())
     return UV_EINVAL;
 
+  Local<Context> context = env()->context();
   js_array = js_value.As<Array>()->Clone().As<Array>();
   length = js_array->Length();
 
   // Convert all array elements to string. Modify the js object itself if
   // needed - it's okay since we cloned the original object.
   for (uint32_t i = 0; i < length; i++) {
-    if (!js_array->Get(i)->IsString())
-      js_array->Set(i, js_array->Get(i)->ToString(env()->isolate()));
+    auto value = js_array->Get(context, i).ToLocalChecked();
+
+    if (!value->IsString())
+      js_array->Set(context, i, value->ToString(env()->isolate())).FromJust();
   }
 
   // Index has a pointer to every string element, plus one more for a final
@@ -999,7 +1034,8 @@ int SyncProcessRunner::CopyJsStringArray(Local<Value> js_value,
   // after every string. Align strings to cache lines.
   data_size = 0;
   for (uint32_t i = 0; i < length; i++) {
-    data_size += StringBytes::StorageSize(isolate, js_array->Get(i), UTF8) + 1;
+    auto value = js_array->Get(context, i).ToLocalChecked();
+    data_size += StringBytes::StorageSize(isolate, value, UTF8) + 1;
     data_size = ROUND_UP(data_size, sizeof(void*));
   }
 
@@ -1010,10 +1046,11 @@ int SyncProcessRunner::CopyJsStringArray(Local<Value> js_value,
 
   for (uint32_t i = 0; i < length; i++) {
     list[i] = buffer + data_offset;
+    auto value = js_array->Get(context, i).ToLocalChecked();
     data_offset += StringBytes::Write(isolate,
                                       buffer + data_offset,
                                       -1,
-                                      js_array->Get(i),
+                                      value,
                                       UTF8);
     buffer[data_offset++] = '\0';
     data_offset = ROUND_UP(data_offset, sizeof(void*));

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -60,6 +60,7 @@ assert.strictEqual(env.stdout.toString().trim(), 'buzz');
     assert.strictEqual(result.options.shell, shell);
     assert.strictEqual(result.options.file, result.file);
     assert.deepStrictEqual(result.options.args, result.args);
+    assert.strictEqual(result.options.windowsHide, undefined);
     assert.strictEqual(result.options.windowsVerbatimArguments,
                        windowsVerbatim);
   }

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -125,6 +125,22 @@ if (!common.isWindows) {
 }
 
 {
+  // Validate the windowsHide option
+  const err = /^TypeError: "windowsHide" must be a boolean$/;
+
+  pass('windowsHide', undefined);
+  pass('windowsHide', null);
+  pass('windowsHide', true);
+  pass('windowsHide', false);
+  fail('windowsHide', 0, err);
+  fail('windowsHide', 1, err);
+  fail('windowsHide', __dirname, err);
+  fail('windowsHide', [], err);
+  fail('windowsHide', {}, err);
+  fail('windowsHide', common.mustNotCall(), err);
+}
+
+{
   // Validate the windowsVerbatimArguments option
   const err = /^TypeError: "windowsVerbatimArguments" must be a boolean$/;
 

--- a/test/parallel/test-child-process-windows-hide.js
+++ b/test/parallel/test-child-process-windows-hide.js
@@ -1,0 +1,48 @@
+// Flags: --expose_internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const internalCp = require('internal/child_process');
+const cmd = process.execPath;
+const args = ['-p', '42'];
+const options = { windowsHide: true };
+
+// Since windowsHide isn't really observable, monkey patch spawn() to verify
+// the flag is being passed through correctly. spawnSync() is kind enough to
+// give all of the parsed inputs back in the result.
+const originalSpawn = internalCp.ChildProcess.prototype.spawn;
+
+internalCp.ChildProcess.prototype.spawn = common.mustCall(function(options) {
+  assert.strictEqual(options.windowsHide, true);
+  return originalSpawn.apply(this, arguments);
+}, 2);
+
+{
+  const child = cp.spawnSync(cmd, args, options);
+
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.options.windowsHide, true);
+  assert.strictEqual(child.stdout.toString().trim(), '42');
+  assert.strictEqual(child.stderr.toString().trim(), '');
+}
+
+{
+  const child = cp.spawn(cmd, args, options);
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+}
+
+{
+  const callback = common.mustCall((err, stdout, stderr) => {
+    assert.ifError(err);
+    assert.strictEqual(stdout.trim(), '42');
+    assert.strictEqual(stderr.trim(), '');
+  });
+
+  cp.execFile(cmd, args, options, callback);
+}


### PR DESCRIPTION
Backport of the commits in https://github.com/nodejs/node/pull/16247.

This PR also contains the commit from #16425 as these commits depend on it, and it has not landed in 8.x yet.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src