### PR TITLE
doc: use American spellings per style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ us a report nonetheless.
   level of privilege possible.
 
 - [#12141](https://github.com/nodejs/node/pull/12141): _buffer: zero fill
-  Buffer(num) by default_. The buffer constructor behaviour was documented,
+  Buffer(num) by default_. The buffer constructor behavior was documented,
   but found to be prone to [mis-use](https://snyk.io/blog/exploiting-buffer/).
   It has since been changed, but despite much debate, was not considered misuse
   prone enough to justify fixing in older release lines and breaking our

--- a/common.gypi
+++ b/common.gypi
@@ -169,7 +169,7 @@
         'msvs_settings': {
           'VCCLCompilerTool': {
             'Optimization': 3, # /Ox, full optimization
-            'FavorSizeOrSpeed': 1, # /Ot, favour speed over size
+            'FavorSizeOrSpeed': 1, # /Ot, favor speed over size
             'InlineFunctionExpansion': 2, # /Ob2, inline anything eligible
             'WholeProgramOptimization': 'true', # /GL, whole program optimization, needed for LTCG
             'OmitFramePointers': 'true',

--- a/lib/internal/repl.js
+++ b/lib/internal/repl.js
@@ -35,7 +35,7 @@ function createRepl(env, opts, cb) {
     opts.terminal = false;
   }
   // the "dumb" special terminal, as defined by terminfo, doesn't support
-  // ANSI colour control codes.
+  // ANSI color control codes.
   // see http://invisible-island.net/ncurses/terminfo.ti.html#toc-_Specials
   if (parseInt(env.NODE_DISABLE_COLORS) || env.TERM === 'dumb') {
     opts.useColors = false;

--- a/lib/internal/trace_events_async_hooks.js
+++ b/lib/internal/trace_events_async_hooks.js
@@ -5,7 +5,7 @@ const async_wrap = process.binding('async_wrap');
 const async_hooks = require('async_hooks');
 
 // Use small letters such that chrome://traceing groups by the name.
-// The behaviour is not only useful but the same as the events emitted using
+// The behavior is not only useful but the same as the events emitted using
 // the specific C++ macros.
 const BEFORE_EVENT = 'b'.charCodeAt(0);
 const END_EVENT = 'e'.charCodeAt(0);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -984,7 +984,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                                      is_forward);
 
   if (needle_length == 0) {
-    // Match String#indexOf() and String#lastIndexOf() behaviour.
+    // Match String#indexOf() and String#lastIndexOf() behavior.
     args.GetReturnValue().Set(static_cast<double>(opt_offset));
     return;
   }
@@ -1097,7 +1097,7 @@ void IndexOfBuffer(const FunctionCallbackInfo<Value>& args) {
                                      is_forward);
 
   if (needle_length == 0) {
-    // Match String#indexOf() and String#lastIndexOf() behaviour.
+    // Match String#indexOf() and String#lastIndexOf() behavior.
     args.GetReturnValue().Set(static_cast<double>(opt_offset));
     return;
   }

--- a/test/addons-napi/test_handle_scope/test_handle_scope.c
+++ b/test/addons-napi/test_handle_scope/test_handle_scope.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 // these tests validate the handle scope functions in the normal
-// flow.  Forcing gc behaviour to fully validate they are doing
+// flow.  Forcing gc behavior to fully validate they are doing
 // the right right thing would be quite hard so we keep it
 // simple for now.
 

--- a/test/addons-napi/test_number/test.js
+++ b/test/addons-napi/test_number/test.js
@@ -39,7 +39,7 @@ const num8 = Number.NEGATIVE_INFINITY;
 assert.strictEqual(num8, test_number.Test(num8));
 
 
-// validate documented behaviour when value is retrieved
+// validate documented behavior when value is retrieved
 // as 32 bit integer with napi_get_value_int32
 assert.strictEqual(1, test_number.TestInt32Truncation(4294967297));
 assert.strictEqual(0, test_number.TestInt32Truncation(4294967296));

--- a/test/parallel/test-child-process-spawn-typeerror.js
+++ b/test/parallel/test-child-process-spawn-typeerror.js
@@ -116,7 +116,7 @@ assert.throws(function() { spawn(cmd, s); }, invalidArgTypeError);
 assert.throws(function() { spawn(cmd, a, s); }, invalidArgTypeError);
 
 
-// verify that execFile has same argument parsing behaviour as spawn
+// verify that execFile has same argument parsing behavior as spawn
 //
 // function execFile(file=f [,args=a] [, options=o] [, callback=c]) has valid
 // combinations:
@@ -176,7 +176,7 @@ assert.throws(function() { execFile(cmd, n, o, s); }, invalidArgValueError);
 assert.doesNotThrow(function() { execFile(cmd, c, s); });
 
 
-// verify that fork has same argument parsing behaviour as spawn
+// verify that fork has same argument parsing behavior as spawn
 //
 // function fork(file=f [,args=a] [, options=o]) has valid combinations:
 //   (f)

--- a/test/parallel/test-http2-compat-socket-set.js
+++ b/test/parallel/test-http2-compat-socket-set.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const h2 = require('http2');
 
-// Tests behaviour of the proxied socket in Http2ServerRequest
+// Tests behavior of the proxied socket in Http2ServerRequest
 // & Http2ServerResponse - specifically property setters
 
 const errMsg = {

--- a/test/parallel/test-http2-compat-socket.js
+++ b/test/parallel/test-http2-compat-socket.js
@@ -7,9 +7,9 @@ const assert = require('assert');
 const h2 = require('http2');
 const net = require('net');
 
-// Tests behaviour of the proxied socket in Http2ServerRequest
+// Tests behavior of the proxied socket in Http2ServerRequest
 // & Http2ServerResponse - this proxy socket should mimic the
-// behaviour of http1 but against the http2 api & model
+// behavior of http1 but against the http2 api & model
 
 const errMsg = {
   code: 'ERR_HTTP2_NO_SOCKET_MANIPULATION',

--- a/test/parallel/test-http2-socket-proxy.js
+++ b/test/parallel/test-http2-socket-proxy.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const h2 = require('http2');
 const net = require('net');
 
-// Tests behaviour of the proxied socket on Http2Session
+// Tests behavior of the proxied socket on Http2Session
 
 const errMsg = {
   code: 'ERR_HTTP2_NO_SOCKET_MANIPULATION',

--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -3,7 +3,7 @@
 
 // Note: This is a variant of test-net-write-fully-async-hex-string.js.
 // This always worked, but it seemed appropriate to add a test that checks the
-// behaviour for Buffers, too.
+// behavior for Buffers, too.
 const common = require('../common');
 const net = require('net');
 

--- a/test/parallel/test-path-zero-length-strings.js
+++ b/test/parallel/test-path-zero-length-strings.js
@@ -1,8 +1,8 @@
 'use strict';
 
-// These testcases are specific to one uncommon behaviour in path module. Few
+// These testcases are specific to one uncommon behavior in path module. Few
 // of the functions in path module, treat '' strings as current working
-// directory. This test makes sure that the behaviour is intact between commits.
+// directory. This test makes sure that the behavior is intact between commits.
 // See: https://github.com/nodejs/node/pull/2106
 
 require('../common');

--- a/test/parallel/test-process-kill-pid.js
+++ b/test/parallel/test-process-kill-pid.js
@@ -92,7 +92,7 @@ function kill(tryPid, trySig, expectPid, expectSig) {
 }
 
 // Note that SIGHUP and SIGTERM map to 1 and 15 respectively, even on Windows
-// (for Windows, libuv maps 1 and 15 to the correct behaviour).
+// (for Windows, libuv maps 1 and 15 to the correct behavior).
 
 kill(0, 'SIGHUP', 0, 1);
 kill(0, undefined, 0, 15);

--- a/test/parallel/test-stream3-cork-end.js
+++ b/test/parallel/test-stream3-cork-end.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const stream = require('stream');
 const Writable = stream.Writable;
 
-// Test the buffering behaviour of Writable streams.
+// Test the buffering behavior of Writable streams.
 //
 // The call to cork() triggers storing chunks which are flushed
 // on calling end() and the stream subsequently ended.

--- a/test/parallel/test-stream3-cork-uncork.js
+++ b/test/parallel/test-stream3-cork-uncork.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const stream = require('stream');
 const Writable = stream.Writable;
 
-// Test the buffering behaviour of Writable streams.
+// Test the buffering behavior of Writable streams.
 //
 // The call to cork() triggers storing chunks which are flushed
 // on calling uncork() in the same tick.

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -47,7 +47,7 @@ const inputs = [
   0.5,
   1,
   1.0,
-  2147483648,     // browser behaviour: timeouts > 2^31-1 run on next tick
+  2147483648,     // browser behavior: timeouts > 2^31-1 run on next tick
   12345678901234  // ditto
 ];
 


### PR DESCRIPTION
Getting kind of trivial here, won't mind if this gets rejected for too much churn, although the `README.md` change at least should land, so I figure why not do all the instances...It's not *that* many files. 
¯\\_(ツ)_/¯

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc