### PR TITLE
src: process release lts property

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1444,7 +1444,11 @@ tarball.
   compiling Node.js native add-ons. _This property is only present on Windows
   builds of Node.js and will be missing on all other platforms._
 * `lts` {string} a string label identifying the [LTS][] label for this release.
-  If the Node.js release is not an LTS release, this will be `undefined`.
+  This property only exists for LTS releases and is `undefined` for all other
+  release types, including _Current_ releases.  Currently the valid values are:
+  - `'Argon'` for the v4.x LTS line beginning with v4.2.0.
+  - `'Boron'` for the v6.x LTS line beginning with v6.9.0.
+  - `'Carbon'` for the v8.x LTS line beginning with v8.9.1.
 
 For example:
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -3496,6 +3496,11 @@ void SetupProcessObject(Environment* env,
   READONLY_PROPERTY(release, "name",
                     OneByteString(env->isolate(), NODE_RELEASE));
 
+#if NODE_VERSION_IS_LTS
+  READONLY_PROPERTY(release, "lts",
+                    OneByteString(env->isolate(), NODE_VERSION_LTS_CODENAME));
+#endif
+
 // if this is a release build and no explicit base has been set
 // substitute the standard release download URL
 #ifndef NODE_RELEASE_URLBASE

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -1,0 +1,16 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const versionParts = process.versions.node.split('.');
+
+assert.equal(process.release.name, 'node');
+
+// it's expected that future LTS release lines will have additional
+// branches in here
+if (versionParts[0] === '4' && versionParts[1] >= 2) {
+  assert.equal(process.release.lts, 'Argon');
+} else if (versionParts[0] === '6' && versionParts[1] >= 9) {
+  assert.equal(process.release.lts, 'Boron');
+} else {
+  assert.strictEqual(process.release.lts, undefined);
+}

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -1,16 +1,20 @@
 'use strict';
+
 require('../common');
+
 const assert = require('assert');
 const versionParts = process.versions.node.split('.');
 
-assert.equal(process.release.name, 'node');
+assert.strictEqual(process.release.name, 'node');
 
 // it's expected that future LTS release lines will have additional
 // branches in here
 if (versionParts[0] === '4' && versionParts[1] >= 2) {
-  assert.equal(process.release.lts, 'Argon');
+  assert.strictEqual(process.release.lts, 'Argon');
 } else if (versionParts[0] === '6' && versionParts[1] >= 9) {
-  assert.equal(process.release.lts, 'Boron');
+  assert.strictEqual(process.release.lts, 'Boron');
+} else if (versionParts[0] === '8' && versionParts[1] >= 9) {
+  assert.strictEqual(process.release.lts, 'Carbon');
 } else {
   assert.strictEqual(process.release.lts, undefined);
 }


### PR DESCRIPTION
This is a forward-port of 455272ad336c9a363dfa1235b63c895df088d992. It is required for LTS release branches to have the correct in-process information when configured with `NODE_VERSION_IS_LTS` and `NODE_VERSION_LTS_CODENAME`. It has no impact otherwise, other than a test which already covers up multiple possible name paths.

This should be backported to 8.x asap as it is missing there and as such `process.release.lts` is `undefined` in 8.9.0. Myself and @MylesBorins are hoping to get this into the security release later this week (from irc).

This lands cleanly on 8.x.

cc also @nodejs/release 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, src, lts

CI: https://ci.nodejs.org/job/node-test-pull-request/11121/