### PR TITLE
doc: mark accessing IPC channel fd as undefined

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -621,6 +621,10 @@ pipes between the parent and child. The value is one of the following:
    will enable [`process.send()`][], [`process.disconnect()`][],
    [`process.on('disconnect')`][], and [`process.on('message')`] within the
    child.
+
+   Accessing the IPC channel fd in any way other than [`process.send()`][]
+   or using the IPC channel with a child process that is not a Node.js instance
+   is not supported.
 3. `'ignore'` - Instructs Node.js to ignore the fd in the child. While Node.js
    will always open fds 0 - 2 for the processes it spawns, setting the fd to
    `'ignore'` will cause Node.js to open `/dev/null` and attach it to the


### PR DESCRIPTION
Adds note that accessing the fd of the IPC channel in any other way than `process.send`, or using the IPC channel with child processes that is not Node.js is undefined.

This adds to what was done in https://github.com/nodejs/node/pull/17460

~~Fixes: https://github.com/nodejs/node/issues/16491~~

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
docs
