### PR TITLE
tools: replace string concatenation with template literals

### DIFF
--- a/tools/doc/preprocess.js
+++ b/tools/doc/preprocess.js
@@ -29,7 +29,7 @@ function processIncludes(inputFile, input, cb) {
   if (incCount === 0) cb(null, input);
   includes.forEach(function(include) {
     var fname = include.replace(/^@include\s+/, '');
-    if (!fname.match(/\.md$/)) fname += '.md';
+    if (!fname.match(/\.md$/)) fname = `${fname}.md`;
 
     if (includeData.hasOwnProperty(fname)) {
       input = input.split(include).join(includeData[fname]);
@@ -51,8 +51,8 @@ function processIncludes(inputFile, input, cb) {
         // Add comments to let the HTML generator know how the anchors for
         // headings should look like.
         includeData[fname] = `<!-- [start-include:${fname}] -->\n` +
-                             inc + `\n<!-- [end-include:${fname}] -->\n`;
-        input = input.split(include + '\n').join(includeData[fname] + '\n');
+                             `${inc}\n<!-- [end-include:${fname}] -->\n`;
+        input = input.split(`${include}\n`).join(`${includeData[fname]}\n`);
         if (incCount === 0) {
           return cb(null, input);
         }


### PR DESCRIPTION
Replace string concatenation in tools/doc/preprocess.js with template literals.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
- tools
