### PR TITLE
refactor: replace assert.throws in tests with common.expectsError

### DIFF
--- a/test/parallel/test-async-hooks-asyncresource-constructor.js
+++ b/test/parallel/test-async-hooks-asyncresource-constructor.js
@@ -3,7 +3,6 @@
 // This tests that AsyncResource throws an error if bad parameters are passed
 
 const common = require('../common');
-const assert = require('assert');
 const async_hooks = require('async_hooks');
 const { AsyncResource } = async_hooks;
 
@@ -12,30 +11,30 @@ async_hooks.createHook({
   init() {}
 }).enable();
 
-assert.throws(() => {
+common.expectsError(() => {
   return new AsyncResource();
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   new AsyncResource('');
-}, common.expectsError({
+}, {
   code: 'ERR_ASYNC_TYPE',
   type: TypeError,
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   new AsyncResource('type', -4);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ASYNC_ID',
   type: RangeError,
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   new AsyncResource('type', Math.PI);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ASYNC_ID',
   type: RangeError,
-}));
+});

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -3,17 +3,16 @@
 // This tests that using falsy values in createHook throws an error.
 
 const common = require('../common');
-const assert = require('assert');
 const async_hooks = require('async_hooks');
 
 for (const badArg of [0, 1, false, true, null, 'hello']) {
   const hookNames = ['init', 'before', 'after', 'destroy', 'promiseResolve'];
   for (const field of hookNames) {
-    assert.throws(() => {
+    common.expectsError(() => {
       async_hooks.createHook({ [field]: badArg });
-    }, common.expectsError({
+    }, {
       code: 'ERR_ASYNC_CALLBACK',
       type: TypeError,
-    }));
+    });
   }
 }

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -887,12 +887,14 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
 }
 
 // Regression test for #5482: should throw but not assert in C++ land.
-assert.throws(() => Buffer.from('', 'buffer'),
-              common.expectsError({
-                code: 'ERR_UNKNOWN_ENCODING',
-                type: TypeError,
-                message: 'Unknown encoding: buffer'
-              }));
+common.expectsError(
+  () => Buffer.from('', 'buffer'),
+  {
+    code: 'ERR_UNKNOWN_ENCODING',
+    type: TypeError,
+    message: 'Unknown encoding: buffer'
+  }
+);
 
 // Regression test for #6111. Constructing a buffer from another buffer
 // should a) work, and b) not corrupt the source buffer.

--- a/test/parallel/test-buffer-arraybuffer.js
+++ b/test/parallel/test-buffer-arraybuffer.js
@@ -65,16 +65,16 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer.from(ab.buffer, 6), common.expectsError({
+  common.expectsError(() => Buffer.from(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"offset" is outside of buffer bounds'
-  }));
-  assert.throws(() => Buffer.from(ab.buffer, 3, 6), common.expectsError({
+  });
+  common.expectsError(() => Buffer.from(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"length" is outside of buffer bounds'
-  }));
+  });
 }
 
 // Test the deprecated Buffer() version also
@@ -93,16 +93,16 @@ b.writeDoubleBE(11.11, 0, true);
   buf[0] = 9;
   assert.strictEqual(ab[1], 9);
 
-  assert.throws(() => Buffer(ab.buffer, 6), common.expectsError({
+  common.expectsError(() => Buffer(ab.buffer, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"offset" is outside of buffer bounds'
-  }));
-  assert.throws(() => Buffer(ab.buffer, 3, 6), common.expectsError({
+  });
+  common.expectsError(() => Buffer(ab.buffer, 3, 6), {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"length" is outside of buffer bounds'
-  }));
+  });
 }
 
 {
@@ -118,13 +118,13 @@ b.writeDoubleBE(11.11, 0, true);
   assert.deepStrictEqual(Buffer.from(ab, [1]), Buffer.from(ab, 1));
 
   // If byteOffset is Infinity, throw.
-  assert.throws(() => {
+  common.expectsError(() => {
     Buffer.from(ab, Infinity);
-  }, common.expectsError({
+  }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"offset" is outside of buffer bounds'
-  }));
+  });
 }
 
 {
@@ -140,11 +140,11 @@ b.writeDoubleBE(11.11, 0, true);
   assert.deepStrictEqual(Buffer.from(ab, 0, [1]), Buffer.from(ab, 0, 1));
 
   //If length is Infinity, throw.
-  assert.throws(() => {
+  common.expectsError(() => {
     Buffer.from(ab, 0, Infinity);
-  }, common.expectsError({
+  }, {
     code: 'ERR_BUFFER_OUT_OF_BOUNDS',
     type: RangeError,
     message: '"length" is outside of buffer bounds'
-  }));
+  });
 }

--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -66,9 +66,9 @@ assert.throws(() => a.compare(b, 0, '0xff'), oor);
 assert.throws(() => a.compare(b, 0, Infinity), oor);
 assert.throws(() => a.compare(b, 0, 1, -1), oor);
 assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
-assert.throws(() => a.compare(), common.expectsError({
+common.expectsError(() => a.compare(), {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "target" argument must be one of ' +
            'type Buffer or Uint8Array. Received type undefined'
-}));
+});

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -38,9 +38,9 @@ assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), errMsg);
 
 assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), errMsg);
 
