### PR TITLE
[v8.x backport] lib: move duplicate spliceOne into internal/util

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -22,6 +22,7 @@
 'use strict';
 
 var domain;
+var spliceOne;
 
 function EventEmitter() {
   EventEmitter.init.call(this);
@@ -389,8 +390,11 @@ EventEmitter.prototype.removeListener =
 
         if (position === 0)
           list.shift();
-        else
+        else {
+          if (spliceOne === undefined)
+            spliceOne = require('internal/util').spliceOne;
           spliceOne(list, position);
+        }
 
         if (list.length === 1)
           events[type] = list[0];
@@ -501,13 +505,6 @@ function listenerCount(type) {
 EventEmitter.prototype.eventNames = function eventNames() {
   return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
 };
-
-// About 1.5x faster than the two-arg version of Array#splice().
-function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
-}
 
 function arrayClone(arr, n) {
   var copy = new Array(n);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -266,6 +266,13 @@ function join(output, separator) {
   return str;
 }
 
+// About 1.5x faster than the two-arg version of Array#splice().
+function spliceOne(list, index) {
+  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
+    list[i] = list[k];
+  list.pop();
+}
+
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -276,10 +283,11 @@ module.exports = {
   filterDuplicateStrings,
   getConstructorOf,
   isError,
+  join,
   normalizeEncoding,
   objectToString,
   promisify,
-  join,
+  spliceOne,
 
   // Symbol used to customize promisify conversion
   customPromisifyArgs: kCustomPromisifyArgsSymbol,

--- a/lib/url.js
+++ b/lib/url.js
@@ -26,6 +26,8 @@ const { toASCII } = process.binding('config').hasIntl ?
 
 const { hexTable } = require('internal/querystring');
 
+const { spliceOne } = require('internal/util');
+
 // WHATWG URL implementation provided by internal/url
 const {
   URL,
@@ -947,13 +949,6 @@ Url.prototype.parseHost = function parseHost() {
   }
   if (host) this.hostname = host;
 };
-
-// About 1.5x faster than the two-arg version of Array#splice().
-function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
-}
 
 // These characters do not need escaping:
 // ! - . _ ~


### PR DESCRIPTION
lib/url.js and lib/events.js are using the same spliceOne function.
This change is to move it into the internal/util for avoiding duplicate
code.

PR-URL: https://github.com/nodejs/node/pull/16221
Reviewed-By: Timothy Gu <timothygu99@gmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Vse Mozhet Byt <vsemozhetbyt@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Anatoli Papirovski <apapirovski@mac.com>
Reviewed-By: Refael Ackermann <refack@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
util,url,events
