### PR TITLE
tools: add lowercase-name-for-primitive eslint rule

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -3,3 +3,4 @@ rules:
   require-buffer: error
   buffer-constructor: error
   no-let-in-for-declaration: error
+  lowercase-name-for-primitive: error

--- a/test/parallel/test-eslint-lowercase-name-for-primitive.js
+++ b/test/parallel/test-eslint-lowercase-name-for-primitive.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('../common');
+
+const RuleTester = require('../../tools/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/lowercase-name-for-primitive');
+
+const valid = [
+  'string',
+  'number',
+  'boolean',
+  'null',
+  'undefined'
+];
+
+new RuleTester().run('lowercase-name-for-primitive', rule, {
+  valid: [
+    'new errors.TypeError("ERR_INVALID_ARG_TYPE", "a", ["string", "number"])',
+    ...valid.map((name) =>
+      `new errors.TypeError("ERR_INVALID_ARG_TYPE", "name", "${name}")`
+    )
+  ],
+  invalid: [
+    {
+      code: 'new errors.TypeError("ERR_INVALID_ARG_TYPE", "a", "Number")',
+      errors: [{ message: 'primitive should use lowercase: Number' }]
+    },
+    {
+      code: 'new errors.TypeError("ERR_INVALID_ARG_TYPE", "a", "STRING")',
+      errors: [{ message: 'primitive should use lowercase: STRING' }]
+    },
+    {
+      code: 'new errors.TypeError("ERR_INVALID_ARG_TYPE", "a",' +
+            '["String", "Number"])',
+      errors: [
+        { message: 'primitive should use lowercase: String' },
+        { message: 'primitive should use lowercase: Number' }
+      ]
+    }
+  ]
+});

--- a/tools/eslint-rules/lowercase-name-for-primitive.js
+++ b/tools/eslint-rules/lowercase-name-for-primitive.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Check that TypeError[ERR_INVALID_ARG_TYPE] uses
+ *               lowercase for primitive types
+ * @author Weijia Wang <starkwang@126.com>
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const primitives = [
+  'number', 'string', 'boolean', 'null', 'undefined'
+];
+
+module.exports = function(context) {
+  return {
+    NewExpression(node) {
+      if (
+        node.callee.property &&
+        node.callee.property.name === 'TypeError' &&
+        node.arguments[0].value === 'ERR_INVALID_ARG_TYPE'
+      ) {
+        checkNamesArgument(node.arguments[2]);
+      }
+
+      function checkNamesArgument(names) {
+        switch (names.type) {
+          case 'Literal':
+            checkName(names.value);
+            break;
+          case 'ArrayExpression':
+            names.elements.forEach((name) => {
+              checkName(name.value);
+            });
+            break;
+        }
+      }
+
+      function checkName(name) {
+        const lowercaseName = name.toLowerCase();
+        if (primitives.includes(lowercaseName) && !primitives.includes(name)) {
+          const msg = `primitive should use lowercase: ${name}`;
+          context.report(node, msg);
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
The primitive types should use lowercase in error message.

refs: https://github.com/nodejs/node/issues/16383, https://github.com/nodejs/node/pull/16401
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools, test