### PR TITLE
test: remove messages for assert

### DIFF
--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const common = require('../../common');
-const assert = require('assert');
 
-// Testing api calls for promises
+// This tests the promise-related n-api calls
+
+const assert = require('assert');
 const test_promise = require(`./build/${common.buildType}/test_promise`);
 
 // A resolution
@@ -40,10 +41,9 @@ const test_promise = require(`./build/${common.buildType}/test_promise`);
     }),
     common.mustNotCall());
   test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
-
-  assert.strictEqual(test_promise.isPromise(promise), true);
 }
 
+assert.strictEqual(test_promise.isPromise(test_promise.createPromise()), true);
 assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true);
 assert.strictEqual(test_promise.isPromise(2.4), false);
 assert.strictEqual(test_promise.isPromise('I promise!'), false);

--- a/test/addons-napi/test_promise/test.js
+++ b/test/addons-napi/test_promise/test.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common');
-const test_promise = require(`./build/${common.buildType}/test_promise`);
 const assert = require('assert');
+
+// Testing api calls for promises
+const test_promise = require(`./build/${common.buildType}/test_promise`);
 
 // A resolution
 {
@@ -10,8 +12,7 @@ const assert = require('assert');
   const promise = test_promise.createPromise();
   promise.then(
     common.mustCall(function(result) {
-      assert.strictEqual(result, expected_result,
-                         `promise resolved as expected, received ${result}`);
+      assert.strictEqual(result, expected_result);
     }),
     common.mustNotCall());
   test_promise.concludeCurrentPromise(expected_result, true);
@@ -24,23 +25,25 @@ const assert = require('assert');
   promise.then(
     common.mustNotCall(),
     common.mustCall(function(result) {
-      assert.strictEqual(result, expected_result,
-                         `promise rejected as expected, received ${result}`);
+      assert.strictEqual(result, expected_result);
     }));
   test_promise.concludeCurrentPromise(expected_result, false);
 }
 
 // Chaining
-const promise = test_promise.createPromise();
-promise.then(
-  common.mustCall(function(result) {
-    assert.strictEqual(result, 'chained answer',
-                       'resolving with a promise chains properly');
-  }),
-  common.mustNotCall());
-test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
+{
+  const expected_result = 'chained answer';
+  const promise = test_promise.createPromise();
+  promise.then(
+    common.mustCall(function(result) {
+      assert.strictEqual(result, expected_result);
+    }),
+    common.mustNotCall());
+  test_promise.concludeCurrentPromise(Promise.resolve('chained answer'), true);
 
-assert.strictEqual(test_promise.isPromise(promise), true);
+  assert.strictEqual(test_promise.isPromise(promise), true);
+}
+
 assert.strictEqual(test_promise.isPromise(Promise.reject(-1)), true);
 assert.strictEqual(test_promise.isPromise(2.4), false);
 assert.strictEqual(test_promise.isPromise('I promise!'), false);


### PR DESCRIPTION
Removes message from assert 
Add global comment
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
