### PR TITLE
doc: move Code of Conduct to admin repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,8 @@
 # Code of Conduct
 
 The Node.js Code of Conduct document has moved to
-https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md. Please update
+https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md. Please update
 links to this document accordingly.
+
+The Node.js Moderation policy can be found at
+https://github.com/nodejs/admin/blob/master/Moderation-Policy.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -862,7 +862,7 @@ By making a contribution to this project, I certify that:
 [benchmark results]: ./doc/guides/writing-and-running-benchmarks.md
 [Building guide]: ./BUILDING.md
 [CI (Continuous Integration) test run]: #ci-testing
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [https://ci.nodejs.org/]: https://ci.nodejs.org/
 [IRC in the #node-dev channel]: https://webchat.freenode.net?channels=node-dev&uio=d4
 [Node.js help repository]: https://github.com/nodejs/help/issues

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ Previous releases may also have been signed with one of the following GPG keys:
 * [Working Groups][]
 
 [npm]: https://www.npmjs.com
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [Contributing to the project]: CONTRIBUTING.md
 [Node.js Help]: https://github.com/nodejs/help
 [Node.js Website]: https://nodejs.org/en/

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -178,6 +178,6 @@ onboarding session.
     accommodation, transportation, visa fees etc. if needed. Check out the
     [summit](https://github.com/nodejs/summit) repository for details.
 
-[Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [`core-validate-commit`]: https://github.com/evanlucas/core-validate-commit
 [`node-core-utils`]: https://github.com/nodejs/node-core-utils


### PR DESCRIPTION
The CoC and moderation guidelines now live in the Admin repo.

This PR updates the copy of CODE_OF_CONDUCT.md and references in
other documents to the proper location.