### PR TITLE
tools: eslint rule for assert.throws -> common.expectsError 

### DIFF
--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -10,6 +10,7 @@ rules:
   # Custom rules in tools/eslint-rules
   prefer-assert-iferror: error
   prefer-assert-methods: error
+  prefer-common-expectserror: error
   prefer-common-mustnotcall: error
   crypto-check: error
   inspector-check: error

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -17,12 +17,12 @@ common.expectsError(
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
   });
-assert.throws(() => {
+common.expectsError(() => {
   new AsyncResource('invalid_trigger_id', { triggerAsyncId: null });
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ASYNC_ID',
   type: RangeError,
-}));
+});
 
 assert.strictEqual(
   new AsyncResource('default_trigger_id').triggerAsyncId(),

--- a/test/parallel/test-assert-fail.js
+++ b/test/parallel/test-assert-fail.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable prefer-common-expectserror */
+
 const common = require('../common');
 const assert = require('assert');
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -20,6 +20,9 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
+
+/* eslint-disable prefer-common-expectserror */
+
 const common = require('../common');
 const assert = require('assert');
 const a = assert;

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -974,12 +974,11 @@ assert.strictEqual(SlowBuffer.prototype.offset, undefined);
 }
 
 // ParseArrayIndex() should reject values that don't fit in a 32 bits size_t.
