### PR TITLE
tools: host remark-preset-lint-node in-tree

### DIFF
--- a/tools/remark-preset-lint-node/LICENSE
+++ b/tools/remark-preset-lint-node/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Daijiro Wachi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/remark-preset-lint-node/README.md
+++ b/tools/remark-preset-lint-node/README.md
@@ -1,0 +1,2 @@
+# remark-preset-lint-node
+remark preset to configure remark-lint with settings for nodejs/node

--- a/tools/remark-preset-lint-node/package.json
+++ b/tools/remark-preset-lint-node/package.json
@@ -1,30 +1,22 @@
 {
-  "_from": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-  "_id": "remark-preset-lint-node@1.0.2",
-  "_inBundle": false,
-  "_integrity": "sha1-UxsozHvbtJwHgKk6AYCqVPvpz8w=",
-  "_location": "/remark-preset-lint-node",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "git",
-    "raw": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-    "rawSpec": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-    "saveSpec": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-    "fetchSpec": null,
-    "gitCommittish": "859eab541e0f63839b33196f26e2bed4dfe2b194"
+  "name": "remark-preset-lint-node",
+  "version": "1.0.2",
+  "description": "remark preset to configure remark-lint with settings for nodejs/node",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "_requiredBy": [
-    "#USER",
-    "/"
-  ],
-  "_resolved": "github:watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-  "_spec": "watilde/remark-preset-lint-node#859eab541e0f63839b33196f26e2bed4dfe2b194",
-  "_where": "/Users/trott/io.js/tools",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watilde/remark-preset-lint-node.git"
+  },
+  "keywords": [],
   "author": "",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/watilde/remark-preset-lint-node/issues"
   },
-  "bundleDependencies": false,
+  "homepage": "https://github.com/watilde/remark-preset-lint-node#readme",
   "dependencies": {
     "remark-lint": "^6.0.0",
     "remark-lint-blockquote-indentation": "^1.0.0",
@@ -60,20 +52,5 @@
     "remark-lint-strong-marker": "^1.0.0",
     "remark-lint-table-cell-padding": "^1.0.0",
     "remark-lint-table-pipes": "^1.0.0"
-  },
-  "deprecated": false,
-  "description": "remark preset to configure remark-lint with settings for nodejs/node",
-  "homepage": "https://github.com/watilde/remark-preset-lint-node#readme",
-  "keywords": [],
-  "license": "MIT",
-  "main": "index.js",
-  "name": "remark-preset-lint-node",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/watilde/remark-preset-lint-node.git"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "version": "1.0.2"
+  }
 }


### PR DESCRIPTION
Moved from https://github.com/watilde/remark-preset-lint-node. The source for this preset will now live in the nodejs/node repository.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tools