### PR TITLE
src: start heap object tracking after platform is initialized

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4506,10 +4506,6 @@ inline int Start(uv_loop_t* event_loop,
   isolate->SetAutorunMicrotasks(false);
   isolate->SetFatalErrorHandler(OnFatalError);
 
-  if (track_heap_objects) {
-    isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
-  }
-
   {
     Mutex::ScopedLock scoped_lock(node_isolate_mutex);
     CHECK_EQ(node_isolate, nullptr);
@@ -4526,6 +4522,9 @@ inline int Start(uv_loop_t* event_loop,
         event_loop,
         v8_platform.Platform(),
         allocator.zero_fill_field());
+    if (track_heap_objects) {
+      isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
+    }
     exit_code = Start(isolate, &isolate_data, argc, argv, exec_argc, exec_argv);
   }
 


### PR DESCRIPTION
Garbage collection is triggered by the heap object tracker. The garbage
collector may spawn garbage collection tasks on the foreground thread.
This is only allowed after registering the isolate in the platform
which happens in IsolateData. This CL moves the starting of the heap
object tracker after calling IsolateData to ensure that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
