### PR TITLE
http2: fix stream reading resumption

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1304,6 +1304,12 @@ function streamOnDrain() {
   }
 }
 
+function handleFlushData(handle, streamID) {
+  assert(handle.flushData(streamID) === undefined,
+         `HTTP/2 Stream ${streamID} does not exist. Please report this as ` +
+         'a bug in Node.js');
+}
+
 function streamOnSessionConnect() {
   const session = this[kSession];
   debug(`[${sessionName(session[kType])}] session connected. emiting stream ` +
@@ -1504,9 +1510,7 @@ class Http2Stream extends Duplex {
       return;
     }
     _unrefActive(this);
-    assert(this[kSession][kHandle].flushData(this[kID]) === undefined,
-           'HTTP/2 Stream #{this[kID]} does not exist. Please report this as ' +
-           'a bug in Node.js');
+    process.nextTick(handleFlushData, this[kSession][kHandle], this[kID]);
   }
 
   // Submits an RST-STREAM frame to shutdown this stream.

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1276,8 +1276,6 @@ function onStreamClosed(code) {
 }
 
 function streamOnResume() {
-  if (this._paused)
-    return this.pause();
   if (this[kID] === undefined) {
     this.once('ready', streamOnResume);
     return;
@@ -1301,8 +1299,7 @@ function streamOnPause() {
 
 function streamOnDrain() {
   const needPause = 0 > this._writableState.highWaterMark;
-  if (this._paused && !needPause) {
-    this._paused = false;
+  if (!needPause) {
     this.resume();
   }
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -282,8 +282,13 @@ function onSessionRead(nread, buf, handle) {
          'report this as a bug in Node.js');
   _unrefActive(owner); // Reset the session timeout timer
   _unrefActive(stream); // Reset the stream timeout timer
-  if (nread >= 0 && !stream.destroyed)
-    return stream.push(buf);
+  if (nread >= 0 && !stream.destroyed) {
+    // prevent overflowing the buffer while pause figures out the
+    // stream needs to actually pause and streamOnPause runs
+    if (!stream.push(buf))
+      owner[kHandle].streamReadStop(id);
+    return;
+  }
 
   // Last chunk was received. End the readable side.
   stream.push(null);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1302,13 +1302,6 @@ function streamOnPause() {
   }
 }
 
-function streamOnDrain() {
-  const needPause = 0 > this._writableState.highWaterMark;
-  if (!needPause) {
-    this.resume();
-  }
-}
-
 function handleFlushData(handle, streamID) {
   assert(handle.flushData(streamID) === undefined,
          `HTTP/2 Stream ${streamID} does not exist. Please report this as ` +
@@ -1365,7 +1358,6 @@ class Http2Stream extends Duplex {
     this.once('finish', onHandleFinish);
     this.on('resume', streamOnResume);
     this.on('pause', streamOnPause);
-    this.on('drain', streamOnDrain);
     session.once('close', state.closeHandler);
 
     if (session[kState].connecting) {

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -756,7 +756,7 @@ void Http2Session::FlushData(const FunctionCallbackInfo<Value>& args) {
   if (!(stream = session->FindStream(id))) {
     return args.GetReturnValue().Set(NGHTTP2_ERR_INVALID_STREAM_ID);
   }
-  stream->FlushDataChunks();
+  stream->ReadResume();
 }
 
 void Http2Session::UpdateChunksSent(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -510,7 +510,7 @@ inline void Nghttp2Session::SendPendingData() {
     // the proceed with the rest.
     while (srcRemaining > destRemaining) {
       DEBUG_HTTP2("Nghttp2Session %s: pushing %d bytes to the socket\n",
-                  TypeName(), destRemaining);
+                  TypeName(), destLength + destRemaining);
       memcpy(dest.base + destOffset, src + srcOffset, destRemaining);
       destLength += destRemaining;
       Send(&dest, destLength);

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -896,6 +896,14 @@ inline void Nghttp2Stream::ReadStart() {
   FlushDataChunks();
 }
 
+inline void Nghttp2Stream::ReadResume() {
+  DEBUG_HTTP2("Nghttp2Stream %d: resume reading\n", id_);
+  flags_ &= ~NGHTTP2_STREAM_FLAG_READ_PAUSED;
+
+  // Flush any queued data chunks immediately out to the JS layer
+  FlushDataChunks();
+}
+
 inline void Nghttp2Stream::ReadStop() {
   DEBUG_HTTP2("Nghttp2Stream %d: stop reading\n", id_);
   if (!IsReading())

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -384,6 +384,9 @@ class Nghttp2Stream {
   // the session to be emitted at the JS side
   inline void ReadStart();
 
+  // Resume Reading
+  inline void ReadResume();
+
   // Stop/Pause Reading.
   inline void ReadStop();
 

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -18,5 +18,7 @@ test-npm-install:      PASS,FLAKY
 [$system==solaris] # Also applies to SmartOS
 
 [$system==freebsd]
+test-http2-compat-serverrequest-pipe: PASS,FLAKY
+test-http2-pipe:                      PASS,FLAKY
 
 [$system==aix]

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -11,9 +11,9 @@ const path = require('path');
 
 // piping should work as expected with createWriteStream
 
-const loc = fixtures.path('person.jpg');
-const fn = path.join(common.tmpDir, 'http2pipe.jpg');
 common.refreshTmpDir();
+const loc = fixtures.path('url-tests.js');
+const fn = path.join(common.tmpDir, 'http2-url-tests.js');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -21,7 +21,7 @@ server.on('request', common.mustCall((req, res) => {
   const dest = req.pipe(fs.createWriteStream(fn));
   dest.on('finish', common.mustCall(() => {
     assert.strictEqual(req.complete, true);
-    assert.deepStrictEqual(fs.readFileSync(loc), fs.readFileSync(fn));
+    assert.strictEqual(fs.readFileSync(loc).length, fs.readFileSync(fn).length);
     fs.unlinkSync(fn);
     res.end();
   }));

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -11,9 +11,9 @@ const path = require('path');
 
 // piping should work as expected with createWriteStream
 
+common.refreshTmpDir();
 const loc = fixtures.path('url-tests.js');
 const fn = path.join(common.tmpDir, 'http2-url-tests.js');
-common.refreshTmpDir();
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const http2 = require('http2');
+const fs = require('fs');
+const path = require('path');
+
+// piping should work as expected with createWriteStream
+
+const loc = fixtures.path('url-tests.js');
+const fn = path.join(common.tmpDir, 'http2-url-tests.js');
+common.refreshTmpDir();
+
+const server = http2.createServer();
+
+server.on('stream', common.mustCall((stream) => {
+  const dest = stream.pipe(fs.createWriteStream(fn));
+  dest.on('finish', common.mustCall(() => {
+    assert.deepStrictEqual(fs.readFileSync(loc), fs.readFileSync(fn));
+    fs.unlinkSync(fn);
+    stream.respond();
+    stream.end();
+  }));
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  let remaining = 2;
+  function maybeClose() {
+    if (--remaining === 0) {
+      server.close();
+      client.destroy();
+    }
+  }
+
+  const req = client.request({ ':method': 'POST' });
+  req.on('response', common.mustCall());
+  req.resume();
+  req.on('end', common.mustCall(maybeClose));
+  const str = fs.createReadStream(loc);
+  str.on('end', common.mustCall(maybeClose));
+  str.pipe(req);
+}));

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -20,7 +20,7 @@ const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   const dest = stream.pipe(fs.createWriteStream(fn));
   dest.on('finish', common.mustCall(() => {
-    assert.deepStrictEqual(fs.readFileSync(loc), fs.readFileSync(fn));
+    assert.strictEqual(fs.readFileSync(loc).length, fs.readFileSync(fn).length);
     fs.unlinkSync(fn);
     stream.respond();
     stream.end();


### PR DESCRIPTION
`_read` should always resume the underlying code that is attempting to push data to a readable stream. Adjust http2 core code to resume its reading appropriately.

> When readable._read() is called, if data is available from the resource, the implementation should begin pushing that data into the read queue using the this.push(dataChunk) method. _read() should continue reading from the resource and pushing data until readable.push() returns false. Only when _read() is called again after it has stopped should it resume pushing additional data onto the queue.

Fixes: https://github.com/nodejs/node/issues/16578
Refs: https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_read_size_1

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test