### PR TITLE
test: replace function with arrow function

### DIFF
--- a/deps/v8/test/mjsunit/compare-known-objects-tostringtag.js
+++ b/deps/v8/test/mjsunit/compare-known-objects-tostringtag.js
@@ -22,26 +22,26 @@ function gt(a, b) {
 
 function test(a, b) {
   // Check CompareIC for less than or equal of known objects.
-  assertThrows(function() {le(a, a)});
-  assertThrows(function() {le(a, b)});
-  assertThrows(function() {le(b, a)});
+  assertThrows(() => {le(a, a)});
+  assertThrows(() => {le(a, b)});
+  assertThrows(() => {le(b, a)});
   // Check CompareIC for less than of known objects.
-  assertThrows(function() {lt(a, a)});
-  assertThrows(function() {lt(a, b)});
-  assertThrows(function() {lt(b, a)});
+  assertThrows(() => {lt(a, a)});
+  assertThrows(() => {lt(a, b)});
+  assertThrows(() => {lt(b, a)});
   // Check CompareIC for greater than or equal of known objects.
-  assertThrows(function() {ge(a, a)});
-  assertThrows(function() {ge(a, b)});
-  assertThrows(function() {ge(b, a)});
+  assertThrows(() => {ge(a, a)});
+  assertThrows(() => {ge(a, b)});
+  assertThrows(() => {ge(b, a)});
   // Check CompareIC for greater than of known objects.
-  assertThrows(function() {gt(a, a)});
-  assertThrows(function() {gt(a, b)});
-  assertThrows(function() {gt(b, a)});
+  assertThrows(() => {gt(a, a)});
+  assertThrows(() => {gt(a, b)});
+  assertThrows(() => {gt(b, a)});
 }
 
 function O() { }
 Object.defineProperty(O.prototype, Symbol.toStringTag, {
-  get: function() { throw "@@toStringTag called!" }
+  get() { throw "@@toStringTag called!" }
 });
 
 var obj1 = new O;

--- a/deps/v8/test/mjsunit/compiler/dont-constant-fold-deopting-checks.js
+++ b/deps/v8/test/mjsunit/compiler/dont-constant-fold-deopting-checks.js
@@ -7,4 +7,4 @@
 function bar(a) { a[0](true); }
 function foo(a) { return bar(1); }
 %OptimizeFunctionOnNextCall(foo);
-assertThrows(function() {bar([foo])}, TypeError);
+assertThrows(() => {bar([foo])}, TypeError);

--- a/deps/v8/test/mjsunit/es6/classes.js
+++ b/deps/v8/test/mjsunit/es6/classes.js
@@ -711,7 +711,7 @@ function assertAccessorDescriptor(object, name) {
 
   var arr = new Array(100);
   var obj = {};
-  assertThrows(function() {Derived.apply(obj, arr);}, TypeError);
+  assertThrows(() => {Derived.apply(obj, arr);}, TypeError);
 })();
 
 

