### PR TITLE
test: use fixtures module for path resolve

### DIFF
--- a/test/parallel/test-http2-respond-with-fd-errors.js
+++ b/test/parallel/test-http2-respond-with-fd-errors.js
@@ -1,10 +1,13 @@
 'use strict';
 
 const common = require('../common');
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
+
+const fixtures = require('../common/fixtures');
+
 const http2 = require('http2');
-const path = require('path');
 
 const {
   constants,
@@ -17,7 +20,7 @@ const {
 // - NGHTTP2_ERR_NOMEM (should emit session error)
 // - every other NGHTTP2 error from binding (should emit stream error)
 
-const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const fname = fixtures.path('elipses.txt');
 
 const specificTestKeys = [
   'NGHTTP2_ERR_NOMEM'


### PR DESCRIPTION
This is a part of the fixture use normalization process [commit](https://github.com/nodejs/node/pull/14332).

Changes in just one file where the path.resolve method replaced with fixtures.path.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
