### PR TITLE
fs: use arrow functions instead of `.bind` or `self`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2091,30 +2091,27 @@ ReadStream.prototype._read = function(n) {
     return this.push(null);
 
   // the actual read.
-  var self = this;
-  fs.read(this.fd, pool, pool.used, toRead, this.pos, onread);
+  fs.read(this.fd, pool, pool.used, toRead, this.pos, (er, bytesRead) => {
+    if (er) {
+      if (this.autoClose) {
+        this.destroy();
+      }
+      this.emit('error', er);
+    } else {
+      var b = null;
+      if (bytesRead > 0) {
+        this.bytesRead += bytesRead;
+        b = thisPool.slice(start, start + bytesRead);
+      }
+
+      this.push(b);
+    }
+  });
 
   // move the pool positions, and internal position for reading.
   if (this.pos !== undefined)
     this.pos += toRead;
   pool.used += toRead;
-
-  function onread(er, bytesRead) {
-    if (er) {
-      if (self.autoClose) {
-        self.destroy();
-      }
-      self.emit('error', er);
-    } else {
-      var b = null;
-      if (bytesRead > 0) {
-        self.bytesRead += bytesRead;
-        b = thisPool.slice(start, start + bytesRead);
-      }
-
-      self.push(b);
-    }
-  }
 };
 
 ReadStream.prototype._destroy = function(err, cb) {
@@ -2209,7 +2206,7 @@ fs.FileWriteStream = fs.WriteStream; // support the legacy name
 
 
 WriteStream.prototype.open = function() {
-  fs.open(this.path, this.flags, this.mode, function(er, fd) {
+  fs.open(this.path, this.flags, this.mode, (er, fd) => {
     if (er) {
       if (this.autoClose) {
         this.destroy();
@@ -2220,7 +2217,7 @@ WriteStream.prototype.open = function() {
 
     this.fd = fd;
     this.emit('open', fd);
-  }.bind(this));
+  });
 };
 
 
@@ -2234,15 +2231,14 @@ WriteStream.prototype._write = function(data, encoding, cb) {
     });
   }
 
-  var self = this;
-  fs.write(this.fd, data, 0, data.length, this.pos, function(er, bytes) {
+  fs.write(this.fd, data, 0, data.length, this.pos, (er, bytes) => {
     if (er) {
-      if (self.autoClose) {
-        self.destroy();
+      if (this.autoClose) {
+        this.destroy();
       }
       return cb(er);
     }
-    self.bytesWritten += bytes;
+    this.bytesWritten += bytes;
     cb();
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
