### PR TITLE
doc: add --abort-on-uncaught-exception + vm note

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -479,8 +479,17 @@ within which it can operate. The process of creating the V8 Context and
 associating it with the `sandbox` object is what this document refers to as
 "contextifying" the `sandbox`.
 
+## Usage with `--abort-on-uncaught-exception`
+
+When Node.js is run with the `--abort-on-uncaught-exception` command line flag,
+exceptions thrown from within a VM context are treated as uncaught, and cause
+the process to abort accordingly.
+[`process.setUncaughtExceptionCaptureCallback()`][] can be used to prevent the
+process from aborting.
+
 [`Error`]: errors.html#errors_class_error
 [`eval()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
+[`process.setUncaughtExceptionCaptureCallback()`]: process.html#process_process_setuncaughtexceptioncapturecallback_fn
 [`script.runInContext()`]: #vm_script_runincontext_contextifiedsandbox_options
 [`script.runInThisContext()`]: #vm_script_runinthiscontext_options
 [`vm.createContext()`]: #vm_vm_createcontext_sandbox


### PR DESCRIPTION
The `--abort-on-uncaught-exception` flag is not compatible with error handling involving the `vm` module. This is because V8 treats exceptions thrown from a VM as unhandled, and cause the process to abort. This commit adds a note to work around the issue using `process.setUncaughtExceptionCaptureCallback()`.

Fixes: https://github.com/nodejs/node/issues/13258

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc