### PR TITLE
test: refactor using template string

### DIFF
--- a/test/abort/test-zlib-invalid-internals-usage.js
+++ b/test/abort/test-zlib-invalid-internals-usage.js
@@ -13,8 +13,8 @@ if (process.argv[2] === 'child') {
   assert.strictEqual(child.stdout.toString(), '');
   assert.ok(child.stderr.includes(
     'WARNING: You are likely using a version of node-tar or npm that ' +
-    'is incompatible with this version of Node.js.' + os.EOL +
+    `is incompatible with this version of Node.js.${os.EOL}` +
     'Please use either the version of npm that is bundled with Node.js, or ' +
     'a version of npm (> 5.5.1 or < 5.4.0) or node-tar (> 4.0.1) that is ' +
-    'compatible with Node.js 9 and above.' + os.EOL));
+    `compatible with Node.js 9 and above.${os.EOL}`));
 }


### PR DESCRIPTION
This is part of NodeFest's Code and Learn https://github.com/nodejs/code-and-learn/issues/72

I replaced string concatnation with template string literal where it's appropriate.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test