### PR TITLE
test: remove unused parameter in test-next-tick-error-spin.js

### DIFF
--- a/test/sequential/test-next-tick-error-spin.js
+++ b/test/sequential/test-next-tick-error-spin.js
@@ -42,7 +42,7 @@ if (process.argv[2] !== 'child') {
   process.maxTickDepth = 10;
 
   // in the error handler, we trigger several MakeCallback events
-  d.on('error', function(e) {
+  d.on('error', function() {
     console.log('a');
     console.log('b');
     console.log('c');


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test
