### PR TITLE
src: CHECK() for argument overflow in Spawn()

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -185,6 +185,8 @@ class ProcessWrap : public HandleWrap {
     if (!argv_v.IsEmpty() && argv_v->IsArray()) {
       Local<Array> js_argv = Local<Array>::Cast(argv_v);
       int argc = js_argv->Length();
+      CHECK_GT(argc + 1, 0);  // Check for overflow.
+
       // Heap allocate to detect errors. +1 is for nullptr.
       options.args = new char*[argc + 1];
       for (int i = 0; i < argc; i++) {
@@ -211,6 +213,7 @@ class ProcessWrap : public HandleWrap {
     if (!env_v.IsEmpty() && env_v->IsArray()) {
       Local<Array> env_opt = Local<Array>::Cast(env_v);
       int envc = env_opt->Length();
+      CHECK_GT(envc + 1, 0);  // Check for overflow.
       options.env = new char*[envc + 1];  // Heap allocated to detect errors.
       for (int i = 0; i < envc; i++) {
         node::Utf8Value pair(env->isolate(),


### PR DESCRIPTION
This commit adds checks for overflow of `args` and `env` in `Spawn()`. It seems extremely unlikely that either of these values would overflow from a valid use case.

Fixes: https://github.com/nodejs/node/issues/15622

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src