### PR TITLE
crypto: warn on invalid authentication tag length

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3767,7 +3767,7 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(false);
   }
 
-  // Restrict GCM tag lengths according to NIST 800-38d, page 9
+  // Restrict GCM tag lengths according to NIST 800-38d, page 9.
   unsigned int tag_len = Buffer::Length(args[0]);
   if (tag_len > 16 || (tag_len < 12 && tag_len != 8 && tag_len != 4)) {
     ProcessEmitWarning(cipher->env(),

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3767,14 +3767,13 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(false);
   }
 
+  // Restrict GCM tag lengths according to NIST 800-38d, page 9
   unsigned int tag_len = Buffer::Length(args[0]);
-  if (EVP_CIPHER_CTX_mode(cipher->ctx_) == EVP_CIPH_GCM_MODE) {
-    if (tag_len > 16 || (tag_len < 12 && tag_len != 8 && tag_len != 4)) {
-      ProcessEmitWarning(cipher->env(),
-          "Permitting authentication tag lengths of %u bytes is deprecated. "
-          "Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.",
-          tag_len);
-    }
+  if (tag_len > 16 || (tag_len < 12 && tag_len != 8 && tag_len != 4)) {
+    ProcessEmitWarning(cipher->env(),
+        "Permitting authentication tag lengths of %u bytes is deprecated. "
+        "Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.",
+        tag_len);
   }
 
   // Note: we don't use std::max() here to work around a header conflict.

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3767,9 +3767,18 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(false);
   }
 
-  // FIXME(bnoordhuis) Throw when buffer length is not a valid tag size.
+  unsigned int tag_len = Buffer::Length(args[0]);
+  if (EVP_CIPHER_CTX_mode(cipher->ctx_) == EVP_CIPH_GCM_MODE) {
+    if (tag_len > 16 || (tag_len < 12 && tag_len != 8 && tag_len != 4)) {
+      ProcessEmitWarning(cipher->env(),
+          "Permitting authentication tag lengths of %u bytes is deprecated. "
+          "Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.",
+          tag_len);
+    }
+  }
+
   // Note: we don't use std::max() here to work around a header conflict.
-  cipher->auth_tag_len_ = Buffer::Length(args[0]);
+  cipher->auth_tag_len_ = tag_len;
   if (cipher->auth_tag_len_ > sizeof(cipher->auth_tag_))
     cipher->auth_tag_len_ = sizeof(cipher->auth_tag_);
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -335,9 +335,9 @@ const errMessages = {
 
 const ciphers = crypto.getCiphers();
 
-common.expectWarning('Warning', common.hasFipsCrypto ? [] : [
+common.expectWarning('Warning', (common.hasFipsCrypto ? [] : [
   'Use Cipheriv for counter mode of aes-192-gcm'
-].concat(
+]).concat(
   [0, 1, 2, 6, 9, 10, 11, 17]
   .map((i) => `Permitting authentication tag lengths of ${i} bytes is ` +
             'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.')

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -335,7 +335,7 @@ const errMessages = {
 
 const ciphers = crypto.getCiphers();
 
-common.expectWarning('Warning', [
+common.expectWarning('Warning', common.hasFipsCrypto ? [] : [
   'Use Cipheriv for counter mode of aes-192-gcm'
 ].concat(
   [0, 1, 2, 6, 9, 10, 11, 17]

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -335,6 +335,14 @@ const errMessages = {
 
 const ciphers = crypto.getCiphers();
 
+common.expectWarning('Warning', [
+  'Use Cipheriv for counter mode of aes-192-gcm'
+].concat(
+  [0, 1, 2, 6, 9, 10, 11, 17]
+  .map((i) => `Permitting authentication tag lengths of ${i} bytes is ` +
+            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.')
+));
+
 for (const i in TEST_CASES) {
   const test = TEST_CASES[i];
 
@@ -475,4 +483,15 @@ for (const i in TEST_CASES) {
   assert.throws(() => encrypt.getAuthTag(), errMessages.state);
   assert.throws(() => encrypt.setAAD(Buffer.from('123', 'ascii')),
                 errMessages.state);
+}
+
+// GCM only supports specific authentication tag lengths, invalid lengths should
+// produce warnings.
+{
+  for (const length of [0, 1, 2, 4, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]) {
+    const decrypt = crypto.createDecipheriv('aes-256-gcm',
+                                            'FxLKsqdmv0E9xrQhp0b1ZgI0K7JFZJM8',
+                                            'qkuZpJWCewa6Szih');
+    decrypt.setAuthTag(Buffer.from('1'.repeat(length)));
+  }
 }

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -216,7 +216,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
 // setAutoPadding/setAuthTag/setAAD should return `this`
 {
   const key = '0123456789';
-  const tagbuf = Buffer.from('tagbuf');
+  const tagbuf = Buffer.from('auth_tag');
   const aadbuf = Buffer.from('aadbuf');
   const decipher = crypto.createDecipher('aes-256-gcm', key);
   assert.strictEqual(decipher.setAutoPadding(), decipher);


### PR DESCRIPTION
From NIST SP 800-38d, page 9:

> The bit length of the tag, denoted *t*, is a security parameter [...]. In general, *t* may be any one of the following five values: 128, 120, 112, 104, or 96. For certain applications, *t* may be 64 or 32 [...].
>
> An implementation shall not support values for *t* that are different from the seven choices in the preceding paragraph. An implementation may restrict its support to as few as one of these values.

Ultimately, we should throw an error in this case, but as that is a semver-major change (as explained in https://github.com/nodejs/node/issues/17523#issuecomment-350085946), this PR logs a warning. If we decide to land this, I will open a separate PR with the semver-major change.

Refs https://github.com/nodejs/node/issues/17523

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto