### PR TITLE
Update test-http-set-cookies to use Countdown

### DIFF
--- a/test/parallel/test-http-set-cookies.js
+++ b/test/parallel/test-http-set-cookies.js
@@ -20,11 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
+const Countdown = require('../common/countdown');
 const assert = require('assert');
 const http = require('http');
 
-let nresponses = 0;
+const countdown = new Countdown(2, common.mustCall(() => {
+  server.close();
+}));
 
 const server = http.createServer(function(req, res) {
   if (req.url === '/one') {
@@ -55,9 +58,7 @@ server.on('listening', function() {
     });
 
     res.on('end', function() {
-      if (++nresponses === 2) {
-        server.close();
-      }
+      countdown.dec();
     });
   });
 
@@ -72,14 +73,8 @@ server.on('listening', function() {
     });
 
     res.on('end', function() {
-      if (++nresponses === 2) {
-        server.close();
-      }
+      countdown.dec();
     });
   });
 
-});
-
-process.on('exit', function() {
-  assert.strictEqual(2, nresponses);
 });


### PR DESCRIPTION
Use `Countdown` class instead of `nresponses` in `test-http-set-cookies.js`

See also: #17169

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test