### PR TITLE
doc: util.isDeepStrictEqual returns boolean

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -462,7 +462,7 @@ added: v9.0.0
 
 * `val1` {any}
 * `val2` {any}
-* Returns: {string}
+* Returns: {boolean}
 
 Returns `true` if there is deep strict equality between `val` and `val2`.
 Otherwise, returns `false`.


### PR DESCRIPTION
Minor doc fix, `util.isDeepStrictEqual` returns a `boolean`, not a `string`.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc