### PR TITLE
events: use Reflect.apply

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -400,7 +400,7 @@ const eventEmit = EventEmitter.prototype.emit;
 EventEmitter.prototype.emit = function emit(...args) {
   const domain = this.domain;
   if (domain === null || domain === undefined || this === process) {
-    return eventEmit.apply(this, args);
+    return Reflect.apply(eventEmit, this, args);
   }
 
   const type = args[0];
@@ -415,7 +415,7 @@ EventEmitter.prototype.emit = function emit(...args) {
 
   domain.enter();
   try {
-    return eventEmit.apply(this, args);
+    return Reflect.apply(eventEmit, this, args);
   } catch (er) {
     if (typeof er === 'object' && er !== null) {
       er.domainEmitter = this;

--- a/lib/events.js
+++ b/lib/events.js
@@ -123,12 +123,12 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     return false;
 
   if (typeof handler === 'function') {
-    handler.apply(this, args);
+    Reflect.apply(handler, this, args);
   } else {
     const len = handler.length;
     const listeners = arrayClone(handler, len);
     for (var i = 0; i < len; ++i)
-      listeners[i].apply(this, args);
+      Reflect.apply(listeners[i], this, args);
   }
 
   return true;
@@ -215,7 +215,7 @@ function onceWrapper(...args) {
   if (!this.fired) {
     this.target.removeListener(this.type, this.wrapFn);
     this.fired = true;
-    this.listener.apply(this.target, args);
+    Reflect.apply(this.listener, this.target, args);
   }
 }
 


### PR DESCRIPTION
Instead of callback bound apply, instead use the standard `Reflect.apply`. This is both safer and appears to offer a slight performance benefit. Perhaps due to not having to search the prototype tree? No clue tbh but I'm seeing 3-5% difference with substantial significance.

Refs: https://github.com/nodejs/node/issues/12956

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
domain, events