### PR TITLE
test: replace fs.accessSync with common.fileExists

### DIFF
--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -57,7 +57,5 @@ function handleExit(error, stdout, stderr) {
 
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
-  assert.doesNotThrow(function() {
-    fs.accessSync(`${installDir}/node_modules/package-name`);
-  });
+  assert(common.fileExists(`${installDir}/node_modules/package-name`));
 }

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -57,5 +57,5 @@ function handleExit(error, stdout, stderr) {
 
   assert.strictEqual(code, 0, `npm install got error code ${code}`);
   assert.strictEqual(signalCode, null, `unexpected signal: ${signalCode}`);
-  assert(common.fileExists(`${installDir}/node_modules/package-name`));
+  assert(fs.existsSync(`${installDir}/node_modules/package-name`));
 }


### PR DESCRIPTION
replace `fs.accessSync` with `common.fileExists` in `test/parallel/test-npm-install.js`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
