### PR TITLE
src: move handle properties to prototype

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -33,26 +33,26 @@ void StreamBase::AddMethods(Environment* env,
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(env->fd_string(),
-                                     GetFD<Base>,
-                                     nullptr,
-                                     env->as_external(),
-                                     v8::DEFAULT,
-                                     attributes);
+  t->PrototypeTemplate()->SetAccessor(env->fd_string(),
+                                      GetFD<Base>,
+                                      nullptr,
+                                      env->as_external(),
+                                      v8::DEFAULT,
+                                      attributes);
 
-  t->InstanceTemplate()->SetAccessor(env->external_stream_string(),
-                                     GetExternal<Base>,
-                                     nullptr,
-                                     env->as_external(),
-                                     v8::DEFAULT,
-                                     attributes);
+  t->PrototypeTemplate()->SetAccessor(env->external_stream_string(),
+                                      GetExternal<Base>,
+                                      nullptr,
+                                      env->as_external(),
+                                      v8::DEFAULT,
+                                      attributes);
 
-  t->InstanceTemplate()->SetAccessor(env->bytes_read_string(),
-                                     GetBytesRead<Base>,
-                                     nullptr,
-                                     env->as_external(),
-                                     v8::DEFAULT,
-                                     attributes);
+  t->PrototypeTemplate()->SetAccessor(env->bytes_read_string(),
+                                      GetBytesRead<Base>,
+                                      nullptr,
+                                      env->as_external(),
+                                      v8::DEFAULT,
+                                      attributes);
 
   env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
   env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);
@@ -81,11 +81,10 @@ void StreamBase::AddMethods(Environment* env,
 template <class Base>
 void StreamBase::GetFD(Local<String> key,
                        const PropertyCallbackInfo<Value>& args) {
-  Base* handle = Unwrap<Base>(args.Holder());
-
   // Mimic implementation of StreamBase::GetFD() and UDPWrap::GetFD().
+  Base* handle;
   ASSIGN_OR_RETURN_UNWRAP(&handle,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(UV_EINVAL));
 
   StreamBase* wrap = static_cast<StreamBase*>(handle);
@@ -99,11 +98,10 @@ void StreamBase::GetFD(Local<String> key,
 template <class Base>
 void StreamBase::GetBytesRead(Local<String> key,
                               const PropertyCallbackInfo<Value>& args) {
-  Base* handle = Unwrap<Base>(args.Holder());
-
   // The handle instance hasn't been set. So no bytes could have been read.
+  Base* handle;
   ASSIGN_OR_RETURN_UNWRAP(&handle,
-                          args.Holder(),
+                          args.This(),
                           args.GetReturnValue().Set(0));
 
   StreamBase* wrap = static_cast<StreamBase*>(handle);
@@ -115,9 +113,8 @@ void StreamBase::GetBytesRead(Local<String> key,
 template <class Base>
 void StreamBase::GetExternal(Local<String> key,
                              const PropertyCallbackInfo<Value>& args) {
-  Base* handle = Unwrap<Base>(args.Holder());
-
-  ASSIGN_OR_RETURN_UNWRAP(&handle, args.Holder());
+  Base* handle;
+  ASSIGN_OR_RETURN_UNWRAP(&handle, args.This());
 
   StreamBase* wrap = static_cast<StreamBase*>(handle);
   Local<External> ext = External::New(args.GetIsolate(), wrap);
@@ -128,8 +125,7 @@ void StreamBase::GetExternal(Local<String> key,
 template <class Base,
           int (StreamBase::*Method)(const FunctionCallbackInfo<Value>& args)>
 void StreamBase::JSMethod(const FunctionCallbackInfo<Value>& args) {
-  Base* handle = Unwrap<Base>(args.Holder());
-
+  Base* handle;
   ASSIGN_OR_RETURN_UNWRAP(&handle, args.Holder());
 
   StreamBase* wrap = static_cast<StreamBase*>(handle);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -169,7 +169,6 @@ void UDPWrap::New(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
   int fd = UV_EBADF;
 #if !defined(_WIN32)
-  HandleScope scope(args.GetIsolate());
   UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
   if (wrap != nullptr)
     uv_fileno(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &fd);

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -113,12 +113,12 @@ void UDPWrap::Initialize(Local<Object> target,
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-  t->InstanceTemplate()->SetAccessor(env->fd_string(),
-                                     UDPWrap::GetFD,
-                                     nullptr,
-                                     env->as_external(),
-                                     v8::DEFAULT,
-                                     attributes);
+  t->PrototypeTemplate()->SetAccessor(env->fd_string(),
+                                      UDPWrap::GetFD,
+                                      nullptr,
+                                      env->as_external(),
+                                      v8::DEFAULT,
+                                      attributes);
 
   env->SetProtoMethod(t, "bind", Bind);
   env->SetProtoMethod(t, "send", Send);
@@ -169,7 +169,7 @@ void UDPWrap::New(const FunctionCallbackInfo<Value>& args) {
 void UDPWrap::GetFD(Local<String>, const PropertyCallbackInfo<Value>& args) {
   int fd = UV_EBADF;
 #if !defined(_WIN32)
-  UDPWrap* wrap = Unwrap<UDPWrap>(args.Holder());
+  UDPWrap* wrap = Unwrap<UDPWrap>(args.This());
   if (wrap != nullptr)
     uv_fileno(reinterpret_cast<uv_handle_t*>(&wrap->handle_), &fd);
 #endif


### PR DESCRIPTION
Reduce the size of wrap objects by moving a couple of accessors from the
instance template to the prototype template.  They occupied one slot per
instance instead of one slot per class.

This commit fixes some instances of unwrapping twice since that code had
to be updated anyway to use `args.This()` instead of `args.Holder()`.

CI: https://ci.nodejs.org/job/node-test-pull-request/10958/