### PR TITLE
test: remove hidden use of common.PORT in parallel tests

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -524,7 +524,7 @@ function _mustCallInner(fn, criteria = 1, field) {
 exports.hasMultiLocalhost = function hasMultiLocalhost() {
   const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
   const t = new TCP(TCPConstants.SOCKET);
-  const ret = t.bind('127.0.0.2', exports.PORT);
+  const ret = t.bind('127.0.0.2', 0);
   t.close();
   return ret === 0;
 };


### PR DESCRIPTION
common.hasMultiLocalhost() uses common.PORT under the hood. This is
problematic in parallel tests because another test using port 0 to
get an arbitrary open port may end up getting common.PORT before the
test using common.PORT gets it.

Therefore, change common.PORT to port 0 in common.hasMultiLocalhost().

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test