### PR TITLE
build: add missing comma in sources list

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -284,7 +284,7 @@
         'src/tracing/agent.h',
         'src/tracing/node_trace_buffer.h',
         'src/tracing/node_trace_writer.h',
-        'src/tracing/trace_event.h'
+        'src/tracing/trace_event.h',
         'src/util.h',
         'src/util-inl.h',
         'deps/http_parser/http_parser.h',


### PR DESCRIPTION
This commit adds a missing comma in the sources list. This effects at
least window which produces the following warning where trace_event.h
and src/util.h are concatenated:
```console
Warning: Missing input files:
src\tracing\trace_event.hsrc\util.h
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build