### PR TITLE
src: fix SetClientCertEngine() nullptr dereference

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1341,7 +1341,8 @@ void SecureContext::SetClientCertEngine(
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsString());
 
-  SecureContext* sc = Unwrap<SecureContext>(args.This());
+  SecureContext* sc;
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.Holder());
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 


### PR DESCRIPTION
Introduced in commit 6ee985f311d ("tls: implement clientCertEngine
option") which was merged yesterday.

CI: https://ci.nodejs.org/job/node-test-pull-request/11376/