### PR TITLE
tools: don't lint-md as part of main lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1114,7 +1114,6 @@ lint:
 	@EXIT_STATUS=0 ; \
 	$(MAKE) lint-js || EXIT_STATUS=$$? ; \
 	$(MAKE) lint-cpp || EXIT_STATUS=$$? ; \
-	$(MAKE) lint-md || EXIT_STATUS=$$? ; \
 	$(MAKE) lint-addon-docs || EXIT_STATUS=$$? ; \
 	exit $$EXIT_STATUS
 CONFLICT_RE=^>>>>>>> [0-9A-Fa-f]+|^<<<<<<< [A-Za-z]+


### PR DESCRIPTION
Followup to https://github.com/nodejs/node/pull/17320.
As per discussion in [TSC Meeting from 2017-12-06](https://github.com/nodejs/TSC/blame/110d5aeabded9993f9ea73684fefcae0a03fcd5f/meetings/2017-12-06.md#L83-L85) skip linting markdown files as part of the `lint` target.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools,build
