### PR TITLE
test: replace function with arrow function

### DIFF
--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -26,7 +26,7 @@ const a = assert;
 
 function makeBlock(f) {
   const args = Array.prototype.slice.call(arguments, 1);
-  return function() {
+  return () => {
     return f.apply(this, args);
   };
 }
@@ -183,7 +183,7 @@ assert.doesNotThrow(makeBlock(a.deepEqual, a1, a2));
 
 // having an identical prototype property
 const nbRoot = {
-  toString: function() { return `${this.first} ${this.last}`; }
+  toString: () => { return `${this.first} ${this.last}`; }
 };
 
 function nameBuilder(first, last) {
@@ -458,10 +458,10 @@ assert.throws(makeBlock(thrower, TypeError));
                      'a.doesNotThrow is not catching type matching errors');
 }
 
-assert.throws(function() { assert.ifError(new Error('test error')); },
+assert.throws(() => { assert.ifError(new Error('test error')); },
               /^Error: test error$/);
-assert.doesNotThrow(function() { assert.ifError(null); });
-assert.doesNotThrow(function() { assert.ifError(); });
+assert.doesNotThrow(() => { assert.ifError(null); });
+assert.doesNotThrow(() => { assert.ifError(); });
 
 assert.throws(() => {
   assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
@@ -501,7 +501,7 @@ assert.throws(() => {
   let threw = false;
   try {
     assert.throws(
-      function() {
+      () => {
         throw ({}); // eslint-disable-line no-throw-literal
       },
       Array
@@ -516,7 +516,7 @@ assert.throws(() => {
 a.throws(makeBlock(thrower, TypeError), /\[object Object\]/);
 
 // use a fn to validate error object
-a.throws(makeBlock(thrower, TypeError), function(err) {
+a.throws(makeBlock(thrower, TypeError), (err) => {
   if ((err instanceof TypeError) && /\[object Object\]/.test(err)) {
     return true;
   }
@@ -607,7 +607,7 @@ testAssertionMessage([1, 2, 3], '[ 1, 2, 3 ]');
 testAssertionMessage(/a/, '/a/');
 testAssertionMessage(/abc/gim, '/abc/gim');
 testAssertionMessage(function f() {}, '[Function: f]');
-testAssertionMessage(function() {}, '[Function]');
+testAssertionMessage(() => {}, '[Function]');
 testAssertionMessage({}, '{}');
 testAssertionMessage(circular, '{ y: 1, x: [Circular] }');
 testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');
@@ -619,7 +619,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
   let threw = false;
   try {
     // eslint-disable-next-line no-restricted-syntax
-    assert.throws(function() {
+    assert.throws(() => {
       assert.ifError(null);
     });
   } catch (e) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -607,7 +607,7 @@ testAssertionMessage([1, 2, 3], '[ 1, 2, 3 ]');
 testAssertionMessage(/a/, '/a/');
 testAssertionMessage(/abc/gim, '/abc/gim');
 testAssertionMessage(function f() {}, '[Function: f]');
-testAssertionMessage(() => {}, '[Function]');
+testAssertionMessage(function() {}, '[Function]');
 testAssertionMessage({}, '{}');
 testAssertionMessage(circular, '{ y: 1, x: [Circular] }');
 testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -183,7 +183,7 @@ assert.doesNotThrow(makeBlock(a.deepEqual, a1, a2));
 
 // having an identical prototype property
 const nbRoot = {
-  toString: () => { return `${this.first} ${this.last}`; }
+  toString() { return `${this.first} ${this.last}`; }
 };
 
 function nameBuilder(first, last) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -27,7 +27,7 @@ const a = assert;
 function makeBlock(f) {
   const args = Array.prototype.slice.call(arguments, 1);
   return () => {
-    return f.apply(this, args);
+    return f.apply(null, args);
   };
 }
 

--- a/test/parallel/test-domain-top-level-error-handler-clears-stack.js
+++ b/test/parallel/test-domain-top-level-error-handler-clears-stack.js
@@ -9,8 +9,8 @@ const domain = require('domain');
  */
 const d = domain.create();
 
-d.on('error', common.mustCall(function() {
-  process.nextTick(function() {
+d.on('error', common.mustCall(() => {
+  process.nextTick(() => {
     // Scheduling a callback with process.nextTick will enter a _new_ domain,
     // and the callback will be called after the domain that handled the error
     // was exited. So there should be only one domain on the domains stack if
@@ -29,6 +29,6 @@ d.on('error', common.mustCall(function() {
   });
 }));
 
-d.run(function() {
+d.run(() => {
   throw new Error('Error from domain');
 });

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -129,7 +129,7 @@ const qsWeirdObjects = [
   [{ regexp: /./g }, 'regexp=', { 'regexp': '' }],
   // eslint-disable-next-line no-unescaped-regexp-dot
   [{ regexp: new RegExp('.', 'g') }, 'regexp=', { 'regexp': '' }],
-  [{ fn: function() {} }, 'fn=', { 'fn': '' }],
+  [{ fn: () => {} }, 'fn=', { 'fn': '' }],
   [{ fn: new Function('') }, 'fn=', { 'fn': '' }],
   [{ math: Math }, 'math=', { 'math': '' }],
   [{ e: extendedFunction }, 'e=', { 'e': '' }],
@@ -192,7 +192,7 @@ function check(actual, expected, input) {
           `Expected keys: ${inspect(expectedKeys)}`;
   }
   assert.deepStrictEqual(actualKeys, expectedKeys, msg);
-  expectedKeys.forEach(function(key) {
+  expectedKeys.forEach((key) => {
     if (typeof input === 'string') {
       msg = `Input: ${inspect(input)}\n` +
             `Key: ${inspect(key)}\n` +
@@ -206,21 +206,21 @@ function check(actual, expected, input) {
 }
 
 // test that the canonical qs is parsed properly.
-qsTestCases.forEach(function(testCase) {
+qsTestCases.forEach((testCase) => {
   check(qs.parse(testCase[0]), testCase[2], testCase[0]);
 });
 
 // test that the colon test cases can do the same
-qsColonTestCases.forEach(function(testCase) {
+qsColonTestCases.forEach((testCase) => {
   check(qs.parse(testCase[0], ';', ':'), testCase[2], testCase[0]);
 });
 
 // test the weird objects, that they get parsed properly
-qsWeirdObjects.forEach(function(testCase) {
+qsWeirdObjects.forEach((testCase) => {
   check(qs.parse(testCase[1]), testCase[2], testCase[1]);
 });
 
-qsNoMungeTestCases.forEach(function(testCase) {
+qsNoMungeTestCases.forEach((testCase) => {
   assert.deepStrictEqual(testCase[0], qs.stringify(testCase[1], '&', '='));
 });
 
@@ -258,15 +258,15 @@ qsNoMungeTestCases.forEach(function(testCase) {
 // now test stringifying
 
 // basic
-qsTestCases.forEach(function(testCase) {
+qsTestCases.forEach((testCase) => {
   assert.strictEqual(testCase[1], qs.stringify(testCase[2]));
 });
 
-qsColonTestCases.forEach(function(testCase) {
+qsColonTestCases.forEach((testCase) => {
   assert.strictEqual(testCase[1], qs.stringify(testCase[2], ';', ':'));
 });
 
-qsWeirdObjects.forEach(function(testCase) {
+qsWeirdObjects.forEach((testCase) => {
   assert.strictEqual(testCase[1], qs.stringify(testCase[0]));
 });
 
@@ -300,7 +300,7 @@ assert.strictEqual('foo=', qs.stringify({ foo: Infinity }));
   assert.strictEqual(f, 'a=b&q=x%3Dy%26y%3Dz');
 }
 
-assert.doesNotThrow(function() {
+assert.doesNotThrow(() => {
   qs.parse(undefined);
 });
 
@@ -432,7 +432,7 @@ check(qs.parse('%\u0100=%\u0101'), { '%Ā': '%ā' });
 }
 
 // Test QueryString.unescapeBuffer
-qsUnescapeTestCases.forEach(function(testCase) {
+qsUnescapeTestCases.forEach((testCase) => {
   assert.strictEqual(qs.unescape(testCase[0]), testCase[1]);
   assert.strictEqual(qs.unescapeBuffer(testCase[0]).toString(), testCase[1]);
 });
@@ -440,7 +440,7 @@ qsUnescapeTestCases.forEach(function(testCase) {
 // test overriding .unescape
 {
   const prevUnescape = qs.unescape;
-  qs.unescape = function(str) {
+  qs.unescape = (str) => {
     return str.replace(/o/g, '_');
   };
   check(

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -12,7 +12,7 @@ const { test, assert_equals, assert_true, assert_array_equals } =
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 /* eslint-disable */
-test(() => {
+test(function() {
     var params = new URLSearchParams('a=b&c=d');
     assert_array_equals(params.getAll('a'), ['b']);
     assert_array_equals(params.getAll('c'), ['d']);
@@ -25,7 +25,7 @@ test(() => {
     assert_array_equals(params.getAll('a'), ['', 'e']);
 }, 'getAll() basics');
 
-test(() => {
+test(function() {
     var params = new URLSearchParams('a=1&a=2&a=3&a');
     assert_true(params.has('a'), 'Search params object has name "a"');
     var matches = params.getAll('a');

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -12,7 +12,7 @@ const { test, assert_equals, assert_true, assert_array_equals } =
    License: http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html
 */
 /* eslint-disable */
-test(function() {
+test(() => {
     var params = new URLSearchParams('a=b&c=d');
     assert_array_equals(params.getAll('a'), ['b']);
     assert_array_equals(params.getAll('c'), ['d']);
@@ -25,7 +25,7 @@ test(function() {
     assert_array_equals(params.getAll('a'), ['', 'e']);
 }, 'getAll() basics');
 
-test(function() {
+test(() => {
     var params = new URLSearchParams('a=1&a=2&a=3&a');
     assert_true(params.has('a'), 'Search params object has name "a"');
     var matches = params.getAll('a');

--- a/test/parallel/test-writeint.js
+++ b/test/parallel/test-writeint.js
@@ -41,10 +41,10 @@ function test8(clazz) {
   assert.strictEqual(0xfb, buffer[1]);
 
   /* Make sure we handle truncation correctly */
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt8(0xabc, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt8(0xabc, 0);
   }, errorOutOfBounds);
 
@@ -54,10 +54,10 @@ function test8(clazz) {
 
   assert.strictEqual(0x7f, buffer[0]);
   assert.strictEqual(0x80, buffer[1]);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt8(0x7f + 1, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt8(-0x80 - 1, 0);
   }, errorOutOfBounds);
 }
@@ -94,10 +94,10 @@ function test16(clazz) {
   assert.strictEqual(0xff, buffer[1]);
   assert.strictEqual(0x80, buffer[2]);
   assert.strictEqual(0x00, buffer[3]);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt16BE(0x7fff + 1, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt16BE(-0x8000 - 1, 0);
   }, errorOutOfBounds);
 
@@ -107,10 +107,10 @@ function test16(clazz) {
   assert.strictEqual(0x7f, buffer[1]);
   assert.strictEqual(0x00, buffer[2]);
   assert.strictEqual(0x80, buffer[3]);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt16LE(0x7fff + 1, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt16LE(-0x8000 - 1, 0);
   }, errorOutOfBounds);
 }
@@ -163,10 +163,10 @@ function test32(clazz) {
   assert.strictEqual(0x00, buffer[5]);
   assert.strictEqual(0x00, buffer[6]);
   assert.strictEqual(0x00, buffer[7]);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt32BE(0x7fffffff + 1, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt32BE(-0x80000000 - 1, 0);
   }, errorOutOfBounds);
 
@@ -180,10 +180,10 @@ function test32(clazz) {
   assert.strictEqual(0x00, buffer[5]);
   assert.strictEqual(0x00, buffer[6]);
   assert.strictEqual(0x80, buffer[7]);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt32LE(0x7fffffff + 1, 0);
   }, errorOutOfBounds);
-  assert.throws(function() {
+  assert.throws(() => {
     buffer.writeInt32LE(-0x80000000 - 1, 0);
   }, errorOutOfBounds);
 }

--- a/test/parallel/test-zerolengthbufferbug.js
+++ b/test/parallel/test-zerolengthbufferbug.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 const http = require('http');
 
-const server = http.createServer(function(req, res) {
+const server = http.createServer((req, res) => {
   const buffer = Buffer.alloc(0);
   // FIXME: WTF gjslint want this?
   res.writeHead(200, { 'Content-Type': 'text/html',
@@ -12,12 +12,12 @@ const server = http.createServer(function(req, res) {
   res.end(buffer);
 });
 
-server.listen(0, common.mustCall(function() {
-  http.get({ port: this.address().port }, common.mustCall(function(res) {
+server.listen(0, common.mustCall(() => {
+  http.get({ port: server.address().port }, common.mustCall((res) => {
 
     res.on('data', common.mustNotCall());
 
-    res.on('end', function(d) {
+    res.on('end', (d) => {
       server.close();
     });
   }));


### PR DESCRIPTION
This is part of Nodefest's Code and Learn nodejs/code-and-learn#72

Among the list of [Code and Learn](https://github.com/nodejs/code-and-learn/issues/72#issuecomment-345667395), I solved the unfinished task of replacing function with arrow function

- test/parallel/test-assert.js
- test/parallel/test-domain-top-level-error-handler-clears-stack.js
- test/parallel/test-querystring.js
- test/parallel/test-whatwg-url-searchparams-getall.js
- test/parallel/test-writeint.js
- test/parallel/test-zerolengthbufferbug.js

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test