### PR TITLE
src: Remove unused __init_cwd() and INITIAL_CWD.

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -285,25 +285,6 @@ MaybeLocal<Module> ModuleWrap::ResolveCallback(Local<Context> context,
 
 namespace {
 
-URL __init_cwd() {
-  std::string specifier = "file://";
-#ifdef _WIN32
-  // MAX_PATH is in characters, not bytes. Make sure we have enough headroom.
-  char buf[MAX_PATH * 4];
-#else
-  char buf[PATH_MAX];
-#endif
-
-  size_t cwd_len = sizeof(buf);
-  int err = uv_cwd(buf, &cwd_len);
-  if (err) {
-    return URL("");
-  }
-  specifier += buf;
-  specifier += "/";
-  return URL(specifier);
-}
-static URL INITIAL_CWD(__init_cwd());
 inline bool is_relative_or_absolute_path(std::string specifier) {
   auto len = specifier.length();
   if (len <= 0) {


### PR DESCRIPTION
This function and object are not used in any other code in the source
tree. Their presence causes the build on CloudABI to fail, due to it not
providing a global filesystem namespace to begin with.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src