### PR TITLE
tools: fix inspector-check reporting

### DIFF
--- a/tools/eslint-rules/inspector-check.js
+++ b/tools/eslint-rules/inspector-check.js
@@ -30,7 +30,7 @@ module.exports = function(context) {
   }
 
   function reportIfMissing(context, node) {
-    if (missingCheckNodes.length > 0 && !hasInspectorCheck) {
+    if (!hasInspectorCheck) {
       missingCheckNodes.forEach((node) => {
         context.report(node, msg);
       });

--- a/tools/eslint-rules/inspector-check.js
+++ b/tools/eslint-rules/inspector-check.js
@@ -14,12 +14,12 @@ const msg = 'Please add a skipIfInspectorDisabled() call to allow this ' +
             'test to be skippped when Node is built \'--without-inspector\'.';
 
 module.exports = function(context) {
-  var usesInspector = false;
+  const missingCheckNodes = [];
   var hasInspectorCheck = false;
 
   function testInspectorUsage(context, node) {
     if (utils.isRequired(node, ['inspector'])) {
-      usesInspector = true;
+      missingCheckNodes.push(node);
     }
   }
 
@@ -30,8 +30,10 @@ module.exports = function(context) {
   }
 
   function reportIfMissing(context, node) {
-    if (usesInspector && !hasInspectorCheck) {
-      context.report(node, msg);
+    if (missingCheckNodes.length > 0 && !hasInspectorCheck) {
+      missingCheckNodes.forEach((node) => {
+        context.report(node, msg);
+      });
     }
   }
 


### PR DESCRIPTION
Currently the inspector-check rule does not store the node when the
usage of a require('inspector') is done. This means that it is not
possible to disable this rule. For example, if you add the following to
a test that uses the inspector module:
```javascript
//common.skipIfInspectorDisabled();
/* eslint-disable inspector-check */
```
This will not disable the check and there will still be a lint error
reported.

This commit stores the node where the require statement is done which
allows for the rule to also be disabled.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools