### PR TITLE
doc: require CI status indicator in PRs

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -142,7 +142,7 @@ test should *fail* before the change, and *pass* after the change.
 All pull requests that modify executable code should be subjected to
 continuous integration tests on the
 [project CI server](https://ci.nodejs.org/).
-The pull request should have a CI status indicator.
+The pull request should have a CI status indicator if possible.
 
 #### Useful CI Jobs
 

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -142,6 +142,7 @@ test should *fail* before the change, and *pass* after the change.
 All pull requests that modify executable code should be subjected to
 continuous integration tests on the
 [project CI server](https://ci.nodejs.org/).
+The pull request should have a CI status indicator.
 
 #### Useful CI Jobs
 


### PR DESCRIPTION
Commits are often landed despite failing on one or more CI platforms.
Having a CI status indicator in the PR should make this less likely to
happen.

Examples from the last 6 months:

664512678d8d02e2ef413136cf262dcf7debb42d
f912080bf2d8fd024d3443f3ab9e399bc84a724b
aa011a111d46815998ddc28179b9ec42b6e662e6
a6973a38117de2e1b7681647160e55c8f9ad4050

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc