### PR TITLE
console, util: add dirxml method

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -162,6 +162,15 @@ Console.prototype.dir = function dir(object, options) {
 };
 
 
+Console.prototype.dirxml = function dirxml(object, options, xml = false) {
+  write(this._ignoreErrors,
+        this._stdout,
+        util.xmlInspect(object, options, xml),
+        this._stdoutErrorHandler,
+        this[kGroupIndent]);
+};
+
+
 Console.prototype.time = function time(label = 'default') {
   // Coerces everything other than Symbol to a string
   label = `${label}`;

--- a/lib/util.js
+++ b/lib/util.js
@@ -299,6 +299,34 @@ function inspect(obj, opts) {
 }
 inspect.custom = customInspectSymbol;
 
+/**
+ * Echos the value of a value. Tries to print the value out
+ * in the best way possible given the different types. Allows
+ * passing a custom inspection function for xml parsing.
+ *
+ * @param {Object} obj The object to print out
+ * @param {Object} opts Optional options object that alters the output.
+ * @param {Function|boolean} xml The custom inspect function or flag
+ */
+function xmlInspect(obj, opts, xml = false) {
+  let custom = false;
+  if (xml !== false ||
+    (opts.customInspect && opts.customInspect !== false)) {
+    custom = true;
+    if (typeof xml === 'function') {
+      obj[inspect.custom] = xml;
+    } else if (xml === true) {
+      if (!(obj.inspect && typeof obj.inspect === 'function')) {
+        throw new errors.TypeError(
+          'ERR_INVALID_ARG_TYPE', 'xml', ['function', 'boolean']
+        );
+      }
+    }
+  }
+  opts = Object.assign({ customInspect: custom }, opts);
+  return inspect(obj, opts);
+}
+
 Object.defineProperty(inspect, 'defaultOptions', {
   get() {
     return inspectDefaultOptions;
@@ -1098,6 +1126,7 @@ module.exports = exports = {
   format,
   inherits,
   inspect,
+  xmlInspect,
   isArray: Array.isArray,
   isBoolean,
   isBuffer,


### PR DESCRIPTION
This is an absolute first draft.
This method was previously exposed by V8 (since Node v8.0.0) and not
implemented in Node directly.
Tests coming soon.

Refs: https://github.com/nodejs/node/issues/17128

**Please don't hesitate to leave me an advice. Tests are coming, and doc, but I first want to be sure I'm doing it right, or not bad at least.**

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console, util