### PR TITLE
console: add dirxml method

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -277,6 +277,21 @@ Defaults to `2`. To make it recurse indefinitely, pass `null`.
 Defaults to `false`. Colors are customizable; see
 [customizing `util.inspect()` colors][].
 
+### console.dirxml(...data)
+<!-- YAML
+added: v8.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/17128
+    description: "`console.dirxml` now calls `console.dir` for each argument."
+-->
+* `...data` {any}
+
+This method calls `console.dir()` with default options for each argument it
+receives. See [`console.dir()`][] for more details about said defaults.
+Please note that this method doesn't produce any xml formatting and uses the
+default `console.dir()` formatting resolution instead.
+
 ### console.error([data][, ...args])
 <!-- YAML
 added: v0.1.100
@@ -435,18 +450,6 @@ The following methods are exposed by the V8 engine in the general API but do
 not display anything unless used in conjunction with the [inspector][]
 (`--inspect` flag).
 
-### console.dirxml(object)
-<!-- YAML
-added: v8.0.0
--->
-* `object` {string}
-
-This method does not display anything unless used in the inspector. The
-`console.dirxml()` method displays in `stdout` an XML interactive tree
-representation of the descendants of the specified `object` if possible, or the
-JavaScript representation if not. Calling `console.dirxml()` on an HTML or XML
-element is equivalent to calling `console.log()`.
-
 ### console.markTimeline(label)
 <!-- YAML
 added: v8.0.0
@@ -521,6 +524,7 @@ added: v8.0.0
 This method does not display anything unless used in the inspector. The
 `console.timelineEnd()` method is the deprecated form of [`console.timeEnd()`][].
 
+[`console.dir()`]: #console_console_dir_obj_options
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -282,15 +282,13 @@ Defaults to `false`. Colors are customizable; see
 added: v8.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/17128
-    description: "`console.dirxml` now calls `console.dir` for each argument."
+    pr-url: https://github.com/nodejs/node/pull/17152
+    description: "`console.dirxml` now calls `console.log` for its arguments."
 -->
 * `...data` {any}
 
-This method calls `console.dir()` with default options for each argument it
-receives. See [`console.dir()`][] for more details about said defaults.
-Please note that this method doesn't produce any xml formatting and uses the
-default `console.dir()` formatting resolution instead.
+This method calls `console.log()` passing it the arguments received.
+Please note that this method does not produce any XML formatting.
 
 ### console.error([data][, ...args])
 <!-- YAML
@@ -524,7 +522,6 @@ added: v8.0.0
 This method does not display anything unless used in the inspector. The
 `console.timelineEnd()` method is the deprecated form of [`console.timeEnd()`][].
 
-[`console.dir()`]: #console_console_dir_obj_options
 [`console.error()`]: #console_console_error_data_args
 [`console.group()`]: #console_console_group_label
 [`console.log()`]: #console_console_log_data_args

