### PR TITLE
benchmark: build the misc/function_call addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-valgrind: all
 test-check-deopts: all
 	$(PYTHON) tools/test.py --mode=release --check-deopts parallel sequential -J
 
-benchmark/misc/function_call/build/Release/binding.node: all \
+benchmark/misc/function_call/build/Release/binding.node: \
 		benchmark/misc/function_call/binding.cc \
 		benchmark/misc/function_call/binding.gyp
 	$(NODE) deps/npm/node_modules/node-gyp/bin/node-gyp rebuild \
@@ -314,7 +314,8 @@ test/addons/.buildstamp: config.gypi \
 # .buildstamp is out of date and need a rebuild.
 # Just goes to show that recursive make really is harmful...
 # TODO(bnoordhuis) Force rebuild after gyp update.
-build-addons: | $(NODE_EXE) test/addons/.buildstamp
+build-addons: | $(NODE_EXE) test/addons/.buildstamp \
+  benchmark/misc/function_call/build/Release/binding.node
 
 ADDONS_NAPI_BINDING_GYPS := \
 	$(filter-out test/addons-napi/??_*/binding.gyp, \
@@ -386,7 +387,8 @@ CI_DOC := doctool
 
 # Build and test addons without building anything else
 test-ci-native: LOGLEVEL := info
-test-ci-native: | test/addons/.buildstamp test/addons-napi/.buildstamp
+test-ci-native: | test/addons/.buildstamp test/addons-napi/.buildstamp \
+	benchmark/misc/function_call/build/Release/binding.node
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
@@ -471,6 +473,7 @@ test-addons: test-build test-addons-napi
 test-addons-clean:
 	$(RM) -r test/addons/??_*/
 	$(RM) -r test/addons/*/build
+	$(RM) -r benchmark/misc/function_call/build
 	$(RM) test/addons/.buildstamp test/addons/.docbuildstamp
 	$(MAKE) test-addons-napi-clean
 

--- a/benchmark/misc/function_call/index.js
+++ b/benchmark/misc/function_call/index.js
@@ -14,8 +14,7 @@ const common = require('../../common.js');
 try {
   var binding = require('./build/Release/binding');
 } catch (er) {
-  console.error('misc/function_call.js Binding failed to load');
-  process.exit(0);
+  throw new Error('misc/function_call.js Binding failed to load');
 }
 const cxx = binding.hello;
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -410,7 +410,7 @@ for /d %%F in (test\addons\??_*) do (
 if %errorlevel% neq 0 exit /b %errorlevel%
 :: building addons
 setlocal EnableDelayedExpansion
-for /d %%F in (test\addons\*) do (
+for /d %%F in (test\addons\* benchmark\misc\function_call) do (
   %node_gyp_exe% rebuild ^
     --directory="%%F" ^
     --nodedir="%cd%"


### PR DESCRIPTION
- Build the addon required by benchmark/misc/function_call
- Throw errors in the addon if the binding could not be loaded

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, benchmark, build

This patch builds the addon for `benchmark/misc/function_call` in build files when running tests, and throw an error in the benchmark when the addon is not built instead of failing silently.