### PR TITLE
tls: unconsume stream on destroy

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -102,6 +102,10 @@ TLSWrap::~TLSWrap() {
   sni_context_.Reset();
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
+  // See test/parallel/test-tls-transport-destroy-after-own-gc.js:
+  // If this TLSWrap is garbage collected, we cannot allow callbacks to be
+  // called on this stream.
+
   if (stream_ == nullptr)
     return;
   stream_->set_destruct_cb({ nullptr, nullptr });

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -101,6 +101,15 @@ TLSWrap::~TLSWrap() {
 #ifdef SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
   sni_context_.Reset();
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
+
+  if (stream_ == nullptr)
+    return;
+  stream_->set_destruct_cb({ nullptr, nullptr });
+  stream_->set_after_write_cb({ nullptr, nullptr });
+  stream_->set_alloc_cb({ nullptr, nullptr });
+  stream_->set_read_cb({ nullptr, nullptr });
+  stream_->set_destruct_cb({ nullptr, nullptr });
+  stream_->Unconsume();
 }
 
 
@@ -564,12 +573,16 @@ uint32_t TLSWrap::UpdateWriteQueueSize(uint32_t write_queue_size) {
 
 
 int TLSWrap::ReadStart() {
-  return stream_->ReadStart();
+  if (stream_ != nullptr)
+    return stream_->ReadStart();
+  return 0;
 }
 
 
 int TLSWrap::ReadStop() {
-  return stream_->ReadStop();
+  if (stream_ != nullptr)
+    return stream_->ReadStop();
+  return 0;
 }
 
 

--- a/test/parallel/test-tls-transport-destroy-after-own-gc.js
+++ b/test/parallel/test-tls-transport-destroy-after-own-gc.js
@@ -1,0 +1,32 @@
+// Flags: --expose-gc
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/17475
+// Unfortunately, this tests only "works" reliably when checked with valgrind or
+// a similar tool.
+
+/* eslint-disable no-unused-vars */
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { TLSSocket } = require('tls');
+const makeDuplexPair = require('../common/duplexpair');
+
+let { clientSide } = makeDuplexPair();
+
+let clientTLS = new TLSSocket(clientSide, { isServer: false });
+let clientTLSHandle = clientTLS._handle;
+
+setImmediate(() => {
+  clientTLS = null;
+  global.gc();
+  clientTLSHandle = null;
+  global.gc();
+  setImmediate(() => {
+    clientSide = null;
+    global.gc();
+  });
+});

--- a/test/parallel/test-tls-transport-destroy-after-own-gc.js
+++ b/test/parallel/test-tls-transport-destroy-after-own-gc.js
@@ -5,19 +5,17 @@
 // Unfortunately, this tests only "works" reliably when checked with valgrind or
 // a similar tool.
 
-/* eslint-disable no-unused-vars */
-
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const { TLSSocket } = require('tls');
 const makeDuplexPair = require('../common/duplexpair');
 
 let { clientSide } = makeDuplexPair();
 
 let clientTLS = new TLSSocket(clientSide, { isServer: false });
+// eslint-disable-next-line no-unused-vars
 let clientTLSHandle = clientTLS._handle;
 
 setImmediate(() => {


### PR DESCRIPTION
When the TLS stream is destroyed for whatever reason,
we should unset all callbacks on the underlying transport
stream.

Fixes ~~Refs (maybe Fixes)~~: https://github.com/nodejs/node/issues/17475

@indutny Could you take a look at this?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tls