### PR TITLE
doc: change v8 to V8

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2606,8 +2606,7 @@ Returns an un-pooled `Buffer`.
 
 In order to avoid the garbage collection overhead of creating many individually
 allocated `Buffer` instances, by default allocations under 4KB are sliced from a
-single larger allocated object. This approach improves both performance and memory
-usage since v8 does not need to track and cleanup as many `Persistent` objects.
+single larger allocated object.
 
 In the case where a developer may need to retain a small chunk of memory from a
 pool for an indeterminate amount of time, it may be appropriate to create an

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -11,7 +11,7 @@ To view this documentation as a manual page in a terminal, run `man node`.
 
 ## Synopsis
 
-`node [options] [v8 options] [script.js | -e "script" | -] [--] [arguments]`
+`node [options] [V8 options] [script.js | -e "script" | -] [--] [arguments]`
 
 `node debug [script.js | -e "script" | <host>:<port>] …`
 
@@ -293,7 +293,7 @@ Track heap object allocations for heap snapshots.
 added: v5.2.0
 -->
 
-Process v8 profiler output generated using the v8 option `--prof`.
+Process V8 profiler output generated using the V8 option `--prof`.
 
 
 ### `--v8-options`
@@ -301,7 +301,7 @@ Process v8 profiler output generated using the v8 option `--prof`.
 added: v0.1.3
 -->
 
-Print v8 command line options.
+Print V8 command line options.
 
 *Note*: V8 options allow words to be separated by both dashes (`-`) or
 underscores (`_`).

--- a/doc/api/synopsis.md
+++ b/doc/api/synopsis.md
@@ -3,7 +3,7 @@
 <!--introduced_in=v0.10.0-->
 <!--type=misc-->
 
-`node [options] [v8 options] [script.js | -e "script" | - ] [arguments]`
+`node [options] [V8 options] [script.js | -e "script" | - ] [arguments]`
 
 Please see the [Command Line Options][] document for information about
 different options and ways to run scripts with Node.js.

--- a/doc/guides/writing-and-running-benchmarks.md
+++ b/doc/guides/writing-and-running-benchmarks.md
@@ -104,7 +104,7 @@ buffers/buffer-tostring.js n=10000000 len=1024 arg=false: 4103857.0726124765
 Each line represents a single benchmark with parameters specified as
 `${variable}=${value}`. Each configuration combination is executed in a separate
 process. This ensures that benchmark results aren't affected by the execution
-order due to v8 optimizations. **The last number is the rate of operations
+order due to V8 optimizations. **The last number is the rate of operations
 measured in ops/sec (higher is better).**
 
 Furthermore a subset of the configurations can be specified, by setting them in

--- a/doc/node.1
+++ b/doc/node.1
@@ -181,13 +181,13 @@ Track heap object allocations for heap snapshots.
 
 .TP
 .BR \-\-prof\-process
-Process v8 profiler output generated using the v8 option \fB\-\-prof\fR
+Process V8 profiler output generated using the V8 option \fB\-\-prof\fR
 
 .TP
 .BR \-\-v8\-options
-Print v8 command line options.
+Print V8 command line options.
 
-Note: v8 options allow words to be separated by both dashes (\fB-\fR) or
+Note: V8 options allow words to be separated by both dashes (\fB-\fR) or
 underscores (\fB_\fR).
 
 For example, \fB\-\-stack\-trace\-limit\fR is equivalent to
@@ -196,7 +196,7 @@ For example, \fB\-\-stack\-trace\-limit\fR is equivalent to
 .TP
 .BR \-\-v8\-pool\-size =\fInum\fR
 Set v8's thread pool size which will be used to allocate background jobs.
-If set to 0 then v8 will choose an appropriate size of the thread pool based
+If set to 0 then V8 will choose an appropriate size of the thread pool based
 on the number of online processors. If the value provided is larger than v8's
 max then the largest value will be chosen.
 


### PR DESCRIPTION
Google's V8 engine is styled "V8" and not "v8". Most Node.js docs style
it correctly. This change fixes a few instances that are not styled
correctly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc