### PR TITLE
test: fix flaky test-benchmark-querystring

### DIFF
--- a/test/parallel/test-benchmark-querystring.js
+++ b/test/parallel/test-benchmark-querystring.js
@@ -4,8 +4,9 @@ require('../common');
 
 const runBenchmark = require('../common/benchmark');
 
-runBenchmark('querystring', [
-  'n=1',
-  'input="there is nothing to unescape here"',
-  'type=noencode'
-]);
+runBenchmark('querystring',
+             [ 'n=1',
+               'input="there is nothing to unescape here"',
+               'type=noencode'
+             ],
+             { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Allow zero iterations for short benchmark in test.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test benchmark querystring