### PR TITLE
crypto: remove BIO_set_shutdown

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -68,8 +68,6 @@ void NodeBIO::AssignEnvironment(Environment* env) {
 int NodeBIO::New(BIO* bio) {
   BIO_set_data(bio, new NodeBIO());
 
-  // XXX Why am I doing it?!
-  BIO_set_shutdown(bio, 1);
   BIO_set_init(bio, 1);
 
   return 1;


### PR DESCRIPTION
I've not been able to find any reason for calling
BIO_set_shutdown(bio, 1). This is done by default for the following
versions of OpenSSL:

https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/crypto/bio/bio_lib.c#L26
https://github.com/openssl/openssl/blob/OpenSSL_1_0_1/crypto/bio/bio_lib.c#L90
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2/crypto/bio/bio_lib.c#L88
https://github.com/openssl/openssl/blob/OpenSSL_1_0_0/crypto/bio/bio_lib.c#L90

This commit removes the call and the comment.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto