### PR TITLE
test: replace assert.throws with common.expectsError

### DIFF
--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -72,28 +72,28 @@ server.listen(0, common.mustCall(function() {
       ':path',
       ':authority',
       ':scheme'
-    ].forEach((header) => assert.throws(
+    ].forEach((header) => common.expectsError(
       () => response.setHeader(header, 'foobar'),
-      common.expectsError({
+      {
         code: 'ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED',
         type: Error,
         message: 'Cannot set HTTP/2 pseudo-headers'
       })
-    ));
-    assert.throws(function() {
+    );
+    common.expectsError(function() {
       response.setHeader(real, null);
-    }, common.expectsError({
+    }, {
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       type: TypeError,
       message: 'Invalid value "null" for header "foo-bar"'
-    }));
-    assert.throws(function() {
+    });
+    common.expectsError(function() {
       response.setHeader(real, undefined);
-    }, common.expectsError({
+    }, {
       code: 'ERR_HTTP2_INVALID_HEADER_VALUE',
       type: TypeError,
       message: 'Invalid value "undefined" for header "foo-bar"'
-    }));
+    });
     common.expectsError(
       () => response.setHeader(), // header name undefined
       {

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -34,24 +34,24 @@ server.listen(0, common.mustCall(function() {
       response.statusCode = realStatusCodes.internalServerError;
     });
 
-    assert.throws(function() {
+    common.expectsError(function() {
       response.statusCode = realStatusCodes.continue;
-    }, common.expectsError({
+    }, {
       code: 'ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
       type: RangeError
-    }));
-    assert.throws(function() {
+    });
+    common.expectsError(function() {
       response.statusCode = fakeStatusCodes.tooLow;
-    }, common.expectsError({
+    }, {
       code: 'ERR_HTTP2_STATUS_INVALID',
       type: RangeError
-    }));
-    assert.throws(function() {
+    });
+    common.expectsError(function() {
       response.statusCode = fakeStatusCodes.tooHigh;
-    }, common.expectsError({
+    }, {
       code: 'ERR_HTTP2_STATUS_INVALID',
       type: RangeError
-    }));
+    });
 
     response.on('finish', common.mustCall(function() {
       server.close();

--- a/test/parallel/test-http2-getpackedsettings.js
+++ b/test/parallel/test-http2-getpackedsettings.js
@@ -44,25 +44,25 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
   ['maxHeaderListSize', -1],
   ['maxHeaderListSize', 2 ** 32]
 ].forEach((i) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     http2.getPackedSettings({ [i[0]]: i[1] });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     type: RangeError,
     message: `Invalid value for setting "${i[0]}": ${i[1]}`
-  }));
+  });
 });
 
 [
   1, null, '', Infinity, new Date(), {}, NaN, [false]
 ].forEach((i) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     http2.getPackedSettings({ enablePush: i });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     type: TypeError,
     message: `Invalid value for setting "enablePush": ${i}`
-  }));
+  });
 });
 
 {
@@ -99,23 +99,23 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
     0x00, 0x02, 0x00, 0x00, 0x00, 0x01]);
 
   [1, true, '', [], {}, NaN].forEach((i) => {
-    assert.throws(() => {
+    common.expectsError(() => {
       http2.getUnpackedSettings(i);
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message:
         'The "buf" argument must be one of type Buffer, TypedArray, or DataView'
-    }));
+    });
   });
 
-  assert.throws(() => {
+  common.expectsError(() => {
     http2.getUnpackedSettings(packed.slice(5));
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH',
     type: RangeError,
     message: 'Packed settings length must be a multiple of six'
-  }));
+  });
 
   const settings = http2.getUnpackedSettings(packed);
 
@@ -160,24 +160,24 @@ assert.doesNotThrow(() => http2.getPackedSettings({ enablePush: false }));
 {
   const packed = Buffer.from([0x00, 0x05, 0x01, 0x00, 0x00, 0x00]);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     http2.getUnpackedSettings(packed, { validate: true });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     type: RangeError,
     message: 'Invalid value for setting "maxFrameSize": 16777216'
-  }));
+  });
 }
 
 // check for maxConcurrentStreams failing the max number
 {
   const packed = Buffer.from([0x00, 0x03, 0xFF, 0xFF, 0xFF, 0xFF]);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     http2.getUnpackedSettings(packed, { validate: true });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
     type: RangeError,
     message: 'Invalid value for setting "maxConcurrentStreams": 4294967295'
-  }));
+  });
 }

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -18,19 +18,19 @@ const afterRespondregex =
 
 function onStream(stream, headers, flags) {
 
-  assert.throws(() => stream.additionalHeaders({ ':status': 201 }),
-                common.expectsError({
-                  code: 'ERR_HTTP2_INVALID_INFO_STATUS',
-                  type: RangeError,
-                  message: /^Invalid informational status code: 201$/
-                }));
+  common.expectsError(() => stream.additionalHeaders({ ':status': 201 }),
+                      {
+                        code: 'ERR_HTTP2_INVALID_INFO_STATUS',
+                        type: RangeError,
+                        message: /^Invalid informational status code: 201$/
+                      });
 
-  assert.throws(() => stream.additionalHeaders({ ':status': 101 }),
-                common.expectsError({
-                  code: 'ERR_HTTP2_STATUS_101',
-                  type: Error,
-                  message: status101regex
-                }));
+  common.expectsError(() => stream.additionalHeaders({ ':status': 101 }),
+                      {
+                        code: 'ERR_HTTP2_STATUS_101',
+                        type: Error,
+                        message: status101regex
+                      });
 
   common.expectsError(
     () => stream.additionalHeaders({ ':method': 'POST' }),
@@ -50,12 +50,12 @@ function onStream(stream, headers, flags) {
     ':status': 200
   });
 
-  assert.throws(() => stream.additionalHeaders({ abc: 123 }),
-                common.expectsError({
-                  code: 'ERR_HTTP2_HEADERS_AFTER_RESPOND',
-                  type: Error,
-                  message: afterRespondregex
-                }));
+  common.expectsError(() => stream.additionalHeaders({ abc: 123 }),
+                      {
+                        code: 'ERR_HTTP2_HEADERS_AFTER_RESPOND',
+                        type: Error,
+                        message: afterRespondregex
+                      });
 
   stream.end('hello world');
 }

--- a/test/parallel/test-http2-misused-pseudoheaders.js
+++ b/test/parallel/test-http2-misused-pseudoheaders.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const h2 = require('http2');
 
 const server = h2.createServer();
@@ -19,10 +18,10 @@ function onStream(stream, headers, flags) {
     ':method',
     ':scheme'
   ].forEach((i) => {
-    assert.throws(() => stream.respond({ [i]: '/' }),
-                  common.expectsError({
-                    code: 'ERR_HTTP2_INVALID_PSEUDOHEADER'
-                  }));
+    common.expectsError(() => stream.respond({ [i]: '/' }),
+                        {
+                          code: 'ERR_HTTP2_INVALID_PSEUDOHEADER'
+                        });
   });
 
   stream.respond({

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -17,11 +17,11 @@ let clients = 2;
 function doTest(session) {
   for (let n = 0; n < maxPendingAck; n++)
     assert.doesNotThrow(() => session.settings({ enablePush: false }));
-  assert.throws(() => session.settings({ enablePush: false }),
-                common.expectsError({
-                  code: 'ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
-                  type: Error
-                }));
+  common.expectsError(() => session.settings({ enablePush: false }),
+                      {
+                        code: 'ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
+                        type: Error
+                      });
 }
 
 server.on('stream', common.mustNotCall());

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -27,17 +27,17 @@ const {
   [],
   [{}]
 ].forEach((i) => {
-  assert.throws(() => assertIsObject(i, 'foo', 'Object'),
-                common.expectsError({
-                  code: 'ERR_INVALID_ARG_TYPE',
-                  message: /^The "foo" argument must be of type Object$/
-                }));
+  common.expectsError(() => assertIsObject(i, 'foo', 'Object'),
+                      {
+                        code: 'ERR_INVALID_ARG_TYPE',
+                        message: /^The "foo" argument must be of type Object$/
+                      });
 });
 
 assert.doesNotThrow(() => assertWithinRange('foo', 1, 0, 2));
 
-assert.throws(() => assertWithinRange('foo', 1, 2, 3),
-              common.expectsError({
-                code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
-                message: /^Invalid value for setting "foo": 1$/
-              }));
+common.expectsError(() => assertWithinRange('foo', 1, 2, 3),
+                    {
+                      code: 'ERR_HTTP2_INVALID_SETTING_VALUE',
+                      message: /^Invalid value for setting "foo": 1$/
+                    });

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -52,91 +52,91 @@ errors.E('TEST_ERROR_2', (a, b) => `${a} ${b}`);
   assert.strictEqual(err.code, 'TEST_ERROR_1');
 }
 
-assert.throws(
+common.expectsError(
   () => new errors.Error('TEST_FOO_KEY'),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('TEST_FOO_KEY')
-  }));
+  });
 // Calling it twice yields same result (using the key does not create it)
