### PR TITLE
Add tests into internal/crypto/random.js to improve coverage

### DIFF
--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -498,6 +498,15 @@ common.expectsError(
   }
 );
 
+common.expectsError(
+  () => crypto.randomBytes(1, null),
+  {
+    code: 'ERR_INVALID_CALLBACK',
+    type: TypeError,
+    message: 'Callback must be a function',
+  }
+);
+
 [1, true, NaN, null, undefined, {}, []].forEach((i) => {
   common.expectsError(
     () => crypto.randomFillSync(i),

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -487,15 +487,6 @@ common.expectsError(
   }
 );
 
-common.expectsError(
-  () => crypto.randomBytes(1, null),
-  {
-    code: 'ERR_INVALID_CALLBACK',
-    type: TypeError,
-    message: 'Callback must be a function',
-  }
-);
-
 [1, true, NaN, null, undefined, {}, []].forEach((i) => {
   const buf = Buffer.alloc(10);
   common.expectsError(
@@ -519,4 +510,15 @@ common.expectsError(
       type: TypeError,
       message: 'Callback must be a function',
     });
+});
+
+[1, true, NaN, null, {}, []].forEach((i) => {
+  common.expectsError(
+    () => crypto.randomBytes(1, i),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: 'Callback must be a function',
+    }
+  );
 });

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -121,17 +121,6 @@ process.setMaxListeners(256);
 
 {
   const buf = Buffer.alloc(10);
-  common.expectsError(
-    () => crypto.randomFill(buf, 0, 10, null),
-    {
-      code: 'ERR_INVALID_CALLBACK',
-      type: TypeError,
-      message: 'Callback must be a function',
-    });
-}
-
-{
-  const buf = Buffer.alloc(10);
   const before = buf.toString('hex');
   crypto.randomFill(buf, common.mustCall((err, buf) => {
     assert.ifError(err);
@@ -508,6 +497,7 @@ common.expectsError(
 );
 
 [1, true, NaN, null, undefined, {}, []].forEach((i) => {
+  const buf = Buffer.alloc(10);
   common.expectsError(
     () => crypto.randomFillSync(i),
     {
@@ -522,4 +512,11 @@ common.expectsError(
       type: TypeError
     }
   );
+  common.expectsError(
+    () => crypto.randomFill(buf, 0, 10, i),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: 'Callback must be a function',
+    });
 });

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -121,6 +121,17 @@ process.setMaxListeners(256);
 
 {
   const buf = Buffer.alloc(10);
+  common.expectsError(
+    () => crypto.randomFill(buf, 0, 10, null),
+    {
+      code: 'ERR_INVALID_CALLBACK',
+      type: TypeError,
+      message: 'Callback must be a function',
+    });
+}
+
+{
+  const buf = Buffer.alloc(10);
   const before = buf.toString('hex');
   crypto.randomFill(buf, common.mustCall((err, buf) => {
     assert.ifError(err);


### PR DESCRIPTION
I added these test case:

- Call randomBytes with cb is not a function
- Call randomFill with cb is not a function

Current coverage is here: https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/crypto/random.js.html

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test