### PR TITLE
http2: custom priority for push streams

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1804,6 +1804,13 @@ class ServerHttp2Stream extends Http2Stream {
 
         const stream = new ServerHttp2Stream(session, ret, options, headers);
 
+        if (options.weight !== undefined) {
+          stream.priority({
+            weight: options.weight,
+            silent: true
+          });
+        }
+
         // If the push stream is a head request, close the writable side of
         // the stream immediately as there won't be any data sent.
         if (headRequest) {

--- a/test/parallel/test-http2-server-push-priority.js
+++ b/test/parallel/test-http2-server-push-priority.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+const expectedWeight = 256;
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream, headers, flags) => {
+  const options = { weight: expectedWeight };
+  stream.pushStream({}, options, common.mustCall((stream, headers, flags) => {
+    // The priority of push streams is changed silently by nghttp2,
+    // without emitting a PRIORITY frame. Flags are ignored.
+    assert.strictEqual(stream.state.weight, expectedWeight);
+    // assert.ok(flags & http2.constants.NGHTTP2_FLAG_PRIORITY);
+  }));
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('test');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const headers = { ':path': '/' };
+  const req = client.request(headers);
+
+  client.on('stream', common.mustCall((stream, headers, flags) => {
+    // Since the push priority is set silently, the client is not informed.
+    // assert.strictEqual(stream.state.weight, expectedWeight);
+    // assert.ok(flags & http2.constants.NGHTTP2_FLAG_PRIORITY);
+  }));
+
+  req.on('data', common.mustCall(() => {}));
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+}));


### PR DESCRIPTION
Sets the priority silently on push streams. Previously the weight options, whilst documented, was simply ignored.

Note that the client is not informed of the non-default priority. The nghttp2 library ignores push stream flags (e.g. 0x20 for priority). It also currently offers no way to set priority value during push stream creation. This appears to be by design, as discussed here:
- https://github.com/nghttp2/nghttp2/issues/429
- https://github.com/nghttp2/nghttp2/pull/430

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2