### PR TITLE
repl: backgrounding command to move awaits to "background" after tick

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -144,9 +144,11 @@ global or scoped variable, the input `fs` will be evaluated on-demand as
 
 #### Top-Level Await
 
-The default evaluator will run top-level await expressions. It will also move
-promises which take longer than a tick to evaluate into the background,
-allowing you to continue working with the repl.
+The default evaluator will run top-level await expressions.
+
+You can also enable await backgrounding using the `.backgrounding` command,
+which will allow top-level awaited promises to enter the background if they
+will take more than a tick to complete.
 
 <!-- eslint-skip -->
 ```js
@@ -156,6 +158,8 @@ allowing you to continue working with the repl.
 
 <!-- eslint-skip -->
 ```js
+> .backgrounding
+Top-level await backgrounding has been enabled
 > await new Promise(resolve => setTimeout(() => resolve(true), 5000))
 AWAIT01 (pending)
 > 5 + 5

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -160,7 +160,10 @@ allowing you to continue working with the repl.
 AWAIT01 (pending)
 > 5 + 5
 10
-> AWAIT01 => true
+> AWAIT01 (resolved) => true
+> await new Promise((_, reject) => setTimeout(() => reject(false), 5000))
+AWAIT02 (pending)
+> AWAIT02 (rejected) => false
 >
 ```
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -142,6 +142,28 @@ global or scoped variable, the input `fs` will be evaluated on-demand as
 > fs.createReadStream('./some/file');
 ```
 
+#### Top-Level Await
+
+The default evaluator will run top-level await expressions. It will also move
+promises which take longer than a second to evaluate into the background,
+allowing you to continue working with the repl.
+
+<!-- eslint-skip -->
+```js
+> await Promise.resolve(5);
+5
+```
+
+<!-- eslint-skip -->
+```js
+> await new Promise(resolve => setTimeout(() => resolve(true), 5000))
+AWAIT01 (pending)
+> 5 + 5
+10
+> AWAIT01 => true
+>
+```
+
 #### Assignment of the `_` (underscore) variable
 
 The default evaluator will, by default, assign the result of the most recently

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -145,7 +145,7 @@ global or scoped variable, the input `fs` will be evaluated on-demand as
 #### Top-Level Await
 
 The default evaluator will run top-level await expressions. It will also move
-promises which take longer than a second to evaluate into the background,
+promises which take longer than a tick to evaluate into the background,
 allowing you to continue working with the repl.
 
 <!-- eslint-skip -->

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -360,7 +360,8 @@ function REPLServer(prompt,
           clearImmediate(awaitImmediate);
           prioritizedSigintQueue.delete(sigintListener);
 
-          finishExecution(undefined, result, awaitId && `${awaitId} => `);
+          finishExecution(undefined, result,
+                          awaitId && `${awaitId} (resolved) => `);
           unpause();
         }, (err) => {
           clearImmediate(awaitImmediate);
@@ -375,11 +376,12 @@ function REPLServer(prompt,
           unpause();
           if (err && process.domain) {
             debug('not recoverable, send to domain');
-            process.domain.emit('error', err);
+            process.domain.emit('error', err, `${awaitId} (rejected) => `);
             process.domain.exit();
             return;
           }
-          finishExecution(err, undefined, awaitId && `${awaitId} => `);
+          finishExecution(err, undefined,
+                          awaitId && `${awaitId} (resolved) => `);
         });
       }
     }
