### PR TITLE
http2: strictly limit number of concurrent streams

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -835,6 +835,8 @@ class Http2Session : public AsyncWrap {
   // Returns pointer to the stream, or nullptr if stream does not exist
   inline Http2Stream* FindStream(int32_t id);
 
+  inline bool CanAddStream();
+
   // Adds a stream instance to this session
   inline void AddStream(Http2Stream* stream);
 

--- a/test/parallel/test-http2-too-many-streams.js
+++ b/test/parallel/test-http2-too-many-streams.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const Countdown = require('../common/countdown');
+const http2 = require('http2');
+const assert = require('assert');
+
+// Test that the maxConcurrentStreams setting is strictly enforced
+
+const server = http2.createServer({ settings: { maxConcurrentStreams: 1 } });
+
+let c = 0;
+
+server.on('stream', common.mustCall((stream) => {
+  // Because we only allow one open stream at a time,
+  // c should never be greater than 1.
+  assert.strictEqual(++c, 1);
+  stream.respond();
+  // Force some asynchronos stuff.
+  setImmediate(() => {
+    stream.end('ok');
+    assert.strictEqual(--c, 0);
+  });
+}, 3));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const countdown = new Countdown(3, common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+
+  client.on('remoteSettings', common.mustCall(() => {
+    assert.strictEqual(client.remoteSettings.maxConcurrentStreams, 1);
+
+    {
+      const req = client.request();
+      req.resume();
+      req.on('close', () => {
+        countdown.dec();
+
+        setImmediate(() => {
+          const req = client.request();
+          req.resume();
+          req.on('close', () => countdown.dec());
+        });
+      });
+    }
+
+    {
+      const req = client.request();
+      req.resume();
+      req.on('close', () => countdown.dec());
+    }
+  }));
+}));


### PR DESCRIPTION
Strictly limit the number of concurrent streams based on the
current setting the MAX_CONCURRENT_STREAMS setting.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2