### PR TITLE
src: add openssl-system-ca-path configure option

### DIFF
--- a/configure
+++ b/configure
@@ -172,6 +172,12 @@ parser.add_option('--openssl-use-def-ca-store',
     dest='use_openssl_ca_store',
     help='Use OpenSSL supplied CA store instead of compiled-in Mozilla CA copy.')
 
+parser.add_option('--openssl-system-ca-path',
+    action="store",
+    dest='openssl_system_ca_path',
+    help='Use the specified path to system CA (PEM format) in addition to '
+         'the OpenSSL supplied CA store or compiled-in Mozilla CA copy.')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -1013,6 +1019,8 @@ def configure_openssl(o):
   o['variables']['openssl_no_asm'] = 1 if options.openssl_no_asm else 0
   if options.use_openssl_ca_store:
     o['defines'] += ['NODE_OPENSSL_CERT_STORE']
+  if options.openssl_system_ca_path:
+    o['variables']['openssl_system_ca_path'] = options.openssl_system_ca_path
   o['variables']['node_without_node_options'] = b(options.without_node_options)
   if options.without_node_options:
       o['defines'] += ['NODE_WITHOUT_NODE_OPTIONS']

--- a/configure
+++ b/configure
@@ -173,7 +173,7 @@ parser.add_option('--openssl-use-def-ca-store',
     help='Use OpenSSL supplied CA store instead of compiled-in Mozilla CA copy.')
 
 parser.add_option('--openssl-system-ca-path',
-    action="store",
+    action='store',
     dest='openssl_system_ca_path',
     help='Use the specified path to system CA (PEM format) in addition to '
          'the OpenSSL supplied CA store or compiled-in Mozilla CA copy.')

--- a/node.gyp
+++ b/node.gyp
@@ -297,13 +297,24 @@
         '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
       ],
 
+      'variables': {
+        'openssl_system_ca_path%': '',
+      },
+
       'defines': [
         'NODE_ARCH="<(target_arch)"',
         'NODE_PLATFORM="<(OS)"',
         'NODE_WANT_INTERNALS=1',
         # Warn when using deprecated V8 APIs.
         'V8_DEPRECATION_WARNINGS=1',
+        'NODE_OPENSSL_SYSTEM_CERT_PATH="<(openssl_system_ca_path)"',
       ],
+
+      'direct_dependent_settings': {
+        'defines': [
+          'NODE_OPENSSL_SYSTEM_CERT_PATH="<(openssl_system_ca_path)"',
+        ],
+      },
     },
     {
       'target_name': 'mkssldef',

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -140,6 +140,8 @@ static const char* const root_certs[] = {
 #include "node_root_certs.h"  // NOLINT(build/include_order)
 };
 
+static const char system_cert_path[] = NODE_OPENSSL_SYSTEM_CERT_PATH;
+
 static std::string extra_root_certs_file;  // NOLINT(runtime/string)
 
 static X509_STORE* root_cert_store;
@@ -792,6 +794,9 @@ static X509_STORE* NewRootCertStore() {
   }
 
   X509_STORE* store = X509_STORE_new();
+  if (*system_cert_path != '\0') {
+    X509_STORE_load_locations(store, system_cert_path, nullptr);
+  }
   if (ssl_openssl_cert_store) {
     X509_STORE_set_default_paths(store);
   } else {

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -45,7 +45,9 @@ if (!fs.existsSync(configPath)) {
 let config = fs.readFileSync(configPath, 'utf8');
 
 // Clean up comment at the first line.
-config = config.split('\n').slice(1).join('\n').replace(/'/g, '"');
+config = config.split('\n').slice(1).join('\n');
+config = config.replace(/"/g, '\\"');
+config = config.replace(/'/g, '"');
 config = JSON.parse(config, function(key, value) {
   if (value === 'true') return true;
   if (value === 'false') return false;


### PR DESCRIPTION
The motivation for this commit is that we need to specify system CA
certificates when building node. While we are aware of the environment
variable `NODE_EXTRA_CA_CERTS` this is not a great solution as we build
an RPM and we also don't want users to be able to unset them.

The suggestion is to add a configure time property like this:
```console
--openssl-system-ca-path=OPENSSL_SYSTEM_CA_PATH
                        Use the specified path to system CA (PEM format) in
                        addition to the OpenSSL supplied CA store or compiled-
                        in Mozilla CA copy.
```
Usage example:
```console
$ ./configure --openssl-system-ca-path=/etc/pki/tls/certs/ca-bundle.crt
```
This would add the specified CA certificates in addition to the ones
already being used.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src, build