### PR TITLE
doc: update subprocess.killed

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1044,10 +1044,11 @@ added: v0.5.10
 -->
 
 * {boolean} Set to `true` after `subprocess.kill()` is used to successfully
-  terminate the child process.
+  send a signal to the child process.
 
-The `subprocess.killed` property indicates whether the child process was
-successfully terminated using `subprocess.kill()`.
+The `subprocess.killed` property indicates whether the child process
+successfully received a signal from `subprocess.kill()`. The `killed` property
+does not indicate that the child process has been terminated.
 
 ### subprocess.pid
 <!-- YAML


### PR DESCRIPTION
This commit changes the wording of `subprocess.killed` to reflect that a child process was successfully signaled, and not necessarily terminated.

Fixes: https://github.com/nodejs/node/issues/16747

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc