### PR TITLE
src,napi: add helper for addons to get the event loop

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3689,7 +3689,7 @@ NAPI_EXTERN napi_status napi_run_script(napi_env env,
 N-API provides a function for getting the current event loop associated with
 a specific `napi_env`.
 
-### napi_uv_get_event_loop
+### napi_get_uv_event_loop
 <!-- YAML
 added: REPLACEME
 -->

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3684,6 +3684,23 @@ NAPI_EXTERN napi_status napi_run_script(napi_env env,
 - `[in] script`: A JavaScript string containing the script to execute.
 - `[out] result`: The value resulting from having executed the script.
 
+## libuv event loop
+
+N-API provides a function for getting the current event loop associated with
+a specific `napi_env`.
+
+### napi_uv_get_event_loop
+<!-- YAML
+added: REPLACEME
+-->
+```C
+NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
+                                               uv_loop_t** loop);
+```
+
+- `[in] env`: The environment that the API is invoked under.
+- `[out] loop`: The current libuv loop instance.
+
 [Promises]: #n_api_promises
 [Simple Asynchronous Operations]: #n_api_simple_asynchronous_operations
 [Custom Asynchronous Operations]: #n_api_custom_asynchronous_operations

--- a/src/node.cc
+++ b/src/node.cc
@@ -4420,7 +4420,11 @@ void RunAtExit(Environment* env) {
 
 
 uv_loop_t* GetCurrentEventLoop(v8::Isolate* isolate) {
-  return Environment::GetCurrent(isolate)->event_loop();
+  HandleScope handle_scope(isolate);
+  auto context = isolate->GetCurrentContext();
+  if (context.IsEmpty())
+    return nullptr;
+  return Environment::GetCurrent(context)->event_loop();
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4419,6 +4419,11 @@ void RunAtExit(Environment* env) {
 }
 
 
+uv_loop_t* GetCurrentEventLoop(v8::Isolate* isolate) {
+  return Environment::GetCurrent(isolate)->event_loop();
+}
+
+
 static uv_key_t thread_local_env;
 
 

--- a/src/node.h
+++ b/src/node.h
@@ -248,6 +248,8 @@ NODE_EXTERN void EmitBeforeExit(Environment* env);
 NODE_EXTERN int EmitExit(Environment* env);
 NODE_EXTERN void RunAtExit(Environment* env);
 
+NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
+
 /* Converts a unixtime to V8 Date */
 #define NODE_UNIXTIME_V8(t) v8::Date::New(v8::Isolate::GetCurrent(),          \
     1000 * static_cast<double>(t))

--- a/src/node.h
+++ b/src/node.h
@@ -248,6 +248,8 @@ NODE_EXTERN void EmitBeforeExit(Environment* env);
 NODE_EXTERN int EmitExit(Environment* env);
 NODE_EXTERN void RunAtExit(Environment* env);
 
+// This may return nullptr if the current v8::Context is not associated
+// with a Node instance.
 NODE_EXTERN struct uv_loop_s* GetCurrentEventLoop(v8::Isolate* isolate);
 
 /* Converts a unixtime to V8 Date */

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -14,6 +14,8 @@
 #include <stdbool.h>
 #include "node_api_types.h"
 
+struct uv_loop_s;  // Forward declaration.
+
 #ifdef _WIN32
   #ifdef BUILDING_NODE_EXTENSION
     #ifdef EXTERNAL_NAPI
@@ -580,6 +582,10 @@ NAPI_EXTERN napi_status napi_adjust_external_memory(napi_env env,
 NAPI_EXTERN napi_status napi_run_script(napi_env env,
                                         napi_value script,
                                         napi_value* result);
+
+// Return the current libuv event loop for a given environment
+NAPI_EXTERN napi_status napi_get_uv_event_loop(napi_env env,
+                                               struct uv_loop_s** loop);
 
 EXTERN_C_END
 

--- a/test/addons-napi/test_general/test.js
+++ b/test/addons-napi/test_general/test.js
@@ -34,7 +34,7 @@ assert.ok(test_general.testGetPrototype(baseObject) !==
 
 // test version management functions
 // expected version is currently 1
-assert.strictEqual(test_general.testGetVersion(), 1);
+assert.strictEqual(test_general.testGetVersion(), 2);
 
 const [ major, minor, patch, release ] = test_general.testGetNodeVersion();
 assert.strictEqual(process.version.split('-')[0],

--- a/test/addons-napi/test_uv_loop/binding.gyp
+++ b/test/addons-napi/test_uv_loop/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "test_uv_loop",
+      "sources": [ "test_uv_loop.cc" ]
+    }
+  ]
+}

--- a/test/addons-napi/test_uv_loop/test.js
+++ b/test/addons-napi/test_uv_loop/test.js
@@ -1,0 +1,5 @@
+'use strict';
+const common = require('../../common');
+const { SetImmediate } = require(`./build/${common.buildType}/test_uv_loop`);
+
+SetImmediate(common.mustCall());

--- a/test/addons-napi/test_uv_loop/test_uv_loop.cc
+++ b/test/addons-napi/test_uv_loop/test_uv_loop.cc
@@ -1,0 +1,79 @@
+#include <node_api.h>
+#include <uv.h>
+#include <utility>
+#include <memory>
+#include <assert.h>
+#include "../common.h"
+
+template<typename T>
+void* SetImmediate(napi_env env, T&& cb) {
+  T* ptr = new T(std::move(cb));
+  uv_loop_t* loop = nullptr;
+  uv_check_t* check = new uv_check_t;
+  check->data = static_cast<void*>(ptr);
+  NAPI_ASSERT(env,
+              napi_get_uv_event_loop(env, &loop) == napi_ok,
+              "can get event loop");
+  uv_check_init(loop, check);
+  uv_check_start(check, [](uv_check_t* check) {
+    std::unique_ptr<T> ptr {static_cast<T*>(check->data)};
+    T cb = std::move(*ptr);
+    uv_check_stop(check);
+    uv_close(reinterpret_cast<uv_handle_t*>(check), [](uv_handle_t* handle) {
+      delete reinterpret_cast<uv_check_t*>(handle);
+    });
+
+    assert(cb() != nullptr);
+  });
+  return nullptr;
+}
+
+static char dummy;
+
+napi_value SetImmediateBinding(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_value _this;
+  void* data;
+  NAPI_CALL(env,
+    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+  NAPI_ASSERT(env, argc >= 1, "Not enough arguments, expected 1.");
+
+  napi_valuetype t;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
+  NAPI_ASSERT(env, t == napi_function,
+      "Wrong first argument, function expected.");
+
+  napi_ref cbref;
+  NAPI_CALL(env,
+    napi_create_reference(env, argv[0], 1, &cbref));
+
+  SetImmediate(env, [=]() -> char* {
+    napi_value undefined;
+    napi_value callback;
+    napi_handle_scope scope;
+    NAPI_CALL(env, napi_open_handle_scope(env, &scope));
+    NAPI_CALL(env, napi_get_undefined(env, &undefined));
+    NAPI_CALL(env, napi_get_reference_value(env, cbref, &callback));
+    NAPI_CALL(env, napi_delete_reference(env, cbref));
+    NAPI_CALL(env,
+        napi_call_function(env, undefined, callback, 0, nullptr, nullptr));
+    NAPI_CALL(env, napi_close_handle_scope(env, scope));
+    return &dummy;
+  });
+
+  return nullptr;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("SetImmediate", SetImmediateBinding)
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/addons-napi/test_uv_loop/test_uv_loop.cc
+++ b/test/addons-napi/test_uv_loop/test_uv_loop.cc
@@ -5,12 +5,12 @@
 #include <assert.h>
 #include "../common.h"
 
-template<typename T>
+template <typename T>
 void* SetImmediate(napi_env env, T&& cb) {
   T* ptr = new T(std::move(cb));
   uv_loop_t* loop = nullptr;
   uv_check_t* check = new uv_check_t;
-  check->data = static_cast<void*>(ptr);
+  check->data = ptr;
   NAPI_ASSERT(env,
               napi_get_uv_event_loop(env, &loop) == napi_ok,
               "can get event loop");
@@ -18,7 +18,6 @@ void* SetImmediate(napi_env env, T&& cb) {
   uv_check_start(check, [](uv_check_t* check) {
     std::unique_ptr<T> ptr {static_cast<T*>(check->data)};
     T cb = std::move(*ptr);
-    uv_check_stop(check);
     uv_close(reinterpret_cast<uv_handle_t*>(check), [](uv_handle_t* handle) {
       delete reinterpret_cast<uv_check_t*>(handle);
     });

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -77,7 +77,7 @@ void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
   v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[1]);
   req->callback.Reset(isolate, callback);
 
-  uv_queue_work(uv_default_loop(),
+  uv_queue_work(node::GetCurrentEventLoop(isolate),
                 &req->req,
                 DoAsync,
                 (uv_after_work_cb)AfterAsync<use_makecallback>);

--- a/test/addons/callback-scope/binding.cc
+++ b/test/addons/callback-scope/binding.cc
@@ -52,7 +52,10 @@ static void TestResolveAsync(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
     uv_work_t* req = new uv_work_t;
 
-    uv_queue_work(uv_default_loop(), req, [](uv_work_t*) {}, Callback);
+    uv_queue_work(node::GetCurrentEventLoop(isolate),
+                  req,
+                  [](uv_work_t*) {},
+                  Callback);
   }
 
   v8::Local<v8::Promise::Resolver> local =


### PR DESCRIPTION
## C++ variant

Add a utility functions for addons to use when they need
a reference to the current event loop.

Currently, `uv_default_loop()` works if the embedder is the
single-threaded default node executable, but even without
the presence of e.g. workers that might not really an API
guarantee for when Node is embedded.

## N-API variant

Add a utility functions for addons to use when they need
a reference to the current event loop.

While the libuv API is not directly part of N-API, it
provides a quite stable C API as well, and is tightly
integrated with Node itself.

As a particular use case, without access to the event loop
it is hard to do something interesting from inside a N-API
finalizer function, since calls into JS and therefore virtually
all other N-API functions are not allowed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

node.h, n-api

/cc @nodejs/n-api 