### PR TITLE
test,lib: remove scatalogical terminology

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -321,7 +321,7 @@ function afterShutdown(status, handle, req) {
 // if the writable side has ended already, then clean everything
 // up.
 function onSocketEnd() {
-  // XXX Should not have to do as much crap in this function.
+  // XXX Should not have to do as much in this function.
   // ended should already be true, since this is called *after*
   // the EOF errno and onread has eof'ed
   debug('onSocketEnd', this._readableState);

--- a/test/parallel/test-async-wrap-uncaughtexception.js
+++ b/test/parallel/test-async-wrap-uncaughtexception.js
@@ -42,5 +42,5 @@ process.on('uncaughtException', common.mustCall(() => {
 require('crypto').randomBytes(1, common.mustCall(() => {
   assert.strictEqual(call_id, async_hooks.executionAsyncId());
   call_log[1]++;
-  throw new Error('ah crap');
+  throw new Error();
 }));


### PR DESCRIPTION
There have been previous efforts to remove profanity from the code base. I'm not sure if the two here were missed, slipped in afterwards, were considered mild enough to be ignored, or if it's just something that is no longer a concern.

Which is a longwinded way of me saying that it's fine with me if this one gets closed without merging. 

That said, this change does make the code base mildly more professional, albeit in a superficial way.

/cc @jasnell 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test lib