### PR TITLE
remove message from test assertion

### DIFF
--- a/test/parallel/test-child-process-spawnsync.js
+++ b/test/parallel/test-child-process-spawnsync.js
@@ -28,7 +28,7 @@ const spawnSync = require('child_process').spawnSync;
 // Echo does different things on Windows and Unix, but in both cases, it does
 // more-or-less nothing if there are no parameters
 const ret = spawnSync('sleep', ['0']);
-assert.strictEqual(ret.status, 0, 'exit status should be zero');
+assert.strictEqual(ret.status, 0);
 
 // Error test when command does not exist
 const ret_err = spawnSync('command_does_not_exist', ['bar']).error;


### PR DESCRIPTION
assert message in strictEqual was hiding error why test has failed, it
just showed what value is expected and in case of failure we want to
know which value has caused test to fail

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
