### PR TITLE
tools: add docs for prefer-util-format-errors rule

### DIFF
--- a/tools/eslint-rules/prefer-util-format-errors.js
+++ b/tools/eslint-rules/prefer-util-format-errors.js
@@ -26,6 +26,11 @@ module.exports = {
         if (!isArrowFunctionWithTemplateLiteral(msg))
           return;
 
+        // Checks to see if order of arguments to function is the same as the
+        // order of them being concatenated in the template string. The idea is
+        // that if both match, then you can use `util.format`-style args.
+        // Would pass rule: (a, b) => `${b}${a}`.
+        // Would fail rule: (a, b) => `${a}${b}`, and needs to be rewritten.
         const { expressions } = msg.body;
         const hasSequentialParams = msg.params.every((param, index) => {
           const expr = expressions[index];


### PR DESCRIPTION
I had a little trouble understanding what the rule was trying to say, so
am documenting what would pass/fail.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools
