### PR TITLE
test: use v8 Default Allocator in cctest fixture

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -73,8 +73,7 @@ class NodeTestFixture : public ::testing::Test {
     platform_ = new node::NodePlatform(8, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
-    allocator_ = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
-    params_.array_buffer_allocator = allocator_;
+    params_.array_buffer_allocator = allocator_.get();
     isolate_ = v8::Isolate::New(params_);
   }
 
@@ -85,7 +84,6 @@ class NodeTestFixture : public ::testing::Test {
       uv_run(&current_loop, UV_RUN_ONCE);
     }
     v8::V8::ShutdownPlatform();
-    delete allocator_;
     delete platform_;
     platform_ = nullptr;
     CHECK_EQ(0, uv_loop_close(&current_loop));
@@ -93,7 +91,8 @@ class NodeTestFixture : public ::testing::Test {
 
  private:
   node::NodePlatform* platform_ = nullptr;
-  v8::ArrayBuffer::Allocator* allocator_ = nullptr;
+  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_{
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator()};
 };
 
 #endif  // TEST_CCTEST_NODE_TEST_FIXTURE_H_

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -61,7 +61,6 @@ class NodeTestFixture : public ::testing::Test {
   node::MultiIsolatePlatform* Platform() const { return platform_; }
 
  protected:
-  v8::Isolate::CreateParams params_;
   v8::Isolate* isolate_;
 
   ~NodeTestFixture() {
@@ -73,6 +72,7 @@ class NodeTestFixture : public ::testing::Test {
     platform_ = new node::NodePlatform(8, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
+    v8::Isolate::CreateParams params_;
     params_.array_buffer_allocator = allocator_.get();
     isolate_ = v8::Isolate::New(params_);
   }

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -9,21 +9,6 @@
 #include "v8.h"
 #include "libplatform/libplatform.h"
 
-class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
- public:
-  virtual void* Allocate(size_t length) {
-    return AllocateUninitialized(length);
-  }
-
-  virtual void* AllocateUninitialized(size_t length) {
-    return calloc(length, 1);
-  }
-
-  virtual void Free(void* data, size_t) {
-    free(data);
-  }
-};
-
 struct Argv {
  public:
   Argv() : Argv({"node", "-p", "process.version"}) {}
@@ -77,7 +62,6 @@ class NodeTestFixture : public ::testing::Test {
 
  protected:
   v8::Isolate::CreateParams params_;
-  ArrayBufferAllocator allocator_;
   v8::Isolate* isolate_;
 
   ~NodeTestFixture() {
@@ -89,7 +73,8 @@ class NodeTestFixture : public ::testing::Test {
     platform_ = new node::NodePlatform(8, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
-    params_.array_buffer_allocator = &allocator_;
+    params_.array_buffer_allocator =
+        v8::ArrayBuffer::Allocator::NewDefaultAllocator();
     isolate_ = v8::Isolate::New(params_);
   }
 

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -73,8 +73,8 @@ class NodeTestFixture : public ::testing::Test {
     platform_ = new node::NodePlatform(8, nullptr);
     v8::V8::InitializePlatform(platform_);
     v8::V8::Initialize();
-    params_.array_buffer_allocator =
-        v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+    allocator_ = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+    params_.array_buffer_allocator = allocator_;
     isolate_ = v8::Isolate::New(params_);
   }
 
@@ -85,6 +85,7 @@ class NodeTestFixture : public ::testing::Test {
       uv_run(&current_loop, UV_RUN_ONCE);
     }
     v8::V8::ShutdownPlatform();
+    delete allocator_;
     delete platform_;
     platform_ = nullptr;
     CHECK_EQ(0, uv_loop_close(&current_loop));
@@ -92,6 +93,7 @@ class NodeTestFixture : public ::testing::Test {
 
  private:
   node::NodePlatform* platform_ = nullptr;
+  v8::ArrayBuffer::Allocator* allocator_ = nullptr;
 };
 
 #endif  // TEST_CCTEST_NODE_TEST_FIXTURE_H_


### PR DESCRIPTION
This commit updates the node_test_fixture to use
v8::ArrayBuffer::Allocator::NewDefaultAllocator() and removes the custom
allocator.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test