### PR TITLE
Corrected fs.md -> createWriteStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -956,7 +956,7 @@ const defaults = {
 
 `options` may also include a `start` option to allow writing data at
 some position past the beginning of the file.  Modifying a file rather
-than replacing it may require a `flags` mode of `r+` rather than the
+than replacing it may require a `flags` mode of `a` rather than the
 default mode `w`. The `encoding` can be any one of those accepted by
 [`Buffer`][].
 


### PR DESCRIPTION
In fs.createWriteStream: corrected flags value to append file instead of overwriting ('a' instead of 'r+')