### PR TITLE
build: fix test-v8 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,7 @@ test-v8: v8
         --no-presubmit \
         --shell-dir=$(PWD)/deps/v8/out/$(V8_ARCH).$(BUILDTYPE_LOWER) \
 	 $(TAP_V8)
+	git clean -fdxq -- deps/v8
 	@echo Testing hash seed
 	$(MAKE) test-hash-seed
 


### PR DESCRIPTION
Clean the deps/v8 directory before rebuilding node for the hash seed
test. It is necessary to avoid the script added in [1] to use ignored
files while generating `node-debug-support.cc`.

[1]: https://github.com/nodejs/node/pull/14901

Fixes: https://github.com/nodejs/node-v8/issues/26

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

/cc @bnoordhuis @mmarchini