### PR TITLE
doc: Update HTTP -> HTTPS in doc/api

### DIFF
--- a/doc/api/_toc.md
+++ b/doc/api/_toc.md
@@ -55,4 +55,4 @@
 <div class="line"></div>
 
 * [GitHub Repo & Issue Tracker](https://github.com/nodejs/node)
-* [Mailing List](http://groups.google.com/group/nodejs)
+* [Mailing List](https://groups.google.com/group/nodejs)

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2396,7 +2396,7 @@ the `crypto`, `tls`, and `https` modules and are generally specific to OpenSSL.
 [`verify.verify()`]: #crypto_verify_verify_object_signature_signatureformat
 [Caveats]: #crypto_support_for_weak_or_compromised_algorithms
 [Crypto Constants]: #crypto_crypto_constants_1
-[HTML5's `keygen` element]: http://www.w3.org/TR/html5/forms.html#the-keygen-element
+[HTML5's `keygen` element]: https://www.w3.org/TR/html5/forms.html#the-keygen-element
 [NIST SP 800-131A]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf
 [NIST SP 800-132]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 [Nonce-Disrespecting Adversaries]: https://github.com/nonce-disrespect/nonce-disrespect

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1013,7 +1013,7 @@ A key is *required* for ciphers that make use of certificates. Either `key` or
 
 If the 'ca' option is not given, then Node.js will use the default
 publicly trusted list of CAs as given in
-<http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt>.
+<https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt>.
 
 
 ## tls.createServer([options][, secureConnectionListener])

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -110,7 +110,7 @@ http.createServer((request, response) => {
   }
 
   // Note: This is not a conformant accept-encoding parser.
-  // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
+  // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
   if (/\bdeflate\b/.test(acceptEncoding)) {
     response.writeHead(200, { 'Content-Encoding': 'deflate' });
     raw.pipe(zlib.createDeflate()).pipe(response);
@@ -235,7 +235,7 @@ All of the constants defined in `zlib.h` are also defined on
 `require('zlib').constants`. In the normal course of operations, it will not be
 necessary to use these  constants. They are documented so that their presence is
 not surprising. This section is taken almost directly from the
-[zlib documentation][].  See <http://zlib.net/manual.html#Constants> for more
+[zlib documentation][].  See <https://zlib.net/manual.html#Constants> for more
 details.
 
 *Note*: Previously, the constants were available directly from
@@ -313,7 +313,7 @@ ignored by the decompression classes.
 * `info` {boolean} (If `true`, returns an object with `buffer` and `engine`)
 
 See the description of `deflateInit2` and `inflateInit2` at
-<http://zlib.net/manual.html#Advanced> for more information on these.
+<https://zlib.net/manual.html#Advanced> for more information on these.
 
 ## Class: zlib.Deflate
 <!-- YAML
@@ -723,4 +723,4 @@ Decompress a chunk of data with [Unzip][].
 [Unzip]: #zlib_class_zlib_unzip
 [`UV_THREADPOOL_SIZE`]: cli.html#cli_uv_threadpool_size_size
 [options]: #zlib_class_options
-[zlib documentation]: http://zlib.net/manual.html#Constants
+[zlib documentation]: https://zlib.net/manual.html#Constants


### PR DESCRIPTION
URLs were updated to use HTTPS protocol in doc/api files.
Update URLs to reduce 301 Redirects for speed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc