### PR TITLE
repl: fix util.inspect() coloring regression

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -103,7 +103,7 @@ function hasOwnProperty(obj, prop) {
 // This is the default "writer" value if none is passed in the REPL options.
 const writer = exports.writer = (obj) => util.inspect(obj, writer.options);
 writer.options =
-    Object.assign(util.inspect.defaultOptions, { showProxy: true });
+    Object.assign({}, util.inspect.defaultOptions, { showProxy: true });
 
 exports._builtinLibs = internalModule.builtinLibs;
 
@@ -470,7 +470,7 @@ function REPLServer(prompt,
   if (self.useColors && self.writer === writer) {
     // Turn on ANSI coloring.
     self.writer = (obj) => util.inspect(obj, self.writer.options);
-    self.writer.options = Object.assign(writer.options, { colors: true });
+    self.writer.options = Object.assign({}, writer.options, { colors: true });
   }
 
   function filterInternalStackFrames(error, structuredStack) {

--- a/test/parallel/test-repl-colors.js
+++ b/test/parallel/test-repl-colors.js
@@ -1,0 +1,31 @@
+/* eslint-disable quotes */
+'use strict';
+require('../common');
+const { Duplex } = require('stream');
+const { inspect } = require('util');
+const { strictEqual } = require('assert');
+const { REPLServer } = require('repl');
+
+let output = '';
+
+const inout = new Duplex({ decodeStrings: false });
+inout._read = function() {
+  this.push('util.inspect("string")\n');
+  this.push(null);
+};
+inout._write = function(s, _, cb) {
+  output += s;
+  cb();
+};
+
+const repl = new REPLServer({ input: inout, output: inout, useColors: true });
+
+process.on('exit', function() {
+  // https://github.com/nodejs/node/pull/16485#issuecomment-350428638
+  // The color setting of the REPL should not have leaked over into
+  // the color setting of `util.inspect.defaultOptions`.
+  strictEqual(output.includes(`'\\'string\\''`), true);
+  strictEqual(output.includes(`'\u001b[32m\\'string\\'\u001b[39m'`), false);
+  strictEqual(inspect.defaultOptions.colors, false);
+  strictEqual(repl.writer.options.colors, true);
+});


### PR DESCRIPTION
The `Object.assign()` calls introduced in commit 90a4390 ("repl: show
proxies as Proxy objects") mutated their first argument, causing the
`{ colors: true }` option from the REPL to leak over into the global
`util.inspect.defaultOptions` object.

Refs: https://github.com/nodejs/node/pull/16485#issuecomment-350428638
CI: https://ci.nodejs.org/job/node-test-pull-request/11995/
