### PR TITLE
build: Allow linking against an external copy of nghttp2.

### DIFF
--- a/configure
+++ b/configure
@@ -220,6 +220,27 @@ shared_optgroup.add_option('--shared-libuv-libpath',
     dest='shared_libuv_libpath',
     help='a directory to search for the shared libuv DLL')
 
+shared_optgroup.add_option('--shared-nghttp2',
+    action='store_true',
+    dest='shared_nghttp2',
+    help='link to a shared nghttp2 DLL instead of static linking')
+
+shared_optgroup.add_option('--shared-nghttp2-includes',
+    action='store',
+    dest='shared_nghttp2_includes',
+    help='directory containing nghttp2 header files')
+
+shared_optgroup.add_option('--shared-nghttp2-libname',
+    action='store',
+    dest='shared_nghttp2_libname',
+    default='nghttp2',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-nghttp2-libpath',
+    action='store',
+    dest='shared_nghttp2_libpath',
+    help='a directory to search for the shared nghttp2 DLLs')
+
 shared_optgroup.add_option('--shared-openssl',
     action='store_true',
     dest='shared_openssl',
@@ -1415,6 +1436,7 @@ configure_library('zlib', output)
 configure_library('http_parser', output)
 configure_library('libuv', output)
 configure_library('libcares', output)
+configure_library('nghttp2', output)
 # stay backwards compatible with shared cares builds
 output['variables']['node_shared_cares'] = \
     output['variables'].pop('node_shared_libcares')

--- a/node.gyp
+++ b/node.gyp
@@ -16,6 +16,7 @@
     'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
     'node_shared_libuv%': 'false',
+    'node_shared_nghttp2%': 'false',
     'node_use_openssl%': 'true',
     'node_shared_openssl%': 'false',
     'node_v8_options%': '',
@@ -176,7 +177,6 @@
 
       'dependencies': [
         'node_js2c#host',
-        'deps/nghttp2/nghttp2.gyp:nghttp2'
       ],
 
       'includes': [
@@ -186,8 +186,7 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
-        'deps/nghttp2/lib/includes'
+        '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
       ],
 
       'sources': [
@@ -927,6 +926,14 @@
         [ 'node_shared_libuv=="false"', {
           'dependencies': [
             'deps/uv/uv.gyp:libuv'
+          ]
+        }],
+        [ 'node_shared_nghttp2=="false"', {
+          'dependencies': [
+            'deps/nghttp2/nghttp2.gyp:nghttp2'
+          ],
+          'include_dirs': [
+            'deps/nghttp2/lib/includes'
           ]
         }],
         [ 'node_use_v8_platform=="true"', {

--- a/node.gypi
+++ b/node.gypi
@@ -133,6 +133,10 @@
       'dependencies': [ 'deps/uv/uv.gyp:libuv' ],
     }],
 
+    [ 'node_shared_nghttp2=="false"', {
+      'dependencies': [ 'deps/nghttp2/nghttp2.gyp:nghttp2' ],
+    }],
+
     [ 'OS=="mac"', {
       # linking Corefoundation is needed since certain OSX debugging tools
       # like Instruments require it for some features


### PR DESCRIPTION
The version of nghttp2 in deps/ does not build on CloudABI, even though
the official version does. Though this is an issue on its own that needs
to be resolved, it is currently a bit hard to work around this. There is
no switch to link against an external version of nghttp2, even though we
do provide this option for other libraries.

This change adds configure flags, similar to the ones we have for
OpenSSL, zlib, http_parser, libuv, etc. and makes the dependency on
deps/nghttp2 optional.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