-assert.throws(
+common.expectsError(
   () => new errors.Error('TEST_FOO_KEY'),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('TEST_FOO_KEY')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.Error(1),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey(1)
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.Error({}),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('\\[object Object\\]')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.Error([]),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.Error(true),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('true')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.TypeError(1),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey(1)
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.TypeError({}),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('\\[object Object\\]')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.TypeError([]),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.TypeError(true),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('true')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.RangeError(1),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey(1)
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.RangeError({}),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('\\[object Object\\]')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.RangeError([]),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('')
-  }));
-assert.throws(
+  });
+common.expectsError(
   () => new errors.RangeError(true),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: invalidKey('true')
-  }));
+  });
 
 
 // Tests for common.expectsError
@@ -166,25 +166,25 @@ assert.doesNotThrow(() => {
   }, common.expectsError({ code: 'TEST_ERROR_1', type: Error }));
 });
 
-assert.throws(() => {
-  assert.throws(() => {
+common.expectsError(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1', type: RangeError }));
-}, common.expectsError({
+  }, { code: 'TEST_ERROR_1', type: RangeError });
+}, {
   code: 'ERR_ASSERTION',
   message: /^.+ is not instance of \S/
-}));
+});
 
-assert.throws(() => {
-  assert.throws(() => {
+common.expectsError(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1',
-                           type: TypeError,
-                           message: /^Error for testing 2/ }));
-}, common.expectsError({
+  }, { code: 'TEST_ERROR_1',
+       type: TypeError,
+       message: /^Error for testing 2/ });
+}, {
   code: 'ERR_ASSERTION',
   message: /.+ does not match \S/
-}));
+});
 
 // // Test ERR_INVALID_ARG_TYPE
 assert.strictEqual(errors.message('ERR_INVALID_ARG_TYPE', ['a', 'b']),
@@ -229,12 +229,12 @@ assert.strictEqual(errors.message('ERR_INVALID_URL_SCHEME', [['http', 'ftp']]),
                    'The URL must be one of scheme http or ftp');
 assert.strictEqual(errors.message('ERR_INVALID_URL_SCHEME', [['a', 'b', 'c']]),
                    'The URL must be one of scheme a, b, or c');
-assert.throws(
+common.expectsError(
   () => errors.message('ERR_INVALID_URL_SCHEME', [[]]),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: /^At least one expected value needs to be specified$/
-  }));
+  });
 
 // Test ERR_MISSING_ARGS
 assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['name']),
@@ -243,12 +243,12 @@ assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['name', 'value']),
                    'The "name" and "value" arguments must be specified');
 assert.strictEqual(errors.message('ERR_MISSING_ARGS', ['a', 'b', 'c']),
                    'The "a", "b", and "c" arguments must be specified');
-assert.throws(
+common.expectsError(
   () => errors.message('ERR_MISSING_ARGS'),
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: /^At least one arg needs to be specified$/
-  }));
+  });
 
 // Test ERR_SOCKET_BAD_PORT
 assert.strictEqual(

--- a/test/parallel/test-module-loading-error.js
+++ b/test/parallel/test-module-loading-error.js
@@ -59,16 +59,16 @@ assert.throws(
   }
 );
 
-assert.throws(
+common.expectsError(
   require,
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: /^missing path$/
-  }));
+  });
 
-assert.throws(
+common.expectsError(
   () => { require({}); },
-  common.expectsError({
+  {
     code: 'ERR_ASSERTION',
     message: /^path must be a string$/
-  }));
+  });

--- a/test/parallel/test-net-better-error-messages-path.js
+++ b/test/parallel/test-net-better-error-messages-path.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const net = require('net');
-const assert = require('assert');
 
 {
   const fp = '/tmp/fadagagsdfgsdf';
@@ -15,8 +14,8 @@ const assert = require('assert');
 }
 
 {
-  assert.throws(
+  common.expectsError(
     () => net.createConnection({ path: {} }),
-    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE' })
+    { code: 'ERR_INVALID_ARG_TYPE' }
   );
 }

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -63,11 +63,11 @@ const net = require('net');
   const hintOptBlocks = doConnect([{ hints: hints }],
                                   () => common.mustNotCall());
   for (const block of hintOptBlocks) {
-    assert.throws(block, common.expectsError({
+    common.expectsError(block, {
       code: 'ERR_INVALID_OPT_VALUE',
       type: TypeError,
       message: /The value "\d+" is invalid for option "hints"/
-    }));
+    });
   }
 }
 

--- a/test/parallel/test-net-options-lookup.js
+++ b/test/parallel/test-net-options-lookup.js
@@ -13,12 +13,12 @@ function connectThrows(input) {
     lookup: input
   };
 
