### PR TITLE
[v6.x backport] test: allow tests to pass without internet

### DIFF
--- a/test/internet/test-dgram-membership.js
+++ b/test/internet/test-dgram-membership.js
@@ -1,0 +1,37 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const multicastAddress = '224.0.0.114';
+
+const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
+
+// addMembership() with valid socket and multicast address should not throw
+{
+  const socket = setup();
+  assert.doesNotThrow(() => { socket.addMembership(multicastAddress); });
+  socket.close();
+}
+
+// dropMembership() without previous addMembership should throw
+{
+  const socket = setup();
+  assert.throws(
+    () => { socket.dropMembership(multicastAddress); },
+    /^Error: dropMembership EADDRNOTAVAIL$/
+  );
+  socket.close();
+}
+
+// dropMembership() after addMembership() should not throw
+{
+  const socket = setup();
+  assert.doesNotThrow(
+    () => {
+      socket.addMembership(multicastAddress);
+      socket.dropMembership(multicastAddress);
+    }
+  );
+  socket.close();
+}

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -56,32 +56,3 @@ const setup = dgram.createSocket.bind(dgram, {type: 'udp4', reuseAddr: true});
                 /^Error: dropMembership EINVAL$/);
   socket.close();
 }
-
-// addMembership() with valid socket and multicast address should not throw
-{
-  const socket = setup();
-  assert.doesNotThrow(() => { socket.addMembership(multicastAddress); });
-  socket.close();
-}
-
-// dropMembership() without previous addMembership should throw
-{
-  const socket = setup();
-  assert.throws(
-    () => { socket.dropMembership(multicastAddress); },
-    /^Error: dropMembership EADDRNOTAVAIL$/
-  );
-  socket.close();
-}
-
-// dropMembership() after addMembership() should not throw
-{
-  const socket = setup();
-  assert.doesNotThrow(
-    () => {
-      socket.addMembership(multicastAddress);
-      socket.dropMembership(multicastAddress);
-    }
-  );
-  socket.close();
-}


### PR DESCRIPTION
Currently when running the test without an internet connection there are
two JavaScript test failures

This commit moves the two JavaScript tests to test/internet.

PR-URL: https://github.com/nodejs/node/pull/16255
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test