### PR TITLE
doc: avoid mentioning 'uncaughtException'

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -142,20 +142,8 @@ myEmitter.emit('error', new Error('whoops!'));
 // Throws and crashes Node.js
 ```
 
-To guard against crashing the Node.js process, a listener can be registered
-on the [`process` object's `uncaughtException` event][] or the [`domain`][] module
-can be used. (Note, however, that the `domain` module has been deprecated.)
-
-```js
-const myEmitter = new MyEmitter();
-
-process.on('uncaughtException', (err) => {
-  console.error('whoops! there was an error');
-});
-
-myEmitter.emit('error', new Error('whoops!'));
-// Prints: whoops! there was an error
-```
+To guard against crashing the Node.js process the [`domain`][] module can be
+used. (Note, however, that the `domain` module has been deprecated.)
 
 As a best practice, listeners should always be added for the `'error'` events.
 
@@ -594,5 +582,4 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 [`fs.ReadStream`]: fs.html#fs_class_fs_readstream
 [`net.Server`]: net.html#net_class_net_server
 [`process.on('warning')`]: process.html#process_event_warning
-[`process` object's `uncaughtException` event]: process.html#process_event_uncaughtexception
 [stream]: stream.html


### PR DESCRIPTION
I think we should not mention the `'uncaughtException'` event in the documentation of the error events. Experience has taught me that it is usually used in the wrong way leading to bizarre situations like parsers blocked in a wrong state, events emitted multiple times when they should not, etc. If an `'error'` event does not have a listener the process should just exit.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc