### PR TITLE
Enhance crypto/sig.js coverage

### DIFF
--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -15,6 +15,12 @@ const certPem = fixtures.readSync('test_cert.pem', 'ascii');
 const keyPem = fixtures.readSync('test_key.pem', 'ascii');
 const modSize = 1024;
 
+{
+  const Sign = crypto.Sign
+  const instance = Sign('SHA256')
+  assert.ok(instance instanceof Sign, 'call sign constructor without new')
+}
+
 // Test signing and verifying
 {
   const s1 = crypto.createSign('SHA1')

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -16,15 +16,15 @@ const keyPem = fixtures.readSync('test_key.pem', 'ascii');
 const modSize = 1024;
 
 {
-  const Sign = crypto.Sign
-  const instance = Sign('SHA256')
-  assert.ok(instance instanceof Sign, 'call sign constructor without new')
+  const Sign = crypto.Sign;
+  const instance = Sign('SHA256');
+  assert.ok(instance instanceof Sign, 'call sign constructor without new');
 }
 
 {
-  const Verify = crypto.Verify
-  const instance = Verify('SHA256')
-  assert.ok(instance instanceof Verify, 'call sign constructor without new')
+  const Verify = crypto.Verify;
+  const instance = Verify('SHA256');
+  assert.ok(instance instanceof Verify, 'call sign constructor without new');
 }
 
 common.expectsError(
@@ -36,7 +36,7 @@ common.expectsError(
     code: 'ERR_INVALID_OPT_VALUE',
     type: Error,
     message: 'The value "undefined" is invalid for option "padding"'
-  })
+  });
 
 common.expectsError(
   () => crypto.createVerify('SHA256').verify({
@@ -47,7 +47,7 @@ common.expectsError(
     code: 'ERR_INVALID_OPT_VALUE',
     type: Error,
     message: 'The value "undefined" is invalid for option "saltLength"'
-  })
+  });
 
 // Test signing and verifying
 {

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -21,6 +21,12 @@ const modSize = 1024;
   assert.ok(instance instanceof Sign, 'call sign constructor without new')
 }
 
+{
+  const Verify = crypto.Verify
+  const instance = Verify('SHA256')
+  assert.ok(instance instanceof Verify, 'call sign constructor without new')
+}
+
 // Test signing and verifying
 {
   const s1 = crypto.createSign('SHA1')

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -18,13 +18,15 @@ const modSize = 1024;
 {
   const Sign = crypto.Sign;
   const instance = Sign('SHA256');
-  assert.ok(instance instanceof Sign, 'call sign constructor without new');
+  assert.ok(instance instanceof Sign, 'Sign is expected to return a new \
+      instance when called without `new` keyword');
 }
 
 {
   const Verify = crypto.Verify;
   const instance = Verify('SHA256');
-  assert.ok(instance instanceof Verify, 'call verify constructor without new');
+  assert.ok(instance instanceof Verify, 'Verify is expected to return a new \
+      instance when called without `new` keyword');
 }
 
 common.expectsError(

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -24,7 +24,7 @@ const modSize = 1024;
 {
   const Verify = crypto.Verify;
   const instance = Verify('SHA256');
-  assert.ok(instance instanceof Verify, 'call sign constructor without new');
+  assert.ok(instance instanceof Verify, 'call verify constructor without new');
 }
 
 common.expectsError(

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -18,15 +18,15 @@ const modSize = 1024;
 {
   const Sign = crypto.Sign;
   const instance = Sign('SHA256');
-  assert.ok(instance instanceof Sign, 'Sign is expected to return a new ' +
-                                      'instance when called without `new`');
+  assert(instance instanceof Sign, 'Sign is expected to return a new ' +
+                                   'instance when called without `new`');
 }
 
 {
   const Verify = crypto.Verify;
   const instance = Verify('SHA256');
-  assert.ok(instance instanceof Verify, 'Verify is expected to return a new ' +
-                                        'instance when called without `new`');
+  assert(instance instanceof Verify, 'Verify is expected to return a new ' +
+                                     'instance when called without `new`');
 }
 
 common.expectsError(

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -18,15 +18,15 @@ const modSize = 1024;
 {
   const Sign = crypto.Sign;
   const instance = Sign('SHA256');
-  assert.ok(instance instanceof Sign, 'Sign is expected to return a new \
-      instance when called without `new` keyword');
+  assert.ok(instance instanceof Sign, 'Sign is expected to return a new ' +
+                                      'instance when called without `new`');
 }
 
 {
   const Verify = crypto.Verify;
   const instance = Verify('SHA256');
-  assert.ok(instance instanceof Verify, 'Verify is expected to return a new \
-      instance when called without `new` keyword');
+  assert.ok(instance instanceof Verify, 'Verify is expected to return a new ' +
+                                        'instance when called without `new`');
 }
 
 common.expectsError(

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -38,6 +38,17 @@ common.expectsError(
     message: 'The value "undefined" is invalid for option "padding"'
   })
 
+common.expectsError(
+  () => crypto.createVerify('SHA256').verify({
+    key: certPem,
+    saltLength: undefined,
+  }, ''),
+  {
+    code: 'ERR_INVALID_OPT_VALUE',
+    type: Error,
+    message: 'The value "undefined" is invalid for option "saltLength"'
+  })
+
 // Test signing and verifying
 {
   const s1 = crypto.createSign('SHA1')

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -27,6 +27,17 @@ const modSize = 1024;
   assert.ok(instance instanceof Verify, 'call sign constructor without new')
 }
 
+common.expectsError(
+  () => crypto.createVerify('SHA256').verify({
+    key: certPem,
+    padding: undefined,
+  }, ''),
+  {
+    code: 'ERR_INVALID_OPT_VALUE',
+    type: Error,
+    message: 'The value "undefined" is invalid for option "padding"'
+  })
+
 // Test signing and verifying
 {
   const s1 = crypto.createSign('SHA1')


### PR DESCRIPTION
I added these case:

1. Call `Sign` without new
1. Call `Verify` without new
1. Call `Verify#verify` with `options.padding !== options.padding >> 0`
1. Call `Verify#verify` with `options.saltLength !== options.saltLength >> 0`

Current coverage: https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/sig.js.html

After this PR: crypto/sig.js become 100% covered even in branch coverage.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test