### PR TITLE
module: add API for identifying core modules

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -817,6 +817,32 @@ The `module.require` method provides a way to load a module as if
 `module` is typically *only* available within a specific module's code, it must
 be explicitly exported in order to be used.
 
+## Listing and Identifying Core Modules
+
+The current set of the core modules may be identified using the
+`Module.isCoreModule()` and `Module.listCoreModules()` methods.
+
+```js
+const {
+  isCoreModule,
+  listCoreModules
+} = require('module');
+
+console.log(isCoreModule('http2'));  // true
+console.log(isCoreModule('foo'));    // false
+
+listCoreModules().forEach(console.log);
+```
+
+### Module.isCoreModule(id)
+
+* `id` {string} A module name
+* Returns `true` if `id` identifies a core module, false otherwise
+
+### Module.getCoreModules()
+
+* Returns: An array of core module names
+
 [`__dirname`]: #modules_dirname
 [`__filename`]: #modules_filename
 [`Error`]: errors.html#errors_class_error

--- a/lib/module.js
+++ b/lib/module.js
@@ -37,6 +37,10 @@ const {
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
 const experimentalModules = !!process.binding('config').experimentalModules;
 
+const kCoreModules =
+  new Set(Object.keys(process.binding('natives'))
+    .filter((name) => !name.startsWith('internal/')));
+
 const errors = require('internal/errors');
 
 const Loader = require('internal/loader/Loader');
@@ -73,6 +77,14 @@ function Module(id, parent) {
   this.children = [];
 }
 module.exports = Module;
+
+Module.getCoreModules = function getCoreModules() {
+  return Array.from(kCoreModules);
+};
+
+Module.isCoreModule = function isCoreModule(name) {
+  return kCoreModules.has(name);
+};
 
 Module._cache = Object.create(null);
 Module._pathCache = Object.create(null);

--- a/test/parallel/test-module-core-modules.js
+++ b/test/parallel/test-module-core-modules.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const natives = process.binding('natives');
+const {
+  isCoreModule,
+  getCoreModules
+} = require('module');
+
+const keys = Object.keys(natives);
+
+keys.filter((name) => !name.startsWith('internal/'))
+  .forEach((i) => assert(isCoreModule(i)));
+
+keys.filter((name) => name.startsWith('internal/'))
+  .forEach((i) => assert(!isCoreModule(i)));
+
+['foo', 'bar', 'baz']
+  .forEach((i) => assert(!isCoreModule(i)));
+
+const list = getCoreModules();
+
+assert(Array.isArray(list));
+assert.deepStrictEqual(list,
+                       keys.filter((name) => !name.startsWith('internal/')));


### PR DESCRIPTION
There is userland code currently making unsafe use of
`process.binding('natives')` to identify core modules.
This points to an obvious need for a supported public
API. Let's provide one to discourage userland use of
private APIs

Userland example: https://github.com/facebook/jest/pull/4740/files#diff-240429220dd8540b70d06b165fc63ad3R5

/cc @bmeck @addaleax @bengl 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
modules