### PR TITLE
http2: simplify mapToHeaders, stricter validation

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -200,7 +200,7 @@ E('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND',
 E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
   'Informational status codes cannot be used');
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-  'HTTP/1 Connection specific headers are forbidden');
+  'HTTP/1 Connection specific headers are forbidden: "%s"');
 E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Value must not be undefined or null');
 E('ERR_HTTP2_INVALID_INFO_STATUS',
   (code) => `Invalid informational status code: ${code}`);

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -399,10 +399,10 @@ function mapToHeaders(map,
   for (var i = 0; i < keys.length; i++) {
     let key = keys[i];
     let value = map[key];
-    let val;
-    if (typeof key === 'symbol' || value === undefined || !key)
+    if (value === undefined || key === '')
       continue;
-    key = String(key).toLowerCase();
+    key = key.toLowerCase();
+    const isSingleValueHeader = kSingleValueHeaders.has(key);
     let isArray = Array.isArray(value);
     if (isArray) {
       switch (value.length) {
@@ -413,34 +413,35 @@ function mapToHeaders(map,
           isArray = false;
           break;
         default:
-          if (kSingleValueHeaders.has(key))
+          if (isSingleValueHeader)
             return new errors.Error('ERR_HTTP2_HEADER_SINGLE_VALUE', key);
       }
+    } else {
+      value = String(value);
+    }
+    if (isSingleValueHeader) {
+      if (singles.has(key))
+        return new errors.Error('ERR_HTTP2_HEADER_SINGLE_VALUE', key);
+      singles.add(key);
     }
     if (key[0] === ':') {
       const err = assertValuePseudoHeader(key);
       if (err !== undefined)
         return err;
-      ret = `${key}\0${String(value)}\0${ret}`;
+      ret = `${key}\0${value}\0${ret}`;
       count++;
     } else {
-      if (kSingleValueHeaders.has(key)) {
-        if (singles.has(key))
-          return new errors.Error('ERR_HTTP2_HEADER_SINGLE_VALUE', key);
-        singles.add(key);
-      }
       if (isIllegalConnectionSpecificHeader(key, value)) {
-        return new errors.Error('ERR_HTTP2_INVALID_CONNECTION_HEADERS');
+        return new errors.Error('ERR_HTTP2_INVALID_CONNECTION_HEADERS', key);
       }
       if (isArray) {
         for (var k = 0; k < value.length; k++) {
-          val = String(value[k]);
+          const val = String(value[k]);
           ret += `${key}\0${val}\0`;
         }
         count += value.length;
       } else {
-        val = String(value);
-        ret += `${key}\0${val}\0`;
+        ret += `${key}\0${value}\0`;
         count++;
       }
     }

--- a/test/parallel/test-http2-server-push-stream-errors-args.js
+++ b/test/parallel/test-http2-server-push-stream-errors-args.js
@@ -31,7 +31,7 @@ server.on('stream', common.mustCall((stream, headers) => {
     () => stream.pushStream({ 'connection': 'test' }, {}, () => {}),
     {
       code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
-      message: 'HTTP/1 Connection specific headers are forbidden'
+      message: 'HTTP/1 Connection specific headers are forbidden: "connection"'
     }
   );
 


### PR DESCRIPTION
Some assorted changes to `mapToHeaders` behaviour, adjusted tests and also an expanded error message.

- No longer check whether key is a symbol as `Object.keys` does not return symbols (or, well, anything other than strings)
- No longer convert key to string as it is always a string (^ see above)
- Validate that only one value is passed for each pseudo-header
- Extend illegal connection header error message to include the name of the problematic header
- Extend tests to cover this behaviour

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test