### PR TITLE
test: bypass dns for IPv6 net tests

### DIFF
--- a/test/parallel/test-https-connect-address-family.js
+++ b/test/parallel/test-https-connect-address-family.js
@@ -1,4 +1,7 @@
 'use strict';
+
+// Test that the family option of https.get is honored.
+
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -9,21 +12,28 @@ if (!common.hasIPv6)
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const https = require('https');
-const dns = require('dns');
 
-function runTest() {
+{
+  // Test that `https` machinery passes host name, and receives IP.
+  const hostAddrIPv6 = '::1';
+  const HOSTNAME = 'dummy';
   https.createServer({
     cert: fixtures.readKey('agent1-cert.pem'),
     key: fixtures.readKey('agent1-key.pem'),
   }, common.mustCall(function(req, res) {
     this.close();
     res.end();
-  })).listen(0, '::1', common.mustCall(function() {
+  })).listen(0, hostAddrIPv6, common.mustCall(function() {
     const options = {
-      host: 'localhost',
+      host: HOSTNAME,
       port: this.address().port,
       family: 6,
       rejectUnauthorized: false,
+      lookup: common.mustCall((addr, opt, cb) => {
+        assert.strictEqual(addr, HOSTNAME);
+        assert.strictEqual(opt.family, 6);
+        cb(null, hostAddrIPv6, opt.family);
+      })
     };
     // Will fail with ECONNREFUSED if the address family is not honored.
     https.get(options, common.mustCall(function() {
@@ -32,17 +42,3 @@ function runTest() {
     }));
   }));
 }
-
-dns.lookup('localhost', { family: 6, all: true }, (err, addresses) => {
-  if (err) {
-    if (err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN')
-      common.skip('localhost does not resolve to ::1');
-
-    throw err;
-  }
-
-  if (addresses.some((val) => val.address === '::1'))
-    runTest();
-  else
-    common.skip('localhost does not resolve to ::1');
-});

--- a/test/parallel/test-net-connect-options-ipv6.js
+++ b/test/parallel/test-net-connect-options-ipv6.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Test that the family option of net.connect is honored.
+
 'use strict';
 const common = require('../common');
 if (!common.hasIPv6)
@@ -27,63 +29,39 @@ if (!common.hasIPv6)
 const assert = require('assert');
 const net = require('net');
 
-const hosts = common.localIPv6Hosts;
-let hostIdx = 0;
-let host = hosts[hostIdx];
-let localhostTries = 10;
+const hostAddrIPv6 = '::1';
+const HOSTNAME = 'dummy';
 
-const server = net.createServer({ allowHalfOpen: true }, function(socket) {
+const server = net.createServer({ allowHalfOpen: true }, (socket) => {
   socket.resume();
   socket.on('end', common.mustCall());
   socket.end();
 });
 
-server.listen(0, '::1', tryConnect);
-
 function tryConnect() {
-  const client = net.connect({
-    host: host,
+  const connectOpt = {
+    host: HOSTNAME,
     port: server.address().port,
     family: 6,
-    allowHalfOpen: true
-  }, function() {
-    console.error('client connect cb');
+    allowHalfOpen: true,
+    lookup: common.mustCall((addr, opt, cb) => {
+      assert.strictEqual(addr, HOSTNAME);
+      assert.strictEqual(opt.family, 6);
+      cb(null, hostAddrIPv6, opt.family);
+    })
+  };
+  // No `mustCall`, since test could skip, and it's the only path to `close`.
+  const client = net.connect(connectOpt, () => {
     client.resume();
-    client.on('end', common.mustCall(function() {
+    client.on('end', () => {
+      // Wait for next uv tick and make sure the socket stream is writable.
       setTimeout(function() {
         assert(client.writable);
         client.end();
       }, 10);
-    }));
-    client.on('close', function() {
-      server.close();
     });
-  }).on('error', function(err) {
-    // ENOTFOUND means we don't have the requested address. In this
-    // case we try the next one in the list and if we run out of
-    // candidates we assume IPv6 is not supported on the
-    // machine and skip the test.
-    // EAI_AGAIN means we tried to remotely resolve the address and
-    // timed out or hit some intermittent connectivity issue with the
-    // dns server.  Although we are looking for local loopback addresses
-    // we may go remote since the list we search includes addresses that
-    // cover more than is available on any one distribution. The
-    // net is that if we get an EAI_AGAIN we were looking for an
-    // address which does not exist in this distribution so the error
-    // is not significant and we should just move on and try the
-    // next address in the list.
-    if ((err.syscall === 'getaddrinfo') && ((err.code === 'ENOTFOUND') ||
-                                            (err.code === 'EAI_AGAIN'))) {
-      if (host !== 'localhost' || --localhostTries === 0)
-        host = hosts[++hostIdx];
-      if (host)
-        tryConnect();
-      else {
-        server.close();
-        common.skip('no IPv6 localhost support');
-      }
-      return;
-    }
-    throw err;
+    client.on('close', () => server.close());
   });
 }
+
+server.listen(0, hostAddrIPv6, tryConnect);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/16248

For to test that target `https` and `net` mock out the call to `dns`, but verify all the right parameters are passed

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test,net,https,dns
