### PR TITLE
[v8.x] https: revert "refactor to use http internals"

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -25,13 +25,8 @@ require('internal/util').assertCrypto();
 
 const tls = require('tls');
 const url = require('url');
+const http = require('http');
 const util = require('util');
-const { Agent: HttpAgent } = require('_http_agent');
-const {
-  Server: HttpServer,
-  _connectionListener
-} = require('_http_server');
-const { ClientRequest } = require('_http_client');
 const { inherits } = util;
 const debug = util.debuglog('https');
 const { urlToOptions, searchParamsSymbol } = require('internal/url');
@@ -56,7 +51,7 @@ function Server(opts, requestListener) {
     opts.ALPNProtocols = ['http/1.1'];
   }
 
-  tls.Server.call(this, opts, _connectionListener);
+  tls.Server.call(this, opts, http._connectionListener);
 
   this.httpAllowHalfOpen = false;
 
@@ -73,12 +68,13 @@ function Server(opts, requestListener) {
   this.keepAliveTimeout = 5000;
 }
 inherits(Server, tls.Server);
+exports.Server = Server;
 
-Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
+Server.prototype.setTimeout = http.Server.prototype.setTimeout;
 
-function createServer(opts, requestListener) {
+exports.createServer = function createServer(opts, requestListener) {
   return new Server(opts, requestListener);
-}
+};
 
 
 // HTTPS agents.
@@ -133,7 +129,7 @@ function Agent(options) {
   if (!(this instanceof Agent))
     return new Agent(options);
 
-  HttpAgent.call(this, options);
+  http.Agent.call(this, options);
   this.defaultPort = 443;
   this.protocol = 'https:';
   this.maxCachedSessions = this.options.maxCachedSessions;
@@ -145,11 +141,11 @@ function Agent(options) {
     list: []
   };
 }
-inherits(Agent, HttpAgent);
+inherits(Agent, http.Agent);
 Agent.prototype.createConnection = createConnection;
 
 Agent.prototype.getName = function getName(options) {
-  var name = HttpAgent.prototype.getName.call(this, options);
+  var name = http.Agent.prototype.getName.call(this, options);
 
   name += ':';
   if (options.ca)
@@ -223,7 +219,10 @@ Agent.prototype._evictSession = function _evictSession(key) {
 
 const globalAgent = new Agent();
 
-function request(options, cb) {
+exports.globalAgent = globalAgent;
+exports.Agent = Agent;
+
+exports.request = function request(options, cb) {
   if (typeof options === 'string') {
     options = url.parse(options);
     if (!options.hostname) {
@@ -237,20 +236,11 @@ function request(options, cb) {
     options = util._extend({}, options);
   }
   options._defaultAgent = globalAgent;
-  return new ClientRequest(options, cb);
-}
+  return http.request(options, cb);
+};
 
-function get(options, cb) {
-  const req = request(options, cb);
+exports.get = function get(options, cb) {
+  var req = exports.request(options, cb);
   req.end();
   return req;
-}
-
-module.exports = {
-  Agent,
-  globalAgent,
-  Server,
-  createServer,
-  get,
-  request
 };


### PR DESCRIPTION
This reverts commit 5118f3146 on the v8.x release line

It is breaking code in the wild that depends on the original behavior
to do tracing.

I don't think we need to necessarily fix this in 9.x but we might want
to reclassify the original commit as Semver Major

Refs: https://github.com/nodejs/node/pull/16395

/cc @nodejs/lts @bengl  @gibfahn @ofrobots