### PR TITLE
domain: fix error emit handling

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -399,32 +399,33 @@ EventEmitter.init = function() {
 const eventEmit = EventEmitter.prototype.emit;
 EventEmitter.prototype.emit = function emit(...args) {
   const domain = this.domain;
-  if (domain === null || domain === undefined || this === process) {
-    return Reflect.apply(eventEmit, this, args);
-  }
 
   const type = args[0];
-  // edge case: if there is a domain and an existing non error object is given,
-  // it should not be errorized
-  // see test/parallel/test-event-emitter-no-error-provided-to-error-event.js
-  if (type === 'error' && args.length > 1 && args[1] &&
-    !(args[1] instanceof Error)) {
-    domain.emit('error', args[1]);
-    return false;
+  const doError = type === 'error' &&
+                  this._events !== undefined &&
+                  this._events.error !== undefined;
+
+  if (doError || domain === null || domain === undefined || this === process) {
+    return Reflect.apply(eventEmit, this, args);
   }
 
-  domain.enter();
-  try {
-    return Reflect.apply(eventEmit, this, args);
-  } catch (er) {
+  if (type === 'error') {
+    const er = args.length > 1 && args[1] ?
+      args[1] : new errors.Error('ERR_UNHANDLED_ERROR');
+
     if (typeof er === 'object' && er !== null) {
       er.domainEmitter = this;
       er.domain = domain;
       er.domainThrown = false;
     }
+
     domain.emit('error', er);
     return false;
-  } finally {
-    domain.exit();
   }
+
+  domain.enter();
+  const ret = Reflect.apply(eventEmit, this, args);
+  domain.exit();
+
+  return ret;
 };

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -415,7 +415,7 @@ EventEmitter.prototype.emit = function emit(...args) {
     const er = args.length > 1 && args[1] ?
       args[1] : new errors.Error('ERR_UNHANDLED_ERROR');
 
-    if (typeof er === 'object' && er !== null) {
+    if (typeof er === 'object') {
       er.domainEmitter = this;
       er.domain = domain;
       er.domainThrown = false;

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -402,8 +402,7 @@ EventEmitter.prototype.emit = function emit(...args) {
 
   const type = args[0];
   const doError = type === 'error' &&
-                  this._events !== undefined &&
-                  this._events.error !== undefined;
+                  this.listenerCount(type) > 0;
 
   if (doError || domain === null || domain === undefined || this === process) {
     return Reflect.apply(eventEmit, this, args);

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -401,10 +401,13 @@ EventEmitter.prototype.emit = function emit(...args) {
   const domain = this.domain;
 
   const type = args[0];
-  const doError = type === 'error' &&
-                  this.listenerCount(type) > 0;
+  const shouldEmitError = type === 'error' &&
+                          this.listenerCount(type) > 0;
 
-  if (doError || domain === null || domain === undefined || this === process) {
+  // Just call original `emit` if current EE instance has `error`
+  // handler, there's no active domain or this is process
+  if (shouldEmitError || domain === null || domain === undefined ||
+      this === process) {
     return Reflect.apply(eventEmit, this, args);
   }
 

--- a/test/parallel/test-domain-ee-error-listener.js
+++ b/test/parallel/test-domain-ee-error-listener.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain').create();
+const EventEmitter = require('events');
+
+domain.on('error', common.mustNotCall());
+
+const ee = new EventEmitter();
+
+const plainObject = { justAn: 'object' };
+ee.once('error', common.mustCall((err) => {
+  assert.deepStrictEqual(err, plainObject);
+}));
+ee.emit('error', plainObject);
+
+const err = new Error('test error');
+ee.once('error', common.expectsError(err));
+ee.emit('error', err);


### PR DESCRIPTION
There are a few errors in the logic of the new domain-specific `emit` and a bit too much fanciness with the falling through try-catch logic. Fixed it all up and created a regression test.

Refs: https://github.com/nodejs/node/pull/17403

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
domain, events, test