### PR TITLE
assert: improve assert.throws

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -740,12 +740,15 @@ assert.throws(
 
 Validate error message using [`RegExp`][]:
 
+Using a regular expression runs `.toString` on the error object, and will
+therefore also include the error name.
+
 ```js
 assert.throws(
   () => {
     throw new Error('Wrong value');
   },
-  /value/
+  /^Error: Wrong value$/
 );
 ```
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -767,16 +767,41 @@ assert.throws(
 
 Note that `error` can not be a string. If a string is provided as the second
 argument, then `error` is assumed to be omitted and the string will be used for
-`message` instead. This can lead to easy-to-miss mistakes:
+`message` instead. This can lead to easy-to-miss mistakes. Please read the
+example below carefully if using a string as the second argument gets
+considered:
 
 <!-- eslint-disable no-restricted-syntax -->
 ```js
-// THIS IS A MISTAKE! DO NOT DO THIS!
-assert.throws(myFunction, 'missing foo', 'did not throw with expected message');
+function throwingFirst() {
+  throw new Error('First');
+}
+function throwingSecond() {
+  throw new Error('Second');
+}
+function notThrowing() {}
 
-// Do this instead.
-assert.throws(myFunction, /missing foo/, 'did not throw with expected message');
+// The second argument is a string and the input function threw an Error.
+// In that case both cases do not throw as neither is going to try to
+// match for the error message thrown by the input function!
+assert.throws(throwingFirst, 'Second');
+assert.throws(throwingSecond, 'Second');
+
+// The string is only used (as message) in case the function does not throw:
+assert.throws(notThrowing, 'Second');
+// AssertionError [ERR_ASSERTION]: Missing expected exception: Second
+
+// If it was intended to match for the error message do this instead:
+assert.throws(throwingSecond, /Second$/);
+// Does not throw because the error messages match.
+assert.throws(throwingFirst, /Second$/);
+// Throws a error:
+// Error: First
+//     at throwingFirst (repl:2:9)
 ```
+
+Due to the confusing notation, it is recommended not to use a string as the
+second argument. This might lead to difficult-to-spot errors.
 
 [`Error.captureStackTrace`]: errors.html#errors_error_capturestacktrace_targetobject_constructoropt
 [`Map`]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Map

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -208,7 +208,11 @@ function expectedException(actual, expected) {
   return expected.call({}, actual) === true;
 }
 
-function tryBlock(block) {
+function getActual(block) {
+  if (typeof block !== 'function') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
+                               block);
+  }
   try {
     block();
   } catch (e) {
@@ -216,60 +220,61 @@ function tryBlock(block) {
   }
 }
 
-function innerThrows(shouldThrow, block, expected, message) {
-  var details = '';
-
-  if (typeof block !== 'function') {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
-                               block);
-  }
-
-  if (typeof expected === 'string') {
-    message = expected;
-    expected = null;
-  }
-
-  const actual = tryBlock(block);
-
-  if (shouldThrow === true) {
-    if (actual === undefined) {
-      if (expected && expected.name) {
-        details += ` (${expected.name})`;
-      }
-      details += message ? `: ${message}` : '.';
-      innerFail({
-        actual,
-        expected,
-        operator: 'throws',
-        message: `Missing expected exception${details}`,
-        stackStartFn: assert.throws
-      });
-    }
-    if (expected && expectedException(actual, expected) === false) {
-      throw actual;
-    }
-  } else if (actual !== undefined) {
-    if (!expected || expectedException(actual, expected)) {
-      details = message ? `: ${message}` : '.';
-      innerFail({
-        actual,
-        expected,
-        operator: 'doesNotThrow',
-        message: `Got unwanted exception${details}\n${actual.message}`,
-        stackStartFn: assert.doesNotThrow
-      });
-    }
-    throw actual;
-  }
-}
-
 // Expected to throw an error.
 assert.throws = function throws(block, error, message) {
-  innerThrows(true, block, error, message);
+  const actual = getActual(block);
+
+  if (typeof error === 'string') {
+    if (arguments.length === 3)
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'error',
+                                 ['Function', 'RegExp'],
+                                 error);
+
+    message = error;
+    error = null;
+  }
+
+  if (actual === undefined) {
+    let details = '';
+    if (error && error.name) {
+      details += ` (${error.name})`;
+    }
+    details += message ? `: ${message}` : '.';
+    innerFail({
+      actual,
+      expected: error,
+      operator: 'throws',
+      message: `Missing expected exception${details}`,
+      stackStartFn: throws
+    });
+  }
+  if (error && expectedException(actual, error) === false) {
+    throw actual;
+  }
 };
 
 assert.doesNotThrow = function doesNotThrow(block, error, message) {
-  innerThrows(false, block, error, message);
+  const actual = getActual(block);
+  if (actual === undefined)
+    return;
+
+  if (typeof error === 'string') {
+    message = error;
+    error = null;
+  }
+
+  if (!error || expectedException(actual, error)) {
+    const details = message ? `: ${message}` : '.';
+    innerFail({
+      actual,
+      expected: error,
+      operator: 'doesNotThrow',
+      message: `Got unwanted exception${details}\n${actual.message}`,
+      stackStartFn: doesNotThrow
+    });
+  }
+  throw actual;
 };
 
 assert.ifError = function ifError(err) { if (err) throw err; };

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -773,3 +773,14 @@ common.expectsError(
     message: 'null == true'
   }
 );
+
+common.expectsError(
+  // eslint-disable-next-line no-restricted-syntax
+  () => assert.throws(() => {}, 'Error message', 'message'),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    type: TypeError,
+    message: 'The "error" argument must be one of type Function or RegExp. ' +
+             'Received type string'
+  }
+);


### PR DESCRIPTION
Throw a TypeError in case a error message is provided in the second
argument and a third argument is present as well.
This is clearly a mistake and should not be done.

CI https://ci.nodejs.org/job/node-test-pull-request/12015/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert