### PR TITLE
test: improve assertion messages in test-domain-safe-exit

### DIFF
--- a/test/parallel/test-domain-safe-exit.js
+++ b/test/parallel/test-domain-safe-exit.js
@@ -25,6 +25,7 @@ require('../common');
 
 const assert = require('assert');
 const domain = require('domain');
+const util = require('util');
 
 const a = domain.create();
 const b = domain.create();
@@ -32,8 +33,8 @@ const b = domain.create();
 a.enter(); // push
 b.enter(); // push
 assert.deepStrictEqual(domain._stack, [a, b], 'b not pushed ' +
-                       `(domain._stack = ${JSON.stringify(domain._stack)})`);
+                       `(domain._stack = ${util.inspect(domain._stack)})`);
 
 domain.create().exit(); // no-op
 assert.deepStrictEqual(domain._stack, [a, b], 'stack mangled! ' +
-                       `(domain._stack = ${JSON.stringify(domain._stack)})`);
+                       `(domain._stack = ${util.inspect(domain._stack)})`);

--- a/test/parallel/test-domain-safe-exit.js
+++ b/test/parallel/test-domain-safe-exit.js
@@ -32,9 +32,9 @@ const b = domain.create();
 
 a.enter(); // push
 b.enter(); // push
-assert.deepStrictEqual(domain._stack, [a, b], 'b not pushed ' +
+assert.deepStrictEqual(domain._stack, [a, b], 'Unexpected stack shape ' +
                        `(domain._stack = ${util.inspect(domain._stack)})`);
 
 domain.create().exit(); // no-op
-assert.deepStrictEqual(domain._stack, [a, b], 'stack mangled! ' +
+assert.deepStrictEqual(domain._stack, [a, b], 'Unexpected stack shape ' +
                        `(domain._stack = ${util.inspect(domain._stack)})`);

--- a/test/parallel/test-domain-safe-exit.js
+++ b/test/parallel/test-domain-safe-exit.js
@@ -20,9 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+require('../common');
 // Make sure the domain stack doesn't get clobbered by un-matched .exit()
 
-require('../common');
 const assert = require('assert');
 const domain = require('domain');
 
@@ -31,7 +31,9 @@ const b = domain.create();
 
 a.enter(); // push
 b.enter(); // push
-assert.deepStrictEqual(domain._stack, [a, b], 'b not pushed');
+assert.deepStrictEqual(domain._stack, [a, b], 'b not pushed ' +
+                       `(domain._stack = ${JSON.stringify(domain._stack)})`);
 
 domain.create().exit(); // no-op
-assert.deepStrictEqual(domain._stack, [a, b], 'stack mangled!');
+assert.deepStrictEqual(domain._stack, [a, b], 'stack mangled! ' +
+                       `(domain._stack = ${JSON.stringify(domain._stack)})`);


### PR DESCRIPTION

Print content of domain stack if it doesn't match expected values.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)