### PR TITLE
zlib: finish migrating to internal/errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1474,6 +1474,11 @@ Used when a given value is out of the accepted range.
 Used when an attempt is made to use a `zlib` object after it has already been
 closed.
 
+<a id="ERR_ZLIB_INITIALIZATION_FAILED"></a>
+### ERR_ZLIB_INITIALIZATION_FAILED
+
+Used when creation of a [`zlib`][] object fails due to incorrect configuration.
+
 [`--force-fips`]: cli.html#cli_force_fips
 [`crypto.timingSafeEqual()`]: crypto.html#crypto_crypto_timingsafeequal_a_b
 [`dgram.createSocket()`]: dgram.html#dgram_dgram_createsocket_options_callback
@@ -1515,3 +1520,4 @@ closed.
 [try-catch]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 [vm]: vm.html
 [WHATWG Supported Encodings]: util.html#util_whatwg_supported_encodings
+[`zlib`]: zlib.html

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -364,6 +364,7 @@ E('ERR_VALUE_OUT_OF_RANGE', (start, end, value) => {
   return `The value of "${start}" must be ${end}. Received "${value}"`;
 });
 E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
+E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed');
 
 function invalidArgType(name, expected, actual) {
   internalAssert(name, 'name is required');

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -161,6 +161,12 @@ function Zlib(opts, mode) {
   var memLevel = Z_DEFAULT_MEMLEVEL;
   var strategy = Z_DEFAULT_STRATEGY;
   var dictionary;
+
+  if (typeof mode !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'number');
+  if (mode < DEFLATE || mode > UNZIP)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
+
   if (opts) {
     chunkSize = opts.chunkSize;
     if (chunkSize !== undefined && chunkSize === chunkSize) {
@@ -258,8 +264,15 @@ function Zlib(opts, mode) {
   this._hadError = false;
   this._writeState = new Uint32Array(2);
 
-  this._handle.init(windowBits, level, memLevel, strategy, this._writeState,
-                    processCallback, dictionary);
+  if (!this._handle.init(windowBits,
+                         level,
+                         memLevel,
+                         strategy,
+                         this._writeState,
+                         processCallback,
+                         dictionary)) {
+    throw new errors.Error('ERR_ZLIB_INITIALIZATION_FAILED');
+  }
 
   this._outBuffer = Buffer.allocUnsafe(chunkSize);
   this._outOffset = 0;

--- a/test/parallel/test-zlib-failed-init.js
+++ b/test/parallel/test-zlib-failed-init.js
@@ -11,9 +11,13 @@ const zlib = require('zlib');
 // no such rejection which is the reason for the version check below
 // (http://zlib.net/ChangeLog.txt).
 if (!/^1\.2\.[0-8]$/.test(process.versions.zlib)) {
-  assert.throws(() => {
-    zlib.createDeflateRaw({ windowBits: 8 });
-  }, /^Error: Init error$/);
+  common.expectsError(
+    () => zlib.createDeflateRaw({ windowBits: 8 }),
+    {
+      code: 'ERR_ZLIB_INITIALIZATION_FAILED',
+      type: Error,
+      message: 'Initialization failed'
+    });
 }
 
 // Regression tests for bugs in the validation logic.


### PR DESCRIPTION
Finish migrating the zlib binding over to use internal/errors

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
zlib, errors