### PR TITLE
refactor : test-http-request-dont-override-options to use common.mustCall

### DIFF
--- a/test/parallel/test-http-request-dont-override-options.js
+++ b/test/parallel/test-http-request-dont-override-options.js
@@ -4,14 +4,13 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
-let requests = 0;
 
-http.createServer(function(req, res) {
+const server = http.createServer(common.mustCall(function(req, res) {
   res.writeHead(200);
   res.end('ok');
+}));
 
-  requests++;
-}).listen(0, function() {
+server.listen(0, function() {
   const agent = new http.Agent();
   agent.defaultPort = this.address().port;
 
@@ -30,16 +29,12 @@ http.createServer(function(req, res) {
 
   http.request(options, function(res) {
     res.resume();
-  }).end();
-
-  process.on('exit', function() {
-    assert.strictEqual(requests, 1);
-
+    server.close();
     assert.strictEqual(options.host, undefined);
     assert.strictEqual(options.hostname, common.localhostIPv4);
     assert.strictEqual(options.port, undefined);
     assert.strictEqual(options.defaultPort, undefined);
     assert.strictEqual(options.path, undefined);
     assert.strictEqual(options.method, undefined);
-  });
-}).unref();
+  }).end();
+});


### PR DESCRIPTION
refactor : `test-http-request-dont-override-options` to use `common.mustCall` as per issue #17169 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