@@ -391,7 +393,7 @@ function REPLServer(prompt,
 
   self.eval = self._domain.bind(eval_);
 
-  self._domain.on('error', function debugDomainError(e) {
+  self._domain.on('error', function debugDomainError(e, prefix) {
     debug('domain error');
     const top = replMap.get(self);
     const pstrace = Error.prepareStackTrace;
@@ -412,7 +414,7 @@ function REPLServer(prompt,
     if (isError && e.stack) {
       top.outputStream.write(`${e.stack}\n`);
     } else {
-      top.outputStream.write(`Thrown: ${String(e)}\n`);
+      top.outputStream.write(`${prefix ? prefix : 'Thrown: '}${String(e)}\n`);
     }
     top.clearBufferedCommand();
     top.lines.level = [];

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -158,6 +158,7 @@ function REPLServer(prompt,
   self.last = undefined;
   self.breakEvalOnSigint = !!breakEvalOnSigint;
   self.editorMode = false;
+  self.awaitId = 0;
 
   // just for backwards compat, see github.com/joyent/node/pull/7127
   self.rli = this;
@@ -264,7 +265,7 @@ function REPLServer(prompt,
     regExMatcher.test(savedRegExMatches.join(sep));
 
     let finished = false;
-    function finishExecution(err, result) {
+    function finishExecution(err, result, prefix) {
       if (finished) return;
       finished = true;
 
@@ -274,7 +275,7 @@ function REPLServer(prompt,
         savedRegExMatches[idx] = RegExp[`$${idx}`];
       }
 
-      cb(err, result);
+      cb(err, result, prefix);
     }
 
     if (!err) {
@@ -332,6 +333,7 @@ function REPLServer(prompt,
         let sigintListener;
         pause();
         let promise = result;
+
         if (self.breakEvalOnSigint) {
           const interrupt = new Promise((resolve, reject) => {
             sigintListener = () => {
@@ -342,15 +344,26 @@ function REPLServer(prompt,
           promise = Promise.race([promise, interrupt]);
         }
 
+        let awaitId = undefined;
+        const awaitImmediate = setImmediate(() => {
+          prioritizedSigintQueue.delete(sigintListener);
+          awaitId = `AWAIT${(++self.awaitId).toString().padStart(2, '0')}`;
+          self.outputStream.write(`${awaitId} (pending)\n`);
+          self.displayPrompt();
+          unpause();
+        });
+
         promise.then((result) => {
           // Remove prioritized SIGINT listener if it was not called.
           // TODO(TimothyGu): Use Promise.prototype.finally when it becomes
           // available.
+          clearImmediate(awaitImmediate);
           prioritizedSigintQueue.delete(sigintListener);
 
-          finishExecution(undefined, result);
+          finishExecution(undefined, result, awaitId && `${awaitId} => `);
           unpause();
         }, (err) => {
+          clearImmediate(awaitImmediate);
           // Remove prioritized SIGINT listener if it was not called.
           prioritizedSigintQueue.delete(sigintListener);
 
@@ -366,7 +379,7 @@ function REPLServer(prompt,
             process.domain.exit();
             return;
           }
-          finishExecution(err);
+          finishExecution(err, undefined, awaitId && `${awaitId} => `);
         });
       }
     }
@@ -599,7 +612,7 @@ function REPLServer(prompt,
     debug('eval %j', evalCmd);
     self.eval(evalCmd, self.context, 'repl', finish);
 
-    function finish(e, ret) {
+    function finish(e, ret, prefix) {
       debug('finish', e, ret);
       _memory.call(self, cmd);
 
@@ -636,12 +649,12 @@ function REPLServer(prompt,
           // When an invalid REPL command is used, error message is printed
           // immediately. We don't have to print anything else. So, only when
           // the second argument to this function is there, print it.
-          arguments.length === 2 &&
+          arguments.length > 1 &&
           (!self.ignoreUndefined || ret !== undefined)) {
         if (!self.underscoreAssigned) {
           self.last = ret;
         }
-        self.outputStream.write(self.writer(ret) + '\n');
+        self.outputStream.write(`${prefix ? prefix : ''}${self.writer(ret)}\n`);
       }
 
       // Display prompt again

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -158,6 +158,7 @@ function REPLServer(prompt,
   self.last = undefined;
   self.breakEvalOnSigint = !!breakEvalOnSigint;
   self.editorMode = false;
+  self.awaitBackgrounding = !!options.awaitBackgrounding;
   self.awaitId = 0;
 
   // just for backwards compat, see github.com/joyent/node/pull/7127
@@ -330,9 +331,11 @@ function REPLServer(prompt,
       }
 
       if (awaitPromise && !err) {
-        let sigintListener;
         pause();
+        let sigintListener;
+        let awaitId;
         let promise = result;
+        let awaitImmediate;
 
         if (self.breakEvalOnSigint) {
           const interrupt = new Promise((resolve, reject) => {
@@ -344,14 +347,15 @@ function REPLServer(prompt,
           promise = Promise.race([promise, interrupt]);
         }
 
-        let awaitId = undefined;
-        const awaitImmediate = setImmediate(() => {
-          prioritizedSigintQueue.delete(sigintListener);
-          awaitId = `AWAIT${(++self.awaitId).toString().padStart(2, '0')}`;
-          self.outputStream.write(`${awaitId} (pending)\n`);
-          self.displayPrompt();
-          unpause();
-        });
+        if (self.awaitBackgrounding) {
+          awaitImmediate = setImmediate(() => {
+            prioritizedSigintQueue.delete(sigintListener);
+            awaitId = `AWAIT${(++self.awaitId).toString().padStart(2, '0')}`;
+            self.outputStream.write(`${awaitId} (pending)\n`);
+            self.displayPrompt();
+            unpause();
+          });
+        }
 
         promise.then((result) => {
           // Remove prioritized SIGINT listener if it was not called.
@@ -376,7 +380,8 @@ function REPLServer(prompt,
           unpause();
           if (err && process.domain) {
             debug('not recoverable, send to domain');
-            process.domain.emit('error', err, `${awaitId} (rejected) => `);
+            process.domain.emit('error', err,
+                                awaitId && `${awaitId} (rejected) => `);
             process.domain.exit();
             return;
           }
@@ -1445,6 +1450,17 @@ function defineDefaultCommands(repl) {
       this.outputStream.write(
         '// Entering editor mode (^D to finish, ^C to cancel)\n');
     }
+  });
+
+  repl.defineCommand('backgrounding', {
+    help: 'Toggle top-level await backgrounding',
+    action() {
+      this.awaitBackgrounding = !this.awaitBackgrounding;
+      const state = this.awaitBackgrounding ? 'enabled' : 'disabled';
+      this.outputStream.write(
+        `Top-level await backgrounding has been ${state}\n`);
+      this.displayPrompt();
+    },
   });
 }
 

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -147,26 +147,42 @@ async function ordinaryTests() {
   }
 }
 
-async function backgroundedTest() {
+async function ctrlCTest() {
   putIn.run([
     `const timeout = (msecs) => new Promise((resolve) => {
        setTimeout(resolve, msecs).unref();
      });`
   ]);
 
-  console.log('Testing backgrounding');
+  console.log('Testing Ctrl+C');
   assert.deepStrictEqual(await runAndWait([
     'await timeout(100000)',
+    { ctrl: true, name: 'c' }
   ]), [
     'await timeout(100000)\r',
+    'Thrown: Error: Script execution interrupted.',
+    PROMPT
+  ]);
+}
+
+async function awaitBackgroundingTest() {
+  putIn.run(['.backgrounding']);
+
+  console.log('Testing await backgrounding');
+
+  assert.deepStrictEqual(await runAndWait([
+    'await timeout(10000)'
+  ]), [
+    'await timeout(10000)\r',
     'AWAIT01 (pending)',
-    PROMPT,
+    PROMPT
   ]);
 }
 
 async function main() {
   await ordinaryTests();
-  await backgroundedTest();
+  await ctrlCTest();
+  await awaitBackgroundingTest();
 }
 
 main();

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -147,27 +147,26 @@ async function ordinaryTests() {
   }
 }
 
-async function ctrlCTest() {
+async function backgroundedTest() {
   putIn.run([
     `const timeout = (msecs) => new Promise((resolve) => {
        setTimeout(resolve, msecs).unref();
      });`
   ]);
 
-  console.log('Testing Ctrl+C');
+  console.log('Testing backgrounding');
   assert.deepStrictEqual(await runAndWait([
     'await timeout(100000)',
-    { ctrl: true, name: 'c' }
   ]), [
     'await timeout(100000)\r',
-    'Thrown: Error: Script execution interrupted.',
-    PROMPT
+    'AWAIT01 (pending)',
+    PROMPT,
   ]);
 }
 
 async function main() {
   await ordinaryTests();
-  await ctrlCTest();
+  await backgroundedTest();
 }
 
 main();


### PR DESCRIPTION
Moves top-level awaited values into "background" after a tick, allowing
the user to continue using the repl while waiting for something that
might take a while or never happen.

closes #17168

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
repl