### PR TITLE
src: use executable + pid as inspector context id

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -4,12 +4,6 @@
 #include "node_buffer.h"
 #include "node_platform.h"
 
-#if defined(_MSC_VER)
-#define getpid GetCurrentProcessId
-#else
-#include <unistd.h>
-#endif
-
 #include <stdio.h>
 #include <algorithm>
 
@@ -184,7 +178,8 @@ void Environment::PrintSyncTrace() const {
   Local<v8::StackTrace> stack =
       StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
 
-  fprintf(stderr, "(node:%d) WARNING: Detected use of sync API\n", getpid());
+  fprintf(stderr, "(node:%u) WARNING: Detected use of sync API\n",
+          GetProcessId());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(i);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -302,7 +302,8 @@ class NodeInspectorClient : public V8InspectorClient {
       : env_(env), platform_(platform), terminated_(false),
         running_nested_loop_(false) {
     client_ = V8Inspector::create(env->isolate(), this);
-    contextCreated(env->context(), "Node.js Main Context");
+    // TODO(bnoordhuis) Make name configurable from src/node.cc.
+    contextCreated(env->context(), GetHumanReadableProcessName());
   }
 
   void runMessageLoopOnPause(int context_group_id) override {

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -13,8 +13,8 @@
 #include <vector>
 
 #ifdef __POSIX__
-#include <limits.h>
-#include <unistd.h>  // setuid, getuid
+#include <limits.h>  // PTHREAD_STACK_MIN
+#include <pthread.h>
 #endif  // __POSIX__
 
 namespace node {
@@ -108,7 +108,8 @@ static int StartDebugSignalHandler() {
   CHECK_EQ(0, pthread_sigmask(SIG_SETMASK, &sigmask, nullptr));
   CHECK_EQ(0, pthread_attr_destroy(&attr));
   if (err != 0) {
-    fprintf(stderr, "node[%d]: pthread_create: %s\n", getpid(), strerror(err));
+    fprintf(stderr, "node[%u]: pthread_create: %s\n",
+            GetProcessId(), strerror(err));
     fflush(stderr);
     // Leave SIGUSR1 blocked.  We don't install a signal handler,
     // receiving the signal would terminate the process.

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -26,17 +26,6 @@ using v8_inspector::StringView;
 template<typename Transport>
 using TransportAndIo = std::pair<Transport*, InspectorIo*>;
 
-std::string GetProcessTitle() {
-  char title[2048];
-  int err = uv_get_process_title(title, sizeof(title));
-  if (err == 0) {
-    return title;
-  } else {
-    // Title is too long, or could not be retrieved.
-    return "Node.js";
-  }
-}
-
 std::string ScriptPath(uv_loop_t* loop, const std::string& script_name) {
   std::string script_path;
 
@@ -484,7 +473,7 @@ std::vector<std::string> InspectorIoDelegate::GetTargetIds() {
 }
 
 std::string InspectorIoDelegate::GetTargetTitle(const std::string& id) {
-  return script_name_.empty() ? GetProcessTitle() : script_name_;
+  return script_name_.empty() ? GetHumanReadableProcessName() : script_name_;
 }
 
 std::string InspectorIoDelegate::GetTargetUrl(const std::string& id) {

--- a/src/node.cc
+++ b/src/node.cc
@@ -99,7 +99,6 @@
 #if defined(_MSC_VER)
 #include <direct.h>
 #include <io.h>
-#define getpid GetCurrentProcessId
 #define umask _umask
 typedef int mode_t;
 #else
@@ -1659,13 +1658,8 @@ NO_RETURN void Assert(const char* const (*args)[4]) {
   if (uv_exepath(exepath, &exepath_size))
     snprintf(exepath, sizeof(exepath), "node");
 
-  char pid[12] = {0};
-#ifndef _WIN32
-  snprintf(pid, sizeof(pid), "[%u]", getpid());
-#endif
-
-  fprintf(stderr, "%s%s: %s:%s:%s%s Assertion `%s' failed.\n",
-          exepath, pid, filename, linenum,
+  fprintf(stderr, "%s[%u]: %s:%s:%s%s Assertion `%s' failed.\n",
+          exepath, GetProcessId(), filename, linenum,
           function, *function ? ":" : "", message);
   fflush(stderr);
 
@@ -3197,7 +3191,8 @@ void SetupProcessObject(Environment* env,
       process_env_template->NewInstance(env->context()).ToLocalChecked();
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "env"), process_env);
 
-  READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
+  READONLY_PROPERTY(process, "pid",
+                    Integer::New(env->isolate(), GetProcessId()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));
 
   CHECK(process->SetAccessor(env->context(),

--- a/src/node.cc
+++ b/src/node.cc
@@ -1653,14 +1653,11 @@ NO_RETURN void Assert(const char* const (*args)[4]) {
   auto message = (*args)[2];
   auto function = (*args)[3];
 
-  char exepath[256];
-  size_t exepath_size = sizeof(exepath);
-  if (uv_exepath(exepath, &exepath_size))
-    snprintf(exepath, sizeof(exepath), "node");
+  char name[1024];
+  GetHumanReadableProcessName(&name);
 
-  fprintf(stderr, "%s[%u]: %s:%s:%s%s Assertion `%s' failed.\n",
-          exepath, GetProcessId(), filename, linenum,
-          function, *function ? ":" : "", message);
+  fprintf(stderr, "%s: %s:%s:%s%s Assertion `%s' failed.\n",
+          name, filename, linenum, function, *function ? ":" : "", message);
   fflush(stderr);
 
   Abort();

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -251,6 +251,9 @@ void RegisterSignalHandler(int signal,
 uint32_t GetProcessId();
 bool SafeGetenv(const char* key, std::string* text);
 
+std::string GetHumanReadableProcessName();
+void GetHumanReadableProcessName(char (*name)[1024]);
+
 template <typename T, size_t N>
 constexpr size_t arraysize(const T(&)[N]) { return N; }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -248,6 +248,7 @@ void RegisterSignalHandler(int signal,
                            bool reset_handler = false);
 #endif
 
+uint32_t GetProcessId();
 bool SafeGetenv(const char* key, std::string* text);
 
 template <typename T, size_t N>

--- a/src/util.cc
+++ b/src/util.cc
@@ -24,6 +24,14 @@
 #include "node_internals.h"
 #include <stdio.h>
 
+#ifdef __POSIX__
+#include <unistd.h>  // getpid()
+#endif
+
+#ifdef _MSC_VER
+#include <windows.h>  // GetCurrentProcessId()
+#endif
+
 namespace node {
 
 using v8::Isolate;
@@ -103,6 +111,14 @@ void LowMemoryNotification() {
       isolate->LowMemoryNotification();
     }
   }
+}
+
+uint32_t GetProcessId() {
+#ifdef _WIN32
+  return GetCurrentProcessId();
+#else
+  return getpid();
+#endif
 }
 
 }  // namespace node

--- a/src/util.cc
+++ b/src/util.cc
@@ -113,6 +113,18 @@ void LowMemoryNotification() {
   }
 }
 
+std::string GetHumanReadableProcessName() {
+  char name[1024];
+  GetHumanReadableProcessName(&name);
+  return name;
+}
+
+void GetHumanReadableProcessName(char (*name)[1024]) {
+  char title[1024] = "Node.js";
+  uv_get_process_title(title, sizeof(title));
+  snprintf(*name, sizeof(*name), "%s[%u]", title, GetProcessId());
+}
+
 uint32_t GetProcessId() {
 #ifdef _WIN32
   return GetCurrentProcessId();

--- a/test/sequential/test-inspector-contexts.js
+++ b/test/sequential/test-inspector-contexts.js
@@ -23,9 +23,18 @@ async function testContextCreatedAndDestroyed() {
 
   session.post('Runtime.enable');
   let contextCreated = await mainContextPromise;
-  strictEqual('Node.js Main Context',
-              contextCreated.params.context.name,
-              JSON.stringify(contextCreated));
+  {
+    const { name } = contextCreated.params.context;
+    if (common.isSunOS || common.isWindows) {
+      // uv_get_process_title() is unimplemented on Solaris-likes, it returns
+      // an empy string.  On the Windows CI buildbots it returns "Administrator:
+      // Windows PowerShell[42]" because of a GetConsoleTitle() quirk. Not much
+      // we can do about either, just verify that it contains the PID.
+      strictEqual(name.includes(`[${process.pid}]`), true);
+    } else {
+      strictEqual(`${process.argv0}[${process.pid}]`, name);
+    }
+  }
 
   const secondContextCreatedPromise =
       notificationPromise('Runtime.executionContextCreated');


### PR DESCRIPTION
Report (for example) "node[1337]" as the human-readable name rather
than the more generic and less helpful "Node.js Main Context."

While not perfect yet, it should be an improvement to people that
debug multiple processes from DevTools, VS Code, etc.

CI: https://ci.nodejs.org/job/node-test-pull-request/11489/