### PR TITLE
deps: V8: backport 14ac02c from upstream

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/profiler/profiler-listener.cc
+++ b/deps/v8/src/profiler/profiler-listener.cc
@@ -16,11 +16,7 @@ namespace internal {
 ProfilerListener::ProfilerListener(Isolate* isolate)
     : function_and_resource_names_(isolate->heap()) {}
 
-ProfilerListener::~ProfilerListener() {
-  for (auto code_entry : code_entries_) {
-    delete code_entry;
-  }
-}
+ProfilerListener::~ProfilerListener() = default;
 
 void ProfilerListener::CallbackEvent(Name* name, Address entry_point) {
   CodeEventsContainer evt_rec(CodeEventRecord::CODE_CREATION);
@@ -286,19 +282,23 @@ CodeEntry* ProfilerListener::NewCodeEntry(
     CodeEventListener::LogEventsAndTags tag, const char* name,
     const char* name_prefix, const char* resource_name, int line_number,
     int column_number, JITLineInfoTable* line_info, Address instruction_start) {
-  CodeEntry* code_entry =
-      new CodeEntry(tag, name, name_prefix, resource_name, line_number,
-                    column_number, line_info, instruction_start);
-  code_entries_.push_back(code_entry);
-  return code_entry;
+  std::unique_ptr<CodeEntry> code_entry = base::make_unique<CodeEntry>(
+      tag, name, name_prefix, resource_name, line_number, column_number,
+      line_info, instruction_start);
+  CodeEntry* raw_code_entry = code_entry.get();
+  code_entries_.push_back(std::move(code_entry));
+  return raw_code_entry;
 }
 
 void ProfilerListener::AddObserver(CodeEventObserver* observer) {
   base::LockGuard<base::Mutex> guard(&mutex_);
-  if (std::find(observers_.begin(), observers_.end(), observer) !=
-      observers_.end())
-    return;
-  observers_.push_back(observer);
+  if (observers_.empty()) {
+    code_entries_.clear();
+  }
+  if (std::find(observers_.begin(), observers_.end(), observer) ==
+      observers_.end()) {
+    observers_.push_back(observer);
+  }
 }
 
 void ProfilerListener::RemoveObserver(CodeEventObserver* observer) {

--- a/deps/v8/src/profiler/profiler-listener.h
+++ b/deps/v8/src/profiler/profiler-listener.h
@@ -74,6 +74,7 @@ class ProfilerListener : public CodeEventListener {
   const char* GetFunctionName(const char* name) {
     return function_and_resource_names_.GetFunctionName(name);
   }
+  size_t entries_count_for_test() const { return code_entries_.size(); }
 
  private:
   void RecordInliningInfo(CodeEntry* entry, AbstractCode* abstract_code);
@@ -87,7 +88,7 @@ class ProfilerListener : public CodeEventListener {
   }
 
   StringsStorage function_and_resource_names_;
-  std::vector<CodeEntry*> code_entries_;
+  std::vector<std::unique_ptr<CodeEntry>> code_entries_;
   std::vector<CodeEventObserver*> observers_;
   base::Mutex mutex_;
 


### PR DESCRIPTION
This fixes a memory leak in the CPU profiler: https://bugs.chromium.org/p/v8/issues/detail?id=6623

This affects `master`, `9.x` and `8.x`. `master` should pick this up through a regular V8 update (if the merge gets approved). This PR is for `9.x`. This should cherry-pick to `8.x` easily except for the version bump, which will need to be migrated to `v8-version.h`.

Original commit message:
>   [cpu-profiler] Clear code entries when no observers are present.
> 
>   Performed manual testing as well by making 20 CPU profile recordings of
>   loading http://meduza.io page. Without the patch the page renderer memory size
>   grows beyond 300MB. With the patch it remains below 200MB.
> 
>   BUG=v8:6623
> 
>   Change-Id: Ifce541b84bb2aaaa5175520f8dd49dbc0cb5dd20
>   Reviewed-on: https://chromium-review.googlesource.com/798020
>   Commit-Queue: Alexei Filippov <alph@chromium.org>
>   Reviewed-by: Yang Guo <yangguo@chromium.org>
>   Cr-Commit-Position: refs/heads/master@{#49914}

Ref: https://github.com/v8/v8/commit/14ac02c49c7a364059704537a10abae4feb15a88

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:V8

R = @nodejs/v8 
CI: https://ci.nodejs.org/job/node-test-pull-request/11929/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1102/
