### PR TITLE
refactor `test-http-exceptions` file to use countdown

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -387,7 +387,7 @@ The `Countdown` module provides a simple countdown mechanism for tests that
 require a particular action to be taken after a given number of completed
 tasks (for instance, shutting down an HTTP server after a specific number of
 requests). Note that _the Countdown will fail the test if the remainder
-not reach 0_.
+did not reach 0_.
 
 <!-- eslint-disable strict, required-modules -->
 ```js

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -386,7 +386,8 @@ Name of the temp directory used by tests.
 The `Countdown` module provides a simple countdown mechanism for tests that
 require a particular action to be taken after a given number of completed
 tasks (for instance, shutting down an HTTP server after a specific number of
-requests).
+requests). Note that the _The Countdown will fail the test if its callback
+is not executed_.
 
 <!-- eslint-disable strict, required-modules -->
 ```js

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -386,8 +386,8 @@ Name of the temp directory used by tests.
 The `Countdown` module provides a simple countdown mechanism for tests that
 require a particular action to be taken after a given number of completed
 tasks (for instance, shutting down an HTTP server after a specific number of
-requests). Note that the _The Countdown will fail the test if its callback
-is not executed_.
+requests). Note that _the Countdown will fail the test if the remainder
+not reach 0_.
 
 <!-- eslint-disable strict, required-modules -->
 ```js

--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -4,13 +4,14 @@
 const assert = require('assert');
 const kLimit = Symbol('limit');
 const kCallback = Symbol('callback');
+const common = require('./');
 
 class Countdown {
   constructor(limit, cb) {
     assert.strictEqual(typeof limit, 'number');
     assert.strictEqual(typeof cb, 'function');
     this[kLimit] = limit;
-    this[kCallback] = cb;
+    this[kCallback] = common.mustCall(cb);
   }
 
   dec() {

--- a/test/fixtures/failcounter.js
+++ b/test/fixtures/failcounter.js
@@ -1,0 +1,2 @@
+const Countdown = require('../common/countdown');
+new Countdown(2, () => {});

--- a/test/parallel/test-common-countdown.js
+++ b/test/parallel/test-common-countdown.js
@@ -1,11 +1,12 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const Countdown = require('../common/countdown');
+const fixtures = require('../common/fixtures');
+const { execFile } = require('child_process');
 
 let done = '';
-
 const countdown = new Countdown(2, () => done = true);
 assert.strictEqual(countdown.remaining, 2);
 countdown.dec();
@@ -13,3 +14,20 @@ assert.strictEqual(countdown.remaining, 1);
 countdown.dec();
 assert.strictEqual(countdown.remaining, 0);
 assert.strictEqual(done, true);
+
+const failFixtures = [
+  [
+    fixtures.path('failcounter.js'),
+    'Mismatched <anonymous> function calls. Expected exactly 1, actual 0.',
+  ]
+];
+
+for (const p of failFixtures) {
+  const [file, expected] = p;
+  execFile(process.argv[0], [file], common.mustCall((ex, stdout, stderr) => {
+    assert.ok(ex);
+    assert.strictEqual(stderr, '');
+    const firstLine = stdout.split('\n').shift();
+    assert.strictEqual(firstLine, expected);
+  }));
+}

--- a/test/parallel/test-common-countdown.js
+++ b/test/parallel/test-common-countdown.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const Countdown = require('../common/countdown');
 
 let done = '';
 
-const countdown = new Countdown(2, common.mustCall(() => done = true));
+const countdown = new Countdown(2, () => done = true);
 assert.strictEqual(countdown.remaining, 2);
 countdown.dec();
 assert.strictEqual(countdown.remaining, 1);

--- a/test/parallel/test-http-after-connect.js
+++ b/test/parallel/test-http-after-connect.js
@@ -32,7 +32,7 @@ const server = http.createServer(common.mustCall((req, res) => {
   setTimeout(() => res.end(req.url), 50);
 }, 2));
 
-const countdown = new Countdown(2, common.mustCall(() => server.close()));
+const countdown = new Countdown(2, () => server.close());
 
 server.on('connect', common.mustCall((req, socket) => {
   socket.write('HTTP/1.1 200 Connection established\r\n\r\n');

--- a/test/parallel/test-http-agent-destroyed-socket.js
+++ b/test/parallel/test-http-agent-destroyed-socket.js
@@ -80,7 +80,7 @@ const server = http.createServer(common.mustCall((req, res) => {
     assert(request1.socket.destroyed);
     // assert not reusing the same socket, since it was destroyed.
     assert.notStrictEqual(request1.socket, request2.socket);
-    const countdown = new Countdown(2, common.mustCall(() => server.close()));
+    const countdown = new Countdown(2, () => server.close());
     request2.socket.on('close', common.mustCall(() => countdown.dec()));
     response.on('end', common.mustCall(() => countdown.dec()));
     response.resume();

--- a/test/parallel/test-http-agent-maxsockets-regress-4050.js
+++ b/test/parallel/test-http-agent-maxsockets-regress-4050.js
@@ -17,7 +17,7 @@ const server = http.createServer(common.mustCall((req, res) => {
   res.end('hello world');
 }, 6));
 
-const countdown = new Countdown(6, common.mustCall(() => server.close()));
+const countdown = new Countdown(6, () => server.close());
 
 function get(path, callback) {
   return http.get({

--- a/test/parallel/test-http-agent-maxsockets.js
+++ b/test/parallel/test-http-agent-maxsockets.js
@@ -26,13 +26,13 @@ function get(path, callback) {
   }, callback);
 }
 
-const countdown = new Countdown(2, common.mustCall(() => {
+const countdown = new Countdown(2, () => {
   const freepool = agent.freeSockets[Object.keys(agent.freeSockets)[0]];
   assert.strictEqual(freepool.length, 2,
                      `expect keep 2 free sockets, but got ${freepool.length}`);
   agent.destroy();
   server.close();
-}));
+});
 
 function dec() {
   process.nextTick(() => countdown.dec());

--- a/test/parallel/test-http-client-abort.js
+++ b/test/parallel/test-http-client-abort.js
@@ -26,7 +26,7 @@ const Countdown = require('../common/countdown');
 
 const N = 8;
 
-const countdown = new Countdown(N, common.mustCall(() => server.close()));
+const countdown = new Countdown(N, () => server.close());
 
 const server = http.Server(common.mustCall((req, res) => {
   res.writeHead(200);
@@ -37,9 +37,9 @@ const server = http.Server(common.mustCall((req, res) => {
 server.listen(0, common.mustCall(() => {
 
   const requests = [];
-  const reqCountdown = new Countdown(N, common.mustCall(() => {
+  const reqCountdown = new Countdown(N, () => {
     requests.forEach((req) => req.abort());
-  }));
+  });
 
   const options = { port: server.address().port };
 

--- a/test/parallel/test-http-client-parse-error.js
+++ b/test/parallel/test-http-client-parse-error.js
@@ -25,7 +25,7 @@ const http = require('http');
 const net = require('net');
 const Countdown = require('../common/countdown');
 
-const countdown = new Countdown(2, common.mustCall(() => server.close()));
+const countdown = new Countdown(2, () => server.close());
 
 const payloads = [
   'HTTP/1.1 302 Object Moved\r\nContent-Length: 0\r\n\r\nhi world',

--- a/test/parallel/test-http-exceptions.js
+++ b/test/parallel/test-http-exceptions.js
@@ -21,7 +21,10 @@
 
 'use strict';
 require('../common');
+const Countdown = require('../common/countdown');
 const http = require('http');
+const NUMBER_OF_EXCEPTIONS = 4;
+const countdown = new Countdown(NUMBER_OF_EXCEPTIONS, () => process.exit(0));
 
 const server = http.createServer(function(req, res) {
   intentionally_not_defined(); // eslint-disable-line no-undef
@@ -30,16 +33,15 @@ const server = http.createServer(function(req, res) {
   res.end();
 });
 
+
 server.listen(0, function() {
-  for (let i = 0; i < 4; i += 1) {
+  for (let i = 0; i < NUMBER_OF_EXCEPTIONS; i += 1) {
     http.get({ port: this.address().port, path: `/busy/${i}` });
   }
 });
 
-let exception_count = 0;
-
 process.on('uncaughtException', function(err) {
   console.log(`Caught an exception: ${err}`);
   if (err.name === 'AssertionError') throw err;
-  if (++exception_count === 4) process.exit(0);
+  countdown.dec();
 });

--- a/test/parallel/test-http2-no-more-streams.js
+++ b/test/parallel/test-http2-no-more-streams.js
@@ -23,10 +23,10 @@ server.listen(0, common.mustCall(() => {
 
     assert.strictEqual(client.state.nextStreamID, nextID);
 
-    const countdown = new Countdown(2, common.mustCall(() => {
+    const countdown = new Countdown(2, () => {
       server.close();
       client.destroy();
-    }));
+    });
 
     {
       // This one will be ok

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -32,10 +32,10 @@ server.listen(0, common.mustCall(() => {
   const port = server.address().port;
   const client = http2.connect(`http://localhost:${port}`);
 
