### PR TITLE
crypto: migrate crypto.randomBytes to internal/errors

### DIFF
--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -3,7 +3,7 @@
 const errors = require('internal/errors');
 const { isArrayBufferView } = require('internal/util/types');
 const {
-  randomBytes,
+  randomBytes: _randomBytes,
   randomFill: _randomFill
 } = process.binding('crypto');
 
@@ -24,7 +24,7 @@ function assertOffset(offset, length) {
   }
 }
 
-function assertSize(size, offset, length) {
+function assertSize(size, offset = 0, length = Infinity) {
   if (typeof size !== 'number' || size !== size) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'size', 'number');
   }
@@ -36,6 +36,13 @@ function assertSize(size, offset, length) {
   if (size + offset > length || size > kMaxLength) {
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'size');
   }
+}
+
+function randomBytes(size, cb) {
+  assertSize(size);
+  if (cb !== undefined && typeof cb !== 'function')
+    throw new errors.TypeError('ERR_INVALID_CALLBACK');
+  return _randomBytes(size, cb);
 }
 
 function randomFillSync(buf, offset = 0, size) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5526,13 +5526,8 @@ void RandomBytesProcessSync(Environment* env,
 void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!args[0]->IsNumber() || args[0].As<v8::Number>()->Value() < 0) {
-    return env->ThrowTypeError("size must be a number >= 0");
-  }
-
   const int64_t size = args[0]->IntegerValue();
-  if (size > Buffer::kMaxLength)
-    return env->ThrowTypeError("size must be a uint32");
+  CHECK(size <= Buffer::kMaxLength);
 
   Local<Object> obj = env->randombytes_constructor_template()->
       NewInstance(env->context()).ToLocalChecked();


### PR DESCRIPTION
Previously had migrated randomBytesFill, this gives the same treatment to `crypto.randomBytes()`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto