### PR TITLE
[v4.x backport] Use external headers in addons tests

### DIFF
--- a/test/addons/buffer-free-callback/binding.cc
+++ b/test/addons/buffer-free-callback/binding.cc
@@ -1,7 +1,8 @@
 #include <node.h>
 #include <node_buffer.h>
-#include <util.h>
 #include <v8.h>
+
+#include <assert.h>
 
 static int alive;
 static char buf[1024];
@@ -25,7 +26,7 @@ void Check(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Isolate* isolate = args.GetIsolate();
   isolate->RequestGarbageCollectionForTesting(
       v8::Isolate::kFullGarbageCollection);
-  CHECK_GT(alive, 0);
+  assert(alive > 0);
 }
 
 void init(v8::Local<v8::Object> target) {

--- a/test/addons/make-callback-recurse/binding.cc
+++ b/test/addons/make-callback-recurse/binding.cc
@@ -1,7 +1,7 @@
 #include "node.h"
 #include "v8.h"
 
-#include "../../../src/util.h"
+#include <assert.h>
 
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -13,8 +13,8 @@ using v8::Value;
 namespace {
 
 void MakeCallback(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsObject());
-  CHECK(args[1]->IsFunction());
+  assert(args[0]->IsObject());
+  assert(args[1]->IsFunction());
   Isolate* isolate = args.GetIsolate();
   Local<Object> recv = args[0].As<Object>();
   Local<Function> method = args[1].As<Function>();

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -1,15 +1,14 @@
 #include "node.h"
 #include "v8.h"
 
-#include "../../../src/util.h"
-
+#include <assert.h>
 #include <vector>
 
 namespace {
 
 void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  CHECK(args[0]->IsObject());
-  CHECK(args[1]->IsFunction() || args[1]->IsString());
+  assert(args[0]->IsObject());
+  assert(args[1]->IsFunction() || args[1]->IsString());
   auto isolate = args.GetIsolate();
   auto recv = args[0].As<v8::Object>();
   std::vector<v8::Local<v8::Value>> argv;
@@ -26,7 +25,7 @@ void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
     result =
         node::MakeCallback(isolate, recv, method, argv.size(), argv.data());
   } else {
-    UNREACHABLE();
+    assert(0 && "unreachable");
   }
   args.GetReturnValue().Set(result);
 }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test/addons