### PR TITLE
test: replace common.fixturesDir with fixtures module

### DIFF
--- a/test/parallel/test-fs-realpath-buffer-encoding.js
+++ b/test/parallel/test-fs-realpath-buffer-encoding.js
@@ -1,9 +1,10 @@
 'use strict';
 const common = require('../common');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const fs = require('fs');
 
-const string_dir = fs.realpathSync(common.fixturesDir);
+const string_dir = fs.realpathSync(fixtures.fixturesDir);
 const buffer_dir = Buffer.from(string_dir);
 
 const encodings = ['ascii', 'utf8', 'utf16le', 'ucs2',


### PR DESCRIPTION
Require `fixturesDir` from `fixtures` module instead of `common`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
