### PR TITLE
src: fix compiler warning

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -555,7 +555,7 @@ class Http2Stream : public AsyncWrap,
   int ReadStop() override;
 
   // Required for StreamBase
-  int DoShutdown(ShutdownWrap* req_wrap);
+  int DoShutdown(ShutdownWrap* req_wrap) override;
 
   // Initiate a response on this stream.
   inline int SubmitResponse(nghttp2_nv* nva,


### PR DESCRIPTION
This commit fixes a -Winconsistent-missing-override warning.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src