### PR TITLE
src: remove superfluous check in backtrace_posix.cc

### DIFF
--- a/src/backtrace_posix.cc
+++ b/src/backtrace_posix.cc
@@ -25,9 +25,6 @@ void DumpBacktrace(FILE* fp) {
 #if HAVE_EXECINFO_H
   void* frames[256];
   const int size = backtrace(frames, arraysize(frames));
-  if (size <= 0) {
-    return;
-  }
   for (int i = 1; i < size; i += 1) {
     void* frame = frames[i];
     fprintf(fp, "%2d: ", i);


### PR DESCRIPTION
The error check doesn't matter because a failure would be ignored as part of the loop condition.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src