### PR TITLE
test: `test-inspector-async-hook-setup-at-signal` flag as flaky

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -10,6 +10,7 @@ prefix sequential
 test-inspector-async-call-stack       : PASS, FLAKY
 test-inspector-bindings               : PASS, FLAKY
 test-inspector-debug-end              : PASS, FLAKY
+test-inspector-async-hook-setup-at-signal:  PASS, FLAKY
 
 [$system==linux]
 


### PR DESCRIPTION
`test-inspector-async-hook-setup-at-signal` is also flaky on VS2017

Refs: https://github.com/nodejs/node/issues/16771

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test,inspector,windows
