### PR TITLE
Allow --perf-prof and --perf-basic-prof in NODE_OPTIONS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -473,6 +473,8 @@ Node options that are allowed are:
 - `--zero-fill-buffers`
 
 V8 options that are allowed are:
+- `--perf-prof`
+- `--perf-basic-prof`
 - `--abort-on-uncaught-exception`
 - `--max-old-space-size`
 - `--stack-trace-limit`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -473,10 +473,10 @@ Node options that are allowed are:
 - `--zero-fill-buffers`
 
 V8 options that are allowed are:
-- `--perf-prof`
-- `--perf-basic-prof`
 - `--abort-on-uncaught-exception`
 - `--max-old-space-size`
+- `--perf-basic-prof`
+- `--perf-prof`
 - `--stack-trace-limit`
 
 ### `NODE_PENDING_DEPRECATION=1`

--- a/src/node.cc
+++ b/src/node.cc
@@ -3595,10 +3595,10 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--force-fips",
     "--openssl-config",
     "--icu-data-dir",
-    "--perf-prof",
-    "--perf-basic-prof",
 
     // V8 options (define with '_', which allows '-' or '_')
+    "--perf_prof",
+    "--perf_basic_prof",
     "--abort_on_uncaught_exception",
     "--max_old_space_size",
     "--stack_trace_limit",

--- a/src/node.cc
+++ b/src/node.cc
@@ -3595,6 +3595,8 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--force-fips",
     "--openssl-config",
     "--icu-data-dir",
+    "--perf-prof",
+    "--perf-basic-prof",
 
     // V8 options (define with '_', which allows '-' or '_')
     "--abort_on_uncaught_exception",

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -26,7 +26,7 @@ expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
 expect('--perf-basic-prof', 'B\n');
 
-if (common.isLinux) {
+if (common.isLinux && ['arm', 'x64', 'ia32', 'mips'].includes(process.arch)) {
   // PerfJitLogger is only implemented in Linux.
   expect('--perf-prof', 'B\n');
 }

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -26,8 +26,7 @@ expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
 expect('--perf-basic-prof', 'B\n');
 
-const archMatched = ['arm', 'x64', 'mips'].includes(process.arch);
-if (common.isLinux && !common.isWindows && archMatched) {
+if (common.isLinux && ['arm', 'x64', 'mips'].includes(process.arch)) {
   // PerfJitLogger is only implemented in Linux.
   expect('--perf-prof', 'B\n');
 }

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -24,7 +24,10 @@ expect('--throw-deprecation', 'B\n');
 expect('--zero-fill-buffers', 'B\n');
 expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
-expect('--perf-basic-prof', 'B\n');
+
+if (!common.isWindows) {
+  expect('--perf-basic-prof', 'B\n');
+}
 
 if (common.isLinux && ['arm', 'x64', 'mips'].includes(process.arch)) {
   // PerfJitLogger is only implemented in Linux.

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -26,7 +26,8 @@ expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
 expect('--perf-basic-prof', 'B\n');
 
-if (common.isLinux && ['arm', 'x64', 'ia32', 'mips'].includes(process.arch)) {
+const archMatched = ['arm', 'x64', 'mips'].includes(process.arch);
+if (common.isLinux && !common.isWindows && archMatched) {
   // PerfJitLogger is only implemented in Linux.
   expect('--perf-prof', 'B\n');
 }

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -24,6 +24,8 @@ expect('--throw-deprecation', 'B\n');
 expect('--zero-fill-buffers', 'B\n');
 expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
+expect('--perf-prof', 'B\n');
+expect('--perf-basic-prof', 'B\n');
 
 if (common.hasCrypto) {
   expect('--use-openssl-ca', 'B\n');

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -28,7 +28,6 @@ expect('--perf-basic-prof', 'B\n');
 
 if (common.isLinux) {
   // PerfJitLogger is only implemented in Linux.
-  // https://github.com/nodejs/node/pull/17600#issuecomment-350664113
   expect('--perf-prof', 'B\n');
 }
 

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -24,8 +24,13 @@ expect('--throw-deprecation', 'B\n');
 expect('--zero-fill-buffers', 'B\n');
 expect('--v8-pool-size=10', 'B\n');
 expect('--trace-event-categories node', 'B\n');
-expect('--perf-prof', 'B\n');
 expect('--perf-basic-prof', 'B\n');
+
+if (common.isLinux) {
+  // PerfJitLogger is only implemented in Linux.
+  // https://github.com/nodejs/node/pull/17600#issuecomment-350664113
+  expect('--perf-prof', 'B\n');
+}
 
 if (common.hasCrypto) {
   expect('--use-openssl-ca', 'B\n');


### PR DESCRIPTION
This PR closes #17571 

I added `--perf-prof` and `--perf-basic-prof` to whitelist.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src
