### PR TITLE
test: refactor fs.write() test

### DIFF
--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -47,10 +47,11 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.strictEqual(expected, found);
   });
 
-  fs.write(fd, '', 0, 'utf8', function(err, written) {
+  const written = common.mustCall(function(err, written) {
     assert.strictEqual(0, written);
   });
 
+  fs.write(fd, '', 0, 'utf8', written);
   fs.write(fd, expected, 0, 'utf8', done);
 }));
 
@@ -71,9 +72,10 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
     assert.strictEqual(expected, found);
   });
 
-  fs.write(fd, '', 0, 'utf8', (err, written) => {
+  const written = common.mustCall(function(err, written) {
     assert.strictEqual(0, written);
   });
 
+  fs.write(fd, '', 0, 'utf8', written);
   fs.write(fd, expected, 0, 'utf8', done);
 }));

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -44,6 +44,7 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   });
 
   const written = common.mustCall(function(err, written) {
+    assert.ifError(err);
     assert.strictEqual(0, written);
   });
 
@@ -65,6 +66,7 @@ fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
   });
 
   const written = common.mustCall(function(err, written) {
+    assert.ifError(err);
     assert.strictEqual(0, written);
   });
 

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -33,16 +33,12 @@ common.refreshTmpDir();
 
 fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   assert.ifError(err);
-  console.log('open done');
 
   const done = common.mustCall(function(err, written) {
-    console.log('write done');
     assert.ifError(err);
     assert.strictEqual(Buffer.byteLength(expected), written);
     fs.closeSync(fd);
     const found = fs.readFileSync(fn, 'utf8');
-    console.log('expected: "%s"', expected);
-    console.log('found: "%s"', found);
     fs.unlinkSync(fn);
     assert.strictEqual(expected, found);
   });
@@ -58,16 +54,12 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
 const args = constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC;
 fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
   assert.ifError(err);
-  console.log('open done');
 
   const done = common.mustCall((err, written) => {
-    console.log('write done');
     assert.ifError(err);
     assert.strictEqual(Buffer.byteLength(expected), written);
     fs.closeSync(fd);
     const found = fs.readFileSync(fn2, 'utf8');
-    console.log('expected: "%s"', expected);
-    console.log('found: "%s"', found);
     fs.unlinkSync(fn2);
     assert.strictEqual(expected, found);
   });

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -34,10 +34,8 @@ common.refreshTmpDir();
 fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   assert.ifError(err);
   console.log('open done');
-  fs.write(fd, '', 0, 'utf8', function(err, written) {
-    assert.strictEqual(0, written);
-  });
-  fs.write(fd, expected, 0, 'utf8', common.mustCall(function(err, written) {
+
+  const done = common.mustCall(function(err, written) {
     console.log('write done');
     assert.ifError(err);
     assert.strictEqual(Buffer.byteLength(expected), written);
@@ -47,26 +45,35 @@ fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
     console.log('found: "%s"', found);
     fs.unlinkSync(fn);
     assert.strictEqual(expected, found);
-  }));
+  });
+
+  fs.write(fd, '', 0, 'utf8', function(err, written) {
+    assert.strictEqual(0, written);
+  });
+
+  fs.write(fd, expected, 0, 'utf8', done);
 }));
 
+const args = constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC;
+fs.open(fn2, args, 0o644, common.mustCall((err, fd) => {
+  assert.ifError(err);
+  console.log('open done');
 
-fs.open(fn2, constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC, 0o644,
-        common.mustCall((err, fd) => {
-          assert.ifError(err);
-          console.log('open done');
-          fs.write(fd, '', 0, 'utf8', (err, written) => {
-            assert.strictEqual(0, written);
-          });
-          fs.write(fd, expected, 0, 'utf8', common.mustCall((err, written) => {
-            console.log('write done');
-            assert.ifError(err);
-            assert.strictEqual(Buffer.byteLength(expected), written);
-            fs.closeSync(fd);
-            const found = fs.readFileSync(fn2, 'utf8');
-            console.log('expected: "%s"', expected);
-            console.log('found: "%s"', found);
-            fs.unlinkSync(fn2);
-            assert.strictEqual(expected, found);
-          }));
-        }));
+  const done = common.mustCall((err, written) => {
+    console.log('write done');
+    assert.ifError(err);
+    assert.strictEqual(Buffer.byteLength(expected), written);
+    fs.closeSync(fd);
+    const found = fs.readFileSync(fn2, 'utf8');
+    console.log('expected: "%s"', expected);
+    console.log('found: "%s"', found);
+    fs.unlinkSync(fn2);
+    assert.strictEqual(expected, found);
+  });
+
+  fs.write(fd, '', 0, 'utf8', (err, written) => {
+    assert.strictEqual(0, written);
+  });
+
+  fs.write(fd, expected, 0, 'utf8', done);
+}));


### PR DESCRIPTION
Refactored fs.write() tests to use `done`, thanks for your help @mcollina.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)