### PR TITLE
tools: auto fix custom eslint rule for prefer-assert-methods.js

### DIFF
--- a/test/parallel/test-eslint-prefer-assert-methods.js
+++ b/test/parallel/test-eslint-prefer-assert-methods.js
@@ -7,31 +7,46 @@ const rule = require('../../tools/eslint-rules/prefer-assert-methods');
 
 new RuleTester().run('prefer-assert-methods', rule, {
   valid: [
-    'assert.strictEqual(foo, bar)',
-    'assert(foo === bar && baz)'
+    'assert.strictEqual(foo, bar);',
+    'assert(foo === bar && baz);',
+    'assert.notStrictEqual(foo, bar);',
+    'assert(foo !== bar && baz);',
+    'assert.equal(foo, bar);',
+    'assert(foo == bar && baz);',
+    'assert.notEqual(foo, bar);',
+    'assert(foo != bar && baz);',
+    'assert.ok(foo);',
+    'assert.ok(foo != bar);',
+    'assert.ok(foo === bar && baz);'
   ],
   invalid: [
     {
-      code: 'assert(foo == bar)',
-      errors: [{ message: "'assert.equal' should be used instead of '=='" }]
+      code: 'assert(foo == bar);',
+      errors: [{
+        message: "'assert.equal' should be used instead of '=='"
+      }],
+      output: 'assert.equal(foo, bar);'
     },
     {
-      code: 'assert(foo === bar)',
+      code: 'assert(foo === bar);',
       errors: [{
         message: "'assert.strictEqual' should be used instead of '==='"
-      }]
+      }],
+      output: 'assert.strictEqual(foo, bar);'
     },
     {
-      code: 'assert(foo != bar)',
+      code: 'assert(foo != bar);',
       errors: [{
         message: "'assert.notEqual' should be used instead of '!='"
-      }]
+      }],
+      output: 'assert.notEqual(foo, bar);'
     },
     {
-      code: 'assert(foo !== bar)',
+      code: 'assert(foo !== bar);',
       errors: [{
         message: "'assert.notStrictEqual' should be used instead of '!=='"
-      }]
-    },
+      }],
+      output: 'assert.notStrictEqual(foo, bar);'
+    }
   ]
 });

--- a/tools/eslint-rules/prefer-assert-methods.js
+++ b/tools/eslint-rules/prefer-assert-methods.js
@@ -1,3 +1,7 @@
+/**
+ * @fileoverview Prohibit the use of assert operators ( ===, !==, ==, != )
+ */
+
 'use strict';
 
 const astSelector = 'ExpressionStatement[expression.type="CallExpression"]' +
@@ -8,20 +12,42 @@ function parseError(method, op) {
   return `'assert.${method}' should be used instead of '${op}'`;
 }
 
-const preferedAssertMethod = {
-  '===': 'strictEqual',
-  '!==': 'notStrictEqual',
-  '==': 'equal',
-  '!=': 'notEqual'
-};
+function checkExpression(arg) {
+  const type = arg.type;
+  return arg && (type === 'BinaryExpression');
+}
+
+function preferedAssertMethod(op) {
+  switch (op) {
+    case '===': return 'strictEqual';
+    case '!==': return 'notStrictEqual';
+    case '==': return 'equal';
+    case '!=': return 'notEqual';
+  }
+}
 
 module.exports = function(context) {
   return {
-    [astSelector]: function(node) {
-      const arg = node.expression.arguments[0];
-      const assertMethod = preferedAssertMethod[arg.operator];
-      if (assertMethod) {
-        context.report(node, parseError(assertMethod, arg.operator));
+    ExpressionStatement(node) {
+      if (isAssert(node)) {
+        const arg = getFirstArg(node.expression);
+        if (checkExpression(arg)) {
+          const assertMethod = preferedAssertMethod(arg.operator);
+          if (assertMethod) {
+            context.report({
+              node,
+              message: parseError(assertMethod, arg.operator),
+              fix: (fixer) => {
+                const sourceCode = context.getSourceCode();
+                const args = `${sourceCode.getText(arg)}`;
+                return fixer.replaceText(
+                  node,
+                  `assert.${assertMethod}(${args});`
+                );
+              }
+            });
+          }
+        }
       }
     }
   };


### PR DESCRIPTION
This adds eslint fixer for auto-fixing the usage of assert operators. Also adding fileoverview for the perfer-assert-methods.js file.

For example the fixer change this ```assert(obj.value !== 9);``` to ```assert.notStrictEqual(obj.value, 9);```


Refs: https://github.com/nodejs/node/issues/16636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
- [x] modify tests
##### Affected core subsystem(s)
Tools