### PR TITLE
util: add tagOnly option to util.inspect

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -63,6 +63,7 @@ const {
 
 const inspectDefaultOptions = Object.seal({
   showHidden: false,
+  tagOnly: false,
   depth: 2,
   colors: false,
   customInspect: true,
@@ -267,6 +268,7 @@ function inspect(obj, opts) {
     seen: [],
     stylize: stylizeNoColor,
     showHidden: inspectDefaultOptions.showHidden,
+    tagOnly: inspectDefaultOptions.tagOnly,
     depth: inspectDefaultOptions.depth,
     colors: inspectDefaultOptions.colors,
     customInspect: inspectDefaultOptions.customInspect,
@@ -589,6 +591,9 @@ function formatValue(ctx, value, recurseTimes, ln) {
                          'special');
     recurseTimes -= 1;
   }
+
+  if (ctx.tagOnly)
+    return braces.join('');
 
   ctx.seen.push(value);
   const output = formatter(ctx, value, recurseTimes, keys);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -111,6 +111,14 @@ assert(!/Object/.test(
   util.inspect({ a: { a: { a: { a: {} } } } }, undefined, null, true)
 ));
 
+for (const [input, output] of [
+  [{ a: 1 }, '{}'],
+  [[1, 2], '[]'],
+  [new Map([['a', 1], [1, 'a']]), 'Map {}'],
+  [new Set([1, 2, 3]), 'Set {}'],
+])
+  assert.strictEqual(util.inspect(input, { tagOnly: true }), output);
+
 for (const showHidden of [true, false]) {
   const ab = new ArrayBuffer(4);
   const dv = new DataView(ab, 1, 2);


### PR DESCRIPTION
Returns the inspected value without inspecting the keys/values of the
object.

I am requesting to add this feature mostly so that it can be used with [console.table](https://github.com/nodejs/node/issues/17128), but I'm sure people will use it for other things too.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util