### PR TITLE
doc: add ES Modules entry to who-to-cc

### DIFF
--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -8,6 +8,7 @@
 | `bootstrap_node.js`                   | @fishrock123                                                          |
 | `doc/*`, `*.md`                       | @nodejs/documentation                                                 |
 | `lib/assert`                          | @nodejs/testing                                                       |
+| `lib/async_hooks`                     | @nodejs/async\_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
 | `lib/buffer`                          | @nodejs/buffer                                                        |
 | `lib/child_process`                   | @bnoordhuis, @cjihrig                                                 |
 | `lib/cluster`                         | @bnoordhuis, @cjihrig, @mcollina                                      |
@@ -29,8 +30,8 @@
 | `src/node_crypto.*`                   | @nodejs/crypto                                                        |
 | `test/*`                              | @nodejs/testing                                                       |
 | `tools/eslint`, `.eslintrc`           | @not-an-aardvark, @silverwind, @trott                                 |
-| async\_hooks                          | @nodejs/async\_hooks for bugs/reviews (+ @nodejs/diagnostics for API) |
 | build                                 | @nodejs/build                                                         |
+| ES Modules                            | @bmeck, @Fishrock123, @guybedford, @jasnell, @MylesBorins             |
 | GYP                                   | @nodejs/gyp                                                           |
 | performance                           | @nodejs/performance                                                   |
 | platform specific                     | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |

--- a/doc/onboarding-extras.md
+++ b/doc/onboarding-extras.md
@@ -31,7 +31,7 @@
 | `test/*`                              | @nodejs/testing                                                       |
 | `tools/eslint`, `.eslintrc`           | @not-an-aardvark, @silverwind, @trott                                 |
 | build                                 | @nodejs/build                                                         |
-| ES Modules                            | @bmeck, @Fishrock123, @guybedford, @jasnell, @MylesBorins             |
+| ES Modules                            | @bmeck, @Fishrock123, @guybedford, @MylesBorins, @targos              |
 | GYP                                   | @nodejs/gyp                                                           |
 | performance                           | @nodejs/performance                                                   |
 | platform specific                     | @nodejs/platform-{aix,arm,freebsd,macos,ppc,smartos,s390,windows}     |


### PR DESCRIPTION
Add ES Modules entry for who-to-cc. Resisted temptation to change it to
"whom to CC". Did add other minor fixes, though (whitespace and moving
`async_hooks`, removing unnecessary escaping).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc