### PR TITLE
http: use 'connect' event only if socket is connecting

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -728,9 +728,13 @@ ClientRequest.prototype.setTimeout = function setTimeout(msecs, callback) {
   }
 
   this.once('socket', function(sock) {
-    sock.once('connect', function() {
+    if (sock.connecting) {
+      sock.once('connect', function() {
+        sock.setTimeout(msecs, emitTimeout);
+      });
+    } else {
       sock.setTimeout(msecs, emitTimeout);
-    });
+    }
   });
 
   return this;

--- a/test/parallel/test-http-client-timeout-connect-listener.js
+++ b/test/parallel/test-http-client-timeout-connect-listener.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+
+// This test ensures that `ClientRequest.prototype.setTimeout()` does
+// not add a listener for the `'connect'` event to socket if the
+// socket is already connected.
+
+const assert = require('assert');
+const http = require('http');
+
+// Maximum allowed value for timeouts.
+const timeout = 2 ** 31 - 1;
+
+const server = http.createServer((req, res) => {
+  res.end();
+});
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  const options = { port: server.address().port, agent: agent };
+
+  doRequest(options, common.mustCall(() => {
+    const req = doRequest(options, common.mustCall(() => {
+      agent.destroy();
+      server.close();
+    }));
+
+    req.on('socket', common.mustCall((socket) => {
+      assert.strictEqual(socket.listenerCount('connect'), 0);
+    }));
+  }));
+}));
+
+function doRequest(options, callback) {
+  const req = http.get(options, (res) => {
+    res.on('end', callback);
+    res.resume();
+  });
+
+  req.setTimeout(timeout);
+  return req;
+}


### PR DESCRIPTION
Fixes a bug that prevented `ClientRequest.prototype.setTimeout()` from
working properly when the socket was reused for multiple requests.

Fixes: https://github.com/nodejs/node/issues/16716

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http