### PR TITLE
http: process array headers _after_ setting up agent

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -164,6 +164,40 @@ function ClientRequest(options, cb) {
     this.once('response', cb);
   }
 
+  if (method === 'GET' ||
+      method === 'HEAD' ||
+      method === 'DELETE' ||
+      method === 'OPTIONS' ||
+      method === 'CONNECT') {
+    this.useChunkedEncodingByDefault = false;
+  } else {
+    this.useChunkedEncodingByDefault = true;
+  }
+
+  this._ended = false;
+  this.res = null;
+  this.aborted = undefined;
+  this.timeoutCb = null;
+  this.upgradeOrConnect = false;
+  this.parser = null;
+  this.maxHeadersCount = null;
+
+  var called = false;
+
+  if (this.agent) {
+    // If there is an agent we should default to Connection:keep-alive,
+    // but only if the Agent will actually reuse the connection!
+    // If it's not a keepAlive agent, and the maxSockets==Infinity, then
+    // there's never a case where this socket will actually be reused
+    if (!this.agent.keepAlive && !Number.isFinite(this.agent.maxSockets)) {
+      this._last = true;
+      this.shouldKeepAlive = false;
+    } else {
+      this._last = false;
+      this.shouldKeepAlive = true;
+    }
+  }
+
   var headersArray = Array.isArray(options.headers);
   if (!headersArray) {
     if (options.headers) {
@@ -173,6 +207,7 @@ function ClientRequest(options, cb) {
         this.setHeader(key, options.headers[key]);
       }
     }
+
     if (host && !this.getHeader('host') && setHost) {
       var hostHeader = host;
 
@@ -191,44 +226,24 @@ function ClientRequest(options, cb) {
       }
       this.setHeader('Host', hostHeader);
     }
-  }
 
-  if (options.auth && !this.getHeader('Authorization')) {
-    this.setHeader('Authorization', 'Basic ' +
-                   Buffer.from(options.auth).toString('base64'));
-  }
-
-  if (method === 'GET' ||
-      method === 'HEAD' ||
-      method === 'DELETE' ||
-      method === 'OPTIONS' ||
-      method === 'CONNECT') {
-    this.useChunkedEncodingByDefault = false;
-  } else {
-    this.useChunkedEncodingByDefault = true;
-  }
-
-  if (headersArray) {
-    this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
-                      options.headers);
-  } else if (this.getHeader('expect')) {
-    if (this._header) {
-      throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'render');
+    if (options.auth && !this.getHeader('Authorization')) {
+      this.setHeader('Authorization', 'Basic ' +
+                     Buffer.from(options.auth).toString('base64'));
     }
 
+    if (this.getHeader('expect')) {
+      if (this._header) {
+        throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'render');
+      }
+
+      this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
+                        this[outHeadersKey]);
+    }
+  } else {
     this._storeHeader(this.method + ' ' + this.path + ' HTTP/1.1\r\n',
-                      this[outHeadersKey]);
+                      options.headers);
   }
-
-  this._ended = false;
-  this.res = null;
-  this.aborted = undefined;
-  this.timeoutCb = null;
-  this.upgradeOrConnect = false;
-  this.parser = null;
-  this.maxHeadersCount = null;
-
-  var called = false;
 
   var oncreate = (err, socket) => {
     if (called)
@@ -242,18 +257,8 @@ function ClientRequest(options, cb) {
     this._deferToConnect(null, null, () => this._flush());
   };
 
+  // initiate connection
   if (this.agent) {
-    // If there is an agent we should default to Connection:keep-alive,
-    // but only if the Agent will actually reuse the connection!
-    // If it's not a keepAlive agent, and the maxSockets==Infinity, then
-    // there's never a case where this socket will actually be reused
-    if (!this.agent.keepAlive && !Number.isFinite(this.agent.maxSockets)) {
-      this._last = true;
-      this.shouldKeepAlive = false;
-    } else {
-      this._last = false;
-      this.shouldKeepAlive = true;
-    }
     this.agent.addRequest(this, options);
   } else {
     // No agent, default to Connection:close.

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -1,0 +1,60 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const http = require('http');
+
+function execute(options) {
+  http.createServer(function(req, res) {
+    const expectHeaders = {
+      'x-foo': 'boom',
+      cookie: 'a=1; b=2; c=3',
+      connection: 'close'
+    };
+
+    // no Host header when you set headers an array
+    if (!Array.isArray(options.headers)) {
+      expectHeaders.host = `localhost:${this.address().port}`;
+    }
+
+    // no Authorization header when you set headers an array
+    if (options.auth && !Array.isArray(options.headers)) {
+      expectHeaders.authorization =
+          `Basic ${Buffer.from(options.auth).toString('base64')}`;
+    }
+
+    this.close();
+
+    assert.deepStrictEqual(req.headers, expectHeaders);
+
+    res.end();
+  }).listen(0, function() {
+    options = Object.assign(options, {
+      port: this.address().port,
+      path: '/'
+    });
+    const req = http.request(options);
+    req.end();
+  });
+}
+
+// should be the same except for implicit Host header on the first two
+execute({ headers: { 'x-foo': 'boom', 'cookie': 'a=1; b=2; c=3' } });
+execute({ headers: { 'x-foo': 'boom', 'cookie': [ 'a=1', 'b=2', 'c=3' ] } });
+execute({ headers: [[ 'x-foo', 'boom' ], [ 'cookie', 'a=1; b=2; c=3' ]] });
+execute({ headers: [
+  [ 'x-foo', 'boom' ], [ 'cookie', [ 'a=1', 'b=2', 'c=3' ]]
+] });
+execute({ headers: [
+  [ 'x-foo', 'boom' ], [ 'cookie', 'a=1' ],
+  [ 'cookie', 'b=2' ], [ 'cookie', 'c=3']
+] });
+
+// Authorization and Host header both missing from the second
+execute({ auth: 'foo:bar', headers:
+  { 'x-foo': 'boom', 'cookie': 'a=1; b=2; c=3' } });
+execute({ auth: 'foo:bar', headers: [
+  [ 'x-foo', 'boom' ], [ 'cookie', 'a=1' ],
+  [ 'cookie', 'b=2' ], [ 'cookie', 'c=3']
+] });


### PR DESCRIPTION
http client accepts the `headers` option as an `Array`. This is not documented but is used in 4 places in our tests: parallel/test-http, parallel/test-http-server-multiheaders, parallel/test-http-server-multiheaders2, parallel/test-http-upgrade-client. I believe it traces all the way back to an old API that was refactored and this support was left in. There is some utility in it, however: it's likely to be slightly more efficient as it skips a few tests and does header setting in batch and sends them straight away, it's also the only way to set full multi-headers (see parallel/test-http-server-multiheaders for an example of this as well as the test case in this PR).

There are a few drawbacks, however, one of which I believe is a bug and is fixed with this PR: the logic to determine whether to use a keep-alive connection happens _after_ the array headers are stored and sent, so it ends up defaulting to `Connection: keep-alive` regardless of how you set your http client up. The same request using an object to set headers sets `Connection: close`. This can lead to an unexpected client "hang" as the connection remains open till timeout. Compare `http.request({ port: 1337, path: '/', headers: { foo: 'bar' }})` with `http.request({ port: 1337, path: '/', headers: [ 'foo', 'bar' ]})`. You get `close` with the former and `keep-alive` with the latter.

This PR rearranges the logic to set the array headers later, allowing the keep-alive logic to run before actually setting the `Connection` header.

The other two problems with array headers is that they you don't get the `Host` header set and `options.auth` won't work. The test case in this PR confirms that. These two are arguably bugs, but it's going to require some non-trivial work to make it happen (particularly if we want to avoid directly appending the submitted array, which I think would be our goal?). So I want to check here first before doing anything about that.

I also have a branch where I'm toying with removing array headers but it's sufficiently embedded in both _http_client.js and _http_outgoing.js and we have 4 test cases showing examples that I'm uneasy just pushing ahead with that as it'd be a breaking change and it's not unlikely that there's lot of people using array headers out there in the wild. I haven't even looked at what would happen on the server side for _sending_ headers since _http_outgoing.js appears to make it possible to do the same thing there.

I think my preference would be to formalise array headers as an option and even document it, but it'd require fixing auth and host. Interested to hear what others think.