### PR TITLE
tools: remove space in man pages linking regex

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -416,7 +416,7 @@ const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 // '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
 function linkManPages(text) {
   return text.replace(
-    / ([a-z.]+)\((\d)([a-z]?)\)/gm,
+    /([a-z.]+)\((\d)([a-z]?)\)/gm,
     (match, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
       const displayAs = `${name}(${number}${optionalCharacter})`;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -416,7 +416,7 @@ const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 // '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
 function linkManPages(text) {
   return text.replace(
-    /([a-z.]+)\((\d)([a-z]?)\)/gm,
+    /\b([a-z.]+)\((\d)([a-z]?)\)/gm,
     (match, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
       const displayAs = `${name}(${number}${optionalCharacter})`;


### PR DESCRIPTION
Removes space in regex for man pages linking in docs generation

##### Checklist

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools

Stumbled upon signal(7) no being linked in [child_process ](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) because in the markdown file it happens to be the start of the line, so there's no space.