### PR TITLE
fs: move type checking for multiple fs methods to js

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1301,7 +1301,7 @@ fs.chownSync = function(path, uid, gid) {
 };
 
 // converts Date or number to a fractional UNIX timestamp
-function toUnixTimestamp(time) {
+function toUnixTimestamp(time, name = 'time') {
   // eslint-disable-next-line eqeqeq
   if (typeof time === 'string' && +time == time) {
     return +time;
@@ -1316,10 +1316,10 @@ function toUnixTimestamp(time) {
     // convert to 123.456 UNIX timestamp
     return time.getTime() / 1000;
   }
-  throw new errors.Error('ERR_INVALID_ARG_TYPE',
-                         'time',
-                         ['Date', 'Time in seconds'],
-                         time);
+  throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                             name,
+                             ['Date', 'Time in seconds'],
+                             time);
 }
 
 // exported for unit tests, not for public consumption
@@ -1347,16 +1347,24 @@ fs.utimesSync = function(path, atime, mtime) {
 };
 
 fs.futimes = function(fd, atime, mtime, callback) {
-  atime = toUnixTimestamp(atime);
-  mtime = toUnixTimestamp(mtime);
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  atime = toUnixTimestamp(atime, 'atime');
+  mtime = toUnixTimestamp(mtime, 'mtime');
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.futimes(fd, atime, mtime, req);
 };
 
 fs.futimesSync = function(fd, atime, mtime) {
-  atime = toUnixTimestamp(atime);
-  mtime = toUnixTimestamp(mtime);
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  atime = toUnixTimestamp(atime, 'atime');
+  mtime = toUnixTimestamp(mtime, 'mtime');
   binding.futimes(fd, atime, mtime);
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -691,18 +691,38 @@ fs.openSync = function(path, flags, mode) {
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (!isUint8Array(buffer))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                               ['Buffer', 'Uint8Array']);
+
+  offset |= 0;
+  length |= 0;
+
   if (length === 0) {
     return process.nextTick(function() {
       callback && callback(null, 0, buffer);
     });
   }
 
+  if (offset < 0 || offset >= buffer.length)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
+
+  if (length < 0 || offset + length > buffer.length)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+
+  if (!Number.isInteger(position))
+    position = -1;
+
   function wrapper(err, bytesRead) {
     // Retain a reference to buffer so that it can't be GC'ed too soon.
     callback && callback(err, bytesRead || 0, buffer);
   }
 
-  var req = new FSReqWrap();
+  const req = new FSReqWrap();
   req.oncomplete = wrapper;
 
   binding.read(fd, buffer, offset, length, position, req);
@@ -712,9 +732,29 @@ Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
 
 fs.readSync = function(fd, buffer, offset, length, position) {
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (!isUint8Array(buffer))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                               ['Buffer', 'Uint8Array']);
+
+  offset |= 0;
+  length |= 0;
+
   if (length === 0) {
     return 0;
   }
+
+  if (offset < 0 || offset >= buffer.length)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
+
+  if (length < 0 || offset + length > buffer.length)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+
+  if (!Number.isInteger(position))
+    position = -1;
 
   return binding.read(fd, buffer, offset, length, position);
 };

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -925,7 +925,7 @@ fs.fdatasyncSync = function(fd) {
 };
 
 fs.fsync = function(fd, callback) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
@@ -935,7 +935,7 @@ fs.fsync = function(fd, callback) {
 };
 
 fs.fsyncSync = function(fd) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1147,11 +1147,11 @@ fs.unlinkSync = function(path) {
 
 fs.fchmod = function(fd, mode, callback) {
   mode = modeNum(mode);
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
-  if (typeof mode !== 'number')
+  if (!Number.isInteger(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'number');
   if (mode < 0 || mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
@@ -1163,11 +1163,11 @@ fs.fchmod = function(fd, mode, callback) {
 
 fs.fchmodSync = function(fd, mode) {
   mode = modeNum(mode);
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
-  if (typeof mode !== 'number')
+  if (!Number.isInteger(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'number');
   if (mode < 0 || mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -907,7 +907,7 @@ fs.rmdirSync = function(path) {
 };
 
 fs.fdatasync = function(fd, callback) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
@@ -917,7 +917,7 @@ fs.fdatasync = function(fd, callback) {
 };
 
 fs.fdatasyncSync = function(fd) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -981,7 +981,7 @@ fs.readdirSync = function(path, options) {
 };
 
 fs.fstat = function(fd, callback) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
@@ -1011,7 +1011,7 @@ fs.stat = function(path, callback) {
 };
 
 fs.fstatSync = function(fd) {
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1249,12 +1249,38 @@ if (constants.O_SYMLINK !== undefined) {
 }
 
 fs.fchown = function(fd, uid, gid, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (!Number.isInteger(uid))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'number');
+  if (uid < 0)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'uid');
+  if (!Number.isInteger(gid))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'number');
+  if (gid < 0)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'gid');
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fchown(fd, uid, gid, req);
 };
 
 fs.fchownSync = function(fd, uid, gid) {
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (!Number.isInteger(uid))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'number');
+  if (uid < 0)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'uid');
+  if (!Number.isInteger(gid))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'number');
+  if (gid < 0)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'gid');
+
   return binding.fchown(fd, uid, gid);
 };
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -636,12 +636,22 @@ fs.readFileSync = function(path, options) {
 };
 
 fs.close = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.close(fd, req);
 };
 
 fs.closeSync = function(fd) {
+  if (!Number.isInteger(fd))
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+
   return binding.close(fd);
 };
 
@@ -854,7 +864,14 @@ fs.ftruncate = function(fd, len, callback) {
   } else if (len === undefined) {
     len = 0;
   }
-  var req = new FSReqWrap();
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (typeof len !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'number');
+  len = Math.max(0, len);
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.ftruncate(fd, len, req);
 };
@@ -863,6 +880,13 @@ fs.ftruncateSync = function(fd, len) {
   if (len === undefined) {
     len = 0;
   }
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (typeof len !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'number');
+  len = Math.max(0, len);
   return binding.ftruncate(fd, len);
 };
 
@@ -883,22 +907,38 @@ fs.rmdirSync = function(path) {
 };
 
 fs.fdatasync = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fdatasync(fd, req);
 };
 
 fs.fdatasyncSync = function(fd) {
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
   return binding.fdatasync(fd);
 };
 
 fs.fsync = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fsync(fd, req);
 };
 
 fs.fsyncSync = function(fd) {
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
   return binding.fsync(fd);
 };
 
@@ -941,7 +981,11 @@ fs.readdirSync = function(path, options) {
 };
 
 fs.fstat = function(fd, callback) {
-  var req = new FSReqWrap();
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  const req = new FSReqWrap();
   req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
 };
@@ -967,6 +1011,10 @@ fs.stat = function(path, callback) {
 };
 
 fs.fstatSync = function(fd) {
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
   binding.fstat(fd);
   return statsFromValues();
 };
@@ -1098,13 +1146,32 @@ fs.unlinkSync = function(path) {
 };
 
 fs.fchmod = function(fd, mode, callback) {
-  var req = new FSReqWrap();
+  mode = modeNum(mode);
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (typeof mode !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'number');
+  if (mode < 0 || mode > 0o777)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
+
+  const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
-  binding.fchmod(fd, modeNum(mode), req);
+  binding.fchmod(fd, mode, req);
 };
 
 fs.fchmodSync = function(fd, mode) {
-  return binding.fchmod(fd, modeNum(mode));
+  mode = modeNum(mode);
+  if (typeof fd !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
+  if (fd < 0 || fd > 0xFFFFFFFF)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
+  if (typeof mode !== 'number')
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'number');
+  if (mode < 0 || mode > 0o777)
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
+  return binding.fchmod(fd, mode);
 };
 
 if (constants.O_SYMLINK !== undefined) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -864,11 +864,11 @@ fs.ftruncate = function(fd, len, callback) {
   } else if (len === undefined) {
     len = 0;
   }
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
-  if (typeof len !== 'number')
+  if (!Number.isInteger(len))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'number');
   len = Math.max(0, len);
   const req = new FSReqWrap();
