### PR TITLE
test: make REPL test pass in coverage mode

### DIFF
--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -519,8 +519,8 @@ const editor = repl.start({
 editorStream.run(['.clear']);
 editorStream.run(['.editor']);
 
-editor.completer('co', common.mustCall((error, data) => {
-  assert.deepStrictEqual(data, [['con'], 'co']);
+editor.completer('Uin', common.mustCall((error, data) => {
+  assert.deepStrictEqual(data, [['Uint'], 'Uin']);
 }));
 
 editorStream.run(['.clear']);


### PR DESCRIPTION
Make a REPL tab completion test pass in coverage mode by using
`Uin` as the common prefix of all `Uint*Array` globals instead
of `co` which could be a prefix for `console` and `coverage`,
so it doesn't expand the way it's expected to in coverage mode.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (presumably)
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/repl