### PR TITLE
Add missing semicolon

### DIFF
--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -462,7 +462,7 @@ inline void Nghttp2Session::HandlePriorityFrame(const nghttp2_frame* frame) {
   // good here
 
 #if defined(DEBUG) && DEBUG
-  CHECK_GT(id, 0)
+  CHECK_GT(id, 0);
 #endif
 
   nghttp2_priority_spec spec = priority_frame.pri_spec;


### PR DESCRIPTION
Typo introduced in 0d50c7061c2c86c1eaa48979c4b0bb14b2f30a84

This causes the build to fail when run with debug mode enabled.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2 support