### PR TITLE
tools/doc: add files to gitignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -579,7 +579,7 @@ available-node = \
 		exit 1; \
 	fi;
 
-run-npm-install = $(PWD)/$(NPM) install
+run-npm-install = $(PWD)/$(NPM) install --production
 
 tools/doc/node_modules/js-yaml/package.json:
 	cd tools/doc && $(call available-node,$(run-npm-install))

--- a/tools/doc/node_modules/.bin/marked
+++ b/tools/doc/node_modules/.bin/marked
@@ -1,1 +1,0 @@
-../marked/bin/marked

--- a/tools/doc/node_modules/marked/lib/marked.js
+++ b/tools/doc/node_modules/marked/lib/marked.js
@@ -1094,7 +1094,8 @@ function escape(html, encode) {
 }
 
 function unescape(html) {
-  return html.replace(/&([#\w]+);/g, function(_, n) {
+	// explicitly match decimal, hex, and named HTML entities
+  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
     n = n.toLowerCase();
     if (n === 'colon') return ':';
     if (n.charAt(0) === '#') {

--- a/tools/doc/node_modules/marked/package.json
+++ b/tools/doc/node_modules/marked/package.json
@@ -1,38 +1,27 @@
 {
-  "_args": [
-    [
-      "marked",
-      "/Users/firedfox/git/node/tools/doc"
-    ]
-  ],
-  "_from": "marked@latest",
-  "_id": "marked@0.3.5",
-  "_inCache": true,
-  "_installable": true,
+  "_from": "marked@^0.3.5",
+  "_id": "marked@0.3.6",
+  "_inBundle": false,
+  "_integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
   "_location": "/marked",
-  "_nodeVersion": "0.12.7",
-  "_npmUser": {
-    "email": "chjjeffrey@gmail.com",
-    "name": "chjj"
-  },
-  "_npmVersion": "2.13.2",
   "_phantomChildren": {},
   "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "marked@^0.3.5",
     "name": "marked",
-    "raw": "marked",
-    "rawSpec": "",
-    "scope": null,
-    "spec": "latest",
-    "type": "tag"
+    "escapedName": "marked",
+    "rawSpec": "^0.3.5",
+    "saveSpec": null,
+    "fetchSpec": "^0.3.5"
   },
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
-  "_shasum": "4113a15ac5d7bca158a5aae07224587b9fa15b94",
-  "_shrinkwrap": null,
-  "_spec": "marked",
-  "_where": "/Users/firedfox/git/node/tools/doc",
+  "_resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+  "_shasum": "b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7",
+  "_spec": "marked@^0.3.5",
+  "_where": "/mnt/d/code/node-github-desktop/tools/doc",
   "author": {
     "name": "Christopher Jeffrey"
   },
@@ -42,7 +31,8 @@
   "bugs": {
     "url": "http://github.com/chjj/marked/issues"
   },
-  "dependencies": {},
+  "bundleDependencies": false,
+  "deprecated": false,
   "description": "A markdown parser built for speed",
   "devDependencies": {
     "gulp": "^3.8.11",
@@ -51,12 +41,6 @@
     "markdown": "*",
     "showdown": "*"
   },
-  "directories": {},
-  "dist": {
-    "shasum": "4113a15ac5d7bca158a5aae07224587b9fa15b94",
-    "tarball": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
-  },
-  "gitHead": "88ce4df47c4d994dc1b1df1477a21fb893e11ddc",
   "homepage": "https://github.com/chjj/marked",
   "keywords": [
     "markdown",
@@ -65,19 +49,11 @@
   ],
   "license": "MIT",
   "main": "./lib/marked.js",
-  "maintainers": [
-    {
-      "email": "chjjeffrey@gmail.com",
-      "name": "chjj"
-    }
-  ],
   "man": [
     "./man/marked.1"
   ],
   "name": "marked",
-  "optionalDependencies": {},
   "preferGlobal": true,
-  "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
     "url": "git://github.com/chjj/marked.git"
@@ -91,5 +67,5 @@
     "markup",
     "html"
   ],
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "node-doc-generator",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+    }
+  }
+}

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -7,10 +7,11 @@
     "node": ">=6"
   },
   "dependencies": {
-    "marked": "^0.3.5",
+    "marked": "^0.3.5"
+  },
+  "devDependencies": {
     "js-yaml": "^3.5.2"
   },
-  "devDependencies": {},
   "optionalDependencies": {},
   "bin": "./generate.js"
 }


### PR DESCRIPTION
This closes https://github.com/nodejs/node/issues/17216 by adding some files to the gitignore which stick around after an aborted build. It is meant as a temporary fix.

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
.gitignore, but related to docs.
