### PR TITLE
test: removed literal from assert

### DIFF
--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -14,5 +14,8 @@ process.env.NODE_PATH = fixtures.path('module-require', 'relative');
 m._initPaths();
 
 const c = require('.');
-
-assert.strictEqual(c.value, 42, `require(".") should honor NODE_PATH; expected 42, found ${c.value}`);
+assert.strictEqual(
+  c.value,
+  42,
+  `require(".") should honor NODE_PATH; expected 42, found ${c.value}`
+);

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -15,4 +15,4 @@ m._initPaths();
 
 const c = require('.');
 
-assert.strictEqual(c.value, 42, 'require(".") should honor NODE_PATH');
+assert.strictEqual(c.value, 42);

--- a/test/parallel/test-require-dot.js
+++ b/test/parallel/test-require-dot.js
@@ -15,4 +15,4 @@ m._initPaths();
 
 const c = require('.');
 
-assert.strictEqual(c.value, 42);
+assert.strictEqual(c.value, 42, `require(".") should honor NODE_PATH; expected 42, found ${c.value}`);


### PR DESCRIPTION
Removed literal from assert to display default message.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test