### PR TITLE
test: refactor test-http-default-port

### DIFF
--- a/test/parallel/test-http-default-port.js
+++ b/test/parallel/test-http-default-port.js
@@ -34,54 +34,27 @@ const options = {
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')
 };
-let gotHttpsResp = false;
-let gotHttpResp = false;
 
-process.on('exit', function() {
-  if (common.hasCrypto) {
-    assert(gotHttpsResp);
-  }
-  assert(gotHttpResp);
-  console.log('ok');
-});
-
-http.createServer(function(req, res) {
-  assert.strictEqual(req.headers.host, hostExpect);
-  assert.strictEqual(req.headers['x-port'], this.address().port.toString());
-  res.writeHead(200);
-  res.end('ok');
-  this.close();
-}).listen(0, function() {
-  http.globalAgent.defaultPort = this.address().port;
-  http.get({
-    host: 'localhost',
-    headers: {
-      'x-port': this.address().port
-    }
-  }, function(res) {
-    gotHttpResp = true;
-    res.resume();
-  });
-});
-
-if (common.hasCrypto) {
-  https.createServer(options, function(req, res) {
+for (const { mod, createServer } of [
+  { mod: http, createServer: http.createServer },
+  { mod: https, createServer: https.createServer.bind(null, options) }
+]) {
+  const server = createServer(common.mustCall((req, res) => {
     assert.strictEqual(req.headers.host, hostExpect);
-    assert.strictEqual(req.headers['x-port'], this.address().port.toString());
+    assert.strictEqual(req.headers['x-port'], `${server.address().port}`);
     res.writeHead(200);
     res.end('ok');
-    this.close();
-  }).listen(0, function() {
-    https.globalAgent.defaultPort = this.address().port;
-    https.get({
+    server.close();
+  })).listen(0, common.mustCall(() => {
+    mod.globalAgent.defaultPort = server.address().port;
+    mod.get({
       host: 'localhost',
       rejectUnauthorized: false,
       headers: {
-        'x-port': this.address().port
+        'x-port': server.address().port
       }
-    }, function(res) {
-      gotHttpsResp = true;
+    }, common.mustCall((res) => {
       res.resume();
-    });
-  });
+    }));
+  }));
 }


### PR DESCRIPTION
- Remove redundant `hasCrypto` checks
- Use `common.mustCall()`
- Use arrow functions
- Deduplicate HTTP & HTTPS code

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test