### PR TITLE
test: call toLowerCase on the resolved module

### DIFF
--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -32,7 +32,7 @@ assert.strictEqual(
   require.resolve(fixtures.path('a')).toLowerCase());
 assert.strictEqual(
   fixtures.path('nested-index', 'one', 'index.js').toLowerCase(),
-  require.resolve(fixtures.path('nested-index', 'one').toLowerCase()));
+  require.resolve(fixtures.path('nested-index', 'one')).toLowerCase());
 assert.strictEqual('path', require.resolve('path'));
 
 console.log('ok');


### PR DESCRIPTION
The commit updates test-require-resolve.js to call toLowerCase on the
resolved module instead of the path. Currently this test will fail if
the path to where node exists contains uppercase letters. For example:
```console
$ out/Release/node
test/parallel/test-require-resolve.js
/root/rpmbuild/BUILD/node-v8.8.0/test/parallel
module.js:515
    throw err;
    ^

Error: Cannot find module
'/root/rpmbuild/build/node-v8.8.0/test/fixtures/nested-index/one'
    at Function.Module._resolveFilename (module.js:513:15)
    at Function.resolve (internal/module.js:18:19)
    at Object.<anonymous>
(/root/rpmbuild/BUILD/node-v8.8.0/test/parallel/test-require-resolve.js:37:11)
    at Module._compile (module.js:612:30)
    at Object.Module._extensions..js (module.js:623:10)
    at Module.load (module.js:531:32)
    at tryModuleLoad (module.js:494:12)
    at Function.Module._load (module.js:486:3)
    at Function.Module.runMain (module.js:653:10)
    at startup (bootstrap_node.js:187:16)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test