### PR TITLE
test: replace assert.throws with common.expectsError

### DIFF
--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -60,29 +60,26 @@ assert.throws(() => {
   test_error.throwTypeError();
 }, /^TypeError: type error$/);
 
-assert.throws(
+common.expectsError(
   () => test_error.throwErrorCode(),
-  common.expectsError({
+  {
     code: 'ERR_TEST_CODE',
     message: 'Error [error]'
-  })
-);
+  });
 
-assert.throws(
+common.expectsError(
   () => test_error.throwRangeErrorCode(),
-  common.expectsError({
+  {
     code: 'ERR_TEST_CODE',
     message: 'RangeError [range error]'
-  })
-);
+  });
 
-assert.throws(
+common.expectsError(
   () => test_error.throwTypeErrorCode(),
-  common.expectsError({
+  {
     code: 'ERR_TEST_CODE',
     message: 'TypeError [type error]'
-  })
-);
+  });
 
 let error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');


### PR DESCRIPTION
Replace `assert.throws(fn, common.expectsError(err));` with `common.expectsError(fn, err);` in `test/addons-napi/test_error/test.js`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test