### PR TITLE
doc,win: clarify WSL support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -66,6 +66,12 @@ note1 - The gcc4.8-libs package needs to be installed, because node
   In "Git bash" if you call the node shell alias (`node` without the `.exe`
   extension), `winpty` is used automatically.
 
+*Note*: The Windows Subsystem for Linux (WSL) is not directly supported, but
+  the GNU/Linux build process and binaries should work. The community will
+  only address issues that reproduce on native GNU/Linux systems, issues that
+  only reproduce on WSL should be reported in the
+  [WSL issue tracker](https://github.com/Microsoft/WSL/issues).
+
 ### Supported toolchains
 
 Depending on host platform, the selection of toolchains may vary.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -66,11 +66,13 @@ note1 - The gcc4.8-libs package needs to be installed, because node
   In "Git bash" if you call the node shell alias (`node` without the `.exe`
   extension), `winpty` is used automatically.
 
-*Note*: The Windows Subsystem for Linux (WSL) is not directly supported, but
-  the GNU/Linux build process and binaries should work. The community will
-  only address issues that reproduce on native GNU/Linux systems, issues that
-  only reproduce on WSL should be reported in the
-  [WSL issue tracker](https://github.com/Microsoft/WSL/issues).
+The Windows Subsystem for Linux (WSL) is not directly supported, but the
+GNU/Linux build process and binaries should work. The community will only
+address issues that reproduce on native GNU/Linux systems. Issues that only
+reproduce on WSL should be reported in the
+[WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
+Windows binary (`node.exe`) in WSL is not recommended, and will not work
+without adjustment (such as stdio redirection).
 
 ### Supported toolchains
 


### PR DESCRIPTION
Following the discussion in https://github.com/nodejs/node/issues/13471, this adds a note to `BUILDING.md` to clarify WSL support.

cc @nodejs/platform-windows @nodejs/build 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc, win