### PR TITLE
benchmark: fix http/simple.js benchmark

### DIFF
--- a/benchmark/fixtures/simple-http-server.js
+++ b/benchmark/fixtures/simple-http-server.js
@@ -34,7 +34,7 @@ module.exports = http.createServer(function(req, res) {
   const arg = params[2];
   const n_chunks = parseInt(params[3], 10);
   const resHow = params.length >= 5 ? params[4] : 'normal';
-  const chunkedEnc = params.length >= 6 && params[5] === 'false' ? false : true;
+  const chunkedEnc = params.length >= 6 && params[5] === '0' ? false : true;
   var status = 200;
 
   var n, i;

--- a/benchmark/http/simple.js
+++ b/benchmark/http/simple.js
@@ -8,14 +8,14 @@ const bench = common.createBenchmark(main, {
   len: [4, 1024, 102400],
   chunks: [1, 4],
   c: [50, 500],
-  chunkedEnc: ['true', 'false'],
+  chunkedEnc: [1, 0],
   res: ['normal', 'setHeader', 'setHeaderWH']
 });
 
 function main(conf) {
   process.env.PORT = PORT;
   var server = require('../fixtures/simple-http-server.js')
-  .listen(process.env.PORT || common.PORT)
+  .listen(PORT)
   .on('listening', function() {
     const path =
       `/${conf.type}/${conf.len}/${conf.chunks}/${conf.res}/${conf.chunkedEnc}`;


### PR DESCRIPTION
`autocannon` appears to have trouble recognizing URLs that contain `false` or `true` within them. Use `0` or `1` instead to represent the same. Prior to this fix, `autocannon` would just print out its help instead of running the actual benchmark.

I'm guessing this also needs fixing in `autocannon` or whatever its using to parse arguments but for now I would like to get our http benchmark working again.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark