### PR TITLE
docs: add note about using cluster networking-less

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -109,7 +109,8 @@ will be dropped and new connections will be refused. Node.js does not
 automatically manage the number of workers, however. It is the application's
 responsibility to manage the worker pool based on its own needs.
 
-
+Although a primary use case for the `cluster` module is networking, it can
+also be used for other use cases requiring worker processes.
 
 ## Class: Worker
 <!-- YAML


### PR DESCRIPTION
Although the primary use-case for the cluster module is networking, the module provides a generic master/worker interface that could also be used if you dont use networking at all. Currently the docs are a bit ambiguous about this as only the primary use-case is ever mentioned, this remark should clarify that the cluster module can also be used without disadvantages if you dont use networking.

Refs: https://github.com/nodejs/help/issues/970

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
