### PR TITLE
fs: fix stat dev unsigned cast overflow

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -438,27 +438,6 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   // We need to check the return value of Number::New() and Date::New()
   // and make sure that we bail out when V8 returns an empty handle.
 
-  // Unsigned integers. It does not actually seem to be specified whether
-  // uid and gid are unsigned or not, but in practice they are unsigned,
-  // and Node’s (F)Chown functions do check their arguments for unsignedness.
-#define X(name)                                                               \
-  Local<Value> name = Integer::NewFromUnsigned(env->isolate(), s->st_##name); \
-  if (name.IsEmpty())                                                         \
-    return Local<Object>();                                                   \
-
-  X(uid)
-  X(gid)
-# if defined(__POSIX__)
-  X(blksize)
-# else
-  Local<Value> blksize = Undefined(env->isolate());
-# endif
-  X(dev)
-  X(mode)
-  X(nlink)
-  X(rdev)
-#undef X
-
   // Numbers.
 #define X(name)                                                               \
   Local<Value> name = Number::New(env->isolate(),                             \
@@ -466,11 +445,19 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
   if (name.IsEmpty())                                                         \
     return Local<Object>();                                                   \
 
+  X(uid)
+  X(gid)
   X(ino)
   X(size)
+  X(dev)
+  X(mode)
+  X(nlink)
+  X(rdev)
 # if defined(__POSIX__)
+  X(blksize)
   X(blocks)
 # else
+  Local<Value> blksize = Undefined(env->isolate());
   Local<Value> blocks = Undefined(env->isolate());
 # endif
 #undef X

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -453,14 +453,6 @@ Local<Value> BuildStatsObject(Environment* env, const uv_stat_t* s) {
 # else
   Local<Value> blksize = Undefined(env->isolate());
 # endif
-#undef X
-
-  // Integers.
-#define X(name)                                                               \
-  Local<Value> name = Integer::New(env->isolate(), s->st_##name);             \
-  if (name.IsEmpty())                                                         \
-    return Local<Object>();                                                   \
-
   X(dev)
   X(mode)
   X(nlink)


### PR DESCRIPTION
The `dev_t` is unsigned on Linux, use Integer::NewFromUnsigned to fix cast overflow

Fixes: https://github.com/nodejs/node/issues/16496

Closes #16667 since this PR is a Semver-Patch alternatives regarding to #16496 only.

According to the linux headers, (http://elixir.free-electrons.com/linux/v4.13.11/source/include/linux/types.h#L15, http://elixir.free-electrons.com/linux/v4.13.11/source/include/uapi/asm-generic/posix_types.h#L23), both `dev_t`, `mode_t`, `nlink_t` are unsigned. Using `Integer::NewFromUnsigned` is more appropriate.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs
