### PR TITLE
module: Fix for #17130 CJS dependency shared with loader

### DIFF
--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -36,9 +36,12 @@ loaders.set('esm', async (url) => {
 });
 
 // Strategy for loading a node-style CommonJS module
+const isWindows = process.platform === 'win32';
+const winSepRegEx = /\//g;
 loaders.set('cjs', async (url) => {
   const pathname = internalURLModule.getPathFromURL(new URL(url));
-  const module = CJSModule._cache[pathname];
+  const module = CJSModule._cache[
+      isWindows ? pathname.replace(winSepRegEx, '\\') : pathname];
   if (module && module.loaded) {
     const ctx = createDynamicModule(['default'], url, undefined);
     ctx.reflect.exports.default.set(module.exports);

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const internalCJSModule = require('internal/module');
+const CJSModule = require('module');
 const internalURLModule = require('internal/url');
 const internalFS = require('internal/fs');
 const NativeModule = require('native_module');
@@ -36,10 +37,15 @@ loaders.set('esm', async (url) => {
 
 // Strategy for loading a node-style CommonJS module
 loaders.set('cjs', async (url) => {
+  const pathname = internalURLModule.getPathFromURL(new URL(url));
+  const module = CJSModule._cache[pathname];
+  if (module && module.loaded) {
+    const ctx = createDynamicModule(['default'], url, undefined);
+    ctx.reflect.exports.default.set(module.exports);
+    return ctx;
+  }
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading CJSModule ${url}`);
-    const CJSModule = require('module');
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
     CJSModule._load(pathname);
   });
 });

--- a/lib/module.js
+++ b/lib/module.js
@@ -39,6 +39,9 @@ const experimentalModules = !!process.binding('config').experimentalModules;
 
 const errors = require('internal/errors');
 
+module.exports = Module;
+
+// these are below module.exports for the circular reference
 const Loader = require('internal/loader/Loader');
 const ModuleJob = require('internal/loader/ModuleJob');
 const { createDynamicModule } = require('internal/loader/ModuleWrap');
@@ -72,7 +75,6 @@ function Module(id, parent) {
   this.loaded = false;
   this.children = [];
 }
-module.exports = Module;
 
 Module._cache = Object.create(null);
 Module._pathCache = Object.create(null);

--- a/test/es-module/test-esm-shared-loader-dep.mjs
+++ b/test/es-module/test-esm-shared-loader-dep.mjs
@@ -1,0 +1,7 @@
+// Flags: --experimental-modules --loader ./test/fixtures/es-module-loaders/loader-shared-dep.mjs
+/* eslint-disable required-modules */
+import assert from 'assert';
+import './test-esm-ok.mjs';
+import dep from '../fixtures/es-module-loaders/loader-dep.js';
+
+assert.strictEqual(dep.format, 'esm');

--- a/test/fixtures/es-module-loaders/loader-shared-dep.mjs
+++ b/test/fixtures/es-module-loaders/loader-shared-dep.mjs
@@ -1,0 +1,7 @@
+import dep from './loader-dep.js';
+import assert from 'assert';
+
+export function resolve(specifier, base, defaultResolve) {
+  assert.equal(dep.format, 'esm');
+  return defaultResolve(specifier, base);
+}


### PR DESCRIPTION
This fixes the issue of a CJS dependency loaded by the loader then not being defined when imported.

The reason for this is that CJS modules define themselves early into the loader on execution, instead of as a result of being imported by the loader. But this defining only happens the first time they are loaded. Because we use a different loader for the loader itself, the modules weren't being redefined, which has been fixed here.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
esmodules
