### PR TITLE
http2: forward protocol error

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -913,6 +913,13 @@ created.
 Used when a message payload is specified for an HTTP response code for which
 a payload is forbidden.
 
+<a id="ERR_HTTP2_PROTOCOL_ERROR"></a>
+### ERR_HTTP2_PROTOCOL_ERROR
+
+Used when a communication error has occurred when attemptinng to use the HTTP/2
+protocol. This typically occurs when attempting to connect an HTTP/2 client to
+a non-HTTP/2 server.
+
 <a id="ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED"></a>
 ### ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -301,6 +301,7 @@ E('ERR_HTTP2_OUT_OF_STREAMS',
   'No stream ID is available because maximum stream ID has been reached');
 E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
   (code) => `Responses with ${code} status must not have a payload`);
+E('ERR_HTTP2_PROTOCOL_ERROR', 'An HTTP2 protocol error occurred: %s');
 E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
 E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -390,6 +390,15 @@ function onSelectPadding(fn) {
   };
 }
 
+function emitProtocolError(self, str) {
+  const err = new errors.Error('ERR_HTTP2_PROTOCOL_ERROR', str);
+  self.emit('error', err);
+}
+
+function onProtocolError(str) {
+  process.nextTick(emitProtocolError, this[kOwner], str);
+}
+
 // When a ClientHttp2Session is first created, the socket may not yet be
 // connected. If request() is called during this time, the actual request
 // will be deferred until the socket is ready to go.
@@ -523,6 +532,7 @@ function setupHandle(session, socket, type, options) {
     handle.onread = onSessionRead;
     handle.onframeerror = onFrameError;
     handle.ongoawaydata = onGoawayData;
+    handle.error = onProtocolError;
 
     if (typeof options.selectPadding === 'function')
       handle.ongetpadding = onSelectPadding(options.selectPadding);

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -882,6 +882,19 @@ void Http2Session::Send(WriteWrap* req, char* buf, size_t length) {
   }
 }
 
+void Http2Session::OnProtocolError(const char* message, size_t len) {
+  Local<Context> context = env()->context();
+  Isolate* isolate = env()->isolate();
+  HandleScope scope(isolate);
+  Context::Scope context_scope(context);
+
+  Local<Value> argv[1] = {
+    OneByteString(isolate, message, len)
+  };
+
+  MakeCallback(env()->error_string(), arraysize(argv), argv);
+}
+
 void Http2Session::OnTrailers(Nghttp2Stream* stream,
                               const SubmitTrailers& submit_trailers) {
   DEBUG_HTTP2("Http2Session: prompting for trailers on stream %d\n",

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -443,6 +443,7 @@ class Http2Session : public AsyncWrap,
   void OnFrameError(int32_t id, uint8_t type, int error_code) override;
   void OnTrailers(Nghttp2Stream* stream,
                   const SubmitTrailers& submit_trailers) override;
+  void OnProtocolError(const char* message, size_t len) override;
 
   void Send(WriteWrap* req, char* buf, size_t length) override;
   WriteWrap* AllocateSend() override;

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -10,7 +10,6 @@
 namespace node {
 namespace http2 {
 
-#ifdef NODE_DEBUG_HTTP2
 inline int Nghttp2Session::OnNghttpError(nghttp2_session* session,
                                          const char* message,
                                          size_t len,
@@ -18,9 +17,9 @@ inline int Nghttp2Session::OnNghttpError(nghttp2_session* session,
   Nghttp2Session* handle = static_cast<Nghttp2Session*>(user_data);
   DEBUG_HTTP2("Nghttp2Session %s: Error '%.*s'\n",
               handle->TypeName(), len, message);
+  handle->OnProtocolError(message, len);
   return 0;
 }
-#endif
 
 inline int32_t GetFrameID(const nghttp2_frame* frame) {
   // If this is a push promise, we want to grab the id of the promised stream
@@ -895,11 +894,8 @@ Nghttp2Session::Callbacks::Callbacks(bool kHasGetPaddingCallback) {
     callbacks, OnFrameNotSent);
   nghttp2_session_callbacks_set_on_invalid_header_callback2(
     callbacks, OnInvalidHeader);
-
-#ifdef NODE_DEBUG_HTTP2
   nghttp2_session_callbacks_set_error_callback(
     callbacks, OnNghttpError);
-#endif
 
   if (kHasGetPaddingCallback) {
     nghttp2_session_callbacks_set_select_padding_callback(

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -180,6 +180,7 @@ class Nghttp2Session {
       size_t count,
       nghttp2_headers_category cat,
       uint8_t flags) {}
+  virtual void OnProtocolError(const char* message, size_t len) {}
   virtual void OnStreamClose(int32_t id, uint32_t code) {}
   virtual void OnDataChunk(Nghttp2Stream* stream,
                            uv_buf_t* chunk) {}
@@ -239,13 +240,10 @@ class Nghttp2Session {
                                  uint32_t* flags);
 
   /* callbacks for nghttp2 */
-#ifdef NODE_DEBUG_HTTP2
   static inline int OnNghttpError(nghttp2_session* session,
                                   const char* message,
                                   size_t len,
                                   void* user_data);
-#endif
-
   static inline int OnBeginHeadersCallback(nghttp2_session* session,
                                            const nghttp2_frame* frame,
                                            void* user_data);

--- a/test/parallel/test-http2-client-http1-server.js
+++ b/test/parallel/test-http2-client-http1-server.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const http2 = require('http2');
+const http = require('http');
+
+const server = http.createServer();
+server.on('stream', common.mustNotCall());
+
+server.listen(0, common.mustCall(() => {
+  server.unref();
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('streamClosed', common.mustCall());
+
+  client.on('error', common.expectsError({
+    code: 'ERR_HTTP2_PROTOCOL_ERROR',
+    type: Error,
+    message: 'An HTTP2 protocol error occurred: Remote peer returned ' +
+              'unexpected data while we expected SETTINGS frame.  Perhaps, ' +
+              'peer does not support HTTP/2 properly.'
+  }));
+}));


### PR DESCRIPTION
@mcollina ... this is only a 90% fix for the issue in #16752 ... there are a couple of bits:

1. nghttp2 does not currently give us an adequate error code to look for when the server responds with an invalid preamble. We get an error message that says that a SETTINGS frame was expected and the session is torn down, but that's it. We don't even get an invalid frame received error. This is likely something that we should go talk to the nghttp2 author about.

2. Currently I'm forwarding this to the `Http2Session` error event *only*. I am not yet forwarding the error to the individual `Http2Stream` objects. Doing so causes all kinds of breakage in our tests. We likely need to sit down this week and sketch out what the exact error flow needs to be through both the core and compat apis on both the server and client side. Right now it feels a bit too haphazard.

Take a look at the modified version of the test that case that I've included.

Fixes: https://github.com/nodejs/node/issues/16752

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2