### PR TITLE
test: Use common.expectsError in tests

### DIFF
--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -58,13 +58,13 @@ const bufferMaxSizeMsg = common.expectsError({
 assert.throws(function() {
   SlowBuffer(Infinity);
 }, bufferMaxSizeMsg);
-assert.throws(function() {
+common.expectsError(function() {
   SlowBuffer(-1);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_OPT_VALUE',
   type: RangeError,
   message: 'The value "-1" is invalid for option "size"'
-}));
+});
 
 assert.throws(function() {
   SlowBuffer(buffer.kMaxLength + 1);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -84,17 +84,17 @@ assert.strictEqual(rangeBuffer.toString({ toString: function() {
 } }), 'abc');
 
 // try toString() with 0 and null as the encoding
-assert.throws(() => {
+common.expectsError(() => {
   rangeBuffer.toString(0, 1, 2);
-}, common.expectsError({
+}, {
   code: 'ERR_UNKNOWN_ENCODING',
   type: TypeError,
   message: 'Unknown encoding: 0'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   rangeBuffer.toString(null, 1, 2);
-}, common.expectsError({
+}, {
   code: 'ERR_UNKNOWN_ENCODING',
   type: TypeError,
   message: 'Unknown encoding: null'
-}));
+});

--- a/test/parallel/test-child-process-send-type-error.js
+++ b/test/parallel/test-child-process-send-type-error.js
@@ -5,9 +5,9 @@ const assert = require('assert');
 const cp = require('child_process');
 
 function fail(proc, args) {
-  assert.throws(() => {
+  common.expectsError(() => {
     proc.send.apply(proc, args);
-  }, common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }));
+  }, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError });
 }
 
 let target = process;

--- a/test/parallel/test-child-process-spawnsync-kill-signal.js
+++ b/test/parallel/test-child-process-spawnsync-kill-signal.js
@@ -29,9 +29,9 @@ if (process.argv[2] === 'child') {
   }
 
   // Verify that an error is thrown for unknown signals.
-  assert.throws(() => {
+  common.expectsError(() => {
     spawn('SIG_NOT_A_REAL_SIGNAL');
-  }, common.expectsError({ code: 'ERR_UNKNOWN_SIGNAL', type: TypeError }));
+  }, { code: 'ERR_UNKNOWN_SIGNAL', type: TypeError });
 
   // Verify that the default kill signal is SIGTERM.
   {

--- a/test/parallel/test-child-process-stdio.js
+++ b/test/parallel/test-child-process-stdio.js
@@ -40,6 +40,6 @@ options = { stdio: 'ignore' };
 child = spawnSync('cat', [], options);
 assert.deepStrictEqual(options, { stdio: 'ignore' });
 
-assert.throws(() => {
+common.expectsError(() => {
   common.spawnPwd({ stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'ipc'] });
-}, common.expectsError({ code: 'ERR_IPC_ONE_PIPE', type: Error }));
+}, { code: 'ERR_IPC_ONE_PIPE', type: Error });

--- a/test/parallel/test-child-process-validate-stdio.js
+++ b/test/parallel/test-child-process-validate-stdio.js
@@ -26,8 +26,9 @@ assert.throws(() => _validateStdio(600), expectedError);
 
 // should throw if stdio has ipc and sync is true
 const stdio2 = ['ipc', 'ipc', 'ipc'];
-assert.throws(() => _validateStdio(stdio2, true),
-              common.expectsError({ code: 'ERR_IPC_SYNC_FORK', type: Error }));
+common.expectsError(() => _validateStdio(stdio2, true),
+                    { code: 'ERR_IPC_SYNC_FORK', type: Error }
+);
 
 {
   const stdio3 = [process.stdin, process.stdout, process.stderr];

--- a/test/parallel/test-common.js
+++ b/test/parallel/test-common.js
@@ -45,12 +45,12 @@ assert.throws(function() {
 }, /^TypeError: Invalid minimum value: \/foo\/$/);
 
 // assert.fail() tests
-assert.throws(
+common.expectsError(
   () => { assert.fail('fhqwhgads'); },
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: /^fhqwhgads$/
-  }));
+  });
 
 const fnOnce = common.mustCall(() => {});
 fnOnce();

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -37,13 +37,13 @@ assert.strictEqual('function', typeof Console);
 
 // make sure that the Console constructor throws
 // when not given a writable stream instance
-assert.throws(
+common.expectsError(
   () => { new Console(); },
-  common.expectsError({
+  {
     code: 'ERR_CONSOLE_WRITABLE_STREAM',
     type: TypeError,
     message: /stdout/
-  })
+  }
 );
 
 // Console constructor should throw if stderr exists but is not writable

--- a/test/parallel/test-dgram-bind.js
+++ b/test/parallel/test-dgram-bind.js
@@ -27,13 +27,13 @@ const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 
 socket.on('listening', common.mustCall(() => {
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.bind();
-  }, common.expectsError({
+  }, {
     code: 'ERR_SOCKET_ALREADY_BOUND',
     type: Error,
     message: /^Socket is already bound$/
-  }));
+  });
 
   socket.close();
 }));

--- a/test/parallel/test-dgram-create-socket-handle.js
+++ b/test/parallel/test-dgram-create-socket-handle.js
@@ -6,12 +6,12 @@ const UDP = process.binding('udp_wrap').UDP;
 const _createSocketHandle = dgram._createSocketHandle;
 
 // Throws if an "existing fd" is passed in.
-assert.throws(() => {
+common.expectsError(() => {
   _createSocketHandle(common.localhostIPv4, 0, 'udp4', 42);
-}, common.expectsError({
+}, {
   code: 'ERR_ASSERTION',
   message: /^false == true$/
-}));
+});
 
 {
   // Create a handle that is not bound.


### PR DESCRIPTION
Refactored tests to replace `assert.throws(fn, common.expectsError(err))`; with `common.expectsError(fn, err);` in following test files :

* test/parallel/test-buffer-slow.js
* test/parallel/test-buffer-tostring-range.js
* test/parallel/test-child-process-send-type-error.js
* test/parallel/test-child-process-spawnsync-kill-signal.js
* test/parallel/test-child-process-stdio.js
* test/parallel/test-child-process-validate-stdio.js
* test/parallel/test-common.js
* test/parallel/test-console-instance.js
* test/parallel/test-dgram-bind.js
* test/parallel/test-dgram-create-socket-handle.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
