### PR TITLE
deps: cherry-pick 1420e44db0 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/debug/debug.cc
+++ b/deps/v8/src/debug/debug.cc
@@ -338,12 +338,11 @@ bool Debug::Load() {
 void Debug::Unload() {
   ClearAllBreakPoints();
   ClearStepping();
+  if (FLAG_block_coverage) RemoveAllCoverageInfos();
   RemoveDebugDelegate();
 
   // Return debugger is not loaded.
   if (!is_loaded()) return;
-
-  if (FLAG_block_coverage) RemoveAllCoverageInfos();
 
   // Clear debugger context global handle.
   GlobalHandles::Destroy(Handle<Object>::cast(debug_context_).location());
@@ -643,8 +642,11 @@ void Debug::ApplyBreakPoints(Handle<DebugInfo> debug_info) {
 }
 
 void Debug::ClearBreakPoints(Handle<DebugInfo> debug_info) {
+  // If we attempt to clear breakpoints but none exist, simply return. This can
+  // happen e.g. CoverageInfos exit but no breakpoints are set.
+  if (!debug_info->HasDebugBytecodeArray()) return;
+
   DisallowHeapAllocation no_gc;
-  DCHECK(debug_info->HasDebugBytecodeArray());
   for (BreakIterator it(debug_info); !it.Done(); it.Next()) {
     it.ClearDebugBreak();
   }


### PR DESCRIPTION
Original commit message:

    [coverage] Correctly free DebugInfo in the absence of breakpoints

    It's quite possible for DebugInfos to exist without the presence of a
    bytecode array, since DebugInfos are created for all functions for which
    we have a CoverageInfo. Free such objects properly.

    Also move the corresponding deletion of CoverageInfos on unload up
    before the early exit.

    Bug: v8:6000
    Change-Id: Idde45b222290aa8b6828b61ff2251918b8ed2aed
    Reviewed-on: https://chromium-review.googlesource.com/664811
    Reviewed-by: Yang Guo <yangguo@chromium.org>
    Commit-Queue: Jakob Gruber <jgruber@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#48024}

Fixes crash when passing Profiler.startPreciseCoverage before
Debug.paused is received.

Refs: https://github.com/bcoe/c8/pull/6#discussion_r153121287

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps (V8)