### PR TITLE
doc: import()

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -33,8 +33,8 @@ node --experimental-modules my-app.mjs
 ### Supported
 
 Only the CLI argument for the main entry point to the program can be an entry
-point into an ESM graph. Dynamic import can also be used to create entry points
-into ESM graphs at run time.
+point into an ESM graph. Dynamic import can also be used with the flag
+`--harmony-dynamic-import` to create entry points into ESM graphs at run time.
 
 ### Unsupported
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -33,14 +33,14 @@ node --experimental-modules my-app.mjs
 ### Supported
 
 Only the CLI argument for the main entry point to the program can be an entry
-point into an ESM graph. `import()` can also be used to create entry points
+point into an ESM graph. Dynamic import can also be used to create entry points
 into ESM graphs at run time.
 
 ### Unsupported
 
 | Feature | Reason |
 | --- | --- |
-| `require('./foo.mjs')` | ES Modules have differing resolution and timing, use language standard `import()` |
+| `require('./foo.mjs')` | ES Modules have differing resolution and timing, use dynamic import |
 | `import.meta` | pending V8 implementation |
 
 ## Notable differences between `import` and `require`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -33,15 +33,14 @@ node --experimental-modules my-app.mjs
 ### Supported
 
 Only the CLI argument for the main entry point to the program can be an entry
-point into an ESM graph. In the future `import()` can be used to create entry
-points into ESM graphs at run time.
+point into an ESM graph. `import()` can also be used to create entry points
+into ESM graphs at run time.
 
 ### Unsupported
 
 | Feature | Reason |
 | --- | --- |
 | `require('./foo.mjs')` | ES Modules have differing resolution and timing, use language standard `import()` |
-| `import()` | pending newer V8 release used in Node.js |
 | `import.meta` | pending V8 implementation |
 
 ## Notable differences between `import` and `require`


### PR DESCRIPTION
I don't know if this should wait until `import()` is out from behind its own flag, but the change will need to happen at some point so here it is.

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
