### PR TITLE
doc: add Support section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,10 @@ policies, and releases are managed under an
 
 **This project is bound by a [Code of Conduct][].**
 
-If you need help using or installing Node.js, please use the
-[nodejs/help](https://github.com/nodejs/help) issue tracker.
-
 
 # Table of Contents
 
-* [Resources for Newcomers](#resources-for-newcomers)
+* [Support](#support)
 * [Release Types](#release-types)
   * [Download](#download)
     * [Current and LTS Releases](#current-and-lts-releases)
@@ -39,25 +36,29 @@ If you need help using or installing Node.js, please use the
     * [Collaborators](#collaborators)
     * [Release Team](#release-team)
 
-## Resources for Newcomers
+## Support
 
-### Official Resources
+Node.js contributors have limited availability to address general support
+questions. Please make sure you are using a [currently-supported version of
+Node.js](https://github.com/nodejs/Release#release-schedule).
 
-* [Website][]
+When looking for support, please first search for your question in these venues:
+
+* [Node.js Website][]
 * [Node.js Help][]
-* [Contributing to the project][]
-* IRC (node core development): [#node-dev on chat.freenode.net][]
+* [Open or closed issues in the Node.js GitHub organization](https://github.com/issues?utf8=%E2%9C%93&q=sort%3Aupdated-desc+org%3Anodejs+is%3Aissue)
+* [Questions tagged 'node.js' on StackOverflow][]
 
-### Unofficial Resources
+If you didn't find an answer in one of the venues above, you can:
 
-* IRC (general questions): [#node.js on chat.freenode.net][]. Please see
-<http://nodeirc.info/> for more information regarding the `#node.js` IRC
-channel.
+* Join the **unofficial** [#node.js channel on chat.freenode.net][]. See
+<http://nodeirc.info/> for more information.
 
-_Please note that unofficial resources are neither managed by (nor necessarily
-endorsed by) the Node.js TSC. Specifically, such resources are not
-currently covered by the [Node.js Moderation Policy][] and the selection and
-actions of resource operators/moderators are not subject to TSC oversight._
+GitHub issues are meant for tracking enhancements and bugs, not general support.
+
+Remember, libre != gratis; the open source license grants you the freedom to use
+and modify, but not commitments of other people's time. Please be respectful,
+and set your expectations accordingly.
 
 ## Release Types
 
@@ -582,11 +583,17 @@ Previous releases may also have been signed with one of the following GPG keys:
 Information on the current Node.js Working Groups can be found in the
 [TSC repository](https://github.com/nodejs/TSC/blob/master/WORKING_GROUPS.md).
 
+### Contributing to Node.js
+
+* [Contributing to the project][]
+* IRC (node core development): [#node-dev on chat.freenode.net][]
+
 [npm]: https://www.npmjs.com
-[Website]: https://nodejs.org/en/
+[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Help]: https://github.com/nodejs/help
 [Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
-[#node.js on chat.freenode.net]: https://webchat.freenode.net?channels=node.js&uio=d4
+[Node.js Website]: https://nodejs.org/en/
+[Questions tagged 'node.js' on StackOverflow]: https://stackoverflow.com/questions/tagged/node.js
+[#node.js channel on chat.freenode.net]: https://webchat.freenode.net?channels=node.js&uio=d4
 [#node-dev on chat.freenode.net]: https://webchat.freenode.net?channels=node-dev&uio=d4
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Add a Support section, borrowing heavily from wp-cli project.

Move stuff about contributing to Node.js to the bottom as vastly more
users are interested in using Node.js and getting help with Node.js than
contributing to Node.js. Information still belongs, just not at the top.
(Many people will know to look in CONTRIBUTING.md anyway.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
