### PR TITLE
build, win: vcbuild improvements

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -25,7 +25,7 @@ EXIT /B
 
 :: Query registry sub-tree for InstallPath
 :find-key
-FOR /F "delims=" %%a IN ('REG QUERY %1 /s  ^| findstr "2." ^| findstr InstallPath') DO IF NOT ERRORLEVEL 1 CALL :find-path %%a
+FOR /F "delims=" %%a IN ('REG QUERY %1 /s 2> NUL ^| findstr "2." ^| findstr InstallPath') DO IF NOT ERRORLEVEL 1 CALL :find-path %%a
 EXIT /B
 
 :: Parse the value of %1 as the path for python.exe

--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -19,7 +19,7 @@ EXIT /B 1
 :: Helper subroutine to handle quotes in %1
 :find-main-branch
 SET main_key="%~1\Python\PythonCore"
-REG QUERY %main_key% /s | findstr "2." | findstr InstallPath > NUL 2> NUL
+REG QUERY %main_key% /s 2> NUL | findstr "2." | findstr InstallPath > NUL 2> NUL
 IF NOT ERRORLEVEL 1 CALL :find-key %main_key%
 EXIT /B
 

--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -1,4 +1,5 @@
 @IF NOT DEFINED DEBUG_HELPER @ECHO OFF
+echo Looking for Python 2.x
 SETLOCAL
 :: If python.exe is in %Path%, just validate
 FOR /F "delims=" %%a IN ('where python 2^> NUL') DO (
@@ -14,7 +15,7 @@ FOR %%K IN ( "HKCU\Software", "HKLM\SOFTWARE", "HKLM\Software\Wow6432Node") DO (
   :: If validate returns 0 just jump to the end
   IF NOT ERRORLEVEL 1 GOTO :validate
 )
-EXIT /B 1
+goto :no-python
 
 :: Helper subroutine to handle quotes in %1
 :find-main-branch
@@ -39,13 +40,20 @@ EXIT /B 1
 
 :: Check if %p% holds a path to a real python2 executable
 :validate
-IF NOT EXIST "%p%python.exe" EXIT /B 1
+IF NOT EXIST "%p%python.exe" goto :no-python
 :: Check if %p% is python2
 "%p%python.exe" -V 2>&1 | findstr /R "^Python.2.*" > NUL
-IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
+IF ERRORLEVEL 1 goto :no-python2
 :: We can wrap it up
 ENDLOCAL & SET pt=%p%& SET need_path_ext=%need_path%
 SET VCBUILD_PYTHON_LOCATION=%pt%python.exe
 IF %need_path_ext%==1 SET Path=%Path%;%pt%
 SET need_path_ext=
 EXIT /B %ERRORLEVEL%
+
+:no-python2
+echo Python found in %p%, but it is not v2.x.
+exit /B 1
+:no-python
+echo Could not find Python.
+exit /B 1

--- a/tools/msvs/vswhere_usability_wrapper.cmd
+++ b/tools/msvs/vswhere_usability_wrapper.cmd
@@ -28,5 +28,4 @@ for /f "usebackq tokens=*" %%i in (`vswhere %VSWHERE_ARGS%`) do (
 
 :no-vswhere
 endlocal
-echo could not find "vswhere"
 exit /B 1

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -166,8 +166,8 @@ if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
 echo Looking for Python 2.x
-call tools\msvs\find_python.cmd > NUL 2> NUL
-if errorlevel 1 echo Could not find Python installation & goto :exit
+call tools\msvs\find_python.cmd
+if errorlevel 1 echo Could not find Python & goto :exit
 
 call :getnodeversion || exit /b 1
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -165,9 +165,8 @@ if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
-echo Looking for Python 2.x
 call tools\msvs\find_python.cmd
-if errorlevel 1 echo Could not find Python & goto :exit
+if errorlevel 1 goto :exit
 
 call :getnodeversion || exit /b 1
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -1,4 +1,4 @@
-@echo off
+@if not defined DEBUG_HELPER @ECHO OFF
 
 cd %~dp0
 
@@ -165,8 +165,9 @@ if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
-call tools\msvs\find_python.cmd
-if errorlevel 1 echo Could not find python2 & goto :exit
+echo Looking for Python 2.x
+call tools\msvs\find_python.cmd > NUL 2> NUL
+if errorlevel 1 echo Could not find Python installation & goto :exit
 
 call :getnodeversion || exit /b 1
 


### PR DESCRIPTION
Adds extra a check for proper Python version. If it is not found, `vcbuild` will exit early.

If no VS2017 installation is found, `vswhere_usability_wrapper.cmd` would print `could not find "vswhere"`. This removes that message, making output look nicer for VS2015 compilation.

Finally, this adds support for `DEBUG_HELPER` to `vcbuild.bat`. Similar to `vswhere_usability_wrapper.cmd`  and `find_python.cmd`, if `DEBUG_HELPER` environment variable is set, `echo off` will not be called, making debugging easier.

Fixes: https://github.com/nodejs/node/issues/16864

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build
