### PR TITLE
test: update test-http-status-code to use countdown

### DIFF
--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -23,6 +23,7 @@
 require('../common');
 const assert = require('assert');
 const http = require('http');
+const Countdown = require('../common/countdown');
 
 // Simple test of Node's HTTP ServerResponse.statusCode
 // ServerResponse.prototype.statusCode
@@ -30,6 +31,7 @@ const http = require('http');
 let testsComplete = 0;
 const tests = [200, 202, 300, 404, 451, 500];
 let testIdx = 0;
+const countdown = new Countdown(tests.length, () => s.close());
 
 const s = http.createServer(function(req, res) {
   const t = tests[testIdx];
@@ -43,9 +45,6 @@ s.listen(0, nextTest);
 
 
 function nextTest() {
-  if (testIdx + 1 === tests.length) {
-    return s.close();
-  }
   const test = tests[testIdx];
 
   http.get({ port: s.address().port }, function(response) {
@@ -55,7 +54,8 @@ function nextTest() {
     response.on('end', function() {
       testsComplete++;
       testIdx += 1;
-      nextTest();
+      if (countdown.dec())
+        nextTest();
     });
     response.resume();
   });
@@ -63,5 +63,5 @@ function nextTest() {
 
 
 process.on('exit', function() {
-  assert.strictEqual(5, testsComplete);
+  assert.strictEqual(6, testsComplete);
 });

--- a/test/parallel/test-http-status-code.js
+++ b/test/parallel/test-http-status-code.js
@@ -28,16 +28,14 @@ const Countdown = require('../common/countdown');
 // Simple test of Node's HTTP ServerResponse.statusCode
 // ServerResponse.prototype.statusCode
 
-let testsComplete = 0;
 const tests = [200, 202, 300, 404, 451, 500];
-let testIdx = 0;
+let test;
 const countdown = new Countdown(tests.length, () => s.close());
 
 const s = http.createServer(function(req, res) {
-  const t = tests[testIdx];
-  res.writeHead(t, { 'Content-Type': 'text/plain' });
+  res.writeHead(test, { 'Content-Type': 'text/plain' });
   console.log(`--\nserver: statusCode after writeHead: ${res.statusCode}`);
-  assert.strictEqual(res.statusCode, t);
+  assert.strictEqual(res.statusCode, test);
   res.end('hello world\n');
 });
 
@@ -45,23 +43,16 @@ s.listen(0, nextTest);
 
 
 function nextTest() {
-  const test = tests[testIdx];
+  test = tests.shift();
 
   http.get({ port: s.address().port }, function(response) {
     console.log(`client: expected status: ${test}`);
     console.log(`client: statusCode: ${response.statusCode}`);
     assert.strictEqual(response.statusCode, test);
     response.on('end', function() {
-      testsComplete++;
-      testIdx += 1;
       if (countdown.dec())
         nextTest();
     });
     response.resume();
   });
 }
-
-
-process.on('exit', function() {
-  assert.strictEqual(6, testsComplete);
-});


### PR DESCRIPTION
The test was changed to use countdown instead of validating
if the index of the array of codes exceeded the size of the
array.

Also the validation that was before didn't allow to execute
the last test, so the assert equal was to 5, and the last
status in the array wasn't tested. The change was to
assert 6 tests complete.

Refs: https://github.com/nodejs/node/issues/17169

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