--- a/deps/v8/test/mjsunit/es6/typedarray-from.js
+++ b/deps/v8/test/mjsunit/es6/typedarray-from.js
@@ -18,7 +18,7 @@ for (var constructor of typedArrayConstructors) {
   assertEquals(1, constructor.from.length);
 
   // TypedArray.from only callable on this subclassing %TypedArray%
-  assertThrows(function () {constructor.from.call(Array, [])}, TypeError);
+  assertThrows(() => {constructor.from.call(Array, [])}, TypeError);
 
   function assertArrayLikeEquals(value, expected, type) {
     assertEquals(value.__proto__, type.prototype);
@@ -42,10 +42,10 @@ for (var constructor of typedArrayConstructors) {
   constructor.from([1], strict_null, null);
 
   // TypedArray.from can only be called on TypedArray constructors
-  assertThrows(function() {constructor.from.call({}, [])}, TypeError);
-  assertThrows(function() {constructor.from.call([], [])}, TypeError);
-  assertThrows(function() {constructor.from.call(1, [])}, TypeError);
-  assertThrows(function() {constructor.from.call(undefined, [])}, TypeError);
+  assertThrows(() => {constructor.from.call({}, [])}, TypeError);
+  assertThrows(() => {constructor.from.call([], [])}, TypeError);
+  assertThrows(() => {constructor.from.call(1, [])}, TypeError);
+  assertThrows(() => {constructor.from.call(undefined, [])}, TypeError);
 
   // Converting from various other types, demonstrating that it can
   // operate on array-like objects as well as iterables.
@@ -72,10 +72,10 @@ for (var constructor of typedArrayConstructors) {
   assertArrayLikeEquals(constructor.from(generator()),
                         [4, 5, 6], constructor);
 
-  assertThrows(function() { constructor.from(null); }, TypeError);
-  assertThrows(function() { constructor.from(undefined); }, TypeError);
-  assertThrows(function() { constructor.from([], null); }, TypeError);
-  assertThrows(function() { constructor.from([], 'noncallable'); },
+  assertThrows(() => { constructor.from(null); }, TypeError);
+  assertThrows(() => { constructor.from(undefined); }, TypeError);
+  assertThrows(() => { constructor.from([], null); }, TypeError);
+  assertThrows(() => { constructor.from([], 'noncallable'); },
                TypeError);
 
   var nullIterator = {};
@@ -84,11 +84,11 @@ for (var constructor of typedArrayConstructors) {
                         constructor);
 
   var nonObjIterator = {};
-  nonObjIterator[Symbol.iterator] = function() { return 'nonObject'; };
-  assertThrows(function() { constructor.from(nonObjIterator); },
+  nonObjIterator[Symbol.iterator] = () => { return 'nonObject'; };
+  assertThrows(() => { constructor.from(nonObjIterator); },
                TypeError);
 
-  assertThrows(function() { constructor.from([], null); }, TypeError);
+  assertThrows(() => { constructor.from([], null); }, TypeError);
 
   // Ensure iterator is only accessed once, and only invoked once
   var called = 0;
@@ -104,11 +104,11 @@ for (var constructor of typedArrayConstructors) {
   }
   var getCalled = 0;
   Object.defineProperty(obj, Symbol.iterator, {
-    get: function() {
+    get() {
       getCalled++;
       return testIterator;
     },
-    set: function() {
+    set() {
       assertUnreachable('@@iterator should not be set');
     }
   });

--- a/deps/v8/test/mjsunit/es6/typedarray-neutered.js
+++ b/deps/v8/test/mjsunit/es6/typedarray-neutered.js
@@ -23,8 +23,8 @@ function TestArrayBufferCreation() {
 
   TestByteLength(0, 0);
 
-  assertThrows(function() { new ArrayBuffer(-10); }, RangeError);
-  assertThrows(function() { new ArrayBuffer(-2.567); }, RangeError);
+  assertThrows(() => { new ArrayBuffer(-10); }, RangeError);
+  assertThrows(() => { new ArrayBuffer(-2.567); }, RangeError);
 
 /* TODO[dslomov]: Reenable the test
   assertThrows(function() {
@@ -44,7 +44,7 @@ function TestByteLengthNotWritable() {
   var ab = new ArrayBuffer(1024);
   assertSame(1024, ab.byteLength);
 
-  assertThrows(function() { "use strict"; ab.byteLength = 42; }, TypeError);
+  assertThrows(() => { "use strict"; ab.byteLength = 42; }, TypeError);
 }
 
 TestByteLengthNotWritable();
@@ -194,20 +194,20 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   assertSame(0, aAtTheEnd.byteLength);
   assertSame(256*elementSize, aAtTheEnd.byteOffset);
 
-  assertThrows(function () { new constr(ab, 257*elementSize); }, RangeError);
+  assertThrows(() => { new constr(ab, 257*elementSize); }, RangeError);
   assertThrows(
-      function () { new constr(ab, 128*elementSize, 192); },
+      () => { new constr(ab, 128*elementSize, 192); },
       RangeError);
 
   if (elementSize !== 1) {
-    assertThrows(function() { new constr(ab, 128*elementSize - 1, 10); },
+    assertThrows(() => { new constr(ab, 128*elementSize - 1, 10); },
                  RangeError);
     var unalignedArrayBuffer = new ArrayBuffer(10*elementSize + 1);
     var goodArray = new constr(unalignedArrayBuffer, 0, 10);
     assertSame(10, goodArray.length);
     assertSame(10*elementSize, goodArray.byteLength);
-    assertThrows(function() { new constr(unalignedArrayBuffer)}, RangeError);
-    assertThrows(function() { new constr(unalignedArrayBuffer, 5*elementSize)},
+    assertThrows(() => { new constr(unalignedArrayBuffer)}, RangeError);
+    assertThrows(() => { new constr(unalignedArrayBuffer, 5*elementSize)},
                  RangeError);
   }
 
@@ -239,7 +239,7 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   assertSame(0, aFromString.byteOffset);
   assertSame(30*elementSize, aFromString.buffer.byteLength);
 
-  assertThrows(function() { new constr(Symbol()); }, TypeError);
+  assertThrows(() => { new constr(Symbol()); }, TypeError);
 
   var jsArray = [];
   for (i = 0; i < 30; i++) {
@@ -309,7 +309,7 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   // is read only once.
   var iteratorReadCount = 0;
   Object.defineProperty(myObject, Symbol.iterator, {
-    get: function() { iteratorReadCount++; return gen; }
+    get() { iteratorReadCount++; return gen; }
   });
   genArr = new constr(myObject);
   assertEquals(10, genArr.length);
@@ -372,7 +372,7 @@ function TestSubArray(constructor, item) {
   var method = constructor.prototype.subarray;
   method.call(new constructor(100), 0, 100);
   var o = {};
-  assertThrows(function() { method.call(o, 0, 100); }, TypeError);
+  assertThrows(() => { method.call(o, 0, 100); }, TypeError);
 }
 
 TestSubArray(Uint8Array, 0xFF);
@@ -420,10 +420,10 @@ var typedArrayConstructors = [
 
 function TestPropertyTypeChecks(constructor) {
   function CheckProperty(name) {
-    assertThrows(function() { 'use strict'; new constructor(10)[name] = 0; })
+    assertThrows(() => { 'use strict'; new constructor(10)[name] = 0; })
     var d = Object.getOwnPropertyDescriptor(constructor.prototype.__proto__, name);
     var o = {};
-    assertThrows(function() {d.get.call(o);}, TypeError);
+    assertThrows(() => {d.get.call(o);}, TypeError);
     for (var i = 0; i < typedArrayConstructors.length; i++) {
       var ctor = typedArrayConstructors[i];
       var a = new ctor(10);
@@ -455,9 +455,9 @@ function TestTypedArraySet() {
   var a12 = new Uint16Array(15)
   a12.set(a11, 3)
   assertArrayPrefix([0, 0, 0, 1, 2, 3, 4, 0, 0xffff, 0, 0], a12)
-  assertThrows(function(){ a11.set(a12) })
+  assertThrows(() => { a11.set(a12) })
 
-  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf: function() {return 3}}]
+  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf: () => {return 3}}]
   var a22 = new Int32Array(12)
   a22.set(a21, 2)
   assertArrayPrefix([0, 0, 1, 0, 10, 0, 0, -1, 3, 0], a22)
@@ -527,11 +527,11 @@ function TestTypedArraySet() {
   }
   a.set({});
   assertArrayPrefix(expected, a);
-  assertThrows(function() { a.set.call({}) }, TypeError);
-  assertThrows(function() { a.set.call([]) }, TypeError);
+  assertThrows(() => { a.set.call({}) }, TypeError);
+  assertThrows(() => { a.set.call([]) }, TypeError);
 
-  assertThrows(function() { a.set(0); }, TypeError);
-  assertThrows(function() { a.set(0, 1); }, TypeError);
+  assertThrows(() => { a.set(0); }, TypeError);
+  assertThrows(() => { a.set(0, 1); }, TypeError);
 
   assertEquals(1, a.set.length);
 }
@@ -676,11 +676,11 @@ function TestDataViewConstructor() {
 
 
   // error cases
-  assertThrows(function() { new DataView(ab, -1); }, RangeError);
-  assertThrows(function() { new DataView(); }, TypeError);
-  assertThrows(function() { new DataView([]); }, TypeError);
-  assertThrows(function() { new DataView(ab, 257); }, RangeError);
-  assertThrows(function() { new DataView(ab, 1, 1024); }, RangeError);
+  assertThrows(() => { new DataView(ab, -1); }, RangeError);
+  assertThrows(() => { new DataView(); }, TypeError);
+  assertThrows(() => { new DataView([]); }, TypeError);
+  assertThrows(() => { new DataView(ab, 257); }, RangeError);
+  assertThrows(() => { new DataView(ab, 1, 1024); }, RangeError);
 }
 
 TestDataViewConstructor();
@@ -690,7 +690,7 @@ function TestDataViewPropertyTypeChecks() {
   function CheckProperty(name) {
     var d = Object.getOwnPropertyDescriptor(DataView.prototype, name);
     var o = {}
-    assertThrows(function() {d.get.call(o);}, TypeError);
+    assertThrows(() => {d.get.call(o);}, TypeError);
     d.get.call(a); // shouldn't throw
   }
 
@@ -767,8 +767,8 @@ TestArbitrary(new DataView(new ArrayBuffer(256)));
 
 
 // Test direct constructor call
-assertThrows(function() { ArrayBuffer(); }, TypeError);
-assertThrows(function() { DataView(new ArrayBuffer()); }, TypeError);
+assertThrows(() => { ArrayBuffer(); }, TypeError);
+assertThrows(() => { DataView(new ArrayBuffer()); }, TypeError);
 
 function TestNonConfigurableProperties(constructor) {
   var arr = new constructor([100])

--- a/deps/v8/test/mjsunit/es6/typedarray.js
+++ b/deps/v8/test/mjsunit/es6/typedarray.js
@@ -41,8 +41,8 @@ function TestArrayBufferCreation() {
 
   TestByteLength(0, 0);
 
-  assertThrows(function() { new ArrayBuffer(-10); }, RangeError);
-  assertThrows(function() { new ArrayBuffer(-2.567); }, RangeError);
+  assertThrows(() => { new ArrayBuffer(-10); }, RangeError);
+  assertThrows(() => { new ArrayBuffer(-2.567); }, RangeError);
 
 /* TODO[dslomov]: Reenable the test
   assertThrows(function() {
@@ -62,7 +62,7 @@ function TestByteLengthNotWritable() {
   var ab = new ArrayBuffer(1024);
   assertSame(1024, ab.byteLength);
 
-  assertThrows(function() { "use strict"; ab.byteLength = 42; }, TypeError);
+  assertThrows(() => { "use strict"; ab.byteLength = 42; }, TypeError);
 }
 
 TestByteLengthNotWritable();
@@ -212,20 +212,20 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   assertSame(0, aAtTheEnd.byteLength);
   assertSame(256*elementSize, aAtTheEnd.byteOffset);
 
-  assertThrows(function () { new constr(ab, 257*elementSize); }, RangeError);
+  assertThrows(() => { new constr(ab, 257*elementSize); }, RangeError);
   assertThrows(
-      function () { new constr(ab, 128*elementSize, 192); },
+      () => { new constr(ab, 128*elementSize, 192); },
       RangeError);
 
   if (elementSize !== 1) {
-    assertThrows(function() { new constr(ab, 128*elementSize - 1, 10); },
+    assertThrows(() => { new constr(ab, 128*elementSize - 1, 10); },
                  RangeError);
     var unalignedArrayBuffer = new ArrayBuffer(10*elementSize + 1);
     var goodArray = new constr(unalignedArrayBuffer, 0, 10);
     assertSame(10, goodArray.length);
     assertSame(10*elementSize, goodArray.byteLength);
-    assertThrows(function() { new constr(unalignedArrayBuffer)}, RangeError);
-    assertThrows(function() { new constr(unalignedArrayBuffer, 5*elementSize)},
+    assertThrows(() => { new constr(unalignedArrayBuffer)}, RangeError);
+    assertThrows(() => { new constr(unalignedArrayBuffer, 5*elementSize)},
                  RangeError);
   }
 
@@ -257,9 +257,9 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   assertSame(0, aFromString.byteOffset);
   assertSame(30*elementSize, aFromString.buffer.byteLength);
 
-  assertThrows(function() { new constr(Symbol()); }, TypeError);
+  assertThrows(() => { new constr(Symbol()); }, TypeError);
 
-  assertThrows(function() { new constr(-1); }, RangeError);
+  assertThrows(() => { new constr(-1); }, RangeError);
 
   var jsArray = [];
   for (i = 0; i < 30; i++) {
@@ -329,7 +329,7 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   // is read only once.
   var iteratorReadCount = 0;
   Object.defineProperty(myObject, Symbol.iterator, {
-    get: function() { iteratorReadCount++; return gen; }
+    get() { iteratorReadCount++; return gen; }
   });
   genArr = new constr(myObject);
   assertEquals(10, genArr.length);
@@ -340,7 +340,7 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   // Modified %ArrayIteratorPrototype%.next() method is honoured (v8:5699)
   const ArrayIteratorPrototype = Object.getPrototypeOf([][Symbol.iterator]());
   const ArrayIteratorPrototypeNext = ArrayIteratorPrototype.next;
-  ArrayIteratorPrototype.next = function() {
+  ArrayIteratorPrototype.next = () => {
     return { done: true };
   };
   genArr = new constr([1, 2, 3]);
@@ -351,7 +351,7 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   // well.
   genArr = new constr(Object.defineProperty([1, , 3], 1, {
     get() {
-      ArrayIteratorPrototype.next = function() {
+      ArrayIteratorPrototype.next = () => {
         return { done: true };
       }
       return 2;
@@ -417,7 +417,7 @@ function TestSubArray(constructor, item) {
   var method = constructor.prototype.subarray;
   method.call(new constructor(100), 0, 100);
   var o = {};
-  assertThrows(function() { method.call(o, 0, 100); }, TypeError);
+  assertThrows(() => { method.call(o, 0, 100); }, TypeError);
 }
 
 TestSubArray(Uint8Array, 0xFF);
@@ -465,10 +465,10 @@ var typedArrayConstructors = [
 
 function TestPropertyTypeChecks(constructor) {
   function CheckProperty(name) {
-    assertThrows(function() { 'use strict'; new constructor(10)[name] = 0; })
+    assertThrows(() => { 'use strict'; new constructor(10)[name] = 0; })
     var d = Object.getOwnPropertyDescriptor(constructor.prototype.__proto__, name);
     var o = {};
-    assertThrows(function() {d.get.call(o);}, TypeError);
+    assertThrows(() => {d.get.call(o);}, TypeError);
     for (var i = 0; i < typedArrayConstructors.length; i++) {
       var ctor = typedArrayConstructors[i];
       var a = new ctor(10);
@@ -510,9 +510,9 @@ function TestTypedArraySet() {
   var a12 = new Uint16Array(15)
   a12.set(a11, 3)
   assertArrayPrefix([0, 0, 0, 1, 2, 3, 4, 0, 0xffff, 0, 0], a12)
-  assertThrows(function(){ a11.set(a12) })
+  assertThrows(() => { a11.set(a12) })
 
-  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf: function() {return 3}}]
+  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf() {return 3}}]
   var a22 = new Int32Array(12)
   a22.set(a21, 2)
   assertArrayPrefix([0, 0, 1, 0, 10, 0, 0, -1, 3, 0], a22)
@@ -587,11 +587,11 @@ function TestTypedArraySet() {
   }
   a.set({});
   assertArrayPrefix(expected, a);
-  assertThrows(function() { a.set.call({}) }, TypeError);
-  assertThrows(function() { a.set.call([]) }, TypeError);
+  assertThrows(() => { a.set.call({}) }, TypeError);
+  assertThrows(() => { a.set.call([]) }, TypeError);
 
-  assertThrows(function() { a.set(0); }, TypeError);
-  assertThrows(function() { a.set(0, 1); }, TypeError);
+  assertThrows(() => { a.set(0); }, TypeError);
+  assertThrows(() => { a.set(0, 1); }, TypeError);
 
   assertEquals(1, a.set.length);
 
@@ -751,11 +751,11 @@ function TestDataViewConstructor() {
 
 
   // error cases
-  assertThrows(function() { new DataView(ab, -1); }, RangeError);
-  assertThrows(function() { new DataView(); }, TypeError);
-  assertThrows(function() { new DataView([]); }, TypeError);
-  assertThrows(function() { new DataView(ab, 257); }, RangeError);
-  assertThrows(function() { new DataView(ab, 1, 1024); }, RangeError);
+  assertThrows(() => { new DataView(ab, -1); }, RangeError);
+  assertThrows(() => { new DataView(); }, TypeError);
+  assertThrows(() => { new DataView([]); }, TypeError);
+  assertThrows(() => { new DataView(ab, 257); }, RangeError);
+  assertThrows(() => { new DataView(ab, 1, 1024); }, RangeError);
 }
 
 TestDataViewConstructor();
@@ -765,7 +765,7 @@ function TestDataViewPropertyTypeChecks() {
   function CheckProperty(name) {
     var d = Object.getOwnPropertyDescriptor(DataView.prototype, name);
     var o = {}
-    assertThrows(function() {d.get.call(o);}, TypeError);
+    assertThrows(() => {d.get.call(o);}, TypeError);
     d.get.call(a); // shouldn't throw
   }
 
@@ -842,8 +842,8 @@ TestArbitrary(new DataView(new ArrayBuffer(256)));
 
 
 // Test direct constructor call
-assertThrows(function() { ArrayBuffer(); }, TypeError);
-assertThrows(function() { DataView(new ArrayBuffer()); }, TypeError);
+assertThrows(() => { ArrayBuffer(); }, TypeError);
+assertThrows(() => { DataView(new ArrayBuffer()); }, TypeError);
 
 function TestNonConfigurableProperties(constructor) {
   var arr = new constructor([100])
@@ -872,7 +872,7 @@ for(i = 0; i < typedArrayConstructors.length; i++) {
     // construct the typed array.
     return;
   }
-  assertThrows(function() {
+  assertThrows(() => {
     new Int8Array(buf);
   }, RangeError);
 })();

--- a/deps/v8/test/mjsunit/harmony/atomics-value-check.js
+++ b/deps/v8/test/mjsunit/harmony/atomics-value-check.js
@@ -15,30 +15,30 @@ var workerScript =
 var worker = new Worker(workerScript);
 
 var value_obj = {
-  valueOf: function() {worker.postMessage({sab:sab}, [sta.buffer]);
+  valueOf() {worker.postMessage({sab:sab}, [sta.buffer]);
                        return 5}
 }
 var value = Object.create(value_obj);
 
-assertThrows(function() {Atomics.exchange(sta, 0, value)});
-assertThrows(function() {Atomics.compareExchange(sta, 0, 5, value)});
-assertThrows(function() {Atomics.compareExchange(sta, 0, value, 5)});
-assertThrows(function() {Atomics.add(sta, 0, value)});
-assertThrows(function() {Atomics.sub(sta, 0, value)});
-assertThrows(function() {Atomics.and(sta, 0, value)});
-assertThrows(function() {Atomics.or(sta, 0, value)});
-assertThrows(function() {Atomics.xor(sta, 0, value)});
+assertThrows(() => {Atomics.exchange(sta, 0, value)});
+assertThrows(() => {Atomics.compareExchange(sta, 0, 5, value)});
+assertThrows(() => {Atomics.compareExchange(sta, 0, value, 5)});
+assertThrows(() => {Atomics.add(sta, 0, value)});
+assertThrows(() => {Atomics.sub(sta, 0, value)});
+assertThrows(() => {Atomics.and(sta, 0, value)});
+assertThrows(() => {Atomics.or(sta, 0, value)});
+assertThrows(() => {Atomics.xor(sta, 0, value)});
 
 var index_obj = {
-  valueOf: function() {worker.postMessage({sab:sab}, [sta.buffer]);
+  valueOf() {worker.postMessage({sab:sab}, [sta.buffer]);
                        return 0}
 }
 var index = Object.create(index_obj);
 
-assertThrows(function() {Atomics.exchange(sta, index, 1)});
-assertThrows(function() {Atomics.compareExchange(sta, index, 5, 2)});
-assertThrows(function() {Atomics.add(sta, index, 3)});
-assertThrows(function() {Atomics.sub(sta, index, 4)});
-assertThrows(function() {Atomics.and(sta, index, 5)});
-assertThrows(function() {Atomics.or(sta, index, 6)});
-assertThrows(function() {Atomics.xor(sta, index, 7)});
+assertThrows(() => {Atomics.exchange(sta, index, 1)});
+assertThrows(() => {Atomics.compareExchange(sta, index, 5, 2)});
+assertThrows(() => {Atomics.add(sta, index, 3)});
+assertThrows(() => {Atomics.sub(sta, index, 4)});
+assertThrows(() => {Atomics.and(sta, index, 5)});
+assertThrows(() => {Atomics.or(sta, index, 6)});
+assertThrows(() => {Atomics.xor(sta, index, 7)});

--- a/deps/v8/test/mjsunit/harmony/private.js
+++ b/deps/v8/test/mjsunit/harmony/private.js
@@ -83,9 +83,9 @@ TestConstructor()
 
 function TestToString() {
   for (var i in symbols) {
-    assertThrows(function() {new String(symbols[i]) }, TypeError)
+    assertThrows(() => {new String(symbols[i]) }, TypeError)
     assertEquals(symbols[i].toString(), String(symbols[i]))
-    assertThrows(function() { symbols[i] + "" }, TypeError)
+    assertThrows(() => { symbols[i] + "" }, TypeError)
     assertTrue(isValidSymbolString(symbols[i].toString()))
     assertTrue(isValidSymbolString(Object(symbols[i]).toString()))
     assertTrue(isValidSymbolString(Symbol.prototype.toString.call(symbols[i])))
@@ -115,8 +115,8 @@ TestToBoolean()
 
 function TestToNumber() {
   for (var i in symbols) {
-    assertThrows(function() { Number(symbols[i]); }, TypeError);
-    assertThrows(function() { symbols[i] + 0; }, TypeError);
+    assertThrows(() => { Number(symbols[i]); }, TypeError);
+    assertThrows(() => { symbols[i] + 0; }, TypeError);
   }
 }
 TestToNumber()
@@ -150,7 +150,7 @@ function TestEquality() {
   }
 
   // Symbols should not be equal to any other value (and the test terminates).
-  var values = [347, 1.275, NaN, "string", null, undefined, {}, function() {}]
+  var values = [347, 1.275, NaN, "string", null, undefined, {}, () => {}]
   for (var i in symbols) {
     for (var j in values) {
       assertFalse(symbols[i] === values[j])
@@ -295,7 +295,7 @@ function TestKeyDelete(obj) {
 }
 
 
-var objs = [{}, [], Object.create({}), Object(1), new Map, function(){}]
+var objs = [{}, [], Object.create({}), Object(1), new Map, () => {}]
 
 for (var i in objs) {
   var obj = objs[i]

--- a/deps/v8/test/mjsunit/harmony/sharedarraybuffer.js
+++ b/deps/v8/test/mjsunit/harmony/sharedarraybuffer.js
@@ -44,8 +44,8 @@ function TestArrayBufferCreation() {
 
   TestByteLength(0, 0);
 
-  assertThrows(function() { new SharedArrayBuffer(-10); }, RangeError);
-  assertThrows(function() { new SharedArrayBuffer(-2.567); }, RangeError);
+  assertThrows(() => { new SharedArrayBuffer(-10); }, RangeError);
+  assertThrows(() => { new SharedArrayBuffer(-2.567); }, RangeError);
 
 /* TODO[dslomov]: Reenable the test
   assertThrows(function() {
@@ -65,7 +65,7 @@ function TestByteLengthNotWritable() {
   var sab = new SharedArrayBuffer(1024);
   assertSame(1024, sab.byteLength);
 
-  assertThrows(function() { "use strict"; sab.byteLength = 42; }, TypeError);
+  assertThrows(() => { "use strict"; sab.byteLength = 42; }, TypeError);
 }
 
 TestByteLengthNotWritable();
@@ -168,20 +168,20 @@ function TestTypedArray(constr, elementSize, typicalElement) {
   assertSame(0, aAtTheEnd.byteLength);
   assertSame(256*elementSize, aAtTheEnd.byteOffset);
 
-  assertThrows(function () { new constr(sab, 257*elementSize); }, RangeError);
+  assertThrows(() => { new constr(sab, 257*elementSize); }, RangeError);
   assertThrows(
-      function () { new constr(sab, 128*elementSize, 192); },
+      () => { new constr(sab, 128*elementSize, 192); },
       RangeError);
 
   if (elementSize !== 1) {
-    assertThrows(function() { new constr(sab, 128*elementSize - 1, 10); },
+    assertThrows(() => { new constr(sab, 128*elementSize - 1, 10); },
                  RangeError);
     var unalignedArrayBuffer = new SharedArrayBuffer(10*elementSize + 1);
     var goodArray = new constr(unalignedArrayBuffer, 0, 10);
     assertSame(10, goodArray.length);
     assertSame(10*elementSize, goodArray.byteLength);
-    assertThrows(function() { new constr(unalignedArrayBuffer)}, RangeError);
-    assertThrows(function() { new constr(unalignedArrayBuffer, 5*elementSize)},
+    assertThrows(() => { new constr(unalignedArrayBuffer)}, RangeError);
+    assertThrows(() => { new constr(unalignedArrayBuffer, 5*elementSize)},
                  RangeError);
   }
 
@@ -306,7 +306,7 @@ function TestPropertyTypeChecks(constructor) {
     var d = Object.getOwnPropertyDescriptor(constructor.prototype.__proto__,
                                             name);
     var o = {};
-    assertThrows(function() {d.get.call(o);}, TypeError);
+    assertThrows(() => {d.get.call(o);}, TypeError);
     for (var i = 0; i < typedArrayConstructors.length; i++) {
       var ctor = typedArrayConstructors[i];
       var a = MakeSharedTypedArray(ctor, 10);
@@ -346,9 +346,9 @@ function TestTypedArraySet() {
   var a12 = MakeSharedTypedArray(Uint16Array, 15);
   a12.set(a11, 3)
   assertArrayPrefix([0, 0, 0, 1, 2, 3, 4, 0, 0xffff, 0, 0], a12)
-  assertThrows(function(){ a11.set(a12) })
+  assertThrows(() => { a11.set(a12) })
 
-  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf: function() {return 3}}]
+  var a21 = [1, undefined, 10, NaN, 0, -1, {valueOf() {return 3}}]
   var a22 = MakeSharedTypedArray(Int32Array, 12)
   a22.set(a21, 2)
   assertArrayPrefix([0, 0, 1, 0, 10, 0, 0, -1, 3, 0], a22)
@@ -418,11 +418,11 @@ function TestTypedArraySet() {
   }
   a.set({});
   assertArrayPrefix(expected, a);
-  assertThrows(function() { a.set.call({}) }, TypeError);
-  assertThrows(function() { a.set.call([]) }, TypeError);
+  assertThrows(() => { a.set.call({}) }, TypeError);
+  assertThrows(() => { a.set.call([]) }, TypeError);
 
-  assertThrows(function() { a.set(0); }, TypeError);
-  assertThrows(function() { a.set(0, 1); }, TypeError);
+  assertThrows(() => { a.set(0); }, TypeError);
+  assertThrows(() => { a.set(0, 1); }, TypeError);
 }
 
 TestTypedArraySet();
@@ -560,9 +560,9 @@ for(i = 0; i < typedArrayConstructors.length; i++) {
 }
 
 // Test direct constructor call
-assertThrows(function() { SharedArrayBuffer(); }, TypeError);
+assertThrows(() => { SharedArrayBuffer(); }, TypeError);
 for(i = 0; i < typedArrayConstructors.length; i++) {
-  assertThrows(function(i) { typedArrayConstructors[i](); }.bind(this, i),
+  assertThrows((i) => { typedArrayConstructors[i](); }.bind(this, i),
                TypeError);
 }
 
@@ -576,13 +576,13 @@ assertEquals(42, s.byteLength);
 var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength');
 s = new SharedArrayBuffer(10);
 Object.defineProperty(s, 'byteLength', desc);
-assertThrows(function() {s.byteLength}, TypeError);
+assertThrows(() => {s.byteLength}, TypeError);
 
 desc = Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype,
   'byteLength');
 var a = new ArrayBuffer(10);
 Object.defineProperty(a, 'byteLength', desc);
-assertThrows(function() {a.byteLength}, TypeError);
+assertThrows(() => {a.byteLength}, TypeError);
 
 // test SharedArrayBuffer species getter
 assertSame(SharedArrayBuffer[Symbol.species], SharedArrayBuffer);

--- a/deps/v8/test/mjsunit/regress/regress-3926.js
+++ b/deps/v8/test/mjsunit/regress/regress-3926.js
@@ -21,8 +21,8 @@ function f(x) {
   return z;
 }
 assertEquals(2, f(1));
-assertThrows(function() {f(2)}, ReferenceError);
-assertThrows(function() {f(3)}, ReferenceError);
+assertThrows(() => {f(2)}, ReferenceError);
+assertThrows(() => {f(3)}, ReferenceError);
 
 // Ensure that hole checks are done even in subordinate scopes
 assertThrows(function() {
@@ -44,9 +44,9 @@ function g(x) {
     case 1:
       let z;
     case 2:
-      return function() { z = 1; }
+      return () => { z = 1; }
     case 3:
-      return function() { return z; }
+      return () => { return z; }
     case 4:
       return eval("z = 1");
     case 5:
@@ -57,8 +57,8 @@ function g(x) {
 assertEquals(undefined, g(1)());
 assertThrows(g(2), ReferenceError);
 assertThrows(g(3), ReferenceError);
-assertThrows(function () {g(4)}, ReferenceError);
-assertThrows(function () {g(5)}, ReferenceError);
+assertThrows(() => {g(4)}, ReferenceError);
+assertThrows(() => {g(5)}, ReferenceError);
 
 // Ensure the same in strict mode, with different eval and function semantics
 
@@ -68,9 +68,9 @@ function h(x) {
     case 1:
       let z;
     case 2:
-      return function() { z = 1; }
+      return () => { z = 1; }
     case 3:
-      return function() { return z; }
+      return () => { return z; }
     case 4:
       return eval("z = 1");
     case 5:
@@ -81,5 +81,5 @@ function h(x) {
 assertEquals(undefined, h(1)());
 assertThrows(h(2), ReferenceError);
 assertThrows(h(3), ReferenceError);
-assertThrows(function () {h(4)}, ReferenceError);
-assertThrows(function () {h(5)}, ReferenceError);
+assertThrows(() => {h(4)}, ReferenceError);
+assertThrows(() => {h(5)}, ReferenceError);


### PR DESCRIPTION
Replaced some classic functions with arrow functions in test files inside folder `deps/v8/test/mjsunit/`

* deps/v8/test/mjsunit/compare-known-objects-tostringtag.js
* deps/v8/test/mjsunit/compiler/dont-constant-fold-deopting-checks.js
* deps/v8/test/mjsunit/es6/classes.js
* deps/v8/test/mjsunit/es6/typedarray-from.js
* deps/v8/test/mjsunit/es6/typedarray-neutered.js
* deps/v8/test/mjsunit/es6/typedarray.js
* deps/v8/test/mjsunit/harmony/atomics-value-check.js
* deps/v8/test/mjsunit/harmony/private.js
* deps/v8/test/mjsunit/harmony/sharedarraybuffer.js
* deps/v8/test/mjsunit/regress/regress-3926.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
