### PR TITLE
src: make StreamBase prototype accessors more robust

### DIFF
--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -11,6 +11,7 @@
 
 namespace node {
 
+using v8::AccessorSignature;
 using v8::External;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -31,27 +32,33 @@ void StreamBase::AddMethods(Environment* env,
   HandleScope scope(env->isolate());
 
   enum PropertyAttribute attributes =
-      static_cast<PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
+      static_cast<PropertyAttribute>(
+        v8::ReadOnly | v8::DontDelete | v8::DontEnum);
+  Local<AccessorSignature> signature =
+    AccessorSignature::New(env->isolate(), t);
   t->PrototypeTemplate()->SetAccessor(env->fd_string(),
                                       GetFD<Base>,
                                       nullptr,
                                       env->as_external(),
                                       v8::DEFAULT,
-                                      attributes);
+                                      attributes,
+                                      signature);
 
   t->PrototypeTemplate()->SetAccessor(env->external_stream_string(),
                                       GetExternal<Base>,
                                       nullptr,
                                       env->as_external(),
                                       v8::DEFAULT,
-                                      attributes);
+                                      attributes,
+                                      signature);
 
   t->PrototypeTemplate()->SetAccessor(env->bytes_read_string(),
                                       GetBytesRead<Base>,
                                       nullptr,
                                       env->as_external(),
                                       v8::DEFAULT,
-                                      attributes);
+                                      attributes,
+                                      signature);
 
   env->SetProtoMethod(t, "readStart", JSMethod<Base, &StreamBase::ReadStart>);
   env->SetProtoMethod(t, "readStop", JSMethod<Base, &StreamBase::ReadStop>);

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -33,9 +33,9 @@ void StreamBase::AddMethods(Environment* env,
 
   enum PropertyAttribute attributes =
       static_cast<PropertyAttribute>(
-        v8::ReadOnly | v8::DontDelete | v8::DontEnum);
+          v8::ReadOnly | v8::DontDelete | v8::DontEnum);
   Local<AccessorSignature> signature =
-    AccessorSignature::New(env->isolate(), t);
+      AccessorSignature::New(env->isolate(), t);
   t->PrototypeTemplate()->SetAccessor(env->fd_string(),
                                       GetFD<Base>,
                                       nullptr,

--- a/test/parallel/test-stream-base-prototype-accessors-enumerability.js
+++ b/test/parallel/test-stream-base-prototype-accessors-enumerability.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+
+// This tests that the prototype accessors added by StreamBase::AddMethods
+// are not enumerable. They could be enumerated when inspecting the prototype
+// with util.inspect or the inspector protocol.
+
+const assert = require('assert');
+
+// Or anything that calls StreamBase::AddMethods when setting up its prototype
+const TTY = process.binding('tty_wrap').TTY;
+
+{
+  assert.strictEqual(TTY.prototype.propertyIsEnumerable('bytesRead'), false);
+  assert.strictEqual(TTY.prototype.propertyIsEnumerable('fd'), false);
+  assert.strictEqual(
+    TTY.prototype.propertyIsEnumerable('_externalStream'), false);
+}

--- a/test/parallel/test-stream-base-prototype-accessors.js
+++ b/test/parallel/test-stream-base-prototype-accessors.js
@@ -1,0 +1,27 @@
+'use strict';
+
+require('../common');
+
+// This tests that the prototype accessors added by StreamBase::AddMethods
+// do not raise assersions when called with incompatible receivers.
+
+const assert = require('assert');
+
+// Or anything that calls StreamBase::AddMethods when setting up its prototype
+const TTY = process.binding('tty_wrap').TTY;
+
+// Should throw instead of raise assertions
+{
+  const msg = /TypeError: Method \w+ called on incompatible receiver/;
+  assert.throws(() => {
+    TTY.prototype.bytesRead;
+  }, msg);
+
+  assert.throws(() => {
+    TTY.prototype.fd;
+  }, msg);
+
+  assert.throws(() => {
+    TTY.prototype._externalStream;
+  }, msg);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src

This problem showed up when I was stepping into `Writable.prototype.write` and hover over `this` from a `console.log` call,  there was assertion like this:

<details>
<summary>see assertion</summary>

```
node[90480]: ../src/util-inl.h:243:TypeName *node::Unwrap(v8::Local<v8::Object>) [TypeName = node::LibuvStreamWrap]: Assertion `(object->InternalFieldCount()) > (0)' failed.
 1: node::Abort() [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 2: node::(anonymous namespace)::DomainEnter(node::Environment*, v8::Local<v8::Object>) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 3: node::LibuvStreamWrap::~LibuvStreamWrap() [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 4: void node::StreamBase::GetBytesRead<node::LibuvStreamWrap>(v8::Local<v8::String>, v8::PropertyCallbackInfo<v8::Value> const&) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 5: v8::internal::PropertyCallbackArguments::Call(void (*)(v8::Local<v8::Name>, v8::PropertyCallbackInfo<v8::Value> const&), v8::internal::Handle<v8::internal::Name>) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 6: v8::internal::Object::GetPropertyWithAccessor(v8::internal::LookupIterator*) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 7: v8::internal::JSReceiver::GetOwnPropertyDescriptor(v8::internal::LookupIterator*, v8::internal::PropertyDescriptor*) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 8: v8::internal::JSReceiver::GetOwnPropertyDescriptor(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSReceiver>, v8::internal::Handle<v8::internal::Object>, v8::internal::PropertyDescriptor*) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
 9: v8::internal::Builtin_Impl_ObjectGetOwnPropertyDescriptor(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/Users/joyee/.tnvm/versions/node/v9.0.0/bin/node]
10: 0x3f95
```
</details>

because the inspector would wrap the inspected project's prototype when generating previews. This is also reproducible when `util.inspect` a prototype setup by `StreamBase::AddMethods`. This PR makes those accessors nonenumerable and check the signatures in the accessors so they throw instead of raise assertions.