### PR TITLE
http2: simplify subsequent rstStream calls

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -970,9 +970,8 @@ class Http2Session extends EventEmitter {
 
     const state = stream[kState];
     if (state.rst) {
-      // rst has already been called, do not call again,
-      // skip straight to destroy
-      stream.destroy();
+      // rst has already been called by self or peer,
+      // do not call again
       return;
     }
     state.rst = true;

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -21,6 +21,10 @@ server.on('listening', common.mustCall(() => {
   // make sure that destroy is called
   req._destroy = common.mustCall(req._destroy.bind(req));
 
+  // second call doesn't do anything
+  assert.doesNotThrow(() => client.rstStream(req, 8));
+  assert.strictEqual(req.rstCode, 0);
+
   req.on('streamClosed', common.mustCall((code) => {
     assert.strictEqual(req.destroyed, true);
     assert.strictEqual(code, 0);


### PR DESCRIPTION
Do not call destroy each time rstStream is called since the first call (or receipt of rst frame) will always trigger destroy. Expand existing test for this behaviour.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test