### PR TITLE
tools: update markdown lint presets

### DIFF
--- a/tools/remark-preset-lint-node/index.js
+++ b/tools/remark-preset-lint-node/index.js
@@ -39,6 +39,13 @@ module.exports.plugins = [
   [require('remark-lint-file-extension'), 'md'],
   [require('remark-lint-first-heading-level'), 1],
   [require('remark-lint-heading-style'), 'atx'],
+  [
+    require('remark-lint-prohibited-strings'),
+    [
+      { no: 'v8', yes: 'V8' },
+      { no: 'Javascript', yes: 'JavaScript' }
+    ]
+  ],
   [require('remark-lint-strong-marker'), '*'],
   [require('remark-lint-table-cell-padding'), 'padded']
 ];

--- a/tools/remark-preset-lint-node/package-lock.json
+++ b/tools/remark-preset-lint-node/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "remark-preset-lint-node",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
-  "preserveSymlinks": "1",
   "requires": true,
   "dependencies": {
     "co": {
@@ -56,7 +55,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-checkbox-character-style": {
@@ -67,7 +66,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3",
+        "unist-util-visit": "1.2.0",
         "vfile-location": "2.0.2"
       }
     },
@@ -79,7 +78,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3",
+        "unist-util-visit": "1.2.0",
         "vfile-location": "2.0.2"
       }
     },
@@ -91,7 +90,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-definition-spacing": {
@@ -102,7 +101,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-fenced-code-flag": {
@@ -113,7 +112,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-fenced-code-marker": {
@@ -124,7 +123,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-file-extension": {
@@ -143,7 +142,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-final-newline": {
@@ -161,7 +160,7 @@
       "requires": {
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-hard-break-spaces": {
@@ -172,7 +171,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-heading-style": {
@@ -183,7 +182,7 @@
         "mdast-util-heading-style": "1.0.3",
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-auto-link-without-protocol": {
@@ -195,7 +194,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-blockquote-without-caret": {
@@ -206,7 +205,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3",
+        "unist-util-visit": "1.2.0",
         "vfile-location": "2.0.2"
       }
     },
@@ -218,7 +217,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-file-name-articles": {
@@ -255,7 +254,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-heading-indent": {
@@ -267,7 +266,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-inline-padding": {
@@ -278,7 +277,7 @@
         "mdast-util-to-string": "1.0.4",
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-multiple-toplevel-headings": {
@@ -289,7 +288,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-shell-dollars": {
@@ -299,7 +298,7 @@
       "requires": {
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-shortcut-reference-image": {
@@ -309,7 +308,7 @@
       "requires": {
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-table-indentation": {
@@ -320,7 +319,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-no-tabs": {
@@ -339,7 +338,16 @@
       "requires": {
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
+      }
+    },
+    "remark-lint-prohibited-strings": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-1.0.0.tgz",
+      "integrity": "sha512-FXqOBjU36+67l3y3RwtACrXdMUusANgyj+kDx6vlXYP8OfaRRjYNse51AcCiNQKR3XHgbGKxEklUHMJFKWfe7A==",
+      "requires": {
+        "unified-lint-rule": "1.0.2",
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-rule-style": {
@@ -350,7 +358,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-strong-marker": {
@@ -361,7 +369,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-table-cell-padding": {
@@ -372,7 +380,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-lint-table-pipes": {
@@ -383,7 +391,7 @@
         "unified-lint-rule": "1.0.2",
         "unist-util-generated": "1.1.1",
         "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.1.3"
+        "unist-util-visit": "1.2.0"
       }
     },
     "remark-message-control": {
@@ -393,7 +401,7 @@
       "requires": {
         "mdast-comment-marker": "1.0.2",
         "trim": "0.0.1",
-        "unist-util-visit": "1.1.3",
+        "unist-util-visit": "1.2.0",
         "vfile-location": "2.0.2"
       }
     },
@@ -420,15 +428,23 @@
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.1.tgz",
       "integrity": "sha1-mfFseJWayFTe58YVwpGSTIv03n8="
     },
+    "unist-util-is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
+      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+    },
     "unist-util-position": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.0.tgz",
       "integrity": "sha1-5uHgPu64HF4a/lU+jUrfvXwNj4I="
     },
     "unist-util-visit": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.3.tgz",
-      "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.2.0.tgz",
+      "integrity": "sha512-lI+jyPlDztHZ2CJhUchcRMQ7MNc0yASgYFxwRTxs0EZ+9HbYFBLVGDJ2FchTBy+pra0O1LVEn0Wkgf19mDVDzw==",
+      "requires": {
+        "unist-util-is": "2.1.1"
+      }
     },
     "vfile-location": {
       "version": "2.0.2",

--- a/tools/remark-preset-lint-node/package.json
+++ b/tools/remark-preset-lint-node/package.json
@@ -1,9 +1,30 @@
 {
-  "private": true,
-  "name": "remark-preset-lint-node",
-  "version": "1.0.0",
-  "description": "remark preset to configure remark-lint with settings for nodejs/node",
-  "main": "index.js",
+  "_from": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+  "_id": "remark-preset-lint-node@1.0.2",
+  "_inBundle": false,
+  "_integrity": "sha1-UxsozHvbtJwHgKk6AYCqVPvpz8w=",
+  "_location": "/remark-preset-lint-node",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "git",
+    "raw": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+    "rawSpec": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+    "saveSpec": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+    "fetchSpec": null,
+    "gitCommittish": "859eab541e0f63839b33196f26e2bed4dfe2b194"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+  "_spec": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
+  "_where": "/Users/trott/io.js/tools",
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/watilde/remark-preset-lint-node/issues"
+  },
+  "bundleDependencies": false,
   "dependencies": {
     "remark-lint": "^6.0.0",
     "remark-lint-blockquote-indentation": "^1.0.0",
@@ -34,9 +55,25 @@
     "remark-lint-no-table-indentation": "^1.0.0",
     "remark-lint-no-tabs": "^1.0.0",
     "remark-lint-no-unused-definitions": "^1.0.0",
+    "remark-lint-prohibited-strings": "^1.0.0",
     "remark-lint-rule-style": "^1.0.0",
     "remark-lint-strong-marker": "^1.0.0",
     "remark-lint-table-cell-padding": "^1.0.0",
     "remark-lint-table-pipes": "^1.0.0"
-  }
+  },
+  "deprecated": false,
+  "description": "remark preset to configure remark-lint with settings for nodejs/node",
+  "homepage": "https://github.com/watilde/remark-preset-lint-node#readme",
+  "keywords": [],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "remark-preset-lint-node",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watilde/remark-preset-lint-node.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "version": "1.0.2"
 }


### PR DESCRIPTION
Update remark-preset-lint-node to version at commit hash
859eab541e0f63839b33196f26e2bed4dfe2b194. This is the most recent
version at this time (although not yet published to npm). It includes
linting for "v8" where "V8" is intended and "Javascript" Where
"JavaScript" is intended. By installing those lint rules now rather than
waiting for a published version, we avoid the possibility that new
markdown text with those prohibited strings will be introduced.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools