### PR TITLE
test: remove common.tmpDirName

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -376,11 +376,6 @@ Synchronous version of `spawnPwd`.
 
 The realpath of the 'tmp' directory.
 
-### tmpDirName
-* return [&lt;String>]
-
-Name of the temp directory used by tests.
-
 ## Countdown Module
 
 The `Countdown` module provides a simple countdown mechanism for tests that

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -40,7 +40,7 @@ exports.fixturesDir = fixturesDir;
 
 // Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
 // gets tools to ignore it by default or by simple rules, especially eslint.
-exports.tmpDirName = '.tmp';
+let tmpDirName = '.tmp';
 // PORT should match the definition in test/testpy/__init__.py.
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
 exports.isWindows = process.platform === 'win32';
@@ -165,9 +165,9 @@ exports.refreshTmpDir = function() {
 
 if (process.env.TEST_THREAD_ID) {
   exports.PORT += process.env.TEST_THREAD_ID * 100;
-  exports.tmpDirName += `.${process.env.TEST_THREAD_ID}`;
+  tmpDirName += `.${process.env.TEST_THREAD_ID}`;
 }
-exports.tmpDir = path.join(testRoot, exports.tmpDirName);
+exports.tmpDir = path.join(testRoot, tmpDirName);
 
 let opensslCli = null;
 let inFreeBSDJail = null;

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -111,7 +111,7 @@ function test_simple_relative_symlink(realpath, realpathSync, callback) {
   const entry = `${tmpDir}/symlink`;
   const expected = `${tmpDir}/cycles/root.js`;
   [
-    [entry, `../${common.tmpDirName}/cycles/root.js`]
+    [entry, `../${path.basename(tmpDir)}/cycles/root.js`]
   ].forEach(function(t) {
     try { fs.unlinkSync(t[0]); } catch (e) {}
     console.log('fs.symlinkSync(%j, %j, %j)', t[1], t[0], 'file');


### PR DESCRIPTION
`common.tmpDirName` is used in only one test and can be replaced with
`path.basename(common.tmpDir)`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test