### PR TITLE
benchmark: set maxHeaderListPairs in http2 headers benchmark

### DIFF
--- a/benchmark/http2/headers.js
+++ b/benchmark/http2/headers.js
@@ -13,7 +13,9 @@ function main(conf) {
   const n = +conf.n;
   const nheaders = +conf.nheaders;
   const http2 = require('http2');
-  const server = http2.createServer();
+  const server = http2.createServer({
+    maxHeaderListPairs: 20000
+  });
 
   const headersObject = {
     ':path': '/',
@@ -34,7 +36,9 @@ function main(conf) {
     stream.end('Hi!');
   });
   server.listen(PORT, () => {
-    const client = http2.connect(`http://localhost:${PORT}/`);
+    const client = http2.connect(`http://localhost:${PORT}/`, {
+      maxHeaderListPairs: 20000
+    });
 
     function doRequest(remaining) {
       const req = client.request(headersObject);


### PR DESCRIPTION
After the introduction of `maxHeaderListPairs`, the headers benchmark needs to be updated to set that value otherwise it fails on the last bench case with error code 11.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark