### PR TITLE
test: replace assert.throws with common.expectsError

### DIFF
--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -23,13 +23,13 @@ const errMessage = /^Bad socket type specified\. Valid types are: udp4, udp6$/;
 
 // Error must be thrown with invalid types
 invalidTypes.forEach((invalidType) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     dgram.createSocket(invalidType);
-  }, common.expectsError({
+  }, {
     code: 'ERR_SOCKET_BAD_TYPE',
     type: TypeError,
     message: errMessage
-  }));
+  });
 });
 
 // Error must not be thrown with valid types

--- a/test/parallel/test-dgram-custom-lookup.js
+++ b/test/parallel/test-dgram-custom-lookup.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const dgram = require('dgram');
 const dns = require('dns');
 
@@ -36,12 +35,12 @@ const dns = require('dns');
 {
   // Verify that non-functions throw.
   [null, true, false, 0, 1, NaN, '', 'foo', {}, Symbol()].forEach((value) => {
-    assert.throws(() => {
+    common.expectsError(() => {
       dgram.createSocket({ type: 'udp4', lookup: value });
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "lookup" argument must be of type Function'
-    }));
+    });
   });
 }

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -11,13 +11,13 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 {
   const socket = setup();
   socket.close(common.mustCall(() => {
-    assert.throws(() => {
+    common.expectsError(() => {
       socket.addMembership(multicastAddress);
-    }, common.expectsError({
+    }, {
       code: 'ERR_SOCKET_DGRAM_NOT_RUNNING',
       type: Error,
       message: /^Not running$/
-    }));
+    });
   }));
 }
 
@@ -25,39 +25,39 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 {
   const socket = setup();
   socket.close(common.mustCall(() => {
-    assert.throws(() => {
+    common.expectsError(() => {
       socket.dropMembership(multicastAddress);
-    }, common.expectsError({
+    }, {
       code: 'ERR_SOCKET_DGRAM_NOT_RUNNING',
       type: Error,
       message: /^Not running$/
-    }));
+    });
   }));
 }
 
 // addMembership() with no argument should throw
 {
   const socket = setup();
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.addMembership();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: /^The "multicastAddress" argument must be specified$/
-  }));
+  });
   socket.close();
 }
 
 // dropMembership() with no argument should throw
 {
   const socket = setup();
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.dropMembership();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: /^The "multicastAddress" argument must be specified$/
-  }));
+  });
   socket.close();
 }
 

--- a/test/parallel/test-dgram-multicast-setTTL.js
+++ b/test/parallel/test-dgram-multicast-setTTL.js
@@ -35,13 +35,13 @@ socket.on('listening', common.mustCall(() => {
     socket.setMulticastTTL(1000);
   }, /^Error: setMulticastTTL EINVAL$/);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.setMulticastTTL('foo');
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "ttl" argument must be of type number. Received type string'
-  }));
+  });
 
   //close the socket
   socket.close();

--- a/test/parallel/test-dgram-send-address-types.js
+++ b/test/parallel/test-dgram-send-address-types.js
@@ -38,19 +38,19 @@ const client = dgram.createSocket('udp4').bind(0, () => {
   client.send(buf, port, onMessage);
 
   // invalid address: object
-  assert.throws(() => {
+  common.expectsError(() => {
     client.send(buf, port, []);
-  }, common.expectsError(expectedError));
+  }, expectedError);
 
   // invalid address: nonzero number
-  assert.throws(() => {
+  common.expectsError(() => {
     client.send(buf, port, 1);
-  }, common.expectsError(expectedError));
+  }, expectedError);
 
   // invalid address: true
-  assert.throws(() => {
+  common.expectsError(() => {
     client.send(buf, port, true);
-  }, common.expectsError(expectedError));
+  }, expectedError);
 });
 
 client.unref();

--- a/test/parallel/test-dgram-sendto.js
+++ b/test/parallel/test-dgram-sendto.js
@@ -1,48 +1,47 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const dgram = require('dgram');
 const socket = dgram.createSocket('udp4');
 
 const errorMessageOffset =
   /^The "offset" argument must be of type number$/;
 
