### PR TITLE
Refactored `test-http-allow-req-after-204-res` file to use countdown

### DIFF
--- a/test/common/countdown.js
+++ b/test/common/countdown.js
@@ -17,6 +17,7 @@ class Countdown {
     assert(this[kLimit] > 0, 'Countdown expired');
     if (--this[kLimit] === 0)
       this[kCallback]();
+    return this[kLimit];
   }
 
   get remaining() {


### PR DESCRIPTION
Refactored the test case `test-http-allow-req-after-204-res` to use countdown, as per issue #17169 


##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
