### PR TITLE
src: fix bad sizeof expression

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -160,7 +160,7 @@ class ChannelWrap : public AsyncWrap {
   }
   inline node_ares_task_list* task_list() { return &task_list_; }
 
-  size_t self_size() const override { return sizeof(this); }
+  size_t self_size() const override { return sizeof(*this); }
 
   static void AresTimeout(uv_timer_t* handle);
 


### PR DESCRIPTION
It was computing the size of the pointer, not the size of the pointed-to
object.

Introduced in commit 727b2911eca ("src,dns: refactor cares_wrap to avoid
global state".)

~~CI: https://ci.nodejs.org/job/node-test-pull-request/11416/~~ (jenkins issue)
CI: https://ci.nodejs.org/job/node-test-pull-request/11418/