### PR TITLE
net: fix timeout with null handle

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -397,13 +397,15 @@ Socket.prototype.setTimeout = function(msecs, callback) {
 
 
 Socket.prototype._onTimeout = function() {
-  // `.prevWriteQueueSize` !== `.updateWriteQueueSize()` means there is
-  // an active write in progress, so we suppress the timeout.
-  const prevWriteQueueSize = this._handle.writeQueueSize;
-  if (prevWriteQueueSize > 0 &&
-      prevWriteQueueSize !== this._handle.updateWriteQueueSize()) {
-    this._unrefTimer();
-    return;
+  if (this._handle) {
+    // `.prevWriteQueueSize` !== `.updateWriteQueueSize()` means there is
+    // an active write in progress, so we suppress the timeout.
+    const prevWriteQueueSize = this._handle.writeQueueSize;
+    if (prevWriteQueueSize > 0 &&
+        prevWriteQueueSize !== this._handle.updateWriteQueueSize()) {
+      this._unrefTimer();
+      return;
+    }
   }
   debug('_onTimeout');
   this.emit('timeout');

--- a/test/parallel/test-net-timeout-no-handle.js
+++ b/test/parallel/test-net-timeout-no-handle.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+
+const socket = new net.Socket();
+socket.setTimeout(common.platformTimeout(50));
+
+socket.on('timeout', common.mustCall(() => {
+  assert.strictEqual(socket._handle, null);
+}));
+
+socket.on('connect', common.mustNotCall());
+
+// since the timeout is unrefed, the code will exit without this
+setTimeout(() => {}, common.platformTimeout(200));


### PR DESCRIPTION
Seems like there's a scenario where `_onTimeout` somehow gets called with `_handle` set to `null`. If anyone has any ideas on how this is possible then let me know so I can put together a better test than I have so far.

This might need to be expedited (< 48 hrs) and turned into 8.8.1? Not sure... 😔 😓 At least it's not LTS yet... \*sigh\*

Fixes: https://github.com/nodejs/node/issues/16484
Refs: https://github.com/nodejs/node/pull/15791

/cc @MylesBorins 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net, test