### PR TITLE
src: fix missing handlescope bug

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -30,6 +30,7 @@ using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
 using v8::Object;
+using v8::Persistent;
 using v8::Value;
 
 using v8_inspector::StringBuffer;
@@ -613,8 +614,7 @@ void Agent::RegisterAsyncHook(Isolate* isolate,
 
 void Agent::EnableAsyncHook() {
   if (!enable_async_hook_function_.IsEmpty()) {
-    Isolate* isolate = parent_env_->isolate();
-    ToggleAsyncHook(isolate, enable_async_hook_function_.Get(isolate));
+    ToggleAsyncHook(parent_env_->isolate(), enable_async_hook_function_);
   } else if (pending_disable_async_hook_) {
     CHECK(!pending_enable_async_hook_);
     pending_disable_async_hook_ = false;
@@ -625,8 +625,7 @@ void Agent::EnableAsyncHook() {
 
 void Agent::DisableAsyncHook() {
   if (!disable_async_hook_function_.IsEmpty()) {
-    Isolate* isolate = parent_env_->isolate();
-    ToggleAsyncHook(isolate, disable_async_hook_function_.Get(isolate));
+    ToggleAsyncHook(parent_env_->isolate(), disable_async_hook_function_);
   } else if (pending_enable_async_hook_) {
     CHECK(!pending_disable_async_hook_);
     pending_enable_async_hook_ = false;
@@ -635,10 +634,11 @@ void Agent::DisableAsyncHook() {
   }
 }
 
-void Agent::ToggleAsyncHook(Isolate* isolate, Local<Function> fn) {
+void Agent::ToggleAsyncHook(Isolate* isolate, const Persistent<Function>& fn) {
   HandleScope handle_scope(isolate);
+  CHECK(!fn.IsEmpty());
   auto context = parent_env_->context();
-  auto result = fn->Call(context, Undefined(isolate), 0, nullptr);
+  auto result = fn.Get(isolate)->Call(context, Undefined(isolate), 0, nullptr);
   if (result.IsEmpty()) {
     FatalError(
         "node::inspector::Agent::ToggleAsyncHook",

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -96,7 +96,8 @@ class Agent {
   void DisableAsyncHook();
 
  private:
-  void ToggleAsyncHook(v8::Isolate* isolate, v8::Local<v8::Function> fn);
+  void ToggleAsyncHook(v8::Isolate* isolate,
+                       const v8::Persistent<v8::Function>& fn);
 
   node::Environment* parent_env_;
   std::unique_ptr<NodeInspectorClient> client_;


### PR DESCRIPTION
Fix a regression that was introduced in commit 5886e204f0 ("inspector:
track async stacks when necessary") and that I overlooked during review:
the persistent handle with the callback must be rematerialized *after*
the `v8::HandleScope` is created, not before.

Apparently `test/sequential/test-inspector-async-call-stack.js` has
no test coverage for this scenario and I'm out of good ideas on how
to create a concise and reliable test case.

Fixes: https://github.com/nodejs/node/issues/17496
CI: https://ci.nodejs.org/job/node-test-pull-request/11962/