### PR TITLE
console: add support for console.debug method

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -238,6 +238,15 @@ undefined
 >
 ```
 
+### console.debug(data[, ...args])
+<!-- YAML
+added: v8.0.0
+-->
+* `data` {any}
+* `...args` {any}
+
+The `console.debug()` function is an alias for [`console.log()`][].
+
 ### console.dir(obj[, options])
 <!-- YAML
 added: v0.1.101

--- a/lib/console.js
+++ b/lib/console.js
@@ -134,6 +134,9 @@ Console.prototype.log = function log(...args) {
 };
 
 
+Console.prototype.debug = Console.prototype.log;
+
+
 Console.prototype.info = Console.prototype.log;
 
 

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -69,6 +69,13 @@ console.log('%s %s', 'foo', 'bar', 'hop');
 console.log({ slashes: '\\\\' });
 console.log(custom_inspect);
 
+// test console.debug() goes to stdout
+console.debug('foo');
+console.debug('foo', 'bar');
+console.debug('%s %s', 'foo', 'bar', 'hop');
+console.debug({ slashes: '\\\\' });
+console.debug(custom_inspect);
+
 // test console.info() goes to stdout
 console.info('foo');
 console.info('foo', 'bar');
@@ -152,6 +159,10 @@ for (const expected of expectedStrings) {
 for (const expected of expectedStrings) {
   assert.strictEqual(strings.shift(), `${expected}\n`);
   assert.strictEqual(errStrings.shift(), `${expected}\n`);
+}
+
+for (const expected of expectedStrings) {
+  assert.strictEqual(strings.shift(), `${expected}\n`);
 }
 
 assert.strictEqual(strings.shift(),


### PR DESCRIPTION
Adds the console.debug() method, alias for console.log()
This method is exposed by V8 and was only available in inspector until now.
Also adds matching test.

Refs: https://github.com/nodejs/node/pull/17004#pullrequestreview-76600095

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console, tests
