### PR TITLE
src: add missing include in node_platform.h

### DIFF
--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -4,6 +4,7 @@
 #include <queue>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 #include "libplatform/libplatform.h"
 #include "node.h"


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/17083

I will fast-track this to un-break CI.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_platform

@fhinkel 