### PR TITLE
build: fix npm install with --shared

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -33,6 +33,7 @@ def try_unlink(path):
 def try_symlink(source_path, link_path):
   print 'symlinking %s -> %s' % (source_path, link_path)
   try_unlink(link_path)
+  try_mkdir_r(os.path.dirname(link_path))
   os.symlink(source_path, link_path)
 
 def try_mkdir_r(path):


### PR DESCRIPTION
The npm install rules had a hidden dependency on the `node` binary
install rule creating the `$PREFIX/bin` directory.

Because with `./configure --shared` no binary is created, the rule
subsequently failed.  Fix that by creating the directory before
creating the symlinks to the npm and npx scripts.

(Whether it makes sense to install npm without a `node` binary is
a separate question.  This commit is not taking positions. :-))

Regression introduced in commit ed8c89a ("build: fix shared installing
target") which, as the commit log indicates, was itself a bug fix for
the `./configure --shared` install.

Fixes: https://github.com/nodejs/node/issues/16437
Refs: https://github.com/nodejs/node/pull/15148