### PR TITLE
benchmark: refactor concatenated string to use template string

### DIFF
--- a/benchmark/zlib/creation.js
+++ b/benchmark/zlib/creation.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 
 function main(conf) {
   const n = +conf.n;
-  const fn = zlib['create' + conf.type];
+  const fn = zlib[`create${conf.type}`];
   if (typeof fn !== 'function')
     throw new Error('Invalid zlib type');
   var i = 0;


### PR DESCRIPTION
Small modification for [Code And Learn at NodeFest 2017](https://github.com/nodejs/code-and-learn/issues/72)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

benchmark