### PR TITLE
net: remove deprecated getters for internals

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -638,7 +638,7 @@ Type: End-of-Life
 <a id="DEP0073"></a>
 ### DEP0073: Several internal properties of net.Server
 
-Type: Runtime
+Type: End-of-Life
 
 Accessing several internal, undocumented properties of `net.Server` instances
 with inappropriate names has been deprecated.

--- a/lib/net.js
+++ b/lib/net.js
@@ -1734,34 +1734,6 @@ if (process.platform === 'win32') {
   _setSimultaneousAccepts = function(handle) {};
 }
 
-// TODO(addaleax): Remove these after the Node 9.x branch cut.
-Object.defineProperty(Server.prototype, '_usingSlaves', {
-  get: internalUtil.deprecate(function() {
-    return this._usingWorkers;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
-  set: internalUtil.deprecate((val) => {
-    this._usingWorkers = val;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
-  configurable: true, enumerable: false
-});
-
-Object.defineProperty(Server.prototype, '_slaves', {
-  get: internalUtil.deprecate(function() {
-    return this._workers;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
-  set: internalUtil.deprecate((val) => {
-    this._workers = val;
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
-  configurable: true, enumerable: false
-});
-
-Object.defineProperty(Server.prototype, '_setupSlave', {
-  value: internalUtil.deprecate(function(socketList) {
-    return this._setupWorker(socketList);
-  }, 'Accessing internal properties of net.Server is deprecated.', 'DEP0073'),
-  configurable: true, enumerable: false
-});
-
 module.exports = {
   _createServerHandle: createServerHandle,
   _normalizeArgs: normalizeArgs,


### PR DESCRIPTION
Remove the getters introduced in 75a19fb379c2d936c6.

Refs: https://github.com/nodejs/node/pull/14449

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

net