-assert.throws(() => Buffer.alloc(1).compare('abc'), common.expectsError({
+common.expectsError(() => Buffer.alloc(1).compare('abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "target" argument must be one of ' +
            'type Buffer or Uint8Array. Received type string'
-}));
+});

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -52,14 +52,14 @@ assertWrongList(['hello', 'world']);
 assertWrongList(['hello', Buffer.from('world')]);
 
 function assertWrongList(value) {
-  assert.throws(() => {
+  common.expectsError(() => {
     Buffer.concat(value);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "list" argument must be one of type ' +
              'Array, Buffer, or Uint8Array'
-  }));
+  });
 }
 
 // eslint-disable-next-line crypto-check

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -303,12 +303,12 @@ function testBufs(string, offset, length, encoding) {
 }
 
 // Make sure these throw.
-assert.throws(
+common.expectsError(
   () => Buffer.allocUnsafe(8).fill('a', -1),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
-assert.throws(
+  { code: 'ERR_INDEX_OUT_OF_RANGE' });
+common.expectsError(
   () => Buffer.allocUnsafe(8).fill('a', 0, 9),
-  common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' }));
+  { code: 'ERR_INDEX_OUT_OF_RANGE' });
 
 // Make sure this doesn't hang indefinitely.
 Buffer.allocUnsafe(8).fill('');
@@ -357,7 +357,7 @@ Buffer.alloc(8, '');
 // magically mangled using Symbol.toPrimitive.
 {
   let elseWasLast = false;
-  assert.throws(() => {
+  common.expectsError(() => {
     let ctr = 0;
     const start = {
       [Symbol.toPrimitive]() {
@@ -374,8 +374,9 @@ Buffer.alloc(8, '');
       }
     };
     Buffer.alloc(1).fill(Buffer.alloc(1), start, 1);
-  }, common.expectsError(
-    { code: undefined, type: RangeError, message: 'Index out of range' }));
+  }, {
+    code: undefined, type: RangeError, message: 'Index out of range'
+  });
   // Make sure -1 is making it to Buffer::Fill().
   assert.ok(elseWasLast,
             'internal API changed, -1 no longer in correct location');
@@ -383,16 +384,17 @@ Buffer.alloc(8, '');
 
 // Testing process.binding. Make sure "start" is properly checked for -1 wrap
 // around.
-assert.throws(() => {
+common.expectsError(() => {
   process.binding('buffer').fill(Buffer.alloc(1), 1, -1, 0, 1);
-}, common.expectsError(
-  { code: undefined, type: RangeError, message: 'Index out of range' }));
+}, {
+  code: undefined, type: RangeError, message: 'Index out of range'
+});
 
 // Make sure "end" is properly checked, even if it's magically mangled using
 // Symbol.toPrimitive.
 {
   let elseWasLast = false;
-  assert.throws(() => {
+  common.expectsError(() => {
     let ctr = 0;
     const end = {
       [Symbol.toPrimitive]() {
@@ -409,8 +411,9 @@ assert.throws(() => {
       }
     };
     Buffer.alloc(1).fill(Buffer.alloc(1), 0, end);
-  }, common.expectsError(
-    { code: undefined, type: RangeError, message: 'Index out of range' }));
+  }, {
+    code: undefined, type: RangeError, message: 'Index out of range'
+  });
   // Make sure -1 is making it to Buffer::Fill().
   assert.ok(elseWasLast,
             'internal API changed, -1 no longer in correct location');

--- a/test/parallel/test-buffer-new.js
+++ b/test/parallel/test-buffer-new.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 
-assert.throws(() => new Buffer(42, 'utf8'), common.expectsError({
+common.expectsError(() => new Buffer(42, 'utf8'), {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "string" argument must be of type string. Received type number'
-}));
+});

--- a/test/parallel/test-buffer-read.js
+++ b/test/parallel/test-buffer-read.js
@@ -8,9 +8,11 @@ const buf = Buffer.from([0xa4, 0xfd, 0x48, 0xea, 0xcf, 0xff, 0xd9, 0x01, 0xde]);
 function read(buff, funx, args, expected) {
 
   assert.strictEqual(buff[funx](...args), expected);
-  assert.throws(
+  common.expectsError(
     () => buff[funx](-1),
-    common.expectsError({ code: 'ERR_INDEX_OUT_OF_RANGE' })
+    {
+      code: 'ERR_INDEX_OUT_OF_RANGE'
+    }
   );
 
   assert.doesNotThrow(


### PR DESCRIPTION
Refactored tests to replace `assert.throws(fn, common.expectsError(err));` with `common.expectsError(fn, err);` in following test files :

* test/parallel/test-async-hooks-asyncresource-constructor.js
* test/parallel/test-async-wrap-constructor.js
* test/parallel/test-buffer-alloc.js
* test/parallel/test-buffer-arraybuffer.js
* test/parallel/test-buffer-compare-offset.js
* test/parallel/test-buffer-compare.js
* test/parallel/test-buffer-concat.js
* test/parallel/test-buffer-fill.js
* test/parallel/test-buffer-new.js
* test/parallel/test-buffer-read.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
