### PR TITLE
http: simplify `isInvalidPath`

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -51,20 +51,7 @@ const errors = require('internal/errors');
 // This function is used in the case of small paths, where manual character code
 // checks can greatly outperform the equivalent regexp (tested in V8 5.4).
 function isInvalidPath(s) {
-  var i = 0;
-  if (s.charCodeAt(0) <= 32) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(1) <= 32) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(2) <= 32) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(3) <= 32) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(4) <= 32) return true;
-  if (++i >= s.length) return false;
-  if (s.charCodeAt(5) <= 32) return true;
-  ++i;
-  for (; i < s.length; ++i)
+  for (var i = 0; i < s.length; ++i)
     if (s.charCodeAt(i) <= 32) return true;
   return false;
 }


### PR DESCRIPTION
The loop unrolling here shows no performance benefits in V8 6.3 any longer, so we can get rid of it. This PR is to simplify `isInvalidPath` without obvious  performance regression.

```
                                               improvement confidence    p.value
 http/create-clientrequest.js n=1000000 len=1       -3.06 %          * 0.03418092
 http/create-clientrequest.js n=1000000 len=128      0.20 %            0.88729859
 http/create-clientrequest.js n=1000000 len=16      -0.50 %            0.66812482
 http/create-clientrequest.js n=1000000 len=32       2.21 %            0.06679157
 http/create-clientrequest.js n=1000000 len=64      -0.06 %            0.95083016
 http/create-clientrequest.js n=1000000 len=8       -0.61 %            0.49496794
```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http