### PR TITLE
assert: fix .throws operator

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -180,7 +180,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         details += ` (${expected.name})`;
       }
       details += message ? `: ${message}` : '.';
-      fail(actual, expected, `Missing expected exception${details}`, fail);
+      fail(actual, expected, `Missing expected exception${details}`, 'throws');
     }
     if (expected && expectedException(actual, expected) === false) {
       throw actual;
@@ -191,7 +191,7 @@ function innerThrows(shouldThrow, block, expected, message) {
       fail(actual,
            expected,
            `Got unwanted exception${details}\n${actual.message}`,
-           fail);
+           'doesNotThrow');
     }
     throw actual;
   }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -466,10 +466,15 @@ assert.throws(() => { assert.ifError(new Error('test error')); },
 assert.doesNotThrow(() => { assert.ifError(null); });
 assert.doesNotThrow(() => { assert.ifError(); });
 
-assert.throws(() => {
-  assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
-}, /Got unwanted exception: user message/,
-              'a.doesNotThrow ignores user message');
+common.expectsError(
+  () => assert.doesNotThrow(makeBlock(thrower, Error), 'user message'),
+  {
+    type: a.AssertionError,
+    code: 'ERR_ASSERTION',
+    operator: 'doesNotThrow',
+    message: 'Got unwanted exception: user message\n[object Object]'
+  }
+);
 
 {
   let threw = false;
@@ -556,7 +561,8 @@ a.throws(makeBlock(thrower, TypeError), (err) => {
     () => { a.throws((noop)); },
     common.expectsError({
       code: 'ERR_ASSERTION',
-      message: /^Missing expected exception\.$/
+      message: /^Missing expected exception\.$/,
+      operator: 'throws'
     }));
 
   assert.throws(


### PR DESCRIPTION
assert.throws and assert.doesNotThrow set the operator to a
internal function. That was actually not intended as the operator
is not defined at all in those cases.

CI https://ci.nodejs.org/job/node-test-pull-request/12003/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert