### PR TITLE
tools,test: use Execute instead of check_output

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1562,18 +1562,15 @@ def ArgsToTestPaths(test_root, args, suites):
   return paths
 
 
-def get_env_type(vm, options_type):
+def get_env_type(vm, options_type, context):
   if options_type is not None:
     env_type = options_type
   else:
-    if "fips" in subprocess.check_output([vm, "-p",
-                                          "process.versions.openssl"]):
-      env_type = "fips"
-    # NOTE(nikhil): "simple" is the default value for var 'env_type' and should
-    # be set last if no if/elif matches. If you plan to add more values, use
-    # 'elif' above.
-    else:
-      env_type = "simple"
+    # 'simple' is the default value for 'env_type'.
+    env_type = 'simple'
+    ssl_ver = Execute([vm, '-p', 'process.versions.openssl'], context).stdout
+    if 'fips' in ssl_ver:
+      env_type = 'fips'
   return env_type
 
 
@@ -1659,7 +1656,7 @@ def Main():
           'mode': mode,
           'system': utils.GuessOS(),
           'arch': vmArch,
-          'type': get_env_type(vm, options.type),
+          'type': get_env_type(vm, options.type, context),
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list


### PR DESCRIPTION
`subprocess.check_output` (f31cf569721e64486ac1593479fe73aadebf1883) is a python2.7 only feature. Using Execute allows
keeping python2.6 compatibility

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools,test