### PR TITLE
test: adding test for catching errors while setting process.cpuUsage

### DIFF
--- a/test/parallel/test-process-setup-cpu-usage-error.js
+++ b/test/parallel/test-process-setup-cpu-usage-error.js
@@ -1,0 +1,16 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+const internalProcess = require('internal/process');
+
+const errMsg = 'setup_cpuUsage failed';
+process.cpuUsage = () => { throw new Error(errMsg); };
+
+internalProcess.setup_cpuUsage();
+
+common.expectsError(() => process.cpuUsage(), {
+  type: Error,
+  message: errMsg
+});


### PR DESCRIPTION
Adding a test that verifies the error propagation from process.cpuUsage function

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
process.cpuUsage
