### PR TITLE
lib: allow process kill by signal number

### DIFF
--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -158,8 +158,8 @@ function setupKillAndExit() {
     }
 
     // preserve null signal
-    if (0 === sig) {
-      err = process._kill(pid, 0);
+    if (sig === (sig | 0)) {
+      err = process._kill(pid, sig);
     } else {
       sig = sig || 'SIGTERM';
       if (constants[sig]) {

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -58,14 +58,14 @@ assert.throws(function() { process.kill(-1 / 0); },
               invalidPidArgument);
 
 // Test that kill throws an error for unknown signal names
-common.expectsError(() => process.kill(1, 'test'), {
+common.expectsError(() => process.kill(0, 'test'), {
   code: 'ERR_UNKNOWN_SIGNAL',
   type: TypeError,
   message: 'Unknown signal: test'
 });
 
 // Test that kill throws an error for invalid signal numbers
-common.expectsError(() => process.kill(1, 987), {
+common.expectsError(() => process.kill(0, 987), {
   code: 'EINVAL',
   type: Error,
   message: 'kill EINVAL'

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -57,16 +57,12 @@ assert.throws(function() { process.kill(1 / 0); },
 assert.throws(function() { process.kill(-1 / 0); },
               invalidPidArgument);
 
-// Test that kill throws an error for invalid signal
-const unknownSignal = common.expectsError({
+// Test that kill throws an error for unknown signal names
+common.expectsError(() => process.kill(1, 'test'), {
   code: 'ERR_UNKNOWN_SIGNAL',
   type: TypeError,
   message: 'Unknown signal: test'
 });
-
-
-assert.throws(function() { process.kill(1, 'test'); },
-              unknownSignal);
 
 // Test kill argument processing in valid cases.
 //

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -64,6 +64,13 @@ common.expectsError(() => process.kill(1, 'test'), {
   message: 'Unknown signal: test'
 });
 
+// Test that kill throws an error for invalid signal numbers
+common.expectsError(() => process.kill(1, 987), {
+  code: 'EINVAL',
+  type: Error,
+  message: 'kill EINVAL'
+});
+
 // Test kill argument processing in valid cases.
 //
 // Monkey patch _kill so that we don't actually send any signals, particularly
@@ -94,6 +101,11 @@ kill(0, 'SIGHUP', 0, 1);
 kill(0, undefined, 0, 15);
 kill('0', 'SIGHUP', 0, 1);
 kill('0', undefined, 0, 15);
+
+// Confirm that numeric signal arguments are supported
+
+kill(0, 1, 0, 1);
+kill(0, 15, 0, 15);
 
 // negative numbers are meaningful on unix
 kill(-1, 'SIGHUP', -1, 1);


### PR DESCRIPTION
This brings the behaviour in line with the documentation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
