### PR TITLE
http: use toLowerCase in matchKnownFields

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -134,12 +134,10 @@ function _addHeaderLines(headers, n) {
 }
 
 
-// This function is used to help avoid the lowercasing of a field name if it
-// matches a 'traditional cased' version of a field name. It then returns the
-// lowercased name to both avoid calling toLowerCase() a second time and to
-// indicate whether the field was a 'no duplicates' field. If a field is not a
-// 'no duplicates' field, a `0` byte is prepended as a flag. The one exception
-// to this is the Set-Cookie header which is indicated by a `1` byte flag, since
+// This function returns the lowercased name and indicates whether the field
+// was a 'no duplicates' field. If a field is not a 'no duplicates' field,
+// a `0` byte is prepended as a flag. The one exception to this is the
+// Set-Cookie header which is indicated by a `1` byte flag, since
 // it is an 'array' field and thus is treated differently in _addHeaderLines().
 // TODO: perhaps http_parser could be returning both raw and lowercased versions
 // of known header names to avoid us having to call toLowerCase() for those
@@ -148,129 +146,33 @@ function _addHeaderLines(headers, n) {
 // 'array' header list is taken from:
 // https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
 function matchKnownFields(field) {
-  var low = false;
-  while (true) {
-    switch (field) {
-      case 'Content-Type':
-      case 'content-type':
-        return 'content-type';
-      case 'Content-Length':
-      case 'content-length':
-        return 'content-length';
-      case 'User-Agent':
-      case 'user-agent':
-        return 'user-agent';
-      case 'Referer':
-      case 'referer':
-        return 'referer';
-      case 'Host':
-      case 'host':
-        return 'host';
-      case 'Authorization':
-      case 'authorization':
-        return 'authorization';
-      case 'Proxy-Authorization':
-      case 'proxy-authorization':
-        return 'proxy-authorization';
-      case 'If-Modified-Since':
-      case 'if-modified-since':
-        return 'if-modified-since';
-      case 'If-Unmodified-Since':
-      case 'if-unmodified-since':
-        return 'if-unmodified-since';
-      case 'From':
-      case 'from':
-        return 'from';
-      case 'Location':
-      case 'location':
-        return 'location';
-      case 'Max-Forwards':
-      case 'max-forwards':
-        return 'max-forwards';
-      case 'Retry-After':
-      case 'retry-after':
-        return 'retry-after';
-      case 'ETag':
-      case 'etag':
-        return 'etag';
-      case 'Last-Modified':
-      case 'last-modified':
-        return 'last-modified';
-      case 'Server':
-      case 'server':
-        return 'server';
-      case 'Age':
-      case 'age':
-        return 'age';
-      case 'Expires':
-      case 'expires':
-        return 'expires';
-      case 'Set-Cookie':
-      case 'set-cookie':
-        return '\u0001';
-      case 'Cookie':
-      case 'cookie':
-        return '\u0002cookie';
-      // The fields below are not used in _addHeaderLine(), but they are common
-      // headers where we can avoid toLowerCase() if the mixed or lower case
-      // versions match the first time through.
-      case 'Transfer-Encoding':
-      case 'transfer-encoding':
-        return '\u0000transfer-encoding';
-      case 'Date':
-      case 'date':
-        return '\u0000date';
-      case 'Connection':
-      case 'connection':
-        return '\u0000connection';
-      case 'Cache-Control':
-      case 'cache-control':
-        return '\u0000cache-control';
-      case 'Vary':
-      case 'vary':
-        return '\u0000vary';
-      case 'Content-Encoding':
-      case 'content-encoding':
-        return '\u0000content-encoding';
-      case 'Origin':
-      case 'origin':
-        return '\u0000origin';
-      case 'Upgrade':
-      case 'upgrade':
-        return '\u0000upgrade';
-      case 'Expect':
-      case 'expect':
-        return '\u0000expect';
-      case 'If-Match':
-      case 'if-match':
-        return '\u0000if-match';
-      case 'If-None-Match':
-      case 'if-none-match':
-        return '\u0000if-none-match';
-      case 'Accept':
-      case 'accept':
-        return '\u0000accept';
-      case 'Accept-Encoding':
-      case 'accept-encoding':
-        return '\u0000accept-encoding';
-      case 'Accept-Language':
-      case 'accept-language':
-        return '\u0000accept-language';
-      case 'X-Forwarded-For':
-      case 'x-forwarded-for':
-        return '\u0000x-forwarded-for';
-      case 'X-Forwarded-Host':
-      case 'x-forwarded-host':
-        return '\u0000x-forwarded-host';
-      case 'X-Forwarded-Proto':
-      case 'x-forwarded-proto':
-        return '\u0000x-forwarded-proto';
-      default:
-        if (low)
-          return '\u0000' + field;
-        field = field.toLowerCase();
-        low = true;
-    }
+  field = field.toLowerCase();
+  switch (field) {
+    case 'content-type':
+    case 'content-length':
+    case 'user-agent':
+    case 'referer':
+    case 'host':
+    case 'authorization':
+    case 'proxy-authorization':
+    case 'if-modified-since':
+    case 'if-unmodified-since':
+    case 'from':
+    case 'location':
+    case 'max-forwards':
+    case 'retry-after':
+    case 'etag':
+    case 'last-modified':
+    case 'server':
+    case 'age':
+    case 'expires':
+      return field;
+    case 'set-cookie':
+      return '\u0001';
+    case 'cookie':
+      return '\u0002cookie';
+    default:
+      return `\u0000${field}`;
   }
 }
 // Add the given (field, value) pair to the message

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -144,7 +144,7 @@ function _addHeaderLines(headers, n) {
 // headers.
 
 // 'array' header list is taken from:
-// https://mxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
+// https://dxr.mozilla.org/mozilla/source/netwerk/protocol/http/src/nsHttpHeaderArray.cpp
 function matchKnownFields(field) {
   field = field.toLowerCase();
   switch (field) {


### PR DESCRIPTION
Remove a micro-optimization that is for the most part actively hurting performance.

- for Content-Type, Content-Length & Proxy-Authorization (capitalized), the new version is about 10-15% slower
- for content-type & content-length (lowercase), the new version is the same
- for all others, the further down the list, the faster the new version is (from 10% to 100%)
- for mixed case headers (or ones that are not on the list), the new version is about 200-400% faster

Based on my testing, it's clear that V8 has some optimizations in `toLowerCase` for strings that are already lower case as those all perform exceptionally well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http