### PR TITLE
doc: fix modules.md export example

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -38,7 +38,7 @@ In this example, the variable `PI` is private to `circle.js`.
 The `module.exports` property can be assigned a new value (such as a function
 or object).
 
-Below, `bar.js` makes use of the `square` module, which exports a constructor:
+Below, `bar.js` makes use of the `square` module, which exports a Square class:
 
 ```js
 const Square = require('./square.js');
@@ -50,10 +50,14 @@ The `square` module is defined in `square.js`:
 
 ```js
 // assigning to exports will not modify module, must use module.exports
-module.exports = (width) => {
-  return {
-    area: () => width ** 2
-  };
+module.exports = class Square {
+  constructor(width) {
+    this.width = width;
+  }
+
+  area() {
+    return this.width ** 2;
+  }
 };
 ```
 


### PR DESCRIPTION
A commit landed recently that made one of our examples no longer execute correctly and instead throw an Error. Updated it to use ES6 and actually make sense.

In hindsight, @Trott's suggestion of adjusting the original wording would've been good but here we are... Since it was a first-time contributor, I would prefer not to revert their changes.

Refs: https://github.com/nodejs/node/pull/17364

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc