### PR TITLE
test: Add test case for missing branch

### DIFF
--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -5,7 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const crypto = require('crypto');
-const notExistsEngineName = 'xxx';
+const invalidEngineName = 'xxx';
 
 common.expectsError(
   () => crypto.setEngine(true),
@@ -24,18 +24,17 @@ common.expectsError(
   });
 
 common.expectsError(
-  () => crypto.setEngine(notExistsEngineName),
+  () => crypto.setEngine(invalidEngineName),
   {
     code: 'ERR_CRYPTO_ENGINE_UNKNOWN',
     type: Error,
-    message: `Engine "${notExistsEngineName}" was not found`
+    message: `Engine "${invalidEngineName}" was not found`
   });
 
 common.expectsError(
-  () => crypto.setEngine(notExistsEngineName,
-                         crypto.constants.ENGINE_METHOD_RSA),
+  () => crypto.setEngine(invalidEngineName, crypto.constants.ENGINE_METHOD_RSA),
   {
     code: 'ERR_CRYPTO_ENGINE_UNKNOWN',
     type: Error,
-    message: `Engine "${notExistsEngineName}" was not found`
+    message: `Engine "${invalidEngineName}" was not found`
   });

--- a/test/parallel/test-crypto-engine.js
+++ b/test/parallel/test-crypto-engine.js
@@ -5,6 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const crypto = require('crypto');
+const notExistsEngineName = 'xxx';
 
 common.expectsError(
   () => crypto.setEngine(true),
@@ -20,4 +21,21 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "flags" argument must be of type number'
+  });
+
+common.expectsError(
+  () => crypto.setEngine(notExistsEngineName),
+  {
+    code: 'ERR_CRYPTO_ENGINE_UNKNOWN',
+    type: Error,
+    message: `Engine "${notExistsEngineName}" was not found`
+  });
+
+common.expectsError(
+  () => crypto.setEngine(notExistsEngineName,
+                         crypto.constants.ENGINE_METHOD_RSA),
+  {
+    code: 'ERR_CRYPTO_ENGINE_UNKNOWN',
+    type: Error,
+    message: `Engine "${notExistsEngineName}" was not found`
   });


### PR DESCRIPTION
Enhance `crypto/util` coverage.
I added:

- The case of id is string, flags is number
- The case of flags is not 0

Current coverage:
<img width="584" alt="screen shot 2017-12-02 at 3 17 39" src="https://user-images.githubusercontent.com/1424963/33496932-65b8adbe-d70f-11e7-9cbe-5f1dc2879606.png">
https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/util.js.html

After this PR:
<img width="585" alt="screen shot 2017-12-02 at 3 24 45" src="https://user-images.githubusercontent.com/1424963/33497165-5f482eb8-d710-11e7-889b-af7dccff8c15.png">

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