-assert.throws(() => {
+common.expectsError(() => {
   socket.sendto();
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: errorMessageOffset
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   socket.sendto('buffer', 1, 'offset', 'port', 'address', 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: /^The "length" argument must be of type number$/
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   socket.sendto('buffer', 'offset', 1, 'port', 'address', 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: errorMessageOffset
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   socket.sendto('buffer', 1, 1, 10, false, 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: /^The "address" argument must be of type string$/
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   socket.sendto('buffer', 1, 1, false, 'address', 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: /^The "port" argument must be of type number$/
-}));
+});

--- a/test/parallel/test-dgram-setTTL.js
+++ b/test/parallel/test-dgram-setTTL.js
@@ -9,13 +9,13 @@ socket.on('listening', common.mustCall(() => {
   const result = socket.setTTL(16);
   assert.strictEqual(result, 16);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.setTTL('foo');
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "ttl" argument must be of type number. Received type string'
-  }));
+  });
 
   // TTL must be a number from > 0 to < 256
   assert.throws(() => {

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -14,21 +14,21 @@ const dgram = require('dgram');
 
   const socket = dgram.createSocket('udp4');
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.setRecvBufferSize(8192);
-  }, common.expectsError(errorObj));
+  }, errorObj);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.setSendBufferSize(8192);
-  }, common.expectsError(errorObj));
+  }, errorObj);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.getRecvBufferSize();
-  }, common.expectsError(errorObj));
+  }, errorObj);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     socket.getSendBufferSize();
-  }, common.expectsError(errorObj));
+  }, errorObj);
 }
 
 {
@@ -45,13 +45,13 @@ const dgram = require('dgram');
 
   socket.bind(common.mustCall(() => {
     badBufferSizes.forEach((badBufferSize) => {
-      assert.throws(() => {
+      common.expectsError(() => {
         socket.setRecvBufferSize(badBufferSize);
-      }, common.expectsError(errorObj));
+      }, errorObj);
 
-      assert.throws(() => {
+      common.expectsError(() => {
         socket.setSendBufferSize(badBufferSize);
-      }, common.expectsError(errorObj));
+      }, errorObj);
     });
     socket.close();
   }));
@@ -83,9 +83,9 @@ function checkBufferSizeError(type, size) {
     'BufferSize';
   const socket = dgram.createSocket('udp4');
   socket.bind(common.mustCall(() => {
-    assert.throws(() => {
+    common.expectsError(() => {
       socket[functionName](size);
-    }, common.expectsError(errorObj));
+    }, errorObj);
     socket.close();
   }));
 }

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -7,51 +7,51 @@ const dns = require('dns');
 // Stub `getaddrinfo` to *always* error.
 cares.getaddrinfo = () => process.binding('uv').UV_ENOENT;
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup(1, {});
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: /^The "hostname" argument must be one of type string or falsy/
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup(false, 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup(false, 'options', 'cb');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup(false, {
     hints: 100,
     family: 0,
     all: false
   }, common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_OPT_VALUE',
   type: TypeError,
   message: 'The value "100" is invalid for option "hints"'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup(false, {
     hints: 0,
     family: 20,
     all: false
   }, common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_OPT_VALUE',
   type: TypeError,
   message: 'The value "20" is invalid for option "family"'
-}));
+});
 
 assert.doesNotThrow(() => {
   dns.lookup(false, {

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -21,18 +21,17 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const dns = require('dns');
 
 // Should not raise assertion error. Issue #7070
-assert.throws(() => dns.resolveNs([]), // bad name
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError,
-                message: /^The "name" argument must be of type string/
-              }));
-assert.throws(() => dns.resolveNs(''), // bad callback
-              common.expectsError({
-                code: 'ERR_INVALID_CALLBACK',
-                type: TypeError
-              }));
+common.expectsError(() => dns.resolveNs([]), // bad name
+                    {
+                      code: 'ERR_INVALID_ARG_TYPE',
+                      type: TypeError,
+                      message: /^The "name" argument must be of type string/
+                    });
+common.expectsError(() => dns.resolveNs(''), // bad callback
+                    {
+                      code: 'ERR_INVALID_CALLBACK',
+                      type: TypeError
+                    });


### PR DESCRIPTION
Refactored tests to replace `assert.throws(fn, common.expectsError(err));` with `common.expectsError(fn, err);` in following test files :

* test/parallel/test-dgram-createSocket-type.js
* test/parallel/test-dgram-custom-lookup.js
* test/parallel/test-dgram-membership.js
* test/parallel/test-dgram-multicast-setTTL.js
* test/parallel/test-dgram-sendto.js
* test/parallel/test-dgram-setTTL.js
* test/parallel/test-dgram-socket-buffer-size.js
* test/parallel/test-dns-lookup.js
* test/parallel/test-dns-regress-7070.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
