### PR TITLE
test: improve assert messages in stream-pipe-await-drain-manual-resume

### DIFF
--- a/test/parallel/test-stream-pipe-await-drain-manual-resume.js
+++ b/test/parallel/test-stream-pipe-await-drain-manual-resume.js
@@ -30,11 +30,13 @@ readable.once('pause', common.mustCall(() => {
   assert.strictEqual(
     readable._readableState.awaitDrain,
     1,
-    'awaitDrain doesn\'t increase'
+    'Expected awaitDrain to equal 1 but instead got ' +
+    `${readable._readableState.awaitDrain}`
   );
   // First pause, resume manually. The next write() to writable will still
   // return false, because chunks are still being buffered, so it will increase
   // the awaitDrain counter again.
+
   process.nextTick(common.mustCall(() => {
     readable.resume();
   }));
@@ -43,7 +45,8 @@ readable.once('pause', common.mustCall(() => {
     assert.strictEqual(
       readable._readableState.awaitDrain,
       1,
-      '.resume() does not reset counter'
+      '.resume() should not reset the counter but instead got ' +
+      `${readable._readableState.awaitDrain}`
     );
     // Second pause, handle all chunks from now on. Once all callbacks that
     // are currently queued up are handled, the awaitDrain drain counter should
@@ -64,7 +67,8 @@ writable.on('finish', common.mustCall(() => {
   assert.strictEqual(
     readable._readableState.awaitDrain,
     0,
-    'awaitDrain not 0 after all chunks are written'
+    'awaitDrain should equal 0 after all chunks are written but instead got' +
+    `${readable._readableState.awaitDrain}`
   );
   // Everything okay, all chunks were written.
 }));


### PR DESCRIPTION

Failing test error message improved so will return the expected and actual value returned.

##### Checklist

- [/ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

