### PR TITLE
doc: add description for inspector-only console methods.

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -241,7 +241,10 @@ undefined
 ### console.debug(data[, ...args])
 <!-- YAML
 added: v8.0.0
-changes: REPLACEME
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17033
+    description: `console.debug` is now an alias for `console.log`.
 -->
 * `data` {any}
 * `...args` {any}

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -428,7 +428,7 @@ The `console.warn()` function is an alias for [`console.error()`][].
 
 ## Inspector only methods
 The following methods are exposed by the V8 engine in the general API but do
-not display anything unless used in conjunction with the inspector tab
+not display anything unless used in conjunction with the [inspector][] tab
 (`--inspect` flag).
 
 ### console.debug(data[, ...args])
@@ -539,5 +539,6 @@ This method does not display anything unless used in the inspector. The
 [`util.format()`]: util.html#util_util_format_format_args
 [`util.inspect()`]: util.html#util_util_inspect_object_options
 [customizing `util.inspect()` colors]: util.html#util_customizing_util_inspect_colors
+[inspector]: debugger.html
 [note on process I/O]: process.html#process_a_note_on_process_i_o
 [web-api-assert]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -240,7 +240,7 @@ undefined
 
 ### console.debug(data[, ...args])
 <!-- YAML
-added: v8.0.0
+added: v9.2.x
 -->
 * `data` {any}
 * `...args` {any}

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -240,7 +240,7 @@ undefined
 
 ### console.debug(data[, ...args])
 <!-- YAML
-added: v9.2.x
+added: REPLACEME
 -->
 * `data` {any}
 * `...args` {any}

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -431,15 +431,6 @@ The following methods are exposed by the V8 engine in the general API but do
 not display anything unless used in conjunction with the [inspector][]
 (`--inspect` flag).
 
-### console.debug(data[, ...args])
-<!-- YAML
-added: v8.0.0
--->
-* `data` {any}
-* `...args` {any}
-
-The `console.debug()` function is an alias for [`console.log()`][].
-
 ### console.dirxml(object)
 <!-- YAML
 added: v8.0.0

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -492,7 +492,7 @@ the report to the **Profiles** panel of the inspector tab. See
 <!-- YAML
 added: v8.0.0
 -->
-* `array` {array|object}
+* `array` {Array|Object}
 * `...args` {any}
 
 This method does not display anything unless used in the inspector. Prints to
@@ -529,9 +529,11 @@ This method does not display anything unless used in the inspector. The
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args
+[`console.profile()`]: #console_console_profile_label
+[`console.profileEnd()`]: #console_console_profileend
 [`console.time()`]: #console_console_time_label
-[`console.timeStamp()`]: #console_console_timestamp_label
 [`console.timeEnd()`]: #console_console_timeend_label
