### PR TITLE
test: check session timeout in http2

### DIFF
--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -43,10 +43,6 @@ server.on('stream', common.mustCall((stream) => {
     'Content-Length': content.length.toString(),
     'Vary': 'Accept-Encoding'
   });
-  stream.setTimeout(serverTimeout);
-  stream.on('timeout', () => {
-    assert.strictEqual(didReceiveData, false, 'Should not timeout');
-  });
   stream.end();
 }));
 server.setTimeout(serverTimeout);


### PR DESCRIPTION
Two instances of a similar test exist, with both testing the timeout on the stream and neither on the session. Adjust one of them to test the session timeout instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test