### PR TITLE
http2: remove non-existent pushStream weight option

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -964,9 +964,6 @@ added: v8.4.0
     Defaults to `false`.
   * `parent` {number} Specifies the numeric identifier of a stream the newly
     created stream is dependent on.
-  * `weight` {number} Specifies the relative dependency of a stream in relation
-    to other streams with the same `parent`. The value is a number between `1`
-    and `256` (inclusive).
 * `callback` {Function} Callback that is called once the push stream has been
   initiated.
 * Returns: {undefined}
@@ -986,6 +983,10 @@ server.on('stream', (stream) => {
   stream.end('some data');
 });
 ```
+
+Setting the weight of a push stream is not allowed in the `HEADERS` frame. Pass
+a `weight` value to `http2stream.priority` with the `silent` option set to
+`true` to enable server-side bandwidth balancing between concurrent streams.
 
 #### http2stream.respond([headers[, options]])
 <!-- YAML


### PR DESCRIPTION
The PRIORITY field is only supported by HTTP/2 in a HEADERS frame initiated by the client, not in a push request sent by the server.

Documents the recommended approach to set a silent priority as used internally by nghttp2.

Alternative to #16444 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2