### PR TITLE
build: make doc target quiet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -522,13 +522,13 @@ doc-only: $(apidocs_html) $(apidocs_json)
 doc: $(NODE_EXE) doc-only
 
 $(apidoc_dirs):
-	mkdir -p $@
+	@mkdir -p $@
 
 out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets
-	cp $< $@
+	@cp $< $@
 
 out/doc/%: doc/%
-	cp -r $< $@
+	@cp -r $< $@
 
 # check if ./node is actually set, else use user pre-installed binary
 gen-json = tools/doc/generate.js --format=json $< > $@
@@ -546,11 +546,11 @@ gen-doc =	\
 	[ -x $(NODE) ] && $(NODE) $(1) || node $(1)
 
 out/doc/api/%.json: doc/api/%.md
-	$(call gen-doc, $(gen-json))
+	@$(call gen-doc, $(gen-json))
 
 # check if ./node is actually set, else use user pre-installed binary
 out/doc/api/%.html: doc/api/%.md
-	$(call gen-doc, $(gen-html))
+	@$(call gen-doc, $(gen-html))
 
 docopen: $(apidocs_html)
 	@$(PYTHON) -mwebbrowser file://$(PWD)/out/doc/api/all.html

--- a/tools/doc/generate.js
+++ b/tools/doc/generate.js
@@ -54,7 +54,6 @@ if (!inputFile) {
   throw new Error('No input file specified');
 }
 
-console.error('Input file = %s', inputFile);
 fs.readFile(inputFile, 'utf8', function(er, input) {
   if (er) throw er;
   // process the input for @include lines

--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -25,7 +25,6 @@ function processIncludes(inputFile, input, cb) {
   const includes = input.match(includeExpr);
   if (includes === null) return cb(null, input);
   var errState = null;
-  console.error(includes);
   var incCount = includes.length;
   if (incCount === 0) cb(null, input);
   includes.forEach(function(include) {


### PR DESCRIPTION
Currently it can be a little difficult to detect errors in the output
from the doc target. This commit suggests reducing the output to make it
easier to identify errors.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build