### PR TITLE
http2: fix several timeout related issues

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1200,7 +1200,12 @@ function createWriteReq(req, handle, data, encoding) {
 }
 
 function afterDoStreamWrite(status, handle, req) {
-  _unrefActive(handle[kOwner]);
+  const session = handle[kOwner];
+  const stream = session[kState].streams.get(req.stream);
+  _unrefActive(session);
+  if (stream !== undefined)
+    _unrefActive(stream);
+
   if (typeof req.callback === 'function')
     req.callback();
   this.handle = undefined;
@@ -1396,10 +1401,11 @@ class Http2Stream extends Duplex {
       this.once('ready', this._write.bind(this, data, encoding, cb));
       return;
     }
-    _unrefActive(this);
     if (!this[kState].headersSent)
       this[kProceed]();
     const session = this[kSession];
+    _unrefActive(this);
+    _unrefActive(session);
     const handle = session[kHandle];
     const req = new WriteWrap();
     req.stream = this[kID];
@@ -1410,7 +1416,6 @@ class Http2Stream extends Duplex {
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
       throw util._errnoException(err, 'write', req.error);
-    this._bytesDispatched += req.bytes;
   }
 
   _writev(data, cb) {
@@ -1418,10 +1423,11 @@ class Http2Stream extends Duplex {
       this.once('ready', this._writev.bind(this, data, cb));
       return;
     }
-    _unrefActive(this);
     if (!this[kState].headersSent)
       this[kProceed]();
     const session = this[kSession];
+    _unrefActive(this);
+    _unrefActive(session);
     const handle = session[kHandle];
     const req = new WriteWrap();
     req.stream = this[kID];

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1088,8 +1088,10 @@ class Http2Session extends EventEmitter {
     // newly fetched, updated value.
     if (this[kState].writeQueueSize > 0) {
       const handle = this[kHandle];
-      if (handle !== undefined &&
-          handle.chunksSentSinceLastWrite !== handle.updateChunksSent()) {
+      const chunksSentSinceLastWrite = handle !== undefined ?
+        handle.chunksSentSinceLastWrite : null;
+      if (chunksSentSinceLastWrite !== null &&
+          chunksSentSinceLastWrite !== handle.updateChunksSent()) {
         _unrefActive(this);
         return;
       }
@@ -1401,8 +1403,10 @@ class Http2Stream extends Duplex {
     // newly fetched, updated value.
     if (this[kState].writeQueueSize > 0) {
       const handle = this[kSession][kHandle];
-      if (handle !== undefined &&
-          handle.chunksSentSinceLastWrite !== handle.updateChunksSent()) {
+      const chunksSentSinceLastWrite = handle !== undefined ?
+        handle.chunksSentSinceLastWrite : null;
+      if (chunksSentSinceLastWrite !== null &&
+          chunksSentSinceLastWrite !== handle.updateChunksSent()) {
         _unrefActive(this);
         _unrefActive(this[kSession]);
         return;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -746,7 +746,8 @@ class Http2Session extends EventEmitter {
       shutdown: false,
       shuttingDown: false,
       pendingAck: 0,
-      maxPendingAck: Math.max(1, (options.maxPendingAck | 0) || 10)
+      maxPendingAck: Math.max(1, (options.maxPendingAck | 0) || 10),
+      writeQueueSize: 0
     };
 
     this[kType] = type;
@@ -1080,6 +1081,20 @@ class Http2Session extends EventEmitter {
   }
 
   _onTimeout() {
+    // This checks whether a write is currently in progress and also whether
+    // that write is actually sending data across the write. The kHandle
+    // stored `chunksSentSinceLastWrite` is only updated when a timeout event
+    // happens, meaning that if a write is ongoing it should never equal the
+    // newly fetched, updated value.
+    if (this[kState].writeQueueSize > 0) {
+      const handle = this[kHandle];
+      if (handle !== undefined &&
+          handle.chunksSentSinceLastWrite !== handle.updateChunksSent()) {
+        _unrefActive(this);
+        return;
+      }
+    }
+
     process.nextTick(emit, this, 'timeout');
   }
 }
@@ -1199,12 +1214,26 @@ function createWriteReq(req, handle, data, encoding) {
   }
 }
 
+function trackWriteState(stream, bytes) {
+  const session = stream[kSession];
+  stream[kState].writeQueueSize += bytes;
+  session[kState].writeQueueSize += bytes;
+  session[kHandle].chunksSentSinceLastWrite = 0;
+}
+
 function afterDoStreamWrite(status, handle, req) {
   const session = handle[kOwner];
-  const stream = session[kState].streams.get(req.stream);
   _unrefActive(session);
-  if (stream !== undefined)
+
+  const state = session[kState];
+  const { bytes } = req;
+  state.writeQueueSize -= bytes;
+
+  const stream = state.streams.get(req.stream);
+  if (stream !== undefined) {
     _unrefActive(stream);
+    stream[kState].writeQueueSize -= bytes;
+  }
 
   if (typeof req.callback === 'function')
     req.callback();
@@ -1317,7 +1346,8 @@ class Http2Stream extends Duplex {
       headersSent: false,
       headRequest: false,
       aborted: false,
-      closeHandler: onSessionClose.bind(this)
+      closeHandler: onSessionClose.bind(this),
+      writeQueueSize: 0
     };
 
     this.once('ready', streamOnceReady);
@@ -1364,6 +1394,21 @@ class Http2Stream extends Duplex {
   }
 
   _onTimeout() {
+    // This checks whether a write is currently in progress and also whether
+    // that write is actually sending data across the write. The kHandle
+    // stored `chunksSentSinceLastWrite` is only updated when a timeout event
+    // happens, meaning that if a write is ongoing it should never equal the
+    // newly fetched, updated value.
+    if (this[kState].writeQueueSize > 0) {
+      const handle = this[kSession][kHandle];
+      if (handle !== undefined &&
+          handle.chunksSentSinceLastWrite !== handle.updateChunksSent()) {
+        _unrefActive(this);
+        _unrefActive(this[kSession]);
+        return;
+      }
+    }
+
     process.nextTick(emit, this, 'timeout');
   }
 
@@ -1416,6 +1461,7 @@ class Http2Stream extends Duplex {
     const err = createWriteReq(req, handle, data, encoding);
     if (err)
       throw util._errnoException(err, 'write', req.error);
+    trackWriteState(this, req.bytes);
   }
 
   _writev(data, cb) {
@@ -1444,6 +1490,7 @@ class Http2Stream extends Duplex {
     const err = handle.writev(req, chunks);
     if (err)
       throw util._errnoException(err, 'write', req.error);
+    trackWriteState(this, req.bytes);
   }
 
   _read(nread) {
@@ -1536,6 +1583,10 @@ class Http2Stream extends Duplex {
       this.once('ready', this._destroy.bind(this, err, callback));
       return;
     }
+
+    const state = this[kState];
+    session[kState].writeQueueSize -= state.writeQueueSize;
+    state.writeQueueSize = 0;
 
     const server = session[kServer];
     if (server !== undefined && err) {
@@ -1631,7 +1682,12 @@ function processRespondWithFD(fd, headers, offset = 0, length = -1,
       if (ret < 0) {
         err = new NghttpError(ret);
         process.nextTick(emit, this, 'error', err);
+        break;
       }
+      // exact length of the file doesn't matter here, since the
+      // stream is closing anyway — just use 1 to signify that
+      // a write does exist
+      trackWriteState(this, 1);
   }
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -111,6 +111,7 @@ class ModuleWrap;
   V(callback_string, "callback")                                              \
   V(change_string, "change")                                                  \
   V(channel_string, "channel")                                                \
+  V(chunks_sent_since_last_write_string, "chunksSentSinceLastWrite")          \
   V(constants_string, "constants")                                            \
   V(oncertcb_string, "oncertcb")                                              \
   V(onclose_string, "_onclose")                                               \

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -474,6 +474,7 @@ class Http2Session : public AsyncWrap,
   static void SubmitGoaway(const FunctionCallbackInfo<Value>& args);
   static void DestroyStream(const FunctionCallbackInfo<Value>& args);
   static void FlushData(const FunctionCallbackInfo<Value>& args);
+  static void UpdateChunksSent(const FunctionCallbackInfo<Value>& args);
 
   template <get_setting fn>
   static void GetSettings(const FunctionCallbackInfo<Value>& args);
@@ -491,6 +492,9 @@ class Http2Session : public AsyncWrap,
   StreamResource::Callback<StreamResource::AllocCb> prev_alloc_cb_;
   StreamResource::Callback<StreamResource::ReadCb> prev_read_cb_;
   padding_strategy_type padding_strategy_ = PADDING_STRATEGY_NONE;
+
+  // use this to allow timeout tracking during long-lasting writes
+  uint32_t chunks_sent_since_last_write_ = 0;
 
   char stream_buf_[kAllocBufferSize];
 };

--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -1,0 +1,89 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const http2 = require('http2');
+const path = require('path');
+
+common.refreshTmpDir();
+
+// This test assesses whether long-running writes can complete
+// or timeout because the session or stream are not aware that the
+// backing stream is still writing.
+// To simulate a slow client, we write a really large chunk and
+// then proceed through the following cycle:
+// 1) Receive first 'data' event and record currently written size
+// 2) Once we've read up to currently written size recorded above,
+//    we pause the stream and wait longer than the server timeout
+// 3) Socket.prototype._onTimeout triggers and should confirm
+//    that the backing stream is still active and writing
+// 4) Our timer fires, we resume the socket and start at 1)
+
+const writeSize = 3000000;
+const minReadSize = 500000;
+const serverTimeout = common.platformTimeout(500);
+let offsetTimeout = common.platformTimeout(100);
+let didReceiveData = false;
+
+const content = Buffer.alloc(writeSize, 0x44);
+const filepath = path.join(common.tmpDir, 'http2-large-write.tmp');
+fs.writeFileSync(filepath, content, 'binary');
+const fd = fs.openSync(filepath, 'r');
+
+const server = http2.createSecureServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+});
+server.on('stream', common.mustCall((stream) => {
+  stream.respondWithFD(fd, {
+    'Content-Type': 'application/octet-stream',
+    'Content-Length': content.length.toString(),
+    'Vary': 'Accept-Encoding'
+  });
+  stream.setTimeout(serverTimeout);
+  stream.on('timeout', () => {
+    assert.strictEqual(didReceiveData, false, 'Should not timeout');
+  });
+  stream.end();
+}));
+server.setTimeout(serverTimeout);
+server.on('timeout', () => {
+  assert.strictEqual(didReceiveData, false, 'Should not timeout');
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`https://localhost:${server.address().port}`,
+                               { rejectUnauthorized: false });
+
+  const req = client.request({ ':path': '/' });
+  req.end();
+
+  const resume = () => req.resume();
+  let receivedBufferLength = 0;
+  let firstReceivedAt;
+  req.on('data', common.mustCallAtLeast((buf) => {
+    if (receivedBufferLength === 0) {
+      didReceiveData = false;
+      firstReceivedAt = Date.now();
+    }
+    receivedBufferLength += buf.length;
+    if (receivedBufferLength >= minReadSize &&
+        receivedBufferLength < writeSize) {
+      didReceiveData = true;
+      receivedBufferLength = 0;
+      req.pause();
+      setTimeout(
+        resume,
+        serverTimeout + offsetTimeout - (Date.now() - firstReceivedAt)
+      );
+      offsetTimeout = 0;
+    }
+  }, 1));
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+}));

--- a/test/sequential/test-http2-timeout-large-write.js
+++ b/test/sequential/test-http2-timeout-large-write.js
@@ -1,0 +1,84 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const http2 = require('http2');
+
+// This test assesses whether long-running writes can complete
+// or timeout because the session or stream are not aware that the
+// backing stream is still writing.
+// To simulate a slow client, we write a really large chunk and
+// then proceed through the following cycle:
+// 1) Receive first 'data' event and record currently written size
+// 2) Once we've read up to currently written size recorded above,
+//    we pause the stream and wait longer than the server timeout
+// 3) Socket.prototype._onTimeout triggers and should confirm
+//    that the backing stream is still active and writing
+// 4) Our timer fires, we resume the socket and start at 1)
+
+const writeSize = 3000000;
+const minReadSize = 500000;
+const serverTimeout = common.platformTimeout(500);
+let offsetTimeout = common.platformTimeout(100);
+let didReceiveData = false;
+
+const server = http2.createSecureServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+});
+server.on('stream', common.mustCall((stream) => {
+  const content = Buffer.alloc(writeSize, 0x44);
+
+  stream.respond({
+    'Content-Type': 'application/octet-stream',
+    'Content-Length': content.length.toString(),
+    'Vary': 'Accept-Encoding'
+  });
+
+  stream.write(content);
+  stream.setTimeout(serverTimeout);
+  stream.on('timeout', () => {
+    assert.strictEqual(didReceiveData, false, 'Should not timeout');
+  });
+  stream.end();
+}));
+server.setTimeout(serverTimeout);
+server.on('timeout', () => {
+  assert.strictEqual(didReceiveData, false, 'Should not timeout');
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`https://localhost:${server.address().port}`,
+                               { rejectUnauthorized: false });
+
+  const req = client.request({ ':path': '/' });
+  req.end();
+
+  const resume = () => req.resume();
+  let receivedBufferLength = 0;
+  let firstReceivedAt;
+  req.on('data', common.mustCallAtLeast((buf) => {
+    if (receivedBufferLength === 0) {
+      didReceiveData = false;
+      firstReceivedAt = Date.now();
+    }
+    receivedBufferLength += buf.length;
+    if (receivedBufferLength >= minReadSize &&
+        receivedBufferLength < writeSize) {
+      didReceiveData = true;
+      receivedBufferLength = 0;
+      req.pause();
+      setTimeout(
+        resume,
+        serverTimeout + offsetTimeout - (Date.now() - firstReceivedAt)
+      );
+      offsetTimeout = 0;
+    }
+  }, 1));
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+}));


### PR DESCRIPTION
This resolves a couple of issues around timeouts in http2.

1. Upon start and stop of write, `_unrefActive` should be called both on stream and on session. I can't really create a good test case for this because it's way too reliant on timers. One can observe this by having a server receive a request, have a timeout of 1000ms on the session and delay the stream response (which has to last longer than 500ms) by 500ms. The session will timeout 500ms after the stream write starts (instead of 1000ms).

2. Long writes will always timeout because once the data is handed off to C++, JS loses all track of it. This is basically the same issue as the one recently patched in net & tls. Solution is a bit different because tracking `writeQueueSize` in C++ is not quite reliable due to framing headers and what not.

(Much like with tls/net, the solution isn't super straightforward because we don't want to completely tank the performance of requests that aren't likely to timeout.)

To test locally, you can use the following server:

```js
'use strict';

const http2 = require('http2');

const server = http2.createServer((req, res) => {

  var content = Buffer.alloc(30000000, 0x44);

  res.writeHead(200, {
    'Content-Type': 'application/octet-stream',
    'Content-Length': content.length.toString(),
    'Vary': 'Accept-Encoding'
  });

  res.write(content);
  res.end();
});
server.setTimeout(1000);

server.listen(8000);
```

and run this in your terminal:

```bash
nghttp http://localhost:8000 | dd bs=1 of=/dev/null
```

A successful result would be `30000000+0 records in` (and take around 40s) but it'll stop after only 1s with current versions of node.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test