### PR TITLE
doc: fs.readFile is async but not partitioned

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1897,6 +1897,11 @@ Any specified file descriptor has to support reading.
 *Note*: If a file descriptor is specified as the `path`, it will not be closed
 automatically.
 
+*Note*: `fs.readFile()` reads the entire file in a single threadpool request.
+To minimize threadpool task length variation, prefer the partitioned APIs
+`fs.read()` and `fs.createReadStream()` when reading files as part of
+fulfilling a client request.
+
 ## fs.readFileSync(path[, options])
 <!-- YAML
 added: v0.1.8


### PR DESCRIPTION
This change was suggested during the discussion of #17054.

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
docs, fs
