### PR TITLE
src: Use program_getpid() instead of getpid() on CloudABI.

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -5,8 +5,14 @@
 
 #if defined(_MSC_VER)
 #define getpid GetCurrentProcessId
+#define GETPID_FORMAT "%d"
+#elif defined(__CloudABI__)
+#include <program.h>
+#define getpid program_getpid
+#define GETPID_FORMAT "%s"
 #else
 #include <unistd.h>
+#define GETPID_FORMAT "%d"
 #endif
 
 #include <stdio.h>
@@ -131,7 +137,9 @@ void Environment::PrintSyncTrace() const {
   Local<v8::StackTrace> stack =
       StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
 
-  fprintf(stderr, "(node:%d) WARNING: Detected use of sync API\n", getpid());
+  fprintf(stderr,
+          "(node:" GETPID_FORMAT ") WARNING: Detected use of sync API\n",
+          getpid());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(i);

--- a/src/node.cc
+++ b/src/node.cc
@@ -124,6 +124,10 @@ typedef int mode_t;
 extern char **environ;
 #endif
 
+#ifdef __CloudABI__
+#include <program.h>
+#endif
+
 namespace node {
 
 using v8::Array;
@@ -3235,7 +3239,12 @@ void SetupProcessObject(Environment* env,
       process_env_template->NewInstance(env->context()).ToLocalChecked();
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "env"), process_env);
 
+#ifdef __CloudABI__
+  READONLY_PROPERTY(process, "pid",
+                    String::NewFromUtf8(env->isolate(), program_getpid()));
+#else
   READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
+#endif
   READONLY_PROPERTY(process, "features", GetFeatures(env));
 
   auto need_immediate_callback_string =


### PR DESCRIPTION
CloudABI does not provide getpid(). The problem with getpid() is that
it, being an integer type, cannot be implemented in a way that it is
unique enough.

On traditional UNIX-like systems, it can be recycled fairly quickly. As
CloudABI is focussing on getting distributed applications (clusters)
right, it makes little sense to have five-digit process numbers.
Instead, we have a program_getpid() function that returns a UUIDv4.

This code patches up process.pid to return the UUIDv4 on CloudABI. It
also fixes up a log message containing the PID to use program_getpid()
instead. For the latter, we also need to adjust the printf() format. Add
a GETPID_FORMAT define that can be used for this purpose. Even POSIX
doesn't guarantee that pid_t is a plain 'int'.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added   **<-- Do we want to change the documentation of `process.pid` that it can return both ints and strings, depending on the OS?**
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src