### PR TITLE
src: make base64.h self-contained

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -6,6 +6,7 @@
 #include "util.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 namespace node {
 //// Base 64 ////


### PR DESCRIPTION
This commit includes stdint.h (for uint8_t, uint32_t, and int8_t) to
make it self-contained.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src