### PR TITLE
update : `test-http-upgrade-client` to use countdown

### DIFF
--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -29,6 +29,7 @@ const assert = require('assert');
 
 const http = require('http');
 const net = require('net');
+const Countdown = require('../common/countdown');
 
 // Create a TCP server
 const srv = net.createServer(function(c) {
@@ -60,7 +61,8 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       ['Origin', 'http://www.websocket.org']
     ]
   ];
-  let left = headers.length;
+  const countdown = new Countdown(headers.length, () => srv.close());
+
   headers.forEach(function(h) {
     const req = http.get({
       port: port,
@@ -87,8 +89,7 @@ srv.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.deepStrictEqual(expectedHeaders, res.headers);
 
       socket.end();
-      if (--left === 0)
-        srv.close();
+      countdown.dec();
     }));
     req.on('close', common.mustCall(function() {
       assert.strictEqual(sawUpgrade, true);


### PR DESCRIPTION
Refactored the test case `test-http-upgrade-client` to use countdown, as per issue #17169 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
