### PR TITLE
src: use internal/errors for startSigintWatchdog

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1247,6 +1247,14 @@ range.
 
 Used by the `REPL` module when it cannot parse data from the REPL history file.
 
+<a id="ERR_REPL_STARTSIGINTWATCHDOG_FAILED"></a>
+### ERR_REPL_STARTSIGINTWATCHDOG_FAILED
+
+The `SigintWatchdog` is an internal utility used by the `repl` module to
+monitor for interupt (`SIGINT`) signals received by the process. If this
+utility cannot be started, the `repl` will not function correctly, so an
+error is thrown.
+
 <a id="ERR_REQUIRE_ESM"></a>
 ### ERR_REQUIRE_ESM
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -615,6 +615,11 @@ Used when attempting to perform an operation outside the bounds of a `Buffer`.
 Used when an attempt has been made to create a `Buffer` larger than the
 maximum allowed size.
 
+<a id="ERR_CANNOT_WATCH_SIGINT"></a>
+### ERR_CANNOT_WATCH_SIGINT
+
+Used when Node.js is unable to watch for the `SIGINT` signal.
+
 <a id="ERR_CHILD_CLOSED_BEFORE_REPLY"></a>
 ### ERR_CHILD_CLOSED_BEFORE_REPLY
 
@@ -1246,14 +1251,6 @@ range.
 ### ERR_PARSE_HISTORY_DATA
 
 Used by the `REPL` module when it cannot parse data from the REPL history file.
-
-<a id="ERR_REPL_STARTSIGINTWATCHDOG_FAILED"></a>
-### ERR_REPL_STARTSIGINTWATCHDOG_FAILED
-
-The `SigintWatchdog` is an internal utility used by the `repl` module to
-monitor for interupt (`SIGINT`) signals received by the process. If this
-utility cannot be started, the `repl` will not function correctly, so an
-error is thrown.
 
 <a id="ERR_REQUIRE_ESM"></a>
 ### ERR_REQUIRE_ESM

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -310,6 +310,7 @@ E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
 E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
+E('ERR_REPL_STARTSIGINTWATCHDOG_FAILED', 'startSigintWatchdog Failed');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
 E('ERR_SERVER_ALREADY_LISTEN',
   'Listen method has been called more than once without closing.');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -151,6 +151,7 @@ E('ERR_ASYNC_TYPE', (s) => `Invalid name for async "type": ${s}`);
 E('ERR_BUFFER_OUT_OF_BOUNDS', bufferOutOfBounds);
 E('ERR_BUFFER_TOO_LARGE',
   `Cannot create a Buffer larger than 0x${kMaxLength.toString(16)} bytes`);
+E('ERR_CANNOT_WATCH_SIGINT', 'Cannot watch for SIGINT signals');
 E('ERR_CHILD_CLOSED_BEFORE_REPLY', 'Child closed before reply received');
 E('ERR_CONSOLE_WRITABLE_STREAM',
   'Console expects a writable stream instance for %s');
@@ -310,7 +311,6 @@ E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
 E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
-E('ERR_REPL_STARTSIGINTWATCHDOG_FAILED', 'startSigintWatchdog Failed');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
 E('ERR_SERVER_ALREADY_LISTEN',
   'Listen method has been called more than once without closing.');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -228,7 +228,7 @@ function REPLServer(prompt,
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn't lead to aborting the process completely.
         if (!utilBinding.startSigintWatchdog())
-          throw new errors.Error('ERR_REPL_STARTSIGINTWATCHDOG_FAILED');
+          throw new errors.Error('ERR_CANNOT_WATCH_SIGINT');
         previouslyInRawMode = self._setRawMode(false);
       }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -227,7 +227,8 @@ function REPLServer(prompt,
       if (self.breakEvalOnSigint) {
         // Start the SIGINT watchdog before entering raw mode so that a very
         // quick Ctrl+C doesn't lead to aborting the process completely.
-        utilBinding.startSigintWatchdog();
+        if (!utilBinding.startSigintWatchdog())
+          throw new errors.Error('ERR_REPL_STARTSIGINTWATCHDOG_FAILED');
         previouslyInRawMode = self._setRawMode(false);
       }
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -135,10 +135,7 @@ static void SetHiddenValue(const FunctionCallbackInfo<Value>& args) {
 
 void StartSigintWatchdog(const FunctionCallbackInfo<Value>& args) {
   int ret = SigintWatchdogHelper::GetInstance()->Start();
-  if (ret != 0) {
-    Environment* env = Environment::GetCurrent(args);
-    env->ThrowErrnoException(ret, "StartSigintWatchdog");
-  }
+  args.GetReturnValue().Set(ret == 0);
 }
 
 


### PR DESCRIPTION
Move the throw out of c++ and into js using internal/errors

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src, repl