### PR TITLE
src: use smart pointer instead of new and delete

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -261,10 +261,10 @@ class InspectorTimer {
   }
 
   static void TimerClosedCb(uv_handle_t* uvtimer) {
-    InspectorTimer* timer =
+    std::unique_ptr<InspectorTimer> timer(
         node::ContainerOf(&InspectorTimer::timer_,
-                          reinterpret_cast<uv_timer_t*>(uvtimer));
-    delete timer;
+                          reinterpret_cast<uv_timer_t*>(uvtimer)));
+    // Unique_ptr goes out of scope here and pointer is deleted.
   }
 
   ~InspectorTimer() {}
@@ -272,6 +272,8 @@ class InspectorTimer {
   uv_timer_t timer_;
   V8InspectorClient::TimerCallback callback_;
   void* data_;
+
+  friend std::unique_ptr<InspectorTimer>::deleter_type;
 };
 
 class InspectorTimerHandle {

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -114,9 +114,9 @@ int CloseAsyncAndLoop(uv_async_t* async) {
 
 // Delete main_thread_req_ on async handle close
 void ReleasePairOnAsyncClose(uv_handle_t* async) {
-  AsyncAndAgent* pair = node::ContainerOf(&AsyncAndAgent::first,
-                                          reinterpret_cast<uv_async_t*>(async));
-  delete pair;
+  std::unique_ptr<AsyncAndAgent> pair(node::ContainerOf(&AsyncAndAgent::first,
+      reinterpret_cast<uv_async_t*>(async)));
+  // Unique_ptr goes out of scope here and pointer is deleted.
 }
 
 }  // namespace


### PR DESCRIPTION
Use an std::unique_ptr for variables that are deleted
right after creation.

Since the destructor of InspectorTimer is private
but needed by the unique_ptr, define deleter_type as friend.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stc