### PR TITLE
test: fix test-cli-node-options on Windows

### DIFF
--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -34,7 +34,7 @@ if (common.hasCrypto) {
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
 expect('--stack-trace-limit=100',
-       /(\s*at f \(\[eval\]:1:\d*\)\n){100}/,
+       /(\s*at f \(\[eval\]:1:\d*\)\r?\n){100}/,
        '(function f() { f(); })();',
        true);
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/16495 broke the Windows build, accounting for `\r\n` newlines should fix it.

Ref: https://github.com/nodejs/node/pull/16495

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

cli