### PR TITLE
benchmark: use unique filenames in fs benchmarks

### DIFF
--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -3,7 +3,8 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const filename = path.resolve(__dirname,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 const assert = require('assert');
 

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -5,7 +5,8 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const filename = path.resolve(__dirname,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -3,7 +3,8 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname, '.removeme-benchmark-garbage');
+const filename = path.resolve(__dirname,
+                              `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 
 const bench = common.createBenchmark(main, {


### PR DESCRIPTION
Use a unique file name for each benchmark. Running benchmarks
simultaneously may be a bit of an unusual use case, but there are use
cases, such as stress testing `test/parallel/test-benchmark-fs.js`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark fs test