### PR TITLE
assert: use Object.is comparison in .strictEqual

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -534,13 +534,16 @@ parameter is an instance of an `Error` then it will be thrown instead of the
 ## assert.notStrictEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17003
+    description: Used comparison changed from Strict Equality to `Object.is()`
 -->
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
 
-Tests strict inequality as determined by the [Strict Equality Comparison][]
-( `!==` ).
+Tests equality determined by the [`Object.is()`][] comparison.
 
 ```js
 const assert = require('assert');
@@ -549,7 +552,7 @@ assert.notStrictEqual(1, 2);
 // OK
 
 assert.notStrictEqual(1, 1);
-// AssertionError: 1 !== 1
+// AssertionError: 1 notStrictEqual 1
 
 assert.notStrictEqual(1, '1');
 // OK
@@ -595,25 +598,28 @@ assert.ok(false, 'it\'s false');
 ## assert.strictEqual(actual, expected[, message])
 <!-- YAML
 added: v0.1.21
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17003
+    description: Used comparison changed from Strict Equality to `Object.is()`
 -->
 * `actual` {any}
 * `expected` {any}
 * `message` {any}
 
-Tests strict equality as determined by the [Strict Equality Comparison][]
-( `===` ).
+Tests equality determined by the [`Object.is()`][] comparison.
 
 ```js
 const assert = require('assert');
 
 assert.strictEqual(1, 2);
-// AssertionError: 1 === 2
+// AssertionError: 1 strictEqual 2
 
 assert.strictEqual(1, 1);
 // OK
 
 assert.strictEqual(1, '1');
-// AssertionError: 1 === '1'
+// AssertionError: 1 strictEqual '1'
 ```
 
 If the values are not strictly equal, an `AssertionError` is thrown with a

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -7,6 +7,9 @@
 The `assert` module provides a simple set of assertion tests that can be used to
 test invariants.
 
+For more information about the used equality comparisons see
+[MDN's guide on equality comparisons and sameness][mdn-equality-guide].
+
 ## assert(value[, message])
 <!-- YAML
 added: v0.5.9
@@ -689,32 +692,6 @@ assert.throws(myFunction, 'missing foo', 'did not throw with expected message');
 // Do this instead.
 assert.throws(myFunction, /missing foo/, 'did not throw with expected message');
 ```
