### PR TITLE
src: use unique_ptr for requests in crypto

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5533,9 +5533,9 @@ void PBKDF2Request::After() {
 
 void PBKDF2Request::After(uv_work_t* work_req, int status) {
   CHECK_EQ(status, 0);
-  PBKDF2Request* req = ContainerOf(&PBKDF2Request::work_req_, work_req);
+  std::unique_ptr<PBKDF2Request> req(
+      ContainerOf(&PBKDF2Request::work_req_, work_req));
   req->After();
-  delete req;
 }
 
 
@@ -5550,7 +5550,6 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
   double raw_keylen = -1;
   int keylen = -1;
   int iter = -1;
-  PBKDF2Request* req = nullptr;
   Local<Object> obj;
 
   passlen = Buffer::Length(args[0]);
@@ -5586,15 +5585,9 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
 
   obj = env->pbkdf2_constructor_template()->
       NewInstance(env->context()).ToLocalChecked();
-  req = new PBKDF2Request(env,
-                          obj,
-                          digest,
-                          passlen,
-                          pass,
-                          saltlen,
-                          salt,
-                          iter,
-                          keylen);
+  std::unique_ptr<PBKDF2Request> req(
+      new PBKDF2Request(env, obj, digest, passlen, pass, saltlen, salt, iter,
+                        keylen));
 
   if (args[5]->IsFunction()) {
     obj->Set(env->ondone_string(), args[5]);
@@ -5607,7 +5600,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     }
 
     uv_queue_work(env->event_loop(),
-                  req->work_req(),
+                  req.release()->work_req(),
                   PBKDF2Request::Work,
                   PBKDF2Request::After);
   } else {
@@ -5615,7 +5608,6 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
     req->Work();
     Local<Value> argv[2];
     req->After(&argv);
-    delete req;
 
     if (argv[0]->IsObject())
       env->isolate()->ThrowException(argv[0]);
@@ -5753,25 +5745,23 @@ void RandomBytesCheck(RandomBytesRequest* req, Local<Value> (*argv)[2]) {
 
 void RandomBytesAfter(uv_work_t* work_req, int status) {
   CHECK_EQ(status, 0);
-  RandomBytesRequest* req =
-      ContainerOf(&RandomBytesRequest::work_req_, work_req);
+  std::unique_ptr<RandomBytesRequest> req(
+      ContainerOf(&RandomBytesRequest::work_req_, work_req));
   Environment* env = req->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
   Local<Value> argv[2];
-  RandomBytesCheck(req, &argv);
+  RandomBytesCheck(req.get(), &argv);
   req->MakeCallback(env->ondone_string(), arraysize(argv), argv);
-  delete req;
 }
 
 
 void RandomBytesProcessSync(Environment* env,
-                            RandomBytesRequest* req,
+                            std::unique_ptr<RandomBytesRequest> req,
                             Local<Value> (*argv)[2]) {
   env->PrintSyncTrace();
   RandomBytesWork(req->work_req());
-  RandomBytesCheck(req, argv);
-  delete req;
+  RandomBytesCheck(req.get(), argv);
 
   if (!(*argv)[0]->IsNull())
     env->isolate()->ThrowException((*argv)[0]);
@@ -5787,12 +5777,12 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
   Local<Object> obj = env->randombytes_constructor_template()->
       NewInstance(env->context()).ToLocalChecked();
   char* data = node::Malloc(size);
-  RandomBytesRequest* req =
+  std::unique_ptr<RandomBytesRequest> req(
       new RandomBytesRequest(env,
                              obj,
                              size,
                              data,
-                             RandomBytesRequest::FREE_DATA);
+                             RandomBytesRequest::FREE_DATA));
 
   if (args[1]->IsFunction()) {
     obj->Set(env->ondone_string(), args[1]);
@@ -5805,13 +5795,13 @@ void RandomBytes(const FunctionCallbackInfo<Value>& args) {
     }
 
     uv_queue_work(env->event_loop(),
-                  req->work_req(),
+                  req.release()->work_req(),
                   RandomBytesWork,
                   RandomBytesAfter);
     args.GetReturnValue().Set(obj);
   } else {
     Local<Value> argv[2];
-    RandomBytesProcessSync(env, req, &argv);
+    RandomBytesProcessSync(env, std::move(req), &argv);
     if (argv[0]->IsNull())
       args.GetReturnValue().Set(argv[1]);
   }
@@ -5834,12 +5824,12 @@ void RandomBytesBuffer(const FunctionCallbackInfo<Value>& args) {
   char* data = Buffer::Data(args[0]);
   data += offset;
 
-  RandomBytesRequest* req =
+  std::unique_ptr<RandomBytesRequest> req(
       new RandomBytesRequest(env,
                              obj,
                              size,
                              data,
-                             RandomBytesRequest::DONT_FREE_DATA);
+                             RandomBytesRequest::DONT_FREE_DATA));
   if (args[3]->IsFunction()) {
     obj->Set(env->context(), env->ondone_string(), args[3]).FromJust();
 
@@ -5851,13 +5841,13 @@ void RandomBytesBuffer(const FunctionCallbackInfo<Value>& args) {
     }
 
     uv_queue_work(env->event_loop(),
-                  req->work_req(),
+                  req.release()->work_req(),
                   RandomBytesWork,
                   RandomBytesAfter);
     args.GetReturnValue().Set(obj);
   } else {
     Local<Value> argv[2];
-    RandomBytesProcessSync(env, req, &argv);
+    RandomBytesProcessSync(env, std::move(req), &argv);
     if (argv[0]->IsNull())
       args.GetReturnValue().Set(argv[1]);
   }


### PR DESCRIPTION
Instead of raw pointerns, use std::unique_ptr for PBKDF2Request and
RandomBytesRequest. This makes ownership more clear.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src