### PR TITLE
timers: minor refinements to TimersList & stricter undefined/null checks

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -55,7 +55,7 @@ const activateImmediateCheck = process._activateImmediateCheck;
 delete process._activateImmediateCheck;
 
 // Timeout values > TIMEOUT_MAX are set to 1.
-const TIMEOUT_MAX = 2147483647; // 2^31-1
+const TIMEOUT_MAX = 2 ** 31 - 1;
 
 
 // HOW and WHY the timers implementation works the way it does.
@@ -173,9 +173,9 @@ function insert(item, unrefed) {
 
   // Use an existing list if there is one, otherwise we need to make a new one.
   var list = lists[msecs];
-  if (!list) {
+  if (list === undefined) {
     debug('no %d list was found in insert, creating a new one', msecs);
-    lists[msecs] = list = createTimersList(msecs, unrefed);
+    lists[msecs] = list = new TimersList(msecs, unrefed);
   }
 
   if (!item[async_id_symbol] || item._destroyed) {
@@ -194,28 +194,21 @@ function insert(item, unrefed) {
   assert(!L.isEmpty(list)); // list is not empty
 }
 
-function createTimersList(msecs, unrefed) {
-  // Make a new linked list of timers, and create a TimerWrap to schedule
-  // processing for the list.
-  const list = new TimersList(msecs, unrefed);
-  L.init(list);
-  list._timer._list = list;
-
-  if (unrefed === true) list._timer.unref();
-  list._timer.start(msecs);
-
-  list._timer[kOnTimeout] = listOnTimeout;
-
-  return list;
-}
-
 function TimersList(msecs, unrefed) {
-  this._idleNext = null; // Create the list with the linkedlist properties to
-  this._idlePrev = null; // prevent any unnecessary hidden class changes.
-  this._timer = new TimerWrap();
+  this._idleNext = this; // Create the list with the linkedlist properties to
+  this._idlePrev = this; // prevent any unnecessary hidden class changes.
   this._unrefed = unrefed;
   this.msecs = msecs;
   this.nextTick = false;
+
+  const timer = this._timer = new TimerWrap();
+  timer._list = this;
+
+  if (unrefed === true)
+    timer.unref();
+  timer.start(msecs);
+
+  timer[kOnTimeout] = listOnTimeout;
 }
 
 function listOnTimeout() {
@@ -359,7 +352,7 @@ function reuse(item) {
 
   var list = refedLists[item._idleTimeout];
   // if empty - reuse the watcher
-  if (list && L.isEmpty(list)) {
+  if (list !== undefined && L.isEmpty(list)) {
     debug('reuse hit');
     list._timer.stop();
     delete refedLists[item._idleTimeout];
@@ -382,7 +375,7 @@ const unenroll = exports.unenroll = function(item) {
   }
 
   var handle = reuse(item);
-  if (handle) {
+  if (handle !== null) {
     debug('unenroll: list empty');
     handle.close();
   }
@@ -610,7 +603,7 @@ Timeout.prototype.unref = function() {
     }
 
     var handle = reuse(this);
-    if (handle) {
+    if (handle !== null) {
       handle._list = undefined;
     }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -652,7 +652,7 @@ function ImmediateList() {
 // Appends an item to the end of the linked list, adjusting the current tail's
 // previous and next pointers where applicable
 ImmediateList.prototype.append = function(item) {
-  if (this.tail) {
+  if (this.tail !== null) {
     this.tail._idleNext = item;
     item._idlePrev = this.tail;
   } else {
@@ -664,11 +664,11 @@ ImmediateList.prototype.append = function(item) {
 // Removes an item from the linked list, adjusting the pointers of adjacent
 // items and the linked list's head or tail pointers as necessary
 ImmediateList.prototype.remove = function(item) {
-  if (item._idleNext) {
+  if (item._idleNext !== null) {
     item._idleNext._idlePrev = item._idlePrev;
   }
 
-  if (item._idlePrev) {
+  if (item._idlePrev !== null) {
     item._idlePrev._idleNext = item._idleNext;
   }
 
@@ -694,7 +694,7 @@ function processImmediate() {
   // immediate callbacks are executed
   immediateQueue.head = immediateQueue.tail = null;
 
-  while (immediate) {
+  while (immediate !== null) {
     domain = immediate.domain;
 
     if (!immediate._onImmediate) {
@@ -715,7 +715,7 @@ function processImmediate() {
 
     // If `clearImmediate(immediate)` wasn't called from the callback, use the
     // `immediate`'s next item
-    if (immediate._idleNext)
+    if (immediate._idleNext !== null)
       immediate = immediate._idleNext;
     else
       immediate = next;
@@ -747,11 +747,11 @@ function tryOnImmediate(immediate, oldTail) {
       }
     }
 
-    if (threw && immediate._idleNext) {
+    if (threw && immediate._idleNext !== null) {
       // Handle any remaining on next tick, assuming we're still alive to do so.
       const curHead = immediateQueue.head;
       const next = immediate._idleNext;
-      if (curHead) {
+      if (curHead !== null) {
         curHead._idlePrev = oldTail;
         oldTail._idleNext = curHead;
         next._idlePrev = null;


### PR DESCRIPTION
A few small refinements to `TimersList` & `ImmediateList`:

- Eliminate the `createTimersList` helper function and instead do all instantiation directly within the constructor
- Define `TIMEOUT_MAX` as `2 ** 31 - 1` instead of having a comment explaining it
- ~~No longer use `delete` on unrefed & refed lists as it's expensive and offers no benefit since we never iterate over the dictionary object in regular usage, except in cases where user-code throws and we can likely accept the minute difference in performance in those cases~~
- Stricter comparisons to `null` & `undefined`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers