### PR TITLE
fs: simplify the error context collection in C++, migrate fs.close errors

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -651,7 +651,11 @@ fs.closeSync = function(fd) {
   if (!isUint32(fd))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
 
-  return binding.close(fd);
+  const ctx = {};
+  binding.close(fd, undefined, ctx);
+  if (ctx.errno !== undefined) {
+    throw new errors.uvException(ctx);
+  }
 };
 
 function modeNum(m, def) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -329,10 +329,10 @@ fs.accessSync = function(path, mode) {
   else
     mode = mode | 0;
 
-  const ctx = {};
+  const ctx = { path };
   binding.access(pathModule.toNamespacedPath(path), mode, undefined, ctx);
 
-  if (ctx.code !== undefined) {
+  if (ctx.errno !== undefined) {
     throw new errors.uvException(ctx);
   }
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,6 +14,7 @@ const kCode = Symbol('code');
 const kInfo = Symbol('info');
 const messages = new Map();
 
+const { errmap } = process.binding('uv');
 const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
 
@@ -194,43 +195,35 @@ function E(sym, val) {
   messages.set(sym, typeof val === 'function' ? val : String(val));
 }
 
-// JS counterpart of StringFromPath, although here path is a buffer.
-function stringFromPath(path) {
-  const str = path.toString();
-  if (process.platform !== 'win32') {
-    return str;
-  }
-
-  if (str.startsWith('\\\\?\\UNC\\')) {
-    return '\\\\' + str.slice(8);
-  } else if (str.startsWith('\\\\?\\')) {
-    return str.slice(4);
-  }
-  return str;
-}
-
 // This creates an error compatible with errors produced in UVException
 // using the context collected in CollectUVExceptionInfo
 // The goal is to migrate them to ERR_* errors later when
 // compatibility is not a concern
 function uvException(ctx) {
   const err = new Error();
-  err.errno = ctx.errno;
-  err.code = ctx.code;
-  err.syscall = ctx.syscall;
 
-  let message = `${ctx.code}: ${ctx.message}, ${ctx.syscall}`;
+  for (const prop of Object.keys(ctx)) {
+    if (prop === 'message' || prop === 'path' || prop === 'dest') {
+      continue;
+    }
+    err[prop] = ctx[prop];
+  }
+
+  const [ code, uvmsg ] = errmap.get(ctx.errno);
+  err.code = code;
+  let message = `${code}: ${uvmsg}, ${ctx.syscall}`;
   if (ctx.path) {
-    const path = stringFromPath(ctx.path);
+    const path = ctx.path.toString();
     message += ` '${path}'`;
     err.path = path;
   }
   if (ctx.dest) {
-    const dest = stringFromPath(ctx.dest);
+    const dest = ctx.dest.toString();
     message += ` -> '${dest}'`;
     err.dest = dest;
   }
   err.message = message;
+
   Error.captureStackTrace(err, uvException);
   return err;
 }

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -1,8 +1,14 @@
 'use strict';
+
+// This tests that fs.access and fs.accessSync works as expected
+// and the errors thrown from these APIs include the desired properties
+
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const uv = process.binding('uv');
+
 const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
 const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
 const readWriteFile = path.join(common.tmpDir, 'read_write_file');
@@ -130,6 +136,24 @@ assert.throws(
       `ENOENT: no such file or directory, access '${doesNotExist}'`
     );
     assert.strictEqual(err.constructor, Error);
+    assert.strictEqual(err.syscall, 'access');
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
+    return true;
+  }
+);
+
+assert.throws(
+  () => { fs.accessSync(Buffer.from(doesNotExist)); },
+  (err) => {
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.path, doesNotExist);
+    assert.strictEqual(
+      err.message,
+      `ENOENT: no such file or directory, access '${doesNotExist}'`
+    );
+    assert.strictEqual(err.constructor, Error);
+    assert.strictEqual(err.syscall, 'access');
+    assert.strictEqual(err.errno, uv.UV_ENOENT);
     return true;
   }
 );

--- a/test/parallel/test-fs-close-errors.js
+++ b/test/parallel/test-fs-close-errors.js
@@ -1,7 +1,12 @@
 'use strict';
 
+// This tests that the errors thrown from fs.close and fs.closeSync
+// include the desired properties
+
 const common = require('../common');
+const assert = require('assert');
 const fs = require('fs');
+const uv = process.binding('uv');
 
 ['', false, null, undefined, {}, []].forEach((i) => {
   common.expectsError(
@@ -21,3 +26,41 @@ const fs = require('fs');
     }
   );
 });
+
+{
+  assert.throws(
+    () => {
+      const fd = fs.openSync(__filename, 'r');
+      fs.closeSync(fd);
+      fs.closeSync(fd);
+    },
+    (err) => {
+      assert.strictEqual(err.code, 'EBADF');
+      assert.strictEqual(
+        err.message,
+        'EBADF: bad file descriptor, close'
+      );
+      assert.strictEqual(err.constructor, Error);
+      assert.strictEqual(err.syscall, 'close');
+      assert.strictEqual(err.errno, uv.UV_EBADF);
+      return true;
+    }
+  );
+}
+
+{
+  const fd = fs.openSync(__filename, 'r');
+  fs.close(fd, common.mustCall((err) => {
+    assert.ifError(err);
+    fs.close(fd, common.mustCall((err) => {
+      assert.strictEqual(err.code, 'EBADF');
+      assert.strictEqual(
+        err.message,
+        'EBADF: bad file descriptor, close'
+      );
+      assert.strictEqual(err.constructor, Error);
+      assert.strictEqual(err.syscall, 'close');
+      assert.strictEqual(err.errno, uv.UV_EBADF);
+    }));
+  }));
+}

--- a/test/parallel/test-uv-binding-constant.js
+++ b/test/parallel/test-uv-binding-constant.js
@@ -9,10 +9,10 @@ const uv = process.binding('uv');
 
 const keys = Object.keys(uv);
 keys.forEach((key) => {
-  if (key === 'errname')
-    return; // skip this
-  const val = uv[key];
-  assert.throws(() => uv[key] = 1,
-                /^TypeError: Cannot assign to read only property/);
-  assert.strictEqual(uv[key], val);
+  if (key.startsWith('UV_')) {
+    const val = uv[key];
+    assert.throws(() => uv[key] = 1,
+                  /^TypeError: Cannot assign to read only property/);
+    assert.strictEqual(uv[key], val);
+  }
 });

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -8,7 +8,7 @@ const uv = process.binding('uv');
 const keys = Object.keys(uv);
 
 keys.forEach((key) => {
-  if (key === 'errname')
+  if (!key.startsWith('UV_'))
     return;
 
   assert.doesNotThrow(() => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

fs: simplify the error context collection in C++

- Simplify the SyncCall template function, only collect error
  number and syscall in the C++ layer and collect the rest of context
  in JS for flexibility.
- Remove the stringFromPath JS helper now that the unprefixed path is
  directly put into the context before the binding is invoked with the
  prefixed path.
- Add a errno -> [error code, uv error message] map to the uv binding
  so the error message can be assembled in the JS layer

fs: throw fs.close errors in JS

* Check fd in JS before invoking the binding and throw
  ERR_INVALID_ARG_TYPE if it's not an integer
* Add a test for checking the errors thrown from fs.close and
  fs.closeSync

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs, test, errors