### PR TITLE
test: fix flaky test-async-wrap-uncaughtexception

### DIFF
--- a/test/parallel/test-async-wrap-uncaughtexception.js
+++ b/test/parallel/test-async-wrap-uncaughtexception.js
@@ -33,7 +33,7 @@ hooks = async_hooks.createHook({
 }).enable();
 
 
-process.on('uncaughtException', common.mustCall(() => {
+process.once('uncaughtException', common.mustCall(() => {
   assert.strictEqual(call_id, async_hooks.executionAsyncId());
   call_log[2]++;
 }));


### PR DESCRIPTION
It's possible for `beforeExit` to be emitted more than once if work is
scheduled by its listeners. Accommodate this fact in the test.

Fixes: https://github.com/nodejs/node/issues/16210

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test async-wrap