### PR TITLE
build: fix HAVE_OPENSSL macro for cctest

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -864,6 +864,9 @@
             '<(OBJ_PATH)<(OBJ_SEPARATOR)node_crypto_clienthello.<(OBJ_SUFFIX)',
             '<(OBJ_PATH)<(OBJ_SEPARATOR)tls_wrap.<(OBJ_SUFFIX)',
           ],
+          'defines': [
+            'HAVE_OPENSSL=1',
+          ],
         }],
         ['v8_enable_inspector==1', {
           'sources': [


### PR DESCRIPTION
I found this bug while writing tests for nodejs/node#14901, because `Environment::handle_wrap_queue()`, `Environment::req_wrap_queue()` and `Environment::context()`weren't working as expected inside C++ tests.

cctest build target wasn't defining the `HAVE_OPENSSL` macro when `node_use_openssl` was `true`, causing inconsistencies on most `node::Environment` member's addresses (every member defined after `AsyncHooks async_hooks_`). For example, if someone wanted to access the context of an environment by using `Environment::context()`, the object returned by the function was pointing to an invalid address, causing a segmentation fault.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build