### PR TITLE
loader, docs, test: named exports from commonjs modules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -86,14 +86,13 @@ or fragment string differs between `import` statements.
 CommonJS modules, when imported, will be handled in one of two ways. By default
 they will provide a single `default` export representing the value of
 `module.exports` at the time they finish evaluating. However, they may also
-provide `__esModule` as per
-[babel spec](https://babeljs.io/docs/plugins/transform-es2015-modules-commonjs)
-to use named exports, representing each enumerable key of `module.exports` at
-the time they finish evaluating.
-In both cases, this should be thought of  like a "snapshot" of the exports at
-the time of importing; asynchronously modifying `module.exports` will not
-affect the values of the exports. Builtin libraries such as `fs` are provided
-with named exports as if they were using `__esModule`
+provide `@@esModule` or `__esModule` to use named exports, representing each
+enumerable key of `module.exports` at the time they finish evaluating.
+`@@esModule` is available as `require('module').esModule` and prefered over
+`__esModule` In both cases, this should be thought of  like a "snapshot" of
+the exports at the time of importing; asynchronously modifying `module.exports`
+will not affect the values of the exports. Builtin libraries are provided with
+named exports as if they were using `@@esModule`.
 
 ```js
 import { readFile } from 'fs';
@@ -111,8 +110,9 @@ readFile('./foo.txt', (err, body) => {
 import { part } from './other.js';
 
 // other.js
+import { esModule } from 'module';
 exports.part = () => {};
-exports.__esModule = true;
+exports[esModule] = true;
 ```
 
 ## Loader hooks

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -85,13 +85,15 @@ or fragment string differs between `import` statements.
 
 CommonJS modules, when imported, will be handled in one of two ways. By default
 they will provide a single `default` export representing the value of
-`module.exports` at the time they finish evaluating. However, they may also
-provide `@@esModuleInterop` or `__esModule` to use named exports, representing
-each enumerable key of `module.exports` at the time they finish evaluating.
+`module.exports` at the time they finish evaluating.
+CJS modules may also provide a boolean `@@esModuleInterop` or `__esModule`
+export indicating that the enumerable keys of `module.exports` should be used
+as named exports.
 In both cases, this should be thought of  like a "snapshot" of the exports at
 the time of importing; asynchronously modifying `module.exports` will not
 affect the values of the exports. Builtin libraries are provided with named
 exports as if they were using `@@esModuleInterop`.
+
 
 ```js
 import { readFile } from 'fs';

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -83,8 +83,9 @@ All CommonJS, JSON, and C++ modules can be used with `import`.
 Modules loaded this way will only be loaded once, even if their query
 or fragment string differs between `import` statements.
 
-When loaded via `import` these modules will provide a single `default` export
-representing the value of `module.exports` at the time they finished evaluating.
+When loaded via `import` these modules will provide a `default` export
+representing the value of `module.exports` at the time they finished evaluating,
+and named exports for each key of `module.exports`.
 
 ```js
 import fs from 'fs';
@@ -95,6 +96,11 @@ fs.readFile('./foo.txt', (err, body) => {
     console.log(body);
   }
 });
+```
+
+```js
+import { readFileSync } from 'fs';
+console.log(readFileSync('./foo.txt').toString());
 ```
 
 ## Loader hooks

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -95,7 +95,8 @@ as named exports.
 In both cases, this should be thought of  like a "snapshot" of the exports at
 the time of importing; asynchronously modifying `module.exports` will not
 affect the values of the exports. Builtin libraries are provided with named
-exports as if they were using `@@esModuleInterop`.
+exports as if they were using `@@esModuleInterop`, as well as the
+`module.exports` of the builtin provided as the `default` export.
 
 
 ```js

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -83,6 +83,9 @@ All CommonJS, JSON, and C++ modules can be used with `import`.
 Modules loaded this way will only be loaded once, even if their query
 or fragment string differs between `import` statements.
 
+JSON and C++ addon modules will provide a single `default` export representing
+the value of `module.exports` at the time they finish evaluating.
+
 CommonJS modules, when imported, will be handled in one of two ways. By default
 they will provide a single `default` export representing the value of
 `module.exports` at the time they finish evaluating.

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -83,13 +83,21 @@ All CommonJS, JSON, and C++ modules can be used with `import`.
 Modules loaded this way will only be loaded once, even if their query
 or fragment string differs between `import` statements.
 
-When loaded via `import` these modules will provide a `default` export
-representing the value of `module.exports` at the time they finished evaluating,
-and named exports for each key of `module.exports`.
+CommonJS modules, when imported, will be handled in one of two ways. By default
+they will provide a single `default` export representing the value of
+`module.exports` at the time they finish evaluating. However, they may also
+provide `__esModule` as per
+[babel spec](https://babeljs.io/docs/plugins/transform-es2015-modules-commonjs)
+to use named exports, representing each enumerable key of `module.exports` at
+the time they finish evaluating.
+In both cases, this should be thought of  like a "snapshot" of the exports at
+the time of importing; asynchronously modifying `module.exports` will not
+affect the values of the exports. Builtin libraries such as `fs` are provided
+with named exports as if they were using `__esModule`
 
 ```js
-import fs from 'fs';
-fs.readFile('./foo.txt', (err, body) => {
+import { readFile } from 'fs';
+readFile('./foo.txt', (err, body) => {
   if (err) {
     console.error(err);
   } else {
@@ -99,8 +107,12 @@ fs.readFile('./foo.txt', (err, body) => {
 ```
 
 ```js
-import { readFileSync } from 'fs';
-console.log(readFileSync('./foo.txt').toString());
+// main.mjs
+import { part } from './other.js';
+
+// other.js
+exports.part = () => {};
+exports.__esModule = true;
 ```
 
 ## Loader hooks

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -86,13 +86,12 @@ or fragment string differs between `import` statements.
 CommonJS modules, when imported, will be handled in one of two ways. By default
 they will provide a single `default` export representing the value of
 `module.exports` at the time they finish evaluating. However, they may also
-provide `@@esModule` or `__esModule` to use named exports, representing each
-enumerable key of `module.exports` at the time they finish evaluating.
-`@@esModule` is available as `require('module').esModule` and prefered over
-`__esModule` In both cases, this should be thought of  like a "snapshot" of
-the exports at the time of importing; asynchronously modifying `module.exports`
-will not affect the values of the exports. Builtin libraries are provided with
-named exports as if they were using `@@esModule`.
+provide `@@esModuleInterop` or `__esModule` to use named exports, representing
+each enumerable key of `module.exports` at the time they finish evaluating.
+In both cases, this should be thought of  like a "snapshot" of the exports at
+the time of importing; asynchronously modifying `module.exports` will not
+affect the values of the exports. Builtin libraries are provided with named
+exports as if they were using `@@esModuleInterop`.
 
 ```js
 import { readFile } from 'fs';
@@ -110,9 +109,8 @@ readFile('./foo.txt', (err, body) => {
 import { part } from './other.js';
 
 // other.js
-import { esModule } from 'module';
 exports.part = () => {};
-exports[esModule] = true;
+exports[Symbol.for('esModuleInterop')] = true;
 ```
 
 ## Loader hooks

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -19,9 +19,6 @@ const search = require('internal/loader/search');
 const asyncReadFile = require('util').promisify(require('fs').readFile);
 const debug = require('util').debuglog('esm');
 
-const hasOwnProperty =
-  Function.prototype.call.bind(Object.prototype.hasOwnProperty);
-
 const esModuleInterop = Symbol.for('esModuleInterop');
 
 const realpathCache = new Map();
@@ -45,7 +42,7 @@ loaders.set('cjs', async (url) => {
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const es = hasOwnProperty(exports, esModuleInterop) ?
+  const es = exports[esModuleProp] !== undefined ?
     exports[esModuleInterop] : exports.__esModule;
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -37,8 +37,6 @@ loaders.set('esm', async (url) => {
 });
 
 // Strategy for loading a node-style CommonJS module
-// Uses babel and typescript style __esModule property for
-// attaching named imports due to the possiblity of `module.exports.default`
 loaders.set('cjs', async (url) => {
   debug(`Loading CJSModule ${url}`);
   const CJSModule = require('module');

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -19,6 +19,9 @@ const search = require('internal/loader/search');
 const asyncReadFile = require('util').promisify(require('fs').readFile);
 const debug = require('util').debuglog('esm');
 
+const hasOwnProperty =
+  Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+
 const esModuleInterop = Symbol.for('esModuleInterop');
 
 const realpathCache = new Map();
@@ -42,7 +45,8 @@ loaders.set('cjs', async (url) => {
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const es = Boolean(exports[esModuleInterop] || exports.__esModule);
+  const es = hasOwnProperty(exports, esModuleInterop) ?
+    exports[esModuleInterop] : exports.__esModule;
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {
     if (es) {
@@ -67,6 +71,9 @@ loaders.set('builtin', async (url) => {
   });
 });
 
+// Strategy for loading a native addon module
+// Named exports will not be parsed from these - see
+// https://github.com/nodejs/abi-stable-node/issues/256#issuecomment-325138872
 loaders.set('addon', async (url) => {
   const ctx = createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading NativeModule ${url}`);

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -35,15 +35,22 @@ loaders.set('esm', async (url) => {
 });
 
 // Strategy for loading a node-style CommonJS module
+// Uses babel and typescript style __esModule property for
+// attaching named imports due to the possiblity of `module.exports.default`
 loaders.set('cjs', async (url) => {
   debug(`Loading CJSModule ${url}`);
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const keys = Object.keys(exports);
-  return createDynamicModule(['default', ...keys], url, (reflect) => {
-    reflect.exports.default.set(exports);
-    for (const key of keys) reflect.exports[key].set(exports[key]);
+  const es = !!exports.__esModule;
+  const keys = es ? Object.keys(exports) : ['default'];
+  return createDynamicModule(keys, url, (reflect) => {
+    if (es) {
+      for (const key of keys)
+        reflect.exports[key].set(exports[key]);
+    } else {
+      reflect.exports.default.set(exports);
+    }
   });
 });
 
@@ -60,14 +67,12 @@ loaders.set('builtin', async (url) => {
 });
 
 loaders.set('addon', async (url) => {
-  debug(`Loading NativeModule ${url}`);
-  const module = { exports: {} };
-  const pathname = internalURLModule.getPathFromURL(new URL(url));
-  process.dlopen(module, _makeLong(pathname));
-  const keys = Object.keys(module.exports);
-  const ctx = createDynamicModule(['default', ...keys], url, (reflect) => {
+  const ctx = createDynamicModule(['default'], url, (reflect) => {
+    debug(`Loading NativeModule ${url}`);
+    const module = { exports: {} };
+    const pathname = internalURLModule.getPathFromURL(new URL(url));
+    process.dlopen(module, _makeLong(pathname));
     reflect.exports.default.set(module.exports);
-    for (const key of keys) reflect.exports[key].set(module.exports[key]);
   });
   return ctx;
 });

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -19,6 +19,8 @@ const search = require('internal/loader/search');
 const asyncReadFile = require('util').promisify(require('fs').readFile);
 const debug = require('util').debuglog('esm');
 
+const esModuleSymbol = exports.esModuleSymbol = Symbol('esModule');
+
 const realpathCache = new Map();
 
 const loaders = new Map();
@@ -42,7 +44,7 @@ loaders.set('cjs', async (url) => {
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const es = !!exports.__esModule;
+  const es = Boolean(exports[esModuleSymbol] || exports.__esModule);
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {
     if (es) {

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -36,31 +36,38 @@ loaders.set('esm', async (url) => {
 
 // Strategy for loading a node-style CommonJS module
 loaders.set('cjs', async (url) => {
-  return createDynamicModule(['default'], url, (reflect) => {
-    debug(`Loading CJSModule ${url}`);
-    const CJSModule = require('module');
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
-    CJSModule._load(pathname);
+  debug(`Loading CJSModule ${url}`);
+  const CJSModule = require('module');
+  const pathname = internalURLModule.getPathFromURL(new URL(url));
+  const exports = CJSModule._load(pathname);
+  const keys = Object.keys(exports);
+  return createDynamicModule(['default', ...keys], url, (reflect) => {
+    reflect.exports.default.set(exports);
+    for (const key of keys) reflect.exports[key].set(exports[key]);
   });
 });
 
 // Strategy for loading a node builtin CommonJS module that isn't
 // through normal resolution
 loaders.set('builtin', async (url) => {
-  return createDynamicModule(['default'], url, (reflect) => {
-    debug(`Loading BuiltinModule ${url}`);
-    const exports = NativeModule.require(url.substr(5));
+  debug(`Loading BuiltinModule ${url}`);
+  const exports = NativeModule.require(url.substr(5));
+  const keys = Object.keys(exports);
+  return createDynamicModule(['default', ...keys], url, (reflect) => {
     reflect.exports.default.set(exports);
+    for (const key of keys) reflect.exports[key].set(exports[key]);
   });
 });
 
 loaders.set('addon', async (url) => {
-  const ctx = createDynamicModule(['default'], url, (reflect) => {
-    debug(`Loading NativeModule ${url}`);
-    const module = { exports: {} };
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
-    process.dlopen(module, _makeLong(pathname));
+  debug(`Loading NativeModule ${url}`);
+  const module = { exports: {} };
+  const pathname = internalURLModule.getPathFromURL(new URL(url));
+  process.dlopen(module, _makeLong(pathname));
+  const keys = Object.keys(module.exports);
+  const ctx = createDynamicModule(['default', ...keys], url, (reflect) => {
     reflect.exports.default.set(module.exports);
+    for (const key of keys) reflect.exports[key].set(module.exports[key]);
   });
   return ctx;
 });

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -47,7 +47,7 @@ loaders.set('cjs', async (url) => {
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {
     if (es) {
-      for (let i = 0; i < keys.length; i++)
+      for (var i = 0; i < keys.length; i++)
         reflect.exports[keys[i]].set(exports[keys[i]]);
     } else {
       reflect.exports.default.set(exports);
@@ -63,7 +63,7 @@ loaders.set('builtin', async (url) => {
   const keys = Object.keys(exports);
   return createDynamicModule(['default', ...keys], url, (reflect) => {
     reflect.exports.default.set(exports);
-    for (let i = 0; i < keys.length; i++)
+    for (var i = 0; i < keys.length; i++)
       reflect.exports[keys[i]].set(exports[keys[i]]);
   });
 });

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -42,7 +42,7 @@ loaders.set('cjs', async (url) => {
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const es = exports[esModuleProp] !== undefined ?
+  const es = exports[esModuleInterop] !== undefined ?
     exports[esModuleInterop] : exports.__esModule;
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -19,7 +19,7 @@ const search = require('internal/loader/search');
 const asyncReadFile = require('util').promisify(require('fs').readFile);
 const debug = require('util').debuglog('esm');
 
-const esModuleSymbol = exports.esModuleSymbol = Symbol('esModule');
+const esModuleInterop = Symbol.for('esModuleInterop');
 
 const realpathCache = new Map();
 
@@ -42,12 +42,12 @@ loaders.set('cjs', async (url) => {
   const CJSModule = require('module');
   const pathname = internalURLModule.getPathFromURL(new URL(url));
   const exports = CJSModule._load(pathname);
-  const es = Boolean(exports[esModuleSymbol] || exports.__esModule);
+  const es = Boolean(exports[esModuleInterop] || exports.__esModule);
   const keys = es ? Object.keys(exports) : ['default'];
   return createDynamicModule(keys, url, (reflect) => {
     if (es) {
-      for (const key of keys)
-        reflect.exports[key].set(exports[key]);
+      for (let i = 0; i < keys.length; i++)
+        reflect.exports[keys[i]].set(exports[keys[i]]);
     } else {
       reflect.exports.default.set(exports);
     }
@@ -62,7 +62,8 @@ loaders.set('builtin', async (url) => {
   const keys = Object.keys(exports);
   return createDynamicModule(['default', ...keys], url, (reflect) => {
     reflect.exports.default.set(exports);
-    for (const key of keys) reflect.exports[key].set(exports[key]);
+    for (let i = 0; i < keys.length; i++)
+      reflect.exports[keys[i]].set(exports[keys[i]]);
   });
 });
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -42,7 +42,6 @@ const errors = require('internal/errors');
 const Loader = require('internal/loader/Loader');
 const ModuleJob = require('internal/loader/ModuleJob');
 const { createDynamicModule } = require('internal/loader/ModuleWrap');
-const { esModuleSymbol } = require('internal/loader/ModuleRequest');
 let ESMLoader;
 
 function stat(filename) {
@@ -80,7 +79,6 @@ Module._pathCache = Object.create(null);
 Module._extensions = Object.create(null);
 var modulePaths = [];
 Module.globalPaths = [];
-Module.esModule = esModuleSymbol;
 
 Module.wrap = function(script) {
   return Module.wrapper[0] + script + Module.wrapper[1];

--- a/lib/module.js
+++ b/lib/module.js
@@ -42,6 +42,7 @@ const errors = require('internal/errors');
 const Loader = require('internal/loader/Loader');
 const ModuleJob = require('internal/loader/ModuleJob');
 const { createDynamicModule } = require('internal/loader/ModuleWrap');
+const { esModuleSymbol } = require('internal/loader/ModuleRequest');
 let ESMLoader;
 
 function stat(filename) {
@@ -79,6 +80,7 @@ Module._pathCache = Object.create(null);
 Module._extensions = Object.create(null);
 var modulePaths = [];
 Module.globalPaths = [];
+Module.esModule = esModuleSymbol;
 
 Module.wrap = function(script) {
   return Module.wrapper[0] + script + Module.wrapper[1];

--- a/test/es-module/es-module.status
+++ b/test/es-module/es-module.status
@@ -5,3 +5,5 @@ prefix es-module
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+
+test-esm-esmoduleinterop-override       : FAIL

--- a/test/es-module/test-esm-cjs-esmodule.mjs
+++ b/test/es-module/test-esm-cjs-esmodule.mjs
@@ -2,7 +2,7 @@
 /* eslint-disable required-modules */
 
 import assert from 'assert';
-import eightyfour, { named as fourtytwo } from
+import eightyfour, { fourtytwo } from
   '../fixtures/es-module-loaders/babel-to-esm.js';
 
 assert.strictEqual(eightyfour, 84);

--- a/test/es-module/test-esm-cjs-esmodule.mjs
+++ b/test/es-module/test-esm-cjs-esmodule.mjs
@@ -1,0 +1,9 @@
+// Flags: --experimental-modules
+/* eslint-disable required-modules */
+
+import assert from 'assert';
+import eightyfour, { named as fourtytwo } from
+  '../fixtures/es-module-loaders/babel-to-esm.js';
+
+assert.strictEqual(eightyfour, 84);
+assert.strictEqual(fourtytwo, 42);

--- a/test/es-module/test-esm-esmoduleinterop-override.mjs
+++ b/test/es-module/test-esm-esmoduleinterop-override.mjs
@@ -1,0 +1,5 @@
+// Flags: --experimental-modules
+/* eslint-disable required-modules */
+
+import eightyfour, { named as fourtytwo }
+  from '../fixtures/es-module-loaders/babel-to-esm-override.js';

--- a/test/es-module/test-esm-esmoduleinterop-override.mjs
+++ b/test/es-module/test-esm-esmoduleinterop-override.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-modules
 /* eslint-disable required-modules */
 
-import eightyfour, { named as fourtytwo }
+import eightyfour, { fourtytwo }
   from '../fixtures/es-module-loaders/babel-to-esm-override.js';

--- a/test/es-module/test-esm-esmoduleinterop-override.mjs
+++ b/test/es-module/test-esm-esmoduleinterop-override.mjs
@@ -1,5 +1,6 @@
 // Flags: --experimental-modules
 /* eslint-disable required-modules */
 
+// eslint-disable-next-line no-unused-vars
 import eightyfour, { fourtytwo }
   from '../fixtures/es-module-loaders/babel-to-esm-override.js';

--- a/test/es-module/test-esm-namespace.mjs
+++ b/test/es-module/test-esm-namespace.mjs
@@ -1,7 +1,9 @@
 // Flags: --experimental-modules
 /* eslint-disable required-modules */
 
-import * as fs from 'fs';
 import assert from 'assert';
+import fs, { readFile } from 'fs';
 
-assert.deepStrictEqual(Object.keys(fs), ['default']);
+assert(fs);
+assert(fs.readFile);
+assert(readFile);

--- a/test/es-module/test-esm-namespace.mjs
+++ b/test/es-module/test-esm-namespace.mjs
@@ -3,7 +3,12 @@
 
 import assert from 'assert';
 import fs, { readFile } from 'fs';
+import main, { named } from
+  '../fixtures/es-module-loaders/cjs-to-es-namespace.js';
 
 assert(fs);
 assert(fs.readFile);
-assert(readFile);
+assert.strictEqual(fs.readFile, readFile);
+
+assert.strictEqual(main, 1);
+assert.strictEqual(named, true);

--- a/test/es-module/test-esm-namespace.mjs
+++ b/test/es-module/test-esm-namespace.mjs
@@ -10,5 +10,5 @@ assert(fs);
 assert(fs.readFile);
 assert.strictEqual(fs.readFile, readFile);
 
-assert.strictEqual(main, 1);
-assert.strictEqual(named, true);
+assert.strictEqual(main, 'default');
+assert.strictEqual(named, 'named');

--- a/test/es-module/test-reserved-keywords.mjs
+++ b/test/es-module/test-reserved-keywords.mjs
@@ -1,0 +1,8 @@
+// Flags: --experimental-modules
+/* eslint-disable required-modules */
+
+import assert from 'assert';
+import { delete as d } from
+  '../fixtures/es-module-loaders/reserved-keywords.js';
+
+assert(d);

--- a/test/es-module/test-reserved-keywords.mjs
+++ b/test/es-module/test-reserved-keywords.mjs
@@ -2,7 +2,7 @@
 /* eslint-disable required-modules */
 
 import assert from 'assert';
-import { delete as d } from
+import { enum as e } from
   '../fixtures/es-module-loaders/reserved-keywords.js';
 
-assert(d);
+assert(e);

--- a/test/fixtures/es-module-loaders/babel-to-esm-override.js
+++ b/test/fixtures/es-module-loaders/babel-to-esm-override.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/*
+created by babel with es2015 preset
+```
+export const named = 42;
+export default 84;
+```
+*/
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var named = exports.named = 42;
+exports.default = 84;
+
+// added after babel compile
+exports[Symbol.for('esModuleInterop')] = false

--- a/test/fixtures/es-module-loaders/babel-to-esm-override.js
+++ b/test/fixtures/es-module-loaders/babel-to-esm-override.js
@@ -3,7 +3,7 @@
 /*
 created by babel with es2015 preset
 ```
-export const named = 42;
+export const fourtytwo = 42;
 export default 84;
 ```
 */
@@ -11,7 +11,7 @@ export default 84;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var named = exports.named = 42;
+var fourtytwo = exports.fourtytwo = 42;
 exports.default = 84;
 
 // added after babel compile

--- a/test/fixtures/es-module-loaders/babel-to-esm.js
+++ b/test/fixtures/es-module-loaders/babel-to-esm.js
@@ -3,7 +3,7 @@
 /*
 created by babel with es2015 preset
 ```
-export const named = 42;
+export const fourtytwo = 42;
 export default 84;
 ```
 */
@@ -11,5 +11,5 @@ export default 84;
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var named = exports.named = 42;
+var fourtytwo = exports.fourtytwo = 42;
 exports.default = 84;

--- a/test/fixtures/es-module-loaders/babel-to-esm.js
+++ b/test/fixtures/es-module-loaders/babel-to-esm.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/*
+created by babel with es2015 preset
+```
+export const named = 42;
+export default 84;
+```
+*/
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var named = exports.named = 42;
+exports.default = 84;

--- a/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
+++ b/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
@@ -1,4 +1,6 @@
-exports.named = true;
-exports.default=  1;
+const { esModule } = require('module');
 
-Object.defineProperty(exports, '__esModule', { value: true });
+exports.named = true;
+exports.default = 1;
+
+exports[esModule] = true;

--- a/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
+++ b/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
@@ -1,4 +1,4 @@
-exports.named = true;
-exports.default = 1;
+exports.named = 'named';
+exports.default = 'default';
 
 exports[Symbol.for('esModuleInterop')] = true;

--- a/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
+++ b/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
@@ -1,6 +1,4 @@
-const { esModule } = require('module');
-
 exports.named = true;
 exports.default = 1;
 
-exports[esModule] = true;
+exports[Symbol.for('esModuleInterop')] = true;

--- a/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
+++ b/test/fixtures/es-module-loaders/cjs-to-es-namespace.js
@@ -1,0 +1,4 @@
+exports.named = true;
+exports.default=  1;
+
+Object.defineProperty(exports, '__esModule', { value: true });

--- a/test/fixtures/es-module-loaders/reserved-keywords.js
+++ b/test/fixtures/es-module-loaders/reserved-keywords.js
@@ -2,4 +2,5 @@ module.exports = {
   enum: 'enum',
   class: 'class',
   delete: 'delete',
+  __esModule: true,
 };

--- a/test/fixtures/es-module-loaders/reserved-keywords.js
+++ b/test/fixtures/es-module-loaders/reserved-keywords.js
@@ -1,6 +1,8 @@
+const { esModule } = require('module');
+
 module.exports = {
   enum: 'enum',
   class: 'class',
   delete: 'delete',
-  __esModule: true,
+  [esModule]: true,
 };

--- a/test/fixtures/es-module-loaders/reserved-keywords.js
+++ b/test/fixtures/es-module-loaders/reserved-keywords.js
@@ -1,0 +1,5 @@
+module.exports = {
+  enum: 'enum',
+  class: 'class',
+  delete: 'delete',
+};

--- a/test/fixtures/es-module-loaders/reserved-keywords.js
+++ b/test/fixtures/es-module-loaders/reserved-keywords.js
@@ -1,8 +1,6 @@
-const { esModule } = require('module');
-
 module.exports = {
   enum: 'enum',
   class: 'class',
   delete: 'delete',
-  [esModule]: true,
+  [Symbol.for('esModuleInterop')]: true,
 };


### PR DESCRIPTION
I know a lot of discussion went into the original decision on how mjs would handle cjs modules but after using the system for a while, and talking with a lot of other people in the community, it just seems like the expected behavior and the wanted behavior is to export named based on the keys. This PR implements that in what is hopefully a performant enough solution, although that shouldn't be too much of a problem since this code only runs during initial module loading.

This implementation remains safe with regard to named exports that are also reserved keywords such as `class` or `delete`.

EDIT: many changes to original impl, definitely read comments and file diff

Refs: https://github.com/nodejs/node-eps/issues/57
Refs: https://github.com/nodejs/abi-stable-node/issues/256#issuecomment-325138872

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
loader