@@ -880,11 +880,11 @@ fs.ftruncateSync = function(fd, len) {
   if (len === undefined) {
     len = 0;
   }
-  if (typeof fd !== 'number')
+  if (!Number.isInteger(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'number');
   if (fd < 0 || fd > 0xFFFFFFFF)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'fd');
-  if (typeof len !== 'number')
+  if (!Number.isInteger(len))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'number');
   len = Math.max(0, len);
   return binding.ftruncate(fd, len);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -806,10 +806,7 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
 static void Fsync(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 1)
-    return TYPE_ERROR("fd is required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
+  CHECK(args[0]->IsInt32());
 
   int fd = args[0]->Int32Value();
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -634,10 +634,7 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
 static void FStat(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 1)
-    return TYPE_ERROR("fd is required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
+  CHECK(args[0]->IsInt32());
 
   int fd = args[0]->Int32Value();
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1254,12 +1254,8 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
 static void FChmod(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 2)
-    return TYPE_ERROR("fd and mode are required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
-  if (!args[1]->IsInt32())
-    return TYPE_ERROR("mode must be an integer");
+  CHECK(args[0]->IsInt32());
+  CHECK(args[1]->IsInt32());
 
   int fd = args[0]->Int32Value();
   int mode = static_cast<int>(args[1]->Int32Value());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -464,10 +464,7 @@ void Access(const FunctionCallbackInfo<Value>& args) {
 void Close(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 1)
-    return TYPE_ERROR("fd is required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
+  CHECK(args[0]->IsInt32());
 
   int fd = args[0]->Int32Value();
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -763,24 +763,11 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
 static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 2)
-    return TYPE_ERROR("fd and length are required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
+  CHECK(args[0]->IsInt32());
+  CHECK(args[1]->IsNumber());
 
   int fd = args[0]->Int32Value();
-
-  // FIXME(bnoordhuis) It's questionable to reject non-ints here but still
-  // allow implicit coercion from null or undefined to zero.  Probably best
-  // handled in lib/fs.js.
-  Local<Value> len_v(args[1]);
-  if (!len_v->IsUndefined() &&
-      !len_v->IsNull() &&
-      !IsInt64(len_v->NumberValue())) {
-    return env->ThrowTypeError("Not an integer");
-  }
-
-  const int64_t len = len_v->IntegerValue();
+  const int64_t len = args[1]->IntegerValue();
 
   if (args[2]->IsObject()) {
     ASYNC_CALL(ftruncate, args[2], UTF8, fd, len)

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1178,12 +1178,8 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
 static void Read(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 2)
-    return TYPE_ERROR("fd and buffer are required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
-  if (!Buffer::HasInstance(args[1]))
-    return TYPE_ERROR("Second argument needs to be a buffer");
+  CHECK(args[0]->IsInt32());
+  CHECK(Buffer::HasInstance(args[1]));
 
   int fd = args[0]->Int32Value();
 
@@ -1199,13 +1195,10 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   size_t buffer_length = Buffer::Length(buffer_obj);
 
   size_t off = args[2]->Int32Value();
-  if (off >= buffer_length) {
-    return env->ThrowError("Offset is out of bounds");
-  }
+  CHECK_LT(off, buffer_length);
 
   len = args[3]->Int32Value();
-  if (!Buffer::IsWithinBounds(off, len, buffer_length))
-    return env->ThrowRangeError("Length extends beyond buffer");
+  CHECK(Buffer::IsWithinBounds(off, len, buffer_length));
 
   pos = GET_OFFSET(args[4]);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1306,19 +1306,9 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
 static void FChown(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  int len = args.Length();
-  if (len < 1)
-    return TYPE_ERROR("fd required");
-  if (len < 2)
-    return TYPE_ERROR("uid required");
-  if (len < 3)
-    return TYPE_ERROR("gid required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be an int");
-  if (!args[1]->IsUint32())
-    return TYPE_ERROR("uid must be an unsigned int");
-  if (!args[2]->IsUint32())
-    return TYPE_ERROR("gid must be an unsigned int");
+  CHECK(args[0]->IsInt32());
+  CHECK(args[1]->IsUint32());
+  CHECK(args[2]->IsUint32());
 
   int fd = args[0]->Int32Value();
   uv_uid_t uid = static_cast<uv_uid_t>(args[1]->Uint32Value());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1353,19 +1353,9 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
 static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  int len = args.Length();
-  if (len < 1)
-    return TYPE_ERROR("fd required");
-  if (len < 2)
-    return TYPE_ERROR("atime required");
-  if (len < 3)
-    return TYPE_ERROR("mtime required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be an int");
-  if (!args[1]->IsNumber())
-    return TYPE_ERROR("atime must be a number");
-  if (!args[2]->IsNumber())
-    return TYPE_ERROR("mtime must be a number");
+  CHECK(args[0]->IsInt32());
+  CHECK(args[1]->IsNumber());
+  CHECK(args[2]->IsNumber());
 
   const int fd = args[0]->Int32Value();
   const double atime = static_cast<double>(args[1]->NumberValue());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -792,10 +792,7 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
 static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (args.Length() < 1)
-    return TYPE_ERROR("fd is required");
-  if (!args[0]->IsInt32())
-    return TYPE_ERROR("fd must be a file descriptor");
+  CHECK(args[0]->IsInt32());
 
   int fd = args[0]->Int32Value();
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1367,8 +1367,7 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 2);
 
   BufferValue tmpl(env->isolate(), args[0]);
-  if (*tmpl == nullptr)
-    return TYPE_ERROR("template must be a string or Buffer");
+  CHECK_NE(*tmpl, nullptr);
 
   const enum encoding encoding = ParseEncoding(env->isolate(), args[1], UTF8);
 

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -108,6 +108,15 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
       assert.strictEqual(mode_async, fs.fstatSync(fd).mode & 0o777);
     }
 
+    common.expectsError(
+      () => fs.fchmod(fd, {}),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "mode" argument must be of type number'
+      }
+    );
+
     fs.fchmodSync(fd, mode_sync);
     if (common.isWindows) {
       assert.ok((fs.fstatSync(fd).mode & 0o777) & mode_sync);
@@ -136,6 +145,43 @@ if (fs.lchmod) {
   }));
 }
 
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.fchmod(i, 0o000),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fchmodSync(i, 0o000),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.fchmod(i, 0o000),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.fchmodSync(i, 0o000),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});
 
 process.on('exit', function() {
   assert.strictEqual(0, openCount);

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.close(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.closeSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.close(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.closeSync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});

--- a/test/parallel/test-fs-fchown.js
+++ b/test/parallel/test-fs-fchown.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.fchown(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fchownSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+
+  common.expectsError(
+    () => fs.fchown(1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "uid" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fchownSync(1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "uid" argument must be of type number'
+    }
+  );
+
+  common.expectsError(
+    () => fs.fchown(1, 1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "gid" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fchownSync(1, 1, i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "gid" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.fchown(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.fchownSync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});
+
+common.expectsError(
+  () => fs.fchown(1, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The "uid" argument is out of range'
+  }
+);
+common.expectsError(
+  () => fs.fchownSync(1, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The "uid" argument is out of range'
+  }
+);
+
+common.expectsError(
+  () => fs.fchown(1, 1, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The "gid" argument is out of range'
+  }
+);
+common.expectsError(
+  () => fs.fchownSync(1, 1, -1),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The "gid" argument is out of range'
+  }
+);

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -66,11 +66,27 @@ fs.open(fileFixture, 'a', 0o777, common.mustCall(function(err, fd) {
       message: 'The "fd" argument must be of type number'
     }
   );
+  common.expectsError(
+    () => fs.fsync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fsyncSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
 });
 
 [-1, 0xFFFFFFFF + 1].forEach((i) => {
   common.expectsError(
-    () => fs.fdatasync(i),
+    () => fs.fsync(i),
     {
       code: 'ERR_OUT_OF_RANGE',
       type: RangeError,
@@ -78,7 +94,7 @@ fs.open(fileFixture, 'a', 0o777, common.mustCall(function(err, fd) {
     }
   );
   common.expectsError(
-    () => fs.fdatasyncSync(i),
+    () => fs.fsyncSync(i),
     {
       code: 'ERR_OUT_OF_RANGE',
       type: RangeError,

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -48,3 +48,41 @@ fs.open(fileFixture, 'a', 0o777, common.mustCall(function(err, fd) {
     }));
   }));
 }));
+
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.fdatasync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fdatasyncSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.fdatasync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.fdatasyncSync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});

--- a/test/parallel/test-fs-read-type.js
+++ b/test/parallel/test-fs-read-type.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
@@ -9,14 +8,20 @@ const fd = fs.openSync(filepath, 'r');
 const expected = 'xyz\n';
 
 // Error must be thrown with string
-assert.throws(() => {
-  fs.read(fd,
-          expected.length,
-          0,
-          'utf-8',
-          common.mustNotCall());
-}, /^TypeError: Second argument needs to be a buffer$/);
+common.expectsError(
+  () => fs.read(fd, expected.length, 0, 'utf-8', common.mustNotCall()),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+  }
+);
 
-assert.throws(() => {
-  fs.readSync(fd, expected.length, 0, 'utf-8');
-}, /^TypeError: Second argument needs to be a buffer$/);
+common.expectsError(
+  () => fs.readSync(fd, expected.length, 0, 'utf-8'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "buffer" argument must be one of type Buffer or Uint8Array'
+  }
+);

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -130,3 +130,41 @@ fs.stat(__filename, common.mustCall(function(err, s) {
     assert.strictEqual(typeof parsed[k], 'string', `${k} should be a string`);
   });
 }));
+
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.fstat(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.fstatSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.fstat(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.fstatSync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -180,8 +180,69 @@ function testFtruncate(cb) {
   fs.writeFileSync(file5, 'Hi');
   const fd = fs.openSync(file5, 'r+');
   process.on('exit', () => fs.closeSync(fd));
+
+  ['', false, null, {}, []].forEach((i) => {
+    common.expectsError(
+      () => fs.ftruncate(fd, i),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "len" argument must be of type number'
+      }
+    );
+  });
+
   fs.ftruncate(fd, undefined, common.mustCall(function(err) {
     assert.ifError(err);
     assert(fs.readFileSync(file5).equals(Buffer.from('')));
   }));
 }
+
+{
+  const file6 = path.resolve(tmp, 'truncate-file-6.txt');
+  fs.writeFileSync(file6, 'Hi');
+  const fd = fs.openSync(file6, 'r+');
+  process.on('exit', () => fs.closeSync(fd));
+  fs.ftruncate(fd, -1, common.mustCall(function(err) {
+    assert.ifError(err);
+    assert(fs.readFileSync(file6).equals(Buffer.from('')));
+  }));
+}
+
+['', false, null, undefined, {}, []].forEach((i) => {
+  common.expectsError(
+    () => fs.ftruncate(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+  common.expectsError(
+    () => fs.ftruncateSync(i),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "fd" argument must be of type number'
+    }
+  );
+});
+
+[-1, 0xFFFFFFFF + 1].forEach((i) => {
+  common.expectsError(
+    () => fs.ftruncate(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+  common.expectsError(
+    () => fs.ftruncateSync(i),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The "fd" argument is out of range'
+    }
+  );
+});


### PR DESCRIPTION
Update errors to use internal/errors, move type checking

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs