### PR TITLE
test: include file mode in assert message

### DIFF
--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -1,4 +1,7 @@
 'use strict';
+
+// Verifies that the REPL history file is created with mode 0600
+
 // Flags: --expose_internals
 
 const common = require('../common');
@@ -39,9 +42,10 @@ const checkResults = common.mustCall(function(err, r) {
 
   r.input.end();
   const stat = fs.statSync(replHistoryPath);
+  const fileMode = stat.mode & 0o777;
   assert.strictEqual(
-    stat.mode & 0o777, 0o600,
-    'REPL history file should be mode 0600');
+    fileMode, 0o600,
+    `REPL history file should be mode 0600 but was 0${fileMode.toString(8)}`);
 });
 
 repl.createInternalRepl(


### PR DESCRIPTION
If the REPL history file is created with an invalid mode include
the failed mode in the error message.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, repl