### PR TITLE
build: fix bsd build with gcc

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -418,7 +418,7 @@
       }],
       ['OS=="freebsd"', {
         'conditions': [
-          ['llvm_version < "4.0"', {
+          ['"0" < llvm_version < "4.0"', {
             # Use this flag because on FreeBSD std::pairs copy constructor is non-trivial.
             # Doesn't apply to llvm 4.0 (FreeBSD 11.1) or later.
             # Refs: https://lists.freebsd.org/pipermail/freebsd-toolchain/2016-March/002094.html

--- a/configure
+++ b/configure
@@ -692,8 +692,7 @@ def check_compiler(o):
     # to a version that is not completely ancient.
     warn('C compiler too old, need gcc 4.2 or clang 3.2 (CC=%s)' % CC)
 
-  if is_clang:
-    o['variables']['llvm_version'] = get_llvm_version(CC)
+  o['variables']['llvm_version'] = get_llvm_version(CC) if is_clang else 0
 
   # Need xcode_version or gas_version when openssl asm files are compiled.
   if options.without_ssl or options.openssl_no_asm or options.shared_openssl:

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -7,7 +7,6 @@
     'is_clang': 0,
     'gcc_version': 0,
     'openssl_no_asm%': 0,
-    'llvm_version%': 0,
     'xcode_version%': 0,
     'gas_version%': 0,
     'openssl_fips%': 'false',


### PR DESCRIPTION
BSD build with GCC was breaking because it was checking for the `llvm_version`
variable on `common.gypi`, even though LLVM wasn't installed (or needed). When
LLVM wasn't installed, `llvm_version` wasn't being defined, causing the build to break.

Fixes: https://github.com/nodejs/node/issues/16257

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build
