### PR TITLE
test: use common.crashOnUnhandledRejection

### DIFF
--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+common.crashOnUnhandledRejection();
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -1,9 +1,10 @@
 'use strict';
 const common = require('../common');
-common.crashOnUnhandledRejection();
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const repl = require('repl');
+
+common.crashOnUnhandledRejection();
 
 const command = `.load ${fixtures.path('repl-load-multiline.js')}`;
 const terminalCode = '\u001b[1G\u001b[0J \u001b[1G';


### PR DESCRIPTION
add `common.crashOnUnhandledRejection()` to `test/parallel/test-repl-load-multiline.js`

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test