### PR TITLE
test: fix flaky test-child-process-pass-fd on Fedora 24

### DIFF
--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -9,26 +9,42 @@ const fork = require('child_process').fork;
 const net = require('net');
 
 const N = 80;
+let messageCallbackCount = 0;
+
+function forkWorker() {
+  const messageCallback = (msg, handle) => {
+    messageCallbackCount++;
+    assert.strictEqual(msg, 'handle');
+    assert.ok(handle);
+    worker.send('got');
+
+    let recvData = '';
+    handle.on('data', common.mustCall((data) => {
+      recvData += data;
+    }));
+
+    handle.on('end', () => {
+      assert.strictEqual(recvData, 'hello');
+      worker.kill();
+    });
+  };
+
+  const worker = fork(__filename, ['child']);
+  worker.on('error', (err) => {
+    if (/\bEAGAIN\b/.test(err.message)) {
+      forkWorker();
+      return;
+    }
+    throw err;
+  });
+  worker.once('message', messageCallback);
+}
 
 if (process.argv[2] !== 'child') {
   for (let i = 0; i < N; ++i) {
-    const worker = fork(__filename, ['child']);
-    worker.once('message', common.mustCall((msg, handle) => {
-      assert.strictEqual(msg, 'handle');
-      assert.ok(handle);
-      worker.send('got');
-
-      let recvData = '';
-      handle.on('data', common.mustCall((data) => {
-        recvData += data;
-      }));
-
-      handle.on('end', () => {
-        assert.strictEqual(recvData, 'hello');
-        worker.kill();
-      });
-    }));
+    forkWorker();
   }
+  process.on('exit', () => { assert.strictEqual(messageCallbackCount, N); });
 } else {
   let socket;
   let cbcalls = 0;


### PR DESCRIPTION
test-child-process-pass-fd needs to launch many processes
simultaneously. On Fedora 24, this can result in EAGAIN "Resource
temporarily unavailable" errors. When this occurs, simply try to launch
a worker again.
    
Fixes: https://github.com/nodejs/node/issues/17589

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test child_process