### PR TITLE
tools: make the lint rules depend on tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -990,12 +990,12 @@ LINT_MD_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
   -not -path '*node_modules*' -name '*.md') $(LINT_MD_ROOT_DOCS)
 LINT_DOC_MD_FILES = $(shell ls doc/**/*.md)
 
-tools/.docmdlintstamp: $(LINT_DOC_MD_FILES)
+tools/.docmdlintstamp: $(LINT_DOC_MD_FILES) tools/remark-cli
 	@echo "Running Markdown linter on docs..."
 	@$(NODE) tools/remark-cli/cli.js -q -f $(LINT_DOC_MD_FILES)
 	@touch $@
 
-tools/.miscmdlintstamp: $(LINT_MD_FILES)
+tools/.miscmdlintstamp: $(LINT_MD_FILES) tools/remark-cli
 	@echo "Running Markdown linter on misc docs..."
 	@$(NODE) tools/remark-cli/cli.js -q -f $(LINT_MD_FILES)
 	@touch $@
@@ -1066,13 +1066,12 @@ ADDON_DOC_LINT_FLAGS=-whitespace/ending_newline,-build/header_guard
 
 lint-cpp: tools/.cpplintstamp
 
-tools/.cpplintstamp: $(LINT_CPP_FILES)
-	@echo "Running C++ linter..."
-	@$(PYTHON) tools/cpplint.py $?
+tools/.cpplintstamp: $(LINT_CPP_FILES) tools/cpplint.py tools/check-imports.py
+	@$(PYTHON) tools/cpplint.py $(LINT_CPP_FILES)
 	@$(PYTHON) tools/check-imports.py
 	@touch $@
 
-lint-addon-docs: test/addons/.docbuildstamp
+lint-addon-docs: test/addons/.docbuildstamp tools/cpplint.py
 	@echo "Running C++ linter on addon docs..."
 	@$(PYTHON) tools/cpplint.py --filter=$(ADDON_DOC_LINT_FLAGS) $(LINT_CPP_ADDON_DOC_FILES)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools

Somewhat related to https://github.com/nodejs/node/pull/16581#issuecomment-342745462 , although this is not related to JS linting. The idea is if we update remark or cpplint.py, then we should re-run the linters so the new changes apply.
