### PR TITLE
module: fixes #16476 ensuring extension lookups for top main

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -435,7 +435,7 @@ Module._load = function(request, parent, isMain) {
           ESMLoader.hook(hooks);
         }
       }
-      await ESMLoader.import(getURLFromFilePath(request).href);
+      await ESMLoader.import(getURLFromFilePath(request).pathname);
     })()
     .catch((e) => {
       console.error(e);

--- a/test/parallel/test-module-main-extension-lookup.js
+++ b/test/parallel/test-module-main-extension-lookup.js
@@ -1,0 +1,7 @@
+'use strict';
+require('../common');
+const { execFileSync } = require('child_process');
+
+const node = process.argv[0];
+
+execFileSync(node, ['--experimental-modules', 'test/es-module/test-esm-ok']);


### PR DESCRIPTION
The reason as stated in https://github.com/nodejs/node/issues/16476#issuecomment-339637581 is that absolute URLs do not go through extension and index checks.

By switching to an absolute path, the resolver still applies extensions properly to the top-level main.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
esmodules