### PR TITLE
src: remove `ClearFatalExceptionHandlers()`

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -169,7 +169,8 @@ void AsyncWrap::EmitPromiseResolve(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_promise_resolve_function();
   FatalTryCatch try_catch(env);
-  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .FromMaybe(Local<Value>());
 }
 
 
@@ -197,7 +198,8 @@ void AsyncWrap::EmitBefore(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_before_function();
   FatalTryCatch try_catch(env);
-  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .FromMaybe(Local<Value>());
 }
 
 
@@ -227,7 +229,8 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_after_function();
   FatalTryCatch try_catch(env);
-  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .FromMaybe(Local<Value>());
 }
 
 class PromiseWrap : public AsyncWrap {
@@ -728,7 +731,8 @@ void AsyncWrap::EmitAsyncInit(Environment* env,
   };
 
   FatalTryCatch try_catch(env);
-  (void)init_fn->Call(env->context(), object, arraysize(argv), argv);
+  init_fn->Call(env->context(), object, arraysize(argv), argv)
+      .FromMaybe(Local<Value>());
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -140,7 +140,7 @@ RetainedObjectInfo* WrapperInfo(uint16_t class_id, Local<Value> wrapper) {
 static void DestroyAsyncIdsCallback(Environment* env, void* data) {
   Local<Function> fn = env->async_hooks_destroy_function();
 
-  TryCatch try_catch(env->isolate());
+  FatalTryCatch try_catch(env);
 
   do {
     std::vector<double> destroy_async_id_list;
@@ -153,11 +153,8 @@ static void DestroyAsyncIdsCallback(Environment* env, void* data) {
       MaybeLocal<Value> ret = fn->Call(
           env->context(), Undefined(env->isolate()), 1, &async_id_value);
 
-      if (ret.IsEmpty()) {
-        ClearFatalExceptionHandlers(env);
-        FatalException(env->isolate(), try_catch);
-        UNREACHABLE();
-      }
+      if (ret.IsEmpty())
+        return;
     }
   } while (!env->destroy_async_id_list()->empty());
 }
@@ -171,14 +168,9 @@ void AsyncWrap::EmitPromiseResolve(Environment* env, double async_id) {
 
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_promise_resolve_function();
-  TryCatch try_catch(env->isolate());
-  MaybeLocal<Value> ar = fn->Call(
-      env->context(), Undefined(env->isolate()), 1, &async_id_value);
-  if (ar.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(env->isolate(), try_catch);
-    UNREACHABLE();
-  }
+  FatalTryCatch try_catch(env);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .ToLocalChecked();
 }
 
 
@@ -205,14 +197,9 @@ void AsyncWrap::EmitBefore(Environment* env, double async_id) {
 
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_before_function();
-  TryCatch try_catch(env->isolate());
-  MaybeLocal<Value> ar = fn->Call(
-      env->context(), Undefined(env->isolate()), 1, &async_id_value);
-  if (ar.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(env->isolate(), try_catch);
-    UNREACHABLE();
-  }
+  FatalTryCatch try_catch(env);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .ToLocalChecked();
 }
 
 
@@ -241,14 +228,9 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
   // end of _fatalException().
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_after_function();
-  TryCatch try_catch(env->isolate());
-  MaybeLocal<Value> ar = fn->Call(
-      env->context(), Undefined(env->isolate()), 1, &async_id_value);
-  if (ar.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(env->isolate(), try_catch);
-    UNREACHABLE();
-  }
+  FatalTryCatch try_catch(env);
+  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
+      .ToLocalChecked();
 }
 
 class PromiseWrap : public AsyncWrap {
@@ -748,14 +730,8 @@ void AsyncWrap::EmitAsyncInit(Environment* env,
     object,
   };
 
-  TryCatch try_catch(env->isolate());
-  MaybeLocal<Value> ret = init_fn->Call(
-      env->context(), object, arraysize(argv), argv);
-
-  if (ret.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(env->isolate(), try_catch);
-  }
+  FatalTryCatch try_catch(env);
+  init_fn->Call(env->context(), object, arraysize(argv), argv).ToLocalChecked();
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -169,8 +169,7 @@ void AsyncWrap::EmitPromiseResolve(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_promise_resolve_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .FromMaybe(Local<Value>());
+  USE(fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value));
 }
 
 
@@ -198,8 +197,7 @@ void AsyncWrap::EmitBefore(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_before_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .FromMaybe(Local<Value>());
+  USE(fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value));
 }
 
 
@@ -229,8 +227,7 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_after_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .FromMaybe(Local<Value>());
+  USE(fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value));
 }
 
 class PromiseWrap : public AsyncWrap {
@@ -731,8 +728,7 @@ void AsyncWrap::EmitAsyncInit(Environment* env,
   };
 
   FatalTryCatch try_catch(env);
-  init_fn->Call(env->context(), object, arraysize(argv), argv)
-      .FromMaybe(Local<Value>());
+  USE(init_fn->Call(env->context(), object, arraysize(argv), argv));
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -169,8 +169,7 @@ void AsyncWrap::EmitPromiseResolve(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_promise_resolve_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .ToLocalChecked();
+  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
 }
 
 
@@ -198,8 +197,7 @@ void AsyncWrap::EmitBefore(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_before_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .ToLocalChecked();
+  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
 }
 
 
@@ -229,8 +227,7 @@ void AsyncWrap::EmitAfter(Environment* env, double async_id) {
   Local<Value> async_id_value = Number::New(env->isolate(), async_id);
   Local<Function> fn = env->async_hooks_after_function();
   FatalTryCatch try_catch(env);
-  fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value)
-      .ToLocalChecked();
+  (void)fn->Call(env->context(), Undefined(env->isolate()), 1, &async_id_value);
 }
 
 class PromiseWrap : public AsyncWrap {
@@ -731,7 +728,7 @@ void AsyncWrap::EmitAsyncInit(Environment* env,
   };
 
   FatalTryCatch try_catch(env);
-  init_fn->Call(env->context(), object, arraysize(argv), argv).ToLocalChecked();
+  (void)init_fn->Call(env->context(), object, arraysize(argv), argv);
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -5358,7 +5358,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   EC_KEY_set_public_key(ecdh->key_, nullptr);
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
-  USE(&mark_pop_error_on_return);  // Silence compiler warning.
+  USE(&mark_pop_error_on_return);
 
   const BIGNUM* priv_key = EC_KEY_get0_private_key(ecdh->key_);
   CHECK_NE(priv_key, nullptr);
@@ -5421,7 +5421,7 @@ bool ECDH::IsKeyValidForCurve(const BIGNUM* private_key) {
 
 bool ECDH::IsKeyPairValid() {
   MarkPopErrorOnReturn mark_pop_error_on_return;
-  USE(&mark_pop_error_on_return);  // Silence compiler warning.
+  USE(&mark_pop_error_on_return);
   return 1 == EC_KEY_check_key(key_);
 }
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1820,7 +1820,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
               String::NewFromUtf8(env->isolate(), mem->data,
                                   String::kNormalString, mem->length));
   }
-  (void) BIO_reset(bio);
+  USE(BIO_reset(bio));
 
   X509_NAME* issuer_name = X509_get_issuer_name(cert);
   if (X509_NAME_print_ex(bio, issuer_name, 0, X509_NAME_FLAGS) > 0) {
@@ -1829,7 +1829,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
               String::NewFromUtf8(env->isolate(), mem->data,
                                   String::kNormalString, mem->length));
   }
-  (void) BIO_reset(bio);
+  USE(BIO_reset(bio));
 
   int nids[] = { NID_subject_alt_name, NID_info_access };
   Local<String> keys[] = { env->subjectaltname_string(),
@@ -1856,7 +1856,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
               String::NewFromUtf8(env->isolate(), mem->data,
                                   String::kNormalString, mem->length));
 
-    (void) BIO_reset(bio);
+    USE(BIO_reset(bio));
   }
 
   EVP_PKEY* pkey = X509_get_pubkey(cert);
@@ -1873,7 +1873,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     info->Set(env->modulus_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
                                   String::kNormalString, mem->length));
-    (void) BIO_reset(bio);
+    USE(BIO_reset(bio));
 
     uint64_t exponent_word = static_cast<uint64_t>(BN_get_word(e));
     uint32_t lo = static_cast<uint32_t>(exponent_word);
@@ -1887,7 +1887,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
     info->Set(env->exponent_string(),
               String::NewFromUtf8(env->isolate(), mem->data,
                                   String::kNormalString, mem->length));
