### PR TITLE
build: prevent echoing of recipes for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,11 @@ test: all
 	$(MAKE) cctest
 else
 test: all
-	$(MAKE) build-addons
-	$(MAKE) build-addons-napi
-	$(MAKE) doc-only
-	$(MAKE) lint
-	$(MAKE) cctest
+	$(MAKE) -s build-addons
+	$(MAKE) -s build-addons-napi
+	$(MAKE) -s doc-only
+	$(MAKE) -s lint
+	$(MAKE) -s cctest
 	$(PYTHON) tools/test.py --mode=release -J \
 		$(CI_ASYNC_HOOKS) \
 		$(CI_JS_SUITES) \


### PR DESCRIPTION
Currenlty the test target will echo additional information that might
not be that useful, for example:
```console
make doc-only
make[1]: Nothing to be done for `doc-only'.
make lint
Running JS linter...
Running C++ linter...
Total errors found: 0
make[2]: Nothing to be done for `lint-md'.
Running C++ linter on addon docs...
Total errors found: 0
make cctest
```

This commit suggests reducing this to:
```console
make -s doc-only
make -s lint
Running JS linter...
Running C++ linter...
Running C++ linter on addon docs...
Total errors found: 0
make -s cctest
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
bulid