### PR TITLE
build: remove cctest extension

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -315,6 +315,11 @@
           'NODE_OPENSSL_SYSTEM_CERT_PATH="<(openssl_system_ca_path)"',
         ],
       },
+      'conditions': [
+        [ 'node_shared=="true" and node_module_version!="" and OS!="win"', {
+          'product_extension': '<(shlib_suffix)',
+        }]
+      ],
     },
     {
       'target_name': 'mkssldef',

--- a/node.gypi
+++ b/node.gypi
@@ -11,11 +11,6 @@
       'defines': [
         'NODE_SHARED_MODE',
       ],
-      'conditions': [
-        [ 'node_module_version!="" and OS!="win"', {
-          'product_extension': '<(shlib_suffix)',
-        }]
-      ],
     }],
     [ 'node_enable_d8=="true"', {
       'dependencies': [ 'deps/v8/src/d8.gyp:d8' ],


### PR DESCRIPTION
cctest appends `so.59` when building node shared library in linux.
The appending is defined in  node.gypi and the cctest target in node.gyp
includes node.gypi. Moving the appending from node.gypi to node target
in node.gyp fix the issue.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
