### PR TITLE
src: fix inspector nullptr deref on abrupt exit

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -325,10 +325,12 @@ class NodeInspectorClient : public V8InspectorClient {
   }
 
   void maxAsyncCallStackDepthChanged(int depth) override {
-    if (depth == 0) {
-      env_->inspector_agent()->DisableAsyncHook();
-    } else {
-      env_->inspector_agent()->EnableAsyncHook();
+    if (auto agent = env_->inspector_agent()) {
+      if (depth == 0) {
+        agent->DisableAsyncHook();
+      } else {
+        agent->EnableAsyncHook();
+      }
     }
   }
 

--- a/test/sequential/test-inspector-async-call-stack-abort.js
+++ b/test/sequential/test-inspector-async-call-stack-abort.js
@@ -1,0 +1,34 @@
+// Check that abrupt termination when async call stack recording is enabled
+// does not segfault the process.
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+common.skipIf32Bits();
+
+const { strictEqual } = require('assert');
+const eyecatcher = 'nou, houdoe he?';
+
+if (process.argv[2] === 'child') {
+  const { Session } = require('inspector');
+  const { promisify } = require('util');
+  const { registerAsyncHook } = process.binding('inspector');
+  (async () => {
+    let enabled = 0;
+    registerAsyncHook(() => ++enabled, () => {});
+    const session = new Session();
+    session.connect();
+    session.post = promisify(session.post);
+    await session.post('Debugger.enable');
+    strictEqual(enabled, 0);
+    await session.post('Debugger.setAsyncCallStackDepth', { maxDepth: 42 });
+    strictEqual(enabled, 1);
+    throw new Error(eyecatcher);
+  })();
+} else {
+  const { spawnSync } = require('child_process');
+  const options = { encoding: 'utf8' };
+  const proc = spawnSync(process.execPath, [__filename, 'child'], options);
+  strictEqual(proc.status, 0);
+  strictEqual(proc.signal, null);
+  strictEqual(proc.stderr.includes(eyecatcher), true);
+}


### PR DESCRIPTION
Fix a nullptr dereference on abrupt termination when async call stack
recording is enabled.

Bug discovered while trying to write a regression test for the bug fix
in commit df79b7d821 ("src: fix missing handlescope bug in inspector".)

CI: https://ci.nodejs.org/job/node-test-pull-request/12005/