### PR TITLE
src: replace ->To*(isolate) with ->To*(context).ToLocalChecked()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -589,7 +589,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   }
   e = Exception::Error(cons);
 
-  Local<Object> obj = e->ToObject(env->isolate());
+  Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
   obj->Set(env->errno_string(), Integer::New(env->isolate(), errorno));
   obj->Set(env->code_string(), estring);
 
@@ -751,7 +751,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
     e = Exception::Error(message);
   }
 
-  Local<Object> obj = e->ToObject(env->isolate());
+  Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
   obj->Set(env->errno_string(), Integer::New(isolate, errorno));
 
   if (path != nullptr) {
@@ -1482,7 +1482,7 @@ static void ReportException(Environment* env,
   if (er->IsUndefined() || er->IsNull()) {
     trace_value = Undefined(env->isolate());
   } else {
-    Local<Object> err_obj = er->ToObject(env->isolate());
+    Local<Object> err_obj = er->ToObject(env->context()).ToLocalChecked();
 
     trace_value = err_obj->Get(env->stack_string());
     arrow =
@@ -2301,7 +2301,8 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowTypeError("flag argument must be an integer.");
   }
 
-  Local<Object> module = args[0]->ToObject(env->isolate());  // Cast
+  Local<Object> module =
+      args[0]->ToObject(env->context()).ToLocalChecked();  // Cast
   node::Utf8Value filename(env->isolate(), args[1]);  // Cast
   DLib dlib;
   dlib.filename_ = *filename;
@@ -2319,7 +2320,8 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
     dlib.Close();
 #ifdef _WIN32
     // Windows needs to add the filename into the error message
-    errmsg = String::Concat(errmsg, args[1]->ToString(env->isolate()));
+    errmsg = String::Concat(errmsg,
+                            args[1]->ToString(env->context()).ToLocalChecked());
 #endif  // _WIN32
     env->isolate()->ThrowException(Exception::Error(errmsg));
     return;
@@ -2364,7 +2366,8 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   modlist_addon = mp;
 
   Local<String> exports_string = env->exports_string();
-  Local<Object> exports = module->Get(exports_string)->ToObject(env->isolate());
+  Local<Object> exports =
+      module->Get(exports_string)->ToObject(env->context()).ToLocalChecked();
 
   if (mp->nm_context_register_func != nullptr) {
     mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);
@@ -4337,7 +4340,7 @@ void EmitBeforeExit(Environment* env) {
   Local<String> exit_code = FIXED_ONE_BYTE_STRING(env->isolate(), "exitCode");
   Local<Value> args[] = {
     FIXED_ONE_BYTE_STRING(env->isolate(), "beforeExit"),
-    process_object->Get(exit_code)->ToInteger(env->isolate())
+    process_object->Get(exit_code)->ToInteger(env->context()).ToLocalChecked()
   };
   MakeCallback(env->isolate(),
                process_object, "emit", arraysize(args), args,

--- a/src/node.cc
+++ b/src/node.cc
@@ -2367,7 +2367,7 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
 
   Local<String> exports_string = env->exports_string();
   Local<Object> exports =
-      module->Get(exports_string)->ToObject(env->context()).ToLocalChecked();
+      module->Get(env->context(), exports_string).ToLocalChecked().As<Object>();
 
   if (mp->nm_context_register_func != nullptr) {
     mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);

--- a/src/node.cc
+++ b/src/node.cc
@@ -2366,8 +2366,18 @@ static void DLOpen(const FunctionCallbackInfo<Value>& args) {
   modlist_addon = mp;
 
   Local<String> exports_string = env->exports_string();
+  MaybeLocal<Value> maybe_exports =
+      module->Get(env->context(), exports_string);
+
+  if (maybe_exports.IsEmpty() ||
+      maybe_exports.ToLocalChecked()->ToObject(env->context()).IsEmpty()) {
+    dlib.Close();
+    return;
+  }
+
   Local<Object> exports =
-      module->Get(env->context(), exports_string).ToLocalChecked().As<Object>();
+      maybe_exports.ToLocalChecked()->ToObject(env->context())
+          .FromMaybe(Local<Object>());
 
   if (mp->nm_context_register_func != nullptr) {
     mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);

--- a/src/node.cc
+++ b/src/node.cc
@@ -589,7 +589,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   }
   e = Exception::Error(cons);
 
-  Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
+  Local<Object> obj = e.As<Object>();
   obj->Set(env->errno_string(), Integer::New(env->isolate(), errorno));
   obj->Set(env->code_string(), estring);
 
@@ -751,7 +751,7 @@ Local<Value> WinapiErrnoException(Isolate* isolate,
     e = Exception::Error(message);
   }
 
-  Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
+  Local<Object> obj = e.As<Object>();
   obj->Set(env->errno_string(), Integer::New(isolate, errorno));
 
   if (path != nullptr) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -606,7 +606,7 @@ void Fill(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  str_obj = args[1]->ToString(env->isolate());
+  str_obj = args[1]->ToString(env->context()).ToLocalChecked();
   enc = ParseEncoding(env->isolate(), args[4], UTF8);
   str_length =
       enc == UTF8 ? str_obj->Utf8Length() :
@@ -677,7 +677,7 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
   if (!args[0]->IsString())
     return env->ThrowTypeError("Argument must be a string");
 
-  Local<String> str = args[0]->ToString(env->isolate());
+  Local<String> str = args[0]->ToString(env->context()).ToLocalChecked();
 
   size_t offset;
   size_t max_length;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -621,7 +621,8 @@ class ContextifyScript : public BaseObject {
         new ContextifyScript(env, args.This());
 
     TryCatch try_catch(env->isolate());
-    Local<String> code = args[0]->ToString(env->context()).ToLocalChecked();
+    Local<String> code =
+        args[0]->ToString(env->context()).FromMaybe(Local<String>());
 
     Local<Value> options = args[1];
     MaybeLocal<String> filename = GetFilenameArg(env, options);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -621,7 +621,7 @@ class ContextifyScript : public BaseObject {
         new ContextifyScript(env, args.This());
 
     TryCatch try_catch(env->isolate());
-    Local<String> code = args[0]->ToString(env->isolate());
+    Local<String> code = args[0]->ToString(env->context()).ToLocalChecked();
 
     Local<Value> options = args[1];
     MaybeLocal<String> filename = GetFilenameArg(env, options);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1219,7 +1219,7 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
 
   char * buf = nullptr;
 
-  Local<Object> buffer_obj = args[1]->ToObject(env->context()).ToLocalChecked();
+  Local<Object> buffer_obj = args[1].As<Object>();
   char *buffer_data = Buffer::Data(buffer_obj);
   size_t buffer_length = Buffer::Length(buffer_obj);
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1219,7 +1219,7 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
 
   char * buf = nullptr;
 
-  Local<Object> buffer_obj = args[1]->ToObject(env->isolate());
+  Local<Object> buffer_obj = args[1]->ToObject(env->context()).ToLocalChecked();
   char *buffer_data = Buffer::Data(buffer_obj);
   size_t buffer_length = Buffer::Length(buffer_obj);
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -466,7 +466,7 @@ class Parser : public AsyncWrap {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
 
       Local<Value> e = Exception::Error(env->parse_error_string());
-      Local<Object> obj = e->ToObject(env->isolate());
+      Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
       obj->Set(env->bytes_parsed_string(), Integer::New(env->isolate(), 0));
       obj->Set(env->code_string(),
                OneByteString(env->isolate(), http_errno_name(err)));

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -466,7 +466,7 @@ class Parser : public AsyncWrap {
       enum http_errno err = HTTP_PARSER_ERRNO(&parser->parser_);
 
       Local<Value> e = Exception::Error(env->parse_error_string());
-      Local<Object> obj = e->ToObject(env->context()).ToLocalChecked();
+      Local<Object> obj = e.As<Object>();
       obj->Set(env->bytes_parsed_string(), Integer::New(env->isolate(), 0));
       obj->Set(env->code_string(),
                OneByteString(env->isolate(), http_errno_name(err)));

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -178,7 +178,7 @@ class ZCtx : public AsyncWrap {
     } else {
       CHECK(Buffer::HasInstance(args[1]));
       Local<Object> in_buf;
-      in_buf = args[1]->ToObject(env->isolate());
+      in_buf = args[1]->ToObject(env->context()).ToLocalChecked();
       in_off = args[2]->Uint32Value();
       in_len = args[3]->Uint32Value();
 
@@ -187,7 +187,7 @@ class ZCtx : public AsyncWrap {
     }
 
     CHECK(Buffer::HasInstance(args[4]));
-    Local<Object> out_buf = args[4]->ToObject(env->isolate());
+    Local<Object> out_buf = args[4]->ToObject(env->context()).ToLocalChecked();
     out_off = args[5]->Uint32Value();
     out_len = args[6]->Uint32Value();
     CHECK(Buffer::IsWithinBounds(out_off, out_len, Buffer::Length(out_buf)));

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -143,7 +143,8 @@ class ProcessWrap : public HandleWrap {
     ProcessWrap* wrap;
     ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
-    Local<Object> js_options = args[0]->ToObject(env->isolate());
+    Local<Object> js_options =
+        args[0]->ToObject(env->context()).ToLocalChecked();
 
     uv_process_options_t options;
     memset(&options, 0, sizeof(uv_process_options_t));

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -127,7 +127,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
         // Buffer chunk, no additional storage required
 
       // String chunk
-      Local<String> string = chunk->ToString(env->isolate());
+      Local<String> string = chunk->ToString(env->context()).ToLocalChecked();
       enum encoding encoding = ParseEncoding(env->isolate(),
                                              chunks->Get(i * 2 + 1));
       size_t chunk_size;
@@ -179,7 +179,7 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
       char* str_storage = req_wrap->Extra(offset);
       size_t str_size = storage_size - offset;
 
-      Local<String> string = chunk->ToString(env->isolate());
+      Local<String> string = chunk->ToString(env->context()).ToLocalChecked();
       enum encoding encoding = ParseEncoding(env->isolate(),
                                              chunks->Get(i * 2 + 1));
       str_size = StringBytes::Write(env->isolate(),

--- a/test/parallel/test-process-dlopen-undefined-exports.js
+++ b/test/parallel/test-process-dlopen-undefined-exports.js
@@ -1,0 +1,10 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const someBindingPath = './test/addons/hello-world/build/Release/binding.node';
+
+assert.throws(() => {
+  process.dlopen({ exports: undefined }, someBindingPath);
+}, Error);

--- a/test/parallel/test-vm-script-throw-in-tostring.js
+++ b/test/parallel/test-vm-script-throw-in-tostring.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const vm = require('vm');
+
+assert.throws(() => {
+  new vm.Script({
+    toString() {
+      throw new Error();
+    }
+  });
+}, Error);


### PR DESCRIPTION
This is part of Nodefest's Code and Learn nodejs/code-and-learn#72

Replace `->To*(isolate)` with `->To*(context).ToLocalChecked()` in `src` files.

See also #17244, and [this safe list](https://github.com/nodejs/code-and-learn/issues/72#issuecomment-346990628).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src