### PR TITLE
process: add one-shot signal handler support

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -177,6 +177,7 @@ added: v0.1.26
 
 * `eventName` {any} The name of the event being listened for
 * `listener` {Function} The event handler function
+* `isOnce` {boolean} If `true` the `listener` was added via the `once()` method
 
 The `EventEmitter` instance will emit its own `'newListener'` event *before*
 a listener is added to its internal array of listeners.
@@ -221,6 +222,7 @@ changes:
 
 * `eventName` {any} The event name
 * `listener` {Function} The event handler function
+* `isOnce` {boolean} If `true` the `listener` was added via the `once()` method
 
 The `'removeListener'` event is emitted *after* the `listener` is removed.
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -189,7 +189,8 @@ function _addListener(target, type, listener, prepend) {
     // adding it to the listeners, first emit "newListener".
     if (events.newListener !== undefined) {
       target.emit('newListener', type,
-                  listener.listener ? listener.listener : listener);
+                  listener.listener || listener,
+                  !!listener.listener);
 
       // Re-assign `events` because a newListener handler could have caused the
       // this._events to be assigned to a new object
@@ -307,8 +308,12 @@ EventEmitter.prototype.removeListener =
           this._events = Object.create(null);
         else {
           delete events[type];
-          if (events.removeListener)
-            this.emit('removeListener', type, list.listener || listener);
+          if (events.removeListener) {
+            this.emit('removeListener',
+                      type,
+                      list.listener || listener,
+                      !!list.listener);
+          }
         }
       } else if (typeof list !== 'function') {
         position = -1;
@@ -335,8 +340,12 @@ EventEmitter.prototype.removeListener =
         if (list.length === 1)
           events[type] = list[0];
 
-        if (events.removeListener !== undefined)
-          this.emit('removeListener', type, originalListener || listener);
+        if (events.removeListener !== undefined) {
+          this.emit('removeListener',
+                    type,
+                    originalListener || listener,
+                    !!originalListener);
+        }
       }
 
       return this;

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -181,37 +181,64 @@ function setupSignalHandlers() {
   // Load events module in order to access prototype elements on process like
   // process.addListener.
   const signalWraps = {};
+  const oneshots = {};
 
   function isSignal(event) {
     return typeof event === 'string' && constants[event] !== undefined;
   }
 
+  function startSignalWrap(type, isOneShot) {
+    if (signalWraps[type]) {
+      signalWraps[type].close();
+      delete signalWraps[type];
+    }
+
+    const Signal = process.binding('signal_wrap').Signal;
+    const wrap = new Signal();
+    wrap.unref();
+
+    wrap.onsignal = function() { process.emit(type, type); };
+
+    const signum = constants[type];
+    const err = wrap.start(signum, isOneShot);
+    if (err) {
+      wrap.close();
+      throw util._errnoException(err, 'uv_signal_start');
+    }
+
+    signalWraps[type] = wrap;
+  }
+
   // Detect presence of a listener for the special signal types
-  process.on('newListener', function(type, listener) {
-    if (isSignal(type) &&
-        !signalWraps.hasOwnProperty(type)) {
-      const Signal = process.binding('signal_wrap').Signal;
-      const wrap = new Signal();
-
-      wrap.unref();
-
-      wrap.onsignal = function() { process.emit(type, type); };
-
-      const signum = constants[type];
-      const err = wrap.start(signum);
-      if (err) {
-        wrap.close();
-        throw util._errnoException(err, 'uv_signal_start');
+  process.on('newListener', function(type, listener, isOnce) {
+    if (isSignal(type)) {
+      if (isOnce) {
+        if (oneshots[type])
+          ++oneshots[type];
+        else
+          oneshots[type] = 1;
       }
 
-      signalWraps[type] = wrap;
+      if (!signalWraps[type] ||
+          !isOnce && this.listenerCount(type) === oneshots[type]) {
+        startSignalWrap(type, isOnce);
+      }
     }
   });
 
-  process.on('removeListener', function(type, listener) {
-    if (signalWraps.hasOwnProperty(type) && this.listenerCount(type) === 0) {
-      signalWraps[type].close();
-      delete signalWraps[type];
+  process.on('removeListener', function(type, listener, isOnce) {
+    if (isOnce)
+      --oneshots[type];
+
+    if (signalWraps[type]) {
+      const count = this.listenerCount(type);
+      if (count === 0) {
+        signalWraps[type].close();
+        delete signalWraps[type];
+        delete oneshots[type];
+      } else if ((count === oneshots[type]) && !isOnce) {
+        startSignalWrap(type, true);
+      }
     }
   });
 }

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -27,6 +27,7 @@
 
 namespace node {
 
+using v8::Boolean;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -87,6 +88,8 @@ class SignalWrap : public HandleWrap {
     SignalWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
     int signum = args[0]->Int32Value();
+    CHECK(args[1]->IsBoolean());
+    bool oneshot = args[1].As<Boolean>()->Value();
 #if defined(__POSIX__) && HAVE_INSPECTOR
     if (signum == SIGPROF) {
       Environment* env = Environment::GetCurrent(args);
@@ -97,7 +100,9 @@ class SignalWrap : public HandleWrap {
       }
     }
 #endif
-    int err = uv_signal_start(&wrap->handle_, OnSignal, signum);
+    int err = oneshot ?
+              uv_signal_start_oneshot(&wrap->handle_, OnSignal, signum) :
+              uv_signal_start(&wrap->handle_, OnSignal, signum);
     args.GetReturnValue().Set(err);
   }
 

--- a/test/parallel/test-event-emitter-add-listeners.js
+++ b/test/parallel/test-event-emitter-add-listeners.js
@@ -28,17 +28,19 @@ const EventEmitter = require('events');
   const ee = new EventEmitter();
   const events_new_listener_emitted = [];
   const listeners_new_listener_emitted = [];
+  const is_once_new_listener_emitted = [];
 
   // Sanity check
   assert.strictEqual(ee.addListener, ee.on);
 
-  ee.on('newListener', function(event, listener) {
+  ee.on('newListener', function(event, listener, isOnce) {
     // Don't track newListener listeners.
     if (event === 'newListener')
       return;
 
     events_new_listener_emitted.push(event);
     listeners_new_listener_emitted.push(listener);
+    is_once_new_listener_emitted.push(isOnce);
   });
 
   const hello = common.mustCall(function(a, b) {
@@ -56,6 +58,7 @@ const EventEmitter = require('events');
   ee.once('foo', assert.fail);
   assert.deepStrictEqual(['hello', 'foo'], events_new_listener_emitted);
   assert.deepStrictEqual([hello, assert.fail], listeners_new_listener_emitted);
+  assert.deepStrictEqual([false, true], is_once_new_listener_emitted);
 
   ee.emit('hello', 'a', 'b');
 }

--- a/test/parallel/test-event-emitter-remove-all-listeners.js
+++ b/test/parallel/test-event-emitter-remove-all-listeners.js
@@ -87,15 +87,28 @@ function expect(expected) {
 {
   const ee = new events.EventEmitter();
   let expectLength = 2;
-  ee.on('removeListener', function(name, noop) {
+  ee.on('removeListener', function(name, noop, isOnce) {
     assert.strictEqual(expectLength--, this.listeners('baz').length);
+    assert.strictEqual(isOnce, expectLength === 1);
   });
   ee.on('baz', common.mustNotCall());
   ee.on('baz', common.mustNotCall());
-  ee.on('baz', common.mustNotCall());
+  ee.once('baz', common.mustNotCall());
   assert.strictEqual(ee.listeners('baz').length, expectLength + 1);
   ee.removeAllListeners('baz');
   assert.strictEqual(ee.listeners('baz').length, 0);
+}
+
+{
+  const ee = new events.EventEmitter();
+  ee.on('removeListener', common.mustCall(function(name, noop, isOnce) {
+    assert.strictEqual(name, 'baz');
+    assert.strictEqual(isOnce, true);
+    assert.strictEqual(ee.listeners('baz').length, 0);
+  }));
+
+  ee.once('baz', common.mustNotCall());
+  ee.removeAllListeners('baz');
 }
 
 {

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -30,9 +30,10 @@ function listener2() {}
 {
   const ee = new EventEmitter();
   ee.on('hello', listener1);
-  ee.on('removeListener', common.mustCall((name, cb) => {
+  ee.on('removeListener', common.mustCall((name, cb, isOnce) => {
     assert.strictEqual(name, 'hello');
     assert.strictEqual(cb, listener1);
+    assert.strictEqual(isOnce, false);
   }));
   ee.removeListener('hello', listener1);
   assert.deepStrictEqual([], ee.listeners('hello'));
@@ -50,16 +51,18 @@ function listener2() {}
   const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('hello', listener2);
-  ee.once('removeListener', common.mustCall((name, cb) => {
+  ee.once('removeListener', common.mustCall((name, cb, isOnce) => {
     assert.strictEqual(name, 'hello');
     assert.strictEqual(cb, listener1);
+    assert.strictEqual(isOnce, false);
     assert.deepStrictEqual([listener2], ee.listeners('hello'));
   }));
   ee.removeListener('hello', listener1);
   assert.deepStrictEqual([listener2], ee.listeners('hello'));
-  ee.once('removeListener', common.mustCall((name, cb) => {
+  ee.once('removeListener', common.mustCall((name, cb, isOnce) => {
     assert.strictEqual(name, 'hello');
     assert.strictEqual(cb, listener2);
+    assert.strictEqual(isOnce, false);
     assert.deepStrictEqual([], ee.listeners('hello'));
   }));
   ee.removeListener('hello', listener2);
@@ -91,13 +94,15 @@ function listener2() {}
   const ee = new EventEmitter();
   ee.on('hello', listener1);
   ee.on('hello', listener2);
-  ee.once('removeListener', common.mustCall((name, cb) => {
+  ee.once('removeListener', common.mustCall((name, cb, isOnce) => {
     assert.strictEqual(name, 'hello');
     assert.strictEqual(cb, listener1);
+    assert.strictEqual(isOnce, false);
     assert.deepStrictEqual([listener2], ee.listeners('hello'));
-    ee.once('removeListener', common.mustCall((name, cb) => {
+    ee.once('removeListener', common.mustCall((name, cb, isOnce) => {
       assert.strictEqual(name, 'hello');
       assert.strictEqual(cb, listener2);
+      assert.strictEqual(isOnce, false);
       assert.deepStrictEqual([], ee.listeners('hello'));
     }));
     ee.removeListener('hello', listener2);
@@ -129,10 +134,25 @@ function listener2() {}
 {
   const ee = new EventEmitter();
 
-  ee.once('hello', listener1);
-  ee.on('removeListener', common.mustCall((eventName, listener) => {
+  const listener = common.mustCall((eventName, listener, isOnce) => {
     assert.strictEqual(eventName, 'hello');
     assert.strictEqual(listener, listener1);
+    assert.strictEqual(isOnce, true);
+  });
+
+  ee.on('removeListener', listener);
+  ee.once('hello', listener1);
+  ee.removeListener('hello', listener1);
+}
+
+{
+  const ee = new EventEmitter();
+
+  ee.once('hello', listener1);
+  ee.on('removeListener', common.mustCall((eventName, listener, isOnce) => {
+    assert.strictEqual(eventName, 'hello');
+    assert.strictEqual(listener, listener1);
+    assert.strictEqual(isOnce, true);
   }));
   ee.emit('hello');
 }

--- a/test/parallel/test-signal-oneshot.js
+++ b/test/parallel/test-signal-oneshot.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const spawn = require('child_process').spawn;
+
+if (common.isWindows)
+  common.skip('Sending signals is not supported');
+
+if (process.argv[2] === 'child') {
+  if (process.argv[3] === 'once') {
+    const on_sigint = () => {};
+    process.on('SIGINT', on_sigint);
+    process.once('SIGINT', () => {});
+    process.removeListener('SIGINT', on_sigint);
+    process.once('message', common.mustCall((msg) => {
+      assert.strictEqual(msg, 'signal');
+      process.send('signal');
+      while (true) {}
+    }));
+  } else if (process.argv[3] === 'on') {
+    let signals = 0;
+    process.once('SIGINT', common.mustCall(() => {
+      process.send('signal');
+    }));
+
+    process.on('SIGINT', common.mustCall(() => {
+      if (++signals === 2)
+        process.exit(0);
+    }, 2));
+  }
+
+  process.send('signal');
+  setTimeout(() => {}, 100000);
+
+  return;
+}
+
+{
+  const child = spawn(process.execPath, [__filename, 'child', 'once'], {
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, null);
+    assert.strictEqual(signal, 'SIGINT');
+  }));
+
+  child.on('message', (msg) => {
+    assert.strictEqual(msg, 'signal');
+    child.kill('SIGINT');
+    child.send('signal');
+  });
+}
+
+{
+  const child = spawn(process.execPath, [__filename, 'child', 'on'], {
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+
+  child.on('message', (msg) => {
+    assert.strictEqual(msg, 'signal');
+    child.kill('SIGINT');
+  });
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
This is a continuation of https://github.com/nodejs/node/pull/13894.

I've divided this PR into 2 different commits to address @mscdex comments from the original PR.
```
events: add isOnce arg to EventEmitter listeners
    
`isOnce` will be true when the new or removed listener was added using
the `EventEmitter.once()` method.
```
```
`one-shot` signal handlers reset the handler once the signal is received
and not when the signal notification reaches the main loop. This commit
adds support for this functionality when *only* there are `once`
listeners on a specific signal.
```

Fixes: https://github.com/nodejs/node/issues/15654
Refs: https://github.com/nodejs/node/issues/9050
Refs: https://github.com/libuv/libuv/issues/1104
Refs: https://github.com/libuv/libuv/pull/1106

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
events, process