### PR TITLE
test: used fixturesDir from fixtures modules

### DIFF
--- a/test/parallel/test-fs-realpath-on-substed-drive.js
+++ b/test/parallel/test-fs-realpath-on-substed-drive.js
@@ -4,6 +4,8 @@ const common = require('../common');
 if (!common.isWindows)
   common.skip('Test for Windows only');
 
+const fixtures = require('../common/fixtures');
+
 const assert = require('assert');
 const fs = require('fs');
 const spawnSync = require('child_process').spawnSync;
@@ -16,7 +18,7 @@ let drive;
 let i;
 for (i = 0; i < driveLetters.length; ++i) {
   drive = `${driveLetters[i]}:`;
-  result = spawnSync('subst', [drive, common.fixturesDir]);
+  result = spawnSync('subst', [drive, fixtures.fixturesDir]);
   if (result.status === 0)
     break;
 }


### PR DESCRIPTION
I required common/fixtures module and swapped the location of fixturesDir
from common to fixtures module.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test