### PR TITLE
zlib: warn before crash on invalid internals usage

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -422,6 +422,16 @@ class ZCtx : public AsyncWrap {
 
   // just pull the ints out of the args and call the other Init
   static void Init(const FunctionCallbackInfo<Value>& args) {
+    // Refs: https://github.com/nodejs/node/issues/16649
+    // Refs: https://github.com/nodejs/node/issues/14161
+    if (args.Length() == 5) {
+      fprintf(stderr,
+          "WARNING: You are likely using a version of node-tar or npm that "
+          "uses the internals of Node.js in an invalid way.\nPlease use "
+          "either the version of npm that is bundled with Node.js, or "
+          "a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) "
+          "that is compatible with Node 9 and above.\n");
+    }
     CHECK(args.Length() == 7 &&
       "init(windowBits, level, memLevel, strategy, writeResult, writeCallback,"
       " dictionary)");

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -427,7 +427,7 @@ class ZCtx : public AsyncWrap {
     if (args.Length() == 5) {
       fprintf(stderr,
           "WARNING: You are likely using a version of node-tar or npm that "
-          "uses the internals of Node.js in an invalid way.\nPlease use "
+          "is incompatible with this version of Node.js.\nPlease use "
           "either the version of npm that is bundled with Node.js, or "
           "a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) "
           "that is compatible with Node.js 9 and above.\n");

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -430,7 +430,7 @@ class ZCtx : public AsyncWrap {
           "uses the internals of Node.js in an invalid way.\nPlease use "
           "either the version of npm that is bundled with Node.js, or "
           "a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) "
-          "that is compatible with Node 9 and above.\n");
+          "that is compatible with Node.js 9 and above.\n");
     }
     CHECK(args.Length() == 7 &&
       "init(windowBits, level, memLevel, strategy, writeResult, writeCallback,"

--- a/test/abort/test-zlib-invalid-internals-usage.js
+++ b/test/abort/test-zlib-invalid-internals-usage.js
@@ -1,6 +1,7 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
+const os = require('os');
 const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
@@ -8,13 +9,12 @@ if (process.argv[2] === 'child') {
   new (process.binding('zlib').Zlib)(0).init(1, 2, 3, 4, 5);
 } else {
   const child = cp.spawnSync(`${process.execPath}`, [`${__filename}`, 'child']);
-  const stderr = child.stderr.toString();
 
   assert.strictEqual(child.stdout.toString(), '');
   assert.ok(child.stderr.includes(
-      'WARNING: You are likely using a version of node-tar or npm that uses ' +
-      'the internals of Node.js in an invalid way.\n' +
-      'Please use either the version of npm that is bundled with Node.js, or ' +
-      'a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) that is ' +
-      'compatible with Node 9 and above.\n'));
+    'WARNING: You are likely using a version of node-tar or npm that ' +
+    'is incompatible with this version of Node.js.' + os.EOL +
+    'Please use either the version of npm that is bundled with Node.js, or ' +
+    'a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) that is ' +
+    'compatible with Node.js 9 and above.' + os.EOL));
 }

--- a/test/abort/test-zlib-invalid-internals-usage.js
+++ b/test/abort/test-zlib-invalid-internals-usage.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  // This is the heart of the test.
+  new (process.binding('zlib').Zlib)(0).init(1, 2, 3, 4, 5);
+} else {
+  const child = cp.spawnSync(`${process.execPath}`, [`${__filename}`, 'child']);
+  const stderr = child.stderr.toString();
+
+  assert.strictEqual(child.stdout.toString(), '');
+  assert.ok(child.stderr.includes(
+      'WARNING: You are likely using a version of node-tar or npm that uses ' +
+      'the internals of Node.js in an invalid way.\n' +
+      'Please use either the version of npm that is bundled with Node.js, or ' +
+      'a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) that is ' +
+      'compatible with Node 9 and above.\n'));
+}


### PR DESCRIPTION
I realize this is a pretty unusual patch but it might make sense to do this given that a lot of people running into #16649 might not understand what is happening or how to fix it.

Refs: https://github.com/nodejs/node/issues/16649
Refs: https://github.com/nodejs/node/issues/14161

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

zlib