### PR TITLE
src: use unique_ptr for scheduled delayed tasks

### DIFF
--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -64,6 +64,8 @@ class PerIsolatePlatformData {
   void CancelPendingDelayedTasks();
 
  private:
+  void DeleteFromScheduledTasks(DelayedTask* task);
+
   static void FlushTasks(uv_async_t* handle);
   static void RunForegroundTask(std::unique_ptr<v8::Task> task);
   static void RunForegroundTask(uv_timer_t* timer);
@@ -74,7 +76,11 @@ class PerIsolatePlatformData {
   uv_async_t* flush_tasks_ = nullptr;
   TaskQueue<v8::Task> foreground_tasks_;
   TaskQueue<DelayedTask> foreground_delayed_tasks_;
-  std::vector<DelayedTask*> scheduled_delayed_tasks_;
+
+  // Use a custom deleter because libuv needs to close the handle first.
+  typedef std::unique_ptr<DelayedTask, std::function<void(DelayedTask*)>>
+      DelayedTaskPointer;
+  std::vector<DelayedTaskPointer> scheduled_delayed_tasks_;
 };
 
 class NodePlatform : public MultiIsolatePlatform {


### PR DESCRIPTION
Use std::unique_ptr for delayed tasks in the scheduled
delayed tasks vector. This makes it clear that the vector
has ownership of the delayed tasks and is responsible for
deleting them.

Use a custom deleter for the pointers because libuv
needs to close the handle and then delete the data. Provide
the handle when creating the pointer instead of invoking the
special delete action everytime an element is removed from the vector.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src