### PR TITLE
tools: auto fix custom eslint rule for buffer-constructor.js

### DIFF
--- a/test/parallel/test-eslint-buffer-constructor.js
+++ b/test/parallel/test-eslint-buffer-constructor.js
@@ -11,7 +11,12 @@ const message = 'Use of the Buffer() constructor has been deprecated. ' +
 
 new RuleTester().run('buffer-constructor', rule, {
   valid: [
-    'Buffer.from(foo)'
+    'Buffer.from(foo)',
+    'Buffer.from(foo, bar)',
+    'Buffer.alloc(foo)',
+    'Buffer.alloc(foo, bar)',
+    'Buffer.allocUnsafe(foo)',
+    'Buffer.allocUnsafe(foo, bar)'
   ],
   invalid: [
     {
@@ -19,7 +24,15 @@ new RuleTester().run('buffer-constructor', rule, {
       errors: [{ message }]
     },
     {
+      code: 'Buffer(foo, bar)',
+      errors: [{ message }]
+    },
+    {
       code: 'new Buffer(foo)',
+      errors: [{ message }]
+    },
+    {
+      code: 'new Buffer(foo, bar)',
       errors: [{ message }]
     }
   ]

--- a/test/parallel/test-eslint-buffer-constructor.js
+++ b/test/parallel/test-eslint-buffer-constructor.js
@@ -21,19 +21,23 @@ new RuleTester().run('buffer-constructor', rule, {
   invalid: [
     {
       code: 'Buffer(foo)',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: 'Buffer.from(foo)'
     },
     {
       code: 'Buffer(foo, bar)',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: 'Buffer.from(foo, bar)'
     },
     {
       code: 'new Buffer(foo)',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: 'Buffer.from(foo)'
     },
     {
       code: 'new Buffer(foo, bar)',
-      errors: [{ message }]
+      errors: [{ message }],
+      output: 'Buffer.from(foo, bar)'
     }
   ]
 });

--- a/tools/eslint-rules/buffer-constructor.js
+++ b/tools/eslint-rules/buffer-constructor.js
@@ -13,7 +13,22 @@ const msg = 'Use of the Buffer() constructor has been deprecated. ' +
 
 function test(context, node) {
   if (node.callee.name === 'Buffer') {
-    context.report(node, msg);
+    const sourceCode = context.getSourceCode();
+    const argumentList = [];
+    node.arguments.forEach((argumentNode) => {
+      argumentList.push(sourceCode.getText(argumentNode));
+    });
+
+    context.report({
+      node,
+      message: msg,
+      fix: (fixer) => {
+        return fixer.replaceText(
+          node,
+          `Buffer.from(${argumentList.join(', ')})`
+        );
+      }
+    });
   }
 }
 


### PR DESCRIPTION
This implements an es-lint fixer method to fix the usage of Deprecated Buffer() constructor.

Also adds some more test cases to the eslint rule.

Refs: https://github.com/nodejs/node/issues/16636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
Tools
