### PR TITLE
test: enable mustCall() during child exit

### DIFF
--- a/test/parallel/test-process-raw-debug.js
+++ b/test/parallel/test-process-raw-debug.js
@@ -50,10 +50,10 @@ function parent() {
     console.log('ok - got expected message');
   });
 
-  child.on('exit', function(c) {
+  child.on('exit', common.mustCall(function(c) {
     assert(!c);
     console.log('ok - child exited nicely');
-  });
+  }));
 }
 
 function child() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Enabling mustCall() for child process on exit.
