### PR TITLE
doc: add link for stream.pipe()

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1505,6 +1505,7 @@ Used when creation of a [`zlib`][] object fails due to incorrect configuration.
 [`hash.update()`]: crypto.html#crypto_hash_update_data_inputencoding
 [`readable._read()`]: stream.html#stream_readable_read_size_1
 [`sign.sign()`]: crypto.html#crypto_sign_sign_privatekey_outputformat
+[`stream.pipe()`]: stream.html#stream_readable_pipe_destination_options
 [`stream.push()`]: stream.html#stream_readable_push_chunk_encoding
 [`stream.unshift()`]: stream.html#stream_readable_unshift_chunk
 [`stream.write()`]: stream.html#stream_writable_write_chunk_encoding_callback


### PR DESCRIPTION
Missing link definition from #16589

cc @mcollina @jasnell 

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc