### PR TITLE
src: use NODE_BUILTIN_MODULE_CONTEXT_AWARE() macro

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -442,10 +442,6 @@ typedef void (*addon_context_register_func)(
     v8::Local<v8::Context> context,
     void* priv);
 
-#define NM_F_BUILTIN   0x01
-#define NM_F_LINKED    0x02
-#define NM_F_INTERNAL  0x04
-
 struct node_module {
   int nm_version;
   unsigned int nm_flags;
@@ -528,9 +524,6 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
 
 #define NODE_MODULE_CONTEXT_AWARE(modname, regfunc)                   \
   NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
-
-#define NODE_MODULE_CONTEXT_AWARE_BUILTIN(modname, regfunc)           \
-  NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, NM_F_BUILTIN)   \
 
 /*
  * For backward compatibility in add-on modules.

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -55,6 +55,12 @@
 #define Z_MAX_LEVEL 9
 #define Z_DEFAULT_LEVEL Z_DEFAULT_COMPRESSION
 
+enum {
+  NM_F_BUILTIN  = 1 << 0,
+  NM_F_LINKED   = 1 << 1,
+  NM_F_INTERNAL = 1 << 2,
+};
+
 struct sockaddr;
 
 // Variation on NODE_DEFINE_CONSTANT that sets a String value.
@@ -115,6 +121,7 @@ struct sockaddr;
     V(stream_wrap)                                                            \
     V(tcp_wrap)                                                               \
     V(timer_wrap)                                                             \
+    V(trace_events)                                                           \
     V(tty_wrap)                                                               \
     V(udp_wrap)                                                               \
     V(url)                                                                    \

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -133,4 +133,4 @@ void InitializeTraceEvents(Local<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(trace_events, node::InitializeTraceEvents)
+NODE_BUILTIN_MODULE_CONTEXT_AWARE(trace_events, node::InitializeTraceEvents)

--- a/test/cctest/node_module_reg.cc
+++ b/test/cctest/node_module_reg.cc
@@ -20,6 +20,7 @@ void _register_spawn_sync() {}
 void _register_stream_wrap() {}
 void _register_tcp_wrap() {}
 void _register_timer_wrap() {}
+void _register_trace_events() {}
 void _register_tty_wrap() {}
 void _register_udp_wrap() {}
 void _register_util() {}


### PR DESCRIPTION
Commit d217b2850e ("async_hooks: add trace events to async_hooks") used
`NODE_MODULE_CONTEXT_AWARE_BUILTIN()` instead.

After commit 8680bb9f1a ("src: explicitly register built-in modules") it
no longer works for static and shared library builds so remove it.

CI: https://ci.nodejs.org/job/node-test-pull-request/11478/