### PR TITLE
crypto: migrate DiffieHellman to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -631,11 +631,98 @@ Used when `Console` is instantiated without `stdout` stream or when `stdout` or
 
 Used when the native call from `process.cpuUsage` cannot be processed properly.
 
+<a id="ERR_CRYPTO_DH_GENERATE_KEYS_FAILED"></a>
+### ERR_CRYPTO_DH_GENERATE_KEYS_FAILED
+
+Used when `diffieHellman.generateKeys()` fails for any reason.
+
+<a id="ERR_CRYPTO_DH_INITIALIZATION_FAILED"></a>
+### ERR_CRYPTO_DH_INITIALIZATION_FAILED
+
+Used when creation of a [`DiffieHellman`][], [`ECDH`][], or
+[`DiffieHellmanGroup`][] instance fails for any reason.
+
+<a id="ERR_CRYPTO_DH_INVALID_KEY"></a>
+### ERR_CRYPTO_DH_INVALID_KEY
+
+Used when [`ecdh.computeSecret()`][] fails because of an invalid input key.
+
+<a id="ERR_CRYPTO_DH_INVALID_KEY_TOO_LARGE"></a>
+### ERR_CRYPTO_DH_INVALID_KEY_TOO_LARGE
+
+Used when [`ecdh.computeSecret()`][] fails because the input key is too large.
+
+<a id="ERR_CRYPTO_DH_INVALID_KEY_TOO_SMALL"></a>
+### ERR_CRYPTO_DH_INVALID_KEY_TOO_SMALL
+
+Used when [`ecdh.computeSecret()`][] fails because the input key is too small.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_ALLOCATE_EC_POINT"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_ALLOCATE_EC_POINT
+
+Used when either [`ecdh.setPublicKey()`][] or [`ecdh.computeSecret()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_COMPUTE_ECDH_KEY"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_COMPUTE_ECDH_KEY
+
+Used when [`ecdh.computeSecret()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN
+
+Used when [`ecdh.setPrivateKey()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT
+
+Used when either [`ecdh.setPublicKey()`][] or [`ecdh.computeSecret()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY
+
+Used when [`ecdh.setPrivateKey()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_GENERATE_PUBLIC_KEY"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_GENERATE_PUBLIC_KEY
+
+Used when [`ecdh.setPrivateKey()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY
+
+Used when [`ecdh.setPrivateKey()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY"></a>
+### ERR_CRYPTO_ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY
+
+Used when [`ecdh.setPublicKey()`][] fails.
+
+<a id="ERR_CRYPTO_ECDH_GENERATE_KEYS_FAILED"></a>
+### ERR_CRYPTO_ECDH_GENERATE_KEYS_FAILED
+
+Used when [`ecdh.generateKeys()`][] fails.
+
 <a id="ERR_CRYPTO_ECDH_INVALID_FORMAT"></a>
 ### ERR_CRYPTO_ECDH_INVALID_FORMAT
 
 Used when an invalid value for the `format` argument has been passed to the
-`crypto.ECDH()` class `getPublicKey()` method.
+[`ECDH`][] class `getPublicKey()` method.
+
+<a id="ERR_CRYPTO_ECDH_INVALID_KEY_PAIR"></a>
+### ERR_CRYPTO_ECDH_INVALID_KEY_PAIR
+
+Used when calling [`diffieHellman.computeSecret()`][] with an invalid key pair.
+
+<a id="ERR_CRYPTO_ECDH_INVALID_PRIVATE_KEY"></a>
+### ERR_CRYPTO_ECDH_INVALID_PRIVATE_KEY
+
+Used when attempt to set an invalid key using
+[`diffieHellman.setPrivateKey()`][] and `ecdh.setPrivateKey()`.
+
+<a id="ERR_CRYPTO_ECDH_UNKNOWN_CURVE"></a>
+### ERR_CRYPTO_ECDH_UNKNOWN_CURVE
+
+Used when creating an [`ECDH`][] instance with an invalid curve name.
 
 <a id="ERR_CRYPTO_ENGINE_UNKNOWN"></a>
 ### ERR_CRYPTO_ENGINE_UNKNOWN
@@ -1348,6 +1435,16 @@ Used when a given value is out of the accepted range.
 Used when an attempt is made to use a `zlib` object after it has already been
 closed.
 
+[`DiffieHellman`]: crypto.html#crypto_class_diffiehellman
+[`DiffieHellmanGroup`]: crypto.html#crypto_class_diffiehellmangroup
+[`diffieHellman.computeSecret()`]: crypto.html#crypto_diffiehellman_computesecret_otherpublickey_inputencoding_outputencoding
+[`diffieHellman.generateKeys()`]: crypto.html#crypto_diffiehellman_generatekeys_encoding
+[`diffieHellman.setPrivateKey()`]: crypto.html#crypto_diffiehellman_setprivatekey_privatekey_encoding
+[`ECDH`]: crypto.html#crypto_class_ecdh
+[`ecdh.computeSecret()`]: crypto.html#crypto_ecdh_computesecret_otherpublickey_inputencoding_outputencoding
+[`ecdh.generateKeys()`]: crypto.html#crypto_ecdh_generatekeys_encoding_format
+[`ecdh.setPrivateKey()`]: crypto.html#crypto_ecdh_setprivatekey_privatekey_encoding
+[`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_publickey_encoding
 [`ERR_INVALID_ARG_TYPE`]: #ERR_INVALID_ARG_TYPE
 [`subprocess.kill()`]: child_process.html#child_process_subprocess_kill_signal
 [`subprocess.send()`]: child_process.html#child_process_subprocess_send_message_sendhandle_options_callback

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -4,13 +4,28 @@ const { Buffer } = require('buffer');
 const errors = require('internal/errors');
 const { isArrayBufferView } = require('internal/util/types');
 const {
+  getCurves,
   getDefaultEncoding,
   toBuf
 } = require('internal/crypto/util');
 const {
   DiffieHellman: _DiffieHellman,
   DiffieHellmanGroup: _DiffieHellmanGroup,
-  ECDH: _ECDH
+  ECDH: _ECDH,
+  DH_INVALID_KEY,
+  DH_INVALID_KEY_TOO_LARGE,
+  DH_INVALID_KEY_TOO_SMALL,
+  ECDH_FAILED_TO_ALLOCATE_EC_POINT,
+  ECDH_FAILED_TO_COMPUTE_ECDH_KEY,
+  ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN,
+  ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT,
+  ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY,
+  ECDH_FAILED_TO_GENERATE_PUBLIC_KEY,
+  ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY,
+  ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY,
+  ECDH_INVALID_KEY_PAIR,
+  ECDH_INVALID_PRIVATE_KEY,
+  dhGroupNames
 } = process.binding('crypto');
 const {
   POINT_CONVERSION_COMPRESSED,
@@ -19,6 +34,9 @@ const {
 } = process.binding('constants').crypto;
 
 const DH_GENERATOR = 2;
+
+const dhGroupsNamesSet = new Set(dhGroupNames);
+const ecdhCurvesSet = new Set(getCurves());
 
 function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   if (!(this instanceof DiffieHellman))
@@ -48,12 +66,26 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
   if (typeof sizeOrKey !== 'number')
     sizeOrKey = toBuf(sizeOrKey, keyEncoding);
 
-  if (!generator)
+  if (generator === undefined)
     generator = DH_GENERATOR;
   else if (typeof generator !== 'number')
     generator = toBuf(generator, genEncoding);
 
+  if (typeof generator !== 'number' &&
+      typeof generator !== 'string' &&
+      !isArrayBufferView(generator)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'generator',
+                               ['number', 'string', 'Buffer', 'TypedArray',
+                                'DataView']);
+  }
+
   this._handle = new _DiffieHellman(sizeOrKey, generator);
+  if (!this._handle.getInitialized()) {
+    const err = new errors.Error('ERR_CRYPTO_DH_INITIALIZATION_FAILED');
+    err.opensslErrorStack = this._handle.opensslErrorStack;
+    this._handle.opensslErrorStack = undefined;
+    throw err;
+  }
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
     value: this._handle.verifyError,
@@ -65,7 +97,17 @@ function DiffieHellman(sizeOrKey, keyEncoding, generator, genEncoding) {
 function DiffieHellmanGroup(name) {
   if (!(this instanceof DiffieHellmanGroup))
     return new DiffieHellmanGroup(name);
+
+  if (typeof name !== 'string')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'name', 'string');
+
+  if (!dhGroupsNamesSet.has(name.toLowerCase()))
+    throw new errors.TypeError('ERR_CRYPTO_UNKNOWN_DH_GROUP', name);
+
   this._handle = new _DiffieHellmanGroup(name);
+  if (!this._handle.getInitialized())
+    throw new errors.Error('ERR_CRYPTO_DH_INITIALIZATION_FAILED');
+
   Object.defineProperty(this, 'verifyError', {
     enumerable: true,
     value: this._handle.verifyError,
@@ -73,17 +115,25 @@ function DiffieHellmanGroup(name) {
   });
 }
 
+DiffieHellmanGroup.getNames = function() {
+  return dhGroupNames.slice();
+};
 
 DiffieHellmanGroup.prototype.generateKeys =
     DiffieHellman.prototype.generateKeys =
     dhGenerateKeys;
 
 function dhGenerateKeys(encoding) {
-  var keys = this._handle.generateKeys();
+  const keys = this._handle.generateKeys();
+  if (keys === undefined) {
+    const err = new errors.Error('ERR_CRYPTO_DH_GENERATE_KEYS_FAILED');
+    err.opensslErrorStack = this._handle.opensslErrorStack;
+    this._handle.opensslErrorStack = undefined;
+    throw err;
+  }
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    keys = keys.toString(encoding);
-  return keys;
+  return encoding && encoding !== 'buffer' ?
+    keys.toString(encoding) : keys;
 }
 
 
@@ -95,10 +145,36 @@ function dhComputeSecret(key, inEnc, outEnc) {
   const encoding = getDefaultEncoding();
   inEnc = inEnc || encoding;
   outEnc = outEnc || encoding;
-  var ret = this._handle.computeSecret(toBuf(key, inEnc));
-  if (outEnc && outEnc !== 'buffer')
-    ret = ret.toString(outEnc);
-  return ret;
+
+  key = toBuf(key, inEnc);
+  if (!isArrayBufferView(key)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'key',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+
+  const ret = this._handle.computeSecret(key);
+
+  switch (ret) {
+    case DH_INVALID_KEY:
+      throw new errors.Error('ERR_CRYPTO_DH_INVALID_KEY');
+    case DH_INVALID_KEY_TOO_LARGE:
+      throw new errors.Error('ERR_CRYPTO_DH_INVALID_KEY_TOO_LARGE');
+    case DH_INVALID_KEY_TOO_SMALL:
+      throw new errors.Error('ERR_CRYPTO_DH_INVALID_KEY_TOO_SMALL');
+    case ECDH_INVALID_KEY_PAIR:
+      throw new errors.Error('ERR_CRYPTO_ECDH_INVALID_KEY_PAIR');
+    case ECDH_FAILED_TO_COMPUTE_ECDH_KEY:
+      throw new errors.Error('ERR_CRYPTO_ECDH_FAILED_TO_COMPUTE_ECDH_KEY');
+    case ECDH_FAILED_TO_ALLOCATE_EC_POINT:
+      throw new errors.Error('ERR_CRYPTO_ECDH_FAILED_TO_ALLOCATE_EC_POINT');
+    case ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT:
+      throw new errors.Error(
+        'ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT');
+    default:
+      if (outEnc && outEnc !== 'buffer')
+        return ret.toString(outEnc);
+      return ret;
+  }
 }
 
 
@@ -107,10 +183,10 @@ DiffieHellmanGroup.prototype.getPrime =
     dhGetPrime;
 
 function dhGetPrime(encoding) {
-  var prime = this._handle.getPrime();
+  const prime = this._handle.getPrime();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    prime = prime.toString(encoding);
+  if (prime !== undefined && encoding && encoding !== 'buffer')
+    return prime.toString(encoding);
   return prime;
 }
 
@@ -120,10 +196,10 @@ DiffieHellmanGroup.prototype.getGenerator =
     dhGetGenerator;
 
 function dhGetGenerator(encoding) {
-  var generator = this._handle.getGenerator();
+  const generator = this._handle.getGenerator();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    generator = generator.toString(encoding);
+  if (generator !== undefined && encoding && encoding !== 'buffer')
+    return generator.toString(encoding);
   return generator;
 }
 
@@ -133,10 +209,10 @@ DiffieHellmanGroup.prototype.getPublicKey =
     dhGetPublicKey;
 
 function dhGetPublicKey(encoding) {
-  var key = this._handle.getPublicKey();
+  const key = this._handle.getPublicKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
+  if (key !== undefined && encoding && encoding !== 'buffer')
+    return key.toString(encoding);
   return key;
 }
 
@@ -146,25 +222,59 @@ DiffieHellmanGroup.prototype.getPrivateKey =
     dhGetPrivateKey;
 
 function dhGetPrivateKey(encoding) {
-  var key = this._handle.getPrivateKey();
+  const key = this._handle.getPrivateKey();
   encoding = encoding || getDefaultEncoding();
-  if (encoding && encoding !== 'buffer')
-    key = key.toString(encoding);
+  if (key !== undefined && encoding && encoding !== 'buffer')
+    return key.toString(encoding);
   return key;
 }
 
 
 DiffieHellman.prototype.setPublicKey = function setPublicKey(key, encoding) {
   encoding = encoding || getDefaultEncoding();
-  this._handle.setPublicKey(toBuf(key, encoding));
-  return this;
+  key = toBuf(key, encoding);
+  if (!isArrayBufferView(key)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'publicKey',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+  switch (this._handle.setPublicKey(key)) {
+    case ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT:
+      throw new errors.Error(
+        'ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT');
+    case ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY:
+      throw new errors.Error(
+        'ERR_CRYPTO_ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY');
+    case ECDH_FAILED_TO_ALLOCATE_EC_POINT:
+      throw new errors.Error('ERR_CRYPTO_ECDH_FAILED_TO_ALLOCATE_EC_POINT');
+    default:
+      return this;
+  }
 };
 
 
 DiffieHellman.prototype.setPrivateKey = function setPrivateKey(key, encoding) {
   encoding = encoding || getDefaultEncoding();
-  this._handle.setPrivateKey(toBuf(key, encoding));
-  return this;
+  key = toBuf(key, encoding);
+  if (!isArrayBufferView(key)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'publicKey',
+                               ['string', 'Buffer', 'TypedArray', 'DataView']);
+  }
+  switch (this._handle.setPrivateKey(key)) {
+    case ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN:
+      throw new errors.Error('ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN');
+    case ECDH_INVALID_PRIVATE_KEY:
+      throw new errors.Error('ERR_CRYPTO_ECDH_INVALID_PRIVATE_KEY');
+    case ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY:
+      throw new errors.Error(
+        'ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY');
+    case ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY:
+      throw new errors.Error(
+        'ERR_CRYPTO_ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY');
+    case ECDH_FAILED_TO_GENERATE_PUBLIC_KEY:
+      throw new errors.Error('ERR_CRYPTO_ECDH_FAILED_TO_GENERATE_PUBLIC_KEY');
+    default:
+      return this;
+  }
 };
 
 
@@ -175,6 +285,9 @@ function ECDH(curve) {
   if (typeof curve !== 'string')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'curve', 'string');
 
+  if (!ecdhCurvesSet.has(curve))
+    throw new errors.TypeError('ERR_CRYPTO_ECDH_UNKNOWN_CURVE', curve);
+
   this._handle = new _ECDH(curve);
 }
 
@@ -184,7 +297,8 @@ ECDH.prototype.setPublicKey = DiffieHellman.prototype.setPublicKey;
 ECDH.prototype.getPrivateKey = DiffieHellman.prototype.getPrivateKey;
 
 ECDH.prototype.generateKeys = function generateKeys(encoding, format) {
-  this._handle.generateKeys();
+  if (!this._handle.generateKeys())
+    throw new errors.Error('ERR_CRYPTO_ECDH_GENERATE_KEYS_FAILED');
 
   return this.getPublicKey(encoding, format);
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -153,13 +153,39 @@ E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
 E('ERR_CPU_USAGE', 'Unable to obtain cpu usage %s');
+E('ERR_CRYPTO_DH_GENERATE_KEYS_FAILED', 'DiffieHellman GenerateKeys failed');
+E('ERR_CRYPTO_DH_INITIALIZATION_FAILED', 'DiffieHellman Initialization failed');
+E('ERR_CRYPTO_DH_INVALID_KEY', 'Invalid key');
+E('ERR_CRYPTO_DH_INVALID_KEY_TOO_LARGE', 'Supplied key is too large');
+E('ERR_CRYPTO_DH_INVALID_KEY_TOO_SMALL', 'Supplied key is too small');
+E('ERR_CRYPTO_ECDH_FAILED_TO_ALLOCATE_EC_POINT',
+  'Failed to allocate EC_POINT for a public key');
+E('ERR_CRYPTO_ECDH_FAILED_TO_COMPUTE_ECDH_KEY', 'Failed to generate ECDH key');
+E('ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN',
+  'Failed to convert Buffer to BN');
+E('ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT',
+  'Failed to convert Buffer to EC_POINT');
+E('ERR_CRYPTO_ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY',
+  'Failed to convert BN to a private key');
+E('ERR_CRYPTO_ECDH_FAILED_TO_GENERATE_PUBLIC_KEY',
+  'Failed to generate ECDH public key');
+E('ERR_CRYPTO_ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY',
+  'Failed to set generated public key');
+E('ERR_CRYPTO_ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY',
+  'Failed to set EC_POINT as the public key');
+E('ERR_CRYPTO_ECDH_GENERATE_KEYS_FAILED', 'ECDH GenerateKeys failed');
 E('ERR_CRYPTO_ECDH_INVALID_FORMAT', 'Invalid ECDH format: %s');
+E('ERR_CRYPTO_ECDH_INVALID_KEY_PAIR', 'Invalid ECDH key pair');
+E('ERR_CRYPTO_ECDH_INVALID_PRIVATE_KEY',
+  'Private key is not valid for specified curve.');
+E('ERR_CRYPTO_ECDH_UNKNOWN_CURVE', 'Unknown ECDH curve name: %s');
 E('ERR_CRYPTO_ENGINE_UNKNOWN', 'Engine "%s" was not found');
 E('ERR_CRYPTO_HASH_DIGEST_NO_UTF16', 'hash.digest() does not support UTF-16');
 E('ERR_CRYPTO_HASH_FINALIZED', 'Digest already called');
 E('ERR_CRYPTO_HASH_UPDATE_FAILED', 'Hash update failed');
 E('ERR_CRYPTO_INVALID_DIGEST', 'Invalid digest: %s');
 E('ERR_CRYPTO_SIGN_KEY_REQUIRED', 'No key provided to sign');
+E('ERR_CRYPTO_UNKNOWN_DH_GROUP', 'Unknown DiffieHellmanGroup name: %s');
 E('ERR_DNS_SET_SERVERS_FAILED', (err, servers) =>
   `c-ares failed to set servers: "${err}" [${servers}]`);
 E('ERR_ENCODING_INVALID_ENCODED_DATA',

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -82,6 +82,22 @@ enum CheckResult {
   CHECK_OK = 1
 };
 
+enum CryptoErrorCodes {
+  ECDH_FAILED_TO_ALLOCATE_EC_POINT,
+  ECDH_FAILED_TO_COMPUTE_ECDH_KEY,
+  ECDH_FAILED_TO_CONVERT_BUFFER_TO_BN,
+  ECDH_FAILED_TO_CONVERT_BUFFER_TO_POINT,
+  ECDH_FAILED_TO_CONVERT_CN_TO_PRIVATEKEY,
+  ECDH_FAILED_TO_GENERATE_PUBLIC_KEY,
+  ECDH_FAILED_TO_SET_GENERATED_PUBLIC_KEY,
+  ECDH_FAILED_TO_SET_POINT_AS_PUBLIC_KEY,
+  ECDH_INVALID_PRIVATE_KEY,
+  ECDH_INVALID_KEY_PAIR,
+  DH_INVALID_KEY,
+  DH_INVALID_KEY_TOO_LARGE,
+  DH_INVALID_KEY_TOO_SMALL
+};
+
 extern int VerifyCallback(int preverify_ok, X509_STORE_CTX* ctx);
 
 extern void UseExtraCaCerts(const std::string& file);
@@ -668,6 +684,7 @@ class DiffieHellman : public BaseObject {
   static void DiffieHellmanGroup(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetInitialized(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GenerateKeys(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPrime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetGenerator(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -689,10 +706,10 @@ class DiffieHellman : public BaseObject {
   }
 
  private:
-  static void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
-                       BIGNUM* (DH::*field), const char* err_if_null);
+  static inline void GetField(const v8::FunctionCallbackInfo<v8::Value>& args,
+                              BIGNUM* (DH::*field));
   static void SetKey(const v8::FunctionCallbackInfo<v8::Value>& args,
-                     BIGNUM* (DH::*field), const char* what);
+                     BIGNUM* (DH::*field));
   bool VerifyContext();
 
   bool initialised_;
@@ -728,7 +745,7 @@ class ECDH : public BaseObject {
   static void GetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetPublicKey(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  EC_POINT* BufferToPoint(char* data, size_t len);
+  EC_POINT* BufferToPoint(char* data, size_t len, int* status);
 
   bool IsKeyPairValid();
   bool IsKeyValidForCurve(const BIGNUM* private_key);


### PR DESCRIPTION
* Export the group names using new DiffieHellmanGroup.getNames() API
* Validate the group name type and value in JS
* Stricter type checking on DiffieHellman
* Refactor DH initialization failure error
* Refactor dh.getNNNN methods to not throw

  The `diffieHellman.getPrime()`, `.getPublicKey()`, `.getPrivateKey()`, and
  `.getGenerator()` methods would throw if the value was null/undefined. That
  behavior was not documented, and not tested as it turns out.

  This refactors those to return undefined.

  Definitely a semver-major, but far more likely to be what users would expect.

* Improve type checking in dh.computeSecrets
* Migrate all DiffieHellman related errors to internal/errors

*Note*: This adds quite a few error codes that are pretty specific to failures within DH related methods. Most of these existing errors weren't even being tested, and it's really not clear if the errors actually add any value. I'd like to refactor them into more generic errors by default, then allow a DEBUG build to
generate more verbose output. For now, this keeps the errors largely one to one with what was already being thrown.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto