### PR TITLE
http2: multiple cleanups and s/streamClosed/close

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -633,7 +633,7 @@ All [`Http2Stream`][] instances are destroyed either when:
 When an `Http2Stream` instance is destroyed, an attempt will be made to send an
 `RST_STREAM` frame will be sent to the connected peer.
 
-Once the `Http2Stream` instance is destroyed, the `'streamClosed'` event will
+When the `Http2Stream` instance is destroyed, the `'close'` event will
 be emitted. Because `Http2Stream` is an instance of `stream.Duplex`, the
 `'end'` event will also be emitted if the stream data is currently flowing.
 The `'error'` event may also be emitted if `http2stream.destroy()` was called
@@ -655,6 +655,18 @@ abnormally aborted in mid-communication.
 *Note*: The `'aborted'` event will only be emitted if the `Http2Stream`
 writable side has not been ended.
 
+#### Event: 'close'
+<!-- YAML
+added: v8.4.0
+-->
+
+The `'close'` event is emitted when the `Http2Stream` is destroyed. Once
+this event is emitted, the `Http2Stream` instance is no longer usable.
+
+The listener callback is passed a single argument specifying the HTTP/2 error
+code specified when closing the stream. If the code is any value other than
+`NGHTTP2_NO_ERROR` (`0`), an `'error'` event will also be emitted.
+
 #### Event: 'error'
 <!-- YAML
 added: v8.4.0
@@ -673,18 +685,6 @@ send a frame. When invoked, the handler function will receive an integer
 argument identifying the frame type, and an integer argument identifying the
 error code. The `Http2Stream` instance will be destroyed immediately after the
 `'frameError'` event is emitted.
-
-#### Event: 'streamClosed'
-<!-- YAML
-added: v8.4.0
--->
-
-The `'streamClosed'` event is emitted when the `Http2Stream` is destroyed. Once
-this event is emitted, the `Http2Stream` instance is no longer usable.
-
-The listener callback is passed a single argument specifying the HTTP/2 error
-code specified when closing the stream. If the code is any value other than
-`NGHTTP2_NO_ERROR` (`0`), an `'error'` event will also be emitted.
 
 #### Event: 'timeout'
 <!-- YAML

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -122,20 +122,6 @@ function onStreamDrain() {
     response.emit('drain');
 }
 
-// TODO Http2Stream does not emit 'close'
-function onStreamClosedRequest() {
-  const request = this[kRequest];
-  if (request !== undefined)
-    request.push(null);
-}
-
-// TODO Http2Stream does not emit 'close'
-function onStreamClosedResponse() {
-  const response = this[kResponse];
-  if (response !== undefined)
-    response.emit('finish');
-}
-
 function onStreamAbortedRequest() {
   const request = this[kRequest];
   if (request !== undefined && request[kState].closed === false) {
@@ -247,7 +233,6 @@ class Http2ServerRequest extends Readable {
     stream.on('trailers', onStreamTrailers);
     stream.on('end', onStreamEnd);
     stream.on('error', onStreamError);
-    stream.on('close', onStreamClosedRequest);
     stream.on('aborted', onStreamAbortedRequest);
     const onfinish = this[kFinish].bind(this);
     stream.on('close', onfinish);
@@ -380,7 +365,6 @@ class Http2ServerResponse extends Stream {
     stream[kResponse] = this;
     this.writable = true;
     stream.on('drain', onStreamDrain);
-    stream.on('close', onStreamClosedResponse);
     stream.on('aborted', onStreamAbortedResponse);
     const onfinish = this[kFinish].bind(this);
     stream.on('close', onfinish);

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -250,7 +250,7 @@ class Http2ServerRequest extends Readable {
     stream.on('close', onStreamClosedRequest);
     stream.on('aborted', onStreamAbortedRequest);
     const onfinish = this[kFinish].bind(this);
-    stream.on('streamClosed', onfinish);
+    stream.on('close', onfinish);
     stream.on('finish', onfinish);
     this.on('pause', onRequestPause);
     this.on('resume', onRequestResume);
@@ -383,7 +383,7 @@ class Http2ServerResponse extends Stream {
     stream.on('close', onStreamClosedResponse);
     stream.on('aborted', onStreamAbortedResponse);
     const onfinish = this[kFinish].bind(this);
-    stream.on('streamClosed', onfinish);
+    stream.on('close', onfinish);
     stream.on('finish', onfinish);
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -707,7 +707,9 @@ class Http2Session extends EventEmitter {
     const setupFn = setupHandle(this, socket, type, options);
     if (socket.connecting) {
       this[kState].connecting = true;
-      socket.once('connect', setupFn);
+      const connectEvent =
+        socket instanceof tls.TLSSocket ? 'secureConnect' : 'connect';
+      socket.once(connectEvent, setupFn);
     } else {
       setupFn();
     }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -226,10 +226,8 @@ function onStreamTrailers() {
   return headersList;
 }
 
-// Called when the stream is closed. The streamClosed event is emitted on the
-// Http2Stream instance. Note that this event is distinctly different than the
-// require('stream') interface 'close' event which deals with the state of the
-// Readable and Writable sides of the Duplex.
+// Called when the stream is closed. The close event is emitted on the
+// Http2Stream instance
 function onStreamClose(code) {
   const stream = this[kOwner];
   stream[kUpdateTimer]();
@@ -1485,7 +1483,7 @@ function continueStreamDestroy(err, callback) {
   abort(this);
   this.push(null);  // Close the readable side
   this.end();       // Close the writable side
-  process.nextTick(emit, this, 'streamClosed', code);
+  process.nextTick(emit, this, 'close', code);
 }
 
 function finishStreamDestroy() {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -661,6 +661,33 @@ function pingCallback(cb) {
   };
 }
 
+function validateSettings(settings) {
+  settings = Object.assign({}, settings);
+  assertWithinRange('headerTableSize',
+                    settings.headerTableSize,
+                    0, kMaxInt);
+  assertWithinRange('initialWindowSize',
+                    settings.initialWindowSize,
+                    0, kMaxInt);
+  assertWithinRange('maxFrameSize',
+                    settings.maxFrameSize,
+                    16384, kMaxFrameSize);
+  assertWithinRange('maxConcurrentStreams',
+                    settings.maxConcurrentStreams,
+                    0, kMaxStreams);
+  assertWithinRange('maxHeaderListSize',
+                    settings.maxHeaderListSize,
+                    0, kMaxInt);
+  if (settings.enablePush !== undefined &&
+      typeof settings.enablePush !== 'boolean') {
+    const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
+                                     'enablePush', settings.enablePush);
+    err.actual = settings.enablePush;
+    throw err;
+  }
+  return settings;
+}
+
 // Upon creation, the Http2Session takes ownership of the socket. The session
 // may not be ready to use immediately if the socket is not yet fully connected.
 class Http2Session extends EventEmitter {
@@ -844,29 +871,7 @@ class Http2Session extends EventEmitter {
 
     // Validate the input first
     assertIsObject(settings, 'settings');
-    settings = Object.assign(Object.create(null), settings);
-    assertWithinRange('headerTableSize',
-                      settings.headerTableSize,
-                      0, kMaxInt);
-    assertWithinRange('initialWindowSize',
-                      settings.initialWindowSize,
-                      0, kMaxInt);
-    assertWithinRange('maxFrameSize',
-                      settings.maxFrameSize,
-                      16384, kMaxFrameSize);
-    assertWithinRange('maxConcurrentStreams',
-                      settings.maxConcurrentStreams,
-                      0, kMaxStreams);
-    assertWithinRange('maxHeaderListSize',
-                      settings.maxHeaderListSize,
-                      0, kMaxInt);
-    if (settings.enablePush !== undefined &&
-        typeof settings.enablePush !== 'boolean') {
-      const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
-                                       'enablePush', settings.enablePush);
-      err.actual = settings.enablePush;
-      throw err;
-    }
+    settings = validateSettings(settings);
     if (state.pendingAck === state.maxPendingAck) {
       throw new errors.Error('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
                              this[kState].pendingAck);
@@ -2364,30 +2369,7 @@ function createServer(options, handler) {
 // HTTP2-Settings header frame.
 function getPackedSettings(settings) {
   assertIsObject(settings, 'settings');
-  settings = settings || Object.create(null);
-  assertWithinRange('headerTableSize',
-                    settings.headerTableSize,
-                    0, kMaxInt);
-  assertWithinRange('initialWindowSize',
-                    settings.initialWindowSize,
-                    0, kMaxInt);
-  assertWithinRange('maxFrameSize',
-                    settings.maxFrameSize,
-                    16384, kMaxFrameSize);
-  assertWithinRange('maxConcurrentStreams',
-                    settings.maxConcurrentStreams,
-                    0, kMaxStreams);
-  assertWithinRange('maxHeaderListSize',
-                    settings.maxHeaderListSize,
-                    0, kMaxInt);
-  if (settings.enablePush !== undefined &&
-      typeof settings.enablePush !== 'boolean') {
-    const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
-                                     'enablePush', settings.enablePush);
-    err.actual = settings.enablePush;
-    throw err;
-  }
-  updateSettingsBuffer(settings);
+  updateSettingsBuffer(validateSettings(settings));
   return binding.packSettings();
 }
 
@@ -2398,7 +2380,7 @@ function getUnpackedSettings(buf, options = {}) {
   }
   if (buf.length % 6 !== 0)
     throw new errors.RangeError('ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH');
-  const settings = Object.create(null);
+  const settings = {};
   let offset = 0;
   while (offset < buf.length) {
     const id = buf.readUInt16BE(offset);
@@ -2409,7 +2391,7 @@ function getUnpackedSettings(buf, options = {}) {
         settings.headerTableSize = value;
         break;
       case NGHTTP2_SETTINGS_ENABLE_PUSH:
-        settings.enablePush = value;
+        settings.enablePush = value !== 0;
         break;
       case NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS:
         settings.maxConcurrentStreams = value;
@@ -2427,30 +2409,8 @@ function getUnpackedSettings(buf, options = {}) {
     offset += 4;
   }
 
-  if (options != null && options.validate) {
-    assertWithinRange('headerTableSize',
-                      settings.headerTableSize,
-                      0, kMaxInt);
-    assertWithinRange('enablePush',
-                      settings.enablePush,
-                      0, 1);
-    assertWithinRange('initialWindowSize',
-                      settings.initialWindowSize,
-                      0, kMaxInt);
-    assertWithinRange('maxFrameSize',
-                      settings.maxFrameSize,
-                      16384, kMaxFrameSize);
-    assertWithinRange('maxConcurrentStreams',
-                      settings.maxConcurrentStreams,
-                      0, kMaxStreams);
-    assertWithinRange('maxHeaderListSize',
-                      settings.maxHeaderListSize,
-                      0, kMaxInt);
-  }
-
-  if (settings.enablePush !== undefined) {
-    settings.enablePush = !!settings.enablePush;
-  }
+  if (options != null && options.validate)
+    validateSettings(settings);
 
   return settings;
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -582,15 +582,15 @@ function doShutdown(options) {
 function submitShutdown(options) {
   const type = this[kType];
   debug(`Http2Session ${sessionName(type)}: submitting shutdown request`);
-  const fn = doShutdown.bind(this, options);
+  const shutdownFn = doShutdown.bind(this, options);
   if (type === NGHTTP2_SESSION_SERVER && options.graceful === true) {
     // first send a shutdown notice
     this[kHandle].shutdownNotice();
     // then, on flip of the event loop, do the actual shutdown
-    setImmediate(fn);
+    setImmediate(shutdownFn);
     return;
   }
-  fn();
+  shutdownFn();
 }
 
 function finishSessionDestroy(socket) {
@@ -877,12 +877,12 @@ class Http2Session extends EventEmitter {
     debug(`Http2Session ${sessionName(this[kType])}: sending settings`);
 
     state.pendingAck++;
-    const fn = submitSettings.bind(this, settings);
+    const settingsFn = submitSettings.bind(this, settings);
     if (state.connecting) {
-      this.once('connect', fn);
+      this.once('connect', settingsFn);
       return;
     }
-    fn();
+    settingsFn();
   }
 
   // Destroy the Http2Session
@@ -968,14 +968,14 @@ class Http2Session extends EventEmitter {
       this.on('shutdown', callback);
     }
 
-    const fn = submitShutdown.bind(this, options);
+    const shutdownFn = submitShutdown.bind(this, options);
     if (state.connecting) {
-      this.once('connect', fn);
+      this.once('connect', shutdownFn);
       return;
     }
 
     debug(`Http2Session ${sessionName(type)}: sending shutdown`);
-    fn();
+    shutdownFn();
   }
 
   _onTimeout() {
@@ -1379,12 +1379,12 @@ class Http2Stream extends Duplex {
     if (code < 0 || code > kMaxInt)
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'code');
 
-    const fn = submitRstStream.bind(this, code);
+    const rstStreamFn = submitRstStream.bind(this, code);
     if (this[kID] === undefined) {
-      this.once('ready', fn);
+      this.once('ready', rstStreamFn);
       return;
     }
-    fn();
+    rstStreamFn();
   }
 
   rstWithNoError() {
@@ -1415,12 +1415,12 @@ class Http2Stream extends Duplex {
     options = Object.assign({}, options);
     validatePriorityOptions(options);
 
-    const fn = submitPriority.bind(this, options);
+    const priorityFn = submitPriority.bind(this, options);
     if (this[kID] === undefined) {
-      this.once('ready', fn);
+      this.once('ready', priorityFn);
       return;
     }
-    fn();
+    priorityFn();
   }
 
   // Called by this.destroy().

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -28,6 +28,8 @@ const { _connectionListener: httpConnectionListener } = require('http');
 const { createPromise, promiseResolve } = process.binding('util');
 const debug = util.debuglog('http2');
 
+const kMaxFrameSize = (2 ** 24) - 1;
+const kMaxInt = (2 ** 32) - 1;
 const kMaxStreams = (2 ** 31) - 1;
 
 const {
@@ -332,9 +334,9 @@ function emitGoaway(self, code, lastStreamID, buf) {
     return;
   if (!state.shuttingDown && !state.shutdown) {
     self.shutdown({}, self.destroy.bind(self));
-  } else {
-    self.destroy();
+    return;
   }
+  self.destroy();
 }
 
 // Called by the native layer when a goaway frame has been received
@@ -582,14 +584,15 @@ function doShutdown(options) {
 function submitShutdown(options) {
   const type = this[kType];
   debug(`Http2Session ${sessionName(type)}: submitting shutdown request`);
+  const fn = doShutdown.bind(this, options);
   if (type === NGHTTP2_SESSION_SERVER && options.graceful === true) {
     // first send a shutdown notice
     this[kHandle].shutdownNotice();
     // then, on flip of the event loop, do the actual shutdown
-    setImmediate(doShutdown.bind(this), options);
-  } else {
-    doShutdown.call(this, options);
+    setImmediate(fn);
+    return;
   }
+  fn();
 }
 
 function finishSessionDestroy(socket) {
@@ -844,19 +847,19 @@ class Http2Session extends EventEmitter {
     settings = Object.assign(Object.create(null), settings);
     assertWithinRange('headerTableSize',
                       settings.headerTableSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
     assertWithinRange('initialWindowSize',
                       settings.initialWindowSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
     assertWithinRange('maxFrameSize',
                       settings.maxFrameSize,
-                      16384, 2 ** 24 - 1);
+                      16384, kMaxFrameSize);
     assertWithinRange('maxConcurrentStreams',
                       settings.maxConcurrentStreams,
                       0, kMaxStreams);
     assertWithinRange('maxHeaderListSize',
                       settings.maxHeaderListSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
     if (settings.enablePush !== undefined &&
         typeof settings.enablePush !== 'boolean') {
       const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
@@ -871,11 +874,12 @@ class Http2Session extends EventEmitter {
     debug(`Http2Session ${sessionName(this[kType])}: sending settings`);
 
     state.pendingAck++;
+    const fn = submitSettings.bind(this, settings);
     if (state.connecting) {
-      this.once('connect', submitSettings.bind(this, settings));
+      this.once('connect', fn);
       return;
     }
-    submitSettings.call(this, settings);
+    fn();
   }
 
   // Destroy the Http2Session
@@ -961,13 +965,14 @@ class Http2Session extends EventEmitter {
       this.on('shutdown', callback);
     }
 
+    const fn = submitShutdown.bind(this, options);
     if (state.connecting) {
-      this.once('connect', submitShutdown.bind(this, options));
+      this.once('connect', fn);
       return;
     }
 
     debug(`Http2Session ${sessionName(type)}: sending shutdown`);
-    submitShutdown.call(this, options);
+    fn();
   }
 
   _onTimeout() {
@@ -1368,7 +1373,7 @@ class Http2Stream extends Duplex {
   rstStream(code = NGHTTP2_NO_ERROR) {
     if (typeof code !== 'number')
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'code', 'number');
-    if (code < 0 || code > 2 ** 32 - 1)
+    if (code < 0 || code > kMaxInt)
       throw new errors.RangeError('ERR_OUT_OF_RANGE', 'code');
 
     const fn = submitRstStream.bind(this, code);
@@ -2362,19 +2367,19 @@ function getPackedSettings(settings) {
   settings = settings || Object.create(null);
   assertWithinRange('headerTableSize',
                     settings.headerTableSize,
-                    0, 2 ** 32 - 1);
+                    0, kMaxInt);
   assertWithinRange('initialWindowSize',
                     settings.initialWindowSize,
-                    0, 2 ** 32 - 1);
+                    0, kMaxInt);
   assertWithinRange('maxFrameSize',
                     settings.maxFrameSize,
-                    16384, 2 ** 24 - 1);
+                    16384, kMaxFrameSize);
   assertWithinRange('maxConcurrentStreams',
                     settings.maxConcurrentStreams,
                     0, kMaxStreams);
   assertWithinRange('maxHeaderListSize',
                     settings.maxHeaderListSize,
-                    0, 2 ** 32 - 1);
+                    0, kMaxInt);
   if (settings.enablePush !== undefined &&
       typeof settings.enablePush !== 'boolean') {
     const err = new errors.TypeError('ERR_HTTP2_INVALID_SETTING_VALUE',
@@ -2425,22 +2430,22 @@ function getUnpackedSettings(buf, options = {}) {
   if (options != null && options.validate) {
     assertWithinRange('headerTableSize',
                       settings.headerTableSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
     assertWithinRange('enablePush',
                       settings.enablePush,
                       0, 1);
     assertWithinRange('initialWindowSize',
                       settings.initialWindowSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
     assertWithinRange('maxFrameSize',
                       settings.maxFrameSize,
-                      16384, 2 ** 24 - 1);
+                      16384, kMaxFrameSize);
     assertWithinRange('maxConcurrentStreams',
                       settings.maxConcurrentStreams,
                       0, kMaxStreams);
     assertWithinRange('maxHeaderListSize',
                       settings.maxHeaderListSize,
-                      0, 2 ** 32 - 1);
+                      0, kMaxInt);
   }
 
   if (settings.enablePush !== undefined) {

--- a/test/parallel/test-http2-client-http1-server.js
+++ b/test/parallel/test-http2-client-http1-server.js
@@ -13,7 +13,7 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
 
   const req = client.request();
-  req.on('streamClosed', common.mustCall());
+  req.on('close', common.mustCall());
 
   client.on('error', common.expectsError({
     code: 'ERR_HTTP2_ERROR',

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -27,7 +27,7 @@ server.on('listening', common.mustCall(() => {
   // second call doesn't do anything
   assert.doesNotThrow(() => req.rstStream(8));
 
-  req.on('streamClosed', common.mustCall((code) => {
+  req.on('close', common.mustCall((code) => {
     assert.strictEqual(req.destroyed, true);
     assert.strictEqual(code, 0);
     server.close();

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -41,7 +41,7 @@ server.on('listening', common.mustCall(() => {
     })(err);
   }));
 
-  req.on('streamClosed', common.mustCall((code) => {
+  req.on('close', common.mustCall((code) => {
     assert.strictEqual(req.rstCode, NGHTTP2_INTERNAL_ERROR);
     assert.strictEqual(code, NGHTTP2_INTERNAL_ERROR);
     server.close();

--- a/test/parallel/test-http2-client-unescaped-path.js
+++ b/test/parallel/test-http2-client-unescaped-path.js
@@ -30,7 +30,7 @@ server.listen(0, common.mustCall(() => {
       type: Error,
       message: 'Stream closed with error code 1'
     }));
-    req.on('streamClosed', common.mustCall(maybeClose));
+    req.on('close', common.mustCall(maybeClose));
   }
 
   for (let i = 0; i <= count; i += 1)

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -183,10 +183,10 @@ const {
 
 
 {
-  // Should be able to call .end with cb from stream 'streamClosed'
+  // Should be able to call .end with cb from stream 'close'
   const server = createServer(mustCall((request, response) => {
     response.writeHead(HTTP_STATUS_OK, { foo: 'bar' });
-    response.stream.on('streamClosed', mustCall(() => {
+    response.stream.on('close', mustCall(() => {
       response.end(mustCall());
     }));
   }));

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -63,8 +63,8 @@ server.on('request', common.mustCall(function(request, response) {
   assert.strictEqual(request.socket.connecting, false);
 
   // socket events are bound and emitted on Http2Stream
-  request.socket.on('streamClosed', common.mustCall());
-  request.socket.once('streamClosed', common.mustCall());
+  request.socket.on('close', common.mustCall());
+  request.socket.once('close', common.mustCall());
   request.socket.on('testEvent', common.mustCall());
   request.socket.emit('testEvent');
 }));

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -20,10 +20,7 @@ function loadKey(keyname) {
 function onStream(stream, headers) {
   const socket = stream.session[kSocket];
   assert(headers[':authority'].startsWith(socket.servername));
-  stream.respond({
-    'content-type': 'text/html',
-    ':status': 200
-  });
+  stream.respond({ 'content-type': 'application/json' });
   stream.end(JSON.stringify({
     servername: socket.servername,
     alpnProtocol: socket.alpnProtocol
@@ -33,35 +30,32 @@ function onStream(stream, headers) {
 function verifySecureSession(key, cert, ca, opts) {
   const server = h2.createSecureServer({ cert, key });
   server.on('stream', common.mustCall(onStream));
-  server.listen(0);
-  server.on('listening', common.mustCall(function() {
-    const headers = { ':path': '/' };
-    if (!opts) {
-      opts = {};
-    }
+  server.listen(0, common.mustCall(() => {
+    opts = opts || { };
     opts.secureContext = tls.createSecureContext({ ca });
-    const client = h2.connect(`https://localhost:${this.address().port}`, opts, function() {
-      const req = client.request(headers);
+    const client = h2.connect(`https://localhost:${server.address().port}`,
+                              opts);
+    // Verify that a 'secureConnect' listener is attached
+    assert.strictEqual(client.socket.listenerCount('secureConnect'), 1);
+    const req = client.request();
 
-      req.on('response', common.mustCall(function(headers) {
-        assert.strictEqual(headers[':status'], 200, 'status code is set');
-        assert.strictEqual(headers['content-type'], 'text/html',
-                           'content type is set');
-        assert(headers['date'], 'there is a date');
-      }));
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+      assert.strictEqual(headers['content-type'], 'application/json');
+      assert(headers['date']);
+    }));
 
-      let data = '';
-      req.setEncoding('utf8');
-      req.on('data', (d) => data += d);
-      req.on('end', common.mustCall(() => {
-        const jsonData = JSON.parse(data);
-        assert.strictEqual(jsonData.servername, opts.servername || 'localhost');
-        assert.strictEqual(jsonData.alpnProtocol, 'h2');
-        server.close();
-        client[kSocket].destroy();
-      }));
-      req.end();
-    });
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', (d) => data += d);
+    req.on('end', common.mustCall(() => {
+      const jsonData = JSON.parse(data);
+      assert.strictEqual(jsonData.servername,
+                         opts.servername || 'localhost');
+      assert.strictEqual(jsonData.alpnProtocol, 'h2');
+      server.close();
+      client[kSocket].destroy();
+    }));
   }));
 }
 

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -128,7 +128,6 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
   assert.strictEqual(settings.enablePush, true);
 }
 
-//should throw if enablePush is not 0 or 1
 {
   const packed = Buffer.from([
     0x00, 0x02, 0x00, 0x00, 0x00, 0x00]);
@@ -140,13 +139,8 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
   const packed = Buffer.from([
     0x00, 0x02, 0x00, 0x00, 0x00, 0x64]);
 
-  assert.throws(() => {
-    http2.getUnpackedSettings(packed, { validate: true });
-  }, common.expectsError({
-    code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-    type: RangeError,
-    message: 'Invalid value for setting "enablePush": 100'
-  }));
+  const settings = http2.getUnpackedSettings(packed, { validate: true });
+  assert.strictEqual(settings.enablePush, true);
 }
 
 //check for what happens if passing {validate: true} and no errors happen

--- a/test/parallel/test-http2-multiheaders-raw.js
+++ b/test/parallel/test-http2-multiheaders-raw.js
@@ -42,7 +42,7 @@ server.on('stream', common.mustCall((stream, headers, flags, rawHeaders) => {
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request(src);
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     server.close();
     client.destroy();
   }));

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -54,7 +54,7 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request(src);
   req.on('response', common.mustCall(checkHeaders));
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     server.close();
     client.destroy();
   }));

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -34,7 +34,7 @@ server.on('stream', common.mustCall((stream) => {
     pushedStream.respond({ ':status': 200 });
     pushedStream.on('aborted', common.mustCall());
     pushedStream.on('error', common.mustNotCall());
-    pushedStream.on('streamClosed',
+    pushedStream.on('close',
                     common.mustCall((code) => assert.strictEqual(code, 8)));
   }));
 
@@ -67,12 +67,12 @@ server.on('listening', common.mustCall(() => {
   client.on('stream', common.mustCall((stream) => {
     stream.resume();
     stream.on('end', common.mustCall());
-    stream.on('streamClosed', common.mustCall(maybeClose));
+    stream.on('close', common.mustCall(maybeClose));
   }));
 
   req.on('response', common.mustCall());
 
   req.resume();
   req.on('end', common.mustCall());
-  req.on('streamClosed', common.mustCall(maybeClose));
+  req.on('close', common.mustCall(maybeClose));
 }));

--- a/test/parallel/test-http2-respond-file-errors.js
+++ b/test/parallel/test-http2-respond-file-errors.js
@@ -117,7 +117,7 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
 
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     client.destroy();
     server.close();
   }));

--- a/test/parallel/test-http2-respond-file-fd-errors.js
+++ b/test/parallel/test-http2-respond-file-fd-errors.js
@@ -144,7 +144,7 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
 
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     client.destroy();
     server.close();
   }));

--- a/test/parallel/test-http2-respond-file-fd-range.js
+++ b/test/parallel/test-http2-respond-file-fd-range.js
@@ -71,7 +71,7 @@ server.listen(0, () => {
     req.on('end', common.mustCall(() => {
       assert.strictEqual(check, data.toString('utf8', 8, 11));
     }));
-    req.on('streamClosed', common.mustCall(maybeClose));
+    req.on('close', common.mustCall(maybeClose));
     req.end();
   }
 
@@ -88,7 +88,7 @@ server.listen(0, () => {
     req.on('end', common.mustCall(() => {
       assert.strictEqual(check, data.toString('utf8', 8, 28));
     }));
-    req.on('streamClosed', common.mustCall(maybeClose));
+    req.on('close', common.mustCall(maybeClose));
     req.end();
   }
 

--- a/test/parallel/test-http2-respond-no-data.js
+++ b/test/parallel/test-http2-respond-no-data.js
@@ -13,7 +13,7 @@ const server = http2.createServer();
 const status = [204, 205, 304];
 
 server.on('stream', common.mustCall((stream) => {
-  stream.on('streamClosed', common.mustCall(() => {
+  stream.on('close', common.mustCall(() => {
     assert.strictEqual(stream.destroyed, true);
   }));
   stream.respond({ ':status': status.shift() });

--- a/test/parallel/test-http2-response-splitting.js
+++ b/test/parallel/test-http2-response-splitting.js
@@ -67,7 +67,7 @@ server.listen(0, common.mustCall(() => {
     }));
     req.resume();
     req.on('end', common.mustCall());
-    req.on('streamClosed', common.mustCall(maybeClose));
+    req.on('close', common.mustCall(maybeClose));
   }
 
   doTest(str, 'location', str);

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -35,7 +35,7 @@ server.on('listening', common.mustCall(() => {
 
   req.on('headers', common.mustNotCall());
 
-  req.on('streamClosed', common.mustCall((code) => {
+  req.on('close', common.mustCall((code) => {
     assert.strictEqual(h2.constants.NGHTTP2_NO_ERROR, code);
     server.close();
     client.destroy();

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -43,7 +43,7 @@ server.listen(0, common.mustCall(() => {
       ':method': 'POST',
       rstmethod: test[0]
     });
-    req.on('streamClosed', common.mustCall((code) => {
+    req.on('close', common.mustCall((code) => {
       assert.strictEqual(code, test[1]);
       countdown.dec();
     }));

--- a/test/parallel/test-http2-server-socketerror.js
+++ b/test/parallel/test-http2-server-socketerror.js
@@ -49,7 +49,7 @@ server.listen(0, common.mustCall(() => {
   const req = client.request();
   req.resume();
   req.on('end', common.mustCall());
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     client.destroy();
     server.close();
   }));

--- a/test/parallel/test-http2-stream-client.js
+++ b/test/parallel/test-http2-stream-client.js
@@ -21,7 +21,7 @@ server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}`);
   const req = client.request();
   req.resume();
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     client.destroy();
     server.close();
   }));

--- a/test/parallel/test-http2-stream-destroy-event-order.js
+++ b/test/parallel/test-http2-stream-destroy-event-order.js
@@ -11,7 +11,7 @@ let req;
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   stream.on('error', common.mustCall(() => {
-    stream.on('streamClosed', common.mustCall((code) => {
+    stream.on('close', common.mustCall((code) => {
       assert.strictEqual(code, 2);
       client.destroy();
       server.close();

--- a/test/parallel/test-http2-too-large-headers.js
+++ b/test/parallel/test-http2-too-large-headers.js
@@ -22,7 +22,7 @@ server.listen(0, common.mustCall(() => {
       type: Error,
       message: 'Stream closed with error code 11'
     }));
-    req.on('streamClosed', common.mustCall((code) => {
+    req.on('close', common.mustCall((code) => {
       assert.strictEqual(code, NGHTTP2_ENHANCE_YOUR_CALM);
       server.close();
       client.destroy();

--- a/test/parallel/test-http2-too-many-headers.js
+++ b/test/parallel/test-http2-too-many-headers.js
@@ -25,7 +25,7 @@ server.listen(0, common.mustCall(() => {
     type: Error,
     message: 'Stream closed with error code 11'
   }));
-  req.on('streamClosed', common.mustCall((code) => {
+  req.on('close', common.mustCall((code) => {
     assert.strictEqual(code, NGHTTP2_ENHANCE_YOUR_CALM);
     server.close();
     client.destroy();

--- a/test/parallel/test-http2-write-callbacks.js
+++ b/test/parallel/test-http2-write-callbacks.js
@@ -30,7 +30,7 @@ server.listen(0, common.mustCall(() => {
   req.setEncoding('utf8');
   req.on('data', (chunk) => actual += chunk);
   req.on('end', common.mustCall(() => assert.strictEqual(actual, 'abcxyz')));
-  req.on('streamClosed', common.mustCall(() => {
+  req.on('close', common.mustCall(() => {
     client.destroy();
     server.close();
   }));


### PR DESCRIPTION
Includes multiple cleanups in core.js along with:

* Use correct connect event for TLSSocket
* Use 'close' event instead of `streamClosed`

/cc @nodejs/http2

Fixes: https://github.com/nodejs/node/issues/15303

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2