### PR TITLE
loader: allow loading modules from url

### DIFF
--- a/lib/internal/loader/Loader.js
+++ b/lib/internal/loader/Loader.js
@@ -95,13 +95,8 @@ class Loader {
       return { url: `node:${url}`, format };
     }
 
-    if (format !== 'dynamic') {
-      if (!ModuleRequest.loaders.has(format)) {
-        throw new errors.Error('ERR_UNKNOWN_MODULE_FORMAT', format);
-      }
-      if (!url.startsWith('file:')) {
-        throw new errors.Error('ERR_INVALID_PROTOCOL', url, 'file:');
-      }
+    if (format !== 'dynamic' && !ModuleRequest.loaders.has(format)) {
+      throw new errors.Error('ERR_UNKNOWN_MODULE_FORMAT', format);
     }
 
     return { url, format };

--- a/lib/internal/loader/ModuleRequest.js
+++ b/lib/internal/loader/ModuleRequest.js
@@ -15,9 +15,9 @@ const {
   createDynamicModule
 } = require('internal/loader/ModuleWrap');
 const errors = require('internal/errors');
-
+const fetch = require('internal/loader/fetch');
 const search = require('internal/loader/search');
-const asyncReadFile = require('util').promisify(require('fs').readFile);
+const asyncReadFile = require('util').promisify(fs.readFile);
 const debug = require('util').debuglog('esm');
 
 const realpathCache = new Map();
@@ -27,7 +27,7 @@ exports.loaders = loaders;
 
 // Strategy for loading a standard JavaScript module
 loaders.set('esm', async (url) => {
-  const source = `${await asyncReadFile(new URL(url))}`;
+  const source = await resolveSource(url);
   debug(`Loading StandardModule ${url}`);
   return {
     module: new ModuleWrap(internalCJSModule.stripShebang(source), url),
@@ -75,10 +75,10 @@ loaders.set('addon', async (url) => {
 });
 
 loaders.set('json', async (url) => {
+  const content = await resolveSource(url);
+  const pathname = internalURLModule.getPathFromURL(new URL(url));
   return createDynamicModule(['default'], url, (reflect) => {
     debug(`Loading JSONModule ${url}`);
-    const pathname = internalURLModule.getPathFromURL(new URL(url));
-    const content = fs.readFileSync(pathname, 'utf8');
     try {
       const exports = JSON.parse(internalCJSModule.stripBOM(content));
       reflect.exports.default.set(exports);
@@ -106,12 +106,7 @@ exports.resolve = (specifier, parentURL) => {
     throw e;
   }
 
-  if (url.protocol !== 'file:') {
-    throw new errors.Error('ERR_INVALID_PROTOCOL',
-                           url.protocol, 'file:');
-  }
-
-  if (!preserveSymlinks) {
+  if (url.protocol === 'file:' && !preserveSymlinks) {
     const real = realpathSync(internalURLModule.getPathFromURL(url), {
       [internalFS.realpathCacheKey]: realpathCache
     });
@@ -136,3 +131,11 @@ exports.resolve = (specifier, parentURL) => {
                              internalURLModule.getPathFromURL(url));
   }
 };
+
+async function resolveSource(url) {
+  const urlObj = new URL(url);
+  if (urlObj.protocol === 'file:')
+    return `${await asyncReadFile(urlObj.pathname)}`;
+
+  return fetch(url);
+}

--- a/lib/internal/loader/fetch.js
+++ b/lib/internal/loader/fetch.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const http = require('http');
+const https = require('https');
+const URL = require('url');
+const zlib = require('zlib');
+
+const requestTypeMap = {
+  'http:': http,
+  'https:': https,
+};
+
+function fetch(url) {
+  return new Promise((resolve, reject) => {
+    const opt = URL.parse(url);
+    opt.method = 'GET';
+    opt.headers = {
+      'Accept-Encoding': 'gzlib, deflate',
+    };
+    const request = requestTypeMap[opt.protocol].get(url);
+
+    let socket;
+
+    const handleError = (err) => {
+      const e = new Error(`Cannot find module: ${url}`);
+      e.code = 'MODULE_NOT_FOUND';
+      reject(e);
+    };
+
+    request.once('abort', handleError);
+    request.once('error', handleError);
+    request.once('socket', (s) => {
+      socket = s;
+      s.once('error', handleError);
+    });
+
+    request.once('response', (response) => {
+      let stream = response;
+      if (shouldUnzip(response)) {
+        stream = response.pipe(zlib.createUnzip({
+          flush: zlib.Z_SYNC_FLUSH,
+          finishFlush: zlib.Z_SYNC_FLUSH,
+        }));
+      }
+
+      if ([200, 201].includes(response.statusCode)) {
+        let body = '';
+        stream.on('data', (c) => { body += c; });
+
+        stream.once('end', () => {
+          if (socket)
+            socket.removeListener('error', handleError);
+
+          resolve(body);
+        });
+      } else if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        resolve(fetch(URL.resolve(url, response.headers.location)));
+      } else {
+        handleError();
+      }
+    });
+
+    request.end();
+  });
+}
+
+function shouldUnzip(res) {
+  if (res.statusCode === 204 || res.statusCode === 304)
+    return false;
+  if (+res.headers['content-length'] === 0)
+    return false;
+  return /^\s*(?:deflate|gzip)\s*$/.test(res.headers['content-encoding']);
+}
+
+module.exports = fetch;

--- a/lib/internal/loader/search.js
+++ b/lib/internal/loader/search.js
@@ -10,6 +10,10 @@ module.exports = (target, base) => {
     // We cannot search without a base.
     throw new errors.Error('ERR_MISSING_MODULE', target);
   }
+
+  if (/^https?:/.test(target))
+    return new URL(target);
+
   try {
     return resolve(target, base);
   } catch (e) {

--- a/node.gyp
+++ b/node.gyp
@@ -107,6 +107,7 @@
       'lib/internal/loader/ModuleWrap.js',
       'lib/internal/loader/ModuleRequest.js',
       'lib/internal/loader/search.js',
+      'lib/internal/loader/fetch.js',
       'lib/internal/safe_globals.js',
       'lib/internal/net.js',
       'lib/internal/module.js',


### PR DESCRIPTION
definitely a WIP, but it works.

CJS+addons would be possible by abusing tmpdir but that seems like a bad idea so i left it out for now.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
lib
