### PR TITLE
doc: slightly relax 50 character rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,10 +309,8 @@ notes about [commit squashing](#commit-squashing)).
 A good commit message should describe what changed and why.
 
 1. The first line should:
-   - contain a short description of the change
-   - be 50 characters or less (or as close as possible to 50 characters if it
-     is necessary to go over in order to provide a *useful* description of the
-     change)
+   - contain a short description of the change (preferably 50 characters or less,
+     and absolutely no more than 72 characters)
    - be entirely in lowercase with the exception of proper nouns, acronyms, and
    the words that refer to code, like function/variable names
    - be prefixed with the name of the changed subsystem and start with an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,9 @@ A good commit message should describe what changed and why.
 
 1. The first line should:
    - contain a short description of the change
-   - be 50 characters or less
+   - be 50 characters or less (or as close as possible to 50 characters if it
+     is necessary to go over in order to provide a *useful* description of the
+     change)
    - be entirely in lowercase with the exception of proper nouns, acronyms, and
    the words that refer to code, like function/variable names
    - be prefixed with the name of the changed subsystem and start with an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,7 @@ A good commit message should describe what changed and why.
 
 1. The first line should:
    - contain a short description of the change (preferably 50 characters or less,
-     and absolutely no more than 72 characters)
+     and no more than 72 characters)
    - be entirely in lowercase with the exception of proper nouns, acronyms, and
    the words that refer to code, like function/variable names
    - be prefixed with the name of the changed subsystem and start with an


### PR DESCRIPTION
Allow commit message first line to exceed 50 chars if necessary

ping @Trott ... btw, note that the contribution guide already uses "should* and not "must"

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc