### PR TITLE
crypto: check SecureContext existence

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1342,6 +1342,7 @@ void SecureContext::SetClientCertEngine(
   CHECK(args[0]->IsString());
 
   SecureContext* sc = Unwrap<SecureContext>(args.This());
+  CHECK_NE(sc, nullptr);
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 


### PR DESCRIPTION
SecureContext should always be present, `CHECK()` it, on theory an explicit crash is better than one due to null pointer deref (if that is even reachable).

@cjihrig @bnoordhuis ?

Fix:

*** CID 179169:  Null pointer dereferences  (NULL_RETURNS)
/src/node_crypto.cc: 1353 in node::crypto::SecureContext::SetClientCertEngine(const v8::FunctionCallbackInfo<v8::Value> &)()
1347
1348       // SSL_CTX_set_client_cert_engine does not itself support multiple
1349       // calls by cleaning up before overwriting the client_cert_engine
1350       // internal context variable.
1351       // Instead of trying to fix up this problem we in turn also do not
1352       // support multiple calls to SetClientCertEngine.
>>>     CID 179169:  Null pointer dereferences  (NULL_RETURNS)
>>>     Dereferencing a null pointer "sc".
1353       if (sc->client_cert_engine_provided_) {
1354         return env->ThrowError(
1355             "Multiple calls to SetClientCertEngine are not allowed");
1356       }
1357
1358       const node::Utf8Value engine_id(env->isolate(), args[0]);

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
