### PR TITLE
http2: improve errors thrown in header validation

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -837,7 +837,7 @@ requests and responses.
 <a id="ERR_HTTP2_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP2_INVALID_HEADER_VALUE
 
-Used to indicate that an invalid HTTP/2 header value has been specified.
+Used to indicate that an invalid HTTP2 header value has been specified.
 
 <a id="ERR_HTTP2_INVALID_INFO_STATUS"></a>
 ### ERR_HTTP2_INVALID_INFO_STATUS

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -280,7 +280,7 @@ E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
   'Informational status codes cannot be used');
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
   'HTTP/1 Connection specific headers are forbidden: "%s"');
-E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Value must not be undefined or null');
+E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Invalid value "%s" for header "%s"');
 E('ERR_HTTP2_INVALID_INFO_STATUS',
   (code) => `Invalid informational status code: ${code}`);
 E('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -40,12 +40,18 @@ let statusMessageWarned = false;
 // close as possible to the current require('http') API
 
 function assertValidHeader(name, value) {
-  if (name === '' || typeof name !== 'string')
-    throw new errors.TypeError('ERR_INVALID_HTTP_TOKEN', 'Header name', name);
-  if (isPseudoHeader(name))
-    throw new errors.Error('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED');
-  if (value === undefined || value === null)
-    throw new errors.TypeError('ERR_HTTP2_INVALID_HEADER_VALUE');
+  let err;
+  if (name === '' || typeof name !== 'string') {
+    err = new errors.TypeError('ERR_INVALID_HTTP_TOKEN', 'Header name', name);
+  } else if (isPseudoHeader(name)) {
+    err = new errors.Error('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED');
+  } else if (value === undefined || value === null) {
+    err = new errors.TypeError('ERR_HTTP2_INVALID_HEADER_VALUE', value, name);
+  }
+  if (err !== undefined) {
+    Error.captureStackTrace(err, assertValidHeader);
+    throw err;
+  }
 }
 
 function isPseudoHeader(name) {

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -85,14 +85,14 @@ server.listen(0, common.mustCall(function() {
     }, common.expectsError({
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       type: TypeError,
-      message: 'Value must not be undefined or null'
+      message: 'Invalid value "null" for header "foo-bar"'
     }));
     assert.throws(function() {
       response.setHeader(real, undefined);
     }, common.expectsError({
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       type: TypeError,
-      message: 'Value must not be undefined or null'
+      message: 'Invalid value "undefined" for header "foo-bar"'
     }));
     common.expectsError(
       () => response.setHeader(), // header name undefined

--- a/test/parallel/test-http2-compat-serverresponse-trailers.js
+++ b/test/parallel/test-http2-compat-serverresponse-trailers.js
@@ -28,7 +28,7 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
         type: TypeError,
-        message: 'Value must not be undefined or null'
+        message: 'Invalid value "undefined" for header "test"'
       }
     );
     common.expectsError(
@@ -36,7 +36,7 @@ server.listen(0, common.mustCall(() => {
       {
         code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
         type: TypeError,
-        message: 'Value must not be undefined or null'
+        message: 'Invalid value "null" for header "test"'
       }
     );
     common.expectsError(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Previously https://github.com/nodejs/node/pull/16715

This PR:

- Include the header name and the value in `ERR_HTTP2_INVALID_HEADER_VALUE` for debug-ability as https://github.com/nodejs/node/issues/16714 suggests. Before it's `Value must not be undefined or null`, after it's `Invalid value "undefined" for header "test"`. If the user is setting the header in a loop this would be much more useful.
- Use `Error.captureStackTrace` to exclude the validation functions from the stack trace

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2