### PR TITLE
src: fix vm module for strict mode

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -346,14 +346,21 @@ class ContextifyContext {
       return;
 
     auto attributes = PropertyAttribute::None;
-    bool is_declared = ctx->global_proxy()
+    bool is_declared_on_global_proxy = ctx->global_proxy()
         ->GetRealNamedPropertyAttributes(ctx->context(), property)
         .To(&attributes);
     bool read_only =
         static_cast<int>(attributes) &
         static_cast<int>(PropertyAttribute::ReadOnly);
 
-    if (is_declared && read_only)
+    bool is_declared_on_sandbox = ctx->sandbox()
+        ->GetRealNamedPropertyAttributes(ctx->context(), property)
+        .To(&attributes);
+    read_only = read_only ||
+        (static_cast<int>(attributes) &
+        static_cast<int>(PropertyAttribute::ReadOnly));
+
+    if (read_only)
       return;
 
     // true for x = 5
@@ -371,9 +378,19 @@ class ContextifyContext {
     // this.f = function() {}, is_contextual_store = false.
     bool is_function = value->IsFunction();
 
+    bool is_declared = is_declared_on_global_proxy || is_declared_on_sandbox;
     if (!is_declared && args.ShouldThrowOnError() && is_contextual_store &&
         !is_function)
       return;
+
+    if (!is_declared_on_global_proxy && is_declared_on_sandbox  &&
+        args.ShouldThrowOnError() && is_contextual_store && !is_function) {
+      // The property exists on the sandbox but not on the global
+      // proxy. Setting it would throw because we are in strict mode.
+      // Don't attempt to set it by signaling that the call was
+      // intercepted. Only change the value on the sandbox.
+      args.GetReturnValue().Set(false);
+    }
 
     ctx->sandbox()->Set(property, value);
   }

--- a/test/parallel/test-vm-strict-mode.js
+++ b/test/parallel/test-vm-strict-mode.js
@@ -7,11 +7,8 @@ const vm = require('vm');
 
 const ctx = vm.createContext({ x: 42 });
 
-// The following line wrongly throws an
-// error because GlobalPropertySetterCallback()
-// does not check if the property exists
-// on the sandbox. It should just set x to 1
-// instead of throwing an error.
+// This might look as if x has not been declared, but x is defined on the
+// sandbox and the assignment should not throw.
 vm.runInContext('"use strict"; x = 1', ctx);
 
 assert.strictEqual(ctx.x, 1);


### PR DESCRIPTION
This patch fixes the problem with variables that
are declared only on the sandbox but not on the
global proxy.

Fixes: https://github.com/nodejs/node/issues/12300

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src