### PR TITLE
Refactor async_hooks initTriggerId

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -547,7 +547,7 @@ function responseKeepAlive(res, req) {
     socket.removeListener('error', socketErrorListener);
     socket.once('error', freeSocketErrorListener);
     // There are cases where _handle === null. Avoid those. Passing null to
-    // nextTick() will call initTriggerId() to retrieve the id.
+    // nextTick() will call getDefaultTriggerAsyncId() to retrieve the id.
     const asyncId = socket._handle ? socket._handle.getAsyncId() : null;
     // Mark this socket as available, AFTER user-added end
     // handlers have a chance to run.

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -15,7 +15,7 @@ const {
   disableHooks,
   // Internal Embedder API
   newUid,
-  initTriggerId,
+  getDefaultTriggerAsyncId,
   emitInit,
   emitBefore,
   emitAfter,
@@ -147,7 +147,7 @@ class AsyncResource {
     if (typeof opts === 'number') {
       opts = { triggerAsyncId: opts, requireManualDestroy: false };
     } else if (opts.triggerAsyncId === undefined) {
-      opts.triggerAsyncId = initTriggerId();
+      opts.triggerAsyncId = getDefaultTriggerAsyncId();
     }
 
     // Unlike emitInitScript, AsyncResource doesn't supports null as the

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -470,19 +470,18 @@ function doSend(ex, self, ip, list, address, port, callback) {
     return;
   }
 
-  var req = new SendWrap();
-  req.list = list;  // Keep reference alive.
-  req.address = address;
-  req.port = port;
-  if (callback) {
-    req.callback = callback;
-    req.oncomplete = afterSend;
-  }
-  // node::SendWrap isn't instantiated and attached to the JS instance of
-  // SendWrap above until send() is called. So don't set the init trigger id
-  // until now.
   var err = defaultTriggerAsyncIdScope(
-    self[async_id_symbol], function() {
+    self[async_id_symbol], [list, port, ip, callback],
+    function([list, port, ip, callback]) {
+      var req = new SendWrap();
+      req.list = list;  // Keep reference alive.
+      req.address = address;
+      req.port = port;
+      if (callback) {
+        req.callback = callback;
+        req.oncomplete = afterSend;
+      }
+
       return self._handle.send(req,
                                list,
                                list.length,

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -28,7 +28,7 @@ const dns = require('dns');
 const util = require('util');
 const { isUint8Array } = require('internal/util/types');
 const EventEmitter = require('events');
-const { setInitTriggerId } = require('internal/async_hooks');
+const { setDefaultTriggerAsyncId } = require('internal/async_hooks');
 const { UV_UDP_REUSEADDR } = process.binding('constants').os;
 const { async_id_symbol } = process.binding('async_wrap');
 const { nextTick } = require('internal/process/next_tick');
@@ -481,7 +481,7 @@ function doSend(ex, self, ip, list, address, port, callback) {
   // node::SendWrap isn't instantiated and attached to the JS instance of
   // SendWrap above until send() is called. So don't set the init trigger id
   // until now.
-  setInitTriggerId(self[async_id_symbol]);
+  setDefaultTriggerAsyncId(self[async_id_symbol]);
   var err = self._handle.send(req,
                               list,
                               list.length,

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -450,51 +450,49 @@ Socket.prototype.send = function(buffer,
   }
 
   const afterDns = (ex, ip) => {
-    doSend(ex, this, ip, list, address, port, callback);
+    defaultTriggerAsyncIdScope(
+      this[async_id_symbol],
+      [ex, this, ip, list, address, port, callback],
+      doSend
+    );
   };
 
   this._handle.lookup(address, afterDns);
 };
 
-
-function doSend(ex, self, ip, list, address, port, callback) {
+function doSend([ex, self, ip, list, address, port, callback]) {
   if (ex) {
     if (typeof callback === 'function') {
-      callback(ex);
+      process.nextTick(callback, ex);
       return;
     }
 
-    self.emit('error', ex);
+    process.nextTick(() => self.emit('error', ex));
     return;
   } else if (!self._handle) {
     return;
   }
 
-  var err = defaultTriggerAsyncIdScope(
-    self[async_id_symbol], [list, port, ip, callback],
-    function([list, port, ip, callback]) {
-      var req = new SendWrap();
-      req.list = list;  // Keep reference alive.
-      req.address = address;
-      req.port = port;
-      if (callback) {
-        req.callback = callback;
-        req.oncomplete = afterSend;
-      }
+  var req = new SendWrap();
+  req.list = list;  // Keep reference alive.
+  req.address = address;
+  req.port = port;
+  if (callback) {
+    req.callback = callback;
+    req.oncomplete = afterSend;
+  }
 
-      return self._handle.send(req,
-                               list,
-                               list.length,
-                               port,
-                               ip,
-                               !!callback);
-    }
-  );
+  var err = self._handle.send(req,
+                              list,
+                              list.length,
+                              port,
+                              ip,
+                              !!callback);
 
   if (err && callback) {
     // don't emit as error, dgram_legacy.js compatibility
     const ex = exceptionWithHostPort(err, 'send', address, port);
-    nextTick(self[async_id_symbol], callback, ex);
+    process.nextTick(callback, ex);
   }
 }
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -28,7 +28,7 @@ const dns = require('dns');
 const util = require('util');
 const { isUint8Array } = require('internal/util/types');
 const EventEmitter = require('events');
-const { setDefaultTriggerAsyncId } = require('internal/async_hooks');
+const { defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { UV_UDP_REUSEADDR } = process.binding('constants').os;
 const { async_id_symbol } = process.binding('async_wrap');
 const { nextTick } = require('internal/process/next_tick');
@@ -481,13 +481,17 @@ function doSend(ex, self, ip, list, address, port, callback) {
   // node::SendWrap isn't instantiated and attached to the JS instance of
   // SendWrap above until send() is called. So don't set the init trigger id
   // until now.
-  setDefaultTriggerAsyncId(self[async_id_symbol]);
-  var err = self._handle.send(req,
-                              list,
-                              list.length,
-                              port,
-                              ip,
-                              !!callback);
+  var err = defaultTriggerAsyncIdScope(
+    self[async_id_symbol], function() {
+      return self._handle.send(req,
+                               list,
+                               list.length,
+                               port,
+                               ip,
+                               !!callback);
+    }
+  );
+
   if (err && callback) {
     // don't emit as error, dgram_legacy.js compatibility
     const ex = exceptionWithHostPort(err, 'send', address, port);

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -460,7 +460,7 @@ Socket.prototype.send = function(buffer,
   this._handle.lookup(address, afterDns);
 };
 
-function doSend([ex, self, ip, list, address, port, callback]) {
+function doSend(ex, self, ip, list, address, port, callback) {
   if (ex) {
     if (typeof callback === 'function') {
       process.nextTick(callback, ex);

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -252,9 +252,9 @@ function getDefaultTriggerAsyncId() {
   var defaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   // Reset value after it's been called so the next constructor doesn't
   // inherit it by accident.
-  async_id_fields[kDefaultTriggerAsyncId] = 0;
+  async_id_fields[kDefaultTriggerAsyncId] = -1;
   // If defaultTriggerAsyncId isn't set, use the executionAsyncId
-  if (defaultTriggerAsyncId <= 0)
+  if (defaultTriggerAsyncId < 0)
     defaultTriggerAsyncId = async_id_fields[kExecutionAsyncId];
   return defaultTriggerAsyncId;
 }
@@ -288,7 +288,7 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
   } else {
     // If a triggerAsyncId was passed, any kDefaultTriggerAsyncId still must be
     // null'd.
-    async_id_fields[kDefaultTriggerAsyncId] = 0;
+    async_id_fields[kDefaultTriggerAsyncId] = -1;
   }
 
   emitInitNative(asyncId, type, triggerAsyncId, resource);

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -257,7 +257,7 @@ function getDefaultTriggerAsyncId() {
 }
 
 
-function defaultTriggerAsyncIdScope(triggerAsyncId, block) {
+function defaultTriggerAsyncIdScope(triggerAsyncId, opaque, block) {
   // CHECK(Number.isSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
   const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
@@ -265,7 +265,7 @@ function defaultTriggerAsyncIdScope(triggerAsyncId, block) {
 
   var ret;
   try {
-    ret = block();
+    ret = block(opaque);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -250,9 +250,6 @@ function newUid() {
 // constructor is complete.
 function getDefaultTriggerAsyncId() {
   var defaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
-  // Reset value after it's been called so the next constructor doesn't
-  // inherit it by accident.
-  async_id_fields[kDefaultTriggerAsyncId] = -1;
   // If defaultTriggerAsyncId isn't set, use the executionAsyncId
   if (defaultTriggerAsyncId < 0)
     defaultTriggerAsyncId = async_id_fields[kExecutionAsyncId];
@@ -260,10 +257,20 @@ function getDefaultTriggerAsyncId() {
 }
 
 
-function setDefaultTriggerAsyncId(triggerAsyncId) {
+function defaultTriggerAsyncIdScope(triggerAsyncId, block) {
   // CHECK(Number.isSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
+  const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   async_id_fields[kDefaultTriggerAsyncId] = triggerAsyncId;
+
+  var ret;
+  try {
+    ret = block();
+  } finally {
+    async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
+  }
+
+  return ret;
 }
 
 
@@ -285,10 +292,6 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
   // manually means that the embedder must have used getDefaultTriggerAsyncId().
   if (triggerAsyncId === null) {
     triggerAsyncId = getDefaultTriggerAsyncId();
-  } else {
-    // If a triggerAsyncId was passed, any kDefaultTriggerAsyncId still must be
-    // null'd.
-    async_id_fields[kDefaultTriggerAsyncId] = -1;
   }
 
   emitInitNative(asyncId, type, triggerAsyncId, resource);
@@ -341,7 +344,7 @@ module.exports = {
   // Internal Embedder API
   newUid,
   getDefaultTriggerAsyncId,
-  setDefaultTriggerAsyncId,
+  defaultTriggerAsyncIdScope,
   emitInit: emitInitScript,
   emitBefore: emitBeforeScript,
   emitAfter: emitAfterScript,

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -265,7 +265,7 @@ function defaultTriggerAsyncIdScope(triggerAsyncId, opaque, block) {
 
   var ret;
   try {
-    ret = block(opaque);
+    ret = Reflect.apply(block, null, opaque);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -14,10 +14,10 @@ const async_wrap = process.binding('async_wrap');
  *  kTriggerAsyncId: The trigger_async_id of the resource responsible for
  *    the current execution stack.
  *  kAsyncIdCounter: Incremental counter tracking the next assigned async_id.
- *  kInitTriggerAsyncId: Written immediately before a resource's constructor
+ *  kDefaultTriggerAsyncId: Written immediately before a resource's constructor
  *    that sets the value of the init()'s triggerAsyncId. The order of
  *    retrieving the triggerAsyncId value is passing directly to the
- *    constructor -> value set in kInitTriggerAsyncId -> executionAsyncId of
+ *    constructor -> value set in kDefaultTriggerAsyncId -> executionAsyncId of
  *    the current resource.
  */
 const { async_hook_fields, async_id_fields } = async_wrap;
@@ -61,7 +61,7 @@ const active_hooks = {
 // for a given step, that step can bail out early.
 const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
         kCheck, kExecutionAsyncId, kAsyncIdCounter,
-        kInitTriggerAsyncId } = async_wrap.constants;
+        kDefaultTriggerAsyncId } = async_wrap.constants;
 
 // Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
@@ -245,25 +245,25 @@ function newUid() {
   return ++async_id_fields[kAsyncIdCounter];
 }
 
-
 // Return the triggerAsyncId meant for the constructor calling it. It's up to
 // the user to safeguard this call and make sure it's zero'd out when the
 // constructor is complete.
-function initTriggerId() {
-  var triggerAsyncId = async_id_fields[kInitTriggerAsyncId];
+function getDefaultTriggerAsyncId() {
+  var defaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
   // Reset value after it's been called so the next constructor doesn't
   // inherit it by accident.
-  async_id_fields[kInitTriggerAsyncId] = 0;
-  if (triggerAsyncId <= 0)
-    triggerAsyncId = async_id_fields[kExecutionAsyncId];
-  return triggerAsyncId;
+  async_id_fields[kDefaultTriggerAsyncId] = 0;
+  // If defaultTriggerAsyncId isn't set, use the executionAsyncId
+  if (defaultTriggerAsyncId <= 0)
+    defaultTriggerAsyncId = async_id_fields[kExecutionAsyncId];
+  return defaultTriggerAsyncId;
 }
 
 
-function setInitTriggerId(triggerAsyncId) {
+function setDefaultTriggerAsyncId(triggerAsyncId) {
   // CHECK(Number.isSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
-  async_id_fields[kInitTriggerAsyncId] = triggerAsyncId;
+  async_id_fields[kDefaultTriggerAsyncId] = triggerAsyncId;
 }
 
 
@@ -282,13 +282,13 @@ function emitInitScript(asyncId, type, triggerAsyncId, resource) {
     return;
 
   // This can run after the early return check b/c running this function
-  // manually means that the embedder must have used initTriggerId().
+  // manually means that the embedder must have used getDefaultTriggerAsyncId().
   if (triggerAsyncId === null) {
-    triggerAsyncId = initTriggerId();
+    triggerAsyncId = getDefaultTriggerAsyncId();
   } else {
-    // If a triggerAsyncId was passed, any kInitTriggerAsyncId still must be
+    // If a triggerAsyncId was passed, any kDefaultTriggerAsyncId still must be
     // null'd.
-    async_id_fields[kInitTriggerAsyncId] = 0;
+    async_id_fields[kDefaultTriggerAsyncId] = 0;
   }
 
   emitInitNative(asyncId, type, triggerAsyncId, resource);
@@ -340,8 +340,8 @@ module.exports = {
   disableHooks,
   // Internal Embedder API
   newUid,
-  initTriggerId,
-  setInitTriggerId,
+  getDefaultTriggerAsyncId,
+  setDefaultTriggerAsyncId,
   emitInit: emitInitScript,
   emitBefore: emitBeforeScript,
   emitAfter: emitAfterScript,

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -369,14 +369,14 @@
     // Internal functions needed to manipulate the stack.
     const { clearAsyncIdStack, asyncIdStackSize } = async_wrap;
     const { kAfter, kExecutionAsyncId,
-            kInitTriggerAsyncId } = async_wrap.constants;
+            kDefaultTriggerAsyncId } = async_wrap.constants;
 
     process._fatalException = function(er) {
       var caught;
 
-      // It's possible that kInitTriggerAsyncId was set for a constructor call
-      // that threw and was never cleared. So clear it now.
-      async_id_fields[kInitTriggerAsyncId] = 0;
+      // It's possible that kDefaultTriggerAsyncId was set for a constructor
+      // call that threw and was never cleared. So clear it now.
+      async_id_fields[kDefaultTriggerAsyncId] = 0;
 
       if (exceptionHandlerState.captureFn !== null) {
         exceptionHandlerState.captureFn(er);

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -376,7 +376,7 @@
 
       // It's possible that kDefaultTriggerAsyncId was set for a constructor
       // call that threw and was never cleared. So clear it now.
-      async_id_fields[kDefaultTriggerAsyncId] = 0;
+      async_id_fields[kDefaultTriggerAsyncId] = -1;
 
       if (exceptionHandlerState.captureFn !== null) {
         exceptionHandlerState.captureFn(er);

--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -48,7 +48,7 @@ function setupNextTick() {
   const promises = require('internal/process/promises');
   const errors = require('internal/errors');
   const emitPendingUnhandledRejections = promises.setup(scheduleMicrotasks);
-  const initTriggerId = async_hooks.initTriggerId;
+  const getDefaultTriggerAsyncId = async_hooks.getDefaultTriggerAsyncId;
   // Two arrays that share state between C++ and JS.
   const { async_hook_fields, async_id_fields } = async_wrap;
   // Used to change the state of the async id stack.
@@ -210,7 +210,7 @@ function setupNextTick() {
     nextTickQueue.push(new TickObject(callback,
                                       args,
                                       ++async_id_fields[kAsyncIdCounter],
-                                      initTriggerId()));
+                                      getDefaultTriggerAsyncId()));
   }
 
   // `internalNextTick()` will not enqueue any callback when the process is
@@ -237,7 +237,7 @@ function setupNextTick() {
     }
 
     if (triggerAsyncId === null)
-      triggerAsyncId = initTriggerId();
+      triggerAsyncId = getDefaultTriggerAsyncId();
     // In V8 6.2, moving tickInfo & async_id_fields[kAsyncIdCounter] into the
     // TickObject incurs a significant performance penalty in the
     // next-tick-breadth-args benchmark (revisit later)

--- a/lib/net.js
+++ b/lib/net.js
@@ -298,14 +298,15 @@ function onSocketFinish() {
   if (!this._handle || !this._handle.shutdown)
     return this.destroy();
 
-  var req = new ShutdownWrap();
-  req.oncomplete = afterShutdown;
-  req.handle = this._handle;
-  // node::ShutdownWrap isn't instantiated and attached to the JS instance of
-  // ShutdownWrap above until shutdown() is called. So don't set the init
-  // trigger id until now.
-  var err = defaultTriggerAsyncIdScope(this[async_id_symbol],
-                                       () => this._handle.shutdown(req));
+  var err = defaultTriggerAsyncIdScope(
+    this[async_id_symbol], [this, afterShutdown],
+    function([self, afterShutdown]) {
+      var req = new ShutdownWrap();
+      req.oncomplete = afterShutdown;
+      req.handle = self._handle;
+      return self._handle.shutdown(req);
+    }
+  );
 
   if (err)
     return this.destroy(errnoException(err, 'shutdown'));
@@ -907,7 +908,7 @@ function checkBindError(err, port, handle) {
 
 
 function internalConnect(
-  self, address, port, addressType, localAddress, localPort) {
+  [self, address, port, addressType, localAddress, localPort]) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
 
@@ -945,26 +946,16 @@ function internalConnect(
     req.localAddress = localAddress;
     req.localPort = localPort;
 
-    // node::TCPConnectWrap isn't instantiated and attached to the JS instance
-    // of TCPConnectWrap above until connect() is called. So don't set the init
-    // trigger id until now.
-    defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
-      if (addressType === 4)
-        err = self._handle.connect(req, address, port);
-      else
-        err = self._handle.connect6(req, address, port);
-    });
-
+    if (addressType === 4)
+      err = self._handle.connect(req, address, port);
+    else
+      err = self._handle.connect6(req, address, port);
   } else {
     const req = new PipeConnectWrap();
     req.address = address;
     req.oncomplete = afterConnect;
-    // node::PipeConnectWrap isn't instantiated and attached to the JS instance
-    // of PipeConnectWrap above until connect() is called. So don't set the
-    // init trigger id until now.
-    err = defaultTriggerAsyncIdScope(
-      self[async_id_symbol],
-      () => self._handle.connect(req, address, afterConnect));
+
+    err = self._handle.connect(req, address, afterConnect);
   }
 
   if (err) {
@@ -1032,7 +1023,9 @@ Socket.prototype.connect = function(...args) {
                                  'string',
                                  path);
     }
-    internalConnect(this, path);
+    defaultTriggerAsyncIdScope(
+      this[async_id_symbol], [this, path], internalConnect
+    );
   } else {
     lookupAndConnect(this, options);
   }
@@ -1075,7 +1068,11 @@ function lookupAndConnect(self, options) {
   if (addressType) {
     nextTick(self[async_id_symbol], function() {
       if (self.connecting)
-        internalConnect(self, host, port, addressType, localAddress, localPort);
+        defaultTriggerAsyncIdScope(
+          self[async_id_symbol],
+          [self, host, port, addressType, localAddress, localPort],
+          internalConnect
+        );
     });
     return;
   }
@@ -1099,7 +1096,7 @@ function lookupAndConnect(self, options) {
   debug('connect: dns options', dnsopts);
   self._host = host;
   var lookup = options.lookup || dns.lookup;
-  defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
+  defaultTriggerAsyncIdScope(self[async_id_symbol], null, function() {
     lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType, host);
 
@@ -1119,12 +1116,11 @@ function lookupAndConnect(self, options) {
         process.nextTick(connectErrorNT, self, err);
       } else {
         self._unrefTimer();
-        internalConnect(self,
-                        ip,
-                        port,
-                        addressType,
-                        localAddress,
-                        localPort);
+        defaultTriggerAsyncIdScope(
+          self[async_id_symbol],
+          [self, ip, port, addressType, localAddress, localPort],
+          internalConnect
+        );
       }
     });
   });

--- a/lib/net.js
+++ b/lib/net.js
@@ -278,7 +278,7 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 };
 
 
-function shutdownSocket([self, callback]) {
+function shutdownSocket(self, callback) {
   var req = new ShutdownWrap();
   req.oncomplete = callback;
   req.handle = self._handle;
@@ -910,7 +910,7 @@ function checkBindError(err, port, handle) {
 
 
 function internalConnect(
-  [self, address, port, addressType, localAddress, localPort]) {
+  self, address, port, addressType, localAddress, localPort) {
   // TODO return promise from Socket.prototype.connect which
   // wraps _connectReq.
 
@@ -1098,7 +1098,7 @@ function lookupAndConnect(self, options) {
   debug('connect: dns options', dnsopts);
   self._host = host;
   var lookup = options.lookup || dns.lookup;
-  defaultTriggerAsyncIdScope(self[async_id_symbol], null, function() {
+  defaultTriggerAsyncIdScope(self[async_id_symbol], [], function() {
     lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType, host);
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -43,7 +43,7 @@ const { TCPConnectWrap } = process.binding('tcp_wrap');
 const { PipeConnectWrap } = process.binding('pipe_wrap');
 const { ShutdownWrap, WriteWrap } = process.binding('stream_wrap');
 const { async_id_symbol } = process.binding('async_wrap');
-const { newUid, setInitTriggerId } = require('internal/async_hooks');
+const { newUid, setDefaultTriggerAsyncId } = require('internal/async_hooks');
 const { nextTick } = require('internal/process/next_tick');
 const errors = require('internal/errors');
 const dns = require('dns');
@@ -304,7 +304,7 @@ function onSocketFinish() {
   // node::ShutdownWrap isn't instantiated and attached to the JS instance of
   // ShutdownWrap above until shutdown() is called. So don't set the init
   // trigger id until now.
-  setInitTriggerId(this[async_id_symbol]);
+  setDefaultTriggerAsyncId(this[async_id_symbol]);
   var err = this._handle.shutdown(req);
 
   if (err)
@@ -948,7 +948,7 @@ function internalConnect(
     // node::TCPConnectWrap isn't instantiated and attached to the JS instance
     // of TCPConnectWrap above until connect() is called. So don't set the init
     // trigger id until now.
-    setInitTriggerId(self[async_id_symbol]);
+    setDefaultTriggerAsyncId(self[async_id_symbol]);
     if (addressType === 4)
       err = self._handle.connect(req, address, port);
     else
@@ -961,7 +961,7 @@ function internalConnect(
     // node::PipeConnectWrap isn't instantiated and attached to the JS instance
     // of PipeConnectWrap above until connect() is called. So don't set the
     // init trigger id until now.
-    setInitTriggerId(self[async_id_symbol]);
+    setDefaultTriggerAsyncId(self[async_id_symbol]);
     err = self._handle.connect(req, address, afterConnect);
   }
 
@@ -1097,7 +1097,7 @@ function lookupAndConnect(self, options) {
   debug('connect: dns options', dnsopts);
   self._host = host;
   var lookup = options.lookup || dns.lookup;
-  setInitTriggerId(self[async_id_symbol]);
+  setDefaultTriggerAsyncId(self[async_id_symbol]);
   lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
     self.emit('lookup', err, ip, addressType, host);
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -277,6 +277,14 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
     timers._unrefActive(s);
 };
 
+
+function shutdownSocket([self, callback]) {
+  var req = new ShutdownWrap();
+  req.oncomplete = callback;
+  req.handle = self._handle;
+  return self._handle.shutdown(req);
+}
+
 // the user has called .end(), and all the bytes have been
 // sent out to the other side.
 function onSocketFinish() {
@@ -299,13 +307,7 @@ function onSocketFinish() {
     return this.destroy();
 
   var err = defaultTriggerAsyncIdScope(
-    this[async_id_symbol], [this, afterShutdown],
-    function([self, afterShutdown]) {
-      var req = new ShutdownWrap();
-      req.oncomplete = afterShutdown;
-      req.handle = self._handle;
-      return self._handle.shutdown(req);
-    }
+    this[async_id_symbol], [this, afterShutdown], shutdownSocket
   );
 
   if (err)

--- a/lib/net.js
+++ b/lib/net.js
@@ -43,7 +43,7 @@ const { TCPConnectWrap } = process.binding('tcp_wrap');
 const { PipeConnectWrap } = process.binding('pipe_wrap');
 const { ShutdownWrap, WriteWrap } = process.binding('stream_wrap');
 const { async_id_symbol } = process.binding('async_wrap');
-const { newUid, setDefaultTriggerAsyncId } = require('internal/async_hooks');
+const { newUid, defaultTriggerAsyncIdScope } = require('internal/async_hooks');
 const { nextTick } = require('internal/process/next_tick');
 const errors = require('internal/errors');
 const dns = require('dns');
@@ -304,8 +304,8 @@ function onSocketFinish() {
   // node::ShutdownWrap isn't instantiated and attached to the JS instance of
   // ShutdownWrap above until shutdown() is called. So don't set the init
   // trigger id until now.
-  setDefaultTriggerAsyncId(this[async_id_symbol]);
-  var err = this._handle.shutdown(req);
+  var err = defaultTriggerAsyncIdScope(this[async_id_symbol],
+                                       () => this._handle.shutdown(req));
 
   if (err)
     return this.destroy(errnoException(err, 'shutdown'));
@@ -948,11 +948,12 @@ function internalConnect(
     // node::TCPConnectWrap isn't instantiated and attached to the JS instance
     // of TCPConnectWrap above until connect() is called. So don't set the init
     // trigger id until now.
-    setDefaultTriggerAsyncId(self[async_id_symbol]);
-    if (addressType === 4)
-      err = self._handle.connect(req, address, port);
-    else
-      err = self._handle.connect6(req, address, port);
+    defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
+      if (addressType === 4)
+        err = self._handle.connect(req, address, port);
+      else
+        err = self._handle.connect6(req, address, port);
+    });
 
   } else {
     const req = new PipeConnectWrap();
@@ -961,8 +962,9 @@ function internalConnect(
     // node::PipeConnectWrap isn't instantiated and attached to the JS instance
     // of PipeConnectWrap above until connect() is called. So don't set the
     // init trigger id until now.
-    setDefaultTriggerAsyncId(self[async_id_symbol]);
-    err = self._handle.connect(req, address, afterConnect);
+    err = defaultTriggerAsyncIdScope(
+      self[async_id_symbol],
+      () => self._handle.connect(req, address, afterConnect));
   }
 
   if (err) {
@@ -1097,33 +1099,34 @@ function lookupAndConnect(self, options) {
   debug('connect: dns options', dnsopts);
   self._host = host;
   var lookup = options.lookup || dns.lookup;
-  setDefaultTriggerAsyncId(self[async_id_symbol]);
-  lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
-    self.emit('lookup', err, ip, addressType, host);
+  defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
+    lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
+      self.emit('lookup', err, ip, addressType, host);
 
-    // It's possible we were destroyed while looking this up.
-    // XXX it would be great if we could cancel the promise returned by
-    // the look up.
-    if (!self.connecting) return;
+      // It's possible we were destroyed while looking this up.
+      // XXX it would be great if we could cancel the promise returned by
+      // the look up.
+      if (!self.connecting) return;
 
-    if (err) {
-      // net.createConnection() creates a net.Socket object and
-      // immediately calls net.Socket.connect() on it (that's us).
-      // There are no event listeners registered yet so defer the
-      // error event to the next tick.
-      err.host = options.host;
-      err.port = options.port;
-      err.message = err.message + ' ' + options.host + ':' + options.port;
-      process.nextTick(connectErrorNT, self, err);
-    } else {
-      self._unrefTimer();
-      internalConnect(self,
-                      ip,
-                      port,
-                      addressType,
-                      localAddress,
-                      localPort);
-    }
+      if (err) {
+        // net.createConnection() creates a net.Socket object and
+        // immediately calls net.Socket.connect() on it (that's us).
+        // There are no event listeners registered yet so defer the
+        // error event to the next tick.
+        err.host = options.host;
+        err.port = options.port;
+        err.message = err.message + ' ' + options.host + ':' + options.port;
+        process.nextTick(connectErrorNT, self, err);
+      } else {
+        self._unrefTimer();
+        internalConnect(self,
+                        ip,
+                        port,
+                        addressType,
+                        localAddress,
+                        localPort);
+      }
+    });
   });
 }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -34,7 +34,7 @@ const kOnTimeout = TimerWrap.kOnTimeout | 0;
 // Two arrays that share state between C++ and JS.
 const { async_hook_fields, async_id_fields } = async_wrap;
 const {
-  initTriggerId,
+  getDefaultTriggerAsyncId,
   // The needed emit*() functions.
   emitInit,
   emitBefore,
@@ -181,7 +181,7 @@ function insert(item, unrefed) {
   if (!item[async_id_symbol] || item._destroyed) {
     item._destroyed = false;
     item[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
-    item[trigger_async_id_symbol] = initTriggerId();
+    item[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
     if (async_hook_fields[kInit] > 0) {
       emitInit(item[async_id_symbol],
                'Timeout',
@@ -560,7 +560,7 @@ function Timeout(callback, after, args, isRepeat) {
   this._destroyed = false;
 
   this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
-  this[trigger_async_id_symbol] = initTriggerId();
+  this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
   if (async_hook_fields[kInit] > 0) {
     emitInit(this[async_id_symbol],
              'Timeout',
@@ -786,7 +786,7 @@ function Immediate(callback, args) {
   this._destroyed = false;
 
   this[async_id_symbol] = ++async_id_fields[kAsyncIdCounter];
-  this[trigger_async_id_symbol] = initTriggerId();
+  this[trigger_async_id_symbol] = getDefaultTriggerAsyncId();
   if (async_hook_fields[kInit] > 0) {
     emitInit(this[async_id_symbol],
              'Immediate',

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -308,12 +308,13 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
       if (parent_wrap == nullptr) {
         parent_wrap = PromiseWrap::New(env, parent_promise, nullptr, true);
       }
-      // get id from parentWrap
-      double trigger_async_id = parent_wrap->get_async_id();
-      env->set_default_trigger_async_id(trigger_async_id);
-    }
 
-    wrap = PromiseWrap::New(env, promise, parent_wrap, silent);
+      AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+        env, parent_wrap->get_async_id());
+      wrap = PromiseWrap::New(env, promise, parent_wrap, silent);
+    } else {
+      wrap = PromiseWrap::New(env, promise, nullptr, silent);
+    }
   }
 
   CHECK_NE(wrap, nullptr);

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -310,7 +310,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
       }
       // get id from parentWrap
       double trigger_async_id = parent_wrap->get_async_id();
-      env->set_init_trigger_async_id(trigger_async_id);
+      env->set_default_trigger_async_id(trigger_async_id);
     }
 
     wrap = PromiseWrap::New(env, promise, parent_wrap, silent);
@@ -542,9 +542,10 @@ void AsyncWrap::Initialize(Local<Object> target,
   //
   // kAsyncUid: Maintains the state of the next unique id to be assigned.
   //
-  // kInitTriggerAsyncId: Write the id of the resource responsible for a
+  // kDefaultTriggerAsyncId: Write the id of the resource responsible for a
   //   handle's creation just before calling the new handle's constructor.
-  //   After the new handle is constructed kInitTriggerAsyncId is set back to 0.
+  //   After the new handle is constructed kDefaultTriggerAsyncId is set back
+  //   to 0.
   FORCE_SET_TARGET_FIELD(target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());
@@ -564,7 +565,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kExecutionAsyncId);
   SET_HOOKS_CONSTANT(kTriggerAsyncId);
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
-  SET_HOOKS_CONSTANT(kInitTriggerAsyncId);
+  SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);
 
@@ -677,7 +678,7 @@ void AsyncWrap::EmitDestroy(Environment* env, double async_id) {
 void AsyncWrap::AsyncReset(double execution_async_id, bool silent) {
   async_id_ =
     execution_async_id == -1 ? env()->new_async_id() : execution_async_id;
-  trigger_async_id_ = env()->get_init_trigger_async_id();
+  trigger_async_id_ = env()->get_default_trigger_async_id();
 
   switch (provider_type()) {
 #define V(PROVIDER)                                                           \
@@ -778,7 +779,7 @@ async_context EmitAsyncInit(Isolate* isolate,
 
   // Initialize async context struct
   if (trigger_async_id == -1)
-    trigger_async_id = env->get_init_trigger_async_id();
+    trigger_async_id = env->get_default_trigger_async_id();
 
   async_context context = {
     env->new_async_id(),  // async_id_

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -49,7 +49,6 @@ void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
   };
 
   if (status == 0) {
-    env->set_default_trigger_async_id(wrap_data->get_async_id());
     // Instantiate the client javascript object and handle.
     Local<Object> client_obj = WrapType::Instantiate(env,
                                                      wrap_data,

--- a/src/connection_wrap.cc
+++ b/src/connection_wrap.cc
@@ -49,7 +49,7 @@ void ConnectionWrap<WrapType, UVType>::OnConnection(uv_stream_t* handle,
   };
 
   if (status == 0) {
-    env->set_init_trigger_async_id(wrap_data->get_async_id());
+    env->set_default_trigger_async_id(wrap_data->get_async_id());
     // Instantiate the client javascript object and handle.
     Local<Object> client_obj = WrapType::Instantiate(env,
                                                      wrap_data,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -176,22 +176,26 @@ inline void Environment::AsyncHooks::clear_async_id_stack() {
   async_id_fields_[kTriggerAsyncId] = 0;
 }
 
-inline Environment::AsyncHooks::InitScope::InitScope(
-    Environment* env, double init_trigger_async_id)
-        : env_(env),
-          async_id_fields_ref_(env->async_hooks()->async_id_fields()) {
-  if (env_->async_hooks()->fields()[AsyncHooks::kCheck] > 0) {
-    CHECK_GE(init_trigger_async_id, -1);
+inline Environment::AsyncHooks::DefaultTriggerAsyncIdScope
+  ::DefaultTriggerAsyncIdScope(Environment* env,
+                               double default_trigger_async_id)
+    : async_id_fields_ref_(env->async_hooks()->async_id_fields()) {
+  if (env->async_hooks()->fields()[AsyncHooks::kCheck] > 0) {
+    CHECK_GE(default_trigger_async_id, 0);
   }
-  env->async_hooks()->push_async_ids(
-    async_id_fields_ref_[AsyncHooks::kExecutionAsyncId],
-    init_trigger_async_id);
+
+  old_default_trigger_async_id_ =
+    async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId];
+  async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId] =
+    default_trigger_async_id;
 }
 
-inline Environment::AsyncHooks::InitScope::~InitScope() {
-  env_->async_hooks()->pop_async_id(
-    async_id_fields_ref_[AsyncHooks::kExecutionAsyncId]);
+inline Environment::AsyncHooks::DefaultTriggerAsyncIdScope
+  ::~DefaultTriggerAsyncIdScope() {
+  async_id_fields_ref_[AsyncHooks::kDefaultTriggerAsyncId] =
+    old_default_trigger_async_id_;
 }
+
 
 inline Environment::AsyncCallbackScope::AsyncCallbackScope(Environment* env)
     : env_(env) {
@@ -456,15 +460,10 @@ inline double Environment::trigger_async_id() {
 inline double Environment::get_default_trigger_async_id() {
   double default_trigger_async_id =
     async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId];
-  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = -1;
   // If defaultTriggerAsyncId isn't set, use the executionAsyncId
   if (default_trigger_async_id < 0)
     default_trigger_async_id = execution_async_id();
   return default_trigger_async_id;
-}
-
-inline void Environment::set_default_trigger_async_id(const double id) {
-  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = id;
 }
 
 inline double* Environment::heap_statistics_buffer() const {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -447,17 +447,18 @@ inline double Environment::trigger_async_id() {
   return async_hooks()->async_id_fields()[AsyncHooks::kTriggerAsyncId];
 }
 
-inline double Environment::get_init_trigger_async_id() {
-  AliasedBuffer<double, v8::Float64Array>& async_id_fields =
-    async_hooks()->async_id_fields();
-  double tid = async_id_fields[AsyncHooks::kInitTriggerAsyncId];
-  async_id_fields[AsyncHooks::kInitTriggerAsyncId] = 0;
-  if (tid <= 0) tid = execution_async_id();
-  return tid;
+inline double Environment::get_default_trigger_async_id() {
+  double default_trigger_async_id =
+    async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId];
+  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = 0;
+  // If defaultTriggerAsyncId isn't set, use the executionAsyncId
+  if (default_trigger_async_id <= 0)
+    default_trigger_async_id = execution_async_id();
+  return default_trigger_async_id;
 }
 
-inline void Environment::set_init_trigger_async_id(const double id) {
-  async_hooks()->async_id_fields()[AsyncHooks::kInitTriggerAsyncId] = id;
+inline void Environment::set_default_trigger_async_id(const double id) {
+  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = id;
 }
 
 inline double* Environment::heap_statistics_buffer() const {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -66,6 +66,12 @@ inline Environment::AsyncHooks::AsyncHooks(v8::Isolate* isolate)
   // and flag changes won't be included.
   fields_[kCheck] = 1;
 
+  // kDefaultTriggerAsyncId should be -1, this indicates that there is no
+  // specified default value and it should fallback to the executionAsyncId.
+  // 0 is not used as the magic value, because that indicates a missing context
+  // which is different from a default context.
+  async_id_fields_[AsyncHooks::kDefaultTriggerAsyncId] = -1;
+
   // kAsyncIdCounter should start at 1 because that'll be the id the execution
   // context during bootstrap (code that runs before entering uv_run()).
   async_id_fields_[AsyncHooks::kAsyncIdCounter] = 1;
@@ -450,9 +456,9 @@ inline double Environment::trigger_async_id() {
 inline double Environment::get_default_trigger_async_id() {
   double default_trigger_async_id =
     async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId];
-  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = 0;
+  async_hooks()->async_id_fields()[AsyncHooks::kDefaultTriggerAsyncId] = -1;
   // If defaultTriggerAsyncId isn't set, use the executionAsyncId
-  if (default_trigger_async_id <= 0)
+  if (default_trigger_async_id < 0)
     default_trigger_async_id = execution_async_id();
   return default_trigger_async_id;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -402,21 +402,22 @@ class Environment {
     inline size_t stack_size();
     inline void clear_async_id_stack();  // Used in fatal exceptions.
 
-    // Used to propagate the trigger_async_id to the constructor of any newly
-    // created resources using RAII. Instead of needing to pass the
-    // trigger_async_id along with other constructor arguments.
-    class InitScope {
+    // Used to set the kDefaultTriggerAsyncId in a scope. This is instead of
+    // passing the trigger_async_id along with other constructor arguments.
+    class DefaultTriggerAsyncIdScope {
      public:
-      InitScope() = delete;
-      explicit InitScope(Environment* env, double init_trigger_async_id);
-      ~InitScope();
+      DefaultTriggerAsyncIdScope() = delete;
+      explicit DefaultTriggerAsyncIdScope(Environment* env,
+                                          double init_trigger_async_id);
+      ~DefaultTriggerAsyncIdScope();
 
      private:
-      Environment* env_;
       AliasedBuffer<double, v8::Float64Array> async_id_fields_ref_;
+      double old_default_trigger_async_id_;
 
-      DISALLOW_COPY_AND_ASSIGN(InitScope);
+      DISALLOW_COPY_AND_ASSIGN(DefaultTriggerAsyncIdScope);
     };
+
 
    private:
     friend class Environment;  // So we can call the constructor.
@@ -559,7 +560,6 @@ class Environment {
   inline double execution_async_id();
   inline double trigger_async_id();
   inline double get_default_trigger_async_id();
-  inline void set_default_trigger_async_id(const double id);
 
   // List of id's that have been destroyed and need the destroy() cb called.
   inline std::vector<double>* destroy_async_id_list();

--- a/src/env.h
+++ b/src/env.h
@@ -381,7 +381,7 @@ class Environment {
       kExecutionAsyncId,
       kTriggerAsyncId,
       kAsyncIdCounter,
-      kInitTriggerAsyncId,
+      kDefaultTriggerAsyncId,
       kUidFieldsCount,
     };
 
@@ -558,8 +558,8 @@ class Environment {
   inline double new_async_id();
   inline double execution_async_id();
   inline double trigger_async_id();
-  inline double get_init_trigger_async_id();
-  inline void set_init_trigger_async_id(const double id);
+  inline double get_default_trigger_async_id();
+  inline void set_default_trigger_async_id(const double id);
 
   // List of id's that have been destroyed and need the destroy() cb called.
   inline std::vector<double>* destroy_async_id_list();

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -53,7 +53,8 @@ Local<Object> PipeWrap::Instantiate(Environment* env,
                                     AsyncWrap* parent,
                                     PipeWrap::SocketType type) {
   EscapableHandleScope handle_scope(env->isolate());
-  AsyncHooks::InitScope init_scope(env, parent->get_async_id());
+  AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(env,
+                                                       parent->get_async_id());
   CHECK_EQ(false, env->pipe_constructor_template().IsEmpty());
   Local<Function> constructor = env->pipe_constructor_template()->GetFunction();
   CHECK_EQ(false, constructor.IsEmpty());

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -143,7 +143,8 @@ void StreamBase::JSMethod(const FunctionCallbackInfo<Value>& args) {
   if (!wrap->IsAlive())
     return args.GetReturnValue().Set(UV_EINVAL);
 
-  AsyncHooks::InitScope init_scope(handle->env(), handle->get_async_id());
+  AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+    handle->env(), handle->get_async_id());
   args.GetReturnValue().Set((wrap->*Method)(args));
 }
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -52,7 +52,7 @@ int StreamBase::Shutdown(const FunctionCallbackInfo<Value>& args) {
 
   AsyncWrap* wrap = GetAsyncWrap();
   CHECK_NE(wrap, nullptr);
-  env->set_default_trigger_async_id(wrap->get_async_id());
+  AsyncHooks::DefaultTriggerAsyncIdScope(env, wrap->get_async_id());
   ShutdownWrap* req_wrap = new ShutdownWrap(env,
                                             req_wrap_obj,
                                             this);
@@ -109,7 +109,6 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
   size_t storage_size = 0;
   uint32_t bytes = 0;
   size_t offset;
-  AsyncWrap* wrap;
   WriteWrap* req_wrap;
   int err;
 
@@ -153,10 +152,13 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
       goto done;
   }
 
-  wrap = GetAsyncWrap();
-  CHECK_NE(wrap, nullptr);
-  env->set_default_trigger_async_id(wrap->get_async_id());
-  req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
+  {
+    AsyncWrap* wrap = GetAsyncWrap();
+    CHECK_NE(wrap, nullptr);
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(env,
+                                                         wrap->get_async_id());
+    req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
+  }
 
   offset = 0;
   if (!all_buffers) {
@@ -227,7 +229,6 @@ int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   const char* data = Buffer::Data(args[1]);
   size_t length = Buffer::Length(args[1]);
 
-  AsyncWrap* wrap;
   WriteWrap* req_wrap;
   uv_buf_t buf;
   buf.base = const_cast<char*>(data);
@@ -243,11 +244,14 @@ int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
     goto done;
   CHECK_EQ(count, 1);
 
-  wrap = GetAsyncWrap();
-  if (wrap != nullptr)
-    env->set_default_trigger_async_id(wrap->get_async_id());
   // Allocate, or write rest
-  req_wrap = WriteWrap::New(env, req_wrap_obj, this);
+  {
+    AsyncWrap* wrap = GetAsyncWrap();
+    CHECK_NE(wrap, nullptr);
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(env,
+                                                         wrap->get_async_id());
+    req_wrap = WriteWrap::New(env, req_wrap_obj, this);
+  }
 
   err = DoWrite(req_wrap, bufs, count, nullptr);
   if (HasWriteQueue())
@@ -278,7 +282,6 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
   Local<Object> req_wrap_obj = args[0].As<Object>();
   Local<String> string = args[1].As<String>();
   Local<Object> send_handle_obj;
-  AsyncWrap* wrap;
   if (args[2]->IsObject())
     send_handle_obj = args[2].As<Object>();
 
@@ -329,10 +332,13 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
     CHECK_EQ(count, 1);
   }
 
-  wrap = GetAsyncWrap();
-  if (wrap != nullptr)
-    env->set_default_trigger_async_id(wrap->get_async_id());
-  req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
+  {
+    AsyncWrap* wrap = GetAsyncWrap();
+    CHECK_NE(wrap, nullptr);
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(env,
+                                                         wrap->get_async_id());
+    req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
+  }
 
   data = req_wrap->Extra();
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -52,7 +52,7 @@ int StreamBase::Shutdown(const FunctionCallbackInfo<Value>& args) {
 
   AsyncWrap* wrap = GetAsyncWrap();
   CHECK_NE(wrap, nullptr);
-  env->set_init_trigger_async_id(wrap->get_async_id());
+  env->set_default_trigger_async_id(wrap->get_async_id());
   ShutdownWrap* req_wrap = new ShutdownWrap(env,
                                             req_wrap_obj,
                                             this);
@@ -155,7 +155,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   wrap = GetAsyncWrap();
   CHECK_NE(wrap, nullptr);
-  env->set_init_trigger_async_id(wrap->get_async_id());
+  env->set_default_trigger_async_id(wrap->get_async_id());
   req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
 
   offset = 0;
@@ -245,7 +245,7 @@ int StreamBase::WriteBuffer(const FunctionCallbackInfo<Value>& args) {
 
   wrap = GetAsyncWrap();
   if (wrap != nullptr)
-    env->set_init_trigger_async_id(wrap->get_async_id());
+    env->set_default_trigger_async_id(wrap->get_async_id());
   // Allocate, or write rest
   req_wrap = WriteWrap::New(env, req_wrap_obj, this);
 
@@ -331,7 +331,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
 
   wrap = GetAsyncWrap();
   if (wrap != nullptr)
-    env->set_init_trigger_async_id(wrap->get_async_id());
+    env->set_default_trigger_async_id(wrap->get_async_id());
   req_wrap = WriteWrap::New(env, req_wrap_obj, this, storage_size);
 
   data = req_wrap->Extra();

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -56,7 +56,8 @@ Local<Object> TCPWrap::Instantiate(Environment* env,
                                    AsyncWrap* parent,
                                    TCPWrap::SocketType type) {
   EscapableHandleScope handle_scope(env->isolate());
-  AsyncHooks::InitScope init_scope(env, parent->get_async_id());
+  AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+    env, parent->get_async_id());
   CHECK_EQ(env->tcp_constructor_template().IsEmpty(), false);
   Local<Function> constructor = env->tcp_constructor_template()->GetFunction();
   CHECK_EQ(constructor.IsEmpty(), false);
@@ -292,7 +293,8 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip4_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    env->set_default_trigger_async_id(wrap->get_async_id());
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+      env, wrap->get_async_id());
     ConnectWrap* req_wrap =
         new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPCONNECTWRAP);
     err = uv_tcp_connect(req_wrap->req(),
@@ -328,7 +330,8 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip6_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    env->set_default_trigger_async_id(wrap->get_async_id());
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+      env, wrap->get_async_id());
     ConnectWrap* req_wrap =
         new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPCONNECTWRAP);
     err = uv_tcp_connect(req_wrap->req(),

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -292,7 +292,7 @@ void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip4_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    env->set_init_trigger_async_id(wrap->get_async_id());
+    env->set_default_trigger_async_id(wrap->get_async_id());
     ConnectWrap* req_wrap =
         new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPCONNECTWRAP);
     err = uv_tcp_connect(req_wrap->req(),
@@ -328,7 +328,7 @@ void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
   int err = uv_ip6_addr(*ip_address, port, &addr);
 
   if (err == 0) {
-    env->set_init_trigger_async_id(wrap->get_async_id());
+    env->set_default_trigger_async_id(wrap->get_async_id());
     ConnectWrap* req_wrap =
         new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_TCPCONNECTWRAP);
     err = uv_tcp_connect(req_wrap->req(),

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -357,8 +357,12 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   node::Utf8Value address(env->isolate(), args[4]);
   const bool have_callback = args[5]->IsTrue();
 
-  env->set_default_trigger_async_id(wrap->get_async_id());
-  SendWrap* req_wrap = new SendWrap(env, req_wrap_obj, have_callback);
+  SendWrap* req_wrap;
+  {
+    AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+      env, wrap->get_async_id());
+    req_wrap = new SendWrap(env, req_wrap_obj, have_callback);
+  }
   size_t msg_size = 0;
 
   MaybeStackBuffer<uv_buf_t, 16> bufs(count);
@@ -507,7 +511,9 @@ Local<Object> UDPWrap::Instantiate(Environment* env,
                                    AsyncWrap* parent,
                                    UDPWrap::SocketType type) {
   EscapableHandleScope scope(env->isolate());
-  AsyncHooks::InitScope init_scope(env, parent->get_async_id());
+  AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(
+    env, parent->get_async_id());
+
   // If this assert fires then Initialize hasn't been called yet.
   CHECK_EQ(env->udp_constructor_function().IsEmpty(), false);
   Local<Object> instance = env->udp_constructor_function()

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -357,7 +357,7 @@ void UDPWrap::DoSend(const FunctionCallbackInfo<Value>& args, int family) {
   node::Utf8Value address(env->isolate(), args[4]);
   const bool have_callback = args[5]->IsTrue();
 
-  env->set_init_trigger_async_id(wrap->get_async_id());
+  env->set_default_trigger_async_id(wrap->get_async_id());
   SendWrap* req_wrap = new SendWrap(env, req_wrap_obj, have_callback);
   size_t msg_size = 0;
 


### PR DESCRIPTION
* The first commit just renames `initTriggerId` to `defaultTriggerAsyncId`. I think `default` is much more descriptive and we try to never use just `id` in `async_hooks` but instead `asyncId`.
* The second commit changes the magic value from `0` to `-1`. This is because `0` in the `executionAsyncId` context refers to a missing context, while `0` in `defaultTriggerAsyncId` previously meant default context. This allows the `defaultTriggerAsyncId` to mean missing context too.
* The third commit is the main change. It changes `defaultTriggerAsyncId` from being set by the setter and reset by the getter, to instead have `defaultTriggerAsyncId` be bound to a scope. The getter then doesn't change the value. This is much more intuitive than getters mutating its own value. This is actually related to the work done by @refack in https://github.com/nodejs/node/pull/14302 but this is a much more complete version of that.

Note: All this is internal logic. However, in node `v8.x` and `v9.x` the `initTriggerId` is unfortunately exported (although deprecated), so properly we need to do a manual backport for those versions.

_edit: Oh, the entire motivation behind this is that I want to improve some of our set `triggerAsyncId`s. However, in those cases, it is not transparent if a new handle is always created thus the `kDefaultTriggerAsyncId` value might leak. Binding `kDefaultTriggerAsyncId` to a scope prevents a leak._

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks
