### PR TITLE
tools: custom eslint autofix for inspector-check.js

### DIFF
--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -13,13 +13,13 @@ new RuleTester().run('inspector-check', rule, {
   valid: [
     'foo;',
     'common.skipIfInspectorDisabled(); require("inspector");',
-    `require("common");
-     common.skipIfInspectorDisabled();
-     require("inspector");`
+    'require("common");\n' +
+    'common.skipIfInspectorDisabled();\n' +
+    'require("inspector");'
   ],
   invalid: [
     {
-      code: 'require("inspector")',
+      code: 'require("inspector");',
       errors: [{ message }],
       output: 'require("common");\n' +
               'common.skipIfInspectorDisabled();\n' +

--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -12,12 +12,18 @@ const message = 'Please add a skipIfInspectorDisabled() call to allow this ' +
 new RuleTester().run('inspector-check', rule, {
   valid: [
     'foo;',
-    'common.skipIfInspectorDisabled(); require("inspector");'
+    'common.skipIfInspectorDisabled(); require("inspector");',
+    `require("common");
+     common.skipIfInspectorDisabled();
+     require("inspector");`
   ],
   invalid: [
     {
       code: 'require("inspector")',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: 'require("common");\n' +
+              'common.skipIfInspectorDisabled();\n' +
+              'require("inspector");'
     }
   ]
 });

--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -13,8 +13,8 @@ new RuleTester().run('inspector-check', rule, {
   valid: [
     'foo;',
     'require("common")\n' +
-    'common.skipIfInspectorDisabled();\n' +
-    'require("inspector")'
+      'common.skipIfInspectorDisabled();\n' +
+      'require("inspector")'
   ],
   invalid: [
     {

--- a/test/parallel/test-eslint-inspector-check.js
+++ b/test/parallel/test-eslint-inspector-check.js
@@ -12,18 +12,18 @@ const message = 'Please add a skipIfInspectorDisabled() call to allow this ' +
 new RuleTester().run('inspector-check', rule, {
   valid: [
     'foo;',
-    'common.skipIfInspectorDisabled(); require("inspector");',
-    'require("common");\n' +
+    'require("common")\n' +
     'common.skipIfInspectorDisabled();\n' +
-    'require("inspector");'
+    'require("inspector")'
   ],
   invalid: [
     {
-      code: 'require("inspector");',
+      code: 'require("common")\n' +
+            'require("inspector")',
       errors: [{ message }],
-      output: 'require("common");\n' +
+      output: 'require("common")\n' +
               'common.skipIfInspectorDisabled();\n' +
-              'require("inspector");'
+              'require("inspector")'
     }
   ]
 });

--- a/tools/eslint-rules/inspector-check.js
+++ b/tools/eslint-rules/inspector-check.js
@@ -11,11 +11,11 @@ const utils = require('./rules-utils.js');
 // Rule Definition
 //------------------------------------------------------------------------------
 const msg = 'Please add a skipIfInspectorDisabled() call to allow this ' +
-  'test to be skippped when Node is built \'--without-inspector\'.';
+            'test to be skippped when Node is built \'--without-inspector\'.';
 
 module.exports = function(context) {
   const missingCheckNodes = [];
-  const commonModuleNodes = [];
+  var commonModuleNode = null;
   var hasInspectorCheck = false;
 
   function testInspectorUsage(context, node) {
@@ -24,7 +24,7 @@ module.exports = function(context) {
     }
 
     if (utils.isCommonModule(node)) {
-      commonModuleNodes.push(node);
+      commonModuleNode = node;
     }
   }
 
@@ -41,10 +41,12 @@ module.exports = function(context) {
           node,
           message: msg,
           fix: (fixer) => {
-            return fixer.insertTextAfter(
-              commonModuleNodes[0],
-              '\ncommon.skipIfInspectorDisabled();'
-            );
+            if (commonModuleNode) {
+              return fixer.insertTextAfter(
+                commonModuleNode,
+                '\ncommon.skipIfInspectorDisabled();'
+              );
+            }
           }
         });
       });

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -25,6 +25,16 @@ module.exports.isBinding = function(node, modules) {
 };
 
 /**
+ * Return true if common module is required
+ * in AST Node under inspection
+ */
+var commonModuleRegExp = new RegExp(/^(\.\.\/)*common(\.js)?$/);
+module.exports.isCommonModule = function(node) {
+  return node.callee.name === 'require' &&
+         commonModuleRegExp.test(node.arguments[0].value);
+};
+
+/**
  * Returns true is the node accesses any property in the properties
  * array on the 'common' object.
  */
@@ -45,8 +55,8 @@ module.exports.usesCommonProperty = function(node, properties) {
 module.exports.inSkipBlock = function(node) {
   var hasSkipBlock = false;
   if (node.test &&
-      node.test.type === 'UnaryExpression' &&
-      node.test.operator === '!') {
+    node.test.type === 'UnaryExpression' &&
+    node.test.operator === '!') {
     const consequent = node.consequent;
     if (consequent.body) {
       consequent.body.some(function(expressionStatement) {
@@ -64,8 +74,8 @@ module.exports.inSkipBlock = function(node) {
 
 function hasSkip(expression) {
   return expression &&
-         expression.callee &&
-         (expression.callee.name === 'skip' ||
-         expression.callee.property &&
-         expression.callee.property.name === 'skip');
+    expression.callee &&
+    (expression.callee.name === 'skip' ||
+      expression.callee.property &&
+      expression.callee.property.name === 'skip');
 }

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -31,6 +31,7 @@ module.exports.isBinding = function(node, modules) {
 var commonModuleRegExp = new RegExp(/^(\.\.\/)*common(\.js)?$/);
 module.exports.isCommonModule = function(node) {
   return node.callee.name === 'require' &&
+         node.arguments.length !== 0 &&
          commonModuleRegExp.test(node.arguments[0].value);
 };
 

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -55,8 +55,8 @@ module.exports.usesCommonProperty = function(node, properties) {
 module.exports.inSkipBlock = function(node) {
   var hasSkipBlock = false;
   if (node.test &&
-    node.test.type === 'UnaryExpression' &&
-    node.test.operator === '!') {
+      node.test.type === 'UnaryExpression' &&
+      node.test.operator === '!') {
     const consequent = node.consequent;
     if (consequent.body) {
       consequent.body.some(function(expressionStatement) {
@@ -74,8 +74,8 @@ module.exports.inSkipBlock = function(node) {
 
 function hasSkip(expression) {
   return expression &&
-    expression.callee &&
-    (expression.callee.name === 'skip' ||
-      expression.callee.property &&
-      expression.callee.property.name === 'skip');
+         expression.callee &&
+         (expression.callee.name === 'skip' ||
+         expression.callee.property &&
+         expression.callee.property.name === 'skip');
 }


### PR DESCRIPTION
This adds eslint fixer method for inspector-check.js. When running eslint with ``` --fix ``` flag, the fixer will add ```common.skipIfInspectorDisabled();``` to the file automatically.

Refs : #16636 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] Added/Updated the test cases.
- [x] Followed commit guidelines.
- [x] `python ./tools/test.py parallel/test-eslint-inspector-check`
##### Affected core subsystem(s)
 Tools 
