### PR TITLE
test: coverage for util.promisify

### DIFF
--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -184,3 +184,13 @@ const stat = promisify(fs.stat);
     })
   ]);
 }
+
+[undefined, null, true, 0, 'str', {}, [], Symbol()].forEach((input) => {
+  common.expectsError(
+    () => promisify(input),
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "original" argument must be of type Function'
+    });
+});


### PR DESCRIPTION
Added missing coverage for scenario where it throws when a non function is passed as argument to `Util.Promisify`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
