### PR TITLE
(v6.x backport) test: use ES6 classes instead of util.inherits

### DIFF
--- a/test/parallel/test-crypto-lazy-transform-writable.js
+++ b/test/parallel/test-crypto-lazy-transform-writable.js
@@ -7,7 +7,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 const Stream = require('stream');
-const util = require('util');
 
 const hasher1 = crypto.createHash('sha256');
 const hasher2 = crypto.createHash('sha256');
@@ -18,12 +17,12 @@ hasher1.end();
 
 const expected = hasher1.read().toString('hex');
 
-function OldStream() {
-  Stream.call(this);
-
-  this.readable = true;
+class OldStream extends Stream {
+  constructor() {
+    super();
+    this.readable = true;
+  }
 }
-util.inherits(OldStream, Stream);
 
 const stream = new OldStream();
 

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -5,26 +5,26 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const stream = require('stream');
-const util = require('util');
 const crypto = require('crypto');
 
-// Small stream to buffer converter
-function Stream2buffer(callback) {
-  stream.Writable.call(this);
-
-  this._buffers = [];
-  this.once('finish', function() {
-    callback(null, Buffer.concat(this._buffers));
-  });
-}
-util.inherits(Stream2buffer, stream.Writable);
-
-Stream2buffer.prototype._write = function(data, encodeing, done) {
-  this._buffers.push(data);
-  return done(null);
-};
-
 if (!common.hasFipsCrypto) {
+  // Small stream to buffer converter
+  class Stream2buffer extends stream.Writable {
+    constructor(callback) {
+      super();
+
+      this._buffers = [];
+      this.once('finish', function() {
+        callback(null, Buffer.concat(this._buffers));
+      });
+    }
+
+    _write(data, encodeing, done) {
+      this._buffers.push(data);
+      return done(null);
+    }
+  }
+
   // Create an md5 hash of "Hallo world"
   const hasher1 = crypto.createHash('md5');
   hasher1.pipe(new Stream2buffer(common.mustCall(function end(err, hash) {

--- a/test/parallel/test-event-emitter-listeners.js
+++ b/test/parallel/test-event-emitter-listeners.js
@@ -3,12 +3,9 @@
 require('../common');
 const assert = require('assert');
 const events = require('events');
-const util = require('util');
 
 function listener() {}
 function listener2() {}
-class TestStream { constructor() { } }
-util.inherits(TestStream, events.EventEmitter);
 
 {
   const ee = new events.EventEmitter();
@@ -47,6 +44,7 @@ util.inherits(TestStream, events.EventEmitter);
 }
 
 {
+  class TestStream extends events.EventEmitter {}
   const s = new TestStream();
   assert.deepStrictEqual(s.listeners('foo'), []);
 }

--- a/test/parallel/test-http-client-read-in-error.js
+++ b/test/parallel/test-http-client-read-in-error.js
@@ -2,38 +2,34 @@
 require('../common');
 const net = require('net');
 const http = require('http');
-const util = require('util');
 
-function Agent() {
-  http.Agent.call(this);
-}
-util.inherits(Agent, http.Agent);
+class Agent extends http.Agent {
+  createConnection() {
+    const socket = new net.Socket();
 
-Agent.prototype.createConnection = function() {
-  const self = this;
-  const socket = new net.Socket();
-
-  socket.on('error', function() {
-    socket.push('HTTP/1.1 200\r\n\r\n');
-  });
-
-  socket.on('newListener', function onNewListener(name) {
-    if (name !== 'error')
-      return;
-    socket.removeListener('newListener', onNewListener);
-
-    // Let other listeners to be set up too
-    process.nextTick(function() {
-      self.breakSocket(socket);
+    socket.on('error', function() {
+      socket.push('HTTP/1.1 200\r\n\r\n');
     });
-  });
 
-  return socket;
-};
+    let onNewListener;
+    socket.on('newListener', onNewListener = (name) => {
+      if (name !== 'error')
+        return;
+      socket.removeListener('newListener', onNewListener);
 
-Agent.prototype.breakSocket = function breakSocket(socket) {
-  socket.emit('error', new Error('Intentional error'));
-};
+      // Let other listeners to be set up too
+      process.nextTick(() => {
+        this.breakSocket(socket);
+      });
+    });
+
+    return socket;
+  }
+
+  breakSocket(socket) {
+    socket.emit('error', new Error('Intentional error'));
+  }
+}
 
 const agent = new Agent();
 

--- a/test/parallel/test-http-client-readable.js
+++ b/test/parallel/test-http-client-readable.js
@@ -2,41 +2,37 @@
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
-const util = require('util');
 
 const Duplex = require('stream').Duplex;
 
-function FakeAgent() {
-  http.Agent.call(this);
+class FakeAgent extends http.Agent {
+  createConnection() {
+    const s = new Duplex();
+    let once = false;
+
+    s._read = function() {
+      if (once)
+        return this.push(null);
+      once = true;
+
+      this.push('HTTP/1.1 200 Ok\r\nTransfer-Encoding: chunked\r\n\r\n');
+      this.push('b\r\nhello world\r\n');
+      this.readable = false;
+      this.push('0\r\n\r\n');
+    };
+
+    // Blackhole
+    s._write = function(data, enc, cb) {
+      cb();
+    };
+
+    s.destroy = s.destroySoon = function() {
+      this.writable = false;
+    };
+
+    return s;
+  }
 }
-util.inherits(FakeAgent, http.Agent);
-
-FakeAgent.prototype.createConnection = function() {
-  const s = new Duplex();
-  let once = false;
-
-  s._read = function() {
-    if (once)
-      return this.push(null);
-    once = true;
-
-    this.push('HTTP/1.1 200 Ok\r\nTransfer-Encoding: chunked\r\n\r\n');
-    this.push('b\r\nhello world\r\n');
-    this.readable = false;
-    this.push('0\r\n\r\n');
-  };
-
-  // Blackhole
-  s._write = function(data, enc, cb) {
-    cb();
-  };
-
-  s.destroy = s.destroySoon = function() {
-    this.writable = false;
-  };
-
-  return s;
-};
 
 let received = '';
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -3,17 +3,14 @@ const common = require('../common');
 const assert = require('assert');
 const readline = require('readline');
 const EventEmitter = require('events').EventEmitter;
-const inherits = require('util').inherits;
 const { Writable, Readable } = require('stream');
 
-function FakeInput() {
-  EventEmitter.call(this);
+class FakeInput extends EventEmitter {
+  resume() {}
+  pause() {}
+  write() {}
+  end() {}
 }
-inherits(FakeInput, EventEmitter);
-FakeInput.prototype.resume = () => {};
-FakeInput.prototype.pause = () => {};
-FakeInput.prototype.write = () => {};
-FakeInput.prototype.end = () => {};
 
 function isWarned(emitter) {
   for (const name in emitter) {

--- a/test/parallel/test-readline-keys.js
+++ b/test/parallel/test-readline-keys.js
@@ -2,14 +2,9 @@
 const common = require('../common');
 const PassThrough = require('stream').PassThrough;
 const assert = require('assert');
-const inherits = require('util').inherits;
 const Interface = require('readline').Interface;
 
-
-function FakeInput() {
-  PassThrough.call(this);
-}
-inherits(FakeInput, PassThrough);
+class FakeInput extends PassThrough {}
 
 function extend(k) {
   return Object.assign({ ctrl: false, meta: false, shift: false }, k);

--- a/test/parallel/test-stream-big-packet.js
+++ b/test/parallel/test-stream-big-packet.js
@@ -1,31 +1,26 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const util = require('util');
 const stream = require('stream');
 
 let passed = false;
 
-function PassThrough() {
-  stream.Transform.call(this);
-}
-util.inherits(PassThrough, stream.Transform);
-PassThrough.prototype._transform = function(chunk, encoding, done) {
-  this.push(chunk);
-  done();
-};
-
-function TestStream() {
-  stream.Transform.call(this);
-}
-util.inherits(TestStream, stream.Transform);
-TestStream.prototype._transform = function(chunk, encoding, done) {
-  if (!passed) {
-    // Char 'a' only exists in the last write
-    passed = chunk.toString().includes('a');
+class PassThrough extends stream.Transform {
+  _transform(chunk, encoding, done) {
+    this.push(chunk);
+    done();
   }
-  done();
-};
+}
+
+class TestStream extends stream.Transform {
+  _transform(chunk, encoding, done) {
+    if (!passed) {
+      // Char 'a' only exists in the last write
+      passed = chunk.toString().includes('a');
+    }
+    done();
+  }
+}
 
 const s1 = new PassThrough();
 const s2 = new PassThrough();

--- a/test/parallel/test-stream-events-prepend.js
+++ b/test/parallel/test-stream-events-prepend.js
@@ -1,26 +1,23 @@
 'use strict';
 const common = require('../common');
 const stream = require('stream');
-const util = require('util');
 
-function Writable() {
-  this.writable = true;
-  stream.Writable.call(this);
-  this.prependListener = undefined;
-}
-util.inherits(Writable, stream.Writable);
-Writable.prototype._write = function(chunk, end, cb) {
-  cb();
-};
+class Writable extends stream.Writable {
+  constructor() {
+    super();
+    this.prependListener = undefined;
+  }
 
-function Readable() {
-  this.readable = true;
-  stream.Readable.call(this);
+  _write(chunk, end, cb) {
+    cb();
+  }
 }
-util.inherits(Readable, stream.Readable);
-Readable.prototype._read = function() {
-  this.push(null);
-};
+
+class Readable extends stream.Readable {
+  _read() {
+    this.push(null);
+  }
+}
 
 const w = new Writable();
 w.on('pipe', common.mustCall());

--- a/test/parallel/test-stream-pipe-after-end.js
+++ b/test/parallel/test-stream-pipe-after-end.js
@@ -3,35 +3,32 @@ const common = require('../common');
 const assert = require('assert');
 const Readable = require('_stream_readable');
 const Writable = require('_stream_writable');
-const util = require('util');
 
-util.inherits(TestReadable, Readable);
-function TestReadable(opt) {
-  if (!(this instanceof TestReadable))
-    return new TestReadable(opt);
-  Readable.call(this, opt);
-  this._ended = false;
+class TestReadable extends Readable {
+  constructor(opt) {
+    super(opt);
+    this._ended = false;
+  }
+
+  _read() {
+    if (this._ended)
+      this.emit('error', new Error('_read called twice'));
+    this._ended = true;
+    this.push(null);
+  }
 }
 
-TestReadable.prototype._read = function() {
-  if (this._ended)
-    this.emit('error', new Error('_read called twice'));
-  this._ended = true;
-  this.push(null);
-};
+class TestWritable extends Writable {
+  constructor(opt) {
+    super(opt);
+    this._written = [];
+  }
 
-util.inherits(TestWritable, Writable);
-function TestWritable(opt) {
-  if (!(this instanceof TestWritable))
-    return new TestWritable(opt);
-  Writable.call(this, opt);
-  this._written = [];
+  _write(chunk, encoding, cb) {
+    this._written.push(chunk);
+    cb();
+  }
 }
-
-TestWritable.prototype._write = function(chunk, encoding, cb) {
-  this._written.push(chunk);
-  cb();
-};
 
 // this one should not emit 'end' until we read() from it later.
 const ender = new TestReadable();

--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -3,32 +3,32 @@ require('../common');
 const assert = require('assert');
 
 const Readable = require('stream').Readable;
-const util = require('util');
 
-util.inherits(MyStream, Readable);
-function MyStream(options) {
-  Readable.call(this, options);
-  this._chunks = 3;
-}
-
-MyStream.prototype._read = function(n) {
-  switch (this._chunks--) {
-    case 0:
-      return this.push(null);
-    case 1:
-      return setTimeout(function() {
-        this.push('last chunk');
-      }.bind(this), 100);
-    case 2:
-      return this.push('second to last chunk');
-    case 3:
-      return process.nextTick(function() {
-        this.push('first chunk');
-      }.bind(this));
-    default:
-      throw new Error('?');
+class MyStream extends Readable {
+  constructor(options) {
+    super(options);
+    this._chunks = 3;
   }
-};
+
+  _read(n) {
+    switch (this._chunks--) {
+      case 0:
+        return this.push(null);
+      case 1:
+        return setTimeout(function() {
+          this.push('last chunk');
+        }.bind(this), 100);
+      case 2:
+        return this.push('second to last chunk');
+      case 3:
+        return process.nextTick(function() {
+          this.push('first chunk');
+        }.bind(this));
+      default:
+        throw new Error('?');
+    }
+  }
+}
 
 const ms = new MyStream();
 const results = [];

--- a/test/parallel/test-stream-writable-change-default-encoding.js
+++ b/test/parallel/test-stream-writable-change-default-encoding.js
@@ -3,19 +3,18 @@ require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
-const util = require('util');
 
-function MyWritable(fn, options) {
-  stream.Writable.call(this, options);
-  this.fn = fn;
+class MyWritable extends stream.Writable {
+  constructor(fn, options) {
+    super(options);
+    this.fn = fn;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-  callback();
-};
 
 (function defaultCondingIsUtf8() {
   const m = new MyWritable(function(isBuffer, type, enc) {

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -3,19 +3,18 @@ require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
-const util = require('util');
 
-function MyWritable(fn, options) {
-  stream.Writable.call(this, options);
-  this.fn = fn;
+class MyWritable extends stream.Writable {
+  constructor(fn, options) {
+    super(options);
+    this.fn = fn;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  this.fn(Buffer.isBuffer(chunk), typeof chunk, encoding);
-  callback();
-};
 
 {
   const m = new MyWritable(function(isBuffer, type, enc) {

--- a/test/parallel/test-stream-writable-null.js
+++ b/test/parallel/test-stream-writable-null.js
@@ -3,18 +3,17 @@ require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
-const util = require('util');
 
-function MyWritable(options) {
-  stream.Writable.call(this, options);
+class MyWritable extends stream.Writable {
+  constructor(opt) {
+    super(opt);
+  }
+
+  _write(chunk, encoding, callback) {
+    assert.notStrictEqual(chunk, null);
+    callback();
+  }
 }
-
-util.inherits(MyWritable, stream.Writable);
-
-MyWritable.prototype._write = function(chunk, encoding, callback) {
-  assert.notStrictEqual(chunk, null);
-  callback();
-};
 
 assert.throws(() => {
   const m = new MyWritable({objectMode: true});

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -3,67 +3,66 @@ const common = require('../common');
 const R = require('_stream_readable');
 const assert = require('assert');
 
-const util = require('util');
 const EE = require('events').EventEmitter;
 
-function TestReader(n) {
-  R.apply(this);
-  this._buffer = Buffer.alloc(n || 100, 'x');
-  this._pos = 0;
-  this._bufs = 10;
-}
-
-util.inherits(TestReader, R);
-
-TestReader.prototype._read = function(n) {
-  const max = this._buffer.length - this._pos;
-  n = Math.max(n, 0);
-  const toRead = Math.min(n, max);
-  if (toRead === 0) {
-    // simulate the read buffer filling up with some more bytes some time
-    // in the future.
-    setTimeout(function() {
-      this._pos = 0;
-      this._bufs -= 1;
-      if (this._bufs <= 0) {
-        // read them all!
-        if (!this.ended)
-          this.push(null);
-      } else {
-        // now we have more.
-        // kinda cheating by calling _read, but whatever,
-        // it's just fake anyway.
-        this._read(n);
-      }
-    }.bind(this), 10);
-    return;
+class TestReader extends R {
+  constructor(n) {
+    super();
+    this._buffer = Buffer.alloc(n || 100, 'x');
+    this._pos = 0;
+    this._bufs = 10;
   }
 
-  const ret = this._buffer.slice(this._pos, this._pos + toRead);
-  this._pos += toRead;
-  this.push(ret);
-};
+  _read(n) {
+    const max = this._buffer.length - this._pos;
+    n = Math.max(n, 0);
+    const toRead = Math.min(n, max);
+    if (toRead === 0) {
+      // simulate the read buffer filling up with some more bytes some time
+      // in the future.
+      setTimeout(() => {
+        this._pos = 0;
+        this._bufs -= 1;
+        if (this._bufs <= 0) {
+          // read them all!
+          if (!this.ended)
+            this.push(null);
+        } else {
+          // now we have more.
+          // kinda cheating by calling _read, but whatever,
+          // it's just fake anyway.
+          this._read(n);
+        }
+      }, 10);
+      return;
+    }
+
+    const ret = this._buffer.slice(this._pos, this._pos + toRead);
+    this._pos += toRead;
+    this.push(ret);
+  }
+}
 
 /////
 
-function TestWriter() {
-  EE.apply(this);
-  this.received = [];
-  this.flush = false;
+class TestWriter extends EE {
+  constructor() {
+    super();
+    this.received = [];
+    this.flush = false;
+  }
+
+  write(c) {
+    this.received.push(c.toString());
+    this.emit('write', c);
+    return true;
+  }
+
+  end(c) {
+    if (c) this.write(c);
+    this.emit('end', this.received);
+  }
 }
-
-util.inherits(TestWriter, EE);
-
-TestWriter.prototype.write = function(c) {
-  this.received.push(c.toString());
-  this.emit('write', c);
-  return true;
-};
-
-TestWriter.prototype.end = function(c) {
-  if (c) this.write(c);
-  this.emit('end', this.received);
-};
 
 {
   // Test basic functionality

--- a/test/parallel/test-stream2-compatibility.js
+++ b/test/parallel/test-stream2-compatibility.js
@@ -4,25 +4,23 @@ const R = require('_stream_readable');
 const W = require('_stream_writable');
 const assert = require('assert');
 
-const util = require('util');
-
 let ondataCalled = 0;
 
-function TestReader() {
-  R.apply(this);
-  this._buffer = Buffer.alloc(100, 'x');
+class TestReader extends R {
+  constructor() {
+    super();
+    this._buffer = Buffer.alloc(100, 'x');
 
-  this.on('data', function() {
-    ondataCalled++;
-  });
+    this.on('data', () => {
+      ondataCalled++;
+    });
+  }
+
+  _read(n) {
+    this.push(this._buffer);
+    this._buffer = Buffer.alloc(0);
+  }
 }
-
-util.inherits(TestReader, R);
-
-TestReader.prototype._read = function(n) {
-  this.push(this._buffer);
-  this._buffer = Buffer.alloc(0);
-};
 
 const reader = new TestReader();
 setImmediate(function() {
@@ -31,17 +29,17 @@ setImmediate(function() {
   reader.push(null);
 });
 
-function TestWriter() {
-  W.apply(this);
-  this.write('foo');
-  this.end();
+class TestWriter extends W {
+  constructor() {
+    super();
+    this.write('foo');
+    this.end();
+  }
+
+  _write(chunk, enc, cb) {
+    cb();
+  }
 }
-
-util.inherits(TestWriter, W);
-
-TestWriter.prototype._write = function(chunk, enc, cb) {
-  cb();
-};
 
 const writer = new TestWriter();
 

--- a/test/parallel/test-stream2-pipe-error-once-listener.js
+++ b/test/parallel/test-stream2-pipe-error-once-listener.js
@@ -1,30 +1,20 @@
 'use strict';
 require('../common');
-
-const util = require('util');
 const stream = require('stream');
 
-
-function Read() {
-  stream.Readable.call(this);
+class Read extends stream.Readable {
+  _read(size) {
+    this.push('x');
+    this.push(null);
+  }
 }
-util.inherits(Read, stream.Readable);
 
-Read.prototype._read = function(size) {
-  this.push('x');
-  this.push(null);
-};
-
-
-function Write() {
-  stream.Writable.call(this);
+class Write extends stream.Writable {
+  _write(buffer, encoding, cb) {
+    this.emit('error', new Error('boom'));
+    this.emit('alldone');
+  }
 }
-util.inherits(Write, stream.Writable);
-
-Write.prototype._write = function(buffer, encoding, cb) {
-  this.emit('error', new Error('boom'));
-  this.emit('alldone');
-};
 
 const read = new Read();
 const write = new Write();

--- a/test/parallel/test-stream2-set-encoding.js
+++ b/test/parallel/test-stream2-set-encoding.js
@@ -2,39 +2,36 @@
 const common = require('../common');
 const assert = require('assert');
 const R = require('_stream_readable');
-const util = require('util');
 
-util.inherits(TestReader, R);
+class TestReader extends R {
+  constructor(n, opts) {
+    super(opts);
+    this.pos = 0;
+    this.len = n || 100;
+  }
 
-function TestReader(n, opts) {
-  R.call(this, opts);
+  _read(n) {
+    setTimeout(() => {
+      if (this.pos >= this.len) {
+        // double push(null) to test eos handling
+        this.push(null);
+        return this.push(null);
+      }
 
-  this.pos = 0;
-  this.len = n || 100;
+      n = Math.min(n, this.len - this.pos);
+      if (n <= 0) {
+        // double push(null) to test eos handling
+        this.push(null);
+        return this.push(null);
+      }
+
+      this.pos += n;
+      const ret = Buffer.alloc(n, 'a');
+
+      return this.push(ret);
+    }, 1);
+  }
 }
-
-TestReader.prototype._read = function(n) {
-  setTimeout(function() {
-
-    if (this.pos >= this.len) {
-      // double push(null) to test eos handling
-      this.push(null);
-      return this.push(null);
-    }
-
-    n = Math.min(n, this.len - this.pos);
-    if (n <= 0) {
-      // double push(null) to test eos handling
-      this.push(null);
-      return this.push(null);
-    }
-
-    this.pos += n;
-    const ret = Buffer.alloc(n, 'a');
-
-    return this.push(ret);
-  }.bind(this), 1);
-};
 
 {
   // Verify utf8 encoding

--- a/test/parallel/test-stream2-unpipe-drain.js
+++ b/test/parallel/test-stream2-unpipe-drain.js
@@ -3,30 +3,27 @@ require('../common');
 const assert = require('assert');
 
 const stream = require('stream');
-const util = require('util');
 
-function TestWriter() {
-  stream.Writable.call(this);
+class TestWriter extends stream.Writable {
+  _write(buffer, encoding, callback) {
+    console.log('write called');
+    // super slow write stream (callback never called)
+  }
 }
-util.inherits(TestWriter, stream.Writable);
-
-TestWriter.prototype._write = function(buffer, encoding, callback) {
-  console.log('write called');
-  // super slow write stream (callback never called)
-};
 
 const dest = new TestWriter();
 
-function TestReader(id) {
-  stream.Readable.call(this);
-  this.reads = 0;
-}
-util.inherits(TestReader, stream.Readable);
+class TestReader extends stream.Readable {
+  constructor() {
+    super();
+    this.reads = 0;
+  }
 
-TestReader.prototype._read = function(size) {
-  this.reads += 1;
-  this.push(Buffer.alloc(size));
-};
+  _read(size) {
+    this.reads += 1;
+    this.push(Buffer.alloc(size));
+  }
+}
 
 const src1 = new TestReader();
 const src2 = new TestReader();

--- a/test/parallel/test-stream2-unpipe-leak.js
+++ b/test/parallel/test-stream2-unpipe-leak.js
@@ -5,29 +5,27 @@ const stream = require('stream');
 
 const chunk = Buffer.from('hallo');
 
-const util = require('util');
-
-function TestWriter() {
-  stream.Writable.call(this);
+class TestWriter extends stream.Writable {
+  _write(buffer, encoding, callback) {
+    callback(null);
+  }
 }
-util.inherits(TestWriter, stream.Writable);
-
-TestWriter.prototype._write = function(buffer, encoding, callback) {
-  callback(null);
-};
 
 const dest = new TestWriter();
 
 // Set this high so that we'd trigger a nextTick warning
 // and/or RangeError if we do maybeReadMore wrong.
-function TestReader() {
-  stream.Readable.call(this, { highWaterMark: 0x10000 });
-}
-util.inherits(TestReader, stream.Readable);
+class TestReader extends stream.Readable {
+  constructor() {
+    super({
+      highWaterMark: 0x10000
+    });
+  }
 
-TestReader.prototype._read = function(size) {
-  this.push(chunk);
-};
+  _read(size) {
+    this.push(chunk);
+  }
+}
 
 const src = new TestReader();
 

--- a/test/parallel/test-stream2-writable.js
+++ b/test/parallel/test-stream2-writable.js
@@ -4,23 +4,22 @@ const W = require('_stream_writable');
 const D = require('_stream_duplex');
 const assert = require('assert');
 
-const util = require('util');
-util.inherits(TestWriter, W);
+class TestWriter extends W {
+  constructor(opts) {
+    super(opts);
+    this.buffer = [];
+    this.written = 0;
+  }
 
-function TestWriter() {
-  W.apply(this, arguments);
-  this.buffer = [];
-  this.written = 0;
+  _write(chunk, encoding, cb) {
+    // simulate a small unpredictable latency
+    setTimeout(() => {
+      this.buffer.push(chunk.toString());
+      this.written += chunk.length;
+      cb();
+    }, Math.floor(Math.random() * 10));
+  }
 }
-
-TestWriter.prototype._write = function(chunk, encoding, cb) {
-  // simulate a small unpredictable latency
-  setTimeout(function() {
-    this.buffer.push(chunk.toString());
-    this.written += chunk.length;
-    cb();
-  }.bind(this), Math.floor(Math.random() * 10));
-};
 
 const chunks = new Array(50);
 for (let i = 0; i < chunks.length; i++) {

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -68,15 +68,16 @@ assert.strictEqual(util.format('o: %j, a: %j'), 'o: %j, a: %j');
 // Errors
 const err = new Error('foo');
 assert.strictEqual(util.format(err), err.stack);
-function CustomError(msg) {
-  Error.call(this);
-  Object.defineProperty(this, 'message',
-                        { value: msg, enumerable: false });
-  Object.defineProperty(this, 'name',
-                        { value: 'CustomError', enumerable: false });
-  Error.captureStackTrace(this, CustomError);
+class CustomError extends Error {
+  constructor(msg) {
+    super();
+    Object.defineProperty(this, 'message',
+                          { value: msg, enumerable: false });
+    Object.defineProperty(this, 'name',
+                          { value: 'CustomError', enumerable: false });
+    Error.captureStackTrace(this, CustomError);
+  }
 }
-util.inherits(CustomError, Error);
 const customError = new CustomError('bar');
 assert.strictEqual(util.format(customError), customError.stack);
 // Doesn't capture stack trace

--- a/test/pummel/test-tls-server-large-request.js
+++ b/test/pummel/test-tls-server-large-request.js
@@ -7,7 +7,6 @@ const assert = require('assert');
 const tls = require('tls');
 const fs = require('fs');
 const stream = require('stream');
-const util = require('util');
 
 const request = Buffer.from(new Array(1024 * 256).join('ABCD')); // 1mb
 
@@ -16,21 +15,22 @@ const options = {
   cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
 };
 
-function Mediator() {
-  stream.Writable.call(this);
-  this.buf = '';
-}
-util.inherits(Mediator, stream.Writable);
-
-Mediator.prototype._write = function _write(data, enc, cb) {
-  this.buf += data;
-  setTimeout(cb, 0);
-
-  if (this.buf.length >= request.length) {
-    assert.strictEqual(this.buf, request.toString());
-    server.close();
+class Mediator extends stream.Writable {
+  constructor() {
+    super();
+    this.buf = '';
   }
-};
+
+  _write(data, enc, cb) {
+    this.buf += data;
+    setTimeout(cb, 0);
+
+    if (this.buf.length >= request.length) {
+      assert.strictEqual(this.buf, request.toString());
+      server.close();
+    }
+  }
+}
 
 const mediator = new Mediator();
 

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -12,27 +12,26 @@ const size = fs.statSync(file).size;
 
 const expectLengths = [1024];
 
-const util = require('util');
 const Stream = require('stream');
 
-util.inherits(TestWriter, Stream);
+class TestWriter extends Stream {
+  constructor() {
+    super();
+    this.buffer = [];
+    this.length = 0;
+  }
 
-function TestWriter() {
-  Stream.apply(this);
-  this.buffer = [];
-  this.length = 0;
+  write(c) {
+    this.buffer.push(c.toString());
+    this.length += c.length;
+    return true;
+  }
+
+  end(c) {
+    if (c) this.buffer.push(c.toString());
+    this.emit('results', this.buffer);
+  }
 }
-
-TestWriter.prototype.write = function(c) {
-  this.buffer.push(c.toString());
-  this.length += c.length;
-  return true;
-};
-
-TestWriter.prototype.end = function(c) {
-  if (c) this.buffer.push(c.toString());
-  this.emit('results', this.buffer);
-};
 
 const r = new FSReadable(file);
 const w = new TestWriter();


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/16938 to v6.x.

Thanks to @MylesBorins for landing backport PRs required for this to land cleanly!