### PR TITLE
src: add method to compute storage in WriteWrap

### DIFF
--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -503,7 +503,7 @@ inline void Nghttp2Session::SendPendingData() {
   while ((srcLength = nghttp2_session_mem_send(session_, &src)) > 0) {
     if (req == nullptr) {
       req = AllocateSend();
-      destRemaining = req->self_size();
+      destRemaining = req->ExtraSize();
       dest = req->Extra();
     }
     DEBUG_HTTP2("Nghttp2Session %s: nghttp2 has %d bytes to send\n",
@@ -525,7 +525,7 @@ inline void Nghttp2Session::SendPendingData() {
       srcRemaining -= destRemaining;
       srcOffset += destRemaining;
       req = AllocateSend();
-      destRemaining = req->self_size();
+      destRemaining = req->ExtraSize();
       dest = req->Extra();
     }
 

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -160,6 +160,10 @@ char* WriteWrap::Extra(size_t offset) {
          offset;
 }
 
+size_t WriteWrap::ExtraSize() const {
+  return storage_size_ - ROUND_UP(sizeof(*this), kAlignSize);
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -77,6 +77,7 @@ class WriteWrap: public ReqWrap<uv_write_t>,
                                size_t extra = 0);
   inline void Dispose();
   inline char* Extra(size_t offset = 0);
+  inline size_t ExtraSize() const;
 
   inline StreamBase* wrap() const { return wrap_; }
 


### PR DESCRIPTION
`WriteWrap` instances may contain extra storage space.
`self_size()` returns the size of the *entire* struct, member fields as
well as storage space, so it is not an accurate measure for the
storage space available.

Add a method `ExtraSize()` (like the existing `Extra()` for accessing
the storage memory) that yields the wanted value, and use it
in the HTTP2 impl to fix a crash.

Ref: https://github.com/nodejs/node/pull/16669

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (they crashe without this)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2

@nodejs/http2 @jasnell Probably want to fast-track this :)