### PR TITLE
build: do not build doc in source tarball

### DIFF
--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -28,7 +28,7 @@ for (const html of linkedHtmls) {
   assert.ok(docs.includes(html), `${html} does not exist`);
 }
 
-const excludes = ['.json', '_toc', 'assets'];
+const excludes = ['.json', '.md', '_toc', 'assets'];
 const generatedHtmls = docs.filter(function(doc) {
   for (const exclude of excludes) {
     if (doc.includes(exclude)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build

Fixes: https://github.com/nodejs/node/issues/16650 

This is the real fix for https://github.com/nodejs/node/issues/16650 , which makes sure that GNU make v4.x won't build the docs if the source is extracted from the source tarball (i.e. doc/api contains built docs) (see the theory in https://github.com/nodejs/node/issues/16650#issuecomment-345265520)

Also during the investigation of this issue I think I have a better idea about https://github.com/nodejs/node/issues/17043, I'll open a separate PR with a more robust `available-node` and try to fix all the `$(NODE)` usage there, hopefully fixing the makefile regression. For this PR the current implementation is enough.

cc @nodejs/build