### PR TITLE
test: use common.hasIntl instead of typeof Intl in Intl v8BreakIterator test

### DIFF
--- a/test/parallel/test-intl-v8BreakIterator.js
+++ b/test/parallel/test-intl-v8BreakIterator.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const vm = require('vm');
 
-if (typeof Intl === 'undefined')
+if (!common.hasIntl)
   common.skip('missing Intl');
 
 assert(!('v8BreakIterator' in Intl));


### PR DESCRIPTION
This is a part of Nodefest's Code and Learn nodejs/code-and-learn#72
I replace `typeof Intl` to `common.hasIntl` intest/parallel/test-intl-v8BreakIterator.js.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
