### PR TITLE
tools,build: allow build without `remark-cli`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,6 +984,7 @@ lint-md-build:
 		echo "Markdown linter: installing remark-preset-lint-node into tools/"; \
 		cd tools/remark-preset-lint-node && ../../$(NODE) ../../$(NPM) install; fi
 
+ifneq ("","$(wildcard tools/remark-cli/node_modules/)")
 LINT_MD_TARGETS = src lib benchmark tools/doc tools/icu
 LINT_MD_ROOT_DOCS := $(wildcard *.md)
 LINT_MD_FILES := $(shell find $(LINT_MD_TARGETS) -type f \
@@ -1002,7 +1003,12 @@ tools/.miscmdlintstamp: $(LINT_MD_FILES)
 
 tools/.mdlintstamp: tools/.miscmdlintstamp tools/.docmdlintstamp
 
-lint-md: | lint-md-build tools/.mdlintstamp
+lint-md: | tools/.mdlintstamp
+else
+lint-md:
+	@echo "The markdown linter is not installed."
+	@echo "To install (requires internet access) run: $ make lint-md-build"
+endif
 
 LINT_JS_TARGETS = benchmark doc lib test tools
 LINT_JS_CMD = tools/eslint/bin/eslint.js --cache \


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/16635#issuecomment-342935096
The `lint` target in the `Makefile` is dependant on `remark-cli` being installed in `/tools/` or alternatively on internet access to the `npm` registry. The source tarball does not include `remark-cli` nor `ESLint`, so this PR uses the same conditional pattern as for `lint-js`: https://github.com/nodejs/node/blob/d597317a209fcf9e0c233093b2adc8f71129b9ef/Makefile#L1082-L1107

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build,tools