+[`console.timeStamp()`]: #console_console_timestamp_label
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdout`]: process.html#process_process_stdout
 [`util.format()`]: util.html#util_util_format_format_args

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -244,7 +244,7 @@ added: v8.0.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/17033
-    description: `console.debug` is now an alias for `console.log`.
+    description: "`console.debug` is now an alias for `console.log`."
 -->
 * `data` {any}
 * `...args` {any}

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -426,10 +426,101 @@ added: v0.1.100
 
 The `console.warn()` function is an alias for [`console.error()`][].
 
+## Inspector only methods
+The following methods are exposed by the V8 engine in the general API but are non-op unless used
+in conjunction with the inspector (`--inspect` flag).
+
+### console.debug(data[, ...args])
+<!-- YAML
+added: v8.0.0
+-->
+* `data` {any}
+* `...args` {any}
+
+The `console.debug()` function is an alias for [`console.log()`][].
+
+### console.dirxml(object)
+<!-- YAML
+added: v8.0.0
+-->
+* `object` {string}
+
+The `console.dirxml()` method displays in `stdout` an XML interactive tree representation of the descendants
+of the specified `object` if possible, or the JavaScript representation if not. Calling
+`console.dirxml()` on an HTML or XML element is equivalent to calling `console.log()`.
+
+### console.markTimeline()
+<!-- YAML
+added: v8.0.0
+-->
+* `label` {string} Defaults to `'default'`.
+
+The `console.markTimeline()` method is the deprecated form of [`console.timeStamp()`][].
+
+### console.profile([label])
+<!-- YAML
+added: v8.0.0
+-->
+* `label` {string}
+
+The `console.profile()` method starts a JavaScript CPU profile with an optional label until
+[`console.profileEnd()`][] is called. The profile is then added to the **Profile** panel of the
+inspector.
+```js
+console.profile('MyLabel');
+// Some code
+console.profileEnd();
+// Adds the profile 'MyLabel' to the Profiles panel of the inspector tab.
+```
+
+### console.profileEnd()
+<!-- YAML
+added: v8.0.0
+-->
+
+Stops the current JavaScript CPU profiling session if one has been started and prints the
+report to the **Profiles** panel of the inspector tab. See [`console.profile()`][] for an
+example.
+
+### console.table(array[, ...args])
+<!-- YAML
+added: v8.0.0
+-->
+* `array` {array|object}
+* `...args` {any}
+
+Prints to `stdout` the array `array` formatted as a table.
+
+### console.timeStamp([label])
+<!-- YAML
+added: v8.0.0
+-->
+* `label` {string}
+
+The `console.timeStamp()` method adds an event with the label `label` to the **Timeline**
+panel of the inspector tab.
+
+### console.timeline([label])
+<!-- YAML
+added: v8.0.0
+-->
+* `label` {string} Defaults to `'default'`.
+
+The `console.timeline()` method is the deprecated form of [`console.time()`][].
+
+### console.timelineEnd([label])
+<!-- YAML
+added: v8.0.0
+-->
+* `label` {string} Defaults to `'default'`.
+
+The `console.timelineEnd()` method is the deprecated form of [`console.timeEnd()`][].
+
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args
 [`console.time()`]: #console_console_time_label
+[`console.timeStamp()`]: #console_console_timestamp_label
 [`console.timeEnd()`]: #console_console_timeend_label
 [`process.stderr`]: process.html#process_process_stderr
 [`process.stdout`]: process.html#process_process_stdout

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -483,12 +483,12 @@ current JavaScript CPU profiling session if one has been started and prints
 the report to the **Profiles** panel of the inspector. See
 [`console.profile()`][] for an example.
 
-### console.table(array[, ...args])
+### console.table(array[, columns])
 <!-- YAML
 added: v8.0.0
 -->
 * `array` {Array|Object}
-* `...args` {any}
+* `columns` {Array}
 
 This method does not display anything unless used in the inspector. Prints to
 `stdout` the array `array` formatted as a table.

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -240,7 +240,8 @@ undefined
 
 ### console.debug(data[, ...args])
 <!-- YAML
-added: REPLACEME
+added: v8.0.0
+changes: REPLACEME
 -->
 * `data` {any}
 * `...args` {any}
@@ -443,7 +444,7 @@ representation of the descendants of the specified `object` if possible, or the
 JavaScript representation if not. Calling `console.dirxml()` on an HTML or XML
 element is equivalent to calling `console.log()`.
 
-### console.markTimeline()
+### console.markTimeline(label)
 <!-- YAML
 added: v8.0.0
 -->

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -427,8 +427,9 @@ added: v0.1.100
 The `console.warn()` function is an alias for [`console.error()`][].
 
 ## Inspector only methods
-The following methods are exposed by the V8 engine in the general API but are non-op unless used
-in conjunction with the inspector (`--inspect` flag).
+The following methods are exposed by the V8 engine in the general API but do
+not display anything unless used in conjunction with the inspector tab
+(`--inspect` flag).
 
 ### console.debug(data[, ...args])
 <!-- YAML
@@ -445,9 +446,11 @@ added: v8.0.0
 -->
 * `object` {string}
 
-The `console.dirxml()` method displays in `stdout` an XML interactive tree representation of the descendants
-of the specified `object` if possible, or the JavaScript representation if not. Calling
-`console.dirxml()` on an HTML or XML element is equivalent to calling `console.log()`.
+This method does not display anything unless used in the inspector. The
+`console.dirxml()` method displays in `stdout` an XML interactive tree
+representation of the descendants of the specified `object` if possible, or the
+JavaScript representation if not. Calling `console.dirxml()` on an HTML or XML
+element is equivalent to calling `console.log()`.
 
 ### console.markTimeline()
 <!-- YAML
@@ -455,7 +458,8 @@ added: v8.0.0
 -->
 * `label` {string} Defaults to `'default'`.
 
-The `console.markTimeline()` method is the deprecated form of [`console.timeStamp()`][].
+This method does not display anything unless used in the inspector. The
+`console.markTimeline()` method is the deprecated form of [`console.timeStamp()`][].
 
 ### console.profile([label])
 <!-- YAML
@@ -463,9 +467,10 @@ added: v8.0.0
 -->
 * `label` {string}
 
-The `console.profile()` method starts a JavaScript CPU profile with an optional label until
-[`console.profileEnd()`][] is called. The profile is then added to the **Profile** panel of the
-inspector.
+This method does not display anything unless used in the inspector. The
+`console.profile()` method starts a JavaScript CPU profile with an optional
+label until [`console.profileEnd()`][] is called. The profile is then added to
+the **Profile** panel of the inspector.
 ```js
 console.profile('MyLabel');
 // Some code
