### PR TITLE
doc: 'constructor' implies use of new keyword

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -44,7 +44,7 @@ Below, `bar.js` makes use of the `square` module, which exports a constructor:
 
 ```js
 const square = require('./square.js');
-const mySquare = square(2);
+const mySquare = new square(2);
 console.log(`The area of my square is ${mySquare.area()}`);
 ```
 

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -45,7 +45,7 @@ Below, `bar.js` makes use of the `square` module, which exports a constructor:
 ```js
 const Square = require('./square.js');
 const mySquare = new Square(2);
-console.log(`The area of my Square is ${mySquare.area()}`);
+console.log(`The area of mySquare is ${mySquare.area()}`);
 ```
 
 The `square` module is defined in `square.js`:

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -43,9 +43,9 @@ or object).
 Below, `bar.js` makes use of the `square` module, which exports a constructor:
 
 ```js
-const square = require('./square.js');
-const mySquare = new square(2);
-console.log(`The area of my square is ${mySquare.area()}`);
+const Square = require('./square.js');
+const mySquare = new Square(2);
+console.log(`The area of my Square is ${mySquare.area()}`);
 ```
 
 The `square` module is defined in `square.js`:


### PR DESCRIPTION
the square module is described as exporting a constructor,
which would mean it would need to be invoked with the
new keyword in bar.js after requiring it. Otherwise it's
technically a factory function, not a constructor.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
