### PR TITLE
console: avoid adding infinite error listeners

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -83,7 +83,10 @@ function createWriteErrorHandler(stream) {
       // an `error` event. Adding a `once` listener will keep that error
       // from becoming an uncaught exception, but since the handler is
       // removed after the event, non-console.* writes won’t be affected.
-      stream.once('error', noop);
+      // we are only adding noop if there is no one else listening for 'error'
+      if (stream.listenerCount('error') === 0) {
+        stream.on('error', noop);
+      }
     }
   };
 }

--- a/test/parallel/test-console-log-stdio-broken-dest.js
+++ b/test/parallel/test-console-log-stdio-broken-dest.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const { Writable } = require('stream');
+const { Console } = require('console');
+const { EventEmitter } = require('events');
+
+const stream = new Writable({
+  write(chunk, enc, cb) {
+    cb();
+  },
+  writev(chunks, cb) {
+    setTimeout(cb, 10, new Error('kaboom'));
+  }
+});
+const myConsole = new Console(stream, stream);
+
+process.on('warning', common.mustNotCall);
+
+stream.cork();
+for (let i = 0; i < EventEmitter.defaultMaxListeners + 1; i++) {
+  myConsole.log('a message');
+}
+stream.uncork();


### PR DESCRIPTION
If the console destination is a unix pipe (net.Socket), write() is
async. If the destination is broken, we are adding an 'error' event
listener to avoid a process crash. This PR makes sure that we are adding
that listener only once.

Fixes: https://github.com/nodejs/node/issues/16767

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

console