### PR TITLE
crypto: migrate setEngine to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -637,6 +637,12 @@ Used when the native call from `process.cpuUsage` cannot be processed properly.
 Used when an invalid value for the `format` argument has been passed to the
 `crypto.ECDH()` class `getPublicKey()` method.
 
+<a id="ERR_CRYPTO_ENGINE_UNKNOWN"></a>
+### ERR_CRYPTO_ENGINE_UNKNOWN
+
+Used when an invalid crypto engine identifier is passed to
+[`require('crypto').setEngine()`][].
+
 <a id="ERR_CRYPTO_INVALID_DIGEST"></a>
 ### ERR_CRYPTO_INVALID_DIGEST
 
@@ -1357,6 +1363,7 @@ closed.
 [`new URLSearchParams(iterable)`]: url.html#url_constructor_new_urlsearchparams_iterable
 [`process.on('uncaughtException')`]: process.html#process_event_uncaughtexception
 [`process.send()`]: process.html#process_process_send_message_sendhandle_options_callback
+[`require('crypto').setEngine()`]: crypto.html#crypto_crypto_setengine_engine_flags
 [Node.js Error Codes]: #nodejs-error-codes
 [V8's stack trace API]: https://github.com/v8/v8/wiki/Stack-Trace-API
 [WHATWG URL API]: url.html#url_the_whatwg_url_api

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -56,7 +56,8 @@ function setEngine(id, flags) {
   if (flags === 0)
     flags = ENGINE_METHOD_ALL;
 
-  return _setEngine(id, flags);
+  if (!_setEngine(id, flags))
+    throw new errors.Error('ERR_CRYPTO_ENGINE_UNKNOWN', id);
 }
 
 module.exports = {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -154,6 +154,7 @@ E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
 E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s');
+E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found');
 E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16');
 E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called');
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed');

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5946,19 +5946,17 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
 
   if (engine == nullptr) {
     int err = ERR_get_error();
-    if (err == 0) {
-      char tmp[1024];
-      snprintf(tmp, sizeof(tmp), "Engine \"%s\" was not found", *engine_id);
-      return env->ThrowError(tmp);
-    } else {
-      return ThrowCryptoError(env, err);
-    }
+    if (err == 0)
+      return args.GetReturnValue().Set(false);
+    return ThrowCryptoError(env, err);
   }
 
   int r = ENGINE_set_default(engine, flags);
   ENGINE_free(engine);
   if (r == 0)
     return ThrowCryptoError(env, ERR_get_error());
+
+  args.GetReturnValue().Set(true);
 }
 #endif  // !OPENSSL_NO_ENGINE
 


### PR DESCRIPTION
Migrate setEngine to use internal/errors, tho it's not entirely clear what conditions are required to trigger it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto