### PR TITLE
test: cover vm.runInNewContext()

### DIFF
--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -73,3 +73,23 @@ const fn = vm.runInNewContext('(function() { obj.p = {}; })', { obj: {} });
 global.gc();
 fn();
 // Should not crash
+
+{
+  // Verify that providing a custom filename as a string argument works.
+  const code = 'throw new Error("foo");';
+  const file = 'test_file.vm';
+
+  assert.throws(() => {
+    vm.runInNewContext(code, {}, file);
+  }, (err) => {
+    const lines = err.stack.split('\n');
+
+    assert.strictEqual(lines[0].trim(), `${file}:1`);
+    assert.strictEqual(lines[1].trim(), code);
+    // Skip lines[2] and lines[3]. They're just a ^ and blank line.
+    assert.strictEqual(lines[4].trim(), 'Error: foo');
+    assert.strictEqual(lines[5].trim(), `at ${file}:1:7`);
+    // The rest of the stack is uninteresting.
+    return true;
+  });
+}


### PR DESCRIPTION
There is currently one `if` branch missing coverage in `lib/vm.js`. This commit adds a test to cover the case where the third argument to `runInNewContext()` is a string.

Coverage to 💯 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test