### PR TITLE
refactor: use of Number.isNaN

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -28,7 +28,7 @@ const { inspect } = require('util');
 
 const is = {
   number: (value, key) => {
-    assert(!isNaN(value), `${key} should not be NaN`);
+    assert(!Number.isNaN(value), `${key} should not be NaN`);
     assert.strictEqual(typeof value, 'number');
   },
   string: (value) => { assert.strictEqual(typeof value, 'string'); },

--- a/test/parallel/test-readdouble.js
+++ b/test/parallel/test-readdouble.js
@@ -72,12 +72,12 @@ function test(clazz) {
   buffer[5] = 0xff;
   buffer[6] = 0x0f;
   buffer[7] = 0x00;
-  assert.ok(isNaN(buffer.readDoubleBE(0)));
+  assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
   assert.strictEqual(2.225073858507201e-308, buffer.readDoubleLE(0));
 
   buffer[6] = 0xef;
   buffer[7] = 0x7f;
-  assert.ok(isNaN(buffer.readDoubleBE(0)));
+  assert.ok(Number.isNaN(buffer.readDoubleBE(0)));
   assert.strictEqual(1.7976931348623157e+308, buffer.readDoubleLE(0));
 
   buffer[0] = 0;

--- a/test/parallel/test-writefloat.js
+++ b/test/parallel/test-writefloat.js
@@ -127,8 +127,8 @@ function test(clazz) {
   // Darwin ia32 does the other kind of NaN.
   // Compiler bug.  No one really cares.
   assert(0x7F === buffer[7] || 0xFF === buffer[7]);
-  assert.ok(isNaN(buffer.readFloatBE(0)));
-  assert.ok(isNaN(buffer.readFloatLE(4)));
+  assert.ok(Number.isNaN(buffer.readFloatBE(0)));
+  assert.ok(Number.isNaN(buffer.readFloatLE(4)));
 }
 
 


### PR DESCRIPTION
Refactored tests to replace `isNaN` with `Number.isNaN`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
