### PR TITLE
test: use arrow functions instead of bind

### DIFF
--- a/test/parallel/test-stream-push-strings.js
+++ b/test/parallel/test-stream-push-strings.js
@@ -36,15 +36,15 @@ class MyStream extends Readable {
       case 0:
         return this.push(null);
       case 1:
-        return setTimeout(function() {
+        return setTimeout(() => {
           this.push('last chunk');
-        }.bind(this), 100);
+        }, 100);
       case 2:
         return this.push('second to last chunk');
       case 3:
-        return process.nextTick(function() {
+        return process.nextTick(() => {
           this.push('first chunk');
-        }.bind(this));
+        });
       default:
         throw new Error('?');
     }

--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -211,14 +211,14 @@ const Transform = require('_stream_transform');
     if (!chunk)
       chunk = '';
     const s = chunk.toString();
-    setTimeout(function() {
+    setTimeout(() => {
       this.state += s.charAt(0);
       if (this.state.length === 3) {
         pt.push(Buffer.from(this.state));
         this.state = '';
       }
       cb();
-    }.bind(this), 10);
+    }, 10);
   };
 
   pt._flush = function(cb) {


### PR DESCRIPTION
Using arrow functions here makes `.bind(this)` obsolete.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test