### PR TITLE
process: slight refinements to nextTick

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -14,35 +14,31 @@ class NextTickQueue {
   constructor() {
     this.head = null;
     this.tail = null;
-    this.length = 0;
   }
 
   push(v) {
     const entry = { data: v, next: null };
-    if (this.length > 0)
+    if (this.tail !== null)
       this.tail.next = entry;
     else
       this.head = entry;
     this.tail = entry;
-    ++this.length;
   }
 
   shift() {
-    if (this.length === 0)
+    if (this.head === null)
       return;
     const ret = this.head.data;
-    if (this.length === 1)
+    if (this.head === this.tail)
       this.head = this.tail = null;
     else
       this.head = this.head.next;
-    --this.length;
     return ret;
   }
 
   clear() {
     this.head = null;
     this.tail = null;
-    this.length = 0;
   }
 }
 
@@ -90,7 +86,7 @@ function setupNextTick() {
         nextTickQueue.clear();
         tickInfo[kLength] = 0;
       } else {
-        tickInfo[kLength] = nextTickQueue.length;
+        tickInfo[kLength] -= tickInfo[kIndex];
       }
     }
     tickInfo[kIndex] = 0;
@@ -124,8 +120,6 @@ function setupNextTick() {
     }
   }
 
-  // Run callbacks that have no domain.
-  // Using domains will cause this to be overridden.
   function _tickCallback() {
     do {
       while (tickInfo[kIndex] < tickInfo[kLength]) {
@@ -137,7 +131,8 @@ function setupNextTick() {
         // CHECK(Number.isSafeInteger(tock[trigger_async_id_symbol]))
         // CHECK(tock[trigger_async_id_symbol] > 0)
 
-        emitBefore(tock[async_id_symbol], tock[trigger_async_id_symbol]);
+        const asyncId = tock[async_id_symbol];
+        emitBefore(asyncId, tock[trigger_async_id_symbol]);
         // emitDestroy() places the async_id_symbol into an asynchronous queue
         // that calls the destroy callback in the future. It's called before
         // calling tock.callback so destroy will be called even if the callback
@@ -148,7 +143,7 @@ function setupNextTick() {
         // any async hooks are enabled during the callback's execution then
         // this tock's after hook will be called, but not its destroy hook.
         if (async_hook_fields[kDestroy] > 0)
-          emitDestroy(tock[async_id_symbol]);
+          emitDestroy(asyncId);
 
         const callback = tock.callback;
         if (tock.args === undefined)
@@ -156,7 +151,7 @@ function setupNextTick() {
         else
           Reflect.apply(callback, undefined, tock.args);
 
-        emitAfter(tock[async_id_symbol]);
+        emitAfter(asyncId);
 
         if (kMaxCallbacksPerLoop < tickInfo[kIndex])
           tickDone();


### PR DESCRIPTION
A couple of very slight refinements to `process.nextTick` & its supporting code.

- Remove `length` prop on `NextTickQueue` class. We technically don't need to keep track of the length of the queue in two places as we already have `tickInfo` doing that work (between the index & the length we have enough data for everything). 
- Store `asyncId` in a const within the `_tickCallback` function. Accessing symbol properties seems to be quite a bit more expensive than string keys so this actually has a decent performance impact.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process