### PR TITLE
stream: improve the error message of `ERR_INVALID_ARG_TYPE`

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -285,7 +285,7 @@ function chunkInvalid(state, chunk) {
       chunk !== undefined &&
       !state.objectMode) {
     er = new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                              'chunk', 'string/Buffer/Uint8Array');
+                              'chunk', ['string', 'Buffer', 'Uint8Array']);
   }
   return er;
 }

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -252,7 +252,8 @@ function validChunk(stream, state, chunk, cb) {
   } else if (typeof chunk !== 'string' &&
              chunk !== undefined &&
              !state.objectMode) {
-    er = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'chunk', 'string/buffer');
+    er = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'chunk',
+                              ['string', 'Buffer']);
   }
   if (er) {
     stream.emit('error', er);


### PR DESCRIPTION
The `expected` argument of `ERR_INVALID_ARG_TYPE` can be an array, which is better than a single string.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
stream
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