-  const countdown = new Countdown(2, common.mustCall(() => {
+  const countdown = new Countdown(2, () => {
     server.close();
     client.destroy();
-  }));
+  });
 
   const req = client.request({ ':method': 'POST' });
   req.on('response', common.mustCall());

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -33,10 +33,10 @@ server.on('stream', (stream, headers) => {
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
 
-  const countdown = new Countdown(tests.length, common.mustCall(() => {
+  const countdown = new Countdown(tests.length, () => {
     client.destroy();
     server.close();
-  }));
+  });
 
   tests.forEach((test) => {
     const req = client.request({

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -64,10 +64,10 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
     new PerformanceObserver(common.mustCall(callback, 3));
 
   const countdown =
-    new Countdown(3, common.mustCall(() => {
+    new Countdown(3, () => {
       observer.disconnect();
       assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_MARK], 1);
-    }));
+    });
 
   function callback(list, obs) {
     assert.strictEqual(obs, observer);

--- a/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
+++ b/test/parallel/test-timers-socket-timeout-removes-other-socket-unref-timer.js
@@ -33,7 +33,7 @@ const server = net.createServer(function onClient(client) {
 });
 
 server.listen(0, common.localhostIPv4, common.mustCall(() => {
-  const countdown = new Countdown(2, common.mustCall(() => server.close()));
+  const countdown = new Countdown(2, () => server.close());
 
   {
     const client = net.connect({ port: server.address().port });


### PR DESCRIPTION
- Refactored the test case `test-http-exceptions` to use countdown, as per issue #17169
- Added `common.mustCall` to the `countdown` callback, since the user will always want this function to be called, and it must fail if the user fails to decrease the counter to 0.
- Removed explicit `common.mustCall` functions around the `Countdown` callbacks in all the tests.
- Add test case for `countdown` to test that a mustCall is in place.
- Updated the `common.md` docs to inform the `countdown` users that the test will fail if the countdown callback was not called.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test