### PR TITLE
http: do not assign intermediate variable

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -21,8 +21,7 @@
 
 'use strict';
 
-const binding = process.binding('http_parser');
-const { methods, HTTPParser } = binding;
+const { methods, HTTPParser } = process.binding('http_parser');
 
 const FreeList = require('internal/freelist');
 const { ondrain } = require('internal/http');


### PR DESCRIPTION
No need for binding, it's only used in the next line to declare more
variables :)

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http