### PR TITLE
crypto, errors: Add CryptoError to internal/errors, update crypto.setEngine

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -60,8 +60,10 @@ function setEngine(id, flags) {
   if (flags === 0)
     flags = ENGINE_METHOD_ALL;
 
-  if (!_setEngine(id, flags))
-    throw new errors.Error('ERR_CRYPTO_ENGINE_UNKNOWN', id);
+  const ctx = {};
+  if (!_setEngine(id, flags, ctx)) {
+    throw new errors.CryptoError('ERR_CRYPTO_ENGINE_UNKNOWN', ctx, id);
+  }
 }
 
 function timingSafeEqual(a, b) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -10,6 +10,7 @@
 // message may change, the code should not.
 
 const kCode = Symbol('code');
+const kInfo = Symbol('info');
 const messages = new Map();
 
 const { kMaxLength } = process.binding('buffer');
@@ -56,6 +57,25 @@ function makeNodeError(Base) {
       });
     }
   };
+}
+
+class CryptoError extends makeNodeError(Error) {
+  constructor(key, context, ...args) {
+    super(key, args);
+    Object.defineProperty(this, kInfo, {
+      value: context || {},
+      enumerable: false,
+      configurable: false
+    });
+  }
+
+  get info() {
+    return this[kInfo];
+  }
+
+  get opensslErrorStack() {
+    return this[kInfo].opensslErrorStack;
+  }
 }
 
 class AssertionError extends Error {
@@ -128,6 +148,7 @@ module.exports = exports = {
   RangeError: makeNodeError(RangeError),
   URIError: makeNodeError(URIError),
   AssertionError,
+  CryptoError,
   E // This is exported only to facilitate testing.
 };
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -93,6 +93,8 @@ Check if there is more than 1gb of total memory.
   * `operator` &lt;any>
     (`AssertionError` only) expected error must have this value for its
     `operator` property.
+  * `additional` [&lt;Function>] A callback function that may be provided to
+    perform additional checks on the error object.
 * `exact` [&lt;Number>] default = 1
 * return [&lt;Function>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -755,6 +755,9 @@ exports.expectsError = function expectsError(fn, settings, exact) {
         }
       });
     }
+    if ('additional' in settings && typeof settings.additional === 'function') {
+      settings.additional.call(undefined, error);
+    }
     return true;
   }, exact);
   if (fn) {

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -35,8 +35,8 @@ common.expectsError(
       assert(err.info, 'does not have info property');
       assert(Array.isArray(err.opensslErrorStack),
              'opensslErrorStack must be an array');
-      assert(typeof err.info.code, 'number');
-      assert(typeof err.info.message, 'string');
+      assert.strictEqual(typeof err.info.code, 'number');
+      assert.strictEqual(typeof err.info.message, 'string');
     }
   }
 );

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -35,10 +35,8 @@ common.expectsError(
       assert(err.info, 'does not have info property');
       assert(Array.isArray(err.opensslErrorStack),
              'opensslErrorStack must be an array');
-      assert.strictEqual(err.info.code, 621174887);
-      assert.strictEqual(err.info.message,
-                         'error:25066067:DSO support routines:DLFCN_LOAD:' +
-                         'could not load the shared library');
+      assert(typeof err.info.code, 'number');
+      assert(typeof err.info.message, 'string');
     }
   }
 );


### PR DESCRIPTION
The way that `throwCryptoError()` is currently defined within `src/node_crypto.cc` makes it rather difficult to refactor those errors to use `internal/errors`. This provides an alternative and an example of it being used.

There are three commits:

* One that adds a new `additional` callback check for `common.expectsError()` that provides the ability to perform additional checks on an error

* One that adds a new `errors.CryptoError` to internal/errors

* One that finishing migrating the `crypto.setEngine()` method to use `errors.CryptoError`, illustrating how the revised mechanism for getting the `opensslErrorStack` and `message` properties would work. The same pattern would be used for all instances of `throwCryptoError()`

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
crypto, errors