### PR TITLE
repl: runtime deprecate NODE_REPL_HISTORY_FILE

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -372,7 +372,7 @@ instead.
 <a id="DEP0041"></a>
 ### DEP0041: NODE\_REPL\_HISTORY\_FILE environment variable
 
-Type: Documentation-only
+Type: Runtime
 
 The `NODE_REPL_HISTORY_FILE` environment variable has been deprecated.
 

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 const debug = util.debuglog('repl');
+const { deprecate } = require('internal/util');
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
 
@@ -167,6 +168,12 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
                             'REPL session history will not be persisted.\n');
       }
       if (!threw) {
+        deprecate(
+          () => oldHistoryPath,
+          'NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead.',
+          'DEP0041'
+        );
+
         // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
         _writeToOutput(
           repl,

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -12,7 +12,7 @@ module.exports.createInternalRepl = createRepl;
 
 const { deprecate } = require('internal/util');
 const _printHistoryDeprecation = deprecate(
-  () =>  {},
+  () => {},
   'NODE_REPL_HISTORY_FILE is deprecated. Use NODE_REPL_HISTORY instead.',
   'DEP0041'
 );

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -12,8 +12,8 @@ module.exports.createInternalRepl = createRepl;
 
 const { deprecate } = require('internal/util');
 const _printHistoryDeprecation = deprecate(
-  () => path,
-  'NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead.',
+  () =>  {},
+  'NODE_REPL_HISTORY_FILE is deprecated. Use NODE_REPL_HISTORY instead.',
   'DEP0041'
 );
 
@@ -174,7 +174,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
                             'REPL session history will not be persisted.\n');
       }
       if (!threw) {
-        _printHistoryDeprecation(oldHistoryPath);
+        _printHistoryDeprecation();
 
         // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
         _writeToOutput(

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -7,9 +7,15 @@ const fs = require('fs');
 const os = require('os');
 const util = require('util');
 const debug = util.debuglog('repl');
-const { deprecate } = require('internal/util');
 module.exports = Object.create(REPL);
 module.exports.createInternalRepl = createRepl;
+
+const { deprecate } = require('internal/util');
+const _printHistoryDeprecation = deprecate(
+  () => path,
+  'NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead.',
+  'DEP0041'
+);
 
 // XXX(chrisdickinson): The 15ms debounce value is somewhat arbitrary.
 // The debounce is to guard against code pasted into the REPL.
@@ -168,11 +174,7 @@ function setupHistory(repl, historyPath, oldHistoryPath, ready) {
                             'REPL session history will not be persisted.\n');
       }
       if (!threw) {
-        deprecate(
-          () => oldHistoryPath,
-          'NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead.',
-          'DEP0041'
-        );
+        _printHistoryDeprecation(oldHistoryPath);
 
         // Grab data from the older pre-v3.0 JSON NODE_REPL_HISTORY_FILE format.
         _writeToOutput(

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -263,7 +263,7 @@ function runTest(assertCleaned) {
   const before = opts.before;
   const deprecated = !!opts.deprecated;
 
-  const depMsg = /NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead./;
+  const depMsg = /NODE_REPL_HISTORY_FILE is deprecated\. Use the plaintext format instead\./;
 
   if (before) before();
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -122,6 +122,7 @@ const tests = [
     expected: [prompt, replDisabled, prompt]
   },
   {
+    deprecated: true,
     env: { NODE_REPL_HISTORY_FILE: emptyHistoryPath },
     test: [UP],
     expected: [prompt, convertMsg, prompt]
@@ -154,6 +155,7 @@ const tests = [
     expected: [prompt]
   },
   {
+    deprecated: true,
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath },
     test: [UP, CLEAR, '\'42\'', ENTER],
     expected: [prompt, convertMsg, prompt, `${prompt}'=^.^='`, prompt, '\'',
@@ -173,6 +175,7 @@ const tests = [
     expected: [prompt, `${prompt}'you look fabulous today'`, prompt]
   },
   {
+    deprecated: true,
     env: { NODE_REPL_HISTORY_FILE: oldHistoryPath,
            NODE_REPL_HISTORY_SIZE: 1 },
     test: [UP, UP, UP, CLEAR],
@@ -258,8 +261,22 @@ function runTest(assertCleaned) {
   const expected = opts.expected;
   const clean = opts.clean;
   const before = opts.before;
+  const deprecated = !!opts.deprecated;
+
+  const depMsg = /NODE_REPL_HISTORY_FILE is deprecated. Use the plaintext format instead./;
 
   if (before) before();
+
+  // TODO: Fix this. There is a bug where env variables/state are shared
+  // between tests. That is why the `if deprecated` is needed, or else tests
+  // will be failing all over the place for no reason. It would better to not
+  // have the guard, because otherwise what if tests that don't have deprecated
+  // set being to have deprecation warnings printed? :(
+  if (deprecated) {
+    common.hijackStderr(function(data) {
+      assert.ok(deprecated && depMsg.test(data));
+    });
+  }
 
   REPL.createInternalRepl(env, {
     input: new ActionStream(),

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -263,7 +263,7 @@ function runTest(assertCleaned) {
   const before = opts.before;
   const deprecated = !!opts.deprecated;
 
-  const depMsg = /NODE_REPL_HISTORY_FILE is deprecated\. Use the plaintext format instead\./;
+  const depMsg = /NODE_REPL_HISTORY_FILE is deprecated\. Use NODE_REPL_HISTORY instead\./;
 
   if (before) before();
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -128,6 +128,7 @@ const tests = [
     expected: [prompt, convertMsg, prompt]
   },
   {
+    deprecated: true,
     env: { NODE_REPL_HISTORY_FILE: defaultHistoryPath },
     test: [UP],
     expected: [prompt, sameHistoryFilePaths, prompt]
@@ -274,7 +275,9 @@ function runTest(assertCleaned) {
   // set being to have deprecation warnings printed? :(
   if (deprecated) {
     common.hijackStderr(function(data) {
-      assert.ok(deprecated && depMsg.test(data));
+      if (data) {
+        assert.ok(deprecated && depMsg.test(data));
+      }
     });
   }
 


### PR DESCRIPTION
Refs: #13876

Just a note that I've been trying to add tests for this, but it's been
difficult because it seems like most REPL tests directly patch into
internals, and are not run via a child process.

Also, not sure if this should even be landing, since it's very close to the v9 release candidate release... cc @jasnell 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl