### PR TITLE
test: make debugging of inspector-port-zero easier

### DIFF
--- a/test/sequential/test-inspector-port-zero.js
+++ b/test/sequential/test-inspector-port-zero.js
@@ -34,7 +34,10 @@ function test(arg, port = '') {
     };
     proc.stdout.on('close', mustCall(() => onclose()));
     proc.stderr.on('close', mustCall(() => onclose()));
-    proc.on('exit', mustCall((exitCode) => assert.strictEqual(exitCode, 0)));
+    proc.on('exit', mustCall((exitCode, signal) => assert.strictEqual(
+      exitCode,
+      0,
+      `exitCode: ${exitCode}, signal: ${signal}`)));
   }
 }
 


### PR DESCRIPTION
If the process was killed, then the exit code will be null, in which
case knowing the signal is really helpful.

Adding this because it failed for me with `exitCode` null, which isn't very helpful.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test