-assert.throws(() => {
+common.expectsError(() => {
   const a = Buffer.alloc(1);
   const b = Buffer.alloc(1);
   a.copy(b, 0, 0x100000000, 0x100000001);
-}, common.expectsError(
-  { code: undefined, type: RangeError, message: 'Index out of range' }));
+}, { code: undefined, type: RangeError, message: 'Index out of range' });
 
 // Unpooled buffer (replaces SlowBuffer)
 {

--- a/test/parallel/test-buffer-fill.js
+++ b/test/parallel/test-buffer-fill.js
@@ -424,21 +424,19 @@ common.expectsError(() => {
 
 // Testing process.binding. Make sure "end" is properly checked for -1 wrap
 // around.
-assert.throws(() => {
+common.expectsError(() => {
   process.binding('buffer').fill(Buffer.alloc(1), 1, 1, -2, 1);
-}, common.expectsError(
-  { code: undefined, type: RangeError, message: 'Index out of range' }));
+}, { code: undefined, type: RangeError, message: 'Index out of range' });
 
 // Test that bypassing 'length' won't cause an abort.
-assert.throws(() => {
+common.expectsError(() => {
   const buf = new Buffer('w00t');
   Object.defineProperty(buf, 'length', {
     value: 1337,
     enumerable: true
   });
   buf.fill('');
-}, common.expectsError(
-  { code: undefined, type: RangeError, message: 'Index out of range' }));
+}, { code: undefined, type: RangeError, message: 'Index out of range' });
 
 assert.deepStrictEqual(
   Buffer.allocUnsafeSlow(16).fill('ab', 'utf16le'),

--- a/test/parallel/test-console-instance.js
+++ b/test/parallel/test-console-instance.js
@@ -47,17 +47,17 @@ common.expectsError(
 );
 
 // Console constructor should throw if stderr exists but is not writable
-assert.throws(
+common.expectsError(
   () => {
     out.write = () => {};
     err.write = undefined;
     new Console(out, err);
   },
-  common.expectsError({
+  {
     code: 'ERR_CONSOLE_WRITABLE_STREAM',
     type: TypeError,
     message: /stderr/
-  })
+  }
 );
 
 out.write = err.write = (d) => {};

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -205,20 +205,20 @@ assert.doesNotThrow(() => {
   }, common.mustCall());
 });
 
-assert.throws(() => dns.lookupService('0.0.0.0'), common.expectsError({
+common.expectsError(() => dns.lookupService('0.0.0.0'), {
   code: 'ERR_MISSING_ARGS',
   type: TypeError,
   message: 'The "host", "port", and "callback" arguments must be specified'
-}));
+});
 
 const invalidHost = 'fasdfdsaf';
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookupService(invalidHost, 0, common.mustNotCall());
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_OPT_VALUE',
   type: TypeError,
   message: `The value "${invalidHost}" is invalid for option "host"`
-}));
+});
 
 const portErr = (port) => {
   common.expectsError(
@@ -238,9 +238,9 @@ portErr(undefined);
 portErr(65538);
 portErr('test');
 
-assert.throws(() => {
+common.expectsError(() => {
   dns.lookupService('0.0.0.0', 80, null);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_CALLBACK',
   type: TypeError
-}));
+});

--- a/test/parallel/test-eslint-prefer-common-expectserror.js
+++ b/test/parallel/test-eslint-prefer-common-expectserror.js
@@ -1,0 +1,27 @@
+'use strict';
+
+require('../common');
+
+const RuleTester = require('../../tools/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/prefer-common-expectserror');
+
+const message = 'Please use common.expectsError(fn, err) instead of ' +
+                'assert.throws(fn, common.expectsError(err)).';
+
+new RuleTester().run('prefer-common-expectserror', rule, {
+  valid: [
+    'assert.throws(fn, /[a-z]/)',
+    'assert.throws(function () {}, function() {})',
+    'common.expectsError(function() {}, err)'
+  ],
+  invalid: [
+    {
+      code: 'assert.throws(function() {}, common.expectsError(err))',
+      errors: [{ message }]
+    },
+    {
+      code: 'assert.throws(fn, common.expectsError(err))',
+      errors: [{ message }]
+    }
+  ]
+});

--- a/test/parallel/test-http-outgoing-proto.js
+++ b/test/parallel/test-http-outgoing-proto.js
@@ -21,80 +21,80 @@ assert.strictEqual(
   typeof ServerResponse.prototype._implicitHeader, 'function');
 
 // validateHeader
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader();
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   type: TypeError,
   message: 'Header name must be a valid HTTP token ["undefined"]'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader('test');
-}, common.expectsError({
+}, {
   code: 'ERR_HTTP_INVALID_HEADER_VALUE',
   type: TypeError,
   message: 'Invalid value "undefined" for header "test"'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader(404);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   type: TypeError,
   message: 'Header name must be a valid HTTP token ["404"]'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader.call({ _header: 'test' }, 'test', 'value');
-}, common.expectsError({
+}, {
   code: 'ERR_HTTP_HEADERS_SENT',
   type: Error,
   message: 'Cannot set headers after they are sent to the client'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.setHeader('200', 'あ');
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_CHAR',
   type: TypeError,
   message: 'Invalid character in header content ["200"]'
-}));
+});
 
 // write
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.write();
-}, common.expectsError({
+}, {
   code: 'ERR_METHOD_NOT_IMPLEMENTED',
   type: Error,
   message: 'The _implicitHeader() method is not implemented'
-}));
+});
 
 assert(OutgoingMessage.prototype.write.call({ _header: 'test' }));
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' });
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The first argument must be one of type string or Buffer'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' }, 1);
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_ARG_TYPE',
   type: TypeError,
   message: 'The first argument must be one of type string or Buffer'
-}));
+});
 
 // addTrailers()
 // The `Error` comes from the JavaScript engine so confirm that it is a
@@ -105,20 +105,20 @@ assert.throws(() => {
   outgoingMessage.addTrailers();
 }, TypeError);
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.addTrailers({ 'あ': 'value' });
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_HTTP_TOKEN',
   type: TypeError,
   message: 'Trailer name must be a valid HTTP token ["あ"]'
-}));
+});
 
-assert.throws(() => {
+common.expectsError(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.addTrailers({ 404: 'あ' });
-}, common.expectsError({
+}, {
   code: 'ERR_INVALID_CHAR',
   type: TypeError,
   message: 'Invalid character in trailer content ["404"]'
-}));
+});

--- a/test/parallel/test-http2-client-request-options-errors.js
+++ b/test/parallel/test-http2-client-request-options-errors.js
@@ -3,7 +3,6 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const http2 = require('http2');
 
 // Check if correct errors are emitted when wrong type of data is passed
@@ -40,19 +39,19 @@ server.listen(0, common.mustCall(() => {
         return;
       }
 
-      assert.throws(
+      common.expectsError(
         () => client.request({
           ':method': 'CONNECT',
           ':authority': `localhost:${port}`
         }, {
           [option]: types[type]
         }),
-        common.expectsError({
+        {
           type: TypeError,
           code: 'ERR_INVALID_OPT_VALUE',
           message: `The value "${String(types[type])}" is invalid ` +
                    `for option "${option}"`
-        })
+        }
       );
     });
   });

--- a/test/parallel/test-http2-connect-method.js
+++ b/test/parallel/test-http2-connect-method.js
@@ -55,36 +55,36 @@ server.listen(0, common.mustCall(() => {
     const client = http2.connect(`http://localhost:${proxy.address().port}`);
 
     // confirm that :authority is required and :scheme & :path are forbidden
-    assert.throws(
+    common.expectsError(
       () => client.request({
         [HTTP2_HEADER_METHOD]: 'CONNECT'
       }),
-      common.expectsError({
+      {
         code: 'ERR_HTTP2_CONNECT_AUTHORITY',
         message: ':authority header is required for CONNECT requests'
-      })
+      }
     );
-    assert.throws(
+    common.expectsError(
       () => client.request({
         [HTTP2_HEADER_METHOD]: 'CONNECT',
         [HTTP2_HEADER_AUTHORITY]: `localhost:${port}`,
         [HTTP2_HEADER_SCHEME]: 'http'
       }),
-      common.expectsError({
+      {
         code: 'ERR_HTTP2_CONNECT_SCHEME',
         message: 'The :scheme header is forbidden for CONNECT requests'
-      })
+      }
     );
-    assert.throws(
+    common.expectsError(
       () => client.request({
         [HTTP2_HEADER_METHOD]: 'CONNECT',
         [HTTP2_HEADER_AUTHORITY]: `localhost:${port}`,
         [HTTP2_HEADER_PATH]: '/'
       }),
-      common.expectsError({
+      {
         code: 'ERR_HTTP2_CONNECT_PATH',
         message: 'The :path header is forbidden for CONNECT requests'
-      })
+      }
     );
 
     // valid CONNECT request

--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -5,7 +5,6 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const fixtures = require('../common/fixtures');
 const http2 = require('http2');
-const assert = require('assert');
 
 const {
   HTTP2_HEADER_CONTENT_TYPE,
@@ -16,16 +15,16 @@ const fname = fixtures.path('elipses.txt');
 
 const server = http2.createServer();
 server.on('stream', (stream) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     stream.respondWithFile(fname, {
       [HTTP2_HEADER_STATUS]: 204,
       [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
     });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
     type: Error,
     message: 'Responses with 204 status must not have a payload'
-  }));
+  });
   stream.respond({});
   stream.end();
 });

--- a/test/parallel/test-http2-server-push-disabled.js
+++ b/test/parallel/test-http2-server-push-disabled.js
@@ -21,16 +21,16 @@ server.on('stream', common.mustCall((stream) => {
   // and pushStream() must throw.
   assert.strictEqual(stream.pushAllowed, false);
 
-  assert.throws(() => {
+  common.expectsError(() => {
     stream.pushStream({
       ':scheme': 'http',
       ':path': '/foobar',
       ':authority': `localhost:${server.address().port}`,
     }, common.mustNotCall());
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_PUSH_DISABLED',
     type: Error
-  }));
+  });
 
   stream.respond({ ':status': 200 });
   stream.end('test');

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -14,15 +14,15 @@ server.on('stream', common.mustCall(onStream));
 function onStream(stream, headers, flags) {
   stream.rstStream();
 
-  assert.throws(() => {
+  common.expectsError(() => {
     stream.additionalHeaders({
       ':status': 123,
       abc: 123
     });
-  }, common.expectsError({
+  }, {
     code: 'ERR_HTTP2_INVALID_STREAM',
     message: /^The stream has been destroyed$/
-  }));
+  });
 }
 
 server.listen(0);

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -101,16 +101,16 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[keyStr, keyStr2], true, invalidCertRE],
   [true, [certBuff, certBuff2], invalidKeyRE]
 ].map((params) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     https.createServer({
       key: params[0],
       cert: params[1]
     });
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: params[2]
-  }));
+  });
 });
 
 // Checks to ensure https.createServer works with the CA parameter
@@ -142,15 +142,15 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
 ].map((params) => {
-  assert.throws(() => {
+  common.expectsError(() => {
     https.createServer({
       key: params[0],
       cert: params[1],
       ca: params[2]
     });
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError,
     message: /^The "ca" argument must be one of type string, Buffer, TypedArray, or DataView$/
-  }));
+  });
 });

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -141,29 +141,29 @@ common.expectsError(
 
 // Tests for common.expectsError
 assert.doesNotThrow(() => {
-  assert.throws(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1' }));
+  }, { code: 'TEST_ERROR_1' });
 });
 
 assert.doesNotThrow(() => {
-  assert.throws(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1',
-                           type: TypeError,
-                           message: /^Error for testing/ }));
+  }, { code: 'TEST_ERROR_1',
+       type: TypeError,
+       message: /^Error for testing/ });
 });
 
 assert.doesNotThrow(() => {
-  assert.throws(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1', type: TypeError }));
+  }, { code: 'TEST_ERROR_1', type: TypeError });
 });
 
 assert.doesNotThrow(() => {
-  assert.throws(() => {
+  common.expectsError(() => {
     throw new errors.TypeError('TEST_ERROR_1', 'a');
-  }, common.expectsError({ code: 'TEST_ERROR_1', type: Error }));
+  }, { code: 'TEST_ERROR_1', type: Error });
 });
 
 common.expectsError(() => {

--- a/test/parallel/test-performance.js
+++ b/test/parallel/test-performance.js
@@ -68,12 +68,13 @@ assert.strictEqual(typeof performance.timeOrigin, 'number');
   });
 
   [undefined, null, 'foo', 1].forEach((i) => {
-    assert.throws(() => performance.measure('test', 'A', i),
-                  common.expectsError({
-                    code: 'ERR_INVALID_PERFORMANCE_MARK',
-                    type: Error,
-                    message: `The "${i}" performance mark has not been set`
-                  }));
+    common.expectsError(
+      () => performance.measure('test', 'A', i),
+      {
+        code: 'ERR_INVALID_PERFORMANCE_MARK',
+        type: Error,
+        message: `The "${i}" performance mark has not been set`
+      });
   });
 
   performance.clearMeasures();

