### PR TITLE
Refactor: Use common.expectsError in tests

### DIFF
--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -68,16 +68,16 @@ const goog = [
 ];
 assert.doesNotThrow(() => dns.setServers(goog));
 assert.deepStrictEqual(dns.getServers(), goog);
-assert.throws(() => dns.setServers(['foobar']), common.expectsError({
+common.expectsError(() => dns.setServers(['foobar']), {
   code: 'ERR_INVALID_IP_ADDRESS',
   type: Error,
   message: 'Invalid IP address: foobar'
-}));
-assert.throws(() => dns.setServers(['127.0.0.1:va']), common.expectsError({
+});
+common.expectsError(() => dns.setServers(['127.0.0.1:va']), {
   code: 'ERR_INVALID_IP_ADDRESS',
   type: Error,
   message: 'Invalid IP address: 127.0.0.1:va'
-}));
+});
 assert.deepStrictEqual(dns.getServers(), goog);
 
 const goog6 = [
@@ -109,14 +109,14 @@ assert.deepStrictEqual(dns.getServers(), portsExpected);
 assert.doesNotThrow(() => dns.setServers([]));
 assert.deepStrictEqual(dns.getServers(), []);
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.resolve('example.com', [], common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "rrtype" argument must be of type string. ' +
            'Received type object'
-}));
+});
 
 // dns.lookup should accept only falsey and string values
 {
@@ -167,24 +167,24 @@ assert.throws(() => {
  * - it's an odd number different than 1, and thus is invalid, because
  * flags are either === 1 or even.
  */
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookup('nodejs.org', { hints: (dns.V4MAPPED | dns.ADDRCONFIG) + 1 },
              common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_OPT_VALUE',
   type: TypeError,
   message: /The value "\d+" is invalid for option "hints"/
-}));
+});
 
-assert.throws(() => dns.lookup('nodejs.org'), common.expectsError({
+common.expectsError(() => dns.lookup('nodejs.org'), {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
-}));
+});
 
-assert.throws(() => dns.lookup('nodejs.org', 4), common.expectsError({
+common.expectsError(() => dns.lookup('nodejs.org', 4), {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
-}));
+});
 
 assert.doesNotThrow(() => dns.lookup('', { family: 4, hints: 0 },
                                      common.mustCall()));

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -225,9 +225,9 @@ function test_cyclic_link_protection(realpath, realpathSync, callback) {
     fs.symlinkSync(t[1], t[0], 'dir');
     unlink.push(t[0]);
   });
