### PR TITLE
zlib: gracefully set windowBits from 8 to 9

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -458,9 +458,13 @@ added: v0.5.8
 
 Creates and returns a new [DeflateRaw][] object with the given [options][].
 
-*Note*: The zlib library rejects requests for 256-byte windows (i.e.,
-`{ windowBits: 8 }` in `options`). An `Error` will be thrown when creating
-a [DeflateRaw][] object with this specific value of the `windowBits` option.
+*Note*: An upgrade of zlib from 1.2.8 to 1.2.11 changed behavior when windowBits
+is set to 8 for raw deflate streams. zlib does not have a working implementation
+of an 8-bit Window for raw deflate streams and would automatically set windowBit
+to 9 if initially set to 8. Newer versions of zlib will throw an exception.
+This creates a potential DOS vector, and as such the behavior ahs been reverted
+in Node.js 8, 6, and 4. Node.js version 9 and higher will throw when windowBits
+is set to 8.
 
 ## zlib.createGunzip([options])
 <!-- YAML

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -459,12 +459,11 @@ added: v0.5.8
 Creates and returns a new [DeflateRaw][] object with the given [options][].
 
 *Note*: An upgrade of zlib from 1.2.8 to 1.2.11 changed behavior when windowBits
-is set to 8 for raw deflate streams. zlib does not have a working implementation
-of an 8-bit Window for raw deflate streams and would automatically set windowBit
-to 9 if initially set to 8. Newer versions of zlib will throw an exception.
-This creates a potential DOS vector, and as such the behavior ahs been reverted
-in Node.js 8, 6, and 4. Node.js version 9 and higher will throw when windowBits
-is set to 8.
+is set to 8 for raw deflate streams. zlib would automatically set windowBits
+to 9 if was initially set to 8. Newer versions of zlib will throw an exception,
+so Node.js restored the original behavior of upgrading a value of 8 to 9,
+since passing `windowBits = 9` to zlib actually results in a compressed stream
+that effectively uses an 8-bit window only.
 
 ## zlib.createGunzip([options])
 <!-- YAML

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -619,6 +619,7 @@ function Gunzip(opts) {
 inherits(Gunzip, Zlib);
 
 function DeflateRaw(opts) {
+  if (opts && opts.windowBits === 8) opts.windowBits = 9;
   if (!(this instanceof DeflateRaw))
     return new DeflateRaw(opts);
   Zlib.call(this, opts, DEFLATERAW);

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -5,23 +5,6 @@ const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 
-// For raw deflate encoding, requests for 256-byte windows are rejected as
-// invalid by zlib (http://zlib.net/manual.html#Advanced).
-// This check was introduced in version 1.2.9 and prior to that there was
-// no such rejection which is the reason for the version check below
-// (http://zlib.net/ChangeLog.txt).
-if (!/^1\.2\.[0-8]$/.test(process.versions.zlib)) {
-  common.expectsError(
-    () => zlib.createDeflateRaw({ windowBits: 8 }),
-    {
-      code: 'ERR_ZLIB_INITIALIZATION_FAILED',
-      type: Error,
-      message: 'Initialization failed'
-    });
-}
-
-// Regression tests for bugs in the validation logic.
-
 common.expectsError(
   () => zlib.createGzip({ chunkSize: 0 }),
   {

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -166,7 +166,8 @@ assert.doesNotThrow(() => {
   // value of the matching deflate’s windowBits. However, inflate raw with
   // windowBits = 8 should be able to handle compressed data from a source
   // that does not know about the silent 8-to-9 upgrade of windowBits
-  // that older versions of zlib/Node perform.
+  // that most versions of zlib/Node perform, and which *still* results in
+  // a valid 8-bit-window zlib stream.
   node.pipe(zlib.createDeflateRaw({ windowBits: 9 }))
       .pipe(zlib.createInflateRaw({ windowBits: 8 }))
       .on('data', (chunk) => reinflated.push(chunk))

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -24,6 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 const zlib = require('zlib');
 const stream = require('stream');
+const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
 let zlibPairs = [
@@ -150,6 +151,28 @@ class SlowStream extends stream.Stream {
   }
 }
 
+// windowBits: 8 shouldn't throw
+assert.doesNotThrow(() => {
+  zlib.createDeflateRaw({ windowBits: 8 });
+}, 'windowsBits set to 8 should follow legacy zlib behavior');
+
+{
+  const node = fs.createReadStream(process.execPath);
+  const raw = [];
+  const reinflated = [];
+  node.on('data', (chunk) => raw.push(chunk));
+
+  // Usually, the inflate windowBits parameter needs to be at least the
+  // value of the matching deflate’s windowBits. However, inflate raw with
+  // windowBits = 8 should be able to handle compressed data from a source
+  // that does not know about the silent 8-to-9 upgrade of windowBits
+  // that older versions of zlib/Node perform.
+  node.pipe(zlib.createDeflateRaw({ windowBits: 9 }))
+      .pipe(zlib.createInflateRaw({ windowBits: 8 }))
+      .on('data', (chunk) => reinflated.push(chunk))
+      .on('end', common.mustCall(
+        () => assert(Buffer.concat(raw).equals(Buffer.concat(reinflated)))));
+}
 
 // for each of the files, make sure that compressing and
 // decompressing results in the same data, for every combination


### PR DESCRIPTION
After looking into the details of the `zlib` behaviour when asked for 8-/9-bit windows more closely, this patch makes sense. I’ve updated the documentation & the test commentary to account for that.

(Addling lts-watch labels for the test/doc updates.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

zlib