### PR TITLE
doc: non-partitioned async crypto operations

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1826,6 +1826,11 @@ Note that this API uses libuv's threadpool, which can have surprising and
 negative performance implications for some applications, see the
 [`UV_THREADPOOL_SIZE`][] documentation for more information.
 
+*Note*: The asynchronous version of `crypto.randomBytes()` is carried out
+in a single threadpool request. To minimize threadpool task length variation,
+partition large `randomBytes` requests when doing so as part of fulfilling a
+client request.
+
 ### crypto.randomFillSync(buffer[, offset][, size])
 <!-- YAML
 added: v7.10.0
@@ -1932,6 +1937,11 @@ crypto.randomFill(c, (err, buf) => {
 Note that this API uses libuv's threadpool, which can have surprising and
 negative performance implications for some applications, see the
 [`UV_THREADPOOL_SIZE`][] documentation for more information.
+
+*Note*: The asynchronous version of `crypto.randomFill()` is carried out
+in a single threadpool request. To minimize threadpool task length variation,
+partition large `randomFill` requests when doing so as part of fulfilling a
+client request.
 
 ### crypto.setEngine(engine[, flags])
 <!-- YAML


### PR DESCRIPTION
Neither crypto.randomBytes nor crypto.randomFill
partitions the work submitted to the threadpool.

This change was suggested during the discussion of #17054.
See also #17154.

##### Checklist
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, crypto
