### PR TITLE
refactor : `test-http-end-throw-socket-handling` to use countdown

### DIFF
--- a/test/parallel/test-http-end-throw-socket-handling.js
+++ b/test/parallel/test-http-end-throw-socket-handling.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const Countdown = require('../common/countdown');
 
 // Make sure that throwing in 'end' handler doesn't lock
 // up the socket forever.
@@ -29,10 +30,10 @@ const common = require('../common');
 // the same, we should not be so brittle and easily broken.
 
 const http = require('http');
+const countdown = new Countdown(10, () => server.close());
 
-let n = 0;
 const server = http.createServer((req, res) => {
-  if (++n === 10) server.close();
+  countdown.dec();
   res.end('ok');
 });
 


### PR DESCRIPTION
Refactored the test case `test-http-end-throw-socket-handling` to use countdown, as per issue #17169

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
