### PR TITLE
build: add a OFFLINE var to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ COVTESTS ?= test-cov
 GTEST_FILTER ?= "*"
 GNUMAKEFLAGS += --no-print-directory
 GCOV ?= gcov
+OFFLINE ?= false
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)
@@ -976,17 +977,21 @@ lint-md-clean:
 	$(RM) -r tools/remark-preset-lint-node/node_modules
 
 lint-md-build:
+ifeq ($(OFFLINE),false)
 	@if [ ! -d tools/remark-cli/node_modules ]; then \
 		echo "Markdown linter: installing remark-cli into tools/"; \
 		cd tools/remark-cli && ../../$(NODE) ../../$(NPM) install; fi
 	@if [ ! -d tools/remark-preset-lint-node/node_modules ]; then \
 		echo "Markdown linter: installing remark-preset-lint-node into tools/"; \
 		cd tools/remark-preset-lint-node && ../../$(NODE) ../../$(NPM) install; fi
+endif
 
 lint-md: lint-md-build
+ifeq ($(OFFLINE),false)
 	@echo "Running Markdown linter..."
 	$(NODE) tools/remark-cli/cli.js -q -f \
 		./*.md doc src lib benchmark tools/doc/ tools/icu/
+endif
 
 LINT_JS_TARGETS = benchmark doc lib test tools
 LINT_JS_CMD = tools/eslint/bin/eslint.js --cache \


### PR DESCRIPTION
We have a build environment that restricts our internet connection and
currently building fails due to the lint-md target needs to be able to
install npm modules.

This commit suggests adding a OFFLINE variable to the Makefile which
can be used like in the following examples:
```console
$ env OFFLINE=true make -j8 test
```
```console
$ make -j8 test OFFLINE=true
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build