### PR TITLE
Enhance Cipher, Decipher coverage

### DIFF
--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -75,6 +75,14 @@ testCipher2(Buffer.from('0123456789abcdef'));
   const instance = crypto.Cipher('aes-256-cbc', 'secret');
   assert(instance instanceof Cipher, 'Cipher is expected to return a new ' +
                                      'instance when called without `new`');
+
+  common.expectsError(
+    () => new Cipher(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "cipher" argument must be of type string'
+    });
 }
 
 {

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -77,7 +77,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
                                      'instance when called without `new`');
 
   common.expectsError(
-    () => new Cipher(null),
+    () => crypto.createCipher(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -85,7 +85,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 
   common.expectsError(
-    () => new Cipher('aes-256-cbc', null),
+    () => crypto.createCipher('aes-256-cbc', null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -94,7 +94,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 
   common.expectsError(
-    () => new Cipher('aes-256-cbc', 'secret').update(null),
+    () => crypto.createCipher('aes-256-cbc', 'secret').update(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -103,7 +103,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 
   common.expectsError(
-    () => new Cipher('aes-256-cbc', 'secret').setAuthTag(null),
+    () => crypto.createCipher('aes-256-cbc', 'secret').setAuthTag(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -112,7 +112,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 
   common.expectsError(
-    () => new Cipher('aes-256-cbc', 'secret').setAAD(null),
+    () => crypto.createCipher('aes-256-cbc', 'secret').setAAD(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -128,7 +128,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
                                        'instance when called without `new`');
 
   common.expectsError(
-    () => new Decipher(null),
+    () => crypto.createDecipher(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -136,7 +136,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 
   common.expectsError(
-    () => new Decipher('aes-256-cbc', null),
+    () => crypto.createDecipher('aes-256-cbc', null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -83,6 +83,15 @@ testCipher2(Buffer.from('0123456789abcdef'));
       type: TypeError,
       message: 'The "cipher" argument must be of type string'
     });
+
+  common.expectsError(
+    () => new Cipher('aes-256-cbc', null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "password" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
 }
 
 {

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -77,6 +77,13 @@ testCipher2(Buffer.from('0123456789abcdef'));
                                      'instance when called without `new`');
 }
 
+{
+  const Decipher = crypto.Decipher;
+  const instance = crypto.Decipher('aes-256-cbc', 'secret');
+  assert(instance instanceof Decipher, 'Decipher is expected to return a new ' +
+                                     'instance when called without `new`');
+}
+
 // Base64 padding regression test, see #4837.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -134,6 +134,15 @@ testCipher2(Buffer.from('0123456789abcdef'));
       type: TypeError,
       message: 'The "cipher" argument must be of type string'
     });
+
+  common.expectsError(
+    () => new Decipher('aes-256-cbc', null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "password" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
 }
 
 // Base64 padding regression test, see #4837.

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -92,6 +92,15 @@ testCipher2(Buffer.from('0123456789abcdef'));
       message: 'The "password" argument must be one of type string, Buffer, ' +
                'TypedArray, or DataView'
     });
+
+  common.expectsError(
+    () => new Cipher('aes-256-cbc', 'secret').update(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "data" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
 }
 
 {

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -125,7 +125,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
   const Decipher = crypto.Decipher;
   const instance = crypto.Decipher('aes-256-cbc', 'secret');
   assert(instance instanceof Decipher, 'Decipher is expected to return a new ' +
-                                     'instance when called without `new`');
+                                       'instance when called without `new`');
 
   common.expectsError(
     () => new Decipher(null),

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -101,6 +101,15 @@ testCipher2(Buffer.from('0123456789abcdef'));
       message: 'The "data" argument must be one of type string, Buffer, ' +
                'TypedArray, or DataView'
     });
+
+  common.expectsError(
+    () => new Cipher('aes-256-cbc', 'secret').setAuthTag(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "buffer" argument must be one of type Buffer, ' +
+               'TypedArray, or DataView'
+    });
 }
 
 {

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -110,6 +110,15 @@ testCipher2(Buffer.from('0123456789abcdef'));
       message: 'The "buffer" argument must be one of type Buffer, ' +
                'TypedArray, or DataView'
     });
+
+  common.expectsError(
+    () => new Cipher('aes-256-cbc', 'secret').setAAD(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "buffer" argument must be one of type Buffer, ' +
+               'TypedArray, or DataView'
+    });
 }
 
 {

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -126,6 +126,14 @@ testCipher2(Buffer.from('0123456789abcdef'));
   const instance = crypto.Decipher('aes-256-cbc', 'secret');
   assert(instance instanceof Decipher, 'Decipher is expected to return a new ' +
                                      'instance when called without `new`');
+
+  common.expectsError(
+    () => new Decipher(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "cipher" argument must be of type string'
+    });
 }
 
 // Base64 padding regression test, see #4837.

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -70,6 +70,13 @@ testCipher1(Buffer.from('MySecretKey123'));
 testCipher2('0123456789abcdef');
 testCipher2(Buffer.from('0123456789abcdef'));
 
+{
+  const Cipher = crypto.Cipher;
+  const instance = crypto.Cipher('aes-256-cbc', 'secret');
+  assert(instance instanceof Cipher, 'Cipher is expected to return a new ' +
+                                     'instance when called without `new`');
+}
+
 // Base64 padding regression test, see #4837.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');


### PR DESCRIPTION
I added those test:

###### Cipher
- Call constructor withour new keyword
- Call constructor with cipher is not string
- Call constructor with cipher is string and password is not string
- Call `Cipher#update` with data is not string
- Call `Cipher#setAuthTag` with tagbuf is not string
- Call `Cipher#setAAD` with aadbuf is not string

###### Decipher
- Call constructor withour new keyword
- Call constructor with cipher is not string
- Call constructor with cipher is string and password is not string

Current coverage is here: https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/cipher.js.html

`Cipheriv` and `Decipheriv` is not covered in this PR to avoid PR too large.
I'm going to write these test in another PR.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
