### PR TITLE
build: remove empty VCLibrarianTool entry

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -212,8 +212,6 @@
         'DisableSpecificWarnings': ['4267'],
         'WarnAsError': 'false',
       },
-      'VCLibrarianTool': {
-      },
       'VCLinkerTool': {
         'conditions': [
           ['target_arch=="ia32"', {


### PR DESCRIPTION
I've come across this empty entry a few times and tried building and running the tests on windows successfully. Wanted to bring this is up in case it was just overlooked. 


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build, win

cc @nodejs/build @nodejs/platform-windows 