### PR TITLE
Add nodejs/gyp team

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -2,43 +2,44 @@
 
 ## Who to CC in issues
 
-| subsystem | maintainers |
-| --- | --- |
-| `benchmark/*` | @nodejs/benchmarking, @mscdex |
-| `bootstrap_node.js` | @fishrock123 |
-| `doc/*`, `*.md` | @nodejs/documentation |
-| `lib/assert` | @nodejs/testing |
-| `lib/buffer` | @nodejs/buffer |
-| `lib/child_process` | @bnoordhuis, @cjihrig |
-| `lib/cluster` | @bnoordhuis, @cjihrig, @mcollina |
-| `lib/{crypto,tls,https}` | @nodejs/crypto |
-| `lib/dgram` | @cjihrig, @mcollina |
-| `lib/domains` | @misterdjules |
-| `lib/fs`, `src/{fs,file}` | @nodejs/fs |
-| `lib/{_}http{*}` | @nodejs/http |
-| `lib/inspector.js`, `src/inspector_*` | @nodejs/v8-inspector |
-| `lib/internal/url`, `src/node_url` | @nodejs/url |
-| `lib/net` | @bnoordhuis, @indutny, @nodejs/streams |
-| `lib/repl` | @addaleax, @fishrock123 |
-| `lib/{_}stream{*}` | @nodejs/streams |
-| `lib/timers` | @fishrock123, @misterdjules |
-| `lib/util` | @bnoordhuis, @cjihrig, @evanlucas |
-| `lib/zlib` | @addaleax, @bnoordhuis, @indutny |
-| `src/async-wrap.*` | @nodejs/async_hooks |
-| `src/node_api.*` | @nodejs/n-api |
-| `src/node_crypto.*` | @nodejs/crypto |
-| `test/*` | @nodejs/testing |
-| `tools/eslint`, `.eslintrc` | @not-an-aardvark, @silverwind, @trott |
-| async_hooks | @nodejs/async_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
-| build | @nodejs/build |
-| performance | @nodejs/performance |
-| platform specific | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows} |
-| python code | @nodejs/python |
-| upgrading c-ares | @jbergstroem |
-| upgrading http-parser | @jbergstroem, @nodejs/http |
-| upgrading libuv | @saghul |
-| upgrading npm | @fishrock123, @MylesBorins |
-| upgrading V8 | @nodejs/v8, @nodejs/post-mortem |
+| Subsystem                             | Maintainers                                                           |
+| ---                                   | ---                                                                   |
+| `benchmark/*`                         | @nodejs/benchmarking, @mscdex                                         |
+| `bootstrap_node.js`                   | @fishrock123                                                          |
+| `doc/*`, `*.md`                       | @nodejs/documentation                                                 |
+| `lib/assert`                          | @nodejs/testing                                                       |
+| `lib/buffer`                          | @nodejs/buffer                                                        |
+| `lib/child_process`                   | @bnoordhuis, @cjihrig                                                 |
+| `lib/cluster`                         | @bnoordhuis, @cjihrig, @mcollina                                      |
+| `lib/{crypto,tls,https}`              | @nodejs/crypto                                                        |
+| `lib/dgram`                           | @cjihrig, @mcollina                                                   |
+| `lib/domains`                         | @misterdjules                                                         |
+| `lib/fs`, `src/{fs,file}`             | @nodejs/fs                                                            |
+| `lib/{_}http{*}`                      | @nodejs/http                                                          |
+| `lib/inspector.js`, `src/inspector_*` | @nodejs/v8-inspector                                                  |
+| `lib/internal/url`, `src/node_url`    | @nodejs/url                                                           |
+| `lib/net`                             | @bnoordhuis, @indutny, @nodejs/streams                                |
+| `lib/repl`                            | @addaleax, @fishrock123                                               |
+| `lib/{_}stream{*}`                    | @nodejs/streams                                                       |
+| `lib/timers`                          | @fishrock123, @misterdjules                                           |
+| `lib/util`                            | @bnoordhuis, @cjihrig, @evanlucas                                     |
+| `lib/zlib`                            | @addaleax, @bnoordhuis, @indutny                                      |
+| `src/async-wrap.*`                    | @nodejs/async\_hooks                                                  |
+| `src/node_api.*`                      | @nodejs/n-api                                                         |
+| `src/node_crypto.*`                   | @nodejs/crypto                                                        |
+| `test/*`                              | @nodejs/testing                                                       |
+| `tools/eslint`, `.eslintrc`           | @not-an-aardvark, @silverwind, @trott                                 |
+| async\_hooks                          | @nodejs/async\_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
+| build                                 | @nodejs/build                                                         |
+| GYP                                   | @nodejs/gyp                                                           |
+| performance                           | @nodejs/performance                                                   |
+| platform specific                     | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |
+| python code                           | @nodejs/python                                                        |
+| upgrading c-ares                      | @jbergstroem                                                          |
+| upgrading http-parser                 | @jbergstroem, @nodejs/http                                            |
+| upgrading libuv                       | @saghul                                                               |
+| upgrading npm                         | @fishrock123, @MylesBorins                                            |
+| upgrading V8                          | @nodejs/v8, @nodejs/post-mortem                                       |
 
 When things need extra attention, are controversial, or `semver-major`: @nodejs/tsc
 


### PR DESCRIPTION
It would be good to have a GYP team to cc/ in issues.

I know @refack and @bnoordhuis have done a fair amount of work on GYP in the past, not sure who else has experience there, maybe @seishun ?

If you want to be on the team, reply here and I'll add you :grin: .

I also formatted the table while I was there. Happy to change it back if people prefer unevenness to long lines.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, build