### PR TITLE
test: use Countdown in http test

### DIFF
--- a/test/parallel/test-http-response-multi-content-length.js
+++ b/test/parallel/test-http-response-multi-content-length.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const http = require('http');
 const assert = require('assert');
+const Countdown = require('../common/countdown');
 
 const MAX_COUNT = 2;
 
@@ -24,7 +25,7 @@ const server = http.createServer((req, res) => {
   res.end('ok');
 });
 
-let count = 0;
+const countdown = new Countdown(MAX_COUNT, () => server.close());
 
 server.listen(0, common.mustCall(() => {
   for (let n = 1; n <= MAX_COUNT; n++) {
@@ -40,13 +41,7 @@ server.listen(0, common.mustCall(() => {
     ).on('error', common.mustCall((err) => {
       assert(/^Parse Error/.test(err.message));
       assert.strictEqual(err.code, 'HPE_UNEXPECTED_CONTENT_LENGTH');
-      count++;
-      if (count === MAX_COUNT)
-        server.close();
+      countdown.dec();
     }));
   }
 }));
-
-process.on('exit', () => {
-  assert.strictEqual(count, MAX_COUNT);
-});


### PR DESCRIPTION
refactored test case in `test-http-response-multi-content-length` to use countdown as per issue #17169 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
