### PR TITLE
test: replace `common.fixturesDir` usage

### DIFF
--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -8,9 +8,9 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const http2 = require('http2');
 const fs = require('fs');
-const path = require('path');
+const fixtures = require('../common/fixtures');
 
-const loc = path.join(common.fixturesDir, 'person.jpg');
+const loc = fixtures.path('person.jpg');
 let fileData;
 
 assert(fs.existsSync(loc));


### PR DESCRIPTION
use `common/fixtures` module instead

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, http2