### PR TITLE
test: fix typos in read-buffer tests

### DIFF
--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -59,13 +59,13 @@ read(buf, 'readUIntBE', [2, 0], 0xfd);
 read(buf, 'readUIntLE', [2, 0], 0x48);
 
 // attempt to overflow buffers, similar to previous bug in array buffers
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(0xffffffff),
+assert.throws(() => Buffer.allocUnsafe(8).readFloatBE(0xffffffff),
               RangeError);
 assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(0xffffffff),
               RangeError);
 
 // ensure negative values can't get past offset
-assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(-1), RangeError);
+assert.throws(() => Buffer.allocUnsafe(8).readFloatBE(-1), RangeError);
 assert.throws(() => Buffer.allocUnsafe(8).readFloatLE(-1), RangeError);
 
 // offset checks


### PR DESCRIPTION
The offset-exceeding tests for readFloat contained a double test
for readFloatLE instead of one for readFloatLE and one for
readFloatBE. This is fixed in this PR.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
