### PR TITLE
doc: format ArrayBufferView as inline code

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1847,10 +1847,10 @@ added: v7.10.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231
-    description: The `buffer` argument may be any `ArrayBufferView`
+    description: The `buffer` argument may be any `TypedArray` or `DataView`.
 -->
 
-* `buffer` {Buffer|Uint8Array|ArrayBufferView} Must be supplied.
+* `buffer` {Buffer|TypedArray|DataView} Must be supplied.
 * `offset` {number} Defaults to `0`.
 * `size` {number} Defaults to `buffer.length - offset`.
 
@@ -1889,10 +1889,10 @@ added: v7.10.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231
-    description: The `buffer` argument may be any `ArrayBufferView`
+    description: The `buffer` argument may be any `TypedArray` or `DataView`.
 -->
 
-* `buffer` {Buffer|Uint8Array|ArrayBufferView} Must be supplied.
+* `buffer` {Buffer|TypedArray|DataView} Must be supplied.
 * `offset` {number} Defaults to `0`.
 * `size` {number} Defaults to `buffer.length - offset`.
 * `callback` {Function} `function(err, buf) {}`.

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1847,7 +1847,7 @@ added: v7.10.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231
-    description: The `buffer` argument may be any ArrayBufferView
+    description: The `buffer` argument may be any `ArrayBufferView`
 -->
 
 * `buffer` {Buffer|Uint8Array|ArrayBufferView} Must be supplied.
@@ -1889,7 +1889,7 @@ added: v7.10.0
 changes:
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/15231
-    description: The `buffer` argument may be any ArrayBufferView
+    description: The `buffer` argument may be any `ArrayBufferView`
 -->
 
 * `buffer` {Buffer|Uint8Array|ArrayBufferView} Must be supplied.


### PR DESCRIPTION
ArrayBufferView should be formatted as `ArrayBufferView`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc