### PR TITLE
module: be lazy when creating CJS facades

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -568,8 +568,9 @@ Module.prototype.load = function(filename) {
     const urlString = `${url}`;
     const exports = this.exports;
     if (ESMLoader.moduleMap.has(urlString) !== true) {
-      ESMLoader.moduleMap.set(urlString,
-                              new ModuleJob(ESMLoader, url, async () => {
+      ESMLoader.moduleMap.set(
+        urlString,
+        new ModuleJob(ESMLoader, url, async () => {
           const ctx = createDynamicModule(
             ['default'], url);
           ctx.reflect.exports.default.set(exports);

--- a/lib/module.js
+++ b/lib/module.js
@@ -566,15 +566,20 @@ Module.prototype.load = function(filename) {
   if (ESMLoader) {
     const url = getURLFromFilePath(filename);
     const urlString = `${url}`;
+    const exports = this.exports;
     if (ESMLoader.moduleMap.has(urlString) !== true) {
-      const ctx = createDynamicModule(['default'], url);
-      ctx.reflect.exports.default.set(this.exports);
       ESMLoader.moduleMap.set(urlString,
-                              new ModuleJob(ESMLoader, url, async () => ctx));
+                              new ModuleJob(ESMLoader, url, async () => {
+          const ctx = createDynamicModule(
+            ['default'], url);
+          ctx.reflect.exports.default.set(exports);
+          return ctx;
+        })
+      );
     } else {
       const job = ESMLoader.moduleMap.get(urlString);
       if (job.reflect)
-        job.reflect.exports.default.set(this.exports);
+        job.reflect.exports.default.set(exports);
     }
   }
 };


### PR DESCRIPTION
This should remove the penalty for loading CJS that is never imported.

Aside: We could probably do more low hanging optimizations if we could reuse facades.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

module