### PR TITLE
src: pass context to Get() operations for cares_wrap

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1227,7 +1227,9 @@ class QueryAnyWrap: public QueryWrap {
       CHECK_EQ(naddrttls, a_count);
       for (int i = 0; i < a_count; i++) {
         Local<Object> obj = Object::New(env()->isolate());
-        obj->Set(context, env()->address_string(), ret->Get(i)).FromJust();
+        obj->Set(context,
+                 env()->address_string(),
+                 ret->Get(context, i).ToLocalChecked()).FromJust();
         obj->Set(context,
                  env()->ttl_string(),
                  Integer::New(env()->isolate(), addrttls[i].ttl)).FromJust();
@@ -1239,7 +1241,9 @@ class QueryAnyWrap: public QueryWrap {
     } else {
       for (int i = 0; i < a_count; i++) {
         Local<Object> obj = Object::New(env()->isolate());
-        obj->Set(context, env()->value_string(), ret->Get(i)).FromJust();
+        obj->Set(context,
+                 env()->value_string(),
+                 ret->Get(context, i).ToLocalChecked()).FromJust();
         obj->Set(context,
                  env()->type_string(),
                  env()->dns_cname_string()).FromJust();
@@ -1268,7 +1272,9 @@ class QueryAnyWrap: public QueryWrap {
     CHECK_EQ(aaaa_count, naddr6ttls);
     for (uint32_t i = a_count; i < ret->Length(); i++) {
       Local<Object> obj = Object::New(env()->isolate());
-      obj->Set(context, env()->address_string(), ret->Get(i)).FromJust();
+      obj->Set(context,
+               env()->address_string(),
+               ret->Get(context, i).ToLocalChecked()).FromJust();
       obj->Set(context,
                env()->ttl_string(),
                Integer::New(env()->isolate(), addr6ttls[i].ttl)).FromJust();
@@ -1295,7 +1301,9 @@ class QueryAnyWrap: public QueryWrap {
     }
     for (uint32_t i = old_count; i < ret->Length(); i++) {
       Local<Object> obj = Object::New(env()->isolate());
-      obj->Set(context, env()->value_string(), ret->Get(i)).FromJust();
+      obj->Set(context,
+               env()->value_string(),
+               ret->Get(context, i).ToLocalChecked()).FromJust();
       obj->Set(context,
                env()->type_string(),
                env()->dns_ns_string()).FromJust();
@@ -1321,7 +1329,9 @@ class QueryAnyWrap: public QueryWrap {
     status = ParseGeneralReply(env(), buf, len, &type, ret);
     for (uint32_t i = old_count; i < ret->Length(); i++) {
       Local<Object> obj = Object::New(env()->isolate());
-      obj->Set(context, env()->value_string(), ret->Get(i)).FromJust();
+      obj->Set(context,
+               env()->value_string(),
+               ret->Get(context, i).ToLocalChecked()).FromJust();
       obj->Set(context,
                env()->type_string(),
                env()->dns_ptr_string()).FromJust();
@@ -1941,10 +1951,14 @@ void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value hostname(env->isolate(), args[1]);
 
-  int32_t flags = (args[3]->IsInt32()) ? args[3]->Int32Value() : 0;
+  int32_t flags = 0;
+  if (args[3]->IsInt32()) {
+    flags = args[3]->Int32Value(env->context()).FromJust();
+  }
+
   int family;
 
-  switch (args[2]->Int32Value()) {
+  switch (args[2]->Int32Value(env->context()).FromJust()) {
   case 0:
     family = AF_UNSPEC;
     break;
@@ -1988,7 +2002,7 @@ void GetNameInfo(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsUint32());
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip(env->isolate(), args[1]);
-  const unsigned port = args[2]->Uint32Value();
+  const unsigned port = args[2]->Uint32Value(env->context()).FromJust();
   struct sockaddr_storage addr;
 
   CHECK(uv_ip4_addr(*ip, port, reinterpret_cast<sockaddr_in*>(&addr)) == 0 ||
@@ -2065,17 +2079,23 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
   int err;
 
   for (uint32_t i = 0; i < len; i++) {
-    CHECK(arr->Get(i)->IsArray());
+    CHECK(arr->Get(env->context(), i).ToLocalChecked()->IsArray());
 
-    Local<Array> elm = Local<Array>::Cast(arr->Get(i));
+    Local<Array> elm =
+        Local<Array>::Cast(arr->Get(env->context(), i).ToLocalChecked());
 
-    CHECK(elm->Get(0)->Int32Value());
-    CHECK(elm->Get(1)->IsString());
-    CHECK(elm->Get(2)->Int32Value());
+    CHECK(elm->Get(env->context(),
+                   0).ToLocalChecked()->Int32Value(env->context()).FromJust());
+    CHECK(elm->Get(env->context(), 1).ToLocalChecked()->IsString());
+    CHECK(elm->Get(env->context(),
+                   2).ToLocalChecked()->Int32Value(env->context()).FromJust());
 
-    int fam = elm->Get(0)->Int32Value();
-    node::Utf8Value ip(env->isolate(), elm->Get(1));
-    int port = elm->Get(2)->Int32Value();
+    int fam = elm->Get(env->context(), 0)
+        .ToLocalChecked()->Int32Value(env->context()).FromJust();
+    node::Utf8Value ip(env->isolate(),
+                       elm->Get(env->context(), 1).ToLocalChecked());
+    int port = elm->Get(env->context(), 2)
+        .ToLocalChecked()->Int32Value(env->context()).FromJust();
 
     ares_addr_port_node* cur = &servers[i];
 
@@ -2125,7 +2145,8 @@ void Cancel(const FunctionCallbackInfo<Value>& args) {
 
 void StrError(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  const char* errmsg = ares_strerror(args[0]->Int32Value());
+  const char* errmsg = ares_strerror(args[0]->Int32Value(env->context())
+                                     .FromJust());
   args.GetReturnValue().Set(OneByteString(env->isolate(), errmsg));
 }
 


### PR DESCRIPTION
Using Get() without the context argument will soon be deprecated.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src