### PR TITLE
doc: Replace string with template string

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -764,7 +764,7 @@ available data. In the latter case, [`stream.read()`][stream-read] will return
 const fs = require('fs');
 const rr = fs.createReadStream('foo.txt');
 rr.on('readable', () => {
-  console.log('readable:', rr.read());
+  console.log(`readable: ${rr.read()}`);
 });
 rr.on('end', () => {
   console.log('end');


### PR DESCRIPTION
This is part of Nodefest's Code and Learn nodejs/code-and-learn#72

I replace string with template string in `doc/api/stream.md`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc