### PR TITLE
test: Replace function with arrow function in test-child-process-send-cb.js

### DIFF
--- a/test/parallel/test-child-process-send-cb.js
+++ b/test/parallel/test-child-process-send-cb.js
@@ -4,15 +4,15 @@ const assert = require('assert');
 const fork = require('child_process').fork;
 
 if (process.argv[2] === 'child') {
-  process.send('ok', common.mustCall(function(err) {
+  process.send('ok', common.mustCall((err) => {
     assert.strictEqual(err, null);
   }));
 } else {
   const child = fork(process.argv[1], ['child']);
-  child.on('message', common.mustCall(function(message) {
+  child.on('message', common.mustCall((message) => {
     assert.strictEqual(message, 'ok');
   }));
-  child.on('exit', common.mustCall(function(exitCode, signalCode) {
+  child.on('exit', common.mustCall((exitCode, signalCode) => {
     assert.strictEqual(exitCode, 0);
     assert.strictEqual(signalCode, null);
   }));


### PR DESCRIPTION
Replace some classic functions with arrow functions in test-child-process-send-cb.js

Thie PR is a part of Code and Learn at NodeFest 2017! (https://github.com/nodejs/code-and-learn/issues/72)

----

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

N/A