### PR TITLE
clarify that docs must be built before make test

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -127,7 +127,7 @@ for more information.
 Note that the above requires that `python` resolve to Python 2.6 or 2.7
 and not a newer version.
 
-To run the tests:
+To run the tests (NB: you must build the docs first - see below):
 
 ```console
 $ make test


### PR DESCRIPTION
See comment in https://github.com/nodejs/node/issues/16650

Running `make test` prior to running `make doc` results in this error:
```
added 3 packages and updated 1 package in 1.717s
/bin/sh: out/doc/api/console.html: No such file or directory
Makefile:579: recipe for target 'out/doc/api/console.html' failed
make[1]: *** [out/doc/api/console.html] Error 1
Makefile:213: recipe for target 'test' failed
make: *** [test] Error 2
```

After running `make doc`, `make test` succeeds.

This PR updates BUILDING.md to clarify.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
