### PR TITLE
stream: use arrow fns for 'this' in readable

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -856,19 +856,18 @@ Readable.prototype.wrap = function(stream) {
   var state = this._readableState;
   var paused = false;
 
-  var self = this;
-  stream.on('end', function() {
+  stream.on('end', () => {
     debug('wrapped end');
     if (state.decoder && !state.ended) {
       var chunk = state.decoder.end();
       if (chunk && chunk.length)
-        self.push(chunk);
+        this.push(chunk);
     }
 
-    self.push(null);
+    this.push(null);
   });
 
-  stream.on('data', function(chunk) {
+  stream.on('data', (chunk) => {
     debug('wrapped data');
     if (state.decoder)
       chunk = state.decoder.write(chunk);
@@ -879,7 +878,7 @@ Readable.prototype.wrap = function(stream) {
     else if (!state.objectMode && (!chunk || !chunk.length))
       return;
 
-    var ret = self.push(chunk);
+    var ret = this.push(chunk);
     if (!ret) {
       paused = true;
       stream.pause();
@@ -900,12 +899,12 @@ Readable.prototype.wrap = function(stream) {
 
   // proxy certain important events.
   for (var n = 0; n < kProxyEvents.length; n++) {
-    stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    stream.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
   }
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.
-  self._read = function(n) {
+  this._read = (n) => {
     debug('wrapped _read', n);
     if (paused) {
       paused = false;
@@ -913,7 +912,7 @@ Readable.prototype.wrap = function(stream) {
     }
   };
 
-  return self;
+  return this;
 };
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
Using arrow functions for this in readable stream.