### PR TITLE
[v8.x backport] util: expand test coverage for util.deprecate

### DIFF
--- a/test/parallel/test-util-deprecate-invalid-code.js
+++ b/test/parallel/test-util-deprecate-invalid-code.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const util = require('util');
+
+[1, true, false, null, {}].forEach((notString) => {
+  common.expectsError(() => util.deprecate(() => {}, 'message', notString), {
+    type: TypeError,
+    message: '`code` argument must be a string'
+  });
+});


### PR DESCRIPTION
Backporting: https://github.com/nodejs/node/pull/16305

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes

##### Affected core subsystem(s)
util
