### PR TITLE
fs: ES6 Spread Operator for extended parameter handling

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -145,8 +145,8 @@ function makeCallback(cb) {
     throw new errors.TypeError('ERR_INVALID_CALLBACK');
   }
 
-  return function() {
-    return cb.apply(undefined, arguments);
+  return function(...args) {
+    return Reflect.apply(cb, undefined, args);
   };
 }
 


### PR DESCRIPTION
Replaced `f.apply(undefined, arguments) ` to ES 6 `f(...arguments)` Extended Parameter Handling Spread Operator in `lib/fs.js`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs
