### PR TITLE
Enhance crypto/hash.js coverage

### DIFF
--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -154,3 +154,10 @@ common.expectsError(
     message: 'The "algorithm" argument must be of type string'
   }
 );
+
+{
+  const Hash = crypto.Hash;
+  const instance = crypto.Hash('sha256');
+  assert(instance instanceof Hash, 'Hash is expected to return a new instance' +
+                                   'when called without `new`');
+}

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -159,5 +159,5 @@ common.expectsError(
   const Hash = crypto.Hash;
   const instance = crypto.Hash('sha256');
   assert(instance instanceof Hash, 'Hash is expected to return a new instance' +
-                                   'when called without `new`');
+                                   ' when called without `new`');
 }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -14,7 +14,7 @@ const crypto = require('crypto');
 }
 
 common.expectsError(
-  () => new crypto.Hmac(null),
+  () => crypto.createHmac(null),
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
@@ -22,7 +22,7 @@ common.expectsError(
   });
 
 common.expectsError(
-  () => new crypto.Hmac('sha1', null),
+  () => crypto.createHmac('sha1', null),
   {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
   const Hmac = crypto.Hmac;
   const instance = crypto.Hmac('sha256', 'Node');
   assert(instance instanceof Hmac, 'Hmac is expected to return a new instance' +
-                                   'when called without `new`');
+                                   ' when called without `new`');
 }
 
 common.expectsError(

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -21,6 +21,15 @@ common.expectsError(
     message: 'The "hmac" argument must be of type string'
   });
 
+common.expectsError(
+  () => new crypto.Hmac('sha1', null),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "key" argument must be one of type string, TypedArray, or ' +
+             'DataView'
+  });
+
 {
   // Test HMAC
   const actual = crypto.createHmac('sha1', 'Node')

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -7,6 +7,13 @@ const assert = require('assert');
 const crypto = require('crypto');
 
 {
+  const Hmac = crypto.Hmac;
+  const instance = crypto.Hmac('sha256');
+  assert(instance instanceof Hmac, 'Hmac is expected to return a new instance' +
+                                   'when called without `new`');
+}
+
+{
   // Test HMAC
   const actual = crypto.createHmac('sha1', 'Node')
     .update('some data')

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -8,7 +8,7 @@ const crypto = require('crypto');
 
 {
   const Hmac = crypto.Hmac;
-  const instance = crypto.Hmac('sha256');
+  const instance = crypto.Hmac('sha256', 'Node');
   assert(instance instanceof Hmac, 'Hmac is expected to return a new instance' +
                                    'when called without `new`');
 }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -13,6 +13,14 @@ const crypto = require('crypto');
                                    'when called without `new`');
 }
 
+common.expectsError(
+  () => new crypto.Hmac(null),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "hmac" argument must be of type string'
+  });
+
 {
   // Test HMAC
   const actual = crypto.createHmac('sha1', 'Node')


### PR DESCRIPTION
Added these case

###### crypto.Hash
- Call constructor without `new` keyword

###### crypto.Hmac
- Call constructor without `new` keyword
- Call constructor with typeof hmac != string
- Call constructor with typeof hmac = string, typeof key != string

Current coverage is here: https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/hash.js.html

I cannot write test case: `this._handle.update` returns false in `Hash#verify`.
Because I don't know how to make `mdctx_` to `nullptr` in Hash::HashUpdate.
See also:

- [lib/internal/crypto/hash.js:57](https://github.com/nodejs/node/blob/master/lib/internal/crypto/hash.js#L57)
- [src/node_crypto.cc:4116](https://github.com/nodejs/node/blob/master/src/node_crypto.cc#L4116)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test