### PR TITLE
lib: fix issue `throw null` and `throw undefined` and also `throw false` crash in repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -257,7 +257,8 @@ function REPLServer(prompt,
         }
       } catch (e) {
         err = e;
-        if (err.message === 'Script execution interrupted.') {
+
+        if (err && err.message === 'Script execution interrupted.') {
           // The stack trace for this case is not very useful anyway.
           Object.defineProperty(err, 'stack', { value: '' });
         }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -263,7 +263,7 @@ function REPLServer(prompt,
           Object.defineProperty(err, 'stack', { value: '' });
         }
 
-        if (err && process.domain) {
+        if (process.domain) {
           debug('not recoverable, send to domain');
           process.domain.emit('error', err);
           process.domain.exit();

--- a/test/parallel/test-repl-throw-null-or-undefined.js
+++ b/test/parallel/test-repl-throw-null-or-undefined.js
@@ -1,7 +1,7 @@
 'use strict';
 require('../common');
 
-// This test makes sures that the repl does not 
+// This test ensures that the repl does not 
 // crash or emit error when throwing `null|undefined`
 // ie `throw null` or `throw undefined`
 
@@ -10,15 +10,9 @@ const repl = require('repl');
 
 const r = repl.start();
 
-r.write('throw null\n');
-r.write('throw undefined\n');
-r.write('.exit\n');
+assert.doesNotThrow(() => {
+  r.write('throw null\n');
+  r.write('throw undefined\n');
+}, TypeError, 'repl crashes/throw error on `throw null|undefined`');
 
-let i = 0;
-r.on('line', function replOutput(output) {
-  const testStatement = i === 0 ? 'null' : 'undefined';
-  const expectedOutput = 'Thrown: ' + testStatement;
-  const msg = 'repl did not throw ' + testStatement;
-  assert.deepStrictEqual(output, expectedOutput, msg);
-  i++;
-});
+r.write('.exit\n');

--- a/test/parallel/test-repl-throw-null-or-undefined.js
+++ b/test/parallel/test-repl-throw-null-or-undefined.js
@@ -1,0 +1,24 @@
+'use strict';
+require('../common');
+
+// This test makes sures that the repl does not 
+// crash or emit error when throwing `null|undefined`
+// ie `throw null` or `throw undefined`
+
+const assert = require('assert');
+const repl = require('repl');
+
+const r = repl.start();
+
+r.write('throw null\n');
+r.write('throw undefined\n');
+r.write('.exit\n');
+
+let i = 0;
+r.on('line', function replOutput(output) {
+  const testStatement = i === 0 ? 'null' : 'undefined';
+  const expectedOutput = 'Thrown: ' + testStatement;
+  const msg = 'repl did not throw ' + testStatement;
+  assert.deepStrictEqual(output, expectedOutput, msg);
+  i++;
+});


### PR DESCRIPTION
The issue was that when it tries to check if `err.message == 'Script execution interrupted.'`
line 269 repl.js it throws error as e would be `null` or `undefined`. Now before it checks
the err.message it checks if err was `null|undefined` and id so returns err before checking
and exits,


```bash
# sample output repl
> throw null
Thrown: null 
> throw undefined 
Thrown: undefined
```

Fixes: https://github.com/nodejs/node/issues/16545
Fixes: https://github.com/nodejs/node/issues/16607

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
For make -j4 test
`
make error 1
Flaky test-timers-block-eventloop` https://github.com/nodejs/node/issues/16310

- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl