### PR TITLE
Allow configure option to link to tcmalloc/ jemalloc

### DIFF
--- a/configure
+++ b/configure
@@ -180,6 +180,54 @@ parser.add_option('--openssl-system-ca-path',
     help='Use the specified path to system CA (PEM format) in addition to '
          'the OpenSSL supplied CA store or compiled-in Mozilla CA copy.')
 
+shared_optgroup.add_option('--shared-jemalloc',
+    action='store_true',
+    dest='shared_jemalloc',
+    help='Use jemalloc instead of libc malloc'
+         'Use this option for custom builds, after examining the impact'
+         'on performance. Ensure that the native add-on is linked to either'
+         'libc or jemalloc and uses the same allocator to alloc and free.')
+
+shared_optgroup.add_option('--shared-jemalloc-includes',
+    action='store',
+    dest='shared_jemalloc_includes',
+    help='directory containing lib jemalloc header files')
+
+shared_optgroup.add_option('--shared-jemalloc-libname',
+    action='store',
+    dest='shared_jemalloc_libname',
+    default='jemalloc',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-jemalloc-libpath',
+    action='store',
+    dest='shared_jemalloc_libpath',
+    help='directory to search for the jemalloc lib')
+
+shared_optgroup.add_option('--shared-tcmalloc',
+    action='store_true',
+    dest='shared_tcmalloc',
+    help='Use tcmalloc instead of libc malloc'
+         'Use this option for custom builds, after examining the impact'
+         'on performance. Ensure that the native add-on is linked to either'
+         'libc or jemalloc and uses the same allocator to alloc and free.')
+
+shared_optgroup.add_option('--shared-tcmalloc-includes',
+    action='store',
+    dest='shared_tcmalloc_includes',
+    help='directory containing lib tcmalloc header files')
+
+shared_optgroup.add_option('--shared-tcmalloc-libname',
+    action='store',
+    dest='shared_tcmalloc_libname',
+    default='tcmalloc',
+    help='alternative lib name to link to [default: %default]')
+
+shared_optgroup.add_option('--shared-tcmalloc-libpath',
+    action='store',
+    dest='shared_tcmalloc_libpath',
+    help='directory to search for the tcmalloc lib')
+
 shared_optgroup.add_option('--shared-http-parser',
     action='store_true',
     dest='shared_http_parser',
@@ -1443,6 +1491,11 @@ configure_library('http_parser', output)
 configure_library('libuv', output)
 configure_library('libcares', output)
 configure_library('nghttp2', output)
+
+# we don't want to link to both tcmalloc and jemalloc
+if bool(options.shared_jemalloc) != bool(options.shared_tcmalloc): 
+  configure_library('jemalloc', output)
+  configure_library('tcmalloc', output)
 # stay backwards compatible with shared cares builds
 output['variables']['node_shared_cares'] = \
     output['variables'].pop('node_shared_libcares')


### PR DESCRIPTION
Both the memory allocators provide better performance on small sized
allocations.

Provide user options to link to jemalloc, tcmalloc. 
Both of them have been known to provide better performance for small sized memory
allocations. The impact on long running apps must be evaluated before enabling it by default on production builds of node binary.
Earlier versions of tcmalloc cause fragmentation leading to overhead in actual physical memory consumed for the same given number of bytes allocated. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ x] tests and/or benchmarks are included
- [ x] documentation is changed or added
- [ x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
Build
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
