### PR TITLE
src: introduce internal C++ SetImmediate() and remove async_hooks destroy timer

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -137,11 +137,7 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
 // end RetainedAsyncInfo
 
 
-static void DestroyAsyncIdsCallback(uv_timer_t* handle) {
-  Environment* env = Environment::from_destroy_async_ids_timer_handle(handle);
-
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
+static void DestroyAsyncIdsCallback(Environment* env, void* data) {
   Local<Function> fn = env->async_hooks_destroy_function();
 
   TryCatch try_catch(env->isolate());
@@ -689,8 +685,7 @@ void AsyncWrap::EmitDestroy(Environment* env, double async_id) {
     return;
 
   if (env->destroy_async_id_list()->empty()) {
-    uv_timer_start(env->destroy_async_ids_timer_handle(),
-                   DestroyAsyncIdsCallback, 0, 0);
+    env->SetImmediate(DestroyAsyncIdsCallback, nullptr);
   }
 
   env->destroy_async_id_list()->push_back(async_id);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -368,15 +368,6 @@ inline uv_idle_t* Environment::immediate_idle_handle() {
   return &immediate_idle_handle_;
 }
 
-inline Environment* Environment::from_destroy_async_ids_timer_handle(
-    uv_timer_t* handle) {
-  return ContainerOf(&Environment::destroy_async_ids_timer_handle_, handle);
-}
-
-inline uv_timer_t* Environment::destroy_async_ids_timer_handle() {
-  return &destroy_async_ids_timer_handle_;
-}
-
 inline void Environment::RegisterHandleCleanup(uv_handle_t* handle,
                                                HandleCleanupCb cb,
                                                void *arg) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -518,6 +518,13 @@ Environment::scheduled_immediate_count() {
   return scheduled_immediate_count_;
 }
 
+void Environment::SetImmediate(native_immediate_callback cb, void* data) {
+  native_immediate_callbacks_.push_back({ cb, data });
+  if (scheduled_immediate_count_[0] == 0)
+    ActivateImmediateCheck();
+  scheduled_immediate_count_[0] = scheduled_immediate_count_[0] + 1;
+}
+
 inline performance::performance_state* Environment::performance_state() {
   return performance_state_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -282,6 +282,59 @@ void Environment::EnvPromiseHook(v8::PromiseHookType type,
   }
 }
 
+void Environment::RunAndClearNativeImmediates() {
+  size_t count = native_immediate_callbacks_.size();
+  if (count > 0) {
+    std::vector<NativeImmediateCallback> list;
+    native_immediate_callbacks_.swap(list);
+    for (const auto& cb : list) {
+      cb.cb_(this, cb.data_);
+    }
+
+#ifdef DEBUG
+    CHECK_GE(scheduled_immediate_count_[0], count);
+#endif
+    scheduled_immediate_count_[0] = scheduled_immediate_count_[0] - count;
+  }
+}
+
+static bool MaybeStopImmediate(Environment* env) {
+  if (env->scheduled_immediate_count()[0] == 0) {
+    uv_check_stop(env->immediate_check_handle());
+    uv_idle_stop(env->immediate_idle_handle());
+    return true;
+  }
+  return false;
+}
+
+
+void Environment::CheckImmediate(uv_check_t* handle) {
+  Environment* env = Environment::from_immediate_check_handle(handle);
+  HandleScope scope(env->isolate());
+  Context::Scope context_scope(env->context());
+
+  if (MaybeStopImmediate(env))
+    return;
+
+  env->RunAndClearNativeImmediates();
+
+  MakeCallback(env->isolate(),
+               env->process_object(),
+               env->immediate_callback_string(),
+               0,
+               nullptr,
+               {0, 0}).ToLocalChecked();
+
+  MaybeStopImmediate(env);
+}
+
+void Environment::ActivateImmediateCheck() {
+  uv_check_start(&immediate_check_handle_, CheckImmediate);
+  // Idle handle is needed only to stop the event loop from blocking in poll.
+  uv_idle_start(&immediate_idle_handle_, [](uv_idle_t*){ });
+}
+
+
 void CollectExceptionInfo(Environment* env,
                           v8::Local<v8::Object> obj,
                           int errorno,

--- a/src/env.cc
+++ b/src/env.cc
@@ -102,8 +102,6 @@ void Environment::Start(int argc,
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_prepare_handle_));
   uv_unref(reinterpret_cast<uv_handle_t*>(&idle_check_handle_));
 
-  uv_timer_init(event_loop(), destroy_async_ids_timer_handle());
-
   auto close_and_finish = [](Environment* env, uv_handle_t* handle, void* arg) {
     handle->data = env;
 
@@ -126,10 +124,6 @@ void Environment::Start(int argc,
       nullptr);
   RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(&idle_check_handle_),
-      close_and_finish,
-      nullptr);
-  RegisterHandleCleanup(
-      reinterpret_cast<uv_handle_t*>(&destroy_async_ids_timer_handle_),
       close_and_finish,
       nullptr);
 

--- a/src/env.h
+++ b/src/env.h
@@ -564,11 +564,8 @@ class Environment {
   inline uint32_t watched_providers() const;
 
   static inline Environment* from_immediate_check_handle(uv_check_t* handle);
-  static inline Environment* from_destroy_async_ids_timer_handle(
-    uv_timer_t* handle);
   inline uv_check_t* immediate_check_handle();
   inline uv_idle_t* immediate_idle_handle();
-  inline uv_timer_t* destroy_async_ids_timer_handle();
 
   // Register clean-up cb to be called on environment destruction.
   inline void RegisterHandleCleanup(uv_handle_t* handle,
@@ -722,7 +719,6 @@ class Environment {
   IsolateData* const isolate_data_;
   uv_check_t immediate_check_handle_;
   uv_idle_t immediate_idle_handle_;
-  uv_timer_t destroy_async_ids_timer_handle_;
   uv_prepare_t idle_prepare_handle_;
   uv_check_t idle_check_handle_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -709,6 +709,11 @@ class Environment {
   bool RemovePromiseHook(promise_hook_func fn, void* arg);
   bool EmitNapiWarning();
 
+  typedef void (*native_immediate_callback)(Environment* env, void* data);
+  inline void SetImmediate(native_immediate_callback cb, void* data);
+  // This needs to be available for the JS-land setImmediate().
+  void ActivateImmediateCheck();
+
  private:
   inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
                          const char* errmsg);
@@ -768,6 +773,14 @@ class Environment {
     size_t enable_count_;
   };
   std::vector<PromiseHookCallback> promise_hooks_;
+
+  struct NativeImmediateCallback {
+    native_immediate_callback cb_;
+    void* data_;
+  };
+  std::vector<NativeImmediateCallback> native_immediate_callbacks_;
+  void RunAndClearNativeImmediates();
+  static void CheckImmediate(uv_check_t* handle);
 
   static void EnvPromiseHook(v8::PromiseHookType type,
                              v8::Local<v8::Promise> promise,

--- a/src/node.cc
+++ b/src/node.cc
@@ -3000,40 +3000,9 @@ static void DebugEnd(const FunctionCallbackInfo<Value>& args);
 
 namespace {
 
-bool MaybeStopImmediate(Environment* env) {
-  if (env->scheduled_immediate_count()[0] == 0) {
-    uv_check_stop(env->immediate_check_handle());
-    uv_idle_stop(env->immediate_idle_handle());
-    return true;
-  }
-  return false;
-}
-
-void CheckImmediate(uv_check_t* handle) {
-  Environment* env = Environment::from_immediate_check_handle(handle);
-  HandleScope scope(env->isolate());
-  Context::Scope context_scope(env->context());
-
-  if (MaybeStopImmediate(env))
-    return;
-
-  MakeCallback(env->isolate(),
-               env->process_object(),
-               env->immediate_callback_string(),
-               0,
-               nullptr,
-               {0, 0}).ToLocalChecked();
-
-  MaybeStopImmediate(env);
-}
-
-
 void ActivateImmediateCheck(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  uv_check_start(env->immediate_check_handle(), CheckImmediate);
-  // Idle handle is needed only to stop the event loop from blocking in poll.
-  uv_idle_start(env->immediate_idle_handle(),
-                [](uv_idle_t*){ /* do nothing, just keep the loop running */ });
+  env->ActivateImmediateCheck();
 }
 
 

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -66,12 +66,14 @@ function onsigusr2() {
 }
 
 function onsigusr2Again() {
-  checkInvocations(
-    signal1, { init: 1, before: 2, after: 2, destroy: 1 },
-    'signal1: when second SIGUSR2 handler is called');
-  checkInvocations(
-    signal2, { init: 1, before: 1 },
-    'signal2: when second SIGUSR2 handler is called');
+  setImmediate(() => {
+    checkInvocations(
+      signal1, { init: 1, before: 2, after: 2, destroy: 1 },
+      'signal1: when second SIGUSR2 handler is called');
+    checkInvocations(
+      signal2, { init: 1, before: 1 },
+      'signal2: when second SIGUSR2 handler is called');
+  });
 }
 
 process.on('exit', onexit);

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -128,8 +128,10 @@ function onconnection(c) {
 function onserverClosed() {
   checkInvocations(tcp1, { init: 1, before: 1, after: 1, destroy: 1 },
                    'tcp1 when server is closed');
-  checkInvocations(tcp2, { init: 1, before: 2, after: 2, destroy: 1 },
-                   'tcp2 when server is closed');
+  setImmediate(() => {
+    checkInvocations(tcp2, { init: 1, before: 2, after: 2, destroy: 1 },
+                     'tcp2 after server is closed');
+  });
   checkInvocations(tcp3, { init: 1, before: 1, after: 1 },
                    'tcp3 synchronously when server is closed');
   tick(2, () => {


### PR DESCRIPTION
Introduce `env->SetImmediate(fn)` and remove the handle we use for `async_hooks` destroys.

After #17105, a similar thing could be done for HTTP/2.

(The one test change is due to the slightly different timing for `async_hooks`, since timer and check handle callbacks run at different times.)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src