### PR TITLE
tls: use correct class name in deprecation message

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -949,6 +949,6 @@ module.exports = {
   createSecurePair:
     internalUtil.deprecate(createSecurePair,
                            'tls.createSecurePair() is deprecated. Please use ' +
-                           'tls.Socket instead.', 'DEP0064'),
+                           'tls.TLSSocket instead.', 'DEP0064'),
   pipe
 };

--- a/test/parallel/test-tls-legacy-deprecated.js
+++ b/test/parallel/test-tls-legacy-deprecated.js
@@ -9,7 +9,7 @@ const tls = require('tls');
 
 common.expectWarning(
   'DeprecationWarning',
-  'tls.createSecurePair() is deprecated. Please use tls.Socket instead.'
+  'tls.createSecurePair() is deprecated. Please use tls.TLSSocket instead.'
 );
 
 assert.doesNotThrow(() => tls.createSecurePair());


### PR DESCRIPTION
`tls.Socket` does not exist, and the deprecation message
should refer to `tls.TLSSocket` (like the documentation
for the deprecation message already does).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tls