### PR TITLE
refactor: test cases in `test-http-status-reason-invalid-chars` to use countdown

### DIFF
--- a/test/parallel/test-http-status-reason-invalid-chars.js
+++ b/test/parallel/test-http-status-reason-invalid-chars.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
+const Countdown = require('../common/countdown');
 
 function explicit(req, res) {
   assert.throws(() => {
@@ -34,13 +35,12 @@ const server = http.createServer((req, res) => {
   }
 }).listen(0, common.mustCall(() => {
   const hostname = 'localhost';
+  const countdown = new Countdown(2, () => server.close());
   const url = `http://${hostname}:${server.address().port}`;
-  let left = 2;
   const check = common.mustCall((res) => {
-    left--;
     assert.notStrictEqual(res.headers['content-type'], 'text/html');
     assert.notStrictEqual(res.headers['content-type'], 'gotcha');
-    if (left === 0) server.close();
+    countdown.dec();
   }, 2);
   http.get(`${url}/explicit`, check).end();
   http.get(`${url}/implicit`, check).end();


### PR DESCRIPTION
Refactored `test-http-status-reason-invalid-chars` file to use countdown as per issue #17169 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
