### PR TITLE
test: use common.mustCall in http test

### DIFF
--- a/test/parallel/test-http-malformed-request.js
+++ b/test/parallel/test-http-malformed-request.js
@@ -20,27 +20,22 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
-const assert = require('assert');
+const common = require('../common');
 const net = require('net');
 const http = require('http');
 const url = require('url');
 
 // Make sure no exceptions are thrown when receiving malformed HTTP
 // requests.
-
-let nrequests_completed = 0;
-const nrequests_expected = 1;
-
-const server = http.createServer(function(req, res) {
+const server = http.createServer(common.mustCall((req, res) => {
   console.log(`req: ${JSON.stringify(url.parse(req.url))}`);
 
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('Hello World');
   res.end();
 
-  if (++nrequests_completed === nrequests_expected) server.close();
-});
+  server.close();
+}));
 server.listen(0);
 
 server.on('listening', function() {
@@ -49,8 +44,4 @@ server.on('listening', function() {
     c.write('GET /hello?foo=%99bar HTTP/1.1\r\n\r\n');
     c.end();
   });
-});
-
-process.on('exit', function() {
-  assert.strictEqual(nrequests_expected, nrequests_completed);
 });


### PR DESCRIPTION
Refactored the test case in `test-http-malformed-request` to use `common.mustCall`, as per issue #17169 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