--- a/lib/console.js
+++ b/lib/console.js
@@ -163,20 +163,8 @@ Console.prototype.dir = function dir(object, options) {
 
 
 Console.prototype.dirxml = function dirxml(...data) {
-  const optionProps = ['showHidden', 'depth', 'colors'],
-    maybeOptions = Object.getOwnPropertyNames(data.slice(-1)),
-    isOption = maybeOptions.some((p) => optionProps.indexOf(p) !== -1);
-  let options = { customInspect: false };
-
-  if (isOption) {
-    options = Object.assign(data.splice(-1), options);
-  }
   for (const item of data) {
-    write(this._ignoreErrors,
-          this._stdout,
-          util.inspect(item, options),
-          this._stdoutErrorHandler,
-          this[kGroupIndent]);
+    Console.prototype.dir.call(this, item);
   }
 };
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -162,11 +162,7 @@ Console.prototype.dir = function dir(object, options) {
 };
 
 
-Console.prototype.dirxml = function dirxml(...data) {
-  for (const item of data) {
-    Console.prototype.dir.call(this, item);
-  }
-};
+Console.prototype.dirxml = Console.prototype.log;
 
 
 Console.prototype.time = function time(label = 'default') {

--- a/lib/console.js
+++ b/lib/console.js
@@ -162,6 +162,25 @@ Console.prototype.dir = function dir(object, options) {
 };
 
 
+Console.prototype.dirxml = function dirxml(...data) {
+  const optionProps = ['showHidden', 'depth', 'colors'],
+    maybeOptions = Object.getOwnPropertyNames(data.slice(-1)),
+    isOption = maybeOptions.some((p) => optionProps.indexOf(p) !== -1);
+  let options = { customInspect: false };
+
+  if (isOption) {
+    options = Object.assign(data.splice(-1), options);
+  }
+  for (const item of data) {
+    write(this._ignoreErrors,
+          this._stdout,
+          util.inspect(item, options),
+          this._stdoutErrorHandler,
+          this[kGroupIndent]);
+  }
+};
+
+
 Console.prototype.time = function time(label = 'default') {
   // Coerces everything other than Symbol to a string
   label = `${label}`;

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -179,13 +179,10 @@ assert.strictEqual(strings.shift(),
                    "{ foo: 'bar', inspect: [Function: inspect] }\n");
 assert.ok(strings.shift().includes('foo: [Object]'));
 assert.strictEqual(strings.shift().includes('baz'), false);
-assert.strictEqual(strings.shift(),
-                   "{ foo: 'bar', inspect: [Function: inspect] }\n");
-assert.strictEqual(strings.shift(),
-                   "{ foo: 'bar', inspect: [Function: inspect] }\n");
-assert.strictEqual(strings.shift().includes('foo: { bar: { baz:'), true);
-assert.strictEqual(strings.shift().includes('quux'), true);
-assert.strictEqual(strings.shift().includes('quux: true'), true);
+assert.strictEqual(strings.shift(), 'inspect inspect\n');
+assert.ok(strings[0].includes('foo: { bar: { baz:'));
+assert.ok(strings[0].includes('quux'));
+assert.ok(strings.shift().includes('quux: true'));
 
 assert.ok(/^label: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -103,6 +103,14 @@ console.dir(custom_inspect, { showHidden: false });
 console.dir({ foo: { bar: { baz: true } } }, { depth: 0 });
 console.dir({ foo: { bar: { baz: true } } }, { depth: 1 });
 
+// test console.dirxml()
+console.dirxml(custom_inspect, custom_inspect);
+console.dirxml(
+  { foo: { bar: { baz: true } } },
+  { foo: { bar: { quux: false } } },
+  { foo: { bar: { quux: true } } }
+);
+
 // test console.trace()
 console.trace('This is a %j %d', { formatted: 'trace' }, 10, 'foo');
 
@@ -171,6 +179,14 @@ assert.strictEqual(strings.shift(),
                    "{ foo: 'bar', inspect: [Function: inspect] }\n");
 assert.ok(strings.shift().includes('foo: [Object]'));
 assert.strictEqual(strings.shift().includes('baz'), false);
+assert.strictEqual(strings.shift(),
+                   "{ foo: 'bar', inspect: [Function: inspect] }\n");
+assert.strictEqual(strings.shift(),
+                   "{ foo: 'bar', inspect: [Function: inspect] }\n");
+assert.strictEqual(strings.shift().includes('foo: { bar: { baz:'), true);
+assert.strictEqual(strings.shift().includes('quux'), true);
+assert.strictEqual(strings.shift().includes('quux: true'), true);
+
 assert.ok(/^label: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^__proto__: \d+\.\d{3}ms$/.test(strings.shift().trim()));
 assert.ok(/^constructor: \d+\.\d{3}ms$/.test(strings.shift().trim()));


### PR DESCRIPTION
This is an absolute ~~first~~ second draft.
This method was previously exposed by V8 (since Node v8.0.0) and not
implemented in Node directly.
Tests coming soon.

Refs: https://github.com/nodejs/node/issues/17128

**Please feel free to comment and give any advice!**

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
console
