### PR TITLE
Update test-http-response-status-message to use Countdown

### DIFF
--- a/test/parallel/test-http-response-status-message.js
+++ b/test/parallel/test-http-response-status-message.js
@@ -20,12 +20,11 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
+const Countdown = require('../common/countdown');
 const assert = require('assert');
 const http = require('http');
 const net = require('net');
-
-let testsComplete = 0;
 
 const testCases = [
   { path: '/200', statusMessage: 'OK',
@@ -49,6 +48,7 @@ testCases.findByPath = function(path) {
   return matching[0];
 };
 
+const countdown = new Countdown(testCases.length, common.mustCall(() => {}));
 const server = net.createServer(function(connection) {
   connection.on('data', function(data) {
     const path = data.toString().match(/GET (.*) HTTP\/1\.1/)[1];
@@ -71,7 +71,7 @@ function runTest(testCaseIndex) {
     assert.strictEqual(testCase.statusMessage, response.statusMessage);
 
     response.on('end', function() {
-      testsComplete++;
+      countdown.dec();
 
       if (testCaseIndex + 1 < testCases.length) {
         runTest(testCaseIndex + 1);
@@ -85,7 +85,3 @@ function runTest(testCaseIndex) {
 }
 
 server.listen(0, function() { runTest(0); });
-
-process.on('exit', function() {
-  assert.strictEqual(testCases.length, testsComplete);
-});


### PR DESCRIPTION
Use `Countdown` class instead of testsComplete in `test-http-response-status-message.js`.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test