### PR TITLE
src: add public API for managing NodePlatform

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4490,6 +4490,18 @@ void FreeEnvironment(Environment* env) {
 }
 
 
+MultiIsolatePlatform* CreatePlatform(
+    int thread_pool_size,
+    v8::TracingController* tracing_controller) {
+  return new NodePlatform(thread_pool_size, tracing_controller);
+}
+
+
+void FreePlatform(MultiIsolatePlatform* platform) {
+  delete platform;
+}
+
+
 Local<Context> NewContext(Isolate* isolate,
                           Local<ObjectTemplate> object_template) {
   auto context = Context::New(isolate, nullptr, object_template);

--- a/src/node.h
+++ b/src/node.h
@@ -97,6 +97,11 @@
 // Forward-declare libuv loop
 struct uv_loop_s;
 
+// Forward-declare TracingController, used by CreatePlatform.
+namespace v8 {
+class TracingController;
+}
+
 // Forward-declare these functions now to stop MSVS from becoming
 // terminally confused when it's done in node_internals.h
 namespace node {
@@ -243,6 +248,11 @@ NODE_EXTERN Environment* CreateEnvironment(IsolateData* isolate_data,
 
 NODE_EXTERN void LoadEnvironment(Environment* env);
 NODE_EXTERN void FreeEnvironment(Environment* env);
+
+NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
+    int thread_pool_size,
+    v8::TracingController* tracing_controller);
+NODE_EXTERN void FreePlatform(MultiIsolatePlatform* platform);
 
 NODE_EXTERN void EmitBeforeExit(Environment* env);
 NODE_EXTERN int EmitExit(Environment* env);


### PR DESCRIPTION
In embedders like Electron, we need to control when to use v8::Platform and when not, and to make Node work correctly we have to create `NodePlatform` manually sometimes. So this requires the ability to manage `NodePlatform` in embedders, while currently the interface of `NodePlatform` is not exported.

This pull request add public APIs for creating/destroying `NodePlatform`, which follows the pattern of the APIs managing `node::Environment`.

/cc @refack @bnoordhuis