-  assert.throws(() => {
+  common.expectsError(() => {
     realpathSync(entry);
-  }, common.expectsError({ code: 'ELOOP', type: Error }));
+  }, { code: 'ELOOP', type: Error });
   asynctest(
     realpath, [entry], callback, common.mustCall(function(err, result) {
       assert.strictEqual(err.path, entry);

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -24,9 +24,9 @@ common.expectsError(
     type: TypeError
   });
 
-assert.throws(function() {
+common.expectsError(function() {
   fs.watchFile(new Object(), common.mustNotCall());
-}, common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }));
+}, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError });
 
 const enoentFile = path.join(common.tmpDir, 'non-existent-file');
 const expectedStatObject = new fs.Stats(

--- a/test/parallel/test-http-client-check-http-token.js
+++ b/test/parallel/test-http-client-check-http-token.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
@@ -18,14 +17,14 @@ const server = http.createServer(common.mustCall((req, res) => {
 
 server.listen(0, common.mustCall(() => {
   expectedFails.forEach((method) => {
-    assert.throws(() => {
+    common.expectsError(() => {
       http.request({ method, path: '/' }, common.mustNotCall());
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "method" argument must be of type string. ' +
                `Received type ${typeof method}`
-    }));
+    });
   });
 
   expectedSuccesses.forEach((method) => {

--- a/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -47,14 +47,14 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
   baseOptions.port = this.address().port;
 
   failingAgentOptions.forEach((agent) => {
-    assert.throws(
+    common.expectsError(
       () => createRequest(agent),
-      common.expectsError({
+      {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "Agent option" argument must be one of type ' +
                  'Agent-like Object, undefined, or false'
-      })
+      }
     );
   });
 

--- a/test/parallel/test-http-client-unescaped-path.js
+++ b/test/parallel/test-http-client-unescaped-path.js
@@ -21,17 +21,16 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
 for (let i = 0; i <= 32; i += 1) {
   const path = `bad${String.fromCharCode(i)}path`;
-  assert.throws(
+  common.expectsError(
     () => http.get({ path }, common.mustNotCall()),
-    common.expectsError({
+    {
       code: 'ERR_UNESCAPED_CHARACTERS',
       type: TypeError,
       message: 'Request path contains unescaped characters'
-    })
+    }
   );
 }

--- a/test/parallel/test-http-hostname-typechecking.js
+++ b/test/parallel/test-http-hostname-typechecking.js
@@ -9,26 +9,26 @@ const http = require('http');
 const vals = [{}, [], NaN, Infinity, -Infinity, true, false, 1, 0, new Date()];
 
 vals.forEach((v) => {
-  assert.throws(
+  common.expectsError(
     () => http.request({ hostname: v }),
-    common.expectsError({
+    {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options.hostname" property must be one of ' +
                'type string, undefined, or null. ' +
                `Received type ${typeof v}`
-    })
+    }
   );
 
-  assert.throws(
+  common.expectsError(
     () => http.request({ host: v }),
-    common.expectsError({
+    {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "options.host" property must be one of ' +
                'type string, undefined, or null. ' +
                `Received type ${typeof v}`
-    })
+    }
   );
 });
 

--- a/test/parallel/test-http-request-invalid-method-error.js
+++ b/test/parallel/test-http-request-invalid-method-error.js
@@ -1,13 +1,12 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const http = require('http');
 
-assert.throws(
+common.expectsError(
   () => http.request({ method: '\0' }),
-  common.expectsError({
+  {
     code: 'ERR_INVALID_HTTP_TOKEN',
     type: TypeError,
     message: 'Method must be a valid HTTP token ["\u0000"]'
-  })
+  }
 );

--- a/test/parallel/test-http-response-statuscode.js
+++ b/test/parallel/test-http-response-statuscode.js
@@ -56,12 +56,12 @@ const server = http.Server(common.mustCall(function(req, res) {
       test(res, '404 this is not valid either', '404 this is not valid either');
       break;
     case 12:
-      assert.throws(() => { res.writeHead(); },
-                    common.expectsError({
-                      code: 'ERR_HTTP_INVALID_STATUS_CODE',
-                      type: RangeError,
-                      message: 'Invalid status code: undefined'
-                    }));
+      common.expectsError(() => { res.writeHead(); },
+                          {
+                            code: 'ERR_HTTP_INVALID_STATUS_CODE',
+                            type: RangeError,
+                            message: 'Invalid status code: undefined'
+                          });
       this.close();
       break;
     default:

--- a/test/parallel/test-http-server-de-chunked-trailer.js
+++ b/test/parallel/test-http-server-de-chunked-trailer.js
@@ -14,8 +14,8 @@ const server = http.createServer(common.mustCall(function(req, res) {
     message: 'Trailers are invalid with this transfer encoding',
     type: Error
   };
-  assert.throws(() => res.writeHead(200, { 'Content-Length': '2' }),
-                common.expectsError(trailerInvalidErr));
+  common.expectsError(() => res.writeHead(200, { 'Content-Length': '2' }),
+                      trailerInvalidErr);
   res.removeHeader('Trailer');
   res.end('ok');
 }));

--- a/test/parallel/test-http-write-head.js
+++ b/test/parallel/test-http-write-head.js
@@ -52,14 +52,13 @@ const s = http.createServer(common.mustCall((req, res) => {
 
   res.writeHead(200, { Test: '2' });
 
-  assert.throws(() => {
+  common.expectsError(() => {
     res.writeHead(100, {});
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP_HEADERS_SENT',
     type: Error,
     message: 'Cannot render headers after they are sent to the client'
-  })
-  );
+  });
 
   res.end();
 }));


### PR DESCRIPTION
Refactored tests to replace `assert.throws(fn, common.expectsError(err));` with `common.expectsError(fn, err);` in following test files :

* test/parallel/test-dns.js
* test/parallel/test-fs-realpath.js
* test/parallel/test-fs-watchfile.js
* test/parallel/test-http-client-check-http-token.js
* test/parallel/test-http-client-reject-unexpected-agent.js
* test/parallel/test-http-client-unescaped-path.js
* test/parallel/test-http-hostname-typechecking.js
* test/parallel/test-http-request-invalid-method-error.js
* test/parallel/test-http-response-statuscode.js
* test/parallel/test-http-server-de-chunked-trailer.js
* test/parallel/test-http-write-head.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
