### PR TITLE
 tools,doc: lint for additional strings in docs

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -89,7 +89,7 @@ change. In the case of pull requests proposed by an existing
 Collaborator, an additional Collaborator is required for sign-off.
 
 In some cases, it may be necessary to summon a qualified Collaborator
-or a Github team to a pull request for review by @-mention.
+or a GitHub team to a pull request for review by @-mention.
 [See "Who to CC in issues"](./doc/onboarding-extras.md#who-to-cc-in-issues)
 
 If you are unsure about the modification and are not prepared to take
@@ -156,7 +156,7 @@ or documentation.
 * [`citgm-smoker`](https://ci.nodejs.org/job/citgm-smoker/)
 uses [`CitGM`](https://github.com/nodejs/citgm) to allow you to run `npm install && npm test`
 on a large selection of common modules. This is useful to check whether a
-change will cause breakage in the ecosystem. To test Node.JS ABI changes
+change will cause breakage in the ecosystem. To test Node.js ABI changes
 you can run [`citgm-abi-smoker`](https://ci.nodejs.org/job/citgm-abi-smoker/).
 
 * [`node-stress-single-test`](https://ci.nodejs.org/job/node-stress-single-test/)
@@ -403,7 +403,7 @@ Changes" section of the release notes.
 
 Collaborators may opt to elevate pull requests or issues to the [TSC][] for
 discussion by assigning the `tsc-review` label or @-mentioning the
-`@nodejs/tsc` Github team. This should be done where a pull request:
+`@nodejs/tsc` GitHub team. This should be done where a pull request:
 
 - is labeled `semver-major`, or
 - has a significant impact on the codebase, or

--- a/tools/remark-preset-lint-node/index.js
+++ b/tools/remark-preset-lint-node/index.js
@@ -42,8 +42,10 @@ module.exports.plugins = [
   [
     require('remark-lint-prohibited-strings'),
     [
-      { no: 'v8', yes: 'V8' },
-      { no: 'Javascript', yes: 'JavaScript' }
+      { no: 'Github', yes: 'GitHub' },
+      { no: 'Javascript', yes: 'JavaScript' },
+      { no: 'Node.JS', yes: 'Node.js' },
+      { no: 'v8', yes: 'V8' }
     ]
   ],
   [require('remark-lint-strong-marker'), '*'],


### PR DESCRIPTION
 Check for uses of `Github` (rather than `GitHub`) and `Node.JS` (rather
than `Node.js`) in markdown files.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, doc