### PR TITLE
test: use common.throwOnUnhandledRejection

### DIFF
--- a/test/parallel/test-async-wrap-promise-after-enabled.js
+++ b/test/parallel/test-async-wrap-promise-after-enabled.js
@@ -9,6 +9,8 @@ const async_hooks = require('async_hooks');
 
 const seenEvents = [];
 
+common.crashOnUnhandledRejection();
+
 const p = new Promise((resolve) => resolve(1));
 p.then(() => seenEvents.push('then'));
 


### PR DESCRIPTION
Add common.crashOnUnhandledRejection to test/parallel/test-async-wrap-promise-after-enabled.js

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
