### PR TITLE
src: use unrefed async for GC tracking

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -215,6 +215,7 @@ void MarkGarbageCollectionEnd(Isolate* isolate,
   uv_async_t* async = new uv_async_t();  // coverity[leaked_storage]
   if (uv_async_init(env->event_loop(), async, PerformanceGCCallback))
     return delete async;
+  uv_unref(reinterpret_cast<uv_handle_t*>(async));
   async->data =
       new PerformanceEntry::Data(env, "gc", "gc",
                                  performance_last_gc_start_mark_,

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,8 +5,6 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# https://github.com/nodejs/node/issues/16210
-test-async-wrap-uncaughtexception: PASS,FLAKY
 
 [$system==win32]
 

--- a/test/parallel/test-performance-gc.js
+++ b/test/parallel/test-performance-gc.js
@@ -48,4 +48,6 @@ const kinds = [
   }));
   obs.observe({ entryTypes: ['gc'] });
   global.gc();
+  // Keep the event loop alive to witness the GC async callback happen.
+  setImmediate(() => setImmediate(() => 0));
 }


### PR DESCRIPTION
Do not let an internal handle keep the event loop alive.

I think this patch is okay since GC isn’t deterministic anyway.

Fixes: https://github.com/nodejs/node/issues/16210

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src

@Trott @refack @jasnell 