### PR TITLE
Use ESLint selectors in custom rules

### DIFF
--- a/tools/eslint-rules/buffer-constructor.js
+++ b/tools/eslint-rules/buffer-constructor.js
@@ -10,16 +10,11 @@
 const msg = 'Use of the Buffer() constructor has been deprecated. ' +
             'Please use either Buffer.alloc(), Buffer.allocUnsafe(), ' +
             'or Buffer.from()';
-
-function test(context, node) {
-  if (node.callee.name === 'Buffer') {
-    context.report(node, msg);
-  }
-}
+const astSelector = 'NewExpression[callee.name="Buffer"],' +
+                    'CallExpression[callee.name="Buffer"]';
 
 module.exports = function(context) {
   return {
-    'NewExpression': (node) => test(context, node),
-    'CallExpression': (node) => test(context, node)
+    [astSelector]: (node) => context.report(node, msg)
   };
 };

--- a/tools/eslint-rules/no-let-in-for-declaration.js
+++ b/tools/eslint-rules/no-let-in-for-declaration.js
@@ -11,46 +11,28 @@
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+const message = 'Use of `let` as the loop variable in a for-loop is ' +
+                'not recommended. Please use `var` instead.';
+const forSelector = 'ForStatement[init.kind="let"]';
+const forInOfSelector = 'ForOfStatement[left.kind="let"],' +
+                        'ForInStatement[left.kind="let"]';
 
 module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
-    const msg = 'Use of `let` as the loop variable in a for-loop is ' +
-                'not recommended. Please use `var` instead.';
 
-    /**
-     * Report function to test if the for-loop is declared using `let`.
-     */
-    function testForLoop(node) {
-      if (node.init && node.init.kind === 'let') {
-        context.report({
-          node: node.init,
-          message: msg,
-          fix: (fixer) =>
-            fixer.replaceText(sourceCode.getFirstToken(node.init), 'var')
-        });
-      }
-    }
-
-    /**
-     * Report function to test if the for-in or for-of loop
-     * is declared using `let`.
-     */
-    function testForInOfLoop(node) {
-      if (node.left && node.left.kind === 'let') {
-        context.report({
-          node: node.left,
-          message: msg,
-          fix: (fixer) =>
-            fixer.replaceText(sourceCode.getFirstToken(node.left), 'var')
-        });
-      }
+    function report(node) {
+      context.report({
+        node,
+        message,
+        fix: (fixer) =>
+          fixer.replaceText(sourceCode.getFirstToken(node), 'var')
+      });
     }
 
     return {
-      'ForStatement': testForLoop,
-      'ForInStatement': testForInOfLoop,
-      'ForOfStatement': testForInOfLoop
+      [forSelector]: (node) => report(node.init),
+      [forInOfSelector]: (node) => report(node.left),
     };
   }
 };

--- a/tools/eslint-rules/prefer-common-mustnotcall.js
+++ b/tools/eslint-rules/prefer-common-mustnotcall.js
@@ -10,30 +10,21 @@
 
 const msg = 'Please use common.mustNotCall(msg) instead of ' +
             'common.mustCall(fn, 0) or common.mustCall(0).';
-
-function isCommonMustCall(node) {
-  return node &&
-         node.callee &&
-         node.callee.object &&
-         node.callee.object.name === 'common' &&
-         node.callee.property &&
-         node.callee.property.name === 'mustCall';
-}
-
-function isArgZero(argument) {
-  return argument &&
-         typeof argument.value === 'number' &&
-         argument.value === 0;
-}
+const mustCallSelector = 'CallExpression[callee.object.name="common"]' +
+                         '[callee.property.name="mustCall"]';
+const arg0Selector = `${mustCallSelector}[arguments.0.value=0]`;
+const arg1Selector = `${mustCallSelector}[arguments.1.value=0]`;
 
 module.exports = function(context) {
+  function report(node) {
+    context.report(node, msg);
+  }
+
   return {
-    CallExpression(node) {
-      if (isCommonMustCall(node) &&
-          (isArgZero(node.arguments[0]) ||  //  catch common.mustCall(0)
-           isArgZero(node.arguments[1]))) { //  catch common.mustCall(fn, 0)
-        context.report(node, msg);
-      }
-    }
+    // Catch common.mustCall(0)
+    [arg0Selector]: report,
+
+    // Catch common.mustCall(fn, 0)
+    [arg1Selector]: report
   };
 };


### PR DESCRIPTION
This PR simplifies several of our custom ESLint rules by using selector syntax instead of handwritten functions to identify matching AST nodes.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools