### PR TITLE
refactor: intuitively handle current object context

### DIFF
--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -83,14 +83,13 @@ const forAllClients = (cb) => common.mustCall(cb, CLIENT_VARIANTS);
       path: serverPath
     });
     const getConnectCb = (index) => common.mustCall(function clientOnConnect() {
-      const client = this;
       // Test if it's wrapping an existing fd
       assert(handleMap.has(index));
       const oldHandle = handleMap.get(index);
       assert.strictEqual(oldHandle.fd, this._handle.fd);
-      client.write(String(oldHandle.fd));
+      this.write(String(oldHandle.fd));
       console.error(`[Pipe]Sending data through fd ${oldHandle.fd}`);
-      client.on('error', function(err) {
+      this.on('error', function(err) {
         console.error(err);
         assert.fail(null, null, `[Pipe Client]${err}`);
       });

--- a/test/parallel/test-net-connect-options-path.js
+++ b/test/parallel/test-net-connect-options-path.js
@@ -20,9 +20,8 @@ const CLIENT_VARIANTS = 12;
   }, CLIENT_VARIANTS))
   .listen(serverPath, common.mustCall(function() {
     const getConnectCb = () => common.mustCall(function() {
-      const client = this;
-      client.end();
-      client.on('close', common.mustCall(function() {
+      this.end();
+      this.on('close', common.mustCall(function() {
         counter++;
         if (counter === CLIENT_VARIANTS) {
           server.close();


### PR DESCRIPTION
Refactored to intuitively handle current object context

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
