### PR TITLE
fs: add `inoString` to fs.Stats

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -339,6 +339,7 @@ similar to this:
 Stats {
   dev: 2114,
   ino: 48064969,
+  inoString: '48064969',
   mode: 33188,
   nlink: 1,
   uid: 85,
@@ -363,6 +364,11 @@ specific. `atime`, `mtime`, `ctime`, and `birthtime` are [`Date`][MDN-Date]
 object alternate representations of the various times. The `Date` and number
 values are not connected. Assigning a new number value, or mutating the `Date`
 value, will not be reflected in the corresponding alternate representation.
+
+*Note*: Since `ino` is an unsigned 64-bit integer, it may lost accuracy in
+JavaScript. This situation may cause some strange bugs in filesystem. So if you
+want to get an accurate [inode][] value, please use `inoString` which is a
+certain string.
 
 
 ### Stat Time Values

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -202,7 +202,8 @@ function Stats(
   atim_msec,
   mtim_msec,
   ctim_msec,
-  birthtim_msec
+  birthtim_msec,
+  ino_str
 ) {
   this.dev = dev;
   this.mode = mode;
@@ -212,6 +213,7 @@ function Stats(
   this.rdev = rdev;
   this.blksize = blksize;
   this.ino = ino;
+  this.inoString = ino_str;
   this.size = size;
   this.blocks = blocks;
   this.atimeMs = atim_msec;
@@ -258,6 +260,7 @@ Stats.prototype.isSocket = function() {
 };
 
 const statValues = binding.getStatValues();
+const getStatInoString = binding.getStatInoString;
 
 function statsFromValues() {
   return new Stats(statValues[0], statValues[1], statValues[2], statValues[3],
@@ -265,7 +268,7 @@ function statsFromValues() {
                    statValues[6] < 0 ? undefined : statValues[6], statValues[7],
                    statValues[8], statValues[9] < 0 ? undefined : statValues[9],
                    statValues[10], statValues[11], statValues[12],
-                   statValues[13]);
+                   statValues[13], getStatInoString(0));
 }
 
 // Don't allow mode to accidentally be overwritten.
@@ -1446,7 +1449,7 @@ function statsFromPrevValues() {
                    statValues[21], statValues[22],
                    statValues[23] < 0 ? undefined : statValues[23],
                    statValues[24], statValues[25], statValues[26],
-                   statValues[27]);
+                   statValues[27], getStatInoString(1));
 }
 function StatWatcher() {
   EventEmitter.call(this);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -317,6 +317,7 @@ inline Environment::Environment(IsolateData* isolate_data,
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
       fs_stats_field_array_(nullptr),
+      fs_ino_array_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());
@@ -368,6 +369,7 @@ inline Environment::~Environment() {
   delete[] heap_space_statistics_buffer_;
   delete[] http_parser_buffer_;
   delete http2_state_;
+  if (nullptr != fs_ino_array_) delete[] fs_ino_array_;
   free(performance_state_);
 }
 
@@ -537,6 +539,10 @@ inline double* Environment::fs_stats_field_array() const {
 inline void Environment::set_fs_stats_field_array(double* fields) {
   CHECK_EQ(fs_stats_field_array_, nullptr);  // Should be set only once.
   fs_stats_field_array_ = fields;
+}
+
+inline char* Environment::fs_ino_array() const {
+  return fs_ino_array_;
 }
 
 inline performance::performance_state* Environment::performance_state() {

--- a/src/env.cc
+++ b/src/env.cc
@@ -30,6 +30,10 @@ void Environment::Start(int argc,
   HandleScope handle_scope(isolate());
   Context::Scope context_scope(context());
 
+  char* temp = new char[2 * FS_INO_STRING_OFFSET];
+  memset(temp, 0, sizeof(char) * 2 * FS_INO_STRING_OFFSET);
+  fs_ino_array_ = temp;
+
   uv_check_init(event_loop(), immediate_check_handle());
   uv_unref(reinterpret_cast<uv_handle_t*>(immediate_check_handle()));
 

--- a/src/env.h
+++ b/src/env.h
@@ -48,6 +48,8 @@ struct nghttp2_rcbuf;
 
 namespace node {
 
+const size_t FS_INO_STRING_OFFSET = 32;
+
 namespace performance {
 struct performance_state;
 }
@@ -615,6 +617,8 @@ class Environment {
   inline double* fs_stats_field_array() const;
   inline void set_fs_stats_field_array(double* fields);
 
+  inline char* fs_ino_array() const;
+
   inline performance::performance_state* performance_state();
   inline std::map<std::string, uint64_t>* performance_marks();
 
@@ -744,6 +748,7 @@ class Environment {
   http2::http2_state* http2_state_ = nullptr;
 
   double* fs_stats_field_array_;
+  char* fs_ino_array_;
 
   struct AtExitCallback {
     void (*cb_)(void* arg);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -190,6 +190,7 @@ void After(uv_fs_t *req) {
     // All have at least two args now.
     argc = 2;
 
+    uv_stat_t* stat = nullptr;
     switch (req->fs_type) {
       // These all have no data to pass.
       case UV_FS_ACCESS:
@@ -216,8 +217,9 @@ void After(uv_fs_t *req) {
       case UV_FS_LSTAT:
       case UV_FS_FSTAT:
         argc = 1;
-        FillStatsArray(env->fs_stats_field_array(),
-                       static_cast<const uv_stat_t*>(req->ptr));
+        stat = static_cast<uv_stat_t*>(req->ptr);
+        FillStatsArray(env->fs_stats_field_array(), stat);
+        SetStatsIno(env->fs_ino_array(), stat);
         break;
 
       case UV_FS_UTIME:
@@ -465,6 +467,16 @@ void FillStatsArray(double* fields, const uv_stat_t* s) {
 #undef X
 }
 
+#ifdef _WIN32
+const char INO_STRING_FORMATTER[] = "%I64u";
+#else
+const char INO_STRING_FORMATTER[] = "%llu";
+#endif
+
+void SetStatsIno(char* ino, const uv_stat_t* s) {
+  snprintf(ino, FS_INO_STRING_OFFSET - 1, INO_STRING_FORMATTER, s->st_ino);
+}
+
 // Used to speed up module loading.  Returns the contents of the file as
 // a string or undefined when the file cannot be opened.  The speedup
 // comes from not creating Error objects on failure.
@@ -556,8 +568,9 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
     ASYNC_CALL(stat, args[1], UTF8, *path)
   } else {
     SYNC_CALL(stat, *path, *path)
-    FillStatsArray(env->fs_stats_field_array(),
-                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
+    const uv_stat_t* stat = static_cast<const uv_stat_t*>(SYNC_REQ.ptr);
+    FillStatsArray(env->fs_stats_field_array(), stat);
+    SetStatsIno(env->fs_ino_array(), stat);
   }
 }
 
@@ -574,8 +587,9 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
     ASYNC_CALL(lstat, args[1], UTF8, *path)
   } else {
     SYNC_CALL(lstat, *path, *path)
-    FillStatsArray(env->fs_stats_field_array(),
-                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
+    const uv_stat_t* stat = static_cast<const uv_stat_t*>(SYNC_REQ.ptr);
+    FillStatsArray(env->fs_stats_field_array(), stat);
+    SetStatsIno(env->fs_ino_array(), stat);
   }
 }
 
@@ -593,8 +607,9 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
     ASYNC_CALL(fstat, args[1], UTF8, fd)
   } else {
     SYNC_CALL(fstat, nullptr, fd)
-    FillStatsArray(env->fs_stats_field_array(),
-                   static_cast<const uv_stat_t*>(SYNC_REQ.ptr));
+    const uv_stat_t* stat = static_cast<const uv_stat_t*>(SYNC_REQ.ptr);
+    FillStatsArray(env->fs_stats_field_array(), stat);
+    SetStatsIno(env->fs_ino_array(), stat);
   }
 }
 
@@ -1415,6 +1430,15 @@ void GetStatValues(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(fields_array);
 }
 
+void GetStatInoString(const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(args.Length(), 1);
+  size_t idx = args[0]->Uint32Value();
+  Environment* env = Environment::GetCurrent(args);
+  char* ino = env->fs_ino_array();
+  args.GetReturnValue().Set(String::NewFromUtf8(env->isolate(),
+                            ino + (idx * FS_INO_STRING_OFFSET)));
+}
+
 void InitFs(Local<Object> target,
             Local<Value> unused,
             Local<Context> context,
@@ -1461,6 +1485,7 @@ void InitFs(Local<Object> target,
   env->SetMethod(target, "mkdtemp", Mkdtemp);
 
   env->SetMethod(target, "getStatValues", GetStatValues);
+  env->SetMethod(target, "getStatInoString", GetStatInoString);
 
   StatWatcher::Initialize(env, target);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -195,6 +195,8 @@ void ProcessEmitWarning(Environment* env, const char* fmt, ...);
 
 void FillStatsArray(double* fields, const uv_stat_t* s);
 
+void SetStatsIno(char* ino, const uv_stat_t* s);
+
 void SetupProcessObject(Environment* env,
                         int argc,
                         const char* const* argv,

--- a/src/node_stat_watcher.cc
+++ b/src/node_stat_watcher.cc
@@ -90,6 +90,8 @@ void StatWatcher::Callback(uv_fs_poll_t* handle,
 
   FillStatsArray(env->fs_stats_field_array(), curr);
   FillStatsArray(env->fs_stats_field_array() + 14, prev);
+  SetStatsIno(env->fs_ino_array(), curr);
+  SetStatsIno(env->fs_ino_array() + FS_INO_STRING_OFFSET, prev);
   Local<Value> arg = Integer::New(env->isolate(), status);
   wrap->MakeCallback(env->onchange_string(), 1, &arg);
 }

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -96,7 +96,8 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     'dev', 'mode', 'nlink', 'uid',
     'gid', 'rdev', 'ino', 'size',
     'atime', 'mtime', 'ctime', 'birthtime',
-    'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs'
+    'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs',
+    'inoString'
   ];
   if (!common.isWindows) {
     keys.push('blocks', 'blksize');
@@ -129,4 +130,9 @@ fs.stat(__filename, common.mustCall(function(err, s) {
   dateFields.forEach((k) => {
     assert.strictEqual(typeof parsed[k], 'string', `${k} should be a string`);
   });
+
+  assert.strictEqual(typeof parsed.inoString,
+                     'string',
+                     'inoString should be a string');
+  assert.strictEqual(/^\d+$/g.test(parsed.inoString), true);
 }));

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -43,7 +43,8 @@ const expectedStatObject = new fs.Stats(
   Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
   Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
-  Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
+  Date.UTC(1970, 0, 1, 0, 0, 0),            // birthtime
+  '0'                                       // ino string
 );
 
 common.refreshTmpDir();


### PR DESCRIPTION
Since `ino` is an unsigned 64-bit integer, it may lost accuracy in
JavaScript. This situation may cause some strange bugs in filesystem. So
a string type `inoString` is added to `fs.Stats`.

Fixes: https://github.com/nodejs/node/issues/16679
Fixes: https://github.com/nodejs/node/issues/12115
Refs: http://docs.libuv.org/en/v1.x/fs.html#c.uv_stat_t

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs