### PR TITLE
http2: fix mapToHeaders() with single string value

### DIFF
--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -401,13 +401,14 @@ function mapToHeaders(map,
     if (typeof key === 'symbol' || value === undefined || !key)
       continue;
     key = String(key).toLowerCase();
-    const isArray = Array.isArray(value);
+    let isArray = Array.isArray(value);
     if (isArray) {
       switch (value.length) {
         case 0:
           continue;
         case 1:
           value = String(value[0]);
+          isArray = false;
           break;
         default:
           if (kSingleValueHeaders.has(key))

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -156,9 +156,10 @@ const {
 
 {
   // Arrays containing a single set-cookie value are handled correctly
-  // (issue #16452)
-  const headers = Object.create({});
-  headers['set-cookie'] = ['foo=bar'];
+  // (https://github.com/nodejs/node/issues/16452)
+  const headers = {
+    'set-cookie': 'foo=bar'
+  };
   assert.deepStrictEqual(
     mapToHeaders(headers),
     [ [ 'set-cookie', 'foo=bar', '' ].join('\0'), 1 ]

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -154,6 +154,17 @@ const {
   );
 }
 
+{
+  // Arrays containing a single set-cookie value are handled correctly
+  // (issue #16452)
+  const headers = Object.create({});
+  headers['set-cookie'] = ['foo=bar'];
+  assert.deepStrictEqual(
+    mapToHeaders(headers),
+    [ [ 'set-cookie', 'foo=bar', '' ].join('\0'), 1 ]
+  );
+}
+
 // The following are not allowed to have multiple values
 [
   HTTP2_HEADER_STATUS,


### PR DESCRIPTION
This is for issue 16452. When 'set-cookie' header is set with an array
that has only one string value, it's split into its individual
characters.

Fix by resetting `isArray` to false when the value is converted from an
array to a string.

Fixes: https://github.com/nodejs/node/issues/16452

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2
