### PR TITLE
tools: auto fix custom eslint rule for no-unescaped-regexp-dot

### DIFF
--- a/test/parallel/test-eslint-no-unescaped-regexp-dot.js
+++ b/test/parallel/test-eslint-no-unescaped-regexp-dot.js
@@ -13,26 +13,18 @@ new RuleTester().run('no-unescaped-regexp-dot', rule, {
     '/.*/',
     '/.?/',
     '/.{5}/',
-    String.raw`/\\\./`,
-    RegExp(/^\.$/),
-    RegExp(/^.+$/),
-    RegExp(/^\\\.$/),
+    String.raw`/\\\./`
   ],
   invalid: [
     {
-      code: '/./',
+      code: String.raw`/./`,
       errors: [{ message: 'Unescaped dot character in regular expression' }],
-      output: '/\\./'
+      output: String.raw`/\./`
     },
     {
       code: String.raw`/\\./`,
       errors: [{ message: 'Unescaped dot character in regular expression' }],
-      output: String.raw`/\./`,
-    },
-    {
-      code: 'RegExp(/^\\.$/)',
-      errors: [{ message: 'Unescaped dot character in regular expression' }],
-      output: RegExp(/^\.$/),
+      output: String.raw`/\./`
     }
   ]
 });

--- a/test/parallel/test-eslint-no-unescaped-regexp-dot.js
+++ b/test/parallel/test-eslint-no-unescaped-regexp-dot.js
@@ -13,16 +13,26 @@ new RuleTester().run('no-unescaped-regexp-dot', rule, {
     '/.*/',
     '/.?/',
     '/.{5}/',
-    String.raw`/\\\./`
+    String.raw`/\\\./`,
+    RegExp(/^\.$/),
+    RegExp(/^.+$/),
+    RegExp(/^\\\.$/),
   ],
   invalid: [
     {
       code: '/./',
-      errors: [{ message: 'Unescaped dot character in regular expression' }]
+      errors: [{ message: 'Unescaped dot character in regular expression' }],
+      output: '/\\./'
     },
     {
       code: String.raw`/\\./`,
-      errors: [{ message: 'Unescaped dot character in regular expression' }]
+      errors: [{ message: 'Unescaped dot character in regular expression' }],
+      output: String.raw`/\./`,
+    },
+    {
+      code: 'RegExp(/^\\.$/)',
+      errors: [{ message: 'Unescaped dot character in regular expression' }],
+      output: RegExp(/^\.$/),
     }
   ]
 });

--- a/test/parallel/test-eslint-no-unescaped-regexp-dot.js
+++ b/test/parallel/test-eslint-no-unescaped-regexp-dot.js
@@ -13,7 +13,8 @@ new RuleTester().run('no-unescaped-regexp-dot', rule, {
     '/.*/',
     '/.?/',
     '/.{5}/',
-    String.raw`/\\\./`
+    String.raw`/\\\./`,
+    String.raw`/\\\\\./`
   ],
   invalid: [
     {
@@ -24,7 +25,12 @@ new RuleTester().run('no-unescaped-regexp-dot', rule, {
     {
       code: String.raw`/\\./`,
       errors: [{ message: 'Unescaped dot character in regular expression' }],
-      output: String.raw`/\./`
+      output: String.raw`/\\\./`
+    },
+    {
+      code: String.raw`/\\\\./`,
+      errors: [{ message: 'Unescaped dot character in regular expression' }],
+      output: String.raw`/\\\\\./`
     }
   ]
 });

--- a/tools/eslint-rules/no-unescaped-regexp-dot.js
+++ b/tools/eslint-rules/no-unescaped-regexp-dot.js
@@ -16,10 +16,29 @@ module.exports = function(context) {
 
   function report(node, startOffset) {
     const indexOfDot = sourceCode.getIndexFromLoc(node.loc.start) + startOffset;
+    const expression = sourceCode.getText(node);
+    const dotOffset = expression.indexOf('.');
+    var correctedExpression = '';
+
+    if (expression.charAt(dotOffset - 1) === '\\') {
+      correctedExpression = expression.slice(0, dotOffset - 1) +
+                            expression.slice(dotOffset);
+    } else {
+      correctedExpression = expression.slice(0, dotOffset) +
+                            '\\' +
+                            expression.slice(dotOffset);
+    }
+
     context.report({
       node,
       loc: sourceCode.getLocFromIndex(indexOfDot),
-      message: 'Unescaped dot character in regular expression'
+      message: 'Unescaped dot character in regular expression',
+      fix: (fixer) => {
+        return fixer.replaceText(
+          node,
+          correctedExpression
+        );
+      }
     });
   }
 

--- a/tools/eslint-rules/no-unescaped-regexp-dot.js
+++ b/tools/eslint-rules/no-unescaped-regexp-dot.js
@@ -16,24 +16,16 @@ module.exports = function(context) {
 
   function report(node, startOffset) {
     const indexOfDot = sourceCode.getIndexFromLoc(node.loc.start) + startOffset;
-    const expression = sourceCode.getText(node);
-    const dotOffset = expression.indexOf('.');
-    var correctedExpression = '';
-
-    if (expression.charAt(dotOffset - 1) === '\\') {
-      correctedExpression = expression.slice(0, dotOffset - 1) +
-                            expression.slice(dotOffset);
-    } else {
-      correctedExpression = expression.slice(0, dotOffset) +
-                            '\\' +
-                            expression.slice(dotOffset);
-    }
-
     context.report({
       node,
       loc: sourceCode.getLocFromIndex(indexOfDot),
       message: 'Unescaped dot character in regular expression',
       fix: (fixer) => {
+        const expression = sourceCode.getText(node);
+        const dotOffset = expression.indexOf('.');
+        const correctedExpression = expression.slice(0, dotOffset) +
+                                    '\\' +
+                                    expression.slice(dotOffset);
         return fixer.replaceText(
           node,
           correctedExpression


### PR DESCRIPTION
1. Added fixer method for resolving lint error.
2. Added additional valid tests + Output for current and new invalid tests.

Refs: #16636

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
Tools