-  assert.throws(() => {
+  common.expectsError(() => {
     net.connect(opts);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError
-  }));
+  });
 }
 
 connectDoesNotThrow(() => {});

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -57,12 +57,12 @@ const listenOnPort = [
     const block = () => {
       net.createServer().listen(options, common.mustNotCall());
     };
-    assert.throws(block,
-                  common.expectsError({
-                    code: 'ERR_INVALID_OPT_VALUE',
-                    type: Error,
-                    message: /^The value "{.*}" is invalid for option "options"$/
-                  }));
+    common.expectsError(block,
+                        {
+                          code: 'ERR_INVALID_OPT_VALUE',
+                          type: Error,
+                          message: /^The value "{.*}" is invalid for option "options"$/
+                        });
   }
 
   shouldFailToListen(false, { port: false });

--- a/test/parallel/test-net-server-options.js
+++ b/test/parallel/test-net-server-options.js
@@ -1,16 +1,15 @@
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
-assert.throws(function() { net.createServer('path'); },
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError
-              }));
+common.expectsError(function() { net.createServer('path'); },
+                    {
+                      code: 'ERR_INVALID_ARG_TYPE',
+                      type: TypeError
+                    });
 
-assert.throws(function() { net.createServer(0); },
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError
-              }));
+common.expectsError(function() { net.createServer(0); },
+                    {
+                      code: 'ERR_INVALID_ARG_TYPE',
+                      type: TypeError
+                    });

--- a/test/parallel/test-net-socket-write-error.js
+++ b/test/parallel/test-net-socket-write-error.js
@@ -1,18 +1,17 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const net = require('net');
 
 const server = net.createServer().listen(0, connectToServer);
 
 function connectToServer() {
   const client = net.createConnection(this.address().port, () => {
-    assert.throws(() => client.write(1337),
-                  common.expectsError({
-                    code: 'ERR_INVALID_ARG_TYPE',
-                    type: TypeError
-                  }));
+    common.expectsError(() => client.write(1337),
+                        {
+                          code: 'ERR_INVALID_ARG_TYPE',
+                          type: TypeError
+                        });
 
     client.end();
   })

--- a/test/parallel/test-path-parse-format.js
+++ b/test/parallel/test-path-parse-format.js
@@ -225,13 +225,13 @@ function checkFormat(path, testCases) {
   }
 
   [null, undefined, 1, true, false, 'string'].forEach((pathObject) => {
-    assert.throws(() => {
+    common.expectsError(() => {
       path.format(pathObject);
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "pathObject" argument must be of type Object. ' +
                `Received type ${typeName(pathObject)}`
-    }));
+    });
   });
 }

--- a/test/parallel/test-path.js
+++ b/test/parallel/test-path.js
@@ -30,9 +30,9 @@ const typeErrorTests = [true, false, 7, null, {}, undefined, [], NaN];
 function fail(fn) {
   const args = Array.from(arguments).slice(1);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     fn.apply(null, args);
-  }, common.expectsError({ code: 'ERR_INVALID_ARG_TYPE', type: TypeError }));
+  }, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError });
 }
 
 typeErrorTests.forEach((test) => {

--- a/test/parallel/test-performance-function.js
+++ b/test/parallel/test-performance-function.js
@@ -71,12 +71,12 @@ const {
 
 {
   [1, {}, [], null, undefined, Infinity].forEach((i) => {
-    assert.throws(() => performance.timerify(i),
-                  common.expectsError({
-                    code: 'ERR_INVALID_ARG_TYPE',
-                    type: TypeError,
-                    message: 'The "fn" argument must be of type Function'
-                  }));
+    common.expectsError(() => performance.timerify(i),
+                        {
+                          code: 'ERR_INVALID_ARG_TYPE',
+                          type: TypeError,
+                          message: 'The "fn" argument must be of type Function'
+                        });
   });
 }
 

--- a/test/parallel/test-process-assert.js
+++ b/test/parallel/test-process-assert.js
@@ -3,19 +3,19 @@ const common = require('../common');
 const assert = require('assert');
 
 assert.strictEqual(process.assert(1, 'error'), undefined);
-assert.throws(() => {
+common.expectsError(() => {
   process.assert(undefined, 'errorMessage');
-}, common.expectsError({
+}, {
   code: 'ERR_ASSERTION',
   type: Error,
   message: 'errorMessage'
-})
+}
 );
-assert.throws(() => {
+common.expectsError(() => {
   process.assert(false);
-}, common.expectsError({
+}, {
   code: 'ERR_ASSERTION',
   type: Error,
   message: 'assertion error'
-})
+}
 );

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -33,34 +33,34 @@ validateTuple(tuple);
 validateTuple(process.hrtime(tuple));
 
 // test that only an Array may be passed to process.hrtime()
-assert.throws(() => {
+common.expectsError(() => {
   process.hrtime(1);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "time" argument must be of type Array. Received type number'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   process.hrtime([]);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
   message: 'The array "time" (length 0) must be of length 2.'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   process.hrtime([1]);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
   message: 'The array "time" (length 1) must be of length 2.'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   process.hrtime([1, 2, 3]);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARRAY_LENGTH',
   type: TypeError,
   message: 'The array "time" (length 3) must be of length 2.'
-}));
+});
 
 function validateTuple(tuple) {
   assert(Array.isArray(tuple));

--- a/test/parallel/test-process-next-tick.js
+++ b/test/parallel/test-process-next-tick.js
@@ -21,7 +21,6 @@
 
 'use strict';
 const common = require('../common');
-const assert = require('assert');
 const N = 2;
 
 function cb() {
@@ -39,10 +38,10 @@ process.on('exit', function() {
 });
 
 [null, 1, 'test', {}, [], Infinity, true].forEach((i) => {
-  assert.throws(() => process.nextTick(i),
-                common.expectsError({
-                  code: 'ERR_INVALID_CALLBACK',
-                  type: TypeError,
-                  message: 'Callback must be a function'
-                }));
+  common.expectsError(() => process.nextTick(i),
+                      {
+                        code: 'ERR_INVALID_CALLBACK',
+                        type: TypeError,
+                        message: 'Callback must be a function'
+                      });
 });

--- a/test/parallel/test-readline-csi.js
+++ b/test/parallel/test-readline-csi.js
@@ -73,13 +73,13 @@ assert.doesNotThrow(() => readline.cursorTo(writable, 'a', 'b'));
 assert.strictEqual(writable.data, '');
 
 writable.data = '';
-assert.throws(
+common.expectsError(
   () => readline.cursorTo(writable, 'a', 1),
-  common.expectsError({
+  {
     type: Error,
     code: 'ERR_INVALID_CURSOR_POS',
     message: 'Cannot set cursor row without setting its column'
-  }));
+  });
 assert.strictEqual(writable.data, '');
 
 writable.data = '';

--- a/test/parallel/test-regress-GH-5727.js
+++ b/test/parallel/test-regress-GH-5727.js
@@ -14,25 +14,25 @@ net.Server().listen(0, function() {
 });
 
 // The first argument is a configuration object
-assert.throws(() => {
+common.expectsError(() => {
   net.Server().listen({ port: invalidPort }, common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_SOCKET_BAD_PORT',
   type: RangeError
-}));
+});
 
 // The first argument is the port, no IP given.
-assert.throws(() => {
+common.expectsError(() => {
   net.Server().listen(invalidPort, common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_SOCKET_BAD_PORT',
   type: RangeError
-}));
+});
 
 // The first argument is the port, the second an IP.
-assert.throws(() => {
+common.expectsError(() => {
   net.Server().listen(invalidPort, '0.0.0.0', common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_SOCKET_BAD_PORT',
   type: RangeError
-}));
+});

--- a/test/parallel/test-require-invalid-package.js
+++ b/test/parallel/test-require-invalid-package.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 
 // Should be an invalid package path.
-assert.throws(() => require('package.json'),
-              common.expectsError({ code: 'MODULE_NOT_FOUND' })
+common.expectsError(() => require('package.json'),
+                    { code: 'MODULE_NOT_FOUND' }
 );

--- a/test/parallel/test-stream-readable-with-unimplemented-_read.js
+++ b/test/parallel/test-stream-readable-with-unimplemented-_read.js
@@ -1,12 +1,11 @@
 'use strict';
 const common = require('../common');
 const stream = require('stream');
-const assert = require('assert');
 
 const readable = new stream.Readable();
 
-assert.throws(() => readable.read(), common.expectsError({
+common.expectsError(() => readable.read(), {
   code: 'ERR_STREAM_READ_NOT_IMPLEMENTED',
   type: Error,
   message: '_read() is not implemented'
-}));
+});

--- a/test/parallel/test-stream-unshift-read-race.js
+++ b/test/parallel/test-stream-unshift-read-race.js
@@ -68,13 +68,13 @@ r._read = function(n) {
 };
 
 function pushError() {
-  assert.throws(function() {
+  common.expectsError(function() {
     r.push(Buffer.allocUnsafe(1));
-  }, common.expectsError({
+  }, {
     code: 'ERR_STREAM_PUSH_AFTER_EOF',
     type: Error,
     message: 'stream.push() after EOF'
-  }));
+  });
 }
 
 
@@ -86,13 +86,13 @@ w._write = function(chunk, encoding, cb) {
 };
 
 r.on('end', common.mustCall(function() {
-  assert.throws(function() {
+  common.expectsError(function() {
     r.unshift(Buffer.allocUnsafe(1));
-  }, common.expectsError({
+  }, {
     code: 'ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
     type: Error,
     message: 'stream.unshift() after end event'
-  }));
+  });
   w.end();
 }));
 

--- a/test/parallel/test-timers-enroll-invalid-msecs.js
+++ b/test/parallel/test-timers-enroll-invalid-msecs.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const timers = require('timers');
-const assert = require('assert');
 
 [
   {},
@@ -11,12 +10,12 @@ const assert = require('assert');
   () => { },
   Symbol('foo')
 ].forEach((val) => {
-  assert.throws(
+  common.expectsError(
     () => timers.enroll({}, val),
-    common.expectsError({
+    {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
-    })
+    }
   );
 });
 
@@ -25,13 +24,13 @@ const assert = require('assert');
   Infinity,
   NaN
 ].forEach((val) => {
-  assert.throws(
+  common.expectsError(
     () => timers.enroll({}, val),
-    common.expectsError({
+    {
       code: 'ERR_VALUE_OUT_OF_RANGE',
       type: RangeError,
       message: 'The value of "msecs" must be a non-negative ' +
                `finite number. Received "${val}"`
-    })
+    }
   );
 });

--- a/test/parallel/test-tls-basic-validations.js
+++ b/test/parallel/test-tls-basic-validations.js
@@ -22,12 +22,12 @@ assert.throws(() => tls.createServer({ key: 'dummykey', passphrase: 1 }),
 assert.throws(() => tls.createServer({ ecdhCurve: 1 }),
               /TypeError: ECDH curve name must be a string/);
 
-assert.throws(() => tls.createServer({ handshakeTimeout: 'abcd' }),
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError,
-                message: 'The "timeout" argument must be of type number'
-              })
+common.expectsError(() => tls.createServer({ handshakeTimeout: 'abcd' }),
+                    {
+                      code: 'ERR_INVALID_ARG_TYPE',
+                      type: TypeError,
+                      message: 'The "timeout" argument must be of type number'
+                    }
 );
 
 assert.throws(() => tls.createServer({ sessionTimeout: 'abcd' }),

--- a/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
+++ b/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
@@ -4,12 +4,11 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const assert = require('assert');
 const tls = require('tls');
 
 {
-  assert.throws(
+  common.expectsError(
     () => { tls.createSecureContext({ clientCertEngine: 0 }); },
-    common.expectsError({ code: 'ERR_INVALID_ARG_TYPE',
-                          message: / Received type number$/ }));
+    { code: 'ERR_INVALID_ARG_TYPE',
+      message: / Received type number$/ });
 }

--- a/test/parallel/test-tls-clientcertengine-unsupported.js
+++ b/test/parallel/test-tls-clientcertengine-unsupported.js
@@ -14,15 +14,14 @@ binding.SecureContext = function() {
   return rv;
 };
 
-const assert = require('assert');
 const tls = require('tls');
 
 {
-  assert.throws(
+  common.expectsError(
     () => { tls.createSecureContext({ clientCertEngine: 'Cannonmouth' }); },
-    common.expectsError({
+    {
       code: 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED',
       message: 'Custom engines not supported by this OpenSSL'
-    })
+    }
   );
 }

--- a/test/parallel/test-tls-no-cert-required.js
+++ b/test/parallel/test-tls-no-cert-required.js
@@ -39,12 +39,12 @@ tls.createServer(assert.fail)
 tls.createServer({})
   .listen(0, common.mustCall(close));
 
-assert.throws(() => tls.createServer('this is not valid'),
-              common.expectsError({
-                code: 'ERR_INVALID_ARG_TYPE',
-                type: TypeError,
-                message: 'The "options" argument must be of type Object'
-              })
+common.expectsError(() => tls.createServer('this is not valid'),
+                    {
+                      code: 'ERR_INVALID_ARG_TYPE',
+                      type: TypeError,
+                      message: 'The "options" argument must be of type Object'
+                    }
 );
 
 tls.createServer()

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -98,13 +98,13 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[keyStr, keyStr2], true, invalidCertRE],
   [true, [certBuff, certBuff2], invalidKeyRE]
 ].map(([key, cert, message]) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     tls.createServer({ key, cert });
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message
-  }));
+  });
 });
 
 // Checks to ensure tls.createServer works with the CA parameter
@@ -132,13 +132,13 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
 ].map(([key, cert, ca]) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     tls.createServer({ key, cert, ca });
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
-  }));
+  });
 });
 
 // Checks to ensure tls.createServer throws an error for CA assignment
@@ -150,13 +150,13 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
 ].map(([key, cert, ca]) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     tls.createServer({ key, cert, ca });
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
-  }));
+  });
 });
 
 // Checks to ensure tls.createSecureContext works with false-y input

--- a/test/parallel/test-util-callbackify.js
+++ b/test/parallel/test-util-callbackify.js
@@ -229,13 +229,13 @@ const values = [
 {
   // Verify that non-function inputs throw.
   ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
-    assert.throws(() => {
+    common.expectsError(() => {
       callbackify(value);
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The "original" argument must be of type Function'
-    }));
+    });
   });
 }
 
@@ -250,12 +250,12 @@ const values = [
   // Verify that the last argument to the callbackified function is a function.
   ['foo', null, undefined, false, 0, {}, Symbol(), []].forEach((value) => {
     args.push(value);
-    assert.throws(() => {
+    common.expectsError(() => {
       cb(...args);
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
       message: 'The last argument must be of type Function'
-    }));
+    });
   });
 }

--- a/test/parallel/test-util-inherits.js
+++ b/test/parallel/test-util-inherits.js
@@ -80,22 +80,22 @@ assert.strictEqual(e.e(), 'e');
 assert.strictEqual(e.constructor, E);
 
 // should throw with invalid arguments
-assert.throws(function() {
+common.expectsError(function() {
   inherits(A, {});
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "superCtor.prototype" property must be of type Function'
-})
+}
 );
 assert.throws(function() {
   inherits(A, null);
 }, errCheck);
