### PR TITLE
test: don't need to remove nonexistent directories(test-fs-mkdir.js)

### DIFF
--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -36,8 +36,6 @@ common.refreshTmpDir();
 {
   const pathname = `${common.tmpDir}/test1`;
 
-  unlink(pathname);
-
   fs.mkdir(pathname, common.mustCall(function(err) {
     assert.strictEqual(err, null);
     assert.strictEqual(common.fileExists(pathname), true);
@@ -50,8 +48,6 @@ common.refreshTmpDir();
 
 {
   const pathname = `${common.tmpDir}/test2`;
-
-  unlink(pathname);
 
   fs.mkdir(pathname, 0o777, common.mustCall(function(err) {
     assert.strictEqual(err, null);

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -24,13 +24,6 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-function unlink(pathname) {
-  try {
-    fs.rmdirSync(pathname);
-  } catch (e) {
-  }
-}
-
 common.refreshTmpDir();
 
 {
@@ -40,10 +33,6 @@ common.refreshTmpDir();
     assert.strictEqual(err, null);
     assert.strictEqual(common.fileExists(pathname), true);
   }));
-
-  process.on('exit', function() {
-    unlink(pathname);
-  });
 }
 
 {
@@ -53,21 +42,14 @@ common.refreshTmpDir();
     assert.strictEqual(err, null);
     assert.strictEqual(common.fileExists(pathname), true);
   }));
-
-  process.on('exit', function() {
-    unlink(pathname);
-  });
 }
 
 {
   const pathname = `${common.tmpDir}/test3`;
 
-  unlink(pathname);
   fs.mkdirSync(pathname);
 
   const exists = common.fileExists(pathname);
-  unlink(pathname);
-
   assert.strictEqual(exists, true);
 }
 


### PR DESCRIPTION
the tempdir is empty , so tempdir/test1 and tempdir/test2 are nonexistent. we don't need to delete nonexistent directories.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test