### PR TITLE
src: use unique pointer for tracing_agent

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -263,8 +263,8 @@ node::DebugOptions debug_options;
 static struct {
 #if NODE_USE_V8_PLATFORM
   void Initialize(int thread_pool_size) {
-    tracing_agent_ =
-        trace_enabled ? new tracing::Agent() : nullptr;
+    tracing_agent_.reset(
+        trace_enabled ? new tracing::Agent() : nullptr);
     platform_ = new NodePlatform(thread_pool_size,
         trace_enabled ? tracing_agent_->GetTracingController() : nullptr);
     V8::InitializePlatform(platform_);
@@ -276,8 +276,7 @@ static struct {
     platform_->Shutdown();
     delete platform_;
     platform_ = nullptr;
-    delete tracing_agent_;
-    tracing_agent_ = nullptr;
+    tracing_agent_.reset(nullptr);
   }
 
   void DrainVMTasks(Isolate* isolate) {
@@ -314,7 +313,7 @@ static struct {
     return platform_;
   }
 
-  tracing::Agent* tracing_agent_;
+  std::unique_ptr<tracing::Agent> tracing_agent_;
   NodePlatform* platform_;
 #else  // !NODE_USE_V8_PLATFORM
   void Initialize(int thread_pool_size) {}


### PR DESCRIPTION
Use std::unique_ptr instead of raw pointers for the
tracing_agent_ in node.cc. This makes ownership clearer and we
don't risk a memory leak.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src