### PR TITLE
src: perf_hooks: fix wrong sized delete

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -196,7 +196,9 @@ void PerformanceGCCallback(uv_async_t* handle) {
 
  cleanup:
   delete data;
-  auto closeCB = [](uv_handle_t* handle) { delete handle; };
+  auto closeCB = [](uv_handle_t* handle) {
+    delete reinterpret_cast<uv_async_t*>(handle);
+  };
   uv_close(reinterpret_cast<uv_handle_t*>(handle), closeCB);
 }
 


### PR DESCRIPTION
Depending on the allocator, existing code leaks memory.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src: perf_hooks

CI: https://ci.nodejs.org/job/node-test-pull-request/11318/