### PR TITLE
lib: add `process` to internal module wrapper

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -593,7 +593,7 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, internalBinding) {',
+    '(function (exports, require, module, internalBinding, process) {',
     '\n});'
   ];
 
@@ -612,7 +612,7 @@
       const requireFn = this.id.startsWith('internal/deps/') ?
         NativeModule.requireForDeps :
         NativeModule.require;
-      fn(this.exports, requireFn, this, internalBinding);
+      fn(this.exports, requireFn, this, internalBinding, process);
 
       this.loaded = true;
     } finally {

--- a/test/parallel/test-repl-let-process.js
+++ b/test/parallel/test-repl-let-process.js
@@ -1,0 +1,10 @@
+'use strict';
+const common = require('../common');
+const repl = require('repl');
+
+common.globalCheck = false;
+
+// Regression test for https://github.com/nodejs/node/issues/6802
+const input = new common.ArrayStream();
+repl.start({ input, output: process.stdout, useGlobal: true });
+input.run(['let process']);


### PR DESCRIPTION
Share `process` through the module wrapper rather than relying
on nobody messing with `global.process`.

Fixes: https://github.com/nodejs/node/issues/6802

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

lib (but in particular the REPL)