### PR TITLE
tools: replace string concetation with template literals

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -499,12 +499,12 @@ function buildToc(lexed, filename, cb) {
 
     depth = tok.depth;
     const realFilename = path.basename(realFilenames[0], '.md');
-    const id = getId(realFilename + '_' + tok.text.trim());
+    const id = getId(`${realFilename}_${tok.text.trim()}`);
     toc.push(new Array((depth - 1) * 2 + 1).join(' ') +
              `* <span class="stability_${tok.stability}">` +
              `<a href="#${id}">${tok.text}</a></span>`);
-    tok.text += '<span><a class="mark" href="#' + id + '" ' +
-                'id="' + id + '">#</a></span>';
+    tok.text += `<span><a class="mark" href="#${id}"` +
+                `id="${id}">#</a></span>`;
   });
 
   toc = marked.parse(toc.join('\n'));
@@ -518,7 +518,7 @@ function getId(text) {
   text = text.replace(/^_+|_+$/, '');
   text = text.replace(/^([^a-z])/, '_$1');
   if (idCounters.hasOwnProperty(text)) {
-    text += '_' + (++idCounters[text]);
+    text += `_${(++idCounters[text])}`;
   } else {
     idCounters[text] = 0;
   }


### PR DESCRIPTION
Replace string concatenation in `tools/doc/html.js` with template literals.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)