### PR TITLE
crypto: migrate setFipsCrypto to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -643,6 +643,17 @@ Used when an invalid value for the `format` argument has been passed to the
 Used when an invalid crypto engine identifier is passed to
 [`require('crypto').setEngine()`][].
 
+<a id="ERR_CRYPTO_FIPS_FORCED"></a>
+### ERR_CRYPTO_FIPS_FORCED
+
+Used when trying to enable or disable FIPS mode in the crypto module and
+the [`--force-fips`][] command-line argument is used.
+
+<a id="ERR_CRYPTO_FIPS_UNAVAILABLE"></a>
+### ERR_CRYPTO_FIPS_UNAVAILABLE
+
+Used when trying to enable or disable FIPS mode when FIPS is not available.
+
 <a id="ERR_CRYPTO_HASH_DIGEST_NO_UTF16"></a>
 ### ERR_CRYPTO_HASH_DIGEST_NO_UTF16
 
@@ -1440,6 +1451,7 @@ Used when a given value is out of the accepted range.
 Used when an attempt is made to use a `zlib` object after it has already been
 closed.
 
+[`--force-fips`]: cli.html#cli_force_fips
 [`crypto.timingSafeEqual()`]: crypto.html#crypto_crypto_timingsafeequal_a_b
 [`dgram.createSocket()`]: dgram.html#dgram_dgram_createsocket_options_callback
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
@@ -1463,6 +1475,7 @@ closed.
 [`require('crypto').setEngine()`]: crypto.html#crypto_crypto_setengine_engine_flags
 [`server.listen()`]: net.html#net_server_listen
 [ES6 module]: esm.html
+[`require('crypto').fips`]: crypto.html#crypto_crypto_fips
 [Node.js Error Codes]: #nodejs-error-codes
 [V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [WHATWG URL API]: url.html#url_the_whatwg_url_api

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -30,7 +30,12 @@ const {
 } = require('internal/util');
 assertCrypto();
 
+const errors = require('internal/errors');
 const constants = process.binding('constants').crypto;
+const {
+  fipsMode,
+  fipsForced
+} = process.binding('config');
 const {
   getFipsCrypto,
   setFipsCrypto,
@@ -173,10 +178,29 @@ module.exports = exports = {
   Verify
 };
 
+function setFipsDisabled() {
+  throw new errors.Error('ERR_CRYPTO_FIPS_UNAVAILABLE');
+}
+
+function setFipsForced(val) {
+  if (val) return;
+  throw new errors.Error('ERR_CRYPTO_FIPS_FORCED');
+}
+
+function getFipsDisabled() {
+  return 0;
+}
+
+function getFipsForced() {
+  return 1;
+}
+
 Object.defineProperties(exports, {
   fips: {
-    get: getFipsCrypto,
-    set: setFipsCrypto
+    get: !fipsMode ? getFipsDisabled :
+      fipsForced ? getFipsForced : getFipsCrypto,
+    set: !fipsMode ? setFipsDisabled :
+      fipsForced ? setFipsForced : setFipsCrypto
   },
   DEFAULT_ENCODING: {
     enumerable: true,

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -156,6 +156,9 @@ E('ERR_CONSOLE_WRITABLE_STREAM',
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
 E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s');
 E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found');
+E('ERR_CRYPTO_FIPS_FORCED',
+  'Cannot set FIPS mode, it was forced with --force-fips at startup.');
+E('ERR_CRYPTO_FIPS_UNAVAILABLE', 'Cannot set FIPS mode in a non-FIPS build.');
 E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16');
 E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called');
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed');

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -44,6 +44,12 @@ static void InitConfig(Local<Object> target,
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 
+#ifdef NODE_FIPS_MODE
+  READONLY_BOOLEAN_PROPERTY("fipsMode");
+  if (force_fips_crypto)
+    READONLY_BOOLEAN_PROPERTY("fipsForced");
+#endif
+
 #ifdef NODE_HAVE_I18N_SUPPORT
 
   READONLY_BOOLEAN_PROPERTY("hasIntl");

--- a/test/parallel/test-crypto-fips.js
+++ b/test/parallel/test-crypto-fips.js
@@ -10,7 +10,12 @@ const fixtures = require('../common/fixtures');
 
 const FIPS_ENABLED = 1;
 const FIPS_DISABLED = 0;
-const FIPS_ERROR_STRING = 'Error: Cannot set FIPS mode';
+const FIPS_ERROR_STRING =
+  'Error [ERR_CRYPTO_FIPS_UNAVAILABLE]: Cannot set FIPS mode in a ' +
+  'non-FIPS build.';
+const FIPS_ERROR_STRING2 =
+  'Error [ERR_CRYPTO_FIPS_FORCED]: Cannot set FIPS mode, it was forced with ' +
+  '--force-fips at startup.';
 const OPTION_ERROR_STRING = 'bad option';
 
 const CNF_FIPS_ON = fixtures.path('openssl_fips_enabled.cnf');
@@ -208,7 +213,7 @@ testHelper(
 testHelper(
   'stderr',
   ['--force-fips'],
-  compiledWithFips() ? FIPS_ERROR_STRING : OPTION_ERROR_STRING,
+  compiledWithFips() ? FIPS_ERROR_STRING2 : OPTION_ERROR_STRING,
   'require("crypto").fips = false',
   process.env);
 
@@ -225,7 +230,7 @@ testHelper(
 testHelper(
   'stderr',
   ['--force-fips', '--enable-fips'],
-  compiledWithFips() ? FIPS_ERROR_STRING : OPTION_ERROR_STRING,
+  compiledWithFips() ? FIPS_ERROR_STRING2 : OPTION_ERROR_STRING,
   'require("crypto").fips = false',
   process.env);
 
@@ -233,6 +238,6 @@ testHelper(
 testHelper(
   'stderr',
   ['--enable-fips', '--force-fips'],
-  compiledWithFips() ? FIPS_ERROR_STRING : OPTION_ERROR_STRING,
+  compiledWithFips() ? FIPS_ERROR_STRING2 : OPTION_ERROR_STRING,
   'require("crypto").fips = false',
   process.env);


### PR DESCRIPTION
With the exception of ThrowCryptoError, use internal/errors to report fips unavailable or forced

Also only exports the `setFipsCrypto` and `getFipsCrypto` methods on `process.binding('crypto')` if FIPS mode is available.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto (fips)