### PR TITLE
test: make use of Number.isNaN to test-readfloat.js

### DIFF
--- a/test/parallel/test-readfloat.js
+++ b/test/parallel/test-readfloat.js
@@ -50,7 +50,7 @@ function test(clazz) {
   buffer[1] = 0xff;
   buffer[2] = 0x7f;
   buffer[3] = 0x7f;
-  assert.ok(isNaN(buffer.readFloatBE(0)));
+  assert.ok(Number.isNaN(buffer.readFloatBE(0)));
   assert.strictEqual(3.4028234663852886e+38, buffer.readFloatLE(0));
 
   buffer[0] = 0xab;


### PR DESCRIPTION
This is part of Nodefest's Code and Learn [nodejs/code-and-learn#72](https://github.com/nodejs/code-and-learn/issues/72)

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