-    (void) BIO_reset(bio);
+    USE(BIO_reset(bio));
   }
 
   if (pkey != nullptr) {
@@ -1904,7 +1904,7 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
   info->Set(env->valid_from_string(),
             String::NewFromUtf8(env->isolate(), mem->data,
                                 String::kNormalString, mem->length));
-  (void) BIO_reset(bio);
+  USE(BIO_reset(bio));
 
   ASN1_TIME_print(bio, X509_get_notAfter(cert));
   BIO_get_mem_ptr(bio, &mem);
@@ -2882,7 +2882,7 @@ int Connection::HandleBIOError(BIO *bio, const char* func, int rv) {
     return rv;
 
   int retry = BIO_should_retry(bio);
-  (void) retry;  // unused if !defined(SSL_PRINT_DEBUG)
+  USE(retry);  // unused if !defined(SSL_PRINT_DEBUG)
 
   if (BIO_should_write(bio)) {
     DEBUG_PRINT("[%p] BIO: %s want write. should retry %d\n",
@@ -5358,7 +5358,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   EC_KEY_set_public_key(ecdh->key_, nullptr);
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
-  (void) &mark_pop_error_on_return;  // Silence compiler warning.
+  USE(&mark_pop_error_on_return);  // Silence compiler warning.
 
   const BIGNUM* priv_key = EC_KEY_get0_private_key(ecdh->key_);
   CHECK_NE(priv_key, nullptr);
@@ -5421,7 +5421,7 @@ bool ECDH::IsKeyValidForCurve(const BIGNUM* private_key) {
 
 bool ECDH::IsKeyPairValid() {
   MarkPopErrorOnReturn mark_pop_error_on_return;
-  (void) &mark_pop_error_on_return;  // Silence compiler warning.
+  USE(&mark_pop_error_on_return);  // Silence compiler warning.
   return 1 == EC_KEY_check_key(key_);
 }
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -277,6 +277,17 @@ void AppendExceptionLine(Environment* env,
 
 NO_RETURN void FatalError(const char* location, const char* message);
 
+// Like a `TryCatch` but it crashes the process if it did catch an exception.
+class FatalTryCatch : public v8::TryCatch {
+ public:
+  explicit FatalTryCatch(Environment* env)
+      : TryCatch(env->isolate()), env_(env) {}
+  ~FatalTryCatch();
+
+ private:
+  Environment* env_;
+};
+
 void ProcessEmitWarning(Environment* env, const char* fmt, ...);
 
 void FillStatsArray(double* fields, const uv_stat_t* s);
@@ -329,11 +340,6 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  private:
   uint32_t zero_fill_field_ = 1;  // Boolean but exposed as uint32 to JS land.
 };
-
-// Clear any domain and/or uncaughtException handlers to force the error's
-// propagation and shutdown the process. Use this to force the process to exit
-// by clearing all callbacks that could handle the error.
-void ClearFatalExceptionHandlers(Environment* env);
 
 namespace Buffer {
 v8::MaybeLocal<v8::Object> Copy(Environment* env, const char* data, size_t len);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -277,7 +277,7 @@ void AppendExceptionLine(Environment* env,
 
 NO_RETURN void FatalError(const char* location, const char* message);
 
-// Like a `TryCatch` but it crashes the process if it did catch an exception.
+// Like a `TryCatch` but exits the process if an exception was caught.
 class FatalTryCatch : public v8::TryCatch {
  public:
   explicit FatalTryCatch(Environment* env)

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2172,7 +2172,7 @@ const Local<Value> URL::ToObject(Environment* env) const {
   };
   SetArgs(env, argv, &context_);
 
-  TryCatch try_catch(isolate);
+  FatalTryCatch try_catch(env);
 
   // The SetURLConstructor method must have been called already to
   // set the constructor function used below. SetURLConstructor is
@@ -2181,11 +2181,6 @@ const Local<Value> URL::ToObject(Environment* env) const {
   MaybeLocal<Value> ret =
       env->url_constructor_function()
           ->Call(env->context(), undef, 9, argv);
-
-  if (ret.IsEmpty()) {
-    ClearFatalExceptionHandlers(env);
-    FatalException(isolate, try_catch);
-  }
 
   return ret.ToLocalChecked();
 }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -2172,15 +2172,17 @@ const Local<Value> URL::ToObject(Environment* env) const {
   };
   SetArgs(env, argv, &context_);
 
-  FatalTryCatch try_catch(env);
+  MaybeLocal<Value> ret;
+  {
+    FatalTryCatch try_catch(env);
 
-  // The SetURLConstructor method must have been called already to
-  // set the constructor function used below. SetURLConstructor is
-  // called automatically when the internal/url.js module is loaded
-  // during the internal/bootstrap_node.js processing.
-  MaybeLocal<Value> ret =
-      env->url_constructor_function()
-          ->Call(env->context(), undef, 9, argv);
+    // The SetURLConstructor method must have been called already to
+    // set the constructor function used below. SetURLConstructor is
+    // called automatically when the internal/url.js module is loaded
+    // during the internal/bootstrap_node.js processing.
+    ret = env->url_constructor_function()
+        ->Call(env->context(), undef, arraysize(argv), argv);
+  }
 
   return ret.ToLocalChecked();
 }

--- a/src/util.h
+++ b/src/util.h
@@ -428,6 +428,7 @@ class BufferValue : public MaybeStackBuffer<char> {
   if (name##_length > 0)                                                      \
     CHECK_NE(name##_data, nullptr);
 
+template <typename T> inline void USE(T&&) {}
 
 }  // namespace node
 

--- a/src/util.h
+++ b/src/util.h
@@ -428,6 +428,8 @@ class BufferValue : public MaybeStackBuffer<char> {
   if (name##_length > 0)                                                      \
     CHECK_NE(name##_data, nullptr);
 
+// Use this when a variable or parameter is unused in order to explicitly
+// silence a compiler warning about that.
 template <typename T> inline void USE(T&&) {}
 
 }  // namespace node


### PR DESCRIPTION
At its call sites, `ClearFatalExceptionHandlers()` was used to
make the process crash as soon as possible once an exception occurred,
without giving JS land a chance to interfere.

`ClearFatalExceptionHandlers()` awkwardly removed the current domain
and any `uncaughtException` handlers, whereas a clearer way is to
execute the relevant reporting (and `exit()`) code directly.

Refs: https://github.com/nodejs/node/pull/17159
Refs: https://github.com/nodejs/node/pull/17324

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src