### PR TITLE
doc: fix json generator warnings

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -216,7 +216,7 @@ undefined
 >
 ```
 
-### console.countReset([label = 'default'])
+### console.countReset([label='default'])
 <!-- YAML
 added: v8.3.0
 -->
@@ -293,7 +293,7 @@ values are concatenated. See [`util.format()`][] for more information.
 added: v8.5.0
 -->
 
-* `label` {any}
+* `...label` {any}
 
 Increases indentation of subsequent lines by two spaces.
 


### PR DESCRIPTION
Fixes the following warnings:

```
Warning: invalid param "label "
 > {"textRaw":"`label` {string} The display label for the counter. Defaults to `'default'`. ","name":"label","type":"string","desc":"The display label for the counter. Defaults to `'default'`."}
 > console.countReset([label = 'default'])
Warning: invalid param "...label"
 > {"textRaw":"`label` {any} ","name":"label","type":"any"}
 > console.group([...label])
Warning: invalid param "label "
 > {"textRaw":"`label` {string} The display label for the counter. Defaults to `'default'`. ","name":"label","type":"string","desc":"The display label for the counter. Defaults to `'default'`."}
 > console.countReset([label = 'default'])
Warning: invalid param "...label"
 > {"textRaw":"`label` {any} ","name":"label","type":"any"}
 > console.group([...label])
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc