### PR TITLE
assert: .throws accept objects

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -711,18 +711,21 @@ instead of the `AssertionError`.
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `error` parameter can now be an object as well.
   - version: v4.2.0
     pr-url: https://github.com/nodejs/node/pull/3276
     description: The `error` parameter can now be an arrow function.
 -->
 * `block` {Function}
-* `error` {RegExp|Function}
+* `error` {RegExp|Function|object}
 * `message` {any}
 
 Expects the function `block` to throw an error.
 
-If specified, `error` can be a constructor, [`RegExp`][], or validation
-function.
+If specified, `error` can be a constructor, [`RegExp`][], a validation
+function, or an object where each property will be tested for.
 
 If specified, `message` will be the message provided by the `AssertionError` if
 the block fails to throw.
@@ -765,6 +768,23 @@ assert.throws(
     }
   },
   'unexpected error'
+);
+```
+
+Custom error object / error instance:
+
+```js
+assert.throws(
+  () => {
+    const err = new TypeError('Wrong value');
+    err.code = 404;
+    throw err;
+  },
+  {
+    name: 'TypeError',
+    message: 'Wrong value'
+    // Note that only properties on the error object will be tested!
+  }
 );
 ```
 

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -23,6 +23,7 @@
 const { isDeepEqual, isDeepStrictEqual } =
   require('internal/util/comparisons');
 const errors = require('internal/errors');
+const { inspect } = require('util');
 
 // The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
@@ -193,10 +194,44 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
   }
 };
 
-function expectedException(actual, expected) {
+function createMsg(msg, key, actual, expected) {
+  if (msg)
+    return msg;
+  return `${key}: expected ${inspect(expected[key])}, ` +
+    `not ${inspect(actual[key])}`;
+}
+
+function expectedException(actual, expected, msg) {
   if (typeof expected !== 'function') {
-    // Should be a RegExp, if not fail hard
-    return expected.test(actual);
+    if (expected instanceof RegExp)
+      return expected.test(actual);
+    // assert.doesNotThrow does not accept objects.
+    if (arguments.length === 2) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'expected',
+                                 ['Function', 'RegExp'], expected);
+    }
+    // The name and message could be non enumerable. Therefore test them
+    // explicitly.
+    if ('name' in expected) {
+      assert.strictEqual(
+        actual.name,
+        expected.name,
+        createMsg(msg, 'name', actual, expected));
+    }
+    if ('message' in expected) {
+      assert.strictEqual(
+        actual.message,
+        expected.message,
+        createMsg(msg, 'message', actual, expected));
+    }
+    const keys = Object.keys(expected);
+    for (const key of keys) {
+      assert.deepStrictEqual(
+        actual[key],
+        expected[key],
+        createMsg(msg, key, actual, expected));
+    }
+    return true;
   }
   // Guard instanceof against arrow functions as they don't have a prototype.
   if (expected.prototype !== undefined && actual instanceof expected) {
@@ -249,7 +284,7 @@ assert.throws = function throws(block, error, message) {
       stackStartFn: throws
     });
   }
-  if (error && expectedException(actual, error) === false) {
+  if (error && expectedException(actual, error, message) === false) {
     throw actual;
   }
 };


### PR DESCRIPTION
From now on it is possible to use a validation object in throws
instead of the other possibilities.

Refs #17557 

I personally am not sure if this is a cool thing or not but I thought I just put something together to get some votes.

CI https://ci.nodejs.org/job/node-test-pull-request/12016/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert