### PR TITLE
doc: Update es module loader example to use module.builtinModules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -147,15 +147,13 @@ be written:
 import url from 'url';
 import path from 'path';
 import process from 'process';
+import module from 'module';
 
-const builtins = new Set(
-  Object.keys(process.binding('natives')).filter((str) =>
-    /^(?!(?:internal|node|v8)\/)/.test(str))
-);
+const builtins = module.builtinModules;
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
 export function resolve(specifier, parentModuleURL/*, defaultResolve */) {
-  if (builtins.has(specifier)) {
+  if (builtins.includes(specifier)) {
     return {
       url: specifier,
       format: 'builtin'

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -147,9 +147,9 @@ be written:
 import url from 'url';
 import path from 'path';
 import process from 'process';
-import module from 'module';
+import Module from 'module';
 
-const builtins = module.builtinModules;
+const builtins = Module.builtinModules;
 const JS_EXTENSIONS = new Set(['.js', '.mjs']);
 
 export function resolve(specifier, parentModuleURL/*, defaultResolve */) {


### PR DESCRIPTION
This makes the example somewhat less intimidating hopefully.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
esmodules, doc