### PR TITLE
build: minor corrections to configure descriptions

### DIFF
--- a/configure
+++ b/configure
@@ -144,7 +144,7 @@ parser.add_option("--partly-static",
 parser.add_option("--enable-vtune-profiling",
     action="store_true",
     dest="enable_vtune_profiling",
-    help="Enable profiling support for Intel VTune profiler to profile"
+    help="Enable profiling support for Intel VTune profiler to profile "
          "JavaScript code executed in nodejs. This feature is only available "
          "for x32, x86 and x64 architectures.")
 
@@ -152,9 +152,9 @@ parser.add_option("--enable-vtune-profiling",
 parser.add_option("--link-module",
     action="append",
     dest="linked_module",
-    help="Path to a JS file to be bundled in the binary as a builtin."
-         "This module will be referenced by path without extension."
-         "e.g. /root/x/y.js will be referenced via require('root/x/y')."
+    help="Path to a JS file to be bundled in the binary as a builtin. "
+         "This module will be referenced by path without extension; "
+         "e.g. /root/x/y.js will be referenced via require('root/x/y'). "
          "Can be used multiple times")
 
 parser.add_option("--openssl-no-asm",


### PR DESCRIPTION
This commit updates `--enable-vtune-profiling` from:
```console
Enable profiling support for Intel VTune profiler to
profileJavaScript code executed in nodejs.
```
to: 
```console
Enable profiling support for Intel VTune profiler to
profile JavaScript code executed in nodejs.
```
And `--link-module=LINKED_MODULE` from:
```console
Path to a JS file to be bundled in the binary as a
builtin.This module will be referenced by path without
extension.e.g. /root/x/y.js will be referenced via
```
to:
```console
Path to a JS file to be bundled in the binary as a
builtin. This module will be referenced by path
without extension; e.g. /root/x/y.js will be
referenced via require('root/x/y').
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build