### PR TITLE
src: destroy inspector agent before context

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -306,7 +306,7 @@ inline Environment::Environment(IsolateData* isolate_data,
       emit_napi_warning_(true),
       makecallback_cntr_(0),
 #if HAVE_INSPECTOR
-      inspector_agent_(this),
+      inspector_agent_(new inspector::Agent(this)),
 #endif
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
@@ -346,6 +346,11 @@ inline Environment::Environment(IsolateData* isolate_data,
 
 inline Environment::~Environment() {
   v8::HandleScope handle_scope(isolate());
+
+#if HAVE_INSPECTOR
+  // Destroy inspector agent before erasing the context.
+  delete inspector_agent_;
+#endif
 
   context()->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex,
                                              nullptr);

--- a/src/env.h
+++ b/src/env.h
@@ -667,8 +667,8 @@ class Environment {
 #undef V
 
 #if HAVE_INSPECTOR
-  inline inspector::Agent* inspector_agent() {
-    return &inspector_agent_;
+  inline inspector::Agent* inspector_agent() const {
+    return inspector_agent_;
   }
 #endif
 
@@ -713,7 +713,7 @@ class Environment {
   std::map<std::string, uint64_t> performance_marks_;
 
 #if HAVE_INSPECTOR
-  inspector::Agent inspector_agent_;
+  inspector::Agent* const inspector_agent_;
 #endif
 
   HandleWrapQueue handle_wrap_queue_;


### PR DESCRIPTION
The inspector_agent depends on the context still being accessible
during the destructor execution.

Fixes: https://github.com/nodejs/node/issues/15558

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
inspector

~~CI: https://ci.nodejs.org/job/node-test-pull-request/10954/~~
https://ci.nodejs.org/job/node-test-pull-request/10969/