### PR TITLE
src: remove unused variable in node_contextify

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -629,7 +629,6 @@ class ContextifyScript : public BaseObject {
     MaybeLocal<String> filename = GetFilenameArg(env, options);
     MaybeLocal<Integer> lineOffset = GetLineOffsetArg(env, options);
     MaybeLocal<Integer> columnOffset = GetColumnOffsetArg(env, options);
-    Maybe<bool> maybe_display_errors = GetDisplayErrorsArg(env, options);
     MaybeLocal<Uint8Array> cached_data_buf = GetCachedData(env, options);
     Maybe<bool> maybe_produce_cached_data = GetProduceCachedData(env, options);
     MaybeLocal<Context> maybe_context = GetContext(env, options);
@@ -639,7 +638,6 @@ class ContextifyScript : public BaseObject {
       return;
     }
 
-    bool display_errors = maybe_display_errors.ToChecked();
     bool produce_cached_data = maybe_produce_cached_data.ToChecked();
 
     ScriptCompiler::CachedData* cached_data = nullptr;


### PR DESCRIPTION
Currently the following warning is show when building:
```console
../src/node_contextify.cc:642:10:
warning: unused variable 'display_errors' [-Wunused-variable]

    bool display_errors = maybe_display_errors.ToChecked();
```
This commit removes the unused variable which became unused in commit
aeddc36 ("src: remove tracking for exception arrow data").

Refs: https://github.com/nodejs/node/pull/17394

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src