### PR TITLE
test: use common.buildType in repl-domain-abort

### DIFF
--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -25,8 +25,7 @@ const assert = require('assert');
 const repl = require('repl');
 const stream = require('stream');
 const path = require('path');
-const buildType = process.config.target_defaults.default_configuration;
-let buildPath = path.join(__dirname, 'build', buildType, 'binding');
+let buildPath = path.join(__dirname, 'build', common.buildType, 'binding');
 // On Windows, escape backslashes in the path before passing it to REPL.
 if (common.isWindows)
   buildPath = buildPath.replace(/\\/g, '/');


### PR DESCRIPTION
use `common.buildType` instead of
`process.config.target_defaults.default_configuration` in
repl-domain-abort addon test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test