### PR TITLE
util: add util.inspect compact option 

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -337,8 +337,7 @@ changes:
     codes. Defaults to `false`. Colors are customizable, see
     [Customizing `util.inspect` colors][].
   * `customInspect` {boolean} If `false`, then custom `inspect(depth, opts)`
-    functions exported on the `object` being inspected will not be called.
-    Defaults to `true`.
+    functions will not be called. Defaults to `true`.
   * `showProxy` {boolean} If `true`, then objects and functions that are
     `Proxy` objects will be introspected to show their `target` and `handler`
     objects. Defaults to `false`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -308,6 +308,9 @@ stream.write('With ES6');
 <!-- YAML
 added: v0.3.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `structured` option is supported now.
   - version: v6.6.0
     pr-url: https://github.com/nodejs/node/pull/8174
     description: Custom inspection functions can now return `this`.
@@ -346,6 +349,12 @@ changes:
   * `breakLength` {number} The length at which an object's keys are split
     across multiple lines. Set to `Infinity` to format an object as a single
     line. Defaults to 60 for legacy compatibility.
+  * `structured` {boolean} This changes the default indentation to use a line
+    break for each object key instead of lining up multiple properties in one
+    line. It will also break text that is above the `breakLength` size into
+    smaller and better readable chunks and indents objects the same as arrays.
+    Note that no text will be reduced below 16 characters, no matter the
+    `breakLength` size. For more information, see the example below.
 
 The `util.inspect()` method returns a string representation of `object` that is
 primarily useful for debugging. Additional `options` may be passed that alter
@@ -380,6 +389,63 @@ console.log(util.inspect(util, { showHidden: true, depth: null }));
 Values may supply their own custom `inspect(depth, opts)` functions, when
 called these receive the current `depth` in the recursive inspection, as well as
 the options object passed to `util.inspect()`.
+
+The following example highlights the difference with the `structured` option:
+
+```js
+const util = require('util');
+
+const o = {
+  a: [1, 2, [[
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ' +
+      'eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    'test',
+    'foo']], 4],
+  b: new Map([['za', 1], ['zb', 'test']])
+};
+console.log(util.inspect(o, { structured: false, depth: 5, breakLength: 80 }));
+
+// This will print
+
+// { a:
+//   [ 1,
+//     2,
+//     [ [ 'Lorem ipsum dolor sit amet, consectetur [...]', // A long line
+//           'test',
+//           'foo' ] ],
+//     4 ],
+//   b: Map { 'za' => 1, 'zb' => 'test' } }
+
+// Setting `structured` to true changes the output to be more readable.
+console.log(util.inspect(o, { structured: true, depth: 5, breakLength: 80 }));
+
+// {
+//   a: [
+//     1,
+//     2,
+//     [
+//       [
+//         'Lorem ipsum dolor sit amet, consectetur ' +
+//           'adipiscing elit, sed do eiusmod tempor ' +
+//           'incididunt ut labore et dolore magna ' +
+//           'aliqua.,
+//         'test',
+//         'foo'
+//       ]
+//     ],
+//     4
+//   ],
+//   b: Map {
+//     'za' => 1,
+//     'zb' => 'test'
+//   }
+// }
+
+// Setting `breakLength` to e.g. 150 will print the "Lorem ipsum" text in a
+// single line.
+// Reducing the `breakLength` will split the "Lorem ipsum" text in smaller
+// chunks.
+```
 
 ### Customizing `util.inspect` colors
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -310,7 +310,7 @@ added: v0.3.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/REPLACEME
-    description: The `structured` option is supported now.
+    description: The `compact` option is supported now.
   - version: v6.6.0
     pr-url: https://github.com/nodejs/node/pull/8174
     description: Custom inspection functions can now return `this`.
@@ -348,12 +348,13 @@ changes:
   * `breakLength` {number} The length at which an object's keys are split
     across multiple lines. Set to `Infinity` to format an object as a single
     line. Defaults to 60 for legacy compatibility.