-
-## Caveats
-
-For the following cases, consider using ES2015 [`Object.is()`][],
-which uses the [SameValueZero][] comparison.
-
-```js
-const a = 0;
-const b = -a;
-assert.notStrictEqual(a, b);
-// AssertionError: 0 !== -0
-// Strict Equality Comparison doesn't distinguish between -0 and +0...
-assert(!Object.is(a, b));
-// but Object.is() does!
-
-const str1 = 'foo';
-const str2 = 'foo';
-assert.strictEqual(str1 / 1, str2 / 1);
-// AssertionError: NaN === NaN
-// Strict Equality Comparison can't be used to check NaN...
-assert(Object.is(str1 / 1, str2 / 1));
-// but Object.is() can!
-```
-
-For more information, see
-[MDN's guide on equality comparisons and sameness][mdn-equality-guide].
 
 [`Error.captureStackTrace`]: errors.html#errors_error_capturestacktrace_targetobject_constructoropt
 [`Map`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Map

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -124,18 +124,15 @@ function notDeepStrictEqual(actual, expected, message) {
   }
 }
 
-// The strict equality assertion tests strict equality, as determined by ===.
 assert.strictEqual = function strictEqual(actual, expected, message) {
-  if (actual !== expected) {
-    innerFail(actual, expected, message, '===', strictEqual);
+  if (!Object.is(actual, expected)) {
+    innerFail(actual, expected, message, 'strictEqual', strictEqual);
   }
 };
 
-// The strict non-equality assertion tests for strict inequality, as
-// determined by !==.
 assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
-  if (actual === expected) {
-    innerFail(actual, expected, message, '!==', notStrictEqual);
+  if (Object.is(actual, expected)) {
+    innerFail(actual, expected, message, 'notStrictEqual', notStrictEqual);
   }
 };
 

--- a/test/addons-napi/test_typedarray/test.js
+++ b/test/addons-napi/test_typedarray/test.js
@@ -27,7 +27,7 @@ assert.strictEqual(byteResult[2], 6);
 const doubleResult = test_typedarray.Multiply(doubleArray, -3);
 assert.ok(doubleResult instanceof Float64Array);
 assert.strictEqual(doubleResult.length, 3);
-assert.strictEqual(doubleResult[0], 0);
+assert.strictEqual(doubleResult[0], -0);
 assert.strictEqual(Math.round(10 * doubleResult[1]) / 10, -3.3);
 assert.strictEqual(Math.round(10 * doubleResult[2]) / 10, -6.6);
 

--- a/test/message/error_exit.out
+++ b/test/message/error_exit.out
@@ -3,7 +3,7 @@ assert.js:*
   throw new errors.AssertionError({
   ^
 
-AssertionError [ERR_ASSERTION]: 1 === 2
+AssertionError [ERR_ASSERTION]: 1 strictEqual 2
     at Object.<anonymous> (*test*message*error_exit.js:*:*)
     at Module._compile (module.js:*:*)
     at Object.Module._extensions..js (module.js:*:*)

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -586,7 +586,7 @@ function testAssertionMessage(actual, expected) {
     assert.strictEqual(actual, '');
   } catch (e) {
     assert.strictEqual(e.message,
-                       [expected, '===', '\'\''].join(' '));
+                       [expected, 'strictEqual', '\'\''].join(' '));
     assert.ok(e.generatedMessage, 'Message not marked as generated');
   }
 }
@@ -633,7 +633,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
 try {
   assert.strictEqual(1, 2);
 } catch (e) {
-  assert.strictEqual(e.message.split('\n')[0], '1 === 2');
+  assert.strictEqual(e.message.split('\n')[0], '1 strictEqual 2');
   assert.ok(e.generatedMessage, 'Message not marked as generated');
 }
 
@@ -727,7 +727,7 @@ assert.throws(() => {
   assert.strictEqual('A'.repeat(1000), '');
 }, common.expectsError({
   code: 'ERR_ASSERTION',
-  message: new RegExp(`^'${'A'.repeat(127)} === ''$`) }));
+  message: new RegExp(`^'${'A'.repeat(127)} strictEqual ''$`) }));
 
 {
   // bad args to AssertionError constructor should throw TypeError
@@ -749,6 +749,6 @@ common.expectsError(
   {
     code: 'ERR_ASSERTION',
     type: assert.AssertionError,
-    message: /^'Error: foo' === 'Error: foobar'$/
+    message: /^'Error: foo' strictEqual 'Error: foobar'$/
   }
 );

--- a/test/parallel/test-readdouble.js
+++ b/test/parallel/test-readdouble.js
@@ -112,7 +112,7 @@ function test(clazz) {
 
   buffer[7] = 0x80;
   assert.strictEqual(6.3e-322, buffer.readDoubleBE(0));
-  assert.strictEqual(0, buffer.readDoubleLE(0));
+  assert.strictEqual(-0, buffer.readDoubleLE(0));
   assert.strictEqual(true, 1 / buffer.readDoubleLE(0) < 0);
 
   buffer[6] = 0xf0;

--- a/test/parallel/test-readfloat.js
+++ b/test/parallel/test-readfloat.js
@@ -70,7 +70,7 @@ function test(clazz) {
 
   buffer[3] = 0x80;
   assert.strictEqual(1.793662034335766e-43, buffer.readFloatBE(0));
-  assert.strictEqual(0, buffer.readFloatLE(0));
+  assert.strictEqual(-0, buffer.readFloatLE(0));
   assert.strictEqual(true, 1 / buffer.readFloatLE(0) < 0);
 
   buffer[0] = 0;


### PR DESCRIPTION
This aligns assert.strictEqual and assert.notStrictEqual with
assert.deepStrictEqual to use the Object.is() comparison instead
of strict equality.

It looked somewhat nicer with `===` but I think it makes sense to use the equality checks in both functions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert