### PR TITLE
deps: cherry-pick cc55747 from V8 upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/test/message/testcfg.py
+++ b/deps/v8/test/message/testcfg.py
@@ -107,7 +107,7 @@ class MessageTestSuite(testsuite.TestSuite):
         expected_lines, actual_lines, fillvalue=''):
       pattern = re.escape(expected.rstrip() % env)
       pattern = pattern.replace("\\*", ".*")
-      pattern = pattern.replace("\\{NUMBER\\}", "\d(?:\.\d*)?")
+      pattern = pattern.replace("\\{NUMBER\\}", "\d+(?:\.\d*)?")
       pattern = "^%s$" % pattern
       if not re.match(pattern, actual):
         return True


### PR DESCRIPTION
This fixes the flaky message/console test on our CI.

Original commit message:
  [test/message] Allow numbers to have more than one leading digit.

  The {NUMBER} regexp only allowed one, leading to occasional test
  failures such as:
  https://build.chromium.org/p/client.v8/builders/V8%20Mac%20-%20debug/builds/17156

  Bug:
  Change-Id: I25a08b80640d9af19ba70c61c846163685f1cb82
  Reviewed-on: https://chromium-review.googlesource.com/753322
  Reviewed-by: Franziska Hinkelmann <franzih@chromium.org>
  Commit-Queue: Georg Neis <neis@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#49109}

Refs: https://github.com/nodejs/build/issues/936

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps