### PR TITLE
Adjust `test-http-content-length` and docs to consider countdown

### DIFF
--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -133,12 +133,15 @@ platforms.
 
 ### The *common* API
 
-Make use of the helpers from the `common` module as much as possible. Please refer to the [common file documentation](https://github.com/nodejs/node/tree/master/test/common) for the full details of the helpers.
+Make use of the helpers from the `common` module as much as possible. Please refer
+to the [common file documentation](https://github.com/nodejs/node/tree/master/test/common)
+for the full details of the helpers.
 
 #### common.mustCall
 
-One interesting case is `common.mustCall`. The use of `common.mustCall` may avoid the use of extra variables and the corresponding assertions. Let's explain
-this with a real test from the test suite.
+One interesting case is `common.mustCall`. The use of `common.mustCall` may avoid
+the use of extra variables and the corresponding assertions. Let's explain this
+with a real test from the test suite.
 
 ```javascript
 'use strict';
@@ -192,9 +195,11 @@ const server = http.createServer(common.mustCall(function(req, res) {
 ```
 #### Countdown Module
 
-The common [Countdown module](https://github.com/nodejs/node/tree/master/test/common#countdown-module) provides a simple countdown mechanism for tests that require a particular action to be taken after a given number of completed tasks (for instance, shutting down an HTTP server after a specific number of requests).
+The common [Countdown module](https://github.com/nodejs/node/tree/master/test/common#countdown-module) provides a simple countdown mechanism for tests that
+require a particular action to be taken after a given number of completed tasks
+(for instance, shutting down an HTTP server after a specific number of requests).
 
-```
+```javascript
 const Countdown = require('../common/countdown');
 
 const countdown = new Countdown(2, function() {

--- a/doc/guides/writing-tests.md
+++ b/doc/guides/writing-tests.md
@@ -133,10 +133,11 @@ platforms.
 
 ### The *common* API
 
-Make use of the helpers from the `common` module as much as possible.
+Make use of the helpers from the `common` module as much as possible. Please refer to the [common file documentation](https://github.com/nodejs/node/tree/master/test/common) for the full details of the helpers.
 
-One interesting case is `common.mustCall`. The use of `common.mustCall` may
-avoid the use of extra variables and the corresponding assertions. Let's explain
+#### common.mustCall
+
+One interesting case is `common.mustCall`. The use of `common.mustCall` may avoid the use of extra variables and the corresponding assertions. Let's explain
 this with a real test from the test suite.
 
 ```javascript
@@ -189,6 +190,21 @@ const server = http.createServer(common.mustCall(function(req, res) {
 });
 
 ```
+#### Countdown Module
+
+The common [Countdown module](https://github.com/nodejs/node/tree/master/test/common#countdown-module) provides a simple countdown mechanism for tests that require a particular action to be taken after a given number of completed tasks (for instance, shutting down an HTTP server after a specific number of requests).
+
+```
+const Countdown = require('../common/countdown');
+
+const countdown = new Countdown(2, function() {
+  console.log('.');
+});
+
+countdown.dec();
+countdown.dec(); // The countdown callback will be invoked now.
+```
+
 
 ### Flags
 

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -2,6 +2,7 @@
 require('../common');
 const assert = require('assert');
 const http = require('http');
+const Countdown = require('../common/countdown');
 
 const expectedHeadersMultipleWrites = {
   'connection': 'close',
@@ -18,8 +19,8 @@ const expectedHeadersEndNoData = {
   'content-length': '0',
 };
 
-let receivedRequests = 0;
-const totalRequests = 3;
+
+const countdown = new Countdown(3, () => server.close());
 
 const server = http.createServer(function(req, res) {
   res.removeHeader('Date');
@@ -42,8 +43,7 @@ const server = http.createServer(function(req, res) {
       throw new Error('Unreachable');
   }
 
-  receivedRequests++;
-  if (totalRequests === receivedRequests) server.close();
+  countdown.dec();
 });
 
 server.listen(0, function() {


### PR DESCRIPTION
Refactored the test suite `test-http-content-length` to use countdown and referred to the countdown usage in the docs; as per issue #17169 

P.S. These small refactors are really good for new contributors to get more personal with the code base. @jasnell I am willing to contribute more to these refactors if needed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc, test