### PR TITLE
test: fix flaky parallel/test-http2-client-upload

### DIFF
--- a/test/parallel/test-http2-client-upload.js
+++ b/test/parallel/test-http2-client-upload.js
@@ -38,7 +38,7 @@ fs.readFile(loc, common.mustCall((err, data) => {
     function maybeClose() {
       if (--remaining === 0) {
         server.close();
-        client.destroy();
+        client.shutdown();
       }
     }
 
@@ -47,7 +47,7 @@ fs.readFile(loc, common.mustCall((err, data) => {
     req.resume();
     req.on('end', common.mustCall(maybeClose));
     const str = fs.createReadStream(loc);
-    str.on('end', common.mustCall(maybeClose));
+    req.on('finish', common.mustCall(maybeClose));
     str.pipe(req);
   }));
 }));


### PR DESCRIPTION
In parallel/test-http2-client-upload, the `client.destroy()`
call could terminate the connection before all data was sent
over the wire successfully.

Using `client.shutdown()` removes the flakiness.

Also, listen on `req.on('finish')` rather than the file stream’s
`end` event, since we’re not interested in when the source stream
finishes, but rather when the HTTP/2 stream finishes.

Refs: https://github.com/nodejs/node/pull/17356

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/http2