### PR TITLE
tools: auto fix custom eslint rule for crypto-check.js

### DIFF
--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -13,20 +13,32 @@ new RuleTester().run('crypto-check', rule, {
     'foo',
     'crypto',
     `
-      if (!common.hasCrypto) {
-        common.skip();
-      }
-      require('crypto');
+    if (!common.hasCrypto) {
+      common.skip();
+    }
+    require('crypto');
     `
   ],
   invalid: [
     {
       code: 'require("crypto")',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: `
+      if (!common.hasCrypto) {
+        common.skip();
+      }
+      require('crypto');
+      `
     },
     {
       code: 'if (common.foo) {} require("crypto")',
-      errors: [{ message }]
+      errors: [{ message }],
+      output:  `
+      if (!common.hasCrypto) {
+        common.skip();
+      }
+      require('crypto');
+      `
     }
   ]
 });

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -16,7 +16,7 @@ new RuleTester().run('crypto-check', rule, {
     if (!common.hasCrypto) {
       common.skip();
     }
-    require('crypto');
+    require("crypto");
     `
   ],
   invalid: [
@@ -25,9 +25,9 @@ new RuleTester().run('crypto-check', rule, {
       errors: [{ message }],
       output: `
       if (!common.hasCrypto) {
-        common.skip();
+        common.skip("missing crypto");
       }
-      require('crypto');
+      require("crypto");
       `
     },
     {
@@ -35,9 +35,9 @@ new RuleTester().run('crypto-check', rule, {
       errors: [{ message }],
       output:  `
       if (!common.hasCrypto) {
-        common.skip();
+        common.skip("missing crypto");
       }
-      require('crypto');
+      require("crypto");
       `
     }
   ]

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -31,7 +31,7 @@ new RuleTester().run('crypto-check', rule, {
               'require("crypto")'
     },
     {
-      code: 'require("common")\n' + 
+      code: 'require("common")\n' +
             'if (common.foo) {}\n' +
             'require("crypto")',
       errors: [{ message }],

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -12,8 +12,7 @@ new RuleTester().run('crypto-check', rule, {
   valid: [
     'foo',
     'crypto',
-    `
-    if (!common.hasCrypto) {
+    `if (!common.hasCrypto) {
       common.skip();
     }
     require("crypto");
@@ -23,8 +22,8 @@ new RuleTester().run('crypto-check', rule, {
     {
       code: 'require("crypto")',
       errors: [{ message }],
-      output: `
-      if (!common.hasCrypto) {
+      output:
+      `if (!common.hasCrypto) {
         common.skip("missing crypto");
       }
       require("crypto");
@@ -33,8 +32,8 @@ new RuleTester().run('crypto-check', rule, {
     {
       code: 'if (common.foo) {} require("crypto")',
       errors: [{ message }],
-      output:  `
-      if (!common.hasCrypto) {
+      output:
+      `if (!common.hasCrypto) {
         common.skip("missing crypto");
       }
       require("crypto");

--- a/test/parallel/test-eslint-crypto-check.js
+++ b/test/parallel/test-eslint-crypto-check.js
@@ -12,32 +12,35 @@ new RuleTester().run('crypto-check', rule, {
   valid: [
     'foo',
     'crypto',
-    `if (!common.hasCrypto) {
-      common.skip();
+    `
+    if (!common.hasCrypto) {
+      common.skip("missing crypto");
     }
     require("crypto");
     `
   ],
   invalid: [
     {
-      code: 'require("crypto")',
+      code: 'require("common")\n' +
+            'require("crypto")',
       errors: [{ message }],
-      output:
-      `if (!common.hasCrypto) {
-        common.skip("missing crypto");
-      }
-      require("crypto");
-      `
+      output: 'require("common")\n' +
+              'if (!common.hasCrypto) {' +
+              ' common.skip("missing crypto");' +
+              '}\n' +
+              'require("crypto")'
     },
     {
-      code: 'if (common.foo) {} require("crypto")',
+      code: 'require("common")\n' + 
+            'if (common.foo) {}\n' +
+            'require("crypto")',
       errors: [{ message }],
-      output:
-      `if (!common.hasCrypto) {
-        common.skip("missing crypto");
-      }
-      require("crypto");
-      `
+      output: 'require("common")\n' +
+              'if (!common.hasCrypto) {' +
+              ' common.skip("missing crypto");' +
+              '}\n' +
+              'if (common.foo) {}\n' +
+              'require("crypto")'
     }
   ]
 });

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -14,7 +14,7 @@ const utils = require('./rules-utils.js');
 // Rule Definition
 //------------------------------------------------------------------------------
 const msg = 'Please add a hasCrypto check to allow this test to be skipped ' +
-  'when Node is built "--without-ssl".';
+            'when Node is built "--without-ssl".';
 
 const cryptoModules = ['crypto', 'http2'];
 const requireModules = cryptoModules.concat(['tls', 'https']);

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -84,10 +84,12 @@ module.exports = function(context) {
         node,
         message: msg,
         fix: (fixer) => {
-          return fixer.insertTextAfter(
-            commonModuleNodes[0],
-            '\nif (!common.hasCrypto)\n  common.skip("missing crypto");'
-          );
+          if (commonModuleNodes.length) {
+            return fixer.insertTextAfter(
+              commonModuleNodes[0],
+              '\nif (!common.hasCrypto)\n  common.skip("missing crypto");'
+            );
+          }
         }
       });
     });

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -87,9 +87,9 @@ module.exports = function(context) {
           if (commonModuleNode) {
             return fixer.insertTextAfter(
               commonModuleNode,
-              `\nif (!common.hasCrypto) {
-                common.skip("missing crypto");
-              }`
+              '\nif (!common.hasCrypto) {' +
+              ' common.skip("missing crypto");' +
+              '}'
             );
           }
         }

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -23,7 +23,7 @@ const bindingModules = cryptoModules.concat(['tls_wrap']);
 module.exports = function(context) {
   const missingCheckNodes = [];
   const requireNodes = [];
-  const commonModuleNodes = [];
+  var commonModuleNode = null;
   var hasSkipCall = false;
 
   function testCryptoUsage(node) {
@@ -33,7 +33,7 @@ module.exports = function(context) {
     }
 
     if (utils.isCommonModule(node)) {
-      commonModuleNodes.push(node);
+      commonModuleNode = node;
     }
   }
 
@@ -84,10 +84,12 @@ module.exports = function(context) {
         node,
         message: msg,
         fix: (fixer) => {
-          if (commonModuleNodes.length) {
+          if (commonModuleNode) {
             return fixer.insertTextAfter(
-              commonModuleNodes[0],
-              '\nif (!common.hasCrypto)\n  common.skip("missing crypto");'
+              commonModuleNode,
+              `\nif (!common.hasCrypto) {
+                common.skip("missing crypto");
+              }`
             );
           }
         }

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -12,6 +12,16 @@ module.exports.isRequired = function(node, modules) {
     modules.includes(node.arguments[0].value);
 };
 
+/** 
+* Return true if common module is required
+* in AST Node under inspection
+*/
+var commonModuleRegExp = new RegExp(/^(\.\.\/)*common(\.js)?$/);
+module.exports.isCommonModule = function(node) {
+  return node.callee.name === 'require' &&
+    commonModuleRegExp.test(node.arguments[0].value);
+};
+
 /**
  * Returns true if any of the passed in modules are used in
  * binding calls.
@@ -45,8 +55,8 @@ module.exports.usesCommonProperty = function(node, properties) {
 module.exports.inSkipBlock = function(node) {
   var hasSkipBlock = false;
   if (node.test &&
-      node.test.type === 'UnaryExpression' &&
-      node.test.operator === '!') {
+    node.test.type === 'UnaryExpression' &&
+    node.test.operator === '!') {
     const consequent = node.consequent;
     if (consequent.body) {
       consequent.body.some(function(expressionStatement) {
@@ -64,8 +74,8 @@ module.exports.inSkipBlock = function(node) {
 
 function hasSkip(expression) {
   return expression &&
-         expression.callee &&
-         (expression.callee.name === 'skip' ||
-         expression.callee.property &&
-         expression.callee.property.name === 'skip');
+    expression.callee &&
+    (expression.callee.name === 'skip' ||
+      expression.callee.property &&
+      expression.callee.property.name === 'skip');
 }

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -19,7 +19,8 @@ module.exports.isRequired = function(node, modules) {
 var commonModuleRegExp = new RegExp(/^(\.\.\/)*common(\.js)?$/);
 module.exports.isCommonModule = function(node) {
   return node.callee.name === 'require' &&
-    commonModuleRegExp.test(node.arguments[0].value);
+         node.arguments.length !== 0 &&
+         commonModuleRegExp.test(node.arguments[0].value);
 };
 
 /**

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -12,7 +12,7 @@ module.exports.isRequired = function(node, modules) {
     modules.includes(node.arguments[0].value);
 };
 
-/** 
+/**
 * Return true if common module is required
 * in AST Node under inspection
 */

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -55,8 +55,8 @@ module.exports.usesCommonProperty = function(node, properties) {
 module.exports.inSkipBlock = function(node) {
   var hasSkipBlock = false;
   if (node.test &&
-    node.test.type === 'UnaryExpression' &&
-    node.test.operator === '!') {
+      node.test.type === 'UnaryExpression' &&
+      node.test.operator === '!') {
     const consequent = node.consequent;
     if (consequent.body) {
       consequent.body.some(function(expressionStatement) {
@@ -74,8 +74,8 @@ module.exports.inSkipBlock = function(node) {
 
 function hasSkip(expression) {
   return expression &&
-    expression.callee &&
-    (expression.callee.name === 'skip' ||
-      expression.callee.property &&
-      expression.callee.property.name === 'skip');
+         expression.callee &&
+         (expression.callee.name === 'skip' ||
+         expression.callee.property &&
+         expression.callee.property.name === 'skip');
 }


### PR DESCRIPTION
This implements an eslint fixer function to auto insert common.hasCryto check if missed out.

Refs: https://github.com/nodejs/node/issues/16636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
- [x] test cases added for changes
- [x] `python ./tools/test.py parallel/test-eslint-crypto-check`
##### Affected core subsystem(s)
Tools
