### PR TITLE
[v6.x backport] build: include src\tracing when linting on win

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -383,8 +383,10 @@ if %errorlevel% equ 0 goto exit
 echo %1 | findstr /c:"src\tree.h"
 if %errorlevel% equ 0 goto exit
 
-@rem skip subfolders under /src
-echo %1 | findstr /r /c:"src\\.*\\.*"
+echo %1 | findstr /r /c:"src\\tracing\\trace_event.h"
+if %errorlevel% equ 0 goto exit
+
+echo %1 | findstr /r /c:"src\\tracing\\trace_event_common.h"
 if %errorlevel% equ 0 goto exit
 
 echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.h"


### PR DESCRIPTION
This commit excludes src\tracing\trace_event.h and
src\tracing\trace_event_common.h from the linter but allows the
rest of the files in src\tracing to be examined by the linter
which is similar to what the Makefile does.

Refs: https://github.com/nodejs/node/pull/16720
PR-URL: https://github.com/nodejs/node/pull/16720
Reviewed-By: James M Snell <jasnell@gmail.com>


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, win