-assert.throws(function() {
+common.expectsError(function() {
   inherits(null, A);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The "ctor" argument must be of type Function'
-})
+}
 );

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1136,22 +1136,22 @@ if (typeof Symbol !== 'undefined') {
     JSON.stringify(oldOptions)
   );
 
-  assert.throws(() => {
+  common.expectsError(() => {
     util.inspect.defaultOptions = null;
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "options" argument must be of type Object'
-  })
+  }
   );
 
-  assert.throws(() => {
+  common.expectsError(() => {
     util.inspect.defaultOptions = 'bad';
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: 'The "options" argument must be of type Object'
-  })
+  }
   );
 }
 

--- a/test/parallel/test-whatwg-encoding-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-textdecoder.js
@@ -52,12 +52,13 @@ assert(TextDecoder);
 if (common.hasIntl) {
   ['unicode-1-1-utf-8', 'utf8', 'utf-8'].forEach((i) => {
     const dec = new TextDecoder(i, { fatal: true });
-    assert.throws(() => dec.decode(buf.slice(0, 8)),
-                  common.expectsError({
-                    code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
-                    type: TypeError,
-                    message: 'The encoded data was not valid for encoding utf-8'
-                  }));
+    common.expectsError(() => dec.decode(buf.slice(0, 8)),
+                        {
+                          code: 'ERR_ENCODING_INVALID_ENCODED_DATA',
+                          type: TypeError,
+                          message: 'The encoded data was not valid ' +
+                          'for encoding utf-8'
+                        });
   });
 
   ['unicode-1-1-utf-8', 'utf8', 'utf-8'].forEach((i) => {
@@ -66,13 +67,13 @@ if (common.hasIntl) {
     assert.doesNotThrow(() => dec.decode(buf.slice(8)));
   });
 } else {
-  assert.throws(
+  common.expectsError(
     () => new TextDecoder('utf-8', { fatal: true }),
-    common.expectsError({
+    {
       code: 'ERR_NO_ICU',
       type: TypeError,
       message: '"fatal" option is not supported on Node.js compiled without ICU'
-    }));
+    });
 }
 
 // Test TextDecoder, UTF-16le
@@ -96,12 +97,12 @@ if (common.hasIntl) {
   });
 
   [{}, [], true, 1, '', new TextEncoder()].forEach((i) => {
-    assert.throws(() => fn.call(i, Infinity, {}),
-                  common.expectsError({
-                    code: 'ERR_INVALID_THIS',
-                    type: TypeError,
-                    message: 'Value of "this" must be of type TextDecoder'
-                  }));
+    common.expectsError(() => fn.call(i, Infinity, {}),
+                        {
+                          code: 'ERR_INVALID_THIS',
+                          type: TypeError,
+                          message: 'Value of "this" must be of type TextDecoder'
+                        });
   });
 }
 

