### PR TITLE
build, win: faster Release rebuilds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -186,10 +186,12 @@
             ],
           },
           'VCLinkerTool': {
-            'LinkTimeCodeGeneration': 1, # link-time code generation
             'OptimizeReferences': 2, # /OPT:REF
             'EnableCOMDATFolding': 2, # /OPT:ICF
             'LinkIncremental': 1, # disable incremental linking
+            'AdditionalOptions': [
+              '/LTCG:INCREMENTAL', # incremental link-time code generation
+            ],
           },
         },
       }


### PR DESCRIPTION
Sets Link Time Code Generation to `INCREMENTAL`, improving Release rebuilds speed. The `/LTCG:INCREMENTAL` was added in VS2015 and is not directly supported in `gyp`, thus it is implemented with `AdditionalOptions`. Some more information can be found in this [vcblog post](https://blogs.msdn.microsoft.com/vcblog/2014/11/12/speeding-up-the-incremental-developer-build-scenario/). 

Adds `exe-only` option to `vcbuild.bat`, which will build only `node.exe` binary. It will skip building `cctest`, which takes as long as building `node.exe` itself.

Currently, on my box `vcbuild` rebuild takes 8 minutes. With those changes `vcbuild exe-only` takes only 1.5 minute.

Ref: https://github.com/nodejs/node/issues/17253
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build

/cc @nodejs/build @nodejs/platform-windows
