### PR TITLE
doc: drop support for VS2015

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ in production.
 |--------------|--------------|----------------------------------|----------------------|------------------|
 | GNU/Linux    | Tier 1       | kernel >= 2.6.32, glibc >= 2.12  | x86, x64, arm, arm64 |                  |
 | macOS        | Tier 1       | >= 10.10                         | x64                  |                  |
-| Windows      | Tier 1       | >= Windows 7 / 2008 R2           | x86, x64             | vs2015 or vs2017 |
+| Windows      | Tier 1       | >= Windows 7 / 2008 R2           | x86, x64             | vs2017           |
 | SmartOS      | Tier 2       | >= 15 < 16.4                     | x86, x64             | see note1        |
 | FreeBSD      | Tier 2       | >= 10                            | x64                  |                  |
 | GNU/Linux    | Tier 2       | kernel >= 3.13.0, glibc >= 2.19  | ppc64le >=power8     |                  |
@@ -76,7 +76,7 @@ Depending on host platform, the selection of toolchains may vary.
 
 #### Windows
 
-* Visual Studio 2015 or Visual C++ Build Tools 2015 or newer
+* Visual Studio 2017 or the Build Tools thereof
 
 ## Building Node.js on supported platforms
 
@@ -192,16 +192,11 @@ $ [sudo] make install
 Prerequisites:
 
 * [Python 2.6 or 2.7](https://www.python.org/downloads/)
-* One of:
-  * [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)
-  * [Visual Studio 2015 Update 3](https://www.visualstudio.com/), all editions
-    including the Community edition (remember to select
-    "Common Tools for Visual C++ 2015" feature during installation).
-  * The "Desktop development with C++" workload from
-    [Visual Studio 2017](https://www.visualstudio.com/downloads/) or the
-    "Visual C++ build tools" workload from the
-    [Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017),
-    with the default optional components.
+* The "Desktop development with C++" workload from
+  [Visual Studio 2017](https://www.visualstudio.com/downloads/) or the
+  "Visual C++ build tools" workload from the
+  [Build Tools](https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017),
+  with the default optional components.
 * Basic Unix tools required for some tests,
   [Git for Windows](http://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.


### PR DESCRIPTION
V8 master no longer builds with VS2015: https://github.com/nodejs/node-v8/issues/19#issuecomment-342440529 There are two main issues:

* Internal compiler error. Might get fixed by Microsoft, but chances are slim since VS2015 is no longer actively supported. There might be a workaround, but the V8 team is probably not eager to spend time tinkering to please an outdated compiler.
* Extended `constexpr` in `bits.h` (introduced in https://github.com/v8/v8/commit/51f4d2e9e3459a5f3f92f24183d52f8d84137596). Supported since VS2017. There is no trivial way to work around it while keeping the function `constexpr`.

Visual Studio Community 2017 is free and supports all the operating systems VS2015 does, so spending extra effort to support VS2015 doesn't seem justifiable.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc