### PR TITLE
inspector: include node_platform.h header

### DIFF
--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -10,6 +10,7 @@
 #endif
 
 #include "node_debug_options.h"
+#include "node_platform.h"
 #include "v8.h"
 
 namespace v8_inspector {
@@ -19,7 +20,6 @@ class StringView;
 namespace node {
 // Forward declaration to break recursive dependency chain with src/env.h.
 class Environment;
-class NodePlatform;
 
 namespace inspector {
 


### PR DESCRIPTION
When Node.js is compiled as a part of the Electron build clang generates a couple of errors (see below). Including a header instead of using a forward declaration fixes them.
It would be great if the code could be changed in the Node.js repo so Electron wouldn't have to have a patch for that.

```
../../vendor/node/src/inspector_agent.cc:516:16: error: member access into incomplete type 'node::NodePlatform'
      platform_->FlushForegroundTasksInternal();
               ^
../../vendor/node/src/inspector_agent.h:19:7: note: forward declaration of 'node::NodePlatform'
class NodePlatform;
      ^
../../vendor/node/src/inspector_agent.cc:670:15: error: assigning to 'v8::Platform *' from incompatible type 'node::NodePlatform *'
  platform_ = platform;
              ^~~~~~~~
2 errors generated.
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
inspector