### PR TITLE
lib: refactored to use ES6 method notation

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -111,10 +111,10 @@ util.inherits(OutgoingMessage, Stream);
 
 
 Object.defineProperty(OutgoingMessage.prototype, '_headers', {
-  get: function() {
+  get() {
     return this.getHeaders();
   },
-  set: function(val) {
+  set(val) {
     if (val == null) {
       this[outHeadersKey] = null;
     } else if (typeof val === 'object') {
@@ -129,7 +129,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headers', {
 });
 
 Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
-  get: function() {
+  get() {
     const headers = this[outHeadersKey];
     if (headers) {
       const out = Object.create(null);
@@ -144,7 +144,7 @@ Object.defineProperty(OutgoingMessage.prototype, '_headerNames', {
       return headers;
     }
   },
-  set: function(val) {
+  set(val) {
     if (typeof val === 'object' && val !== null) {
       const headers = this[outHeadersKey];
       if (!headers)
@@ -618,7 +618,7 @@ OutgoingMessage.prototype._implicitHeader = function _implicitHeader() {
 Object.defineProperty(OutgoingMessage.prototype, 'headersSent', {
   configurable: true,
   enumerable: true,
-  get: function() { return !!this._header; }
+  get() { return !!this._header; }
 });
 
 

--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -69,7 +69,7 @@ Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function() {
+  get() {
     return this._writableState.highWaterMark;
   }
 });

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -920,7 +920,7 @@ Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function() {
+  get() {
     return this._readableState.highWaterMark;
   }
 });

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -177,7 +177,7 @@ var realHasInstance;
 if (typeof Symbol === 'function' && Symbol.hasInstance) {
   realHasInstance = Function.prototype[Symbol.hasInstance];
   Object.defineProperty(Writable, Symbol.hasInstance, {
-    value: function(object) {
+    value(object) {
       if (realHasInstance.call(this, object))
         return true;
       if (this !== Writable)
@@ -340,7 +340,7 @@ Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
   // because otherwise some prototype manipulation in
   // userland will fail
   enumerable: false,
-  get: function() {
+  get() {
     return this._writableState.highWaterMark;
   }
 });

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -376,7 +376,7 @@ CryptoStream.prototype.setKeepAlive = function(enable, initialDelay) {
 Object.defineProperty(CryptoStream.prototype, 'bytesWritten', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket ? this.socket.bytesWritten : 0;
   }
 });
@@ -504,7 +504,7 @@ CryptoStream.prototype._done = function() {
 // readyState is deprecated. Don't use it.
 // Deprecation Code: DEP0004
 Object.defineProperty(CryptoStream.prototype, 'readyState', {
-  get: function() {
+  get() {
     if (this.connecting) {
       return 'opening';
     } else if (this.readable && this.writable) {
@@ -527,10 +527,10 @@ function CleartextStream(pair, options) {
   // on top of net Sockets
   var self = this;
   this._handle = {
-    readStop: function() {
+    readStop() {
       self._reading = false;
     },
-    readStart: function() {
+    readStart() {
       if (self._reading && self._readableState.length > 0) return;
       self._reading = true;
       self.read(0);
@@ -557,7 +557,7 @@ CleartextStream.prototype.address = function() {
 Object.defineProperty(CleartextStream.prototype, 'remoteAddress', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket && this.socket.remoteAddress;
   }
 });
@@ -565,7 +565,7 @@ Object.defineProperty(CleartextStream.prototype, 'remoteAddress', {
 Object.defineProperty(CleartextStream.prototype, 'remoteFamily', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket && this.socket.remoteFamily;
   }
 });
@@ -573,7 +573,7 @@ Object.defineProperty(CleartextStream.prototype, 'remoteFamily', {
 Object.defineProperty(CleartextStream.prototype, 'remotePort', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket && this.socket.remotePort;
   }
 });
@@ -581,7 +581,7 @@ Object.defineProperty(CleartextStream.prototype, 'remotePort', {
 Object.defineProperty(CleartextStream.prototype, 'localAddress', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket && this.socket.localAddress;
   }
 });
@@ -589,7 +589,7 @@ Object.defineProperty(CleartextStream.prototype, 'localAddress', {
 Object.defineProperty(CleartextStream.prototype, 'localPort', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     return this.socket && this.socket.localPort;
   }
 });

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -36,10 +36,10 @@ const { createHook } = require('async_hooks');
 var _domain = [null];
 Object.defineProperty(process, 'domain', {
   enumerable: true,
-  get: function() {
+  get() {
     return _domain[0];
   },
-  set: function(arg) {
+  set(arg) {
     return _domain[0] = arg;
   }
 });

--- a/lib/events.js
+++ b/lib/events.js
@@ -47,10 +47,10 @@ function lazyErrors() {
 
 Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
   enumerable: true,
-  get: function() {
+  get() {
     return defaultMaxListeners;
   },
-  set: function(arg) {
+  set(arg) {
     // check whether the input is a positive number (whose value is zero or
     // greater and not a NaN).
     if (typeof arg !== 'number' || arg < 0 || arg !== arg) {

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -40,11 +40,11 @@ const handleConversion = {
   'net.Native': {
     simultaneousAccepts: true,
 
-    send: function(message, handle, options) {
+    send(message, handle, options) {
       return handle;
     },
 
-    got: function(message, handle, emit) {
+    got(message, handle, emit) {
       emit(handle);
     }
   },
@@ -52,11 +52,11 @@ const handleConversion = {
   'net.Server': {
     simultaneousAccepts: true,
 
-    send: function(message, server, options) {
+    send(message, server, options) {
       return server._handle;
     },
 
-    got: function(message, handle, emit) {
+    got(message, handle, emit) {
       var server = new net.Server();
       server.listen(handle, function() {
         emit(server);
@@ -65,7 +65,7 @@ const handleConversion = {
   },
 
   'net.Socket': {
-    send: function(message, socket, options) {
+    send(message, socket, options) {
       if (!socket._handle)
         return;
 
@@ -99,7 +99,7 @@ const handleConversion = {
       return handle;
     },
 
-    postSend: function(message, handle, options, callback, target) {
+    postSend(message, handle, options, callback, target) {
       // Store the handle after successfully sending it, so it can be closed
       // when the NODE_HANDLE_ACK is received. If the handle could not be sent,
       // just close it.
@@ -117,7 +117,7 @@ const handleConversion = {
       }
     },
 
-    got: function(message, handle, emit) {
+    got(message, handle, emit) {
       var socket = new net.Socket({ handle: handle });
       socket.readable = socket.writable = true;
 
@@ -138,11 +138,11 @@ const handleConversion = {
   'dgram.Native': {
     simultaneousAccepts: false,
 
-    send: function(message, handle, options) {
+    send(message, handle, options) {
       return handle;
     },
 
-    got: function(message, handle, emit) {
+    got(message, handle, emit) {
       emit(handle);
     }
   },
@@ -150,13 +150,13 @@ const handleConversion = {
   'dgram.Socket': {
     simultaneousAccepts: false,
 
-    send: function(message, socket, options) {
+    send(message, socket, options) {
       message.dgramType = socket.type;
 
       return socket._handle;
     },
 
-    got: function(message, handle, emit) {
+    got(message, handle, emit) {
       var socket = new dgram.Socket(message.dgramType);
 
       socket.bind(handle, function() {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2037,7 +2037,7 @@ const setTimeout = {
   configurable: true,
   enumerable: true,
   writable: true,
-  value: function(msecs, callback) {
+  value(msecs, callback) {
     if (typeof msecs !== 'number') {
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
                                  'msecs',

--- a/lib/net.js
+++ b/lib/net.js
@@ -456,14 +456,14 @@ Socket.prototype.address = function() {
 
 
 Object.defineProperty(Socket.prototype, '_connecting', {
-  get: function() {
+  get() {
     return this.connecting;
   }
 });
 
 
 Object.defineProperty(Socket.prototype, 'readyState', {
-  get: function() {
+  get() {
     if (this.connecting) {
       return 'opening';
     } else if (this.readable && this.writable) {
@@ -480,7 +480,7 @@ Object.defineProperty(Socket.prototype, 'readyState', {
 
 
 Object.defineProperty(Socket.prototype, 'bufferSize', {
-  get: function() {
+  get() {
     if (this._handle) {
       return this._handle.writeQueueSize + this._writableState.length;
     }
@@ -1539,7 +1539,7 @@ function lookupAndListen(self, port, address, backlog, exclusive) {
 }
 
 Object.defineProperty(Server.prototype, 'listening', {
-  get: function() {
+  get() {
     return !!this._handle;
   },
   configurable: true,

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -228,7 +228,7 @@ inherits(Interface, EventEmitter);
 Object.defineProperty(Interface.prototype, 'columns', {
   configurable: true,
   enumerable: true,
-  get: function() {
+  get() {
     var columns = Infinity;
     if (this.output && this.output.columns)
       columns = this.output.columns;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1333,7 +1333,7 @@ function _turnOffEditorMode(repl) {
 function defineDefaultCommands(repl) {
   repl.defineCommand('break', {
     help: 'Sometimes you get stuck, this gets you out',
-    action: function() {
+    action() {
       this.clearBufferedCommand();
       this.displayPrompt();
     }
@@ -1347,7 +1347,7 @@ function defineDefaultCommands(repl) {
   }
   repl.defineCommand('clear', {
     help: clearMessage,
-    action: function() {
+    action() {
       this.clearBufferedCommand();
       if (!this.useGlobal) {
         this.outputStream.write('Clearing context...\n');
@@ -1359,14 +1359,14 @@ function defineDefaultCommands(repl) {
 
   repl.defineCommand('exit', {
     help: 'Exit the repl',
-    action: function() {
+    action() {
       this.close();
     }
   });
 
   repl.defineCommand('help', {
     help: 'Print this help message',
-    action: function() {
+    action() {
       const names = Object.keys(this.commands).sort();
       const longestNameLength = names.reduce(
         (max, name) => Math.max(max, name.length),
@@ -1385,7 +1385,7 @@ function defineDefaultCommands(repl) {
 
   repl.defineCommand('save', {
     help: 'Save all evaluated commands in this REPL session to a file',
-    action: function(file) {
+    action(file) {
       try {
         fs.writeFileSync(file, this.lines.join('\n') + '\n');
         this.outputStream.write('Session saved to:' + file + '\n');
@@ -1398,7 +1398,7 @@ function defineDefaultCommands(repl) {
 
   repl.defineCommand('load', {
     help: 'Load JS from a file into the REPL session',
-    action: function(file) {
+    action(file) {
       try {
         var stats = fs.statSync(file);
         if (stats && stats.isFile()) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -664,7 +664,7 @@ function createProperty(ctor) {
   return {
     configurable: true,
     enumerable: true,
-    value: function(options) {
+    value(options) {
       return new ctor(options);
     }
   };


### PR DESCRIPTION
Refactored to use ES6 method notation in object property definitions

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
lib, lib/internal
