### PR TITLE
v8: migrate setFlagsFromString to internal/errors

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -133,10 +133,11 @@ For example:
 }
 ```
 
-## v8.setFlagsFromString(string)
+## v8.setFlagsFromString(flags)
 <!-- YAML
 added: v1.0.0
 -->
+* `flags` {string}
 
 The `v8.setFlagsFromString()` method can be used to programmatically set
 V8 command line flags. This method should be used with care. Changing settings

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const { Buffer } = require('buffer');
+const errors = require('internal/errors');
 const {
   Serializer: _Serializer,
   Deserializer: _Deserializer
@@ -32,7 +33,7 @@ class Deserializer extends _Deserializer { }
 
 const {
   cachedDataVersionTag,
-  setFlagsFromString,
+  setFlagsFromString: _setFlagsFromString,
   heapStatisticsArrayBuffer,
   heapSpaceStatisticsArrayBuffer,
   updateHeapStatisticsArrayBuffer,
@@ -63,6 +64,12 @@ const heapStatisticsBuffer =
 
 const heapSpaceStatisticsBuffer =
     new Float64Array(heapSpaceStatisticsArrayBuffer);
+
+function setFlagsFromString(flags) {
+  if (typeof flags !== 'string')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'flags', 'string');
+  _setFlagsFromString(flags);
+}
 
 function getHeapStatistics() {
   const buffer = heapStatisticsBuffer;

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -114,13 +114,7 @@ void UpdateHeapSpaceStatisticsBuffer(const FunctionCallbackInfo<Value>& args) {
 
 
 void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  if (args.Length() < 1)
-    return env->ThrowTypeError("v8 flag is required");
-  if (!args[0]->IsString())
-    return env->ThrowTypeError("v8 flag must be a string");
-
+  CHECK(args[0]->IsString());
   String::Utf8Value flags(args[0]);
   V8::SetFlagsFromString(*flags, flags.length());
 }

--- a/test/parallel/test-v8-flag-type-check.js
+++ b/test/parallel/test-v8-flag-type-check.js
@@ -1,9 +1,14 @@
 'use strict';
-require('../common');
-const assert = require('assert');
+const common = require('../common');
 const v8 = require('v8');
 
-assert.throws(function() { v8.setFlagsFromString(1); },
-              /^TypeError: v8 flag must be a string$/);
-assert.throws(function() { v8.setFlagsFromString(); },
-              /^TypeError: v8 flag is required$/);
+[ 1, undefined ].forEach((i) => {
+  common.expectsError(
+    () => v8.setFlagsFromString(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "flags" argument must be of type string'
+    }
+  );
+});


### PR DESCRIPTION
Simple type checking and quick doc clean up to sync with the code

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
v8