### PR TITLE
assert: improve error check

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -342,11 +342,14 @@ class AssertionError extends Error {
         red = '\u001b[31m';
       }
       const util = lazyUtil();
-
-      if (actual && actual.stack && actual instanceof Error)
+      if (typeof actual === 'object' && actual !== null &&
+        'stack' in actual && actual instanceof Error) {
         actual = `${actual.name}: ${actual.message}`;
-      if (expected && expected.stack && expected instanceof Error)
+      }
+      if (typeof expected === 'object' && expected !== null &&
+        'stack' in expected && expected instanceof Error) {
         expected = `${expected.name}: ${expected.message}`;
+      }
 
       if (errorDiff === 0) {
         let res = util.inspect(actual);


### PR DESCRIPTION
With newer V8 versions instanceof checks became very fast and
we do not have to check for the property existence anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert