### PR TITLE
test: use the common/fixtures module to load the fixtures

### DIFF
--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -1,20 +1,21 @@
 'use strict';
 
+// Check that spawn child don't create duplicated entries
+require('common');
 const REPETITIONS = 2;
-
 const assert = require('assert');
-const common = require('../common');
-const cp = require('child_process');
-const path = require('path');
-const targetScript = path.resolve(common.fixturesDir, 'guess-hash-seed.js');
+const fixtures = require('common/fixtures');
+const { spawnSync } = require('child_process');
+const targetScript = fixtures.path('guess-hash-seed.js');
 const seeds = [];
 
 for (let i = 0; i < REPETITIONS; ++i) {
-  const seed = cp.spawnSync(process.execPath, [targetScript],
-                            { encoding: 'utf8' }).stdout.trim();
+  const seed = spawnSync(process.execPath, [targetScript], {
+    encoding: 'utf8'
+  }).stdout.trim();
   seeds.push(seed);
 }
 
 console.log(`Seeds: ${seeds}`);
-const hasDuplicates = (new Set(seeds)).size !== seeds.length;
+const hasDuplicates = new Set(seeds).size !== seeds.length;
 assert.strictEqual(hasDuplicates, false);

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Check that spawn child don't create duplicated entries
+// Check that spawn child doesn't create duplicated entries
 require('common');
 const REPETITIONS = 2;
 const assert = require('assert');

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -1,10 +1,10 @@
 'use strict';
 
 // Check that spawn child doesn't create duplicated entries
-require('common');
+require('../common');
 const REPETITIONS = 2;
 const assert = require('assert');
-const fixtures = require('common/fixtures');
+const fixtures = require('../common/fixtures');
 const { spawnSync } = require('child_process');
 const targetScript = fixtures.path('guess-hash-seed.js');
 const seeds = [];
@@ -17,5 +17,4 @@ for (let i = 0; i < REPETITIONS; ++i) {
 }
 
 console.log(`Seeds: ${seeds}`);
-const hasDuplicates = new Set(seeds).size !== seeds.length;
-assert.strictEqual(hasDuplicates, false);
+assert.strictEqual(new Set(seeds).size, seeds.length);


### PR DESCRIPTION
Use the common/fixtures module to load the fixtures on test-hash-seed file

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test:
