### PR TITLE
zlib: fix decompression of empty data streams

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -95,6 +95,8 @@ function zlibBufferOnEnd() {
   var err;
   if (this.nread >= kMaxLength) {
     err = new errors.RangeError('ERR_BUFFER_TOO_LARGE');
+  } else if (this.nread === 0) {
+    buf = Buffer.alloc(0);
   } else {
     var bufs = this.buffers;
     buf = (bufs.length === 1 ? bufs[0] : Buffer.concat(bufs, this.nread));
@@ -484,6 +486,9 @@ function processChunkSync(self, chunk, flushFlag) {
   }
 
   _close(self);
+
+  if (nread === 0)
+    return Buffer.alloc(0);
 
   return (buffers.length === 1 ? buffers[0] : Buffer.concat(buffers, nread));
 }

--- a/test/parallel/test-zlib-empty-buffer.js
+++ b/test/parallel/test-zlib-empty-buffer.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common');
+const zlib = require('zlib');
+const { inspect, promisify } = require('util');
+const assert = require('assert');
+const emptyBuffer = new Buffer(0);
+
+common.crashOnUnhandledRejection();
+
+(async function() {
+  for (const [ compress, decompress, method ] of [
+    [ zlib.deflateRawSync, zlib.inflateRawSync, 'raw sync' ],
+    [ zlib.deflateSync, zlib.inflateSync, 'deflate sync' ],
+    [ zlib.gzipSync, zlib.gunzipSync, 'gzip sync' ],
+    [ promisify(zlib.deflateRaw), promisify(zlib.inflateRaw), 'raw' ],
+    [ promisify(zlib.deflate), promisify(zlib.inflate), 'deflate' ],
+    [ promisify(zlib.gzip), promisify(zlib.gunzip), 'gzip' ]
+  ]) {
+    const compressed = await compress(emptyBuffer);
+    const decompressed = await decompress(compressed);
+    assert.deepStrictEqual(
+      emptyBuffer, decompressed,
+      `Expected ${inspect(compressed)} to match ${inspect(decompressed)} ` +
+      `to match for ${method}`);
+  }
+})();


### PR DESCRIPTION
add4b0ab8cc0ec6 made the assumption that compressed data
would never lead to an empty decompressed stream.

Fix that by explicitly checking the number of read bytes.

Fixes: https://github.com/nodejs/node/issues/17041
Refs: https://github.com/nodejs/node/pull/13322

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

zlib