### PR TITLE
test: use arrow function instead of bind

### DIFF
--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -67,6 +67,6 @@ const test = common.mustCall(function(res) {
   res.on('data', function(chunk) {
     bytes += chunk.length;
     this.pause();
-    setTimeout(this.resume.bind(this), 1);
+    setTimeout(() => { this.resume() }, 1);
   });
 });


### PR DESCRIPTION
Using an arrow function here eliminates the need to call `bind()`.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
