### PR TITLE
lib: make require.resolve.length = 1 to match docs

### DIFF
--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -14,7 +14,7 @@ function makeRequireFunction(mod) {
     }
   }
 
-  function resolve(request, options) {
+  function resolve(request, options = null) {
     return Module._resolveFilename(request, mod, false, options);
   }
 

--- a/test/parallel/test-require-resolve.js
+++ b/test/parallel/test-require-resolve.js
@@ -24,6 +24,7 @@ require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
+assert.strictEqual(require.resolve.length, 1);
 assert.strictEqual(
   fixtures.path('a.js').toLowerCase(),
   require.resolve(fixtures.path('a')).toLowerCase());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/16687

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
lib