### PR TITLE
 build: better error message on python fail

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -1,7 +1,8 @@
 @IF NOT DEFINED DEBUG_HELPER @ECHO OFF
+IF NOT "%VCBUILD_PYTHON_LOCATION%"=="" EXIT /B
 SETLOCAL
 :: If python.exe is in %Path%, just validate
-FOR /F "delims=" %%a IN ('where python 2^> NUL') DO (
+FOR /F "delims=" %%a IN ('where python') DO (
   SET need_path=0
   SET p=%%~dpa
   IF NOT ERRORLEVEL 1 GOTO :validate
@@ -19,7 +20,7 @@ EXIT /B 1
 :: Helper subroutine to handle quotes in %1
 :find-main-branch
 SET main_key="%~1\Python\PythonCore"
-REG QUERY %main_key% /s | findstr "2." | findstr InstallPath > NUL 2> NUL
+REG QUERY %main_key% /s | findstr "2." | findstr InstallPath
 IF NOT ERRORLEVEL 1 CALL :find-key %main_key%
 EXIT /B
 
@@ -41,7 +42,7 @@ EXIT /B 1
 :validate
 IF NOT EXIST "%p%python.exe" EXIT /B 1
 :: Check if %p% is python2
-"%p%python.exe" -V 2>&1 | findstr /R "^Python.2.*" > NUL
+"%p%python.exe" -V 2>&1 | findstr /R "^Python.2.*"
 IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 :: We can wrap it up
 ENDLOCAL & SET pt=%p%& SET need_path_ext=%need_path%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -127,7 +127,7 @@ goto next-arg
 
 :environment-validate
 REM Make sure we can find python
-call :run-python --version > NUL
+call :run-python --version > NUL 2>&1
 if errorlevel 1 (
   echo Could not find python2. More information can be found at
   echo https://github.com/nodejs/node/blob/master/BUILDING.md#windows-1
@@ -176,12 +176,14 @@ if "%i18n_arg%"=="without-intl" set configure_flags=%configure_flags% --without-
 
 if defined config_flags set configure_flags=%configure_flags% %config_flags%
 
+if not "%target%"=="Clean" goto no-clean
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
-if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
+for /d %%I IN ("%~dp0%config%\node-v*") do rmdir /Q /S "%%I"
+:no-clean
 
 if defined noprojgen if defined nobuild if not defined sign if not defined msi goto licensertf
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -53,7 +53,7 @@ set nghttp2_debug=
 set link_module=
 
 :next-arg
-if "%1"=="" goto args-done
+if "%1"=="" goto environment-validate
 if /i "%1"=="debug"         set config=Debug&goto arg-ok
 if /i "%1"=="release"       set config=Release&goto arg-ok
 if /i "%1"=="clean"         set target=Clean&goto arg-ok
@@ -125,19 +125,19 @@ shift
 shift
 goto next-arg
 
-:args-done
-
-REM Shortcut for just linting (does not need python)
-if "%*"=="lint" (
-  goto lint-cpp
-)
-
+:environment-validate
 REM Make sure we can find python
 call :run-python --version > NUL
 if errorlevel 1 (
   echo Could not find python2. More information can be found at
   echo https://github.com/nodejs/node/blob/master/BUILDING.md#windows-1
   exit /b 1
+)
+
+
+REM Shortcut for just linting (does not need python)
+if "%*"=="lint" (
+  goto lint-cpp
 )
 
 if defined build_release (


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/16864
Refs: https://github.com/nodejs/node/pull/17293

On a machine without python installed:
```
d:\code\node$ vcbuild
Could not find python2. More information can be found at
https://github.com/nodejs/node/blob/master/BUILDING.md#windows-1
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build,windows,tools