### PR TITLE
src: use uv_os_getpid() to get process id

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -173,7 +173,7 @@ void Environment::PrintSyncTrace() const {
       StackTrace::CurrentStackTrace(isolate(), 10, StackTrace::kDetailed);
 
   fprintf(stderr, "(node:%u) WARNING: Detected use of sync API\n",
-          GetProcessId());
+          uv_os_getpid());
 
   for (int i = 0; i < stack->GetFrameCount() - 1; i++) {
     Local<StackFrame> stack_frame = stack->GetFrame(i);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -109,7 +109,7 @@ static int StartDebugSignalHandler() {
   CHECK_EQ(0, pthread_attr_destroy(&attr));
   if (err != 0) {
     fprintf(stderr, "node[%u]: pthread_create: %s\n",
-            GetProcessId(), strerror(err));
+            uv_os_getpid(), strerror(err));
     fflush(stderr);
     // Leave SIGUSR1 blocked.  We don't install a signal handler,
     // receiving the signal would terminate the process.
@@ -144,7 +144,7 @@ static int StartDebugSignalHandler() {
   DWORD pid;
   LPTHREAD_START_ROUTINE* handler;
 
-  pid = GetCurrentProcessId();
+  pid = uv_os_getpid();
 
   if (GetDebugSignalHandlerMappingName(pid,
                                        mapping_name,
@@ -692,4 +692,3 @@ bool Agent::IsWaitingForConnect() {
 
 }  // namespace inspector
 }  // namespace node
-

--- a/src/node.cc
+++ b/src/node.cc
@@ -3105,7 +3105,7 @@ void SetupProcessObject(Environment* env,
   process->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "env"), process_env);
 
   READONLY_PROPERTY(process, "pid",
-                    Integer::New(env->isolate(), GetProcessId()));
+                    Integer::New(env->isolate(), uv_os_getpid()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));
 
   CHECK(process->SetAccessor(env->context(),

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -248,7 +248,6 @@ void RegisterSignalHandler(int signal,
                            bool reset_handler = false);
 #endif
 
-uint32_t GetProcessId();
 bool SafeGetenv(const char* key, std::string* text);
 
 std::string GetHumanReadableProcessName();

--- a/src/util.cc
+++ b/src/util.cc
@@ -22,15 +22,8 @@
 #include "string_bytes.h"
 #include "node_buffer.h"
 #include "node_internals.h"
+#include "uv.h"
 #include <stdio.h>
-
-#ifdef __POSIX__
-#include <unistd.h>  // getpid()
-#endif
-
-#ifdef _MSC_VER
-#include <windows.h>  // GetCurrentProcessId()
-#endif
 
 namespace node {
 
@@ -122,15 +115,7 @@ std::string GetHumanReadableProcessName() {
 void GetHumanReadableProcessName(char (*name)[1024]) {
   char title[1024] = "Node.js";
   uv_get_process_title(title, sizeof(title));
-  snprintf(*name, sizeof(*name), "%s[%u]", title, GetProcessId());
-}
-
-uint32_t GetProcessId() {
-#ifdef _WIN32
-  return GetCurrentProcessId();
-#else
-  return getpid();
-#endif
+  snprintf(*name, sizeof(*name), "%s[%u]", title, uv_os_getpid());
 }
 
 }  // namespace node


### PR DESCRIPTION
This commit uses the new `uv_os_getpid()` method to retrieve the
current process id.

I currently left `GetProcessId()` in util.cc. Not sure if it should be removed or not.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src