### PR TITLE
src: explicitly register built-in modules

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -808,6 +808,7 @@
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
 
       'sources': [
+        'test/cctest/node_module_reg.cc',
         'test/cctest/node_test_fixture.cc',
         'test/cctest/test_aliased_buffer.cc',
         'test/cctest/test_base64.cc',

--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -719,4 +719,4 @@ void EmitAsyncDestroy(Isolate* isolate, async_context asyncContext) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(async_wrap, node::AsyncWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(async_wrap, node::AsyncWrap::Initialize)

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2265,4 +2265,4 @@ void Initialize(Local<Object> target,
 }  // namespace cares_wrap
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(cares_wrap, node::cares_wrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(cares_wrap, node::cares_wrap::Initialize)

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -221,4 +221,4 @@ void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs_event_wrap, node::FSEventWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(fs_event_wrap, node::FSEventWrap::Initialize)

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -348,5 +348,5 @@ void InitInspectorBindings(Local<Object> target, Local<Value> unused,
 }  // namespace inspector
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(inspector,
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector,
                                   node::inspector::InitInspectorBindings);

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -251,4 +251,4 @@ void JSStream::Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(js_stream, node::JSStream::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(js_stream, node::JSStream::Initialize)

--- a/src/node.cc
+++ b/src/node.cc
@@ -124,6 +124,16 @@ typedef int mode_t;
 extern char **environ;
 #endif
 
+// This is used to load built-in modules. Instead of using
+// __attribute__((constructor)), we call the _register_<modname>
+// function for each built-in modules explicitly in
+// node::RegisterBuiltinModules(). This is only forward declaration.
+// The definitions are in each module's implementation when calling
+// the NODE_BUILTIN_MODULE_CONTEXT_AWARE.
+#define V(modname) void _register_##modname();
+  NODE_BUILTIN_MODULES(V)
+#undef V
+
 namespace node {
 
 using v8::Array;
@@ -4305,6 +4315,9 @@ void Init(int* argc,
   // Initialize prog_start_time to get relative uptime.
   prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
 
+  // Register built-in modules
+  node::RegisterBuiltinModules();
+
   // Make inherited handles noninheritable.
   uv_disable_stdio_inheritance();
 
@@ -4694,11 +4707,18 @@ int Start(int argc, char** argv) {
   return exit_code;
 }
 
+// Call built-in modules' _register_<module name> function to
+// do module registration explicitly.
+void RegisterBuiltinModules() {
+#define V(modname) _register_##modname();
+  NODE_BUILTIN_MODULES(V)
+#undef V
+}
 
 }  // namespace node
 
 #if !HAVE_INSPECTOR
-static void InitEmptyBindings() {}
+void InitEmptyBindings() {}
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(inspector, InitEmptyBindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(inspector, InitEmptyBindings)
 #endif  // !HAVE_INSPECTOR

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1300,4 +1300,4 @@ void Initialize(Local<Object> target,
 }  // namespace Buffer
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(buffer, node::Buffer::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(buffer, node::Buffer::Initialize)

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -132,4 +132,4 @@ static void InitConfig(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(config, node::InitConfig)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(config, node::InitConfig)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1171,4 +1171,4 @@ void InitContextify(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(contextify, node::InitContextify)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(contextify, node::InitContextify)

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6285,4 +6285,4 @@ void InitCrypto(Local<Object> target,
 }  // namespace crypto
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(crypto, node::crypto::InitCrypto)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(crypto, node::crypto::InitCrypto)

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1473,4 +1473,4 @@ void InitFs(Local<Object> target,
 
 }  // end namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs, node::InitFs)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(fs, node::InitFs)

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1396,4 +1396,4 @@ HTTP_STATUS_CODES(V)
 }  // namespace http2
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(http2, node::http2::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(http2, node::http2::Initialize)

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -808,4 +808,4 @@ void InitHttpParser(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(http_parser, node::InitHttpParser)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(http_parser, node::InitHttpParser)

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -874,6 +874,6 @@ void Init(Local<Object> target,
 }  // namespace i18n
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(icu, node::i18n::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(icu, node::i18n::Init)
 
 #endif  // NODE_HAVE_I18N_SUPPORT

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -73,6 +73,81 @@ struct sockaddr;
                               constant_attributes).FromJust();                \
   } while (0)
 
+
+#if HAVE_OPENSSL
+#define NODE_BUILTIN_OPENSSL_MODULES(V) V(crypto) V(tls_wrap)
+#else
+#define NODE_BUILTIN_OPENSSL_MODULES(V)
+#endif
+
+#if NODE_HAVE_I18N_SUPPORT
+#define NODE_BUILTIN_ICU_MODULES(V) V(icu)
+#else
+#define NODE_BUILTIN_ICU_MODULES(V)
+#endif
+
+// A list of built-in modules. In order to do module registration
+// in node::Init(), need to add built-in modules in the following list.
+// Then in node::RegisterBuiltinModules(), it calls modules' registration
+// function. This helps the built-in modules are loaded properly when
+// node is built as static library. No need to depends on the
+// __attribute__((constructor)) like mechanism in GCC.
+#define NODE_BUILTIN_STANDARD_MODULES(V)                                      \
+    V(async_wrap)                                                             \
+    V(buffer)                                                                 \
+    V(cares_wrap)                                                             \
+    V(config)                                                                 \
+    V(contextify)                                                             \
+    V(fs)                                                                     \
+    V(fs_event_wrap)                                                          \
+    V(http2)                                                                  \
+    V(http_parser)                                                            \
+    V(inspector)                                                              \
+    V(js_stream)                                                              \
+    V(module_wrap)                                                            \
+    V(os)                                                                     \
+    V(performance)                                                            \
+    V(pipe_wrap)                                                              \
+    V(process_wrap)                                                           \
+    V(serdes)                                                                 \
+    V(signal_wrap)                                                            \
+    V(spawn_sync)                                                             \
+    V(stream_wrap)                                                            \
+    V(tcp_wrap)                                                               \
+    V(timer_wrap)                                                             \
+    V(tty_wrap)                                                               \
+    V(udp_wrap)                                                               \
+    V(url)                                                                    \
+    V(util)                                                                   \
+    V(uv)                                                                     \
+    V(v8)                                                                     \
+    V(zlib)
+
+#define NODE_BUILTIN_MODULES(V)                                               \
+  NODE_BUILTIN_STANDARD_MODULES(V)                                            \
+  NODE_BUILTIN_OPENSSL_MODULES(V)                                             \
+  NODE_BUILTIN_ICU_MODULES(V)
+
+#define NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
+  static node::node_module _module = {                                        \
+    NODE_MODULE_VERSION,                                                      \
+    flags,                                                                    \
+    nullptr,                                                                  \
+    __FILE__,                                                                 \
+    nullptr,                                                                  \
+    (node::addon_context_register_func) (regfunc),                            \
+    NODE_STRINGIFY(modname),                                                  \
+    priv,                                                                     \
+    nullptr                                                                   \
+  };                                                                          \
+  void _register_ ## modname() {                                              \
+    node_module_register(&_module);                                           \
+  }
+
+
+#define NODE_BUILTIN_MODULE_CONTEXT_AWARE(modname, regfunc)                   \
+  NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_BUILTIN)
+
 namespace node {
 
 // Set in node.cc by ParseArgs with the value of --openssl-config.
@@ -200,6 +275,12 @@ void SetupProcessObject(Environment* env,
                         const char* const* argv,
                         int exec_argc,
                         const char* const* exec_argv);
+
+// Call _register<module_name> functions for all of
+// the built-in modules. Because built-in modules don't
+// use the __attribute__((constructor)). Need to
+// explicitly call the _register* functions.
+void RegisterBuiltinModules();
 
 enum Endianness {
   kLittleEndian,  // _Not_ LITTLE_ENDIAN, clashes with endian.h.
@@ -650,8 +731,8 @@ static inline const char *errno_string(int errorno) {
   }
 }
 
-#define NODE_MODULE_CONTEXT_AWARE_INTERNAL(modname, regfunc)          \
-  NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, NM_F_INTERNAL)  \
+#define NODE_MODULE_CONTEXT_AWARE_INTERNAL(modname, regfunc)                  \
+  NODE_MODULE_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_INTERNAL)
 
 }  // namespace node
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -428,4 +428,4 @@ void Initialize(Local<Object> target,
 }  // namespace os
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(os, node::os::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(os, node::os::Initialize)

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -388,4 +388,4 @@ void Init(Local<Object> target,
 }  // namespace performance
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(performance, node::performance::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(performance, node::performance::Init)

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -483,4 +483,4 @@ void InitializeSerdesBindings(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(serdes, node::InitializeSerdesBindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(serdes, node::InitializeSerdesBindings)

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2220,4 +2220,4 @@ static void Init(Local<Object> target,
 }  // namespace url
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(url, node::url::Init)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(url, node::url::Init)

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -230,4 +230,4 @@ void Initialize(Local<Object> target,
 }  // namespace util
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(util, node::util::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(util, node::util::Initialize)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "node.h"
+#include "node_internals.h"
 #include "env-inl.h"
 #include "util-inl.h"
 #include "v8.h"
@@ -200,4 +201,4 @@ void InitializeV8Bindings(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(v8, node::InitializeV8Bindings)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(v8, node::InitializeV8Bindings)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -710,4 +710,4 @@ void InitZlib(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(zlib, node::InitZlib)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(zlib, node::InitZlib)

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -204,4 +204,4 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(pipe_wrap, node::PipeWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(pipe_wrap, node::PipeWrap::Initialize)

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -311,4 +311,4 @@ class ProcessWrap : public HandleWrap {
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(process_wrap, node::ProcessWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(process_wrap, node::ProcessWrap::Initialize)

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -126,4 +126,4 @@ class SignalWrap : public HandleWrap {
 }  // namespace node
 
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(signal_wrap, node::SignalWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(signal_wrap, node::SignalWrap::Initialize)

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -1081,5 +1081,5 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(spawn_sync,
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(spawn_sync,
   node::SyncProcessRunner::Initialize)

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -398,5 +398,5 @@ void LibuvStreamWrap::OnAfterWriteImpl(WriteWrap* w, void* ctx) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(stream_wrap,
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(stream_wrap,
                                   node::LibuvStreamWrap::Initialize)

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -360,4 +360,4 @@ Local<Object> AddressToJS(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tcp_wrap, node::TCPWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(tcp_wrap, node::TCPWrap::Initialize)

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -136,4 +136,4 @@ class TimerWrap : public HandleWrap {
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(timer_wrap, node::TimerWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(timer_wrap, node::TimerWrap::Initialize)

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -982,4 +982,4 @@ void TLSWrap::Initialize(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tls_wrap, node::TLSWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(tls_wrap, node::TLSWrap::Initialize)

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -176,4 +176,4 @@ TTYWrap::TTYWrap(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tty_wrap, node::TTYWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(tty_wrap, node::TTYWrap::Initialize)

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -514,4 +514,4 @@ uv_udp_t* UDPWrap::UVHandle() {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(udp_wrap, node::UDPWrap::Initialize)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(udp_wrap, node::UDPWrap::Initialize)

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -21,6 +21,7 @@
 
 #include "uv.h"
 #include "node.h"
+#include "node_internals.h"
 #include "env-inl.h"
 
 namespace node {
@@ -58,4 +59,4 @@ void InitializeUV(Local<Object> target,
 }  // anonymous namespace
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(uv, node::InitializeUV)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(uv, node::InitializeUV)

--- a/test/cctest/node_module_reg.cc
+++ b/test/cctest/node_module_reg.cc
@@ -1,0 +1,28 @@
+// Need to create empty definition for these modules'
+// registration function for cctest. Because when
+// building cctest, the definitions for the following
+// registration functions are not included.
+void _register_cares_wrap() {}
+void _register_config() {}
+void _register_contextify() {}
+void _register_fs() {}
+void _register_fs_event_wrap() {}
+void _register_http2() {}
+void _register_http_parser() {}
+void _register_js_stream() {}
+void _register_module_wrap() {}
+void _register_os() {}
+void _register_pipe_wrap() {}
+void _register_process_wrap() {}
+void _register_serdes() {}
+void _register_signal_wrap() {}
+void _register_spawn_sync() {}
+void _register_stream_wrap() {}
+void _register_tcp_wrap() {}
+void _register_timer_wrap() {}
+void _register_tty_wrap() {}
+void _register_udp_wrap() {}
+void _register_util() {}
+void _register_uv() {}
+void _register_v8() {}
+void _register_zlib() {}


### PR DESCRIPTION
Previously, built-in modules are registered before main() via
`__attribute__((constructor))` mechanism in GCC and similiar
mechanism in MSVC. This causes some issues when node is built as
static library. Calling module registration function for built-in
modules in node::Init() helps to avoid the issues.

Refs: https://github.com/nodejs/node/pull/14986#issuecomment-332758206
Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
