### PR TITLE
test: replace `fs.accessAsync` with `common.fileExists`

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -58,6 +58,6 @@ function handleExit(error, stdout, stderr) {
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
   assert.doesNotThrow(function() {
-    fs.accessSync(`${installDir}/node_modules/package-name`);
+    common.fileExists(`${installDir}/node_modules/package-name`);
   });
 }


### PR DESCRIPTION
replace calls to `fs.accessAsync` with `common.fileExists` in `test/parallel/test-npm-install.js`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
