### PR TITLE
src: fix size of CounterSet

### DIFF
--- a/src/node_win32_perfctr_provider.cc
+++ b/src/node_win32_perfctr_provider.cc
@@ -180,7 +180,7 @@ void InitPerfCountersWin32() {
 
     status = perfctr_setCounterSetInfo(NodeCounterProvider,
                                        &NodeCounterSetInfo.CounterSet,
-                                       sizeof(NodeCounterSetInfo));
+                                       sizeof(NodeCounterSetInfo.CounterSet));
     if (status != ERROR_SUCCESS) {
       perfctr_stopProvider(NodeCounterProvider);
       NodeCounterProvider = nullptr;


### PR DESCRIPTION
Some machines sometimes crash at SetCounterSetInfo from incorrect parameter.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
