### PR TITLE
deps: cherry-pick 3c8195d from V8 upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/builtins/builtins-collections-gen.cc
+++ b/deps/v8/src/builtins/builtins-collections-gen.cc
@@ -302,10 +302,11 @@ TF_BUILTIN(MapConstructor, CollectionsBuiltinsAssembler) {
 
     BIND(&if_notobject);
     {
-      Node* const exception = MakeTypeError(
-          MessageTemplate::kIteratorValueNotAnObject, context, next_value);
-      var_exception.Bind(exception);
-      Goto(&if_exception);
+      Node* ret = CallRuntime(
+          Runtime::kThrowTypeError, context,
+          SmiConstant(MessageTemplate::kIteratorValueNotAnObject), next_value);
+      GotoIfException(ret, &if_exception, &var_exception);
+      Unreachable();
     }
   }
 

--- a/deps/v8/test/inspector/debugger/caught-uncaught-exceptions-expected.txt
+++ b/deps/v8/test/inspector/debugger/caught-uncaught-exceptions-expected.txt
@@ -3,3 +3,11 @@ paused in throwCaught
 uncaught: false
 paused in throwUncaught
 uncaught: true
+paused in throwInPromiseCaught
+uncaught: false
+paused in promiseUncaught
+uncaught: true
+paused in throwInMapConstructor
+uncaught: true
+paused in throwInAsyncIterator
+uncaught: true


### PR DESCRIPTION
Original commit message:

  [map] Fix map constructor to correctly throw.

  We need to throw before rethrowing, otherwise the exception does
  not trigger a debugger event and is not reported if uncaught.

  R=gsathya@chromium.org, jgruber@chromium.org

  Bug: v8:7047
  Change-Id: I7ce0253883a21d6059e4e0ed0fc56dc55a0dcba6
  Reviewed-on: https://chromium-review.googlesource.com/758372
  Reviewed-by: Jakob Gruber <jgruber@chromium.org>
  Reviewed-by: Sathya Gunasekaran <gsathya@chromium.org>
  Commit-Queue: Yang Guo <yangguo@chromium.org>
  Cr-Commit-Position: refs/heads/master@{#49237}

Fixes: https://github.com/nodejs/node/issues/16856

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps