### PR TITLE
Better commit message for breaking changes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,6 +334,10 @@ use `Refs:`.
    - `Refs: http://eslint.org/docs/rules/space-in-parens.html`
    - `Refs: https://github.com/nodejs/node/pull/3615`
 
+5. If your commit introduce a breaking change (`semver-major`), it should contain
+an explanation about the reason of the breaking change, which situation would trigger
+the breaking change and what is the exact change.
+
 Sample complete commit message:
 
 ```txt
@@ -625,6 +629,7 @@ Focus first on the most significant aspects of the change:
 1. Does this change make sense for Node.js?
 2. Does this change make Node.js better, even if only incrementally?
 3. Are there clear bugs or larger scale issues that need attending to?
+4. Is the commit message readable and correct? If it contains a breaking change is it clear enough?
 
 When changes are necessary, *request* them, do not *demand* them, and do not
 assume that the submitter already knows how to add a test or run a benchmark.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,9 +334,13 @@ use `Refs:`.
    - `Refs: http://eslint.org/docs/rules/space-in-parens.html`
    - `Refs: https://github.com/nodejs/node/pull/3615`
 
-5. If your commit introduce a breaking change (`semver-major`), it should contain
+5. If your commit introduces a breaking change (`semver-major`), it should contain
 an explanation about the reason of the breaking change, which situation would trigger
 the breaking change and what is the exact change.
+
+Breaking changes will be listed in the wiki with the aim to make upgrading easier.
+Please have a look at [Breaking Changes](https://github.com/nodejs/node/wiki/Breaking-changes-between-v4-LTS-and-v6-LTS) 
+for the level of detail that's suitable.
 
 Sample complete commit message:
 


### PR DESCRIPTION
In this change, I would like to propose to emphasize on the importance of a good commit message in general.
But also and especially on breaking changes to make the documentation process easier.

I think the readiness of the commit message and a proper and detailled content can make a whole world of difference to understand breaking changes and the reason behind them.

This suggestion comes from a Twitter discussion available here: https://twitter.com/MylesBorins/status/927625601112006656

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
- Documentation

<strike>PS: I am sorry, I'm proposing a change regarding commit messages and mine is awful, I did this on Github editor, I will rebase this commit to change its message at once.</strike>
