### PR TITLE
inspector: no async tracking for promises

### DIFF
--- a/lib/internal/inspector_async_hook.js
+++ b/lib/internal/inspector_async_hook.js
@@ -17,31 +17,31 @@ const hook = createHook({
     // this should be fine as long as we call asyncTaskCanceled() too.
     const recurring = true;
     if (type === 'PROMISE')
-      this.promises.add(asyncId);
+      this.promiseIds.add(asyncId);
     else
       inspector.asyncTaskScheduled(type, asyncId, recurring);
   },
 
   before(asyncId) {
-    if (this.promises.has(asyncId))
+    if (this.promiseIds.has(asyncId))
       return;
     inspector.asyncTaskStarted(asyncId);
   },
 
   after(asyncId) {
-    if (this.promises.has(asyncId))
+    if (this.promiseIds.has(asyncId))
       return;
     inspector.asyncTaskFinished(asyncId);
   },
 
   destroy(asyncId) {
-    if (this.promises.has(asyncId))
-      return this.promises.delete(asyncId);
+    if (this.promiseIds.has(asyncId))
+      return this.promiseIds.delete(asyncId);
     inspector.asyncTaskCanceled(asyncId);
   },
 });
 
-hook.promises = new Set();
+hook.promiseIds = new Set();
 
 function enable() {
   if (config.bits < 64) {

--- a/lib/internal/inspector_async_hook.js
+++ b/lib/internal/inspector_async_hook.js
@@ -16,21 +16,32 @@ const hook = createHook({
     // in https://github.com/nodejs/node/pull/13870#discussion_r124515293,
     // this should be fine as long as we call asyncTaskCanceled() too.
     const recurring = true;
-    inspector.asyncTaskScheduled(type, asyncId, recurring);
+    if (type === 'PROMISE')
+      this.promises.add(asyncId);
+    else
+      inspector.asyncTaskScheduled(type, asyncId, recurring);
   },
 
   before(asyncId) {
+    if (this.promises.has(asyncId))
+      return;
     inspector.asyncTaskStarted(asyncId);
   },
 
   after(asyncId) {
+    if (this.promises.has(asyncId))
+      return;
     inspector.asyncTaskFinished(asyncId);
   },
 
   destroy(asyncId) {
+    if (this.promises.has(asyncId))
+      return this.promises.delete(asyncId);
     inspector.asyncTaskCanceled(asyncId);
   },
 });
+
+hook.promises = new Set();
 
 function enable() {
   if (config.bits < 64) {

--- a/test/sequential/test-inspector-async-stack-traces-promise-then.js
+++ b/test/sequential/test-inspector-async-stack-traces-promise-then.js
@@ -54,7 +54,7 @@ function debuggerPausedAt(msg, functionName, previousTickLocation) {
     `${Object.keys(msg.params)} contains "asyncStackTrace" property`);
 
   assert.strictEqual(msg.params.callFrames[0].functionName, functionName);
-  assert.strictEqual(msg.params.asyncStackTrace.description, 'PROMISE');
+  assert.strictEqual(msg.params.asyncStackTrace.description, 'Promise.resolve');
 
   const frameLocations = msg.params.asyncStackTrace.callFrames.map(
     (frame) => `${frame.functionName}:${frame.lineNumber}`);


### PR DESCRIPTION
`Promise` instances are already tracked by V8 itself.
This fixes `sequential/test-inspector-async-stack-traces-promise-then`
in debug mode (it previously crashed because our tracking
and the V8 tracking were not properly nested).

Ref: https://chromium-review.googlesource.com/c/v8/v8/+/707058 (fyi @ak239) 
Fixes: https://github.com/nodejs/node/issues/17017

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

inspector