### PR TITLE
Rename internalModuleReadFile to internalModuleReadJSON.

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -31,7 +31,7 @@ const fs = require('fs');
 const internalFS = require('internal/fs');
 const path = require('path');
 const {
-  internalModuleReadFile,
+  internalModuleReadJSON,
   internalModuleStat
 } = process.binding('fs');
 const preserveSymlinks = !!process.binding('config').preserveSymlinks;
@@ -114,7 +114,7 @@ function readPackage(requestPath) {
     return entry;
 
   const jsonPath = path.resolve(requestPath, 'package.json');
-  const json = internalModuleReadFile(path.toNamespacedPath(jsonPath));
+  const json = internalModuleReadJSON(path.toNamespacedPath(jsonPath));
 
   if (json === undefined) {
     return false;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -470,7 +470,7 @@ void FillStatsArray(double* fields, const uv_stat_t* s) {
 // a string or undefined when the file cannot be opened.  Returns an empty
 // string when the file does not contain the substring '"main"' because that
 // is the property we care about.
-static void InternalModuleReadFile(const FunctionCallbackInfo<Value>& args) {
+static void InternalModuleReadJSON(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   uv_loop_t* loop = env->event_loop();
 
@@ -1430,7 +1430,7 @@ void InitFs(Local<Object> target,
   env->SetMethod(target, "rmdir", RMDir);
   env->SetMethod(target, "mkdir", MKDir);
   env->SetMethod(target, "readdir", ReadDir);
-  env->SetMethod(target, "internalModuleReadFile", InternalModuleReadFile);
+  env->SetMethod(target, "internalModuleReadJSON", InternalModuleReadJSON);
   env->SetMethod(target, "internalModuleStat", InternalModuleStat);
   env->SetMethod(target, "stat", Stat);
   env->SetMethod(target, "lstat", LStat);

--- a/test/parallel/test-module-binding.js
+++ b/test/parallel/test-module-binding.js
@@ -1,14 +1,14 @@
 'use strict';
 require('../common');
 const fixtures = require('../common/fixtures');
-const { internalModuleReadFile } = process.binding('fs');
+const { internalModuleReadJSON } = process.binding('fs');
 const { readFileSync } = require('fs');
 const { strictEqual } = require('assert');
 
-strictEqual(internalModuleReadFile('nosuchfile'), undefined);
-strictEqual(internalModuleReadFile(fixtures.path('empty.txt')), '');
-strictEqual(internalModuleReadFile(fixtures.path('empty-with-bom.txt')), '');
+strictEqual(internalModuleReadJSON('nosuchfile'), undefined);
+strictEqual(internalModuleReadJSON(fixtures.path('empty.txt')), '');
+strictEqual(internalModuleReadJSON(fixtures.path('empty-with-bom.txt')), '');
 {
   const filename = fixtures.path('require-bin/package.json');
-  strictEqual(internalModuleReadFile(filename), readFileSync(filename, 'utf8'));
+  strictEqual(internalModuleReadJSON(filename), readFileSync(filename, 'utf8'));
 }


### PR DESCRIPTION
This PR addresses #17076 by simply renaming `internalModuleReadFile` to `internalModuleReadJSON`.

>With the addition of PR #15767 the internal `InternalModuleReadFile` and  pseudo exposed `process.binding("fs").internalModuleReadFile` are no longer generic read file helpers and are essentially [locked down](https://github.com/nodejs/node/pull/15767/files#diff-fc4b9abe619d933ad78b886bab48caf3R521) to just `json`. `InternalModuleReadFile` was more generically useful before and could have been applied to loading more than just `json`. 
>
>I think the name `InternalModuleReadFile`, and the pseudo exposed `process.binding("fs").internalModuleReadFile`, should either be renamed or a new internal for `json`-only should be created *(maybe that wraps `InternalModuleReadFile`)*.

I'm actually cool with keeping `internalModuleReadFile` just for the potential to use it for other things besides `json`, but this was the easy way to address the root of #17076 without digging into `c++`.