--- a/test/parallel/test-whatwg-encoding-textencoder.js
+++ b/test/parallel/test-whatwg-encoding-textencoder.js
@@ -41,11 +41,11 @@ assert(TextEncoder);
   });
 
   [{}, [], true, 1, '', new TextDecoder()].forEach((i) => {
-    assert.throws(() => fn.call(i, Infinity, {}),
-                  common.expectsError({
-                    code: 'ERR_INVALID_THIS',
-                    type: TypeError,
-                    message: 'Value of "this" must be of type TextEncoder'
-                  }));
+    common.expectsError(() => fn.call(i, Infinity, {}),
+                        {
+                          code: 'ERR_INVALID_THIS',
+                          type: TypeError,
+                          message: 'Value of "this" must be of type TextEncoder'
+                        });
   });
 }

--- a/test/parallel/test-whatwg-url-searchparams-append.js
+++ b/test/parallel/test-whatwg-url-searchparams-append.js
@@ -52,20 +52,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.append.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.append('a');
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" and "value" arguments must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-delete.js
+++ b/test/parallel/test-whatwg-url-searchparams-delete.js
@@ -62,20 +62,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.delete.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.delete();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" argument must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-entries.js
+++ b/test/parallel/test-whatwg-url-searchparams-entries.js
@@ -26,17 +26,17 @@ assert.deepStrictEqual(entries.next(), {
   done: true
 });
 
-assert.throws(() => {
+common.expectsError(() => {
   entries.next.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParamsIterator'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   params.entries.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParams'
-}));
+});

--- a/test/parallel/test-whatwg-url-searchparams-foreach.js
+++ b/test/parallel/test-whatwg-url-searchparams-foreach.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const { URL, URLSearchParams } = require('url');
 const { test, assert_array_equals, assert_unreached } =
   require('../common/wpt');
@@ -50,11 +49,11 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.forEach.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
+  });
 }

--- a/test/parallel/test-whatwg-url-searchparams-get.js
+++ b/test/parallel/test-whatwg-url-searchparams-get.js
@@ -37,20 +37,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.get.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.get();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" argument must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-getall.js
+++ b/test/parallel/test-whatwg-url-searchparams-getall.js
@@ -42,20 +42,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.getAll.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.getAll();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" argument must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-has.js
+++ b/test/parallel/test-whatwg-url-searchparams-has.js
@@ -40,20 +40,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.has.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.has();
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" argument must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-keys.js
+++ b/test/parallel/test-whatwg-url-searchparams-keys.js
@@ -27,17 +27,17 @@ assert.deepStrictEqual(keys.next(), {
   done: true
 });
 
-assert.throws(() => {
+common.expectsError(() => {
   keys.next.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParamsIterator'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   params.keys.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParams'
-}));
+});

--- a/test/parallel/test-whatwg-url-searchparams-set.js
+++ b/test/parallel/test-whatwg-url-searchparams-set.js
@@ -38,20 +38,20 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.set.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
-  assert.throws(() => {
+  });
+  common.expectsError(() => {
     params.set('a');
-  }, common.expectsError({
+  }, {
     code: 'ERR_MISSING_ARGS',
     type: TypeError,
     message: 'The "name" and "value" arguments must be specified'
-  }));
+  });
 
   const obj = {
     toString() { throw new Error('toString'); },

--- a/test/parallel/test-whatwg-url-searchparams-stringifier.js
+++ b/test/parallel/test-whatwg-url-searchparams-stringifier.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
 const URLSearchParams = require('url').URLSearchParams;
 const { test, assert_equals } = require('../common/wpt');
 
@@ -126,11 +125,11 @@ test(function() {
 // Tests below are not from WPT.
 {
   const params = new URLSearchParams();
-  assert.throws(() => {
+  common.expectsError(() => {
     params.toString.call(undefined);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_THIS',
     type: TypeError,
     message: 'Value of "this" must be of type URLSearchParams'
-  }));
+  });
 }

--- a/test/parallel/test-whatwg-url-searchparams-values.js
+++ b/test/parallel/test-whatwg-url-searchparams-values.js
@@ -27,17 +27,17 @@ assert.deepStrictEqual(values.next(), {
   done: true
 });
 
-assert.throws(() => {
+common.expectsError(() => {
   values.next.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParamsIterator'
-}));
-assert.throws(() => {
+});
+common.expectsError(() => {
   params.values.call(undefined);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_THIS',
   type: TypeError,
   message: 'Value of "this" must be of type URLSearchParams'
-}));
+});


### PR DESCRIPTION
Refactored tests to replace `assert.throws(fn, common.expectsError(err));` with `common.expectsError(fn, err); `

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
