### PR TITLE
tools,test: throw if common.PORT used in parallel tests

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -39,8 +39,9 @@ const noop = () => {};
 // Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
 // gets tools to ignore it by default or by simple rules, especially eslint.
 let tmpDirName = '.tmp';
-// PORT should match the definition in test/testpy/__init__.py.
+
 exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
+
 exports.isWindows = process.platform === 'win32';
 exports.isWOW64 = exports.isWindows &&
                   (process.env.PROCESSOR_ARCHITEW6432 !== undefined);
@@ -162,7 +163,6 @@ exports.refreshTmpDir = function() {
 };
 
 if (process.env.TEST_THREAD_ID) {
-  exports.PORT += process.env.TEST_THREAD_ID * 100;
   tmpDirName += `.${process.env.TEST_THREAD_ID}`;
 }
 exports.tmpDir = path.join(testRoot, tmpDirName);

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -40,7 +40,16 @@ const noop = () => {};
 // gets tools to ignore it by default or by simple rules, especially eslint.
 let tmpDirName = '.tmp';
 
-exports.PORT = +process.env.NODE_COMMON_PORT || 12346;
+Object.defineProperty(exports, 'PORT', {
+  get: () => {
+    if (+process.env.TEST_PARALLEL) {
+      throw new Error('common.PORT cannot be used in a parallelized test');
+    }
+    return +process.env.NODE_COMMON_PORT || 12346;
+  },
+  enumerable: true
+});
+
 
 exports.isWindows = process.platform === 'win32';
 exports.isWOW64 = exports.isWindows &&

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -61,10 +61,7 @@ class SimpleTestCase(test.TestCase):
     source = open(self.file).read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:
-      # PORT should match the definition in test/common/index.js.
-      env = { 'PORT': int(os.getenv('NODE_COMMON_PORT', '12346')) }
-      env['PORT'] += self.thread_id * 100
-      flag = flags_match.group(1).strip().format(**env).split()
+      flag = flags_match.group(1).strip().split()
       # The following block reads config.gypi to extract the v8_enable_inspector
       # value. This is done to check if the inspector is disabled in which case
       # the '--inspect' flag cannot be passed to the node process as it will

--- a/tools/test.py
+++ b/tools/test.py
@@ -532,7 +532,8 @@ class TestCase(object):
 
     try:
       result = self.RunCommand(self.GetCommand(), {
-        "TEST_THREAD_ID": "%d" % self.thread_id
+        "TEST_THREAD_ID": "%d" % self.thread_id,
+        "TEST_PARALLEL" : "%d" % self.parallel
       })
     finally:
       # Tests can leave the tty in non-blocking mode. If the test runner


### PR DESCRIPTION
common.PORT should not be used in parallelized tests. (There can be a
port collision if another tests requests an arbitrary open port from the
operating system and ends up getting common.PORT before a test that uses
common.PORT uses the port.) In such a situation, throw an error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test tools