### PR TITLE
test: fix flaky test-http-dns-error

### DIFF
--- a/test/parallel/test-http-dns-error.js
+++ b/test/parallel/test-http-dns-error.js
@@ -30,30 +30,41 @@ const http = require('http');
 const https = require('https');
 
 const host = '*'.repeat(256);
+const MAX_TRIES = 5;
 
-function do_not_call() {
-  throw new Error('This function should not have been called.');
-}
-
-function test(mod) {
-
+function tryGet(mod, tries) {
   // Bad host name should not throw an uncatchable exception.
   // Ensure that there is time to attach an error listener.
-  const req1 = mod.get({ host: host, port: 42 }, do_not_call);
-  req1.on('error', common.mustCall(function(err) {
+  const req = mod.get({ host: host, port: 42 }, common.mustNotCall());
+  req.on('error', common.mustCall(function(err) {
+    if (err.code === 'EAGAIN' && tries < MAX_TRIES) {
+      tryGet(mod, ++tries);
+      return;
+    }
     assert.strictEqual(err.code, 'ENOTFOUND');
   }));
   // http.get() called req1.end() for us
+}
 
-  const req2 = mod.request({
+function tryRequest(mod, tries) {
+  const req = mod.request({
     method: 'GET',
     host: host,
     port: 42
-  }, do_not_call);
-  req2.on('error', common.mustCall(function(err) {
+  }, common.mustNotCall());
+  req.on('error', common.mustCall(function(err) {
+    if (err.code === 'EAGAIN' && tries < MAX_TRIES) {
+      tryRequest(mod, ++tries);
+      return;
+    }
     assert.strictEqual(err.code, 'ENOTFOUND');
   }));
-  req2.end();
+  req.end();
+}
+
+function test(mod) {
+  tryGet(mod, 0);
+  tryRequest(mod, 0);
 }
 
 if (common.hasCrypto) {


### PR DESCRIPTION
Under some conditions, the error received from getaddrinfo might
actually be EAGAIN, meaning the request should be retried. Allowing for
5 retries before erroring out.

> This was happening to me about 50% of the time when running `make test-parallel`, and about 5-10% of the time when running this test file alone. My machine: `Linux benglbox 4.12.4-1-ARCH #1 SMP PREEMPT Fri Jul 28 18:54:18 UTC 2017 x86_64 GNU/Linux`. 

Also replace one-off function with common.mustNotCall().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test