### PR TITLE
tls: set ecdhCurve default to 'auto'

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1154,8 +1154,7 @@ added: v0.11.13
 -->
 
 The default curve name to use for ECDH key agreement in a tls server. The
-default value is `'prime256v1'` (NIST P-256). Consult [RFC 4492] and
-[FIPS.186-4] for more details.
+default value is `'auto'`. See [`tls.createSecureContext()`] for further information.
 
 
 ## Deprecated APIs
@@ -1286,13 +1285,11 @@ where `secure_socket` has the same API as `pair.cleartext`.
 [Chrome's 'modern cryptography' setting]: https://www.chromium.org/Home/chromium-security/education/tls#TOC-Cipher-Suites
 [DHE]: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
 [ECDHE]: https://en.wikipedia.org/wiki/Elliptic_curve_Diffie%E2%80%93Hellman
-[FIPS.186-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
 [Forward secrecy]: https://en.wikipedia.org/wiki/Perfect_forward_secrecy
 [OCSP request]: https://en.wikipedia.org/wiki/OCSP_stapling
 [OpenSSL Options]: crypto.html#crypto_openssl_options
 [OpenSSL cipher list format documentation]: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT
 [Perfect Forward Secrecy]: #tls_perfect_forward_secrecy
-[RFC 4492]: https://www.rfc-editor.org/rfc/rfc4492.txt
 [SSL_CTX_set_timeout]: https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_timeout.html
 [SSL_METHODS]: https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
 [Stream]: stream.html#stream_stream

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -45,7 +45,7 @@ exports.SLAB_BUFFER_SIZE = 10 * 1024 * 1024;
 exports.DEFAULT_CIPHERS =
     process.binding('constants').crypto.defaultCipherList;
 
-exports.DEFAULT_ECDH_CURVE = 'prime256v1';
+exports.DEFAULT_ECDH_CURVE = 'auto';
 
 exports.getCiphers = internalUtil.cachedResult(
   () => internalUtil.filterDuplicateStrings(binding.getSSLCiphers(), true)

--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -80,7 +80,7 @@ function testDHE2048() {
 }
 
 function testECDHE256() {
-  test(256, 'ECDH', tls.DEFAULT_ECDH_CURVE, testECDHE512);
+  test(256, 'ECDH', 'prime256v1', testECDHE512);
   ntests++;
 }
 


### PR DESCRIPTION
For best out-of-the-box compatibility there should not be one default `ecdhCurve` for the tls client, OpenSSL should choose them automatically.

I've had a lot of struggle connecting to a server that did not support the default curve. Many third party modules have no support for setting `ecdhCurve`, therefore I think the tls client should support as much curves as possible by default. Using `'auto'` would achieve this.

Refs: https://github.com/nodejs/node/issues/16196
Refs: https://github.com/nodejs/node/issues/1495
Refs: https://wiki.openssl.org/index.php/Manual:SSL_CTX_set1_curves(3)
Refs: https://github.com/nodejs/node/pull/15206

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tls