@@ -478,9 +483,10 @@ console.profileEnd();
 added: v8.0.0
 -->
 
-Stops the current JavaScript CPU profiling session if one has been started and prints the
-report to the **Profiles** panel of the inspector tab. See [`console.profile()`][] for an
-example.
+This method does not display anything unless used in the inspector. Stops the
+current JavaScript CPU profiling session if one has been started and prints
+the report to the **Profiles** panel of the inspector tab. See
+[`console.profile()`][] for an example.
 
 ### console.table(array[, ...args])
 <!-- YAML
@@ -489,7 +495,8 @@ added: v8.0.0
 * `array` {array|object}
 * `...args` {any}
 
-Prints to `stdout` the array `array` formatted as a table.
+This method does not display anything unless used in the inspector. Prints to
+`stdout` the array `array` formatted as a table.
 
 ### console.timeStamp([label])
 <!-- YAML
@@ -497,8 +504,9 @@ added: v8.0.0
 -->
 * `label` {string}
 
-The `console.timeStamp()` method adds an event with the label `label` to the **Timeline**
-panel of the inspector tab.
+This method does not display anything unless used in the inspector. The
+`console.timeStamp()` method adds an event with the label `label` to the
+**Timeline** panel of the inspector tab.
 
 ### console.timeline([label])
 <!-- YAML
@@ -506,7 +514,8 @@ added: v8.0.0
 -->
 * `label` {string} Defaults to `'default'`.
 
-The `console.timeline()` method is the deprecated form of [`console.time()`][].
+This method does not display anything unless used in the inspector. The
+`console.timeline()` method is the deprecated form of [`console.time()`][].
 
 ### console.timelineEnd([label])
 <!-- YAML
@@ -514,7 +523,8 @@ added: v8.0.0
 -->
 * `label` {string} Defaults to `'default'`.
 
-The `console.timelineEnd()` method is the deprecated form of [`console.timeEnd()`][].
+This method does not display anything unless used in the inspector. The
+`console.timelineEnd()` method is the deprecated form of [`console.timeEnd()`][].
 
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -428,7 +428,7 @@ The `console.warn()` function is an alias for [`console.error()`][].
 
 ## Inspector only methods
 The following methods are exposed by the V8 engine in the general API but do
-not display anything unless used in conjunction with the [inspector][] tab
+not display anything unless used in conjunction with the [inspector][]
 (`--inspect` flag).
 
 ### console.debug(data[, ...args])
@@ -475,7 +475,7 @@ the **Profile** panel of the inspector.
 console.profile('MyLabel');
 // Some code
 console.profileEnd();
-// Adds the profile 'MyLabel' to the Profiles panel of the inspector tab.
+// Adds the profile 'MyLabel' to the Profiles panel of the inspector.
 ```
 
 ### console.profileEnd()
@@ -485,7 +485,7 @@ added: v8.0.0
 
 This method does not display anything unless used in the inspector. Stops the
 current JavaScript CPU profiling session if one has been started and prints
-the report to the **Profiles** panel of the inspector tab. See
+the report to the **Profiles** panel of the inspector. See
 [`console.profile()`][] for an example.
 
 ### console.table(array[, ...args])
@@ -506,7 +506,7 @@ added: v8.0.0
 
 This method does not display anything unless used in the inspector. The
 `console.timeStamp()` method adds an event with the label `label` to the
-**Timeline** panel of the inspector tab.
+**Timeline** panel of the inspector.
 
 ### console.timeline([label])
 <!-- YAML


### PR DESCRIPTION
Description inspired by dev tools reference and inspector err messages

Added:
* intro
* console.debug()
* console.dirxml()
* console.markTimeline()
* console.profile()
* console.profileEnd()
* console.table()
* console.timeStamp()
* console.timeline()
* console.timelineEnd()

Fixes: https://github.com/nodejs/node/issues/16755

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
