### PR TITLE
src: do not include x.h if x-inl.h is included

### DIFF
--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -127,6 +127,21 @@ class FancyContainer {
 
 What it says in the title.
 
+## Do not include `*.h` if `*-inl.h` has already been included
+
+Do
+
+```cpp
+#include "util-inl.h"  // already includes util.h
+```
+
+instead of
+
+```cpp
+#include "util.h"
+#include "util-inl.h"
+```
+
 ## Avoid throwing JavaScript errors in nested C++ methods
 
 If you need to throw JavaScript errors from a C++ binding method, try to do it

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -3,7 +3,6 @@
 #define SRC_ALIASED_BUFFER_H_
 
 #include "v8.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/async-wrap-inl.h
+++ b/src/async-wrap-inl.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async-wrap.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 #include "node_internals.h"
 

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -19,11 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include "uv.h"

--- a/src/base-object-inl.h
+++ b/src/base-object-inl.h
@@ -25,9 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "base-object.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -21,14 +21,10 @@
 
 #define CARES_STATICLIB
 #include "ares.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "node.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "uv.h"
 

--- a/src/connect_wrap.cc
+++ b/src/connect_wrap.cc
@@ -1,10 +1,7 @@
 #include "connect_wrap.h"
 
-#include "env.h"
 #include "env-inl.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -2,11 +2,9 @@
 
 #include "connect_wrap.h"
 #include "env-inl.h"
-#include "env.h"
 #include "pipe_wrap.h"
 #include "stream_wrap.h"
 #include "tcp_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -27,7 +27,6 @@
 #include "aliased_buffer.h"
 #include "env.h"
 #include "node.h"
-#include "util.h"
 #include "util-inl.h"
 #include "uv.h"
 #include "v8.h"

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -19,11 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "node.h"
 #include "handle_wrap.h"

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -20,11 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "handle_wrap.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "node.h"
 

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -1,7 +1,6 @@
 #include "inspector_io.h"
 
 #include "inspector_socket_server.h"
-#include "env.h"
 #include "env-inl.h"
 #include "node.h"
 #include "node_crypto.h"

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,4 +1,3 @@
-#include "base-object.h"
 #include "base-object-inl.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -1,5 +1,4 @@
 #include "inspector_socket.h"
-#include "util.h"
 #include "util-inl.h"
 
 #define NODE_WANT_INTERNALS 1

--- a/src/inspector_socket.h
+++ b/src/inspector_socket.h
@@ -2,7 +2,6 @@
 #define SRC_INSPECTOR_SOCKET_H_
 
 #include "http_parser.h"
-#include "util.h"
 #include "util-inl.h"
 #include "uv.h"
 

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -1,10 +1,8 @@
 #include "js_stream.h"
 
 #include "async-wrap.h"
-#include "env.h"
 #include "env-inl.h"
 #include "node_buffer.h"
-#include "stream_base.h"
 #include "stream_base-inl.h"
 #include "v8.h"
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -5,7 +5,6 @@
 
 #include "env.h"
 #include "node_url.h"
-#include "util.h"
 #include "util-inl.h"
 #include "node_internals.h"
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <vector>
 #include "node_url.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 
 namespace node {

--- a/src/node.cc
+++ b/src/node.cc
@@ -54,14 +54,11 @@
 #endif
 
 #include "ares.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "http_parser.h"
 #include "nghttp2/nghttp2ver.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "string_bytes.h"
 #include "tracing/agent.h"

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -22,11 +22,9 @@
 #include "node.h"
 #include "node_buffer.h"
 
-#include "env.h"
 #include "env-inl.h"
 #include "string_bytes.h"
 #include "string_search.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8-profiler.h"
 #include "v8.h"

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -1,8 +1,6 @@
 #include "node.h"
 #include "node_i18n.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "node_debug_options.h"
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -21,7 +21,6 @@
 
 #include "node_internals.h"
 #include "node_watchdog.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 #include "v8-debug.h"
 

--- a/src/node_counters.cc
+++ b/src/node_counters.cc
@@ -21,7 +21,6 @@
 
 #include "node_counters.h"
 #include "uv.h"
-#include "env.h"
 #include "env-inl.h"
 
 #include <string.h>

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -28,12 +28,9 @@
 #include "node_mutex.h"
 #include "tls_wrap.h"  // TLSWrap
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "string_bytes.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 // CNNIC Hash WhiteList is taken from

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -25,15 +25,13 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "node_crypto_clienthello.h"  // ClientHelloParser
+// ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
 
 #include "node_buffer.h"
 
 #include "env.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 
 #include "v8.h"

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -21,7 +21,6 @@
 
 #include "node_crypto_bio.h"
 #include "openssl/bio.h"
-#include "util.h"
 #include "util-inl.h"
 #include <limits.h>
 #include <string.h>

--- a/src/node_crypto_bio.h
+++ b/src/node_crypto_bio.h
@@ -25,9 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "openssl/bio.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_crypto_clienthello-inl.h
+++ b/src/node_crypto_clienthello-inl.h
@@ -25,7 +25,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node_crypto_clienthello.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/node_crypto_clienthello.cc
+++ b/src/node_crypto_clienthello.cc
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "node_crypto_clienthello.h"
 #include "node_crypto_clienthello-inl.h"
 
 namespace node {

--- a/src/node_dtrace.cc
+++ b/src/node_dtrace.cc
@@ -24,7 +24,6 @@
 #ifdef HAVE_DTRACE
 #include "node_provider.h"
 #elif HAVE_ETW
-#include "node_win32_etw_provider.h"
 #include "node_win32_etw_provider-inl.h"
 #else
 #define NODE_HTTP_SERVER_REQUEST(arg0, arg1)

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -23,7 +23,6 @@
 #include "node_internals.h"
 #include "node_stat_watcher.h"
 
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "string_bytes.h"
 

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "util.h"
 #include "util-inl.h"
 #include "uv.h"
 #include "nghttp2/nghttp2.h"

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -22,14 +22,10 @@
 #include "node.h"
 #include "node_buffer.h"
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "http_parser.h"
-#include "stream_base.h"
 #include "stream_base-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -46,11 +46,8 @@
 
 #include "node.h"
 #include "node_buffer.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 #include "v8.h"
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -25,9 +25,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "util.h"
 #include "util-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "uv.h"
 #include "v8.h"

--- a/src/node_lttng.cc
+++ b/src/node_lttng.cc
@@ -21,7 +21,6 @@
 #define NODE_GC_DONE(arg0, arg1, arg2)
 #endif
 
-#include "env.h"
 #include "env-inl.h"
 
 namespace node {

--- a/src/node_perf.h
+++ b/src/node_perf.h
@@ -6,7 +6,6 @@
 #include "node.h"
 #include "node_perf_common.h"
 #include "env.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 
 #include "v8.h"

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -1,6 +1,5 @@
 #include "node_internals.h"
 #include "node_buffer.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 
 namespace node {

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -20,11 +20,8 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node_stat_watcher.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <string.h>

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -1,6 +1,5 @@
 #include "node_url.h"
 #include "node_internals.h"
-#include "base-object.h"
 #include "base-object-inl.h"
 #include "node_i18n.h"
 

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -4,7 +4,6 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 
 #include <string>

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -20,9 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/node_win32_etw_provider.cc
+++ b/src/node_win32_etw_provider.cc
@@ -19,7 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "node_win32_etw_provider.h"
 #include "node_etw_provider.h"
 #include "node_win32_etw_provider-inl.h"
 

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -22,11 +22,8 @@
 #include "node.h"
 #include "node_buffer.h"
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include "v8.h"

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -23,7 +23,6 @@
 
 #include "async-wrap.h"
 #include "connection_wrap.h"
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "node.h"
@@ -32,7 +31,6 @@
 #include "connect_wrap.h"
 #include "stream_wrap.h"
 #include "util-inl.h"
-#include "util.h"
 
 namespace node {
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -19,11 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <string.h>

--- a/src/req-wrap-inl.h
+++ b/src/req-wrap-inl.h
@@ -4,11 +4,8 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "req-wrap.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -19,12 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -6,7 +6,6 @@
 #include "stream_base.h"
 
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 #include "v8.h"
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -1,14 +1,11 @@
-#include "stream_base.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
 
 #include "node.h"
 #include "node_buffer.h"
-#include "env.h"
 #include "env-inl.h"
 #include "js_stream.h"
 #include "string_bytes.h"
-#include "util.h"
 #include "util-inl.h"
 #include "v8.h"
 

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -5,7 +5,6 @@
 
 #include "env.h"
 #include "async-wrap.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "node.h"
 #include "util.h"

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -20,20 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "stream_wrap.h"
-#include "stream_base.h"
 #include "stream_base-inl.h"
 
 #include "env-inl.h"
-#include "env.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_counters.h"
 #include "pipe_wrap.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "tcp_wrap.h"
 #include "udp_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <stdlib.h>  // abort()

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -28,7 +28,6 @@
 
 #include "v8.h"
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 #include "util.h"
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -22,14 +22,12 @@
 #include "tcp_wrap.h"
 
 #include "connection_wrap.h"
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_wrap.h"
 #include "connect_wrap.h"
 #include "stream_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <stdlib.h>

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -19,12 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <stdint.h>

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -20,16 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "tls_wrap.h"
-#include "async-wrap.h"
 #include "async-wrap-inl.h"
 #include "node_buffer.h"  // Buffer
 #include "node_crypto.h"  // SecureContext
 #include "node_crypto_bio.h"  // NodeBIO
-#include "node_crypto_clienthello.h"  // ClientHelloParser
+// ClientHelloParser
 #include "node_crypto_clienthello-inl.h"
 #include "node_counters.h"
 #include "node_internals.h"
-#include "stream_base.h"
 #include "stream_base-inl.h"
 
 namespace node {

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -21,15 +21,12 @@
 
 #include "tty_wrap.h"
 
-#include "env.h"
 #include "env-inl.h"
 #include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_wrap.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "stream_wrap.h"
-#include "util.h"
 #include "util-inl.h"
 
 namespace node {

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -20,13 +20,10 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "udp_wrap.h"
-#include "env.h"
 #include "env-inl.h"
 #include "node_buffer.h"
 #include "handle_wrap.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
-#include "util.h"
 #include "util-inl.h"
 
 #include <stdlib.h>

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -27,7 +27,6 @@
 #include "async-wrap.h"
 #include "env.h"
 #include "handle_wrap.h"
-#include "req-wrap.h"
 #include "req-wrap-inl.h"
 #include "uv.h"
 #include "v8.h"

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -21,7 +21,6 @@
 
 #include "uv.h"
 #include "node.h"
-#include "env.h"
 #include "env-inl.h"
 
 namespace node {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src


Refs: https://github.com/nodejs/node/issues/16519

Looks like V8 does not do this anymore: https://github.com/nodejs/node/blob/master/deps/v8/src/objects.cc#L12

So remove the headers. FWIW, less includes to sort, also makes the churn smaller if we want to use `clang-format`.

Also add this rule to the C++ style guide.

This could use a pre-backport, I can open those if this gets landed (this patch is created with a script anyway).

cc @bnoordhuis 