### PR TITLE
test: make common.mustNotCall show file:linenumber

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -134,7 +134,7 @@ a reason otherwise.
 Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
 
 ### getCallSite(func)
-* `func` [&lt;Function]
+* `func` [&lt;Function>]
 * return [&lt;String>]
 
 Returns the file name and line number for the provided Function.

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -133,6 +133,12 @@ a reason otherwise.
 
 Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
 
+### getCallSite(func)
+* `func` [&lt;Function]
+* return [&lt;String>]
+
+Returns the file name and line number for the provided Function.
+
 ### globalCheck
 * [&lt;Boolean>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -576,7 +576,7 @@ function getCallSite(level = 2) {
   // formatted until it is accessed
   err.stack;
   Error.prepareStackTrace = originalStackFormatter;
-  err.stack;
+  return err.stack;
 }
 
 exports.mustNotCall = function(msg) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -572,8 +572,7 @@ exports.getCallSite = function getCallSite(top) {
     `${stack[0].getFileName()}:${stack[0].getLineNumber()}`;
   const err = new Error();
   Error.captureStackTrace(err, top);
-  // the way V8 Error API works, the stack is not
-  // formatted until it is accessed
+  // with the V8 Error API, the stack is not formatted until it is accessed
   err.stack;
   Error.prepareStackTrace = originalStackFormatter;
   return err.stack;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -566,9 +566,24 @@ exports.canCreateSymLink = function() {
   return true;
 };
 
+function getCallSite(level = 2) {
+  const originalStackFormatter = Error.prepareStackTrace;
+  Error.prepareStackTrace = (err, stack) =>
+    `${stack[level].getFileName()}:${stack[level].getLineNumber()}`;
+  const err = new Error();
+  Error.captureStackTrace(err, level);
+  // the way V8 Error API works, the stack is not
+  // formatted until it is accessed
+  err.stack;
+  Error.prepareStackTrace = originalStackFormatter;
+  err.stack;
+}
+
 exports.mustNotCall = function(msg) {
+  const callSite = getCallSite();
   return function mustNotCall() {
-    assert.fail(msg || 'function should not have been called');
+    assert.fail(
+      `${msg || 'function should not have been called'} at ${callSite}`);
   };
 };
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -566,21 +566,21 @@ exports.canCreateSymLink = function() {
   return true;
 };
 
-function getCallSite(level = 2) {
+exports.getCallSite = function getCallSite(level = 2) {
   const originalStackFormatter = Error.prepareStackTrace;
   Error.prepareStackTrace = (err, stack) =>
     `${stack[level].getFileName()}:${stack[level].getLineNumber()}`;
   const err = new Error();
-  Error.captureStackTrace(err, level);
+  Error.captureStackTrace(err);
   // the way V8 Error API works, the stack is not
   // formatted until it is accessed
   err.stack;
   Error.prepareStackTrace = originalStackFormatter;
   return err.stack;
-}
+};
 
 exports.mustNotCall = function(msg) {
-  const callSite = getCallSite();
+  const callSite = exports.getCallSite();
   return function mustNotCall() {
     assert.fail(
       `${msg || 'function should not have been called'} at ${callSite}`);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -566,12 +566,12 @@ exports.canCreateSymLink = function() {
   return true;
 };
 
-exports.getCallSite = function getCallSite(level = 2) {
+exports.getCallSite = function getCallSite(top) {
   const originalStackFormatter = Error.prepareStackTrace;
   Error.prepareStackTrace = (err, stack) =>
-    `${stack[level].getFileName()}:${stack[level].getLineNumber()}`;
+    `${stack[0].getFileName()}:${stack[0].getLineNumber()}`;
   const err = new Error();
-  Error.captureStackTrace(err);
+  Error.captureStackTrace(err, top);
   // the way V8 Error API works, the stack is not
   // formatted until it is accessed
   err.stack;
@@ -580,7 +580,7 @@ exports.getCallSite = function getCallSite(level = 2) {
 };
 
 exports.mustNotCall = function(msg) {
-  const callSite = exports.getCallSite();
+  const callSite = exports.getCallSite(exports.mustNotCall);
   return function mustNotCall() {
     assert.fail(
       `${msg || 'function should not have been called'} at ${callSite}`);

--- a/test/parallel/test-common-must-not-call.js
+++ b/test/parallel/test-common-must-not-call.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+
+const message = 'message';
+const testFunction = common.mustNotCall(message);
+
+const validateError = common.mustCall((e) => {
+  const prefix = `${message} at `;
+  assert.ok(e.message.startsWith(prefix));
+  const [ fileName, lineNumber ] = e.message
+                                    .substring(prefix.length).split(':');
+  assert.strictEqual(path.basename(fileName), 'test-common-must-not-call.js');
+  assert.strictEqual(lineNumber, '8');
+});
+
+try {
+  testFunction();
+} catch (e) {
+  validateError(e);
+}

--- a/test/parallel/test-common-must-not-call.js
+++ b/test/parallel/test-common-must-not-call.js
@@ -10,6 +10,9 @@ const testFunction = common.mustNotCall(message);
 const validateError = common.mustCall((e) => {
   const prefix = `${message} at `;
   assert.ok(e.message.startsWith(prefix));
+  if (process.platform === 'win32') {
+    e.message = e.message.substring(2); // remove 'C:'
+  }
   const [ fileName, lineNumber ] = e.message
                                     .substring(prefix.length).split(':');
   assert.strictEqual(path.basename(fileName), 'test-common-must-not-call.js');


### PR DESCRIPTION
When a test fails via `common.mustNotCall` it is sometimes hard to
determine exactly what was called. This modification stores the
caller's file and line number by using the V8 Error API to capture
a stack at the time `common.mustNotCall()` is called. In the event
of failure, this information is printed.

~~I tried to write a test for this, but `common.mustNotCall()` ultimately
calls `assert.fail()` which made it difficult to do.~~ I did simulate a
failure, and this is what the output looked like:

```text
assert.js:42
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: function should not have been called at /Users/lanceball/src/node/test/parallel/test-http-host-headers.js:60
    at ClientRequest.mustNotCall (/Users/lanceball/src/node/test/common/index.js:587:12)
    at ClientRequest.emit (events.js:159:13)
    at Socket.socketErrorListener (_http_client.js:389:9)
    at Socket.emit (events.js:159:13)
    at emitErrorNT (internal/streams/destroy.js:64:8)
    at _combinedTickCallback (internal/process/next_tick.js:137:11)
    at process._tickCallback (internal/process/next_tick.js:179:9)
```

~~@nodejs/collaborators if you have a recommendation for testing this, I'm all ears.~~

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
