### PR TITLE
doc: deprecate top-level this being bound to module.exports

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -737,6 +737,14 @@ Type: Runtime
 internal mechanics of the `REPLServer` itself, and is therefore not
 necessary in user space.
 
+<a id="DEP0083"></a>
+### DEP0083: Top-level `this` bound to `module.exports`
+
+Type: Documentation-only
+
+Assigning properties to the top-level `this` as an alternative
+to `module.exports` is deprecated. Developers should use `exports`
+or `module.exports` instead.
 
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -737,8 +737,8 @@ Type: Runtime
 internal mechanics of the `REPLServer` itself, and is therefore not
 necessary in user space.
 
-<a id="DEP0083"></a>
-### DEP0083: Top-level `this` bound to `module.exports`
+<a id="DEP00XX"></a>
+### DEP00XX: Top-level `this` bound to `module.exports`
 
 Type: Documentation-only
 


### PR DESCRIPTION
Added using the top-level `this` as an alternative to `module.exports` to the list of deprecated APIs.

Fixes: https://github.com/nodejs/node/issues/9623

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc