### PR TITLE
(v6.x backport) test: remove node-tap lookalike

### DIFF
--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -65,42 +65,8 @@ TestWriter.prototype.end = function(c) {
   this.emit('end', this.received);
 };
 
-////////
-
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-
-test('a most basic test', function(t) {
+{
+  // Test basic functionality
   const r = new TestReader(20);
 
   const reads = [];
@@ -121,10 +87,9 @@ test('a most basic test', function(t) {
                    'xxxxxxxxxxxxxxxxxxxxxxxxx',
                    'xxxxxxxxxxxxxxxxxxxxx' ];
 
-  r.on('end', function() {
+  r.on('end', common.mustCall(function() {
     assert.deepStrictEqual(reads, expect);
-    t.end();
-  });
+  }));
 
   let readSize = 1;
   function flow() {
@@ -136,9 +101,10 @@ test('a most basic test', function(t) {
   }
 
   flow();
-});
+}
 
-test('pipe', function(t) {
+{
+  // Verify pipe
   const r = new TestReader(5);
 
   const expect = [ 'xxxxx',
@@ -154,72 +120,64 @@ test('pipe', function(t) {
 
   const w = new TestWriter();
 
-  w.on('end', function(received) {
+  w.on('end', common.mustCall(function(received) {
     assert.deepStrictEqual(received, expect);
-    t.end();
-  });
+  }));
 
   r.pipe(w);
-});
+}
 
 
 [1, 2, 3, 4, 5, 6, 7, 8, 9].forEach(function(SPLIT) {
-  test('unpipe', function(t) {
-    const r = new TestReader(5);
+  // Verify unpipe
+  const r = new TestReader(5);
 
-    // unpipe after 3 writes, then write to another stream instead.
-    let expect = [ 'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx' ];
-    expect = [ expect.slice(0, SPLIT), expect.slice(SPLIT) ];
+  // unpipe after 3 writes, then write to another stream instead.
+  let expect = [ 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx' ];
+  expect = [ expect.slice(0, SPLIT), expect.slice(SPLIT) ];
 
-    const w = [ new TestWriter(), new TestWriter() ];
+  const w = [ new TestWriter(), new TestWriter() ];
 
-    let writes = SPLIT;
-    w[0].on('write', function() {
-      if (--writes === 0) {
-        r.unpipe();
-        assert.strictEqual(r._readableState.pipes, null);
-        w[0].end();
-        r.pipe(w[1]);
-        assert.strictEqual(r._readableState.pipes, w[1]);
-      }
-    });
-
-    let ended = 0;
-
-    let ended0 = false;
-    let ended1 = false;
-    w[0].on('end', function(results) {
-      assert.strictEqual(ended0, false);
-      ended0 = true;
-      ended++;
-      assert.deepStrictEqual(results, expect[0]);
-    });
-
-    w[1].on('end', function(results) {
-      assert.strictEqual(ended1, false);
-      ended1 = true;
-      ended++;
-      assert.strictEqual(ended, 2);
-      assert.deepStrictEqual(results, expect[1]);
-      t.end();
-    });
-
-    r.pipe(w[0]);
+  let writes = SPLIT;
+  w[0].on('write', function() {
+    if (--writes === 0) {
+      r.unpipe();
+      assert.strictEqual(r._readableState.pipes, null);
+      w[0].end();
+      r.pipe(w[1]);
+      assert.strictEqual(r._readableState.pipes, w[1]);
+    }
   });
+
+  let ended = 0;
+
+  w[0].on('end', common.mustCall(function(results) {
+    ended++;
+    assert.strictEqual(ended, 1);
+    assert.deepStrictEqual(results, expect[0]);
+  }));
+
+  w[1].on('end', common.mustCall(function(results) {
+    ended++;
+    assert.strictEqual(ended, 2);
+    assert.deepStrictEqual(results, expect[1]);
+  }));
+
+  r.pipe(w[0]);
 });
 
 
-// both writers should get the same exact data.
-test('multipipe', function(t) {
+{
+  // Verify both writers get the same data when piping to destinations
   const r = new TestReader(5);
   const w = [ new TestWriter(), new TestWriter() ];
 
@@ -234,69 +192,66 @@ test('multipipe', function(t) {
                    'xxxxx',
                    'xxxxx' ];
 
-  let c = 2;
-  w[0].on('end', function(received) {
+  w[0].on('end', common.mustCall(function(received) {
     assert.deepStrictEqual(received, expect, 'first');
-    if (--c === 0) t.end();
-  });
-  w[1].on('end', function(received) {
+  }));
+  w[1].on('end', common.mustCall(function(received) {
     assert.deepStrictEqual(received, expect, 'second');
-    if (--c === 0) t.end();
-  });
+  }));
 
   r.pipe(w[0]);
   r.pipe(w[1]);
-});
+}
 
 
 [1, 2, 3, 4, 5, 6, 7, 8, 9].forEach(function(SPLIT) {
-  test('multi-unpipe', function(t) {
-    const r = new TestReader(5);
+  // Verify multi-unpipe
+  const r = new TestReader(5);
 
-    // unpipe after 3 writes, then write to another stream instead.
-    let expect = [ 'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx',
-                   'xxxxx' ];
-    expect = [ expect.slice(0, SPLIT), expect.slice(SPLIT) ];
+  // unpipe after 3 writes, then write to another stream instead.
+  let expect = [ 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx',
+                 'xxxxx' ];
+  expect = [ expect.slice(0, SPLIT), expect.slice(SPLIT) ];
 
-    const w = [ new TestWriter(), new TestWriter(), new TestWriter() ];
+  const w = [ new TestWriter(), new TestWriter(), new TestWriter() ];
 
-    let writes = SPLIT;
-    w[0].on('write', function() {
-      if (--writes === 0) {
-        r.unpipe();
-        w[0].end();
-        r.pipe(w[1]);
-      }
-    });
-
-    let ended = 0;
-
-    w[0].on('end', function(results) {
-      ended++;
-      assert.deepStrictEqual(results, expect[0]);
-    });
-
-    w[1].on('end', function(results) {
-      ended++;
-      assert.strictEqual(ended, 2);
-      assert.deepStrictEqual(results, expect[1]);
-      t.end();
-    });
-
-    r.pipe(w[0]);
-    r.pipe(w[2]);
+  let writes = SPLIT;
+  w[0].on('write', function() {
+    if (--writes === 0) {
+      r.unpipe();
+      w[0].end();
+      r.pipe(w[1]);
+    }
   });
+
+  let ended = 0;
+
+  w[0].on('end', common.mustCall(function(results) {
+    ended++;
+    assert.strictEqual(ended, 1);
+    assert.deepStrictEqual(results, expect[0]);
+  }));
+
+  w[1].on('end', common.mustCall(function(results) {
+    ended++;
+    assert.strictEqual(ended, 2);
+    assert.deepStrictEqual(results, expect[1]);
+  }));
+
+  r.pipe(w[0]);
+  r.pipe(w[2]);
 });
 
-test('back pressure respected', function(t) {
+{
+  // Verify that back pressure is respected
   const r = new R({ objectMode: true });
   r._read = common.mustNotCall();
   let counter = 0;
@@ -308,7 +263,6 @@ test('back pressure respected', function(t) {
 
   const w1 = new R();
   w1.write = function(chunk) {
-    console.error('w1.emit("close")');
     assert.strictEqual(chunk[0], 'one');
     w1.emit('close');
     process.nextTick(function() {
@@ -324,7 +278,6 @@ test('back pressure respected', function(t) {
 
   let w2 = new R();
   w2.write = function(chunk) {
-    console.error('w2 write', chunk, counter);
     assert.strictEqual(chunk[0], expected.shift());
     assert.strictEqual(counter, 0);
 
@@ -336,7 +289,6 @@ test('back pressure respected', function(t) {
 
     setTimeout(function() {
       counter--;
-      console.error('w2 drain');
       w2.emit('drain');
     }, 10);
 
@@ -346,7 +298,6 @@ test('back pressure respected', function(t) {
 
   let w3 = new R();
   w3.write = function(chunk) {
-    console.error('w3 write', chunk, counter);
     assert.strictEqual(chunk[0], expected.shift());
     assert.strictEqual(counter, 1);
 
@@ -358,20 +309,19 @@ test('back pressure respected', function(t) {
 
     setTimeout(function() {
       counter--;
-      console.error('w3 drain');
       w3.emit('drain');
     }, 50);
 
     return false;
   };
-  w3.end = function() {
+  w3.end = common.mustCall(function() {
     assert.strictEqual(counter, 2);
     assert.strictEqual(expected.length, 0);
-    t.end();
-  };
-});
+  });
+}
 
-test('read(0) for ended streams', function(t) {
+{
+  // Verify read(0) behavior for ended streams
   const r = new R();
   let written = false;
   let ended = false;
@@ -392,16 +342,16 @@ test('read(0) for ended streams', function(t) {
     assert.strictEqual(buffer.toString(), 'foo');
   };
 
-  w.end = function() {
+  w.end = common.mustCall(function() {
     ended = true;
     assert.strictEqual(written, true);
-    t.end();
-  };
+  });
 
   r.pipe(w);
-});
+}
 
-test('sync _read ending', function(t) {
+{
+  // Verify synchronous _read ending
   const r = new R();
   let called = false;
   r._read = function(n) {
@@ -409,6 +359,7 @@ test('sync _read ending', function(t) {
   };
 
   r.once('end', function() {
+    // Verify that this is called before the next tick
     called = true;
   });
 
@@ -416,11 +367,11 @@ test('sync _read ending', function(t) {
 
   process.nextTick(function() {
     assert.strictEqual(called, true);
-    t.end();
   });
-});
+}
 
-test('adding readable triggers data flow', function(t) {
+{
+  // Verify that adding readable listeners trigger data flow
   const r = new R({ highWaterMark: 5 });
   let onReadable = false;
   let readCalled = 0;
@@ -437,17 +388,16 @@ test('adding readable triggers data flow', function(t) {
     r.read();
   });
 
-  r.on('end', function() {
+  r.on('end', common.mustCall(function() {
     assert.strictEqual(readCalled, 3);
     assert.ok(onReadable);
-    t.end();
-  });
-});
+  }));
+}
 
-test('chainable', function(t) {
+{
+  // Verify that streams are chainable
   const r = new R();
   r._read = common.mustCall();
   const r2 = r.setEncoding('utf8').pause().resume().pause();
   assert.strictEqual(r, r2);
-  t.end();
-});
+}

--- a/test/parallel/test-stream2-objects.js
+++ b/test/parallel/test-stream2-objects.js
@@ -4,40 +4,6 @@ const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
 const assert = require('assert');
 
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
 function toArray(callback) {
   const stream = new Writable({ objectMode: true });
   const list = [];
@@ -45,9 +11,9 @@ function toArray(callback) {
     list.push(chunk);
   };
 
-  stream.end = function() {
+  stream.end = common.mustCall(function() {
     callback(list);
-  };
+  });
 
   return stream;
 }
@@ -63,7 +29,8 @@ function fromArray(list) {
   return r;
 }
 
-test('can read objects from stream', function(t) {
+{
+  // Verify that objects can be read from the stream
   const r = fromArray([{ one: '1'}, { two: '2' }]);
 
   const v1 = r.read();
@@ -73,34 +40,30 @@ test('can read objects from stream', function(t) {
   assert.deepStrictEqual(v1, { one: '1' });
   assert.deepStrictEqual(v2, { two: '2' });
   assert.deepStrictEqual(v3, null);
+}
 
-  t.end();
-});
-
-test('can pipe objects into stream', function(t) {
+{
+  // Verify that objects can be piped into the stream
   const r = fromArray([{ one: '1'}, { two: '2' }]);
 
-  r.pipe(toArray(function(list) {
+  r.pipe(toArray(common.mustCall(function(list) {
     assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('read(n) is ignored', function(t) {
+{
+  // Verify that read(n) is ignored
   const r = fromArray([{ one: '1'}, { two: '2' }]);
-
   const value = r.read(2);
 
   assert.deepStrictEqual(value, { one: '1' });
+}
 
-  t.end();
-});
-
-test('can read objects from _read (sync)', function(t) {
+{
+  // Verify that objects can be synchronously read
   const r = new Readable({ objectMode: true });
   const list = [{ one: '1'}, { two: '2' }];
   r._read = function(n) {
@@ -108,17 +71,16 @@ test('can read objects from _read (sync)', function(t) {
     r.push(item || null);
   };
 
-  r.pipe(toArray(function(list) {
+  r.pipe(toArray(common.mustCall(function(list) {
     assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('can read objects from _read (async)', function(t) {
+{
+  // Verify that objects can be asynchronously read
   const r = new Readable({ objectMode: true });
   const list = [{ one: '1'}, { two: '2' }];
   r._read = function(n) {
@@ -128,17 +90,16 @@ test('can read objects from _read (async)', function(t) {
     });
   };
 
-  r.pipe(toArray(function(list) {
+  r.pipe(toArray(common.mustCall(function(list) {
     assert.deepStrictEqual(list, [
       { one: '1' },
       { two: '2' }
     ]);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('can read strings as objects', function(t) {
+{
+  // Verify that strings can be read as objects
   const r = new Readable({
     objectMode: true
   });
@@ -149,14 +110,13 @@ test('can read strings as objects', function(t) {
   });
   r.push(null);
 
-  r.pipe(toArray(function(array) {
+  r.pipe(toArray(common.mustCall(function(array) {
     assert.deepStrictEqual(array, list);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('read(0) for object streams', function(t) {
+{
+  // Verify read(0) behavior for object streams
   const r = new Readable({
     objectMode: true
   });
@@ -165,14 +125,13 @@ test('read(0) for object streams', function(t) {
   r.push('foobar');
   r.push(null);
 
-  r.pipe(toArray(function(array) {
+  r.pipe(toArray(common.mustCall(function(array) {
     assert.deepStrictEqual(array, ['foobar']);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('falsey values', function(t) {
+{
+  // Verify the behavior of pushing falsey values
   const r = new Readable({
     objectMode: true
   });
@@ -183,14 +142,13 @@ test('falsey values', function(t) {
   r.push('');
   r.push(null);
 
-  r.pipe(toArray(function(array) {
+  r.pipe(toArray(common.mustCall(function(array) {
     assert.deepStrictEqual(array, [false, 0, '']);
+  })));
+}
 
-    t.end();
-  }));
-});
-
-test('high watermark _read', function(t) {
+{
+  // Verify high watermark _read() behavior
   const r = new Readable({
     highWaterMark: 6,
     objectMode: true
@@ -218,11 +176,10 @@ test('high watermark _read', function(t) {
   assert.strictEqual(v3, '3');
 
   assert.strictEqual(calls, 1);
+}
 
-  t.end();
-});
-
-test('high watermark push', function(t) {
+{
+  // Verify high watermark push behavior
   const r = new Readable({
     highWaterMark: 6,
     objectMode: true
@@ -232,11 +189,10 @@ test('high watermark push', function(t) {
     const bool = r.push(i);
     assert.strictEqual(bool, i !== 5);
   }
+}
 
-  t.end();
-});
-
-test('can write objects to stream', function(t) {
+{
+  // Verify that objects can be written to stream
   const w = new Writable({ objectMode: true });
 
   w._write = function(chunk, encoding, cb) {
@@ -244,15 +200,13 @@ test('can write objects to stream', function(t) {
     cb();
   };
 
-  w.on('finish', function() {
-    t.end();
-  });
-
+  w.on('finish', common.mustCall());
   w.write({ foo: 'bar' });
   w.end();
-});
+}
 
-test('can write multiple objects to stream', function(t) {
+{
+  // Verify that multiple objects can be written to stream
   const w = new Writable({ objectMode: true });
   const list = [];
 
@@ -261,11 +215,9 @@ test('can write multiple objects to stream', function(t) {
     cb();
   };
 
-  w.on('finish', function() {
+  w.on('finish', common.mustCall(function() {
     assert.deepStrictEqual(list, [0, 1, 2, 3, 4]);
-
-    t.end();
-  });
+  }));
 
   w.write(0);
   w.write(1);
@@ -273,9 +225,10 @@ test('can write multiple objects to stream', function(t) {
   w.write(3);
   w.write(4);
   w.end();
-});
+}
 
-test('can write strings as objects', function(t) {
+{
+  // Verify that strings can be written as objects
   const w = new Writable({
     objectMode: true
   });
@@ -286,11 +239,9 @@ test('can write strings as objects', function(t) {
     process.nextTick(cb);
   };
 
-  w.on('finish', function() {
+  w.on('finish', common.mustCall(function() {
     assert.deepStrictEqual(list, ['0', '1', '2', '3', '4']);
-
-    t.end();
-  });
+  }));
 
   w.write('0');
   w.write('1');
@@ -298,9 +249,10 @@ test('can write strings as objects', function(t) {
   w.write('3');
   w.write('4');
   w.end();
-});
+}
 
-test('buffers finish until cb is called', function(t) {
+{
+  // Verify that stream buffers finish until callback is called
   const w = new Writable({
     objectMode: true
   });
@@ -315,12 +267,10 @@ test('buffers finish until cb is called', function(t) {
     });
   };
 
-  w.on('finish', function() {
+  w.on('finish', common.mustCall(function() {
     assert.strictEqual(called, true);
-
-    t.end();
-  });
+  }));
 
   w.write('foo');
   w.end();
-});
+}

--- a/test/parallel/test-stream2-readable-from-list.js
+++ b/test/parallel/test-stream2-readable-from-list.js
@@ -5,33 +5,6 @@ const assert = require('assert');
 const fromList = require('_stream_readable')._fromList;
 const BufferList = require('internal/streams/BufferList');
 
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
 function bufferListFromArray(arr) {
   const bl = new BufferList();
   for (let i = 0; i < arr.length; ++i)
@@ -39,15 +12,8 @@ function bufferListFromArray(arr) {
   return bl;
 }
 
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-
-test('buffers', function(t) {
+{
+  // Verify behavior with buffers
   let list = [ Buffer.from('foog'),
                Buffer.from('bark'),
                Buffer.from('bazy'),
@@ -56,27 +22,26 @@ test('buffers', function(t) {
 
   // read more than the first element.
   let ret = fromList(6, { buffer: list, length: 16 });
-  t.equal(ret.toString(), 'foogba');
+  assert.strictEqual(ret.toString(), 'foogba');
 
   // read exactly the first element.
   ret = fromList(2, { buffer: list, length: 10 });
-  t.equal(ret.toString(), 'rk');
+  assert.strictEqual(ret.toString(), 'rk');
 
   // read less than the first element.
   ret = fromList(2, { buffer: list, length: 8 });
-  t.equal(ret.toString(), 'ba');
+  assert.strictEqual(ret.toString(), 'ba');
 
   // read more than we have.
   ret = fromList(100, { buffer: list, length: 6 });
-  t.equal(ret.toString(), 'zykuel');
+  assert.strictEqual(ret.toString(), 'zykuel');
 
   // all consumed.
-  t.same(list, new BufferList());
+  assert.deepStrictEqual(list, new BufferList());
+}
 
-  t.end();
-});
-
-test('strings', function(t) {
+{
+  // Verify behavior with strings
   let list = [ 'foog',
                'bark',
                'bazy',
@@ -85,22 +50,20 @@ test('strings', function(t) {
 
   // read more than the first element.
   let ret = fromList(6, { buffer: list, length: 16, decoder: true });
-  t.equal(ret, 'foogba');
+  assert.strictEqual(ret, 'foogba');
 
   // read exactly the first element.
   ret = fromList(2, { buffer: list, length: 10, decoder: true });
-  t.equal(ret, 'rk');
+  assert.strictEqual(ret, 'rk');
 
   // read less than the first element.
   ret = fromList(2, { buffer: list, length: 8, decoder: true });
-  t.equal(ret, 'ba');
+  assert.strictEqual(ret, 'ba');
 
   // read more than we have.
   ret = fromList(100, { buffer: list, length: 6, decoder: true });
-  t.equal(ret, 'zykuel');
+  assert.strictEqual(ret, 'zykuel');
 
   // all consumed.
-  t.same(list, new BufferList());
-
-  t.end();
-});
+  assert.deepStrictEqual(list, new BufferList());
+}

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -1,44 +1,8 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const R = require('_stream_readable');
 const util = require('util');
-
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-/////
 
 util.inherits(TestReader, R);
 
@@ -68,13 +32,12 @@ TestReader.prototype._read = function(n) {
     this.pos += n;
     const ret = Buffer.alloc(n, 'a');
 
-    console.log('this.push(ret)', ret);
-
     return this.push(ret);
   }.bind(this), 1);
 };
 
-test('setEncoding utf8', function(t) {
+{
+  // Verify utf8 encoding
   const tr = new TestReader(100);
   tr.setEncoding('utf8');
   const out = [];
@@ -96,14 +59,14 @@ test('setEncoding utf8', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
 
-test('setEncoding hex', function(t) {
+{
+  // Verify hex encoding
   const tr = new TestReader(100);
   tr.setEncoding('hex');
   const out = [];
@@ -135,13 +98,13 @@ test('setEncoding hex', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('setEncoding hex with read(13)', function(t) {
+{
+  // Verify hex encoding with read(13)
   const tr = new TestReader(100);
   tr.setEncoding('hex');
   const out = [];
@@ -164,20 +127,18 @@ test('setEncoding hex with read(13)', function(t) {
       '16161' ];
 
   tr.on('readable', function flow() {
-    console.log('readable once');
     let chunk;
     while (null !== (chunk = tr.read(13)))
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    console.log('END');
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('setEncoding base64', function(t) {
+{
+  // Verify base64 encoding
   const tr = new TestReader(100);
   tr.setEncoding('base64');
   const out = [];
@@ -203,13 +164,13 @@ test('setEncoding base64', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: utf8', function(t) {
+{
+  // Verify utf8 encoding
   const tr = new TestReader(100, { encoding: 'utf8' });
   const out = [];
   const expect =
@@ -230,14 +191,14 @@ test('encoding: utf8', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
 
-test('encoding: hex', function(t) {
+{
+  // Verify hex encoding
   const tr = new TestReader(100, { encoding: 'hex' });
   const out = [];
   const expect =
@@ -268,13 +229,13 @@ test('encoding: hex', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: hex with read(13)', function(t) {
+{
+  // Verify hex encoding with read(13)
   const tr = new TestReader(100, { encoding: 'hex' });
   const out = [];
   const expect =
@@ -301,13 +262,13 @@ test('encoding: hex with read(13)', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('encoding: base64', function(t) {
+{
+  // Verify base64 encoding
   const tr = new TestReader(100, { encoding: 'base64' });
   const out = [];
   const expect =
@@ -332,14 +293,13 @@ test('encoding: base64', function(t) {
       out.push(chunk);
   });
 
-  tr.on('end', function() {
-    t.same(out, expect);
-    t.end();
-  });
-});
+  tr.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(out, expect);
+  }));
+}
 
-test('chainable', function(t) {
+{
+  // Verify chaining behavior
   const tr = new TestReader(100);
-  t.equal(tr.setEncoding('utf8'), tr);
-  t.end();
-});
+  assert.deepStrictEqual(tr.setEncoding('utf8'), tr);
+}

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -1,47 +1,11 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const PassThrough = require('_stream_passthrough');
 const Transform = require('_stream_transform');
 
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    ok: assert,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-/////
-
-test('writable side consumption', function(t) {
+{
+  // Verify writable side consumption
   const tx = new Transform({
     highWaterMark: 10
   });
@@ -58,17 +22,16 @@ test('writable side consumption', function(t) {
   }
   tx.end();
 
-  t.equal(tx._readableState.length, 10);
-  t.equal(transformed, 10);
-  t.equal(tx._transformState.writechunk.length, 5);
-  t.same(tx._writableState.getBuffer().map(function(c) {
+  assert.strictEqual(tx._readableState.length, 10);
+  assert.strictEqual(transformed, 10);
+  assert.strictEqual(tx._transformState.writechunk.length, 5);
+  assert.deepStrictEqual(tx._writableState.getBuffer().map(function(c) {
     return c.chunk.length;
   }), [6, 7, 8, 9, 10]);
+}
 
-  t.end();
-});
-
-test('passthrough', function(t) {
+{
+  // Verify passthrough behavior
   const pt = new PassThrough();
 
   pt.write(Buffer.from('foog'));
@@ -77,14 +40,14 @@ test('passthrough', function(t) {
   pt.write(Buffer.from('kuel'));
   pt.end();
 
-  t.equal(pt.read(5).toString(), 'foogb');
-  t.equal(pt.read(5).toString(), 'arkba');
-  t.equal(pt.read(5).toString(), 'zykue');
-  t.equal(pt.read(5).toString(), 'l');
-  t.end();
-});
+  assert.strictEqual(pt.read(5).toString(), 'foogb');
+  assert.strictEqual(pt.read(5).toString(), 'arkba');
+  assert.strictEqual(pt.read(5).toString(), 'zykue');
+  assert.strictEqual(pt.read(5).toString(), 'l');
+}
 
-test('object passthrough', function(t) {
+{
+  // Verify object passthrough behavior
   const pt = new PassThrough({ objectMode: true });
 
   pt.write(1);
@@ -96,25 +59,24 @@ test('object passthrough', function(t) {
   pt.write({ a: 'b'});
   pt.end();
 
-  t.equal(pt.read(), 1);
-  t.equal(pt.read(), true);
-  t.equal(pt.read(), false);
-  t.equal(pt.read(), 0);
-  t.equal(pt.read(), 'foo');
-  t.equal(pt.read(), '');
-  t.same(pt.read(), { a: 'b'});
-  t.end();
-});
+  assert.strictEqual(pt.read(), 1);
+  assert.strictEqual(pt.read(), true);
+  assert.strictEqual(pt.read(), false);
+  assert.strictEqual(pt.read(), 0);
+  assert.strictEqual(pt.read(), 'foo');
+  assert.strictEqual(pt.read(), '');
+  assert.deepStrictEqual(pt.read(), { a: 'b'});
+}
 
-test('passthrough constructor', function(t) {
+{
+  // Verify passthrough constructor behavior
   const pt = PassThrough();
 
   assert(pt instanceof PassThrough);
+}
 
-  t.end();
-});
-
-test('simple transform', function(t) {
+{
+  // Perform a simple transform
   const pt = new Transform();
   pt._transform = function(c, e, cb) {
     const ret = Buffer.alloc(c.length, 'x');
@@ -128,14 +90,14 @@ test('simple transform', function(t) {
   pt.write(Buffer.from('kuel'));
   pt.end();
 
-  t.equal(pt.read(5).toString(), 'xxxxx');
-  t.equal(pt.read(5).toString(), 'xxxxx');
-  t.equal(pt.read(5).toString(), 'xxxxx');
-  t.equal(pt.read(5).toString(), 'x');
-  t.end();
-});
+  assert.strictEqual(pt.read(5).toString(), 'xxxxx');
+  assert.strictEqual(pt.read(5).toString(), 'xxxxx');
+  assert.strictEqual(pt.read(5).toString(), 'xxxxx');
+  assert.strictEqual(pt.read(5).toString(), 'x');
+}
 
-test('simple object transform', function(t) {
+{
+  // Verify simple object transform
   const pt = new Transform({ objectMode: true });
   pt._transform = function(c, e, cb) {
     pt.push(JSON.stringify(c));
@@ -151,17 +113,17 @@ test('simple object transform', function(t) {
   pt.write({ a: 'b'});
   pt.end();
 
-  t.equal(pt.read(), '1');
-  t.equal(pt.read(), 'true');
-  t.equal(pt.read(), 'false');
-  t.equal(pt.read(), '0');
-  t.equal(pt.read(), '"foo"');
-  t.equal(pt.read(), '""');
-  t.equal(pt.read(), '{"a":"b"}');
-  t.end();
-});
+  assert.strictEqual(pt.read(), '1');
+  assert.strictEqual(pt.read(), 'true');
+  assert.strictEqual(pt.read(), 'false');
+  assert.strictEqual(pt.read(), '0');
+  assert.strictEqual(pt.read(), '"foo"');
+  assert.strictEqual(pt.read(), '""');
+  assert.strictEqual(pt.read(), '{"a":"b"}');
+}
 
-test('async passthrough', function(t) {
+{
+  // Verify async passthrough
   const pt = new Transform();
   pt._transform = function(chunk, encoding, cb) {
     setTimeout(function() {
@@ -176,16 +138,16 @@ test('async passthrough', function(t) {
   pt.write(Buffer.from('kuel'));
   pt.end();
 
-  pt.on('finish', function() {
-    t.equal(pt.read(5).toString(), 'foogb');
-    t.equal(pt.read(5).toString(), 'arkba');
-    t.equal(pt.read(5).toString(), 'zykue');
-    t.equal(pt.read(5).toString(), 'l');
-    t.end();
-  });
-});
+  pt.on('finish', common.mustCall(function() {
+    assert.strictEqual(pt.read(5).toString(), 'foogb');
+    assert.strictEqual(pt.read(5).toString(), 'arkba');
+    assert.strictEqual(pt.read(5).toString(), 'zykue');
+    assert.strictEqual(pt.read(5).toString(), 'l');
+  }));
+}
 
-test('assymetric transform (expand)', function(t) {
+{
+  // Verify assymetric transform (expand)
   const pt = new Transform();
 
   // emit each chunk 2 times.
@@ -205,19 +167,19 @@ test('assymetric transform (expand)', function(t) {
   pt.write(Buffer.from('kuel'));
   pt.end();
 
-  pt.on('finish', function() {
-    t.equal(pt.read(5).toString(), 'foogf');
-    t.equal(pt.read(5).toString(), 'oogba');
-    t.equal(pt.read(5).toString(), 'rkbar');
-    t.equal(pt.read(5).toString(), 'kbazy');
-    t.equal(pt.read(5).toString(), 'bazyk');
-    t.equal(pt.read(5).toString(), 'uelku');
-    t.equal(pt.read(5).toString(), 'el');
-    t.end();
-  });
-});
+  pt.on('finish', common.mustCall(function() {
+    assert.strictEqual(pt.read(5).toString(), 'foogf');
+    assert.strictEqual(pt.read(5).toString(), 'oogba');
+    assert.strictEqual(pt.read(5).toString(), 'rkbar');
+    assert.strictEqual(pt.read(5).toString(), 'kbazy');
+    assert.strictEqual(pt.read(5).toString(), 'bazyk');
+    assert.strictEqual(pt.read(5).toString(), 'uelku');
+    assert.strictEqual(pt.read(5).toString(), 'el');
+  }));
+}
 
-test('assymetric transform (compress)', function(t) {
+{
+  // Verify assymetric trasform (compress)
   const pt = new Transform();
 
   // each output is the first char of 3 consecutive chunks,
@@ -262,17 +224,17 @@ test('assymetric transform (compress)', function(t) {
   pt.end();
 
   // 'abcdeabcdeabcd'
-  pt.on('finish', function() {
-    t.equal(pt.read(5).toString(), 'abcde');
-    t.equal(pt.read(5).toString(), 'abcde');
-    t.equal(pt.read(5).toString(), 'abcd');
-    t.end();
-  });
-});
+  pt.on('finish', common.mustCall(function() {
+    assert.strictEqual(pt.read(5).toString(), 'abcde');
+    assert.strictEqual(pt.read(5).toString(), 'abcde');
+    assert.strictEqual(pt.read(5).toString(), 'abcd');
+  }));
+}
 
 // this tests for a stall when data is written to a full stream
 // that has empty transforms.
-test('complex transform', function(t) {
+{
+  // Verify compex transform behavior
   let count = 0;
   let saved = null;
   const pt = new Transform({highWaterMark: 3});
@@ -293,118 +255,96 @@ test('complex transform', function(t) {
   pt.once('readable', function() {
     process.nextTick(function() {
       pt.write(Buffer.from('d'));
-      pt.write(Buffer.from('ef'), function() {
+      pt.write(Buffer.from('ef'), common.mustCall(function() {
         pt.end();
-        t.end();
-      });
-      t.equal(pt.read().toString(), 'abcdef');
-      t.equal(pt.read(), null);
+      }));
+      assert.strictEqual(pt.read().toString(), 'abcdef');
+      assert.strictEqual(pt.read(), null);
     });
   });
 
   pt.write(Buffer.from('abc'));
-});
+}
 
 
-test('passthrough event emission', function(t) {
+{
+  // Verify passthrough event emission
   const pt = new PassThrough();
   let emits = 0;
   pt.on('readable', function() {
-    console.error('>>> emit readable %d', emits);
     emits++;
   });
 
   pt.write(Buffer.from('foog'));
-
-  console.error('need emit 0');
   pt.write(Buffer.from('bark'));
 
-  console.error('should have emitted readable now 1 === %d', emits);
-  t.equal(emits, 1);
-
-  t.equal(pt.read(5).toString(), 'foogb');
-  t.equal(String(pt.read(5)), 'null');
-
-  console.error('need emit 1');
+  assert.strictEqual(emits, 1);
+  assert.strictEqual(pt.read(5).toString(), 'foogb');
+  assert.strictEqual(String(pt.read(5)), 'null');
 
   pt.write(Buffer.from('bazy'));
-  console.error('should have emitted, but not again');
   pt.write(Buffer.from('kuel'));
 
-  console.error('should have emitted readable now 2 === %d', emits);
-  t.equal(emits, 2);
-
-  t.equal(pt.read(5).toString(), 'arkba');
-  t.equal(pt.read(5).toString(), 'zykue');
-  t.equal(pt.read(5), null);
-
-  console.error('need emit 2');
+  assert.strictEqual(emits, 2);
+  assert.strictEqual(pt.read(5).toString(), 'arkba');
+  assert.strictEqual(pt.read(5).toString(), 'zykue');
+  assert.strictEqual(pt.read(5), null);
 
   pt.end();
 
-  t.equal(emits, 3);
+  assert.strictEqual(emits, 3);
+  assert.strictEqual(pt.read(5).toString(), 'l');
+  assert.strictEqual(pt.read(5), null);
 
-  t.equal(pt.read(5).toString(), 'l');
-  t.equal(pt.read(5), null);
+  assert.strictEqual(emits, 3);
+}
 
-  console.error('should not have emitted again');
-  t.equal(emits, 3);
-  t.end();
-});
-
-test('passthrough event emission reordered', function(t) {
+{
+  // Verify passthrough event emission reordering
   const pt = new PassThrough();
   let emits = 0;
   pt.on('readable', function() {
-    console.error('emit readable', emits);
     emits++;
   });
 
   pt.write(Buffer.from('foog'));
-  console.error('need emit 0');
   pt.write(Buffer.from('bark'));
-  console.error('should have emitted readable now 1 === %d', emits);
-  t.equal(emits, 1);
 
-  t.equal(pt.read(5).toString(), 'foogb');
-  t.equal(pt.read(5), null);
+  assert.strictEqual(emits, 1);
+  assert.strictEqual(pt.read(5).toString(), 'foogb');
+  assert.strictEqual(pt.read(5), null);
 
-  console.error('need emit 1');
-  pt.once('readable', function() {
-    t.equal(pt.read(5).toString(), 'arkba');
+  pt.once('readable', common.mustCall(function() {
+    assert.strictEqual(pt.read(5).toString(), 'arkba');
+    assert.strictEqual(pt.read(5), null);
 
-    t.equal(pt.read(5), null);
-
-    console.error('need emit 2');
-    pt.once('readable', function() {
-      t.equal(pt.read(5).toString(), 'zykue');
-      t.equal(pt.read(5), null);
-      pt.once('readable', function() {
-        t.equal(pt.read(5).toString(), 'l');
-        t.equal(pt.read(5), null);
-        t.equal(emits, 4);
-        t.end();
-      });
+    pt.once('readable', common.mustCall(function() {
+      assert.strictEqual(pt.read(5).toString(), 'zykue');
+      assert.strictEqual(pt.read(5), null);
+      pt.once('readable', common.mustCall(function() {
+        assert.strictEqual(pt.read(5).toString(), 'l');
+        assert.strictEqual(pt.read(5), null);
+        assert.strictEqual(emits, 4);
+      }));
       pt.end();
-    });
+    }));
     pt.write(Buffer.from('kuel'));
-  });
+  }));
 
   pt.write(Buffer.from('bazy'));
-});
+}
 
-test('passthrough facaded', function(t) {
-  console.error('passthrough facaded');
+{
+  // Verify passthrough facade
   const pt = new PassThrough();
   const datas = [];
   pt.on('data', function(chunk) {
     datas.push(chunk.toString());
   });
 
-  pt.on('end', function() {
-    t.same(datas, ['foog', 'bark', 'bazy', 'kuel']);
-    t.end();
-  });
+  pt.on('end', common.mustCall(function() {
+    assert.deepStrictEqual(datas, ['foog', 'bark', 'bazy', 'kuel']);
+  }));
 
   pt.write(Buffer.from('foog'));
   setTimeout(function() {
@@ -419,10 +359,10 @@ test('passthrough facaded', function(t) {
       }, 10);
     }, 10);
   }, 10);
-});
+}
 
-test('object transform (json parse)', function(t) {
-  console.error('json parse stream');
+{
+  // Verify object transform (JSON parse)
   const jp = new Transform({ objectMode: true });
   jp._transform = function(data, encoding, cb) {
     try {
@@ -450,21 +390,20 @@ test('object transform (json parse)', function(t) {
   objects.forEach(function(obj) {
     jp.write(JSON.stringify(obj));
     const res = jp.read();
-    t.same(res, obj);
+    assert.deepStrictEqual(res, obj);
   });
 
   jp.end();
   // read one more time to get the 'end' event
   jp.read();
 
-  process.nextTick(function() {
-    t.ok(ended);
-    t.end();
-  });
-});
+  process.nextTick(common.mustCall(function() {
+    assert.strictEqual(ended, true);
+  }));
+}
 
-test('object transform (json stringify)', function(t) {
-  console.error('json parse stream');
+{
+  // Verify object transform (JSON stringify)
   const js = new Transform({ objectMode: true });
   js._transform = function(data, encoding, cb) {
     try {
@@ -492,15 +431,14 @@ test('object transform (json stringify)', function(t) {
   objects.forEach(function(obj) {
     js.write(obj);
     const res = js.read();
-    t.equal(res, JSON.stringify(obj));
+    assert.strictEqual(res, JSON.stringify(obj));
   });
 
   js.end();
   // read one more time to get the 'end' event
   js.read();
 
-  process.nextTick(function() {
-    t.ok(ended);
-    t.end();
-  });
-});
+  process.nextTick(common.mustCall(function() {
+    assert.strictEqual(ended, true);
+  }));
+}

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const W = require('_stream_writable');
 const D = require('_stream_duplex');
 const assert = require('assert');
@@ -27,66 +27,32 @@ for (let i = 0; i < chunks.length; i++) {
   chunks[i] = new Array(i + 1).join('x');
 }
 
-// tiny node-tap lookalike.
-const tests = [];
-let count = 0;
-
-function test(name, fn) {
-  count++;
-  tests.push([name, fn]);
-}
-
-function run() {
-  const next = tests.shift();
-  if (!next)
-    return console.error('ok');
-
-  const name = next[0];
-  const fn = next[1];
-  console.log('# %s', name);
-  fn({
-    same: assert.deepStrictEqual,
-    equal: assert.strictEqual,
-    end: function() {
-      count--;
-      run();
-    }
-  });
-}
-
-// ensure all tests have run
-process.on('exit', function() {
-  assert.strictEqual(count, 0);
-});
-
-process.nextTick(run);
-
-test('write fast', function(t) {
+{
+  // Verify fast writing
   const tw = new TestWriter({
     highWaterMark: 100
   });
 
-  tw.on('finish', function() {
-    t.same(tw.buffer, chunks, 'got chunks in the right order');
-    t.end();
-  });
+  tw.on('finish', common.mustCall(function() {
+    assert.deepStrictEqual(tw.buffer, chunks, 'got chunks in the right order');
+  }));
 
   chunks.forEach(function(chunk) {
-    // screw backpressure.  Just buffer it all up.
+    // Ignore backpressure. Just buffer it all up.
     tw.write(chunk);
   });
   tw.end();
-});
+}
 
-test('write slow', function(t) {
+{
+  // Verify slow writing
   const tw = new TestWriter({
     highWaterMark: 100
   });
 
-  tw.on('finish', function() {
-    t.same(tw.buffer, chunks, 'got chunks in the right order');
-    t.end();
-  });
+  tw.on('finish', common.mustCall(function() {
+    assert.deepStrictEqual(tw.buffer, chunks, 'got chunks in the right order');
+  }));
 
   let i = 0;
   (function W() {
@@ -96,20 +62,20 @@ test('write slow', function(t) {
     else
       tw.end();
   })();
-});
+}
 
-test('write backpressure', function(t) {
+{
+  // Verify write backpressure
   const tw = new TestWriter({
     highWaterMark: 50
   });
 
   let drains = 0;
 
-  tw.on('finish', function() {
-    t.same(tw.buffer, chunks, 'got chunks in the right order');
-    t.equal(drains, 17);
-    t.end();
-  });
+  tw.on('finish', common.mustCall(function() {
+    assert.deepStrictEqual(tw.buffer, chunks, 'got chunks in the right order');
+    assert.strictEqual(drains, 17);
+  }));
 
   tw.on('drain', function() {
     drains++;
@@ -129,9 +95,10 @@ test('write backpressure', function(t) {
       tw.end();
     }
   })();
-});
+}
 
-test('write bufferize', function(t) {
+{
+  // Verify write buffersize
   const tw = new TestWriter({
     highWaterMark: 100
   });
@@ -151,7 +118,7 @@ test('write bufferize', function(t) {
       undefined ];
 
   tw.on('finish', function() {
-    t.same(tw.buffer, chunks, 'got the expected chunks');
+    assert.deepStrictEqual(tw.buffer, chunks, 'got the expected chunks');
   });
 
   chunks.forEach(function(chunk, i) {
@@ -159,10 +126,10 @@ test('write bufferize', function(t) {
     chunk = Buffer.from(chunk);
     tw.write(chunk.toString(enc), enc);
   });
-  t.end();
-});
+}
 
-test('write no bufferize', function(t) {
+{
+  // Verify write with no buffersize
   const tw = new TestWriter({
     highWaterMark: 100,
     decodeStrings: false
@@ -189,7 +156,7 @@ test('write no bufferize', function(t) {
       undefined ];
 
   tw.on('finish', function() {
-    t.same(tw.buffer, chunks, 'got the expected chunks');
+    assert.deepStrictEqual(tw.buffer, chunks, 'got the expected chunks');
   });
 
   chunks.forEach(function(chunk, i) {
@@ -197,10 +164,10 @@ test('write no bufferize', function(t) {
     chunk = Buffer.from(chunk);
     tw.write(chunk.toString(enc), enc);
   });
-  t.end();
-});
+}
 
-test('write callbacks', function(t) {
+{
+  // Verify write callbacks
   const callbacks = chunks.map(function(chunk, i) {
     return [i, function() {
       callbacks._called[i] = chunk;
@@ -215,118 +182,115 @@ test('write callbacks', function(t) {
     highWaterMark: 100
   });
 
-  tw.on('finish', function() {
-    process.nextTick(function() {
-      t.same(tw.buffer, chunks, 'got chunks in the right order');
-      t.same(callbacks._called, chunks, 'called all callbacks');
-      t.end();
-    });
-  });
+  tw.on('finish', common.mustCall(function() {
+    process.nextTick(common.mustCall(function() {
+      assert.deepStrictEqual(tw.buffer, chunks,
+                             'got chunks in the right order');
+      assert.deepStrictEqual(callbacks._called, chunks, 'called all callbacks');
+    }));
+  }));
 
   chunks.forEach(function(chunk, i) {
     tw.write(chunk, callbacks[`callback-${i}`]);
   });
   tw.end();
-});
+}
 
-test('end callback', function(t) {
+{
+  // Verify end() callback
   const tw = new TestWriter();
-  tw.end(function() {
-    t.end();
-  });
-});
+  tw.end(common.mustCall());
+}
 
-test('end callback with chunk', function(t) {
+{
+  // Verify end() callback with chunk
   const tw = new TestWriter();
-  tw.end(Buffer.from('hello world'), function() {
-    t.end();
-  });
-});
+  tw.end(Buffer.from('hello world'), common.mustCall());
+}
 
-test('end callback with chunk and encoding', function(t) {
+{
+  // Verify end() callback with chunk and encoding
   const tw = new TestWriter();
-  tw.end('hello world', 'ascii', function() {
-    t.end();
-  });
-});
+  tw.end('hello world', 'ascii', common.mustCall());
+}
 
-test('end callback after .write() call', function(t) {
+{
+  // Verify end() callback after write() call
   const tw = new TestWriter();
   tw.write(Buffer.from('hello world'));
-  tw.end(function() {
-    t.end();
-  });
-});
+  tw.end(common.mustCall());
+}
 
-test('end callback called after write callback', function(t) {
+{
+  // Verify end() callback after write() callback
   const tw = new TestWriter();
   let writeCalledback = false;
   tw.write(Buffer.from('hello world'), function() {
     writeCalledback = true;
   });
-  tw.end(function() {
-    t.equal(writeCalledback, true);
-    t.end();
-  });
-});
+  tw.end(common.mustCall(function() {
+    assert.strictEqual(writeCalledback, true);
+  }));
+}
 
-test('encoding should be ignored for buffers', function(t) {
+{
+  // Verify encoding is ignored for buffers
   const tw = new W();
   const hex = '018b5e9a8f6236ffe30e31baf80d2cf6eb';
-  tw._write = function(chunk) {
-    t.equal(chunk.toString('hex'), hex);
-    t.end();
-  };
+  tw._write = common.mustCall(function(chunk) {
+    assert.strictEqual(chunk.toString('hex'), hex);
+  });
   const buf = Buffer.from(hex, 'hex');
   tw.write(buf, 'latin1');
-});
+}
 
-test('writables are not pipable', function(t) {
+{
+  // Verify writables cannot be piped
   const w = new W();
-  w._write = () => {};
+  w._write = common.mustNotCall();
   let gotError = false;
   w.on('error', function() {
     gotError = true;
   });
   w.pipe(process.stdout);
-  assert(gotError);
-  t.end();
-});
+  assert.strictEqual(gotError, true);
+}
 
-test('duplexes are pipable', function(t) {
+{
+  // Verify that duplex streams cannot be piped
   const d = new D();
-  d._read = () => {};
-  d._write = () => {};
+  d._read = common.mustCall();
+  d._write = common.mustNotCall();
   let gotError = false;
   d.on('error', function() {
     gotError = true;
   });
   d.pipe(process.stdout);
-  assert(!gotError);
-  t.end();
-});
+  assert.strictEqual(gotError, false);
+}
 
-test('end(chunk) two times is an error', function(t) {
+{
+  // Verify that end(chunk) twice is an error
   const w = new W();
   w._write = () => {};
   let gotError = false;
   w.on('error', function(er) {
     gotError = true;
-    t.equal(er.message, 'write after end');
+    assert.strictEqual(er.message, 'write after end');
   });
   w.end('this is the end');
   w.end('and so is this');
-  process.nextTick(function() {
-    assert(gotError);
-    t.end();
-  });
-});
+  process.nextTick(common.mustCall(function() {
+    assert.strictEqual(gotError, true);
+  }));
+}
 
-test('dont end while writing', function(t) {
+{
+  // Verify stream doesn't end while writing
   const w = new W();
   let wrote = false;
   w._write = function(chunk, e, cb) {
-    assert(!this.writing);
+    assert.strictEqual(this.writing, undefined);
     wrote = true;
     this.writing = true;
     setTimeout(function() {
@@ -334,15 +298,15 @@ test('dont end while writing', function(t) {
       cb();
     }, 1);
   };
-  w.on('finish', function() {
-    assert(wrote);
-    t.end();
-  });
+  w.on('finish', common.mustCall(function() {
+    assert.strictEqual(wrote, true);
+  }));
   w.write(Buffer.alloc(0));
   w.end();
-});
+}
 
-test('finish does not come before write cb', function(t) {
+{
+  // Verify finish does not come before write() callback
   const w = new W();
   let writeCb = false;
   w._write = function(chunk, e, cb) {
@@ -351,38 +315,36 @@ test('finish does not come before write cb', function(t) {
       cb();
     }, 10);
   };
-  w.on('finish', function() {
-    assert(writeCb);
-    t.end();
-  });
+  w.on('finish', common.mustCall(function() {
+    assert.strictEqual(writeCb, true);
+  }));
   w.write(Buffer.alloc(0));
   w.end();
-});
+}
 
-test('finish does not come before sync _write cb', function(t) {
+{
+  // Verify finish does not come before synchronous _write() callback
   const w = new W();
   let writeCb = false;
   w._write = function(chunk, e, cb) {
     cb();
   };
-  w.on('finish', function() {
-    assert(writeCb);
-    t.end();
-  });
+  w.on('finish', common.mustCall(function() {
+    assert.strictEqual(writeCb, true);
+  }));
   w.write(Buffer.alloc(0), function() {
     writeCb = true;
   });
   w.end();
-});
+}
 
-test('finish is emitted if last chunk is empty', function(t) {
+{
+  // Verify finish is emitted if the last chunk is empty
   const w = new W();
   w._write = function(chunk, e, cb) {
     process.nextTick(cb);
   };
-  w.on('finish', function() {
-    t.end();
-  });
+  w.on('finish', common.mustCall());
   w.write(Buffer.allocUnsafe(1));
   w.end(Buffer.alloc(0));
-});
+}


### PR DESCRIPTION
Manual backport of https://github.com/nodejs/node/pull/13707 to v6.x. This is another step towards backporting https://github.com/nodejs/node/pull/16938.

CI: https://ci.nodejs.org/job/node-test-commit/14017/