### PR TITLE
test: remove unnecessary use of common.PORT in addons test

### DIFF
--- a/test/addons/openssl-client-cert-engine/test.js
+++ b/test/addons/openssl-client-cert-engine/test.js
@@ -21,8 +21,6 @@ const agentKey = fs.readFileSync(fixture.path('/keys/agent1-key.pem'));
 const agentCert = fs.readFileSync(fixture.path('/keys/agent1-cert.pem'));
 const agentCa = fs.readFileSync(fixture.path('/keys/ca1-cert.pem'));
 
-const port = common.PORT;
-
 const serverOptions = {
   key: agentKey,
   cert: agentCert,
@@ -34,11 +32,11 @@ const serverOptions = {
 const server = https.createServer(serverOptions, (req, res) => {
   res.writeHead(200);
   res.end('hello world');
-}).listen(port, common.localhostIPv4, () => {
+}).listen(0, common.localhostIPv4, () => {
   const clientOptions = {
     method: 'GET',
     host: common.localhostIPv4,
-    port: port,
+    port: server.address().port,
     path: '/test',
     clientCertEngine: engine,  // engine will provide key+cert
     rejectUnauthorized: false, // prevent failing on self-signed certificates


### PR DESCRIPTION
Using port 0 to request an open port from the operating system is
sufficient in openssl-client-cert-engine/test.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test