### PR TITLE
test: reduce benchmark cases in test-benchmark-buffer

### DIFF
--- a/test/sequential/test-benchmark-buffer.js
+++ b/test/sequential/test-benchmark-buffer.js
@@ -8,6 +8,7 @@ runBenchmark('buffers',
              [
                'aligned=true',
                'args=1',
+               'buffer=fast',
                'encoding=utf8',
                'len=2',
                'method=',


### PR DESCRIPTION
Specify `buffer=fast` so that we only run that and not that along with
`buffer=slow` in two benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark buffer