### PR TITLE
tools: avoid using process.cwd in tools/lint-js

### DIFF
--- a/tools/lint-js.js
+++ b/tools/lint-js.js
@@ -13,7 +13,6 @@ const totalCPUs = require('os').cpus().length;
 const CLIEngine = require('./eslint').CLIEngine;
 const glob = require('./eslint/node_modules/glob');
 
-const cwd = process.cwd();
 const cliOptions = {
   rulePaths: rulesDirs,
   extensions: extensions,
@@ -82,9 +81,7 @@ if (cluster.isMaster) {
   if (i !== -1) {
     if (!process.argv[i + 1])
       throw new Error('Missing output filename');
-    var outPath = process.argv[i + 1];
-    if (!path.isAbsolute(outPath))
-      outPath = path.join(cwd, outPath);
+    const outPath = path.resolve(process.argv[i + 1]);
     fd = fs.openSync(outPath, 'w');
     outFn = function(str) {
       fs.writeSync(fd, str, 'utf8');
@@ -176,8 +173,6 @@ if (cluster.isMaster) {
       while (paths.length) {
         var dir = paths.shift();
         curPath = dir;
-        if (dir.indexOf('/') > 0)
-          dir = path.join(cwd, dir);
         const patterns = cli.resolveFileGlobPatterns([dir]);
         dir = path.resolve(patterns[0]);
         files = glob.sync(dir, globOptions);


### PR DESCRIPTION
The first occurrence of `path.join()` can be replaced with `path.resolve()`. The second occurrence should be unnecessary as ESLint will resolve the path internally, and the old check probably did not work as intended anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

CI: https://ci.nodejs.org/job/node-test-linter/13675/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools