### PR TITLE
doc: make error descriptions more concise

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -599,7 +599,7 @@ found [here][online].
 <a id="ERR_ARG_NOT_ITERABLE"></a>
 ### ERR_ARG_NOT_ITERABLE
 
-An iterable argument (i.e. a value that works with `for...of` loops) is
+An iterable argument (i.e. a value that works with `for...of` loops) was
 required, but not provided to a Node.js API.
 
 <a id="ERR_ASSERTION"></a>
@@ -618,8 +618,8 @@ An attempt was made to register something that is not a function as an
 <a id="ERR_ASYNC_TYPE"></a>
 ### ERR_ASYNC_TYPE
 
-The type of an asynchronous resource is invalid. Note that users are also able
-to define their own types when using the public embedder API.
+The type of an asynchronous resource was invalid. Note that users are also able
+to define their own types if using the public embedder API.
 
 <a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
 ### ERR_BUFFER_OUT_OF_BOUNDS
@@ -680,13 +680,13 @@ to enable or disable FIPS mode in the `crypto` module.
 <a id="ERR_CRYPTO_FIPS_UNAVAILABLE"></a>
 ### ERR_CRYPTO_FIPS_UNAVAILABLE
 
-There was an attempt to enable or disable FIPS mode, but FIPS mode is not
+An attempt was made to enable or disable FIPS mode, but FIPS mode was not
 available.
 
 <a id="ERR_CRYPTO_HASH_DIGEST_NO_UTF16"></a>
 ### ERR_CRYPTO_HASH_DIGEST_NO_UTF16
 
-The UTF-16 encoding was used with [`hash.digest()`][]. While the 
+The UTF-16 encoding was used with [`hash.digest()`][]. While the
 `hash.digest()` method does allow an `encoding` argument to be passed in,
 causing the method to return a string rather than a `Buffer`, the UTF-16
 encoding (e.g. `ucs` or `utf16le`) is not supported.
@@ -710,8 +710,8 @@ An invalid [crypto digest algorithm][] was specified.
 <a id="ERR_CRYPTO_INVALID_STATE"></a>
 ### ERR_CRYPTO_INVALID_STATE
 
-A crypto method was used on an object that is in an invalid state. For instance,
-calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
+A crypto method was used on an object that was in an invalid state. For
+instance, calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
 
 <a id="ERR_CRYPTO_SIGN_KEY_REQUIRED"></a>
 ### ERR_CRYPTO_SIGN_KEY_REQUIRED
@@ -732,7 +732,7 @@ A signing `key` was not provided to the [`sign.sign()`][] method.
 <a id="ERR_ENCODING_INVALID_ENCODED_DATA"></a>
 ### ERR_ENCODING_INVALID_ENCODED_DATA
 
-Data provided to `util.TextDecoder()` API is invalid according to the encoding
+Data provided to `util.TextDecoder()` API was invalid according to the encoding
 provided.
 
 <a id="ERR_ENCODING_NOT_SUPPORTED"></a>
@@ -750,7 +750,7 @@ falsy value.
 <a id="ERR_HTTP_HEADERS_SENT"></a>
 ### ERR_HTTP_HEADERS_SENT
 
-Headers have already been sent and another attempt was made to add more headers.
+An attempt was made to add more headers after the headers had already been sent.
 
 <a id="ERR_HTTP_INVALID_CHAR"></a>
 ### ERR_HTTP_INVALID_CHAR
@@ -761,12 +761,12 @@ phrase).
 <a id="ERR_HTTP_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP_INVALID_HEADER_VALUE
 
-An invalid HTTP header value has been specified.
+An invalid HTTP header value was specified.
 
 <a id="ERR_HTTP_INVALID_STATUS_CODE"></a>
 ### ERR_HTTP_INVALID_STATUS_CODE
 
-Status code is outside the regular status code range (100-999).
+Status code was outside the regular status code range (100-999).
 
 <a id="ERR_HTTP_TRAILER_INVALID"></a>
 ### ERR_HTTP_TRAILER_INVALID
@@ -800,23 +800,23 @@ A failure occurred sending an individual frame on the HTTP/2 session.
 <a id="ERR_HTTP2_HEADER_REQUIRED"></a>
 ### ERR_HTTP2_HEADER_REQUIRED
 
-A required header is missing in an HTTP/2 message.
+A required header was missing in an HTTP/2 message.
 
 <a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
 ### ERR_HTTP2_HEADER_SINGLE_VALUE
 
-Multiple values have been provided for an HTTP/2 header field that is required
-to have only a single value.
+Multiple values were provided for an HTTP/2 header field that was required to
+have only a single value.
 
 <a id="ERR_HTTP2_HEADERS_AFTER_RESPOND"></a>
 ### ERR_HTTP2_HEADERS_AFTER_RESPOND
 
-Additional headers may not be specified after an HTTP/2 response initiated.
+An additional headers was specified after an HTTP/2 response was initiated.
 
 <a id="ERR_HTTP2_HEADERS_OBJECT"></a>
 ### ERR_HTTP2_HEADERS_OBJECT
 
-An HTTP/2 Headers Object is expected.
+An HTTP/2 Headers Object was expected.
 
 <a id="ERR_HTTP2_HEADERS_SENT"></a>
 ### ERR_HTTP2_HEADERS_SENT
@@ -844,7 +844,7 @@ requests and responses.
 <a id="ERR_HTTP2_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP2_INVALID_HEADER_VALUE
 
-An invalid HTTP2 header value has been specified.
+An invalid HTTP/2 header value was specified.
 
 <a id="ERR_HTTP2_INVALID_INFO_STATUS"></a>
 ### ERR_HTTP2_INVALID_INFO_STATUS
@@ -868,7 +868,7 @@ and `:method`) may be used.
 <a id="ERR_HTTP2_INVALID_SESSION"></a>
 ### ERR_HTTP2_INVALID_SESSION
 
-An action was performed on an `Http2Session` object that has already been
+An action was performed on an `Http2Session` object that had already been
 destroyed.
 
 <a id="ERR_HTTP2_INVALID_SETTING_VALUE"></a>
@@ -879,7 +879,7 @@ An invalid value has been specified for an HTTP/2 setting.
 <a id="ERR_HTTP2_INVALID_STREAM"></a>
 ### ERR_HTTP2_INVALID_STREAM
 
-An operation has been performed on a stream that has already been destroyed.
+An operation was performed on a stream that had already been destroyed.
 
 <a id="ERR_HTTP2_MAX_PENDING_SETTINGS_ACK"></a>
 ### ERR_HTTP2_MAX_PENDING_SETTINGS_ACK
@@ -893,13 +893,14 @@ reached.
 <a id="ERR_HTTP2_NO_SOCKET_MANIPULATION"></a>
 ### ERR_HTTP2_NO_SOCKET_MANIPULATION
 
-A socket attached to an `Http2Session` may not be directly manipulated
-(e.g read, write, pause, resume, etc.).
+An attempt was made to directly manipulate (read, write, pause, resume, etc.) a
+socket attached to an `Http2Session`.
 
 <a id="ERR_HTTP2_OUT_OF_STREAMS"></a>
 ### ERR_HTTP2_OUT_OF_STREAMS
 
-The maximum number of streams on a single HTTP/2 session have been created.
+The number of streams created on a single HTTP/2 session reached the maximum
+limit.
 
 <a id="ERR_HTTP2_PAYLOAD_FORBIDDEN"></a>
 ### ERR_HTTP2_PAYLOAD_FORBIDDEN
@@ -916,20 +917,20 @@ key names that begin with the `:` prefix.
 <a id="ERR_HTTP2_PUSH_DISABLED"></a>
 ### ERR_HTTP2_PUSH_DISABLED
 
-Push streams have been disabled by the client, but an attempt to create a push
-stream was made.
+An attempt was made to create a push stream, which had been disabled by the
+client.
 
 <a id="ERR_HTTP2_SEND_FILE"></a>
 ### ERR_HTTP2_SEND_FILE
 
-The `Http2Stream.prototype.responseWithFile()` API may only be used to send a
-regular file.
+An attempt was made to use the `Http2Stream.prototype.responseWithFile()` API to
+send something other than a regular file.
 
 <a id="ERR_HTTP2_SOCKET_BOUND"></a>
 ### ERR_HTTP2_SOCKET_BOUND
 
 An attempt was made to connect a `Http2Session` object to a `net.Socket` or
-`tls.TLSSocket` that has already been bound to another `Http2Session` object.
+`tls.TLSSocket` that had already been bound to another `Http2Session` object.
 
 <a id="ERR_HTTP2_STATUS_101"></a>
 ### ERR_HTTP2_STATUS_101
@@ -945,12 +946,12 @@ between `100` and `599` (inclusive).
 <a id="ERR_HTTP2_STREAM_CLOSED"></a>
 ### ERR_HTTP2_STREAM_CLOSED
 
-An action has been performed on an HTTP/2 Stream that has already been closed.
+An action was performed on an HTTP/2 Stream that had already been closed.
 
 <a id="ERR_HTTP2_STREAM_ERROR"></a>
 ### ERR_HTTP2_STREAM_ERROR
 
-A non-zero error code has been specified in an `RST_STREAM` frame.
+A non-zero error code was been specified in an `RST_STREAM` frame.
 
 <a id="ERR_HTTP2_STREAM_SELF_DEPENDENCY"></a>
 ### ERR_HTTP2_STREAM_SELF_DEPENDENCY
@@ -968,19 +969,19 @@ made to mark a stream and dependent of itself.
 <a id="ERR_INDEX_OUT_OF_RANGE"></a>
 ### ERR_INDEX_OUT_OF_RANGE
 
-A given index is out of the accepted range (e.g. negative offsets).
+A given index was out of the accepted range (e.g. negative offsets).
 
 <a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
 ### ERR_INSPECTOR_ALREADY_CONNECTED
 
 While using the `inspector` module, an attempt was made to connect when the
-inspector is already connected.
+inspector was already connected.
 
 <a id="ERR_INSPECTOR_CLOSED"></a>
 ### ERR_INSPECTOR_CLOSED
 
 While using the `inspector` module, an attempt was made to use the inspector
-after the session has already closed.
+after the session had already closed.
 
 <a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
 ### ERR_INSPECTOR_NOT_AVAILABLE
@@ -996,40 +997,39 @@ before it was connected.
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 
-An argument of the wrong type has been passed to a Node.js API.
+An argument of the wrong type was passed to a Node.js API.
 
 <a id="ERR_INVALID_ARG_VALUE"></a>
 ### ERR_INVALID_ARG_VALUE
 
-An invalid or unsupported value has been passed for a given argument.
+An invalid or unsupported value was passed for a given argument.
 
 <a id="ERR_INVALID_ARRAY_LENGTH"></a>
 ### ERR_INVALID_ARRAY_LENGTH
 
-An Array is not of the expected length or in a valid range.
+An Array was not of the expected length or in a valid range.
 
 <a id="ERR_INVALID_ASYNC_ID"></a>
 ### ERR_INVALID_ASYNC_ID
 
 An invalid `asyncId` or `triggerAsyncId` was passed using `AsyncHooks`. An id
-less than -1 should
-never happen.
+less than -1 should never happen.
 
 <a id="ERR_INVALID_BUFFER_SIZE"></a>
 ### ERR_INVALID_BUFFER_SIZE
 
-A swap was performed on a `Buffer` but its size is not compatible with the
+A swap was performed on a `Buffer` but its size was not compatible with the
 operation.
 
 <a id="ERR_INVALID_CALLBACK"></a>
 ### ERR_INVALID_CALLBACK
 
-A callback function is required and has not been provided to a Node.js API.
+A callback function was required but was not been provided to a Node.js API.
 
 <a id="ERR_INVALID_CHAR"></a>
 ### ERR_INVALID_CHAR
 
-Invalid characters are detected in headers.
+Invalid characters were detected in headers.
 
 <a id="ERR_INVALID_CURSOR_POS"></a>
 ### ERR_INVALID_CURSOR_POS
@@ -1045,12 +1045,12 @@ specified column.
 <a id="ERR_INVALID_FD"></a>
 ### ERR_INVALID_FD
 
-A file descriptor ('fd') is not valid (e.g. it has a negative value).
+A file descriptor ('fd') was not valid (e.g. it was a negative value).
 
 <a id="ERR_INVALID_FD_TYPE"></a>
 ### ERR_INVALID_FD_TYPE
 
-A file descriptor ('fd') type is not valid.
+A file descriptor ('fd') type was not valid.
 
 <a id="ERR_INVALID_FILE_URL_HOST"></a>
 ### ERR_INVALID_FILE_URL_HOST
@@ -1077,7 +1077,7 @@ more information.
 <a id="ERR_INVALID_HTTP_TOKEN"></a>
 ### ERR_INVALID_HTTP_TOKEN
 
-`options.method` received an invalid HTTP token.
+An invalid HTTP token was supplied.
 
 <a id="ERR_INVALID_IP_ADDRESS"></a>
 ### ERR_INVALID_IP_ADDRESS
@@ -1087,7 +1087,7 @@ An IP address is not valid.
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### ERR_INVALID_OPT_VALUE
 
-An invalid or unexpected value has been passed in an options object.
+An invalid or unexpected value was passed in an options object.
 
 <a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
 ### ERR_INVALID_OPT_VALUE_ENCODING
@@ -1103,13 +1103,13 @@ invalid.
 <a id="ERR_INVALID_PROTOCOL"></a>
 ### ERR_INVALID_PROTOCOL
 
-An invalid `options.protocol` is passed.
+An invalid `options.protocol` was passed.
 
 <a id="ERR_INVALID_REPL_EVAL_CONFIG"></a>
 ### ERR_INVALID_REPL_EVAL_CONFIG
 
-Both `breakEvalOnSigint` and `eval` options are set in the REPL config, which is
-not supported.
+Both `breakEvalOnSigint` and `eval` options were set in the REPL config, which
+is not supported.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
@@ -1138,7 +1138,7 @@ urlSearchParams.has.call(buf, 'foo');
 ### ERR_INVALID_TUPLE
 
 An element in the `iterable` provided to the [WHATWG][WHATWG URL API]
-[`URLSearchParams` constructor][`new URLSearchParams(iterable)`] does not
+[`URLSearchParams` constructor][`new URLSearchParams(iterable)`] did not
 represent a `[name, value]` tuple – that is, if an element is not iterable, or
 does not consist of exactly two elements.
 
@@ -1166,14 +1166,13 @@ in other Node.js APIs as well in the future.
 <a id="ERR_IPC_CHANNEL_CLOSED"></a>
 ### ERR_IPC_CHANNEL_CLOSED
 
-An attempt was made to use an IPC communication channel that has already been
-closed.
+An attempt was made to use an IPC communication channel that was already closed.
 
 <a id="ERR_IPC_DISCONNECTED"></a>
 ### ERR_IPC_DISCONNECTED
 
-An attempt is made to disconnect an already disconnected IPC communication
-channel between two Node.js processes. See the documentation for the
+An attempt was made to disconnect an IPC communication channel that was already
+disconnected. See the documentation for the
 [`child_process`](child_process.html) module for more information.
 
 <a id="ERR_IPC_ONE_PIPE"></a>
@@ -1186,7 +1185,7 @@ communication channel. See the documentation for the
 <a id="ERR_IPC_SYNC_FORK"></a>
 ### ERR_IPC_SYNC_FORK
 
-An attempt was made to open an IPC communication channel with a synchronous
+An attempt was made to open an IPC communication channel with a synchronously
 forked Node.js process. See the documentation for the
 [`child_process`](child_process.html) module for more information.
 
@@ -1248,7 +1247,7 @@ While using `N-API`, `Constructor.prototype` was not an object.
 <a id="ERR_NO_CRYPTO"></a>
 ### ERR_NO_CRYPTO
 
-An attempt was made to use crypto features while Node.js is not compiled with
+An attempt was made to use crypto features while Node.js was not compiled with
 OpenSSL crypto support.
 
 <a id="ERR_NO_ICU"></a>
@@ -1267,7 +1266,7 @@ For example: `Buffer.write(string, encoding, offset[, length])`
 <a id="ERR_OUTOFMEMORY"></a>
 ### ERR_OUTOFMEMORY
 
-An operation caused an out of memory condition.
+An operation caused an out-of-memory condition.
 
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
@@ -1301,7 +1300,7 @@ An attempt was made to bind a socket that has already been bound.
 <a id="ERR_SOCKET_BAD_BUFFER_SIZE"></a>
 ### ERR_SOCKET_BAD_BUFFER_SIZE
 
-An invalid (negative) size is passed for either the `recvBufferSize` or
+An invalid (negative) size was passed for either the `recvBufferSize` or
 `sendBufferSize` options in [`dgram.createSocket()`][].
 
 <a id="ERR_SOCKET_BAD_PORT"></a>
@@ -1312,7 +1311,7 @@ An API function expecting a port > 0 and < 65536 received an invalid value.
 <a id="ERR_SOCKET_BAD_TYPE"></a>
 ### ERR_SOCKET_BAD_TYPE
 
-An API function expecting a socket type (`udp4` or `udp6`) receivee an invalid
+An API function expecting a socket type (`udp4` or `udp6`) received an invalid
 value.
 
 <a id="ERR_SOCKET_BUFFER_SIZE"></a>
@@ -1340,13 +1339,13 @@ A call was made and the UDP subsystem was not running.
 ### ERR_STDERR_CLOSE
 
 An attempt was made to close the `process.stderr` stream. By design, Node.js
-does not allow `stdout` or `stderr` Streams to be closed by user code.
+does not allow `stdout` or `stderr` streams to be closed by user code.
 
 <a id="ERR_STDOUT_CLOSE"></a>
 ### ERR_STDOUT_CLOSE
 
 An attempt was made to close the `process.stdout` stream. By design, Node.js
-does not allow `stdout` or `stderr` Streams to be closed by user code.
+does not allow `stdout` or `stderr` streams to be closed by user code.
 
 <a id="ERR_STREAM_CANNOT_PIPE"></a>
 ### ERR_STREAM_CANNOT_PIPE
@@ -1367,20 +1366,20 @@ pushed to the stream.
 <a id="ERR_STREAM_READ_NOT_IMPLEMENTED"></a>
 ### ERR_STREAM_READ_NOT_IMPLEMENTED
 
-An attempt was made to use a readable stream that has not implemented
+An attempt was made to use a readable stream that did not implement
 [`readable._read()`][].
 
 <a id="ERR_STREAM_UNSHIFT_AFTER_END_EVENT"></a>
 ### ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 
-An attempt was made to call [`stream.unshift()`][] after the `end` event has
-been emitted.
+An attempt was made to call [`stream.unshift()`][] after the `end` event was
+emitted.
 
 <a id="ERR_STREAM_WRAP"></a>
 ### ERR_STREAM_WRAP
 
-Prevents an abort if a string decoder was set on the Socket or if in
-`objectMode`.
+Prevents an abort if a string decoder was set on the Socket or if the decoder
+is in `objectMode`.
 
 Example
 ```js
@@ -1453,7 +1452,7 @@ A Transform stream finished with data still in the write buffer.
 <a id="ERR_UNESCAPED_CHARACTERS"></a>
 ### ERR_UNESCAPED_CHARACTERS
 
-A string that contains unescaped characters was received.
+A string that contained unescaped characters was received.
 
 <a id="ERR_UNHANDLED_ERROR"></a>
 ### ERR_UNHANDLED_ERROR
@@ -1471,14 +1470,15 @@ An invalid or unknown encoding option was passed to an API.
 
 > Stability: 1 - Experimental
 
-Attempting to load a module with an unknown or unsupported file extension.
+An attempt was made to load a module with an unknown or unsupported file
+extension.
 
 <a id="ERR_UNKNOWN_MODULE_FORMAT"></a>
 ### ERR_UNKNOWN_MODULE_FORMAT
 
 > Stability: 1 - Experimental
 
-Attempting to load a module with an unknown or unsupported format.
+An attempt was made to load a module with an unknown or unsupported format.
 
 <a id="ERR_UNKNOWN_SIGNAL"></a>
 ### ERR_UNKNOWN_SIGNAL
@@ -1490,17 +1490,15 @@ signal (such as [`subprocess.kill()`][]).
 ### ERR_UNKNOWN_STDIN_TYPE
 
 An attempt was made to launch a Node.js process with an unknown `stdin` file
-type. Errors of this kind cannot typically be caused by errors in user code,
-although it is possible. Occurrences of this error are more likely an indication
-of a bug within Node.js itself.
+type. This error is usually an indication of a bug within Node.js itself,
+although it is possible for user code to trigger it.
 
 <a id="ERR_UNKNOWN_STREAM_TYPE"></a>
 ### ERR_UNKNOWN_STREAM_TYPE
 
 An attempt was made to launch a Node.js process with an unknown `stdout` or
-`stderr` file type. Errors of this kind cannot typically be caused by errors in
-user code, although it is possible. Occurrences of this error are most likely an
-indication of a bug within Node.js itself.
+`stderr` file type. This error is usually an indication of a bug within Node.js
+itself, although it is possible for user code to trigger it.
 
 <a id="ERR_V8BREAKITERATOR"></a>
 ### ERR_V8BREAKITERATOR

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -656,8 +656,8 @@ The native call from `process.cpuUsage` could be processed properly.
 <a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
 ### ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED
 
-Used when a client certificate engine is requested that is not supported by the
-version of OpenSSL being used.
+A client certificate engine was requested that is not supported by the version
+of OpenSSL being used.
 
 <a id="ERR_CRYPTO_ECDH_INVALID_FORMAT"></a>
 ### ERR_CRYPTO_ECDH_INVALID_FORMAT
@@ -886,7 +886,7 @@ An operation has been performed on a stream that has already been destroyed.
 
 Whenever an HTTP/2 `SETTINGS` frame is sent to a connected peer, the peer is
 required to send an acknowledgement that it has received and applied the new
-SETTINGS. By default, a maximum number of un-acknowledged `SETTINGS` frame may
+`SETTINGS`. By default, a maximum number of unacknowledged `SETTINGS` frames may
 be sent at any given time. This error code is used when that limit has been
 reached.
 
@@ -973,16 +973,14 @@ A given index is out of the accepted range (e.g. negative offsets).
 <a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
 ### ERR_INSPECTOR_ALREADY_CONNECTED
 
-When using the `inspector` module, the `ERR_INSPECTOR_ALREADY_CONNECTED` error
-code is used when an attempt is made to connect when the inspector is already
-connected.
+While using the `inspector` module, an attempt was made to connect when the
+inspector is already connected.
 
 <a id="ERR_INSPECTOR_CLOSED"></a>
 ### ERR_INSPECTOR_CLOSED
 
-When using the `inspector` module, the `ERR_INSPECTOR_CLOSED` error code is
-used when an attempt is made to use the inspector after the session has
-already closed.
+While using the `inspector` module, an attempt was made to use the inspector
+after the session has already closed.
 
 <a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
 ### ERR_INSPECTOR_NOT_AVAILABLE
@@ -992,8 +990,8 @@ The `inspector` module is not available for use.
 <a id="ERR_INSPECTOR_NOT_CONNECTED"></a>
 ### ERR_INSPECTOR_NOT_CONNECTED
 
-When using the `inspector` module, the `ERR_INSPECTOR_NOT_CONNECTED` error code
-is used when an attempt is made to use the inspector before it is connected.
+While using the `inspector` module, an attempt was made to use the inspector
+before it was connected.
 
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -599,59 +599,59 @@ found [here][online].
 <a id="ERR_ARG_NOT_ITERABLE"></a>
 ### ERR_ARG_NOT_ITERABLE
 
-Used generically to identify that an iterable argument (i.e. a value that works
-with `for...of` loops) is required, but not provided to a Node.js API.
+An iterable argument (i.e. a value that works with `for...of` loops) is
+required, but not provided to a Node.js API.
 
 <a id="ERR_ASSERTION"></a>
 ### ERR_ASSERTION
 
-Used as special type of error that can be triggered whenever Node.js detects an
+A special type of error that can be triggered whenever Node.js detects an
 exceptional logic violation that should never occur. These are raised typically
 by the `assert` module.
 
 <a id="ERR_ASYNC_CALLBACK"></a>
 ### ERR_ASYNC_CALLBACK
 
-Used with `AsyncHooks` to indicate an attempt of registering something that is
-not a function as a callback.
+An attempt was made to register something that is not a function as an
+`AsyncHooks` callback.
 
 <a id="ERR_ASYNC_TYPE"></a>
 ### ERR_ASYNC_TYPE
 
-Used when the type of an asynchronous resource is invalid. Note that users are
-also able to define their own types when using the public embedder API.
+The type of an asynchronous resource is invalid. Note that users are also able
+to define their own types when using the public embedder API.
 
 <a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
 ### ERR_BUFFER_OUT_OF_BOUNDS
 
-Used when attempting to perform an operation outside the bounds of a `Buffer`.
+An operation outside the bounds of a `Buffer` was attempted.
 
 <a id="ERR_BUFFER_TOO_LARGE"></a>
 ### ERR_BUFFER_TOO_LARGE
 
-Used when an attempt has been made to create a `Buffer` larger than the
-maximum allowed size.
+An attempt has been made to create a `Buffer` larger than the maximum allowed
+size.
 
 <a id="ERR_CANNOT_WATCH_SIGINT"></a>
 ### ERR_CANNOT_WATCH_SIGINT
 
-Used when Node.js is unable to watch for the `SIGINT` signal.
+Node.js was unable to watch for the `SIGINT` signal.
 
 <a id="ERR_CHILD_CLOSED_BEFORE_REPLY"></a>
 ### ERR_CHILD_CLOSED_BEFORE_REPLY
 
-Used when a child process is closed before the parent received a reply.
+A child process was closed before the parent received a reply.
 
 <a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
 ### ERR_CONSOLE_WRITABLE_STREAM
 
-Used when `Console` is instantiated without `stdout` stream or when `stdout` or
-`stderr` streams are not writable.
+`Console` was instantiated without `stdout` stream, or `Console` has a
+non-writable `stdout` or `stderr` stream.
 
 <a id="ERR_CPU_USAGE"></a>
 ### ERR_CPU_USAGE
 
-Used when the native call from `process.cpuUsage` cannot be processed properly.
+The native call from `process.cpuUsage` could be processed properly.
 
 <a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
 ### ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED
@@ -662,30 +662,31 @@ version of OpenSSL being used.
 <a id="ERR_CRYPTO_ECDH_INVALID_FORMAT"></a>
 ### ERR_CRYPTO_ECDH_INVALID_FORMAT
 
-Used when an invalid value for the `format` argument has been passed to the
-`crypto.ECDH()` class `getPublicKey()` method.
+An invalid value for the `format` argument was passed to the `crypto.ECDH()`
+class `getPublicKey()` method.
 
 <a id="ERR_CRYPTO_ENGINE_UNKNOWN"></a>
 ### ERR_CRYPTO_ENGINE_UNKNOWN
 
-Used when an invalid crypto engine identifier is passed to
+An invalid crypto engine identifier was passed to
 [`require('crypto').setEngine()`][].
 
 <a id="ERR_CRYPTO_FIPS_FORCED"></a>
 ### ERR_CRYPTO_FIPS_FORCED
 
-Used when trying to enable or disable FIPS mode in the crypto module and
-the [`--force-fips`][] command-line argument is used.
+The [`--force-fips`][] command-line argument was used but there was an attempt
+to enable or disable FIPS mode in the `crypto` module.
 
 <a id="ERR_CRYPTO_FIPS_UNAVAILABLE"></a>
 ### ERR_CRYPTO_FIPS_UNAVAILABLE
 
-Used when trying to enable or disable FIPS mode when FIPS is not available.
+There was an attempt to enable or disable FIPS mode but FIPS mode is not
+available.
 
 <a id="ERR_CRYPTO_HASH_DIGEST_NO_UTF16"></a>
 ### ERR_CRYPTO_HASH_DIGEST_NO_UTF16
 
-Used when the UTF-16 encoding is used with [`hash.digest()`][]. While the
+The UTF-16 encoding was used with [`hash.digest()`][]. While the 
 `hash.digest()` method does allow an `encoding` argument to be passed in,
 causing the method to return a string rather than a `Buffer`, the UTF-16
 encoding (e.g. `ucs` or `utf16le`) is not supported.
@@ -693,88 +694,85 @@ encoding (e.g. `ucs` or `utf16le`) is not supported.
 <a id="ERR_CRYPTO_HASH_FINALIZED"></a>
 ### ERR_CRYPTO_HASH_FINALIZED
 
-Used when [`hash.digest()`][] is called multiple times. The `hash.digest()`
-method must be called no more than one time per instance of a `Hash` object.
+[`hash.digest()`][] was called multiple times. The `hash.digest()` method must
+be called no more than one time per instance of a `Hash` object.
 
 <a id="ERR_CRYPTO_HASH_UPDATE_FAILED"></a>
 ### ERR_CRYPTO_HASH_UPDATE_FAILED
 
-Used when [`hash.update()`][] fails for any reason. This should rarely, if
-ever, happen.
+[`hash.update()`][] failed for any reason. This should rarely, if ever, happen.
 
 <a id="ERR_CRYPTO_INVALID_DIGEST"></a>
 ### ERR_CRYPTO_INVALID_DIGEST
 
-Used when an invalid [crypto digest algorithm][] is specified.
+An invalid [crypto digest algorithm][] was specified.
 
 <a id="ERR_CRYPTO_INVALID_STATE"></a>
 ### ERR_CRYPTO_INVALID_STATE
 
-Used generically when a crypto method is used on an object that is in an
-invalid state. For instance, calling [`cipher.getAuthTag()`][] before calling
-`cipher.final()`.
+A crypto method was used on an object that is in an invalid state. For instance,
+calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
 
 <a id="ERR_CRYPTO_SIGN_KEY_REQUIRED"></a>
 ### ERR_CRYPTO_SIGN_KEY_REQUIRED
 
-Used when a signing `key` is not provided to the [`sign.sign()`][] method.
+A signing `key` was not provided to the [`sign.sign()`][] method.
 
 <a id="ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH"></a>
 ### ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH
 
-Used when calling [`crypto.timingSafeEqual()`][] with `Buffer`, `TypedArray`,
-or `DataView` arguments of different lengths.
+[`crypto.timingSafeEqual()`][] was called with `Buffer`, `TypedArray`, or
+`DataView` arguments of different lengths.
 
 <a id="ERR_DNS_SET_SERVERS_FAILED"></a>
 ### ERR_DNS_SET_SERVERS_FAILED
 
-Used when `c-ares` failed to set the DNS server.
+`c-ares` failed to set the DNS server.
 
 <a id="ERR_ENCODING_INVALID_ENCODED_DATA"></a>
 ### ERR_ENCODING_INVALID_ENCODED_DATA
 
-Used by the `util.TextDecoder()` API when the data provided is invalid
-according to the encoding provided.
+Data provided to `util.TextDecoder()` API is invalid according to the encoding
+provided.
 
 <a id="ERR_ENCODING_NOT_SUPPORTED"></a>
 ### ERR_ENCODING_NOT_SUPPORTED
 
-Used by the `util.TextDecoder()` API when the encoding provided is not one of
-the [WHATWG Supported Encodings][].
+Encoding provided to `util.TextDecoder()` API was not one of the
+[WHATWG Supported Encodings][].
 
 <a id="ERR_FALSY_VALUE_REJECTION"></a>
 ### ERR_FALSY_VALUE_REJECTION
 
-Used by the `util.callbackify()` API when a callbackified `Promise` is rejected
-with a falsy value (e.g. `null`).
+A `Promise` that was callbackified via `util.callbackify()` was rejected with a
+falsy value.
 
 <a id="ERR_HTTP_HEADERS_SENT"></a>
 ### ERR_HTTP_HEADERS_SENT
 
-Used when headers have already been sent and another attempt is made to add
-more headers.
+Headers have already been sent and another attempt was made to add more headers.
 
 <a id="ERR_HTTP_INVALID_CHAR"></a>
 ### ERR_HTTP_INVALID_CHAR
 
-Used when an invalid character is found in an HTTP response status message
-(reason phrase).
+An invalid character was found in an HTTP response status message (reason
+phrase).
 
 <a id="ERR_HTTP_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP_INVALID_HEADER_VALUE
 
-Used to indicate that an invalid HTTP header value has been specified.
+An invalid HTTP header value has been specified.
 
 <a id="ERR_HTTP_INVALID_STATUS_CODE"></a>
 ### ERR_HTTP_INVALID_STATUS_CODE
 
-Used for status codes outside the regular status code ranges (100-999).
+Status code is outside the regular status code range (100-999).
 
 <a id="ERR_HTTP_TRAILER_INVALID"></a>
 ### ERR_HTTP_TRAILER_INVALID
 
-Used when the `Trailer` header is set even though the transfer encoding does not
-support that.
+The `Trailer` header was set even though the transfer encoding does not support
+that.
 
 <a id="ERR_HTTP2_CONNECT_AUTHORITY"></a>
 ### ERR_HTTP2_CONNECT_AUTHORITY
@@ -797,35 +795,33 @@ forbidden.
 <a id="ERR_HTTP2_FRAME_ERROR"></a>
 ### ERR_HTTP2_FRAME_ERROR
 
-Used when a failure occurs sending an individual frame on the HTTP/2
-session.
+A failure occurred sending an individual frame on the HTTP/2 session.
 
 <a id="ERR_HTTP2_HEADER_REQUIRED"></a>
 ### ERR_HTTP2_HEADER_REQUIRED
 
-Used when a required header is missing in an HTTP/2 message.
+A required header is missing in an HTTP/2 message.
 
 <a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
 ### ERR_HTTP2_HEADER_SINGLE_VALUE
 
-Used when multiple values have been provided for an HTTP header field that
-required to have only a single value.
+Multiple values have been provided for an HTTP header field that is required to
+have only a single value.
 
 <a id="ERR_HTTP2_HEADERS_AFTER_RESPOND"></a>
 ### ERR_HTTP2_HEADERS_AFTER_RESPOND
 
-Used when trying to specify additional headers after an HTTP/2 response
-initiated.
+Additional headers may not be specified after an HTTP/2 response initiated.
 
 <a id="ERR_HTTP2_HEADERS_OBJECT"></a>
 ### ERR_HTTP2_HEADERS_OBJECT
 
-Used when an HTTP/2 Headers Object is expected.
+An HTTP/2 Headers Object is expected.
 
 <a id="ERR_HTTP2_HEADERS_SENT"></a>
 ### ERR_HTTP2_HEADERS_SENT
 
-Used when an attempt is made to send multiple response headers.
+An attempt was made to send multiple response headers.
 
 <a id="ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND"></a>
 ### ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND
@@ -848,7 +844,7 @@ requests and responses.
 <a id="ERR_HTTP2_INVALID_HEADER_VALUE"></a>
 ### ERR_HTTP2_INVALID_HEADER_VALUE
 
-Used to indicate that an invalid HTTP2 header value has been specified.
+An invalid HTTP2 header value has been specified.
 
 <a id="ERR_HTTP2_INVALID_INFO_STATUS"></a>
 ### ERR_HTTP2_INVALID_INFO_STATUS
@@ -872,8 +868,8 @@ and `:method`) may be used.
 <a id="ERR_HTTP2_INVALID_SESSION"></a>
 ### ERR_HTTP2_INVALID_SESSION
 
-Used when any action is performed on an `Http2Session` object that has already
-been destroyed.
+An action was performed on an `Http2Session` object that has already been
+destroyed.
 
 <a id="ERR_HTTP2_INVALID_SETTING_VALUE"></a>
 ### ERR_HTTP2_INVALID_SETTING_VALUE
@@ -883,8 +879,7 @@ An invalid value has been specified for an HTTP/2 setting.
 <a id="ERR_HTTP2_INVALID_STREAM"></a>
 ### ERR_HTTP2_INVALID_STREAM
 
-Used when an operation has been performed on a stream that has already been
-destroyed.
+An operation has been performed on a stream that has already been destroyed.
 
 <a id="ERR_HTTP2_MAX_PENDING_SETTINGS_ACK"></a>
 ### ERR_HTTP2_MAX_PENDING_SETTINGS_ACK
@@ -898,45 +893,43 @@ reached.
 <a id="ERR_HTTP2_NO_SOCKET_MANIPULATION"></a>
 ### ERR_HTTP2_NO_SOCKET_MANIPULATION
 
-Used when attempting to directly manipulate (e.g read, write, pause, resume,
-etc.) a socket attached to an `Http2Session`.
+A socket attached to an `Http2Session` may not be directly manipulated
+(e.g read, write, pause, resume, etc.).
 
 <a id="ERR_HTTP2_OUT_OF_STREAMS"></a>
 ### ERR_HTTP2_OUT_OF_STREAMS
 
-Used when the maximum number of streams on a single HTTP/2 session have been
-created.
+The maximum number of streams on a single HTTP/2 session have been created.
 
 <a id="ERR_HTTP2_PAYLOAD_FORBIDDEN"></a>
 ### ERR_HTTP2_PAYLOAD_FORBIDDEN
 
-Used when a message payload is specified for an HTTP response code for which
-a payload is forbidden.
+A message payload was specified for an HTTP response code for which a payload is
+forbidden.
 
 <a id="ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED"></a>
 ### ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED
 
-Used to indicate that an HTTP/2 pseudo-header has been used inappropriately.
-Pseudo-headers are header key names that begin with the `:` prefix.
+An HTTP/2 pseudo-header has been used inappropriately. Pseudo-headers are header
+key names that begin with the `:` prefix.
 
 <a id="ERR_HTTP2_PUSH_DISABLED"></a>
 ### ERR_HTTP2_PUSH_DISABLED
 
-Used when push streams have been disabled by the client but an attempt to
-create a push stream is made.
+Push streams have been disabled by the client but an attempt to create a push
+stream was made.
 
 <a id="ERR_HTTP2_SEND_FILE"></a>
 ### ERR_HTTP2_SEND_FILE
 
-Used when an attempt is made to use the
-`Http2Stream.prototype.responseWithFile()` API to send a non-regular file.
+The `Http2Stream.prototype.responseWithFile()` API may only be used to send a
+regular file.
 
 <a id="ERR_HTTP2_SOCKET_BOUND"></a>
 ### ERR_HTTP2_SOCKET_BOUND
 
-Used when an attempt is made to connect a `Http2Session` object to a
-`net.Socket` or `tls.TLSSocket` that has already been bound to another
-`Http2Session` object.
+An attempt was made to connect a `Http2Session` object to a `net.Socket` or
+`tls.TLSSocket` that has already been bound to another `Http2Session` object.
 
 <a id="ERR_HTTP2_STATUS_101"></a>
 ### ERR_HTTP2_STATUS_101
@@ -952,13 +945,12 @@ between `100` and `599` (inclusive).
 <a id="ERR_HTTP2_STREAM_CLOSED"></a>
 ### ERR_HTTP2_STREAM_CLOSED
 
-Used when an action has been performed on an HTTP/2 Stream that has already
-been closed.
+An action has been performed on an HTTP/2 Stream that has already been closed.
 
 <a id="ERR_HTTP2_STREAM_ERROR"></a>
 ### ERR_HTTP2_STREAM_ERROR
 
-Used when a non-zero error code has been specified in an `RST_STREAM` frame.
+A non-zero error code has been specified in an `RST_STREAM` frame.
 
 <a id="ERR_HTTP2_STREAM_SELF_DEPENDENCY"></a>
 ### ERR_HTTP2_STREAM_SELF_DEPENDENCY
@@ -970,13 +962,13 @@ made to mark a stream and dependent of itself.
 <a id="ERR_HTTP2_UNSUPPORTED_PROTOCOL"></a>
 ### ERR_HTTP2_UNSUPPORTED_PROTOCOL
 
-Used when `http2.connect()` is passed a URL that uses any protocol other than
-`http:` or `https:`.
+`http2.connect()` was passed a URL that uses any protocol other than `http:` or
+`https:`.
 
 <a id="ERR_INDEX_OUT_OF_RANGE"></a>
 ### ERR_INDEX_OUT_OF_RANGE
 
-Used when a given index is out of the accepted range (e.g. negative offsets).
+A given index is out of the accepted range (e.g. negative offsets).
 
 <a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
 ### ERR_INSPECTOR_ALREADY_CONNECTED
@@ -995,7 +987,7 @@ already closed.
 <a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
 ### ERR_INSPECTOR_NOT_AVAILABLE
 
-Used to identify when the `inspector` module is not available for use.
+The `inspector` module is not available for use.
 
 <a id="ERR_INSPECTOR_NOT_CONNECTED"></a>
 ### ERR_INSPECTOR_NOT_CONNECTED
@@ -1006,136 +998,132 @@ is used when an attempt is made to use the inspector before it is connected.
 <a id="ERR_INVALID_ARG_TYPE"></a>
 ### ERR_INVALID_ARG_TYPE
 
-Used generically to identify that an argument of the wrong type has been passed
-to a Node.js API.
+An argument of the wrong type has been passed to a Node.js API.
 
 <a id="ERR_INVALID_ARG_VALUE"></a>
 ### ERR_INVALID_ARG_VALUE
 
-Used generically to identify that an invalid or unsupported value has been
-passed for a given argument.
+An invalid or unsupported value has been passed for a given argument.
 
 <a id="ERR_INVALID_ARRAY_LENGTH"></a>
 ### ERR_INVALID_ARRAY_LENGTH
 
-Used when an Array is not of the expected length or in a valid range.
+An Array is not of the expected length or in a valid range.
 
 <a id="ERR_INVALID_ASYNC_ID"></a>
 ### ERR_INVALID_ASYNC_ID
 
-Used with `AsyncHooks` when an invalid `asyncId` or `triggerAsyncId` is passed.
-An id less than -1 should never happen.
+An invalid `asyncId` or `triggerAsyncId` was passed using `AsyncHooks`. An id
+less than -1 should
+never happen.
 
 <a id="ERR_INVALID_BUFFER_SIZE"></a>
 ### ERR_INVALID_BUFFER_SIZE
 
-Used when performing a swap on a `Buffer` but it's size is not compatible with the operation.
+A swap was performed on a `Buffer` but its size is not compatible with the
+operation.
 
 <a id="ERR_INVALID_CALLBACK"></a>
 ### ERR_INVALID_CALLBACK
 
-Used generically to identify that a callback function is required and has not
-been provided to a Node.js API.
+A callback function is required and has not been provided to a Node.js API.
 
 <a id="ERR_INVALID_CHAR"></a>
 ### ERR_INVALID_CHAR
 
-Used when invalid characters are detected in headers.
+Invalid characters are detected in headers.
 
 <a id="ERR_INVALID_CURSOR_POS"></a>
 ### ERR_INVALID_CURSOR_POS
 
-The `'ERR_INVALID_CURSOR_POS'` is thrown specifically when a cursor on a given
-stream is attempted to move to a specified row without a specified column.
+A cursor on a given stream cannot be moved to a specified row without a
+specified column.
 
 <a id="ERR_INVALID_DOMAIN_NAME"></a>
 ### ERR_INVALID_DOMAIN_NAME
 
-Used when `hostname` can not be parsed from a provided URL.
+`hostname` can not be parsed from a provided URL.
 
 <a id="ERR_INVALID_FD"></a>
 ### ERR_INVALID_FD
 
-Used when a file descriptor ('fd') is not valid (e.g. it has a negative value).
+A file descriptor ('fd') is not valid (e.g. it has a negative value).
 
 <a id="ERR_INVALID_FD_TYPE"></a>
 ### ERR_INVALID_FD_TYPE
 
-Used when a file descriptor ('fd') type is not valid.
+A file descriptor ('fd') type is not valid.
 
 <a id="ERR_INVALID_FILE_URL_HOST"></a>
 ### ERR_INVALID_FILE_URL_HOST
 
-Used when a Node.js API that consumes `file:` URLs (such as certain functions in
-the [`fs`][] module) encounters a file URL with an incompatible host. Currently,
-this situation can only occur on Unix-like systems, where only `localhost` or an
-empty host is supported.
+A Node.js API that consumes `file:` URLs (such as certain functions in the
+[`fs`][] module) encountered a file URL with an incompatible host. This
+situation can only occur on Unix-like systems where only `localhost` or an empty
+host is supported.
 
 <a id="ERR_INVALID_FILE_URL_PATH"></a>
 ### ERR_INVALID_FILE_URL_PATH
 
-Used when a Node.js API that consumes `file:` URLs (such as certain
-functions in the [`fs`][] module) encounters a file URL with an incompatible
-path. The exact semantics for determining whether a path can be used is
-platform-dependent.
+A Node.js API that consumes `file:` URLs (such as certain functions in the
+[`fs`][] module) encountered a file URL with an incompatible path. The exact
+semantics for determining whether a path can be used is platform-dependent.
 
 <a id="ERR_INVALID_HANDLE_TYPE"></a>
 ### ERR_INVALID_HANDLE_TYPE
 
-Used when an attempt is made to send an unsupported "handle" over an IPC
-communication channel to a child process. See [`subprocess.send()`] and
-[`process.send()`] for more information.
+An attempt was made to send an unsupported "handle" over an IPC communication
+channel to a child process. See [`subprocess.send()`] and [`process.send()`] for
+more information.
 
 <a id="ERR_INVALID_HTTP_TOKEN"></a>
 ### ERR_INVALID_HTTP_TOKEN
 
-Used when `options.method` received an invalid HTTP token.
+`options.method` received an invalid HTTP token.
 
 <a id="ERR_INVALID_IP_ADDRESS"></a>
 ### ERR_INVALID_IP_ADDRESS
 
-Used when an IP address is not valid.
+An IP address is not valid.
 
 <a id="ERR_INVALID_OPT_VALUE"></a>
 ### ERR_INVALID_OPT_VALUE
 
-Used generically to identify when an invalid or unexpected value has been
-passed in an options object.
+An invalid or unexpected value has been passed in an options object.
 
 <a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
 ### ERR_INVALID_OPT_VALUE_ENCODING
 
-Used when an invalid or unknown file encoding is passed.
+An invalid or unknown file encoding was passed.
 
 <a id="ERR_INVALID_PERFORMANCE_MARK"></a>
 ### ERR_INVALID_PERFORMANCE_MARK
 
-Used by the Performance Timing API (`perf_hooks`) when a performance mark is
+While using the Performance Timing API (`perf_hooks`), a performance mark is
 invalid.
 
 <a id="ERR_INVALID_PROTOCOL"></a>
 ### ERR_INVALID_PROTOCOL
 
-Used when an invalid `options.protocol` is passed.
+An invalid `options.protocol` is passed.
 
 <a id="ERR_INVALID_REPL_EVAL_CONFIG"></a>
 ### ERR_INVALID_REPL_EVAL_CONFIG
 
-Used when both `breakEvalOnSigint` and `eval` options are set
-in the REPL config, which is not supported.
+Both `breakEvalOnSigint` and `eval` options are set in the REPL config, which is
+not supported.
 
 <a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
 ### ERR_INVALID_SYNC_FORK_INPUT
 
-Used when a `Buffer`, `Uint8Array` or `string` is provided as stdio input to a
+A `Buffer`, `Uint8Array` or `string` was provided as stdio input to a
 synchronous fork. See the documentation for the
 [`child_process`](child_process.html) module for more information.
 
 <a id="ERR_INVALID_THIS"></a>
 ### ERR_INVALID_THIS
 
-Used generically to identify that a Node.js API function is called with an
-incompatible `this` value.
+A Node.js API function was called with an incompatible `this` value.
 
 Example:
 
@@ -1151,20 +1139,20 @@ urlSearchParams.has.call(buf, 'foo');
 <a id="ERR_INVALID_TUPLE"></a>
 ### ERR_INVALID_TUPLE
 
-Used when an element in the `iterable` provided to the [WHATWG][WHATWG URL
-API] [`URLSearchParams` constructor][`new URLSearchParams(iterable)`] does not
+An element in the `iterable` provided to the [WHATWG][WHATWG URL API]
+[`URLSearchParams` constructor][`new URLSearchParams(iterable)`] does not
 represent a `[name, value]` tuple – that is, if an element is not iterable, or
 does not consist of exactly two elements.
 
 <a id="ERR_INVALID_URI"></a>
 ### ERR_INVALID_URI
 
-Used when an invalid URI is passed.
+An invalid URI was passed.
 
 <a id="ERR_INVALID_URL"></a>
 ### ERR_INVALID_URL
 
-Used when an invalid URL is passed to the [WHATWG][WHATWG URL API]
+An invalid URL was passed to the [WHATWG][WHATWG URL API]
 [`URL` constructor][`new URL(input)`] to be parsed. The thrown error object
 typically has an additional property `'input'` that contains the URL that failed
 to parse.
@@ -1172,48 +1160,48 @@ to parse.
 <a id="ERR_INVALID_URL_SCHEME"></a>
 ### ERR_INVALID_URL_SCHEME
 
-Used generically to signify an attempt to use a URL of an incompatible scheme
-(aka protocol) for a specific purpose. It is currently only used in the
-[WHATWG URL API][] support in the [`fs`][] module (which only accepts URLs with
-`'file'` scheme), but may be used in other Node.js APIs as well in the future.
+An attempt was made to use a URL of an incompatible scheme (protocol) for a
+specific purpose. It is only used in the [WHATWG URL API][] support in the
+[`fs`][] module (which only accepts URLs with `'file'` scheme), but may be used
+in other Node.js APIs as well in the future.
 
 <a id="ERR_IPC_CHANNEL_CLOSED"></a>
 ### ERR_IPC_CHANNEL_CLOSED
 
-Used when an attempt is made to use an IPC communication channel that has
-already been closed.
+An attempt was made to use an IPC communication channel that has already been
+closed.
 
 <a id="ERR_IPC_DISCONNECTED"></a>
 ### ERR_IPC_DISCONNECTED
 
-Used when an attempt is made to disconnect an already disconnected IPC
-communication channel between two Node.js processes. See the documentation for
-the [`child_process`](child_process.html) module for more information.
+An attempt is made to disconnect an already disconnected IPC communication
+channel between two Node.js processes. See the documentation for the
+[`child_process`](child_process.html) module for more information.
 
 <a id="ERR_IPC_ONE_PIPE"></a>
 ### ERR_IPC_ONE_PIPE
 
-Used when an attempt is made to create a child Node.js process using more than
-one IPC communication channel. See the documentation for the
+An attempt was made to create a child Node.js process using more than one IPC
+communication channel. See the documentation for the
 [`child_process`](child_process.html) module for more information.
 
 <a id="ERR_IPC_SYNC_FORK"></a>
 ### ERR_IPC_SYNC_FORK
 
-Used when an attempt is made to open an IPC communication channel with a
-synchronous forked Node.js process. See the documentation for the
+An attempt was made to open an IPC communication channel with a synchronous
+forked Node.js process. See the documentation for the
 [`child_process`](child_process.html) module for more information.
 
 <a id="ERR_METHOD_NOT_IMPLEMENTED"></a>
 ### ERR_METHOD_NOT_IMPLEMENTED
 
-Used when a method is required but not implemented.
+A method is required but not implemented.
 
 <a id="ERR_MISSING_ARGS"></a>
 ### ERR_MISSING_ARGS
 
-Used when a required argument of a Node.js API is not passed. This is only used
-for strict compliance with the API specification (which in some cases may accept
+A required argument of a Node.js API was not passed. This is only used for
+strict compliance with the API specification (which in some cases may accept
 `func(undefined)` but not `func()`). In most native Node.js APIs,
 `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
@@ -1223,27 +1211,27 @@ for strict compliance with the API specification (which in some cases may accept
 
 > Stability: 1 - Experimental
 
-Used when an [ES6 module][] loader hook specifies `format: 'dynamic` but does
-not provide a `dynamicInstantiate` hook.
+An [ES6 module][] loader hook specified `format: 'dynamic` but did not provide a
+`dynamicInstantiate` hook.
 
 <a id="ERR_MISSING_MODULE"></a>
 ### ERR_MISSING_MODULE
 
 > Stability: 1 - Experimental
 
-Used when an [ES6 module][] cannot be resolved.
+An [ES6 module][] could not be resolved.
 
 <a id="ERR_MODULE_RESOLUTION_LEGACY"></a>
 ### ERR_MODULE_RESOLUTION_LEGACY
 
 > Stability: 1 - Experimental
 
-Used when a failure occurs resolving imports in an [ES6 module][].
+A failure occurred resolving imports in an [ES6 module][].
 
 <a id="ERR_MULTIPLE_CALLBACK"></a>
 ### ERR_MULTIPLE_CALLBACK
 
-Used when a callback is called more then once.
+A callback was called more then once.
 
 *Note*: A callback is almost always meant to only be called once as the query
 can either be fulfilled or rejected but not both at the same time. The latter
@@ -1252,153 +1240,148 @@ would be possible by calling a callback more then once.
 <a id="ERR_NAPI_CONS_FUNCTION"></a>
 ### ERR_NAPI_CONS_FUNCTION
 
-Used by the `N-API` when a constructor passed is not a function.
+While using `N-API`, a constructor passed was not a function.
 
 <a id="ERR_NAPI_CONS_PROTOTYPE_OBJECT"></a>
 ### ERR_NAPI_CONS_PROTOTYPE_OBJECT
 
-Used by the `N-API` when `Constructor.prototype` is not an object.
+While using `N-API`, `Constructor.prototype` was not an object.
 
 <a id="ERR_NO_CRYPTO"></a>
 ### ERR_NO_CRYPTO
 
-Used when an attempt is made to use crypto features while Node.js is not
-compiled with OpenSSL crypto support.
+An attempt was made to use crypto features while Node.js is not compiled with
+OpenSSL crypto support.
 
 <a id="ERR_NO_ICU"></a>
 ### ERR_NO_ICU
 
-Used when an attempt is made to use features that require [ICU][], while
-Node.js is not compiled with ICU support.
+An attempt was made to use features that require [ICU][], but Node.js was not
+compiled with ICU support.
 
 <a id="ERR_NO_LONGER_SUPPORTED"></a>
 ### ERR_NO_LONGER_SUPPORTED
 
-Used when a Node.js API is called in an unsupported manner.
+A Node.js API was called in an unsupported manner.
 
 For example: `Buffer.write(string, encoding, offset[, length])`
 
 <a id="ERR_OUTOFMEMORY"></a>
 ### ERR_OUTOFMEMORY
 
-Used generically to identify that an operation caused an out of memory
-condition.
+An operation caused an out of memory condition.
 
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
 
-Used generically when an input argument value values outside an acceptable
-range.
+An input argument value was outside an acceptable range.
 
 <a id="ERR_PARSE_HISTORY_DATA"></a>
 ### ERR_PARSE_HISTORY_DATA
 
-Used by the `REPL` module when it cannot parse data from the REPL history file.
+The `REPL` module was unable parse data from the REPL history file.
 
 <a id="ERR_REQUIRE_ESM"></a>
 ### ERR_REQUIRE_ESM
 
 > Stability: 1 - Experimental
 
-Used when an attempt is made to `require()` an [ES6 module][].
+An attempt was made to `require()` an [ES6 module][].
 
 <a id="ERR_SERVER_ALREADY_LISTEN"></a>
 ### ERR_SERVER_ALREADY_LISTEN
 
-Used when the [`server.listen()`][] method is called while a `net.Server` is
-already listening. This applies to all instances of `net.Server`, including
-HTTP, HTTPS, and HTTP/2 Server instances.
+The [`server.listen()`][] method was called while a `net.Server` was already
+listening. This applies to all instances of `net.Server`, including HTTP, HTTPS,
+and HTTP/2 Server instances.
 
 <a id="ERR_SOCKET_ALREADY_BOUND"></a>
 ### ERR_SOCKET_ALREADY_BOUND
 
-Used when an attempt is made to bind a socket that has already been bound.
+An attempt was made to bind a socket that has already been bound.
 
 <a id="ERR_SOCKET_BAD_BUFFER_SIZE"></a>
 ### ERR_SOCKET_BAD_BUFFER_SIZE
 
-Used when an invalid (negative) size is passed for either the `recvBufferSize`
-or `sendBufferSize` options in [`dgram.createSocket()`][].
+An invalid (negative) size is passed for either the `recvBufferSize` or
+`sendBufferSize` options in [`dgram.createSocket()`][].
 
 <a id="ERR_SOCKET_BAD_PORT"></a>
 ### ERR_SOCKET_BAD_PORT
 
-Used when an API function expecting a port > 0 and < 65536 receives an invalid
-value.
+An API function expecting a port > 0 and < 65536 received an invalid value.
 
 <a id="ERR_SOCKET_BAD_TYPE"></a>
 ### ERR_SOCKET_BAD_TYPE
 
-Used when an API function expecting a socket type (`udp4` or `udp6`) receives an
-invalid value.
+An API function expecting a socket type (`udp4` or `udp6`) receivee an invalid
+value.
 
 <a id="ERR_SOCKET_BUFFER_SIZE"></a>
 ### ERR_SOCKET_BUFFER_SIZE
 
-Used when using [`dgram.createSocket()`][] and the size of the receive or send
-`Buffer` cannot be determined.
+While using [`dgram.createSocket()`][], the size of the receive or send `Buffer`
+could not be determined.
 
 <a id="ERR_SOCKET_CANNOT_SEND"></a>
 ### ERR_SOCKET_CANNOT_SEND
 
-Used when data cannot be sent on a socket.
+Data could be sent on a socket.
 
 <a id="ERR_SOCKET_CLOSED"></a>
 ### ERR_SOCKET_CLOSED
 
-Used when an attempt is made to operate on an already closed socket.
+An attempt was made to operate on an already closed socket.
 
 <a id="ERR_SOCKET_DGRAM_NOT_RUNNING"></a>
 ### ERR_SOCKET_DGRAM_NOT_RUNNING
 
-Used when a call is made and the UDP subsystem is not running.
+A call was made and the UDP subsystem was not running.
 
 <a id="ERR_STDERR_CLOSE"></a>
 ### ERR_STDERR_CLOSE
 
-Used when an attempt is made to close the `process.stderr` stream. By design,
-Node.js does not allow `stdout` or `stderr` Streams to be closed by user code.
+An attempt was made to close the `process.stderr` stream. By design, Node.js
+does not allow `stdout` or `stderr` Streams to be closed by user code.
 
 <a id="ERR_STDOUT_CLOSE"></a>
 ### ERR_STDOUT_CLOSE
 
-Used when an attempt is made to close the `process.stdout` stream. By design,
-Node.js does not allow `stdout` or `stderr` Streams to be closed by user code.
+An attempt was made to close the `process.stdout` stream. By design, Node.js
+does not allow `stdout` or `stderr` Streams to be closed by user code.
 
 <a id="ERR_STREAM_CANNOT_PIPE"></a>
 ### ERR_STREAM_CANNOT_PIPE
 
-Used when an attempt is made to call [`stream.pipe()`][] on a
-[`Writable`][] stream.
+An attempt was made to call [`stream.pipe()`][] on a [`Writable`][] stream.
 
 <a id="ERR_STREAM_NULL_VALUES"></a>
 ### ERR_STREAM_NULL_VALUES
 
-Used when an attempt is made to call [`stream.write()`][] with a `null`
-chunk.
+An attempt was made to call [`stream.write()`][] with a `null` chunk.
 
 <a id="ERR_STREAM_PUSH_AFTER_EOF"></a>
 ### ERR_STREAM_PUSH_AFTER_EOF
 
-Used when an attempt is made to call [`stream.push()`][] after a `null`(EOF)
-has been pushed to the stream.
+An attempt was made to call [`stream.push()`][] after a `null`(EOF) had been
+pushed to the stream.
 
 <a id="ERR_STREAM_READ_NOT_IMPLEMENTED"></a>
 ### ERR_STREAM_READ_NOT_IMPLEMENTED
 
-Used when an attempt is made to use a readable stream that has not implemented
+An attempt was made to use a readable stream that has not implemented
 [`readable._read()`][].
 
 <a id="ERR_STREAM_UNSHIFT_AFTER_END_EVENT"></a>
 ### ERR_STREAM_UNSHIFT_AFTER_END_EVENT
 
-Used when an attempt is made to call [`stream.unshift()`][] after the
-`end` event has been emitted.
+An attempt was made to call [`stream.unshift()`][] after the `end` event has
+been emitted.
 
 <a id="ERR_STREAM_WRAP"></a>
 ### ERR_STREAM_WRAP
 
-Used to prevent an abort if a string decoder was set on the Socket or if in
+Prevents an abort if a string decoder was set on the Socket or if in
 `objectMode`.
 
 Example
@@ -1412,26 +1395,26 @@ instance.setEncoding('utf8');
 <a id="ERR_STREAM_WRITE_AFTER_END"></a>
 ### ERR_STREAM_WRITE_AFTER_END
 
-Used when an attempt is made to call [`stream.write()`][] after
-`stream.end()` has been called.
+An attempt was made to call [`stream.write()`][] after `stream.end()` has been
+called.
 
 <a id="ERR_SYSTEM_ERROR"></a>
 ### ERR_SYSTEM_ERROR
 
-The `ERR_SYSTEM_ERROR` code is used when an unspecified or non-specific system
-error has occurred within the Node.js process. The error object will have an
-`err.info` object property with additional details.
+An unspecified or non-specific system error has occurred within the Node.js
+process. The error object will have an `err.info` object property with
+additional details.
 
 <a id="ERR_TLS_CERT_ALTNAME_INVALID"></a>
 ### ERR_TLS_CERT_ALTNAME_INVALID
 
-Used with TLS, when the hostname/IP of the peer does not match any of the
+While using TLS, the hostname/IP of the peer did not match any of the
 subjectAltNames in its certificate.
 
 <a id="ERR_TLS_DH_PARAM_SIZE"></a>
 ### ERR_TLS_DH_PARAM_SIZE
 
-Used with TLS when the parameter offered for the Diffie-Hellman (`DH`)
+While using TLS, the parameter offered for the Diffie-Hellman (`DH`)
 key-agreement protocol is too small. By default, the key length must be greater
 than or equal to 1024 bits to avoid vulnerabilities, even though it is strongly
 recommended to use 2048 bits or larger for stronger security.
@@ -1439,118 +1422,113 @@ recommended to use 2048 bits or larger for stronger security.
 <a id="ERR_TLS_HANDSHAKE_TIMEOUT"></a>
 ### ERR_TLS_HANDSHAKE_TIMEOUT
 
-A TLS error emitted by the server whenever a TLS/SSL handshake times out. In
-this case, the server must also abort the connection.
+A TLS/SSL handshake timed out. In this case, the server must also abort the
+connection.
 
 <a id="ERR_TLS_RENEGOTIATION_FAILED"></a>
 ### ERR_TLS_RENEGOTIATION_FAILED
 
-Used when a TLS renegotiation request has failed in a non-specific way.
+A TLS renegotiation request has failed in a non-specific way.
 
 <a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
 ### ERR_TLS_REQUIRED_SERVER_NAME
 
-Used with TLS, when calling the `server.addContext()` method without providing
+While using TLS, the `server.addContext()` method was called without providing
 a hostname in the first parameter.
 
 <a id="ERR_TLS_SESSION_ATTACK"></a>
 ### ERR_TLS_SESSION_ATTACK
 
-Used when an excessive amount of TLS renegotiations is detected, which is a
-potential vector for denial-of-service attacks.
+An excessive amount of TLS renegotiations is detected, which is a potential
+vector for denial-of-service attacks.
 
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING
 
-Used in Transform streams when the stream finishes while it is still
-transforming.
+A Transform stream finished while it was still transforming.
 
 <a id="ERR_TRANSFORM_WITH_LENGTH_0"></a>
 ### ERR_TRANSFORM_WITH_LENGTH_0
 
-Used in Transform streams when the stream finishes with data still in the write
-buffer.
+A Transform stream finished with data still in the write buffer.
 
 <a id="ERR_UNESCAPED_CHARACTERS"></a>
 ### ERR_UNESCAPED_CHARACTERS
 
-Used when a string that contains unescaped characters was received.
+A string that contains unescaped characters was received.
 
 <a id="ERR_UNHANDLED_ERROR"></a>
 ### ERR_UNHANDLED_ERROR
 
-Used when an unhandled "error" occurs (for instance, when an `'error'` event
-is emitted by an [`EventEmitter`][] but an `'error'` handler is not registered).
+An unhandled error occurred (for instance, when an `'error'` event is emitted
+by an [`EventEmitter`][] but an `'error'` handler is not registered).
 
 <a id="ERR_UNKNOWN_ENCODING"></a>
 ### ERR_UNKNOWN_ENCODING
 
-Used when an invalid or unknown encoding option is passed to an API.
+An invalid or unknown encoding option was passed to an API.
 
 <a id="ERR_UNKNOWN_FILE_EXTENSION"></a>
 ### ERR_UNKNOWN_FILE_EXTENSION
 
 > Stability: 1 - Experimental
 
-Used when attempting to load a module with an unknown or unsupported file
-extension.
+Attempting to load a module with an unknown or unsupported file extension.
 
 <a id="ERR_UNKNOWN_MODULE_FORMAT"></a>
 ### ERR_UNKNOWN_MODULE_FORMAT
 
 > Stability: 1 - Experimental
 
-Used when attempting to load a module with an unknown or unsupported format.
+Attempting to load a module with an unknown or unsupported format.
 
 <a id="ERR_UNKNOWN_SIGNAL"></a>
 ### ERR_UNKNOWN_SIGNAL
 
-Used when an invalid or unknown process signal is passed to an API expecting a
-valid signal (such as [`subprocess.kill()`][]).
+An invalid or unknown process signal was passed to an API expecting a valid
+signal (such as [`subprocess.kill()`][]).
 
 <a id="ERR_UNKNOWN_STDIN_TYPE"></a>
 ### ERR_UNKNOWN_STDIN_TYPE
 
-Used when an attempt is made to launch a Node.js process with an unknown `stdin`
-file type. Errors of this kind cannot *typically* be caused by errors in user
-code, although it is not impossible. Occurrences of this error are most likely
-an indication of a bug within Node.js itself.
+An attempt was made to launch a Node.js process with an unknown `stdin` file
+type. Errors of this kind cannot typically be caused by errors in user code,
+although it is possible. Occurrences of this error are more likely an indication
+of a bug within Node.js itself.
 
 <a id="ERR_UNKNOWN_STREAM_TYPE"></a>
 ### ERR_UNKNOWN_STREAM_TYPE
 
-Used when an attempt is made to launch a Node.js process with an unknown
-`stdout` or `stderr` file type. Errors of this kind cannot *typically* be caused
-by errors in user code, although it is not impossible. Occurrences of this error
-are most likely an indication of a bug within Node.js itself.
+An attempt was made to launch a Node.js process with an unknown `stdout` or
+`stderr` file type. Errors of this kind cannot typically be caused by errors in
+user code, although it is possible. Occurrences of this error are most likely an
+indication of a bug within Node.js itself.
 
 <a id="ERR_V8BREAKITERATOR"></a>
 ### ERR_V8BREAKITERATOR
 
-Used when the V8 BreakIterator API is used but the full ICU data set is not
-installed.
+The V8 BreakIterator API was used but the full ICU data set is not installed.
 
 <a id="ERR_VALID_PERFORMANCE_ENTRY_TYPE"></a>
 ### ERR_VALID_PERFORMANCE_ENTRY_TYPE
 
-Used by the Performance Timing API (`perf_hooks`) when no valid performance
+While using the Performance Timing API (`perf_hooks`), no valid performance
 entry types were found.
 
 <a id="ERR_VALUE_OUT_OF_RANGE"></a>
 ### ERR_VALUE_OUT_OF_RANGE
 
-Used when a given value is out of the accepted range.
+A given value is out of the accepted range.
 
 <a id="ERR_ZLIB_BINDING_CLOSED"></a>
 ### ERR_ZLIB_BINDING_CLOSED
 
-Used when an attempt is made to use a `zlib` object after it has already been
-closed.
+An attempt was made to use a `zlib` object after it has already been closed.
 
 <a id="ERR_ZLIB_INITIALIZATION_FAILED"></a>
 ### ERR_ZLIB_INITIALIZATION_FAILED
 
-Used when creation of a [`zlib`][] object fails due to incorrect configuration.
+Creation of a [`zlib`][] object failed due to incorrect configuration.
 
 [`--force-fips`]: cli.html#cli_force_fips
 [`cipher.getAuthTag()`]: crypto.html#crypto_cipher_getauthtag

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -680,7 +680,7 @@ to enable or disable FIPS mode in the `crypto` module.
 <a id="ERR_CRYPTO_FIPS_UNAVAILABLE"></a>
 ### ERR_CRYPTO_FIPS_UNAVAILABLE
 
-There was an attempt to enable or disable FIPS mode but FIPS mode is not
+There was an attempt to enable or disable FIPS mode, but FIPS mode is not
 available.
 
 <a id="ERR_CRYPTO_HASH_DIGEST_NO_UTF16"></a>
@@ -916,7 +916,7 @@ key names that begin with the `:` prefix.
 <a id="ERR_HTTP2_PUSH_DISABLED"></a>
 ### ERR_HTTP2_PUSH_DISABLED
 
-Push streams have been disabled by the client but an attempt to create a push
+Push streams have been disabled by the client, but an attempt to create a push
 stream was made.
 
 <a id="ERR_HTTP2_SEND_FILE"></a>

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -805,8 +805,8 @@ A required header is missing in an HTTP/2 message.
 <a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
 ### ERR_HTTP2_HEADER_SINGLE_VALUE
 
-Multiple values have been provided for an HTTP header field that is required to
-have only a single value.
+Multiple values have been provided for an HTTP/2 header field that is required
+to have only a single value.
 
 <a id="ERR_HTTP2_HEADERS_AFTER_RESPOND"></a>
 ### ERR_HTTP2_HEADERS_AFTER_RESPOND

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -651,7 +651,7 @@ non-writable `stdout` or `stderr` stream.
 <a id="ERR_CPU_USAGE"></a>
 ### ERR_CPU_USAGE
 
-The native call from `process.cpuUsage` could be processed properly.
+The native call from `process.cpuUsage` could not be processed.
 
 <a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
 ### ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED


### PR DESCRIPTION
Remove the practice of starting most error descriptions with "Used when"
or wordier variations.

Change errors of the form:

> Used when the type of an asynchronous resource is invalid.

...to:

> The type of an asynchronous resource was invalid.

Change errors of the form:

> The `'ERR_INVALID_CURSOR_POS'` is thrown specifically when a cursor on
> a given stream is attempted to move to a specified row without a specified
> column.

...to:

> A cursor on a given stream cannot be moved to a specified row without
> a specified column.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors doc