### PR TITLE
doc: explicitly document highWaterMark option

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -865,6 +865,7 @@ changes:
   * `autoClose` {boolean}
   * `start` {integer}
   * `end` {integer}
+  * `highWaterMark` {integer}
 
 Returns a new [`ReadStream`][] object. (See [Readable Stream][]).
 
@@ -880,7 +881,8 @@ const defaults = {
   encoding: null,
   fd: null,
   mode: 0o666,
-  autoClose: true
+  autoClose: true,
+  highWaterMark: 64 * 1024
 };
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

`highWaterMark` is currently only implicityl documented in a separate paragraph. This PR add this property and its default value to the argument documentation.

The value is set in [lib/fs.js#L1990](https://github.com/nodejs/node/blob/master/lib/fs.js#L1990).

Should we add an additional note about what `highWaterMark` does or is the link to `ReadStream` enough?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
