### PR TITLE
tools: enforce no unused trailing arguments tools directory

### DIFF
--- a/tools/.eslintrc.yaml
+++ b/tools/.eslintrc.yaml
@@ -1,0 +1,4 @@
+rules:
+  # Variables
+  # http://eslint.org/docs/rules/#variables
+  no-unused-vars: [error, { args: 'after-used' }]

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -224,7 +224,7 @@ function altDocs(filename) {
   const host = 'https://nodejs.org';
   const href = (v) => `${host}/docs/latest-v${v.num}/api/${filename}.html`;
 
-  function li(v, i) {
+  function li(v) {
     let html = `<li><a href="${href(v)}">${v.num}`;
 
     if (v.lts)

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -54,7 +54,7 @@ module.exports = function(context) {
     }
   }
 
-  function reportIfMissingCheck(node) {
+  function reportIfMissingCheck() {
     if (hasSkipCall) {
       return;
     }


### PR DESCRIPTION
For code in the tools directory, enable ESLint rule configuration to require that the last argument in a function signature must be used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools