### PR TITLE
test: add test of transform

### DIFF
--- a/test/parallel/test-stream2-transform.js
+++ b/test/parallel/test-stream2-transform.js
@@ -97,6 +97,13 @@ const Transform = require('_stream_transform');
 }
 
 {
+  // Verify transform constructor behavior
+  const pt = Transform();
+
+  assert(pt instanceof Transform);
+}
+
+{
   // Perform a simple transform
   const pt = new Transform();
   pt._transform = function(c, e, cb) {


### PR DESCRIPTION
This is part of Nodefest's Code and Learn https://github.com/nodejs/code-and-learn/issues/72

I added a test case of Transform constructor. The constructor can work without `new` operator, but the behavior doesn't seem covered in current test cases according to the latest coverage report ( https://coverage.nodejs.org/coverage-3a4fe7791e1c2a1b/root/_stream_transform.js.html ).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
