### PR TITLE
process: compute and expose image checksum

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1161,6 +1161,22 @@ setTimeout(() => {
 }, 1000);
 ```
 
+## process.imagesha()
+<!-- YAML
+added: v10.0.0
+-->
+
+The `process.imagesha()` method reads the process image and computes a simple
+sha checksum in a platform independent manner. Useful for uniquely identifying
+the image from other distros. As it depends on `crypto` module, the return value
+is undefined when ran with node distributions without `crypto` capability.
+
+Example:
+```txt
+$ node -p 'process.imagesha()'
+b69cbe0cf01f354730ded9cc74fe05cf1f8eaa6d
+$
+```
 
 ## process.initgroups(user, extra_group)
 <!-- YAML

--- a/lib/internal/process.js
+++ b/lib/internal/process.js
@@ -247,6 +247,17 @@ function setupRawDebug() {
   };
 }
 
+process.imagesha = function() {
+  if (!process.versions.openssl)
+    return;
+  const crypto = require('crypto');
+  const fs = require('fs');
+  const image = fs.readFileSync(process.execPath);
+  const hasher = crypto.createHash('sha');
+  const hash = hasher.update(image);
+  return hash.digest('hex');
+};
+
 module.exports = {
   setup_performance,
   setup_cpuUsage,


### PR DESCRIPTION
Pluralities of node distributions, but in-distinguishable from the version string. In best case cross-checking some subcomponent version mismatch will help, in worst case core dump debugging. Often, I ended up tracing the route the customers took to figure out which distro they are using.

Use a simple checksum of the process image, that can be easily run and easily verified.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
