### PR TITLE
Included reference to 'constant time' in crypto.timingSafeEqual descr…

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1969,6 +1969,7 @@ added: v6.6.0
 - `a` {Buffer | TypedArray | DataView}
 - `b` {Buffer | TypedArray | DataView}
 
+This function is based on a constant-time algorithm.
 Returns true if `a` is equal to `b`, without leaking timing information that
 would allow an attacker to guess one of the values. This is suitable for
 comparing HMAC digests or secret values like authentication cookies or


### PR DESCRIPTION
Included reference to 'constant time' in crypto.timingSafeEqual description

Fixes : #16504 