### PR TITLE
cli: add --stack-trace-limit to NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -471,6 +471,7 @@ Node options that are allowed are:
 V8 options that are allowed are:
 - `--abort-on-uncaught-exception`
 - `--max-old-space-size`
+- `--stack-trace-limit`
 
 ### `NODE_PENDING_DEPRECATION=1`
 <!-- YAML

--- a/src/node.cc
+++ b/src/node.cc
@@ -4043,6 +4043,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     // V8 options (define with '_', which allows '-' or '_')
     "--abort_on_uncaught_exception",
     "--max_old_space_size",
+    "--stack_trace_limit",
   };
 
   for (unsigned i = 0; i < arraysize(whitelist); i++) {

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -33,16 +33,26 @@ if (common.hasCrypto) {
 // V8 options
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
+expect('--stack-trace-limit=100',
+       /(\s*at f \(\[eval\]:1:\d*\)\n){100}/,
+       '(function f() { f(); })();',
+       true);
 
-function expect(opt, want) {
-  const argv = ['-e', 'console.log("B")'];
+function expect(opt, want, command = 'console.log("B")', wantsError = false) {
+  const argv = ['-e', command];
   const opts = {
     env: Object.assign({}, process.env, { NODE_OPTIONS: opt }),
     maxBuffer: 1e6,
   };
-  exec(process.execPath, argv, opts, common.mustCall((err, stdout) => {
-    assert.ifError(err);
-    if (stdout.includes(want)) return;
+  if (typeof want === 'string')
+    want = new RegExp(want);
+  exec(process.execPath, argv, opts, common.mustCall((err, stdout, stderr) => {
+    if (wantsError) {
+      stdout = stderr;
+    } else {
+      assert.ifError(err);
+    }
+    if (want.test(stdout)) return;
 
     const o = JSON.stringify(opt);
     assert.fail(`For ${o}, failed to find ${want} in: <\n${stdout}\n>`);


### PR DESCRIPTION
I decided that it would make a lot of sense for me to set `NODE_OPTIONS=--stack-trace-limit=100` on my development machine.

This code allows me to do that. :)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

cli