### PR TITLE
Enhance Cipheriv, Decipheriv coverage

### DIFF
--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -88,7 +88,7 @@ function testCipher3(key, iv) {
                                        'instance when called without `new`');
 
   common.expectsError(
-    () => new Cipheriv(null),
+    () => crypto.createCipheriv(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -96,7 +96,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => new Cipheriv('des-ede3-cbc', null),
+    () => crypto.createCipheriv('des-ede3-cbc', null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -105,7 +105,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => new Cipheriv('des-ede3-cbc', key, null),
+    () => crypto.createCipheriv('des-ede3-cbc', key, null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -124,7 +124,7 @@ function testCipher3(key, iv) {
                                          ' instance when called without `new`');
 
   common.expectsError(
-    () => new Decipheriv(null),
+    () => crypto.createDecipheriv(null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -132,7 +132,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => new Decipheriv('des-ede3-cbc', null),
+    () => crypto.createDecipheriv('des-ede3-cbc', null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
@@ -141,7 +141,7 @@ function testCipher3(key, iv) {
     });
 
   common.expectsError(
-    () => new Decipheriv('des-ede3-cbc', key, null),
+    () => crypto.createDecipheriv('des-ede3-cbc', key, null),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -114,6 +114,42 @@ function testCipher3(key, iv) {
     });
 }
 
+{
+  const Decipheriv = crypto.Decipheriv;
+  const key = '123456789012345678901234';
+  const iv = '12345678';
+
+  const instance = Decipheriv('des-ede3-cbc', key, iv);
+  assert(instance instanceof Decipheriv, 'Decipheriv expected to return a new' +
+                                         ' instance when called without `new`');
+
+  common.expectsError(
+    () => new Decipheriv(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "cipher" argument must be of type string'
+    });
+
+  common.expectsError(
+    () => new Decipheriv('des-ede3-cbc', null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "key" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
+
+  common.expectsError(
+    () => new Decipheriv('des-ede3-cbc', key, null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "iv" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
+}
+
 testCipher1('0123456789abcd0123456789', '12345678');
 testCipher1('0123456789abcd0123456789', Buffer.from('12345678'));
 testCipher1(Buffer.from('0123456789abcd0123456789'), '12345678');

--- a/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -78,6 +78,42 @@ function testCipher3(key, iv) {
          `encryption/decryption with key ${key} and iv ${iv}`);
 }
 
+{
+  const Cipheriv = crypto.Cipheriv;
+  const key = '123456789012345678901234';
+  const iv = '12345678';
+
+  const instance = Cipheriv('des-ede3-cbc', key, iv);
+  assert(instance instanceof Cipheriv, 'Cipheriv is expected to return a new ' +
+                                       'instance when called without `new`');
+
+  common.expectsError(
+    () => new Cipheriv(null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "cipher" argument must be of type string'
+    });
+
+  common.expectsError(
+    () => new Cipheriv('des-ede3-cbc', null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "key" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
+
+  common.expectsError(
+    () => new Cipheriv('des-ede3-cbc', key, null),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "iv" argument must be one of type string, Buffer, ' +
+               'TypedArray, or DataView'
+    });
+}
+
 testCipher1('0123456789abcd0123456789', '12345678');
 testCipher1('0123456789abcd0123456789', Buffer.from('12345678'));
 testCipher1(Buffer.from('0123456789abcd0123456789'), '12345678');


### PR DESCRIPTION
I added these tests:

###### Cipheriv
- Call constructor without new keyword
- Call constructor with cipher is not string
- Call constructor with cipher is string and key is not string
- Call constructor with cipher is strong, key is string and iv is not string

###### Decipheriv
- Call constructor without new keyword
- Call constructor with cipher is not string
- Call constructor with cipher is string and key is not string
- Call constructor with cipher is strong, key is string and iv is not string

Current coverage is here: https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/cipher.js.html

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
