### PR TITLE
http: improve errors thrown in header validation

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -754,6 +754,11 @@ more headers.
 Used when an invalid character is found in an HTTP response status message
 (reason phrase).
 
+<a id="ERR_HTTP_INVALID_HEADER_VALUE"></a>
+### ERR_HTTP_INVALID_HEADER_VALUE
+
+Used to indicate that an invalid HTTP header value has been specified.
+
 <a id="ERR_HTTP_INVALID_STATUS_CODE"></a>
 ### ERR_HTTP_INVALID_STATUS_CODE
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -437,16 +437,7 @@ function _storeHeader(firstLine, headers) {
 
 function storeHeader(self, state, key, value, validate) {
   if (validate) {
-    if (typeof key !== 'string' || !key || !checkIsHttpToken(key)) {
-      throw new errors.TypeError(
-        'ERR_INVALID_HTTP_TOKEN', 'Header name', key);
-    }
-    if (value === undefined) {
-      throw new errors.TypeError('ERR_MISSING_ARGS', `header "${key}"`);
-    } else if (checkInvalidHeaderChar(value)) {
-      debug('Header "%s" contains invalid characters', key);
-      throw new errors.TypeError('ERR_INVALID_CHAR', 'header content', key);
-    }
+    validateHeader(key, value);
   }
   state.header += key + ': ' + escapeHeaderValue(value) + CRLF;
   matchHeader(self, state, key, value);
@@ -494,20 +485,27 @@ function matchHeader(self, state, field, value) {
   }
 }
 
-function validateHeader(msg, name, value) {
-  if (typeof name !== 'string' || !name || !checkIsHttpToken(name))
-    throw new errors.TypeError('ERR_INVALID_HTTP_TOKEN', 'Header name', name);
-  if (value === undefined)
-    throw new errors.TypeError('ERR_MISSING_ARGS', 'value');
-  if (msg._header)
-    throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'set');
-  if (checkInvalidHeaderChar(value)) {
+function validateHeader(name, value) {
+  let err;
+  if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
+    err = new errors.TypeError('ERR_INVALID_HTTP_TOKEN', 'Header name', name);
+  } else if (value === undefined) {
+    err = new errors.TypeError('ERR_HTTP_INVALID_HEADER_VALUE', value, name);
+  } else if (checkInvalidHeaderChar(value)) {
     debug('Header "%s" contains invalid characters', name);
-    throw new errors.TypeError('ERR_INVALID_CHAR', 'header content', name);
+    err = new errors.TypeError('ERR_INVALID_CHAR', 'header content', name);
+  }
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validateHeader);
+    throw err;
   }
 }
+
 OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
-  validateHeader(this, name, value);
+  if (this._header) {
+    throw new errors.Error('ERR_HTTP_HEADERS_SENT', 'set');
+  }
+  validateHeader(name, value);
 
   if (!this[outHeadersKey])
     this[outHeadersKey] = {};

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -317,6 +317,7 @@ E('ERR_HTTP2_UNSUPPORTED_PROTOCOL',
 E('ERR_HTTP_HEADERS_SENT',
   'Cannot %s headers after they are sent to the client');
 E('ERR_HTTP_INVALID_CHAR', 'Invalid character in statusMessage.');
+E('ERR_HTTP_INVALID_HEADER_VALUE', 'Invalid value "%s" for header "%s"');
 E('ERR_HTTP_INVALID_STATUS_CODE',
   (originalStatusCode) => `Invalid status code: ${originalStatusCode}`);
 E('ERR_HTTP_TRAILER_INVALID',

--- a/test/parallel/test-http-mutable-headers.js
+++ b/test/parallel/test-http-mutable-headers.js
@@ -61,9 +61,9 @@ const s = http.createServer(common.mustCall((req, res) => {
       common.expectsError(
         () => res.setHeader('someHeader'),
         {
-          code: 'ERR_MISSING_ARGS',
+          code: 'ERR_HTTP_INVALID_HEADER_VALUE',
           type: TypeError,
-          message: 'The "value" argument must be specified'
+          message: 'Invalid value "undefined" for header "someHeader"'
         }
       );
       common.expectsError(

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -34,9 +34,9 @@ assert.throws(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader('test');
 }, common.expectsError({
-  code: 'ERR_MISSING_ARGS',
+  code: 'ERR_HTTP_INVALID_HEADER_VALUE',
   type: TypeError,
-  message: 'The "value" argument must be specified'
+  message: 'Invalid value "undefined" for header "test"'
 }));
 
 assert.throws(() => {

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -44,9 +44,9 @@ const s = http.createServer(common.mustCall((req, res) => {
   common.expectsError(
     () => res.setHeader('foo', undefined),
     {
-      code: 'ERR_MISSING_ARGS',
+      code: 'ERR_HTTP_INVALID_HEADER_VALUE',
       type: TypeError,
-      message: 'The "value" argument must be specified'
+      message: 'Invalid value "undefined" for header "foo"'
     }
   );
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Previously https://github.com/nodejs/node/pull/16715
Fixes: https://github.com/nodejs/node/issues/16714

This PR:

- Replace `ERR_MISSING_ARGS` with `ERR_HTTP_INVALID_HEADER_VALUE`, include the header name and the value for debug-ability as https://github.com/nodejs/node/issues/16714 suggests. Before it's `The "value" argument must be specified`, after it's `Invalid value "undefined" for header "test"`. If the user is setting the header in a loop this would be much more useful.
- Use `Error.captureStackTrace` to exclude the validation functions from the stack trace

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http