-  * `structured` {boolean} This changes the default indentation to use a line
-    break for each object key instead of lining up multiple properties in one
-    line. It will also break text that is above the `breakLength` size into
-    smaller and better readable chunks and indents objects the same as arrays.
-    Note that no text will be reduced below 16 characters, no matter the
-    `breakLength` size. For more information, see the example below.
+  * `compact` {boolean} Setting this to `false` changes the default indentation
+    to use a line break for each object key instead of lining up multiple
+    properties in one line. It will also break text that is above the
+    `breakLength` size into smaller and better readable chunks and indents
+    objects the same as arrays. Note that no text will be reduced below 16
+    characters, no matter the `breakLength` size. For more information, see the
+    example below. Defaults to `true`.
 
 The `util.inspect()` method returns a string representation of `object` that is
 primarily useful for debugging. Additional `options` may be passed that alter
@@ -389,7 +390,7 @@ Values may supply their own custom `inspect(depth, opts)` functions, when
 called these receive the current `depth` in the recursive inspection, as well as
 the options object passed to `util.inspect()`.
 
-The following example highlights the difference with the `structured` option:
+The following example highlights the difference with the `compact` option:
 
 ```js
 const util = require('util');
@@ -402,7 +403,7 @@ const o = {
     'foo']], 4],
   b: new Map([['za', 1], ['zb', 'test']])
 };
-console.log(util.inspect(o, { structured: false, depth: 5, breakLength: 80 }));
+console.log(util.inspect(o, { compact: true, depth: 5, breakLength: 80 }));
 
 // This will print
 
@@ -415,8 +416,8 @@ console.log(util.inspect(o, { structured: false, depth: 5, breakLength: 80 }));
 //     4 ],
 //   b: Map { 'za' => 1, 'zb' => 'test' } }
 
-// Setting `structured` to true changes the output to be more readable.
-console.log(util.inspect(o, { structured: true, depth: 5, breakLength: 80 }));
+// Setting `compact` to false changes the output to be more reader friendly.
+console.log(util.inspect(o, { compact: false, depth: 5, breakLength: 80 }));
 
 // {
 //   a: [

--- a/lib/util.js
+++ b/lib/util.js
@@ -259,14 +259,14 @@ function debuglog(set) {
 }
 
 /**
- * Echos the value of a value. Tries to print the value out
+ * Echos the value of any input. Tries to print the value out
  * in the best way possible given the different types.
  *
- * @param {Object} obj The object to print out.
+ * @param {any} value The value to print out.
  * @param {Object} opts Optional options object that alters the output.
  */
-/* Legacy: obj, showHidden, depth, colors*/
-function inspect(obj, opts) {
+/* Legacy: value, showHidden, depth, colors*/
+function inspect(value, opts) {
   // Default options
   const ctx = {
     seen: [],
@@ -301,7 +301,7 @@ function inspect(obj, opts) {
   }
   if (ctx.colors) ctx.stylize = stylizeWithColor;
   if (ctx.maxArrayLength === null) ctx.maxArrayLength = Infinity;
-  return formatValue(ctx, obj, ctx.depth);
+  return formatValue(ctx, value, ctx.depth);
 }
 inspect.custom = customInspectSymbol;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -490,7 +490,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
         const formatted = formatPrimitive(stylizeNoColor, raw, ctx);
         if (keyLength === raw.length)
           return ctx.stylize(`[String: ${formatted}]`, 'string');
-        base = ` [String: ${formatted}]`;
+        base = `[String: ${formatted}]`;
         // For boxed Strings, we have to remove the 0-n indexed entries,
         // since they just noisy up the output and are redundant
         // Make boxed primitive Strings look like such
@@ -512,12 +512,12 @@ function formatValue(ctx, value, recurseTimes, ln) {
         `${constructor || tag}${value.name ? `: ${value.name}` : ''}`;
       if (keyLength === 0)
         return ctx.stylize(`[${name}]`, 'special');
-      base = ` [${name}]`;
+      base = `[${name}]`;
     } else if (isRegExp(value)) {
       // Make RegExps say that they are RegExps
       if (keyLength === 0 || recurseTimes < 0)
         return ctx.stylize(regExpToString.call(value), 'regexp');
-      base = ` ${regExpToString.call(value)}`;
+      base = `${regExpToString.call(value)}`;
     } else if (isDate(value)) {
       if (keyLength === 0) {
         if (Number.isNaN(value.getTime()))
@@ -525,12 +525,12 @@ function formatValue(ctx, value, recurseTimes, ln) {
         return ctx.stylize(dateToISOString.call(value), 'date');
       }
       // Make dates with properties first say the date
-      base = ` ${dateToISOString.call(value)}`;
+      base = `${dateToISOString.call(value)}`;
     } else if (isError(value)) {
       // Make error with message first say the error
       if (keyLength === 0)
         return formatError(value);
-      base = ` ${formatError(value)}`;
+      base = `${formatError(value)}`;
     } else if (isAnyArrayBuffer(value)) {
       // Fast path for ArrayBuffer and SharedArrayBuffer.
       // Can't do the same for DataView because it has a non-primitive
@@ -560,13 +560,13 @@ function formatValue(ctx, value, recurseTimes, ln) {
         const formatted = formatPrimitive(stylizeNoColor, raw);
         if (keyLength === 0)
           return ctx.stylize(`[Number: ${formatted}]`, 'number');
-        base = ` [Number: ${formatted}]`;
+        base = `[Number: ${formatted}]`;
       } else if (typeof raw === 'boolean') {
         // Make boxed primitive Booleans look like such
         const formatted = formatPrimitive(stylizeNoColor, raw);
         if (keyLength === 0)
           return ctx.stylize(`[Boolean: ${formatted}]`, 'boolean');
-        base = ` [Boolean: ${formatted}]`;
+        base = `[Boolean: ${formatted}]`;
       } else if (typeof raw === 'symbol') {
         const formatted = formatPrimitive(stylizeNoColor, raw);
         return ctx.stylize(`[Symbol: ${formatted}]`, 'symbol');
@@ -890,8 +890,7 @@ function reduceToSingleString(ctx, output, base, braces, addLn) {
   var i = 0;
   if (ctx.structured === true) {
     const indentation = ' '.repeat(ctx.indentationLvl);
-    var res = braces[0];
-    res += `${base}\n${indentation}  `;
+    var res = `${base ? `${base} ` : ''}${braces[0]}\n${indentation}  `;
     for (; i < output.length - 1; i++) {
       res += `${output[i]},\n${indentation}  `;
     }
@@ -908,7 +907,8 @@ function reduceToSingleString(ctx, output, base, braces, addLn) {
       }
     }
     if (length <= breakLength)
-      return `${braces[0]}${base} ${join(output, ', ')} ${braces[1]}`;
+      return `${braces[0]}${base ? ` ${base}` : ''} ${join(output, ', ')} ` +
+        braces[1];
   }
   // If the opening "brace" is too large, like in the case of "Set {",
   // we need to force the first item to be on the next line or the
@@ -916,7 +916,7 @@ function reduceToSingleString(ctx, output, base, braces, addLn) {
   const indentation = ' '.repeat(ctx.indentationLvl);
   const extraLn = addLn === true ? `\n${indentation}` : '';
   const ln = base === '' && braces[0].length === 1 ?
-    ' ' : `${base}\n${indentation}  `;
+    ' ' : `${base ? ` ${base}` : base}\n${indentation}  `;
   const str = join(output, `,\n${indentation}  `);
   return `${extraLn}${braces[0]}${ln}${str} ${braces[1]}`;
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -70,7 +70,7 @@ const inspectDefaultOptions = Object.seal({
   showProxy: false,
   maxArrayLength: 100,
   breakLength: 60,
-  structured: false
+  compact: true
 });
 
 const propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
@@ -88,7 +88,7 @@ const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const colorRegExp = /\u001b\[\d\d?m/g;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;
 
-const structuredRE = {};
+const readableRegExps = {};
 
 const MIN_LINE_LENGTH = 16;
 
@@ -279,7 +279,7 @@ function inspect(value, opts) {
     maxArrayLength: inspectDefaultOptions.maxArrayLength,
     breakLength: inspectDefaultOptions.breakLength,
     indentationLvl: 0,
-    structured: inspectDefaultOptions.structured
+    compact: inspectDefaultOptions.compact
   };
   // Legacy...
   if (arguments.length > 2) {
@@ -611,7 +611,7 @@ function formatNumber(fn, value) {
 
 function formatPrimitive(fn, value, ctx) {
   if (typeof value === 'string') {
-    if (ctx.structured &&
+    if (ctx.compact === false &&
       value.length > MIN_LINE_LENGTH &&
       ctx.indentationLvl + value.length > ctx.breakLength) {
       // eslint-disable-next-line max-len
@@ -620,7 +620,7 @@ function formatPrimitive(fn, value, ctx) {
       const averageLineLength = Math.ceil(value.length / Math.ceil(value.length / minLineLength));
       const divisor = Math.max(averageLineLength, MIN_LINE_LENGTH);
       var res = '';
-      if (structuredRE[divisor] === undefined)
+      if (readableRegExps[divisor] === undefined)
         // Build a new RegExp that naturally breaks text into multiple lines.
         //
         // Rules
@@ -629,10 +629,10 @@ function formatPrimitive(fn, value, ctx) {
         // 2. If none matches, non-greedy match any text up to a whitespace or
         //    the end of the string.
         //
-        // eslint-disable-next-line max-len
-        structuredRE[divisor] = new RegExp(`.{1,${divisor}}(\\s|$)|.+?(\\s|$)`, 'gm');
+        // eslint-disable-next-line max-len, no-unescaped-regexp-dot
+        readableRegExps[divisor] = new RegExp(`(.|\\n){1,${divisor}}(\\s|$)|(\\n|.)+?(\\s|$)`, 'gm');
       const indent = ' '.repeat(ctx.indentationLvl);
-      const matches = value.match(structuredRE[divisor]);
+      const matches = value.match(readableRegExps[divisor]);
       if (matches.length > 1) {
         res += `${fn(strEscape(matches[0]), 'string')} +\n`;
         for (var i = 1; i < matches.length - 1; i++) {
@@ -854,7 +854,7 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
   const desc = Object.getOwnPropertyDescriptor(value, key) ||
     { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
-    const diff = array !== 0 || ctx.structured === true ? 2 : 3;
+    const diff = array !== 0 || ctx.compact === false ? 2 : 3;
     ctx.indentationLvl += diff;
     str = formatValue(ctx, desc.value, recurseTimes, array === 0);
     ctx.indentationLvl -= diff;
@@ -888,7 +888,7 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
 function reduceToSingleString(ctx, output, base, braces, addLn) {
   const breakLength = ctx.breakLength;
   var i = 0;
-  if (ctx.structured === true) {
+  if (ctx.compact === false) {
     const indentation = ' '.repeat(ctx.indentationLvl);
     var res = `${base ? `${base} ` : ''}${braces[0]}\n${indentation}  `;
     for (; i < output.length - 1; i++) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -620,7 +620,7 @@ function formatPrimitive(fn, value, ctx) {
       const averageLineLength = Math.ceil(value.length / Math.ceil(value.length / minLineLength));
       const divisor = Math.max(averageLineLength, MIN_LINE_LENGTH);
       var res = '';
-      if (readableRegExps[divisor] === undefined)
+      if (readableRegExps[divisor] === undefined) {
         // Build a new RegExp that naturally breaks text into multiple lines.
         //
         // Rules
@@ -631,6 +631,7 @@ function formatPrimitive(fn, value, ctx) {
         //
         // eslint-disable-next-line max-len, no-unescaped-regexp-dot
         readableRegExps[divisor] = new RegExp(`(.|\\n){1,${divisor}}(\\s|$)|(\\n|.)+?(\\s|$)`, 'gm');
+      }
       const indent = ' '.repeat(ctx.indentationLvl);
       const matches = value.match(readableRegExps[divisor]);
       if (matches.length > 1) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -69,7 +69,8 @@ const inspectDefaultOptions = Object.seal({
   customInspect: true,
   showProxy: false,
   maxArrayLength: 100,
-  breakLength: 60
+  breakLength: 60,
+  structured: false
 });
 
 const propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
@@ -86,6 +87,10 @@ const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c]/g;
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
 const colorRegExp = /\u001b\[\d\d?m/g;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;
+
+const structuredRE = {};
+
+const MIN_LINE_LENGTH = 16;
 
 // Escaped special characters. Use empty strings to fill up unused entries.
 const meta = [
@@ -273,7 +278,8 @@ function inspect(obj, opts) {
     showProxy: inspectDefaultOptions.showProxy,
     maxArrayLength: inspectDefaultOptions.maxArrayLength,
     breakLength: inspectDefaultOptions.breakLength,
-    indentationLvl: 0
+    indentationLvl: 0,
+    structured: inspectDefaultOptions.structured
   };
   // Legacy...
   if (arguments.length > 2) {
@@ -359,7 +365,7 @@ function stylizeNoColor(str, styleType) {
 function formatValue(ctx, value, recurseTimes, ln) {
   // Primitive types cannot have properties
   if (typeof value !== 'object' && typeof value !== 'function') {
-    return formatPrimitive(ctx.stylize, value);
+    return formatPrimitive(ctx.stylize, value, ctx);
   }
   if (value === null) {
     return ctx.stylize('null', 'null');
@@ -481,7 +487,7 @@ function formatValue(ctx, value, recurseTimes, ln) {
       } catch (e) { /* ignore */ }
 
       if (typeof raw === 'string') {
-        const formatted = formatPrimitive(stylizeNoColor, raw);
+        const formatted = formatPrimitive(stylizeNoColor, raw, ctx);
         if (keyLength === raw.length)
           return ctx.stylize(`[String: ${formatted}]`, 'string');
         base = ` [String: ${formatted}]`;
@@ -603,9 +609,41 @@ function formatNumber(fn, value) {
   return fn(`${value}`, 'number');
 }
 
-function formatPrimitive(fn, value) {
-  if (typeof value === 'string')
+function formatPrimitive(fn, value, ctx) {
+  if (typeof value === 'string') {
+    if (ctx.structured &&
+      value.length > MIN_LINE_LENGTH &&
+      ctx.indentationLvl + value.length > ctx.breakLength) {
+      // eslint-disable-next-line max-len
+      const minLineLength = Math.max(ctx.breakLength - ctx.indentationLvl, MIN_LINE_LENGTH);
+      // eslint-disable-next-line max-len
+      const averageLineLength = Math.ceil(value.length / Math.ceil(value.length / minLineLength));
+      const divisor = Math.max(averageLineLength, MIN_LINE_LENGTH);
+      var res = '';
+      if (structuredRE[divisor] === undefined)
+        // Build a new RegExp that naturally breaks text into multiple lines.
+        //
+        // Rules
+        // 1. Greedy match all text up the max line length that ends with a
+        //    whitespace or the end of the string.
+        // 2. If none matches, non-greedy match any text up to a whitespace or
+        //    the end of the string.
+        //
+        // eslint-disable-next-line max-len
+        structuredRE[divisor] = new RegExp(`.{1,${divisor}}(\\s|$)|.+?(\\s|$)`, 'gm');
+      const indent = ' '.repeat(ctx.indentationLvl);
+      const matches = value.match(structuredRE[divisor]);
+      if (matches.length > 1) {
+        res += `${fn(strEscape(matches[0]), 'string')} +\n`;
+        for (var i = 1; i < matches.length - 1; i++) {
+          res += `${indent}  ${fn(strEscape(matches[i]), 'string')} +\n`;
+        }
+        res += `${indent}  ${fn(strEscape(matches[i]), 'string')}`;
+        return res;
+      }
+    }
     return fn(strEscape(value), 'string');
+  }
   if (typeof value === 'number')
     return formatNumber(fn, value);
   if (typeof value === 'boolean')
@@ -816,7 +854,7 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
   const desc = Object.getOwnPropertyDescriptor(value, key) ||
     { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
-    const diff = array === 0 ? 3 : 2;
+    const diff = array !== 0 || ctx.structured === true ? 2 : 3;
     ctx.indentationLvl += diff;
     str = formatValue(ctx, desc.value, recurseTimes, array === 0);
     ctx.indentationLvl -= diff;
@@ -849,9 +887,20 @@ function formatProperty(ctx, value, recurseTimes, key, array) {
 
 function reduceToSingleString(ctx, output, base, braces, addLn) {
   const breakLength = ctx.breakLength;
+  var i = 0;
+  if (ctx.structured === true) {
+    const indentation = ' '.repeat(ctx.indentationLvl);
+    var res = braces[0];
+    res += `${base}\n${indentation}  `;
+    for (; i < output.length - 1; i++) {
+      res += `${output[i]},\n${indentation}  `;
+    }
+    res += `${output[i]}\n${indentation}${braces[1]}`;
+    return res;
+  }
   if (output.length * 2 <= breakLength) {
     var length = 0;
-    for (var i = 0; i < output.length && length <= breakLength; i++) {
+    for (; i < output.length && length <= breakLength; i++) {
       if (ctx.colors) {
         length += output[i].replace(colorRegExp, '').length + 1;
       } else {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1311,4 +1311,31 @@ assert.doesNotThrow(() => util.inspect(process));
     '  \'0\''
   ].join('\n');
   assert.strictEqual(out, expect);
+
+  o.a = () => {};
+  o.b = new Number(3);
+  out = util.inspect(
+    o,
+    { structured: true, breakLength: 3 });
+  expect = [
+    '{',
+    '  a: [Function],',
+    '  b: [Number: 3]',
+    '}'
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(
+    o,
+    { structured: true, breakLength: 3, showHidden: 3 });
+  expect = [
+    '{',
+    '  a: [Function] {',
+    '    [length]: 0,',
+    "    [name]: ''",
+    '  },',
+    '  b: [Number: 3]',
+    '}'
+  ].join('\n');
+  assert.strictEqual(out, expect);
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1344,4 +1344,9 @@ assert.doesNotThrow(() => util.inspect(process));
   out = util.inspect(o, { compact: false, breakLength: 3 });
   expect = '12 45 78 01 34 67 90 23';
   assert.strictEqual(out, expect);
+
+  o[util.inspect.custom] = () => ({ a: '12 45 78 01 34 67 90 23' });
+  out = util.inspect(o, { compact: false, breakLength: 3 });
+  expect = '{\n  a: \'12 45 78 01 34 \' +\n    \'67 90 23\'\n}';
+  assert.strictEqual(out, expect);
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1213,3 +1213,102 @@ assert.doesNotThrow(() => util.inspect(process));
   assert.strictEqual(util.inspect(new NotStringClass()),
                      'NotStringClass {}');
 }
+
+{
+  const o = {
+    a: [1, 2, [[
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ' +
+        'eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      'test',
+      'foo']], 4],
+    b: new Map([['za', 1], ['zb', 'test']])
+  };
+
+  let out = util.inspect(o, { structured: false, depth: 5, breakLength: 80 });
+  let expect = [
+    '{ a: ',
+    '   [ 1,',
+    '     2,',
+    "     [ [ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed " +
+      "do eiusmod tempor incididunt ut labore et dolore magna aliqua.',",
+    "         'test',",
+    "         'foo' ] ],",
+    '     4 ],',
+    "  b: Map { 'za' => 1, 'zb' => 'test' } }",
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(o, { structured: true, depth: 5, breakLength: 60 });
+  expect = [
+    '{',
+    '  a: [',
+    '    1,',
+    '    2,',
+    '    [',
+    '      [',
+    '        \'Lorem ipsum dolor sit amet, consectetur \' +',
+    '          \'adipiscing elit, sed do eiusmod tempor \' +',
+    '          \'incididunt ut labore et dolore magna \' +',
+    '          \'aliqua.\',',
+    '        \'test\',',
+    '        \'foo\'',
+    '      ]',
+    '    ],',
+    '    4',
+    '  ],',
+    '  b: Map {',
+    '    \'za\' => 1,',
+    '    \'zb\' => \'test\'',
+    '  }',
+    '}'
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(o.a[2][0][0], { structured: true, breakLength: 30 });
+  expect = [
+    '\'Lorem ipsum dolor sit \' +',
+    '  \'amet, consectetur \' +',
+    '  \'adipiscing elit, sed do \' +',
+    '  \'eiusmod tempor incididunt \' +',
+    '  \'ut labore et dolore magna \' +',
+    '  \'aliqua.\''
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(
+    '12345678901234567890123456789012345678901234567890',
+    { structured: true, breakLength: 3 });
+  expect = '\'12345678901234567890123456789012345678901234567890\'';
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(
+    '12 45 78 01 34 67 90 23 56 89 123456789012345678901234567890',
+    { structured: true, breakLength: 3 });
+  expect = [
+    '\'12 45 78 01 34 \' +',
+    '  \'67 90 23 56 89 \' +',
+    '  \'123456789012345678901234567890\''
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(
+    '12 45 78 01 34 67 90 23 56 89 1234567890123 0',
+    { structured: true, breakLength: 3 });
+  expect = [
+    '\'12 45 78 01 34 \' +',
+    '  \'67 90 23 56 89 \' +',
+    '  \'1234567890123 0\''
+  ].join('\n');
+  assert.strictEqual(out, expect);
+
+  out = util.inspect(
+    '12 45 78 01 34 67 90 23 56 89 12345678901234567 0',
+    { structured: true, breakLength: 3 });
+  expect = [
+    '\'12 45 78 01 34 \' +',
+    '  \'67 90 23 56 89 \' +',
+    '  \'12345678901234567 \' +',
+    '  \'0\''
+  ].join('\n');
+  assert.strictEqual(out, expect);
+}

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1217,20 +1217,20 @@ assert.doesNotThrow(() => util.inspect(process));
 {
   const o = {
     a: [1, 2, [[
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ' +
+      'Lorem ipsum dolor\nsit amet,\tconsectetur adipiscing elit, sed do ' +
         'eiusmod tempor incididunt ut labore et dolore magna aliqua.',
       'test',
       'foo']], 4],
     b: new Map([['za', 1], ['zb', 'test']])
   };
 
-  let out = util.inspect(o, { structured: false, depth: 5, breakLength: 80 });
+  let out = util.inspect(o, { compact: true, depth: 5, breakLength: 80 });
   let expect = [
     '{ a: ',
     '   [ 1,',
     '     2,',
-    "     [ [ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed " +
-      "do eiusmod tempor incididunt ut labore et dolore magna aliqua.',",
+    "     [ [ 'Lorem ipsum dolor\\nsit amet,\\tconsectetur adipiscing elit, " +
+      "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',",
     "         'test',",
     "         'foo' ] ],",
     '     4 ],',
@@ -1238,7 +1238,7 @@ assert.doesNotThrow(() => util.inspect(process));
   ].join('\n');
   assert.strictEqual(out, expect);
 
-  out = util.inspect(o, { structured: true, depth: 5, breakLength: 60 });
+  out = util.inspect(o, { compact: false, depth: 5, breakLength: 60 });
   expect = [
     '{',
     '  a: [',
@@ -1246,7 +1246,7 @@ assert.doesNotThrow(() => util.inspect(process));
     '    2,',
     '    [',
     '      [',
-    '        \'Lorem ipsum dolor sit amet, consectetur \' +',
+    '        \'Lorem ipsum dolor\\nsit amet,\\tconsectetur \' +',
     '          \'adipiscing elit, sed do eiusmod tempor \' +',
     '          \'incididunt ut labore et dolore magna \' +',
     '          \'aliqua.\',',
@@ -1264,10 +1264,10 @@ assert.doesNotThrow(() => util.inspect(process));
   ].join('\n');
   assert.strictEqual(out, expect);
 
-  out = util.inspect(o.a[2][0][0], { structured: true, breakLength: 30 });
+  out = util.inspect(o.a[2][0][0], { compact: false, breakLength: 30 });
   expect = [
-    '\'Lorem ipsum dolor sit \' +',
-    '  \'amet, consectetur \' +',
+    '\'Lorem ipsum dolor\\nsit \' +',
+    '  \'amet,\\tconsectetur \' +',
     '  \'adipiscing elit, sed do \' +',
     '  \'eiusmod tempor incididunt \' +',
     '  \'ut labore et dolore magna \' +',
@@ -1277,13 +1277,13 @@ assert.doesNotThrow(() => util.inspect(process));
 
   out = util.inspect(
     '12345678901234567890123456789012345678901234567890',
-    { structured: true, breakLength: 3 });
+    { compact: false, breakLength: 3 });
   expect = '\'12345678901234567890123456789012345678901234567890\'';
   assert.strictEqual(out, expect);
 
   out = util.inspect(
     '12 45 78 01 34 67 90 23 56 89 123456789012345678901234567890',
-    { structured: true, breakLength: 3 });
+    { compact: false, breakLength: 3 });
   expect = [
     '\'12 45 78 01 34 \' +',
     '  \'67 90 23 56 89 \' +',
@@ -1293,7 +1293,7 @@ assert.doesNotThrow(() => util.inspect(process));
 
   out = util.inspect(
     '12 45 78 01 34 67 90 23 56 89 1234567890123 0',
-    { structured: true, breakLength: 3 });
+    { compact: false, breakLength: 3 });
   expect = [
     '\'12 45 78 01 34 \' +',
     '  \'67 90 23 56 89 \' +',
@@ -1303,7 +1303,7 @@ assert.doesNotThrow(() => util.inspect(process));
 
   out = util.inspect(
     '12 45 78 01 34 67 90 23 56 89 12345678901234567 0',
-    { structured: true, breakLength: 3 });
+    { compact: false, breakLength: 3 });
   expect = [
     '\'12 45 78 01 34 \' +',
     '  \'67 90 23 56 89 \' +',
@@ -1314,9 +1314,7 @@ assert.doesNotThrow(() => util.inspect(process));
 
   o.a = () => {};
   o.b = new Number(3);
-  out = util.inspect(
-    o,
-    { structured: true, breakLength: 3 });
+  out = util.inspect(o, { compact: false, breakLength: 3 });
   expect = [
     '{',
     '  a: [Function],',
@@ -1325,9 +1323,7 @@ assert.doesNotThrow(() => util.inspect(process));
   ].join('\n');
   assert.strictEqual(out, expect);
 
-  out = util.inspect(
-    o,
-    { structured: true, breakLength: 3, showHidden: 3 });
+  out = util.inspect(o, { compact: false, breakLength: 3, showHidden: true });
   expect = [
     '{',
     '  a: [Function] {',
@@ -1337,5 +1333,15 @@ assert.doesNotThrow(() => util.inspect(process));
     '  b: [Number: 3]',
     '}'
   ].join('\n');
+  assert.strictEqual(out, expect);
+
+  o[util.inspect.custom] = () => 42;
+  out = util.inspect(o, { compact: false, breakLength: 3 });
+  expect = '42';
+  assert.strictEqual(out, expect);
+
+  o[util.inspect.custom] = () => '12 45 78 01 34 67 90 23';
+  out = util.inspect(o, { compact: false, breakLength: 3 });
+  expect = '12 45 78 01 34 67 90 23';
   assert.strictEqual(out, expect);
 }


### PR DESCRIPTION
I personally really dislike the formatting used in util.inspect and this should
improve the situation a lot. I am also working on a feature that requires a
more structural util.inspect output. In general, I do not argue about it being
perfect, so if anyone has some further input, I am all ears.

commit - util: add util.inspect structured option
```
The current default formatting is not ideal and this improves
the situation by formatting the output more intuitiv.

1) All object keys are now indented by 2 characters instead of
   something 2 and sometimes 3 characters.
2) Each object key will now use a individual line instead of
   sharing a line potentially with multiple object keys.
3) Long strings will now be split into multiple lines in case
   they exceed the "lineBreak" option length (including the
   current indentation).
4) Opening braces are now directly behind a object property
   instead of using a new line.
```
commit - util: rename util.inspect argument
```
util.inspect can actually receive any property and the description
was wrong so far. This fixes it by renaming the argument to
value and also updating the description.
```
commit - util: fix custom inspect description
```
Using a custom inspect function on the inspected object is
deprecated. Remove the reference from the option description
to make sure the user will read about the deprecation in the
more detailed description.
```

CI https://ci.nodejs.org/job/node-test-pull-request/12008/

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util