### PR TITLE
src: add process.ppid

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1416,6 +1416,19 @@ system platform on which the Node.js process is running. For instance
 console.log(`This platform is ${process.platform}`);
 ```
 
+## process.ppid
+<!-- YAML
+added: REPLACEME
+-->
+
+* {integer}
+
+The `process.ppid` property returns the PID of the current parent process.
+
+```js
+console.log(`The parent process is pid ${process.ppid}`);
+```
+
 ## process.release
 <!-- YAML
 added: v3.0.0

--- a/src/node.cc
+++ b/src/node.cc
@@ -2906,6 +2906,12 @@ static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
 }
 
 
+static void GetParentProcessId(Local<Name> property,
+                               const PropertyCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(Integer::New(info.GetIsolate(), uv_os_getppid()));
+}
+
+
 static Local<Object> GetFeatures(Environment* env) {
   EscapableHandleScope scope(env->isolate());
 
@@ -3237,6 +3243,9 @@ void SetupProcessObject(Environment* env,
 
   READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));
+
+  process->SetAccessor(FIXED_ONE_BYTE_STRING(env->isolate(), "ppid"),
+                       GetParentProcessId);
 
   auto need_immediate_callback_string =
       FIXED_ONE_BYTE_STRING(env->isolate(), "_needImmediateCallback");

--- a/test/parallel/test-process-ppid.js
+++ b/test/parallel/test-process-ppid.js
@@ -1,0 +1,16 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  // The following console.log() call is part of the test's functionality.
+  console.log(process.ppid);
+} else {
+  const child = cp.spawnSync(process.execPath, [__filename, 'child']);
+
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(+child.stdout.toString().trim(), process.pid);
+  assert.strictEqual(child.stderr.toString().trim(), '');
+}


### PR DESCRIPTION
Only the `src: add process.ppid` commit is relevant, but it depends on the libuv 1.16.0 update, which hasn't landed yet (https://github.com/nodejs/node/pull/16835).

Fixes: https://github.com/nodejs/node/issues/14957

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src