### PR TITLE
Add a Habitat plan for NodeJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ icu_config.gypi
 deps/uv/.github/
 deps/uv/docs/code/
 deps/uv/docs/src/guide/
+results/

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,45 @@
+
+pkg_name=node
+pkg_origin=nodejs
+pkg_description="Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine."
+pkg_upstream_url=https://nodejs.org/
+pkg_license=('MIT')
+pkg_maintainer="The NodeJS Maintainers"
+pkg_deps=(core/glibc core/gcc-libs)
+pkg_build_deps=(core/python2 core/gcc core/grep core/make)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/node)
+pkg_lib_dirs=(lib)
+
+pkg_version() {
+  "$(pkg_path_for core/python2)/bin/python2" ../tools/getnodeversion.py
+}
+
+do_before() {
+  update_pkg_version
+}
+
+do_prepare() {
+  # ./configure has a shebang of #!/usr/bin/env python2. Fix it.
+  sed -e "s#/usr/bin/env python#$(pkg_path_for python2)/bin/python2#" -i configure
+}
+
+do_build() {
+  ./configure \
+    --prefix "${pkg_prefix}" \
+    --dest-cpu "x64" \
+    --dest-os "linux"
+
+  make -j"$(nproc)"
+}
+
+do_install() {
+  do_default_install
+
+  # Node produces a lot of scripts that hardcode `/usr/bin/env`, so we need to
+  # fix that everywhere to point directly at the env binary in core/coreutils.
+  grep -nrlI '^\#\!/usr/bin/env' "$pkg_prefix" | while read -r target; do
+    sed -e "s#\#\!/usr/bin/env node#\#\!${pkg_prefix}/bin/node#" -i "$target"
+  done
+}


### PR DESCRIPTION
This will allow Habitat to build NodeJS whenever new commits are added to the main repo instead of consuming only stable/current releases.

I have taken the liberty of creating an origin in Habitat https://bldr.habitat.sh/#/origins/nodejs/packages but I am happy to relinquish control of it to the NodeJS community of maintainers.

Signed-off-by: Travis Elliott Davis <edavis@chef.io>

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
packaging