--- a/test/parallel/test-performanceobserver.js
+++ b/test/parallel/test-performanceobserver.js
@@ -28,33 +28,34 @@ assert.strictEqual(counts[NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION], 0);
 
 {
   [1, null, undefined, {}, [], Infinity].forEach((i) => {
-    assert.throws(() => new PerformanceObserver(i),
-                  common.expectsError({
-                    code: 'ERR_INVALID_CALLBACK',
-                    type: TypeError,
-                    message: 'Callback must be a function'
-                  }));
+    common.expectsError(() => new PerformanceObserver(i),
+                        {
+                          code: 'ERR_INVALID_CALLBACK',
+                          type: TypeError,
+                          message: 'Callback must be a function'
+                        });
   });
   const observer = new PerformanceObserver(common.mustNotCall());
 
   [1, null, undefined].forEach((i) => {
     //observer.observe(i);
-    assert.throws(() => observer.observe(i),
-                  common.expectsError({
-                    code: 'ERR_INVALID_ARG_TYPE',
-                    type: TypeError,
-                    message: 'The "options" argument must be of type Object'
-                  }));
+    common.expectsError(
+      () => observer.observe(i),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: 'The "options" argument must be of type Object'
+      });
   });
 
   [1, undefined, null, {}, Infinity].forEach((i) => {
-    assert.throws(() => observer.observe({ entryTypes: i }),
-                  common.expectsError({
-                    code: 'ERR_INVALID_OPT_VALUE',
-                    type: TypeError,
-                    message: 'The value "[object Object]" is invalid for ' +
-                             'option "entryTypes"'
-                  }));
+    common.expectsError(() => observer.observe({ entryTypes: i }),
+                        {
+                          code: 'ERR_INVALID_OPT_VALUE',
+                          type: TypeError,
+                          message: 'The value "[object Object]" is invalid ' +
+                                   'for option "entryTypes"'
+                        });
   });
 }
 

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -357,46 +357,46 @@ function isWarned(emitter) {
   // constructor throws if completer is not a function or undefined
   {
     const fi = new FakeInput();
-    assert.throws(function() {
+    common.expectsError(function() {
       readline.createInterface({
         input: fi,
         completer: 'string is not valid'
       });
-    }, common.expectsError({
+    }, {
       type: TypeError,
       code: 'ERR_INVALID_OPT_VALUE'
-    }));
+    });
   }
 
   // constructor throws if historySize is not a positive number
   {
     const fi = new FakeInput();
-    assert.throws(function() {
+    common.expectsError(function() {
       readline.createInterface({
         input: fi, historySize: 'not a number'
       });
-    }, common.expectsError({
+    }, {
       type: RangeError,
       code: 'ERR_INVALID_OPT_VALUE'
-    }));
+    });
 
-    assert.throws(function() {
+    common.expectsError(function() {
       readline.createInterface({
         input: fi, historySize: -1
       });
-    }, common.expectsError({
+    }, {
       type: RangeError,
       code: 'ERR_INVALID_OPT_VALUE'
-    }));
+    });
 
-    assert.throws(function() {
+    common.expectsError(function() {
       readline.createInterface({
         input: fi, historySize: NaN
       });
-    }, common.expectsError({
+    }, {
       type: RangeError,
       code: 'ERR_INVALID_OPT_VALUE'
-    }));
+    });
   }
 
   // duplicate lines are removed from history when

--- a/test/sequential/test-tls-lookup.js
+++ b/test/sequential/test-tls-lookup.js
@@ -13,12 +13,12 @@ const tls = require('tls');
     lookup: input
   };
 
-  assert.throws(function() {
+  common.expectsError(function() {
     tls.connect(opts);
-  }, common.expectsError({
+  }, {
     code: 'ERR_INVALID_ARG_TYPE',
     type: TypeError
-  }));
+  });
 });
 
 connectDoesNotThrow(common.mustCall(() => {}));

--- a/tools/eslint-rules/prefer-common-expectserror.js
+++ b/tools/eslint-rules/prefer-common-expectserror.js
@@ -1,0 +1,21 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const msg = 'Please use common.expectsError(fn, err) instead of ' +
+            'assert.throws(fn, common.expectsError(err)).';
+
+const astSelector =
+  'CallExpression[arguments.length=2]' +
+                '[callee.object.name="assert"]' +
+                '[callee.property.name="throws"]' +
+                '[arguments.1.callee.object.name="common"]' +
+                '[arguments.1.callee.property.name="expectsError"]';
+
+module.exports = function(context) {
+  return {
+    [astSelector]: (node) => context.report(node, msg)
+  };
+};


### PR DESCRIPTION
Pretty straight-forward — eslint rule that checks for usage of `assert.throws(fn, common.expectsError(err));` and suggests using `common.expectsError(fn, err);` instead.

First commit fixes all remaining instances that violate this rule. Second commit introduces the rule & a test for it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test, tools