### PR TITLE
src: implement v8::TaskRunner API in NodePlatform

### DIFF
--- a/deps/v8/include/v8-platform.h
+++ b/deps/v8/include/v8-platform.h
@@ -37,6 +37,51 @@ class IdleTask {
 };
 
 /**
+ * A TaskRunner allows scheduling of tasks. The TaskRunner may still be used to
+ * post tasks after the isolate gets destructed, but these tasks may not get
+ * executed anymore. All tasks posted to a given TaskRunner will be invoked in
+ * sequence. Tasks can be posted from any thread.
+ */
+class TaskRunner {
+ public:
+  /**
+   * Schedules a task to be invoked by this TaskRunner. The TaskRunner
+   * implementation takes ownership of |task|.
+   */
+  virtual void PostTask(std::unique_ptr<Task> task) = 0;
+
+  /**
+   * Schedules a task to be invoked by this TaskRunner. The task is scheduled
+   * after the given number of seconds |delay_in_seconds|. The TaskRunner
+   * implementation takes ownership of |task|.
+   */
+  virtual void PostDelayedTask(std::unique_ptr<Task> task,
+                               double delay_in_seconds) = 0;
+
+  /**
+   * Schedules an idle task to be invoked by this TaskRunner. The task is
+   * scheduled when the embedder is idle. Requires that
+   * TaskRunner::SupportsIdleTasks(isolate) is true. Idle tasks may be reordered
+   * relative to other task types and may be starved for an arbitrarily long
+   * time if no idle time is available. The TaskRunner implementation takes
+   * ownership of |task|.
+   */
+  virtual void PostIdleTask(std::unique_ptr<IdleTask> task) = 0;
+
+  /**
+   * Returns true if idle tasks are enabled for this TaskRunner.
+   */
+  virtual bool IdleTasksEnabled() = 0;
+
+  TaskRunner() = default;
+  virtual ~TaskRunner() = default;
+
+ private:
+  TaskRunner(const TaskRunner&) = delete;
+  TaskRunner& operator=(const TaskRunner&) = delete;
+};
+
+/**
  * The interface represents complex arguments to trace events.
  */
 class ConvertableToTraceFormat {
@@ -149,6 +194,28 @@ class Platform {
    * |CallOnBackgroundThread|.
    */
   virtual size_t NumberOfAvailableBackgroundThreads() { return 0; }
+
+  /**
+   * Returns a TaskRunner which can be used to post a task on the foreground.
+   * This function should only be called from a foreground thread.
+   */
+  virtual std::unique_ptr<v8::TaskRunner> GetForegroundTaskRunner(
+      Isolate* isolate) {
+    // TODO(ahaas): Make this function abstract after it got implemented on all
+    // platforms.
+    return {};
+  }
+
+  /**
+   * Returns a TaskRunner which can be used to post a task on a background.
+   * This function should only be called from a foreground thread.
+   */
+  virtual std::unique_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
+      Isolate* isolate) {
+    // TODO(ahaas): Make this function abstract after it got implemented on all
+    // platforms.
+    return {};
+  }
 
   /**
    * Schedules a task to be invoked on a background thread. |expected_runtime|

--- a/deps/v8/include/v8-platform.h
+++ b/deps/v8/include/v8-platform.h
@@ -199,7 +199,7 @@ class Platform {
    * Returns a TaskRunner which can be used to post a task on the foreground.
    * This function should only be called from a foreground thread.
    */
-  virtual std::unique_ptr<v8::TaskRunner> GetForegroundTaskRunner(
+  virtual std::shared_ptr<v8::TaskRunner> GetForegroundTaskRunner(
       Isolate* isolate) {
     // TODO(ahaas): Make this function abstract after it got implemented on all
     // platforms.
@@ -210,7 +210,7 @@ class Platform {
    * Returns a TaskRunner which can be used to post a task on a background.
    * This function should only be called from a foreground thread.
    */
-  virtual std::unique_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
+  virtual std::shared_ptr<v8::TaskRunner> GetBackgroundTaskRunner(
       Isolate* isolate) {
     // TODO(ahaas): Make this function abstract after it got implemented on all
     // platforms.

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -38,13 +38,12 @@ void BackgroundTaskRunner::PostTask(std::unique_ptr<Task> task) {
 }
 
 void BackgroundTaskRunner::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
-  CHECK(false && "idle tasks not enabled");
+  UNREACHABLE();
 }
 
 void BackgroundTaskRunner::PostDelayedTask(std::unique_ptr<v8::Task> task,
                                            double delay_in_seconds) {
-  // It's unclear whether this is required at all for background tasks.
-  PostTask(std::move(task));
+  UNREACHABLE();
 }
 
 void BackgroundTaskRunner::BlockingDrain() {
@@ -77,7 +76,7 @@ void PerIsolatePlatformData::FlushTasks(uv_async_t* handle) {
 }
 
 void PerIsolatePlatformData::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
-  CHECK(false && "idle tasks not enabled");
+  UNREACHABLE();
 }
 
 void PerIsolatePlatformData::PostTask(std::unique_ptr<Task> task) {

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -26,12 +26,10 @@ static void BackgroundRunner(void* data) {
 
 BackgroundTaskRunner::BackgroundTaskRunner(int thread_pool_size) {
   for (int i = 0; i < thread_pool_size; i++) {
-    uv_thread_t* t = new uv_thread_t();
-    if (uv_thread_create(t, BackgroundRunner, &background_tasks_) != 0) {
-      delete t;
+    std::unique_ptr<uv_thread_t> t { new uv_thread_t() };
+    if (uv_thread_create(t.get(), BackgroundRunner, &background_tasks_) != 0)
       break;
-    }
-    threads_.push_back(std::unique_ptr<uv_thread_t>(t));
+    threads_.push_back(std::move(t));
   }
 }
 

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -24,6 +24,46 @@ static void BackgroundRunner(void* data) {
   }
 }
 
+BackgroundTaskRunner::BackgroundTaskRunner(int thread_pool_size) {
+  for (int i = 0; i < thread_pool_size; i++) {
+    uv_thread_t* t = new uv_thread_t();
+    if (uv_thread_create(t, BackgroundRunner, &background_tasks_) != 0) {
+      delete t;
+      break;
+    }
+    threads_.push_back(std::unique_ptr<uv_thread_t>(t));
+  }
+}
+
+void BackgroundTaskRunner::PostTask(std::unique_ptr<Task> task) {
+  background_tasks_.Push(std::move(task));
+}
+
+void BackgroundTaskRunner::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
+  CHECK(false && "idle tasks not enabled");
+}
+
+void BackgroundTaskRunner::PostDelayedTask(std::unique_ptr<v8::Task> task,
+                                           double delay_in_seconds) {
+  // It's unclear whether this is required at all for background tasks.
+  PostTask(std::move(task));
+}
+
+void BackgroundTaskRunner::BlockingDrain() {
+  background_tasks_.BlockingDrain();
+}
+
+void BackgroundTaskRunner::Shutdown() {
+  background_tasks_.Stop();
+  for (size_t i = 0; i < threads_.size(); i++) {
+    CHECK_EQ(0, uv_thread_join(threads_[i].get()));
+  }
+}
+
+size_t BackgroundTaskRunner::NumberOfAvailableBackgroundThreads() const {
+  return threads_.size();
+}
+
 PerIsolatePlatformData::PerIsolatePlatformData(
     v8::Isolate* isolate, uv_loop_t* loop)
   : isolate_(isolate), loop_(loop) {
@@ -38,17 +78,20 @@ void PerIsolatePlatformData::FlushTasks(uv_async_t* handle) {
   platform_data->FlushForegroundTasksInternal();
 }
 
-void PerIsolatePlatformData::CallOnForegroundThread(
-    std::unique_ptr<Task> task) {
+void PerIsolatePlatformData::PostIdleTask(std::unique_ptr<v8::IdleTask> task) {
+  CHECK(false && "idle tasks not enabled");
+}
+
+void PerIsolatePlatformData::PostTask(std::unique_ptr<Task> task) {
   foreground_tasks_.Push(std::move(task));
   uv_async_send(flush_tasks_);
 }
 
-void PerIsolatePlatformData::CallDelayedOnForegroundThread(
-  std::unique_ptr<Task> task, double delay_in_seconds) {
+void PerIsolatePlatformData::PostDelayedTask(
+    std::unique_ptr<Task> task, double delay_in_seconds) {
   std::unique_ptr<DelayedTask> delayed(new DelayedTask());
   delayed->task = std::move(task);
-  delayed->platform_data = this;
+  delayed->platform_data = shared_from_this();
   delayed->timeout = delay_in_seconds;
   foreground_delayed_tasks_.Push(std::move(delayed));
   uv_async_send(flush_tasks_);
@@ -80,49 +123,43 @@ NodePlatform::NodePlatform(int thread_pool_size,
     TracingController* controller = new TracingController();
     tracing_controller_.reset(controller);
   }
-  for (int i = 0; i < thread_pool_size; i++) {
-    uv_thread_t* t = new uv_thread_t();
-    if (uv_thread_create(t, BackgroundRunner, &background_tasks_) != 0) {
-      delete t;
-      break;
-    }
-    threads_.push_back(std::unique_ptr<uv_thread_t>(t));
-  }
+  background_task_runner_ =
+      std::make_shared<BackgroundTaskRunner>(thread_pool_size);
 }
 
 void NodePlatform::RegisterIsolate(IsolateData* isolate_data, uv_loop_t* loop) {
   Isolate* isolate = isolate_data->isolate();
   Mutex::ScopedLock lock(per_isolate_mutex_);
-  PerIsolatePlatformData* existing = per_isolate_[isolate];
-  if (existing != nullptr)
+  std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
+  if (existing) {
     existing->ref();
-  else
-    per_isolate_[isolate] = new PerIsolatePlatformData(isolate, loop);
+  } else {
+    per_isolate_[isolate] =
+        std::make_shared<PerIsolatePlatformData>(isolate, loop);
+  }
 }
 
 void NodePlatform::UnregisterIsolate(IsolateData* isolate_data) {
   Isolate* isolate = isolate_data->isolate();
   Mutex::ScopedLock lock(per_isolate_mutex_);
-  PerIsolatePlatformData* existing = per_isolate_[isolate];
-  CHECK_NE(existing, nullptr);
+  std::shared_ptr<PerIsolatePlatformData> existing = per_isolate_[isolate];
+  CHECK(existing);
   if (existing->unref() == 0) {
-    delete existing;
     per_isolate_.erase(isolate);
   }
 }
 
 void NodePlatform::Shutdown() {
-  background_tasks_.Stop();
-  for (size_t i = 0; i < threads_.size(); i++) {
-    CHECK_EQ(0, uv_thread_join(threads_[i].get()));
+  background_task_runner_->Shutdown();
+
+  {
+    Mutex::ScopedLock lock(per_isolate_mutex_);
+    per_isolate_.clear();
   }
-  Mutex::ScopedLock lock(per_isolate_mutex_);
-  for (const auto& pair : per_isolate_)
-    delete pair.second;
 }
 
 size_t NodePlatform::NumberOfAvailableBackgroundThreads() {
-  return threads_.size();
+  return background_task_runner_->NumberOfAvailableBackgroundThreads();
 }
 
 void PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<Task> task) {
@@ -155,14 +192,14 @@ void PerIsolatePlatformData::CancelPendingDelayedTasks() {
 }
 
 void NodePlatform::DrainBackgroundTasks(Isolate* isolate) {
-  PerIsolatePlatformData* per_isolate = ForIsolate(isolate);
+  std::shared_ptr<PerIsolatePlatformData> per_isolate = ForIsolate(isolate);
 
   do {
     // Right now, there is no way to drain only background tasks associated
     // with a specific isolate, so this sometimes does more work than
     // necessary. In the long run, that functionality is probably going to
     // be available anyway, though.
-    background_tasks_.BlockingDrain();
+    background_task_runner_->BlockingDrain();
   } while (per_isolate->FlushForegroundTasksInternal());
 }
 
@@ -198,24 +235,25 @@ bool PerIsolatePlatformData::FlushForegroundTasksInternal() {
 
 void NodePlatform::CallOnBackgroundThread(Task* task,
                                           ExpectedRuntime expected_runtime) {
-  background_tasks_.Push(std::unique_ptr<Task>(task));
+  background_task_runner_->PostTask(std::unique_ptr<Task>(task));
 }
 
-PerIsolatePlatformData* NodePlatform::ForIsolate(Isolate* isolate) {
+std::shared_ptr<PerIsolatePlatformData>
+NodePlatform::ForIsolate(Isolate* isolate) {
   Mutex::ScopedLock lock(per_isolate_mutex_);
-  PerIsolatePlatformData* data = per_isolate_[isolate];
-  CHECK_NE(data, nullptr);
+  std::shared_ptr<PerIsolatePlatformData> data = per_isolate_[isolate];
+  CHECK(data);
   return data;
 }
 
 void NodePlatform::CallOnForegroundThread(Isolate* isolate, Task* task) {
-  ForIsolate(isolate)->CallOnForegroundThread(std::unique_ptr<Task>(task));
+  ForIsolate(isolate)->PostTask(std::unique_ptr<Task>(task));
 }
 
 void NodePlatform::CallDelayedOnForegroundThread(Isolate* isolate,
                                                  Task* task,
                                                  double delay_in_seconds) {
-  ForIsolate(isolate)->CallDelayedOnForegroundThread(
+  ForIsolate(isolate)->PostDelayedTask(
     std::unique_ptr<Task>(task), delay_in_seconds);
 }
 
@@ -228,6 +266,16 @@ void NodePlatform::CancelPendingDelayedTasks(v8::Isolate* isolate) {
 }
 
 bool NodePlatform::IdleTasksEnabled(Isolate* isolate) { return false; }
+
+std::shared_ptr<v8::TaskRunner>
+NodePlatform::GetBackgroundTaskRunner(Isolate* isolate) {
+  return background_task_runner_;
+}
+
+std::shared_ptr<v8::TaskRunner>
+NodePlatform::GetForegroundTaskRunner(Isolate* isolate) {
+  return ForIsolate(isolate);
+}
 
 double NodePlatform::MonotonicallyIncreasingTime() {
   // Convert nanos to seconds.


### PR DESCRIPTION
V8 is switching APIs for scheduling tasks. Implement the new APIs.

Fixes: nodejs/node-v8#24
Refs: v8/v8@c690f54

Note: This cherry-picks the API change itself (which is scheduled for V8 6.4) into this branch. We can wait for that release to perform the change if we like, but I’m not sure how we’d do node-canary coverage without this?

/cc @nodejs/v8 @gahaas

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (the WASM test fails without it, see the linked issue)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/node_platform

~~CI: https://ci.nodejs.org/job/node-test-commit/14146/~~
CI: https://ci.nodejs.org/job/node-test-commit/14147/