### PR TITLE
build: refine static and shared lib build

### DIFF
--- a/configure
+++ b/configure
@@ -878,7 +878,6 @@ def configure_node(o):
     configure_mips(o)
 
   if flavor == 'aix':
-    o['variables']['node_core_target_name'] = 'node_base'
     o['variables']['node_target_type'] = 'static_library'
 
   if target_arch in ('x86', 'x64', 'ia32', 'x32'):
@@ -987,6 +986,13 @@ def configure_node(o):
     o['variables']['coverage'] = 'true'
   else:
     o['variables']['coverage'] = 'false'
+
+  if options.shared:
+    o['variables']['node_target_type'] = 'shared_library'
+  elif options.enable_static:
+    o['variables']['node_target_type'] = 'static_library'
+  else:
+    o['variables']['node_target_type'] = 'executable'
 
 def configure_library(lib, output):
   shared_lib = 'shared_' + lib
@@ -1488,6 +1494,7 @@ config = {
   'BUILDTYPE': 'Debug' if options.debug else 'Release',
   'USE_XCODE': str(int(options.use_xcode or 0)),
   'PYTHON': sys.executable,
+  'NODE_TARGET_TYPE': variables['node_target_type'],
 }
 
 if options.prefix:

--- a/node.gyp
+++ b/node.gyp
@@ -22,6 +22,8 @@
     'node_v8_options%': '',
     'node_enable_v8_vtunejit%': 'false',
     'node_core_target_name%': 'node',
+    'node_lib_target_name%': 'node_lib',
+    'node_intermediate_lib_type%': 'static_library',
     'library_files': [
       'lib/internal/bootstrap_node.js',
       'lib/async_hooks.js',
@@ -161,6 +163,17 @@
     'conditions': [
       [ 'node_shared=="true"', {
         'node_target_type%': 'shared_library',
+        'conditions': [
+          ['OS=="aix"', {
+            # For AIX, always generate static library first,
+            # It needs an extra step to generate exp and
+            # then use both static lib and exp to create
+            # shared lib.
+            'node_intermediate_lib_type': 'static_library',
+          }, {
+            'node_intermediate_lib_type': 'shared_library',
+          }],
+        ],
       }, {
         'node_target_type%': 'executable',
       }],
@@ -177,7 +190,81 @@
   'targets': [
     {
       'target_name': '<(node_core_target_name)',
-      'type': '<(node_target_type)',
+      'type': 'executable',
+      'sources': [
+        'src/node_main.cc'
+      ],
+      'include_dirs': [
+        'src',
+        'deps/v8/include',
+      ],
+      'conditions': [
+        [ 'node_intermediate_lib_type=="static_library" and '
+            'node_shared=="true" and OS=="aix"', {
+          # For AIX, shared lib is linked by static lib and .exp. In the
+          # case here, the executable needs to link to shared lib.
+          # Therefore, use 'node_aix_shared' target to generate the
+          # shared lib and then executable.
+          'dependencies': [ 'node_aix_shared' ],
+        }, {
+          'dependencies': [ '<(node_lib_target_name)' ],
+        }],
+        [ 'node_intermediate_lib_type=="static_library" and '
+            'node_shared=="false"', {
+          'includes': [
+            'node.gypi'
+          ],
+          'xcode_settings': {
+            'OTHER_LDFLAGS': [
+              '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)'
+                  '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+            ],
+          },
+          'msvs_settings': {
+            'VCLinkerTool': {
+              'AdditionalOptions': [
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)\\lib\\'
+                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+              ],
+            },
+          },
+          'conditions': [
+            ['OS in "linux freebsd openbsd solaris android"', {
+              'ldflags': [
+                '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
+                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
+                '-Wl,--no-whole-archive',
+              ],
+            }],
+            [ 'OS=="win"', {
+              'sources': [ 'src/res/node.rc' ],
+              'conditions': [
+                [ 'node_use_etw=="true"', {
+                  'sources': [
+                    'tools/msvs/genfiles/node_etw_provider.rc'
+                  ],
+                }],
+                [ 'node_use_perfctr=="true"', {
+                  'sources': [
+                    'tools/msvs/genfiles/node_perfctr_provider.rc',
+                   ],
+                }]
+              ],
+            }],
+          ],
+        }],
+        [ 'node_intermediate_lib_type=="shared_library" and OS=="win"', {
+          # On Windows, having the same name for both executable and shared
+          # lib causes filename collision. Need a different PRODUCT_NAME for
+          # the executable and rename it back to node.exe later
+          'product_name': '<(node_core_target_name)-win',
+        }],
+      ],
+    },
+    {
+      'target_name': '<(node_lib_target_name)',
+      'type': '<(node_intermediate_lib_type)',
+      'product_name': '<(node_core_target_name)',
 
       'dependencies': [
         'node_js2c#host',
@@ -189,7 +276,6 @@
 
       'include_dirs': [
         'src',
-        'tools/msvs/genfiles',
         '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
       ],
 
@@ -215,7 +301,6 @@
         'src/node_file.cc',
         'src/node_http2.cc',
         'src/node_http_parser.cc',
-        'src/node_main.cc',
         'src/node_os.cc',
         'src/node_platform.cc',
         'src/node_perf.cc',
@@ -320,6 +405,9 @@
         [ 'node_shared=="true" and node_module_version!="" and OS!="win"', {
           'product_extension': '<(shlib_suffix)',
         }],
+        ['node_shared=="true" and OS=="aix"', {
+          'product_name': 'node_base',
+        }],
         [ 'v8_enable_inspector==1', {
           'defines': [
             'HAVE_INSPECTOR=1',
@@ -350,7 +438,7 @@
             'src/backtrace_win32.cc',
           ],
           'conditions': [
-            [ 'node_target_type!="static_library"', {
+            [ 'node_intermediate_lib_type!="static_library"', {
               'sources': [
                 'src/res/node.rc',
               ],
@@ -369,6 +457,64 @@
         }, { # POSIX
           'defines': [ '__POSIX__' ],
           'sources': [ 'src/backtrace_posix.cc' ],
+        }],
+        [ 'node_use_etw=="true"', {
+          'defines': [ 'HAVE_ETW=1' ],
+          'dependencies': [ 'node_etw' ],
+          'include_dirs': [
+            'src',
+            'tools/msvs/genfiles',
+            '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+          ],
+          'sources': [
+            'src/node_win32_etw_provider.h',
+            'src/node_win32_etw_provider-inl.h',
+            'src/node_win32_etw_provider.cc',
+            'src/node_dtrace.cc',
+            'tools/msvs/genfiles/node_etw_provider.h',
+          ],
+          'conditions': [
+            ['node_intermediate_lib_type != "static_library"', {
+              'sources': [
+                'tools/msvs/genfiles/node_etw_provider.rc',
+              ],
+            }],
+          ],
+        }],
+        [ 'node_use_perfctr=="true"', {
+          'defines': [ 'HAVE_PERFCTR=1' ],
+          'dependencies': [ 'node_perfctr' ],
+          'include_dirs': [
+            'src',
+            'tools/msvs/genfiles',
+            '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+          ],
+          'sources': [
+            'src/node_win32_perfctr_provider.h',
+            'src/node_win32_perfctr_provider.cc',
+            'src/node_counters.cc',
+            'src/node_counters.h',
+          ],
+          'conditions': [
+            ['node_intermediate_lib_type != "static_library"', {
+              'sources': [
+                'tools/msvs/genfiles/node_perfctr_provider.rc',
+              ],
+            }],
+          ],
+        }],
+        [ 'node_use_lttng=="true"', {
+          'defines': [ 'HAVE_LTTNG=1' ],
+          'include_dirs': [ '<(SHARED_INTERMEDIATE_DIR)' ],
+          'libraries': [ '-llttng-ust' ],
+          'include_dirs': [
+            'src',
+            'tools/msvs/genfiles',
+            '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
+          ],
+          'sources': [
+            'src/node_lttng.cc'
+          ],
         }],
         [ 'node_use_dtrace=="true"', {
           'defines': [ 'HAVE_DTRACE=1' ],
@@ -410,7 +556,6 @@
           ] ]
         } ],
         [ 'node_use_openssl=="true"', {
-          'defines': [ 'HAVE_OPENSSL=1' ],
           'sources': [
             'src/node_crypto.cc',
             'src/node_crypto_bio.cc',
@@ -421,49 +566,6 @@
             'src/tls_wrap.cc',
             'src/tls_wrap.h'
           ],
-          'conditions': [
-            ['openssl_fips != ""', {
-              'defines': [ 'NODE_FIPS_MODE' ],
-            }],
-            [ 'node_shared_openssl=="false"', {
-              'dependencies': [
-                './deps/openssl/openssl.gyp:openssl',
-
-                # For tests
-                './deps/openssl/openssl.gyp:openssl-cli',
-              ],
-              'conditions': [
-                # -force_load or --whole-archive are not applicable for
-                # the static library
-                [ 'node_target_type!="static_library"', {
-                  'xcode_settings': {
-                    'OTHER_LDFLAGS': [
-                      '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
-                    ],
-                  },
-                  'conditions': [
-                    ['OS in "linux freebsd" and node_shared=="false"', {
-                      'ldflags': [
-                        '-Wl,--whole-archive,'
-                            '<(OBJ_DIR)/deps/openssl/'
-                            '<(OPENSSL_PRODUCT)',
-                        '-Wl,--no-whole-archive',
-                      ],
-                    }],
-                    # openssl.def is based on zlib.def, zlib symbols
-                    # are always exported.
-                    ['use_openssl_def==1', {
-                      'sources': ['<(SHARED_INTERMEDIATE_DIR)/openssl.def'],
-                    }],
-                    ['OS=="win" and use_openssl_def==0', {
-                      'sources': ['deps/zlib/win32/zlib.def'],
-                    }],
-                  ],
-                }],
-              ],
-            }]]
-        }, {
-          'defines': [ 'HAVE_OPENSSL=0' ]
         }],
       ],
     },
@@ -521,7 +623,7 @@
       'target_name': 'node_etw',
       'type': 'none',
       'conditions': [
-        [ 'node_use_etw=="true" and node_target_type!="static_library"', {
+        [ 'node_use_etw=="true"', {
           'actions': [
             {
               'action_name': 'node_etw',
@@ -542,7 +644,7 @@
       'target_name': 'node_perfctr',
       'type': 'none',
       'conditions': [
-        [ 'node_use_perfctr=="true" and node_target_type!="static_library"', {
+        [ 'node_use_perfctr=="true"', {
           'actions': [
             {
               'action_name': 'node_perfctr_man',
@@ -604,15 +706,13 @@
             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',
           ],
           'conditions': [
-            [ 'node_use_dtrace=="false" and node_use_etw=="false" or '
-              'node_target_type=="static_library"', {
+            [ 'node_use_dtrace=="false" and node_use_etw=="false"', {
               'inputs': [ 'src/notrace_macros.py' ]
             }],
-            ['node_use_lttng=="false" or node_target_type=="static_library"', {
+            [ 'node_use_lttng=="false"', {
               'inputs': [ 'src/nolttng_macros.py' ]
             }],
-            [ 'node_use_perfctr=="false" or '
-              'node_target_type=="static_library"', {
+            [ 'node_use_perfctr=="false"', {
               'inputs': [ 'src/noperfctr_macros.py' ]
             }]
           ],
@@ -662,10 +762,10 @@
             {
               'action_name': 'node_dtrace_provider_o',
               'inputs': [
-                '<(OBJ_DIR)/node/src/node_dtrace.o',
+                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace.o',
               ],
               'outputs': [
-                '<(OBJ_DIR)/node/src/node_dtrace_provider.o'
+                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace_provider.o'
               ],
               'action': [ 'dtrace', '-G', '-xnolibs', '-s', 'src/node_provider.d',
                 '<@(_inputs)', '-o', '<@(_outputs)' ]
@@ -715,7 +815,7 @@
                 '<(SHARED_INTERMEDIATE_DIR)/v8constants.h'
               ],
               'outputs': [
-                '<(OBJ_DIR)/node/src/node_dtrace_ustack.o'
+                '<(OBJ_DIR)/<(node_lib_target_name)/src/node_dtrace_ustack.o'
               ],
               'conditions': [
                 [ 'target_arch=="ia32" or target_arch=="arm"', {
@@ -763,11 +863,40 @@
       ]
     },
     {
+      # When using shared lib to build executable in Windows, in order to avoid
+      # filename collision, the executable name is node-win.exe. Need to rename
+      # it back to node.exe
+      'target_name': 'rename_node_bin_win',
+      'type': 'none',
+      'dependencies': [
+        '<(node_core_target_name)',
+      ],
+      'conditions': [
+        [ 'OS=="win" and node_intermediate_lib_type=="shared_library"', {
+          'actions': [
+            {
+              'action_name': 'rename_node_bin_win',
+              'inputs': [
+                '<(PRODUCT_DIR)/<(node_core_target_name)-win.exe'
+              ],
+              'outputs': [
+                '<(PRODUCT_DIR)/<(node_core_target_name).exe',
+              ],
+              'action': [
+                'mv', '<@(_inputs)', '<@(_outputs)',
+              ],
+            },
+          ],
+        } ],
+      ]
+    },
+    {
       'target_name': 'cctest',
       'type': 'executable',
 
       'dependencies': [
         '<(node_core_target_name)',
+        'rename_node_bin_win',
         'deps/gtest/gtest.gyp:gtest',
         'node_js2c#host',
         'node_dtrace_header',
@@ -776,9 +905,9 @@
       ],
 
       'variables': {
-        'OBJ_PATH': '<(OBJ_DIR)/node/src',
-        'OBJ_GEN_PATH': '<(OBJ_DIR)/node/gen',
-        'OBJ_TRACING_PATH': '<(OBJ_DIR)/node/src/tracing',
+        'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src',
+        'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/gen',
+        'OBJ_TRACING_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src/tracing',
         'OBJ_SUFFIX': 'o',
         'OBJ_SEPARATOR': '/',
         'conditions': [
@@ -789,18 +918,19 @@
             'OBJ_PATH': '<(OBJ_DIR)/src',
             'OBJ_GEN_PATH': '<(OBJ_DIR)/gen',
             'OBJ_TRACING_PATH': '<(OBJ_DIR)/src/tracing',
-            'OBJ_SEPARATOR': '/node.',
+            'OBJ_SEPARATOR': '/<(node_lib_target_name).',
           }, {
             'conditions': [
               ['OS=="win"', {
-                'OBJ_PATH': '<(OBJ_DIR)/node',
-                'OBJ_GEN_PATH': '<(OBJ_DIR)/node',
-                'OBJ_TRACING_PATH': '<(OBJ_DIR)/node',
+                'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
+                'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
+                'OBJ_TRACING_PATH': '<(OBJ_DIR)/<(node_lib_target_name)',
               }],
               ['OS=="aix"', {
-                'OBJ_PATH': '<(OBJ_DIR)/node_base/src',
-                'OBJ_GEN_PATH': '<(OBJ_DIR)/node_base/gen',
-                'OBJ_TRACING_PATH': '<(OBJ_DIR)/node_base/src/tracing',
+                'OBJ_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/src',
+                'OBJ_GEN_PATH': '<(OBJ_DIR)/<(node_lib_target_name)/gen',
+                'OBJ_TRACING_PATH':
+                  '<(OBJ_DIR)/<(node_lib_target_name)/src/tracing',
               }],
             ]}
           ]
@@ -832,34 +962,29 @@
         'test/cctest/test_url.cc'
       ],
 
-      'sources!': [
-        'src/node_main.cc'
+      'libraries': [
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)async_wrap.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)env.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_buffer.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_debug_options.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_i18n.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_perf.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_platform.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_url.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)util.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)string_bytes.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)string_search.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)stream_base.<(OBJ_SUFFIX)',
+        '<(OBJ_PATH)<(OBJ_SEPARATOR)node_constants.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)agent.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_buffer.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_writer.<(OBJ_SUFFIX)',
+        '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)trace_event.<(OBJ_SUFFIX)',
+        '<(OBJ_GEN_PATH)<(OBJ_SEPARATOR)node_javascript.<(OBJ_SUFFIX)',
       ],
 
       'conditions': [
-        ['node_target_type!="static_library"', {
-          'libraries': [
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)async_wrap.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)env.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_buffer.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_debug_options.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_i18n.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_perf.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_platform.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_url.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)util.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)string_bytes.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)string_search.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)stream_base.<(OBJ_SUFFIX)',
-            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_constants.<(OBJ_SUFFIX)',
-            '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)agent.<(OBJ_SUFFIX)',
-            '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_buffer.<(OBJ_SUFFIX)',
-            '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)node_trace_writer.<(OBJ_SUFFIX)',
-            '<(OBJ_TRACING_PATH)<(OBJ_SEPARATOR)trace_event.<(OBJ_SUFFIX)',
-            '<(OBJ_GEN_PATH)<(OBJ_SEPARATOR)node_javascript.<(OBJ_SUFFIX)',
-          ],
-        }],
         [ 'node_use_openssl=="true"', {
           'libraries': [
             '<(OBJ_PATH)<(OBJ_SEPARATOR)node_crypto.<(OBJ_SUFFIX)',
@@ -869,6 +994,14 @@
           ],
           'defines': [
             'HAVE_OPENSSL=1',
+          ],
+        }],
+        [ 'node_use_perfctr=="true"', {
+          'defines': [ 'HAVE_PERFCTR=1' ],
+          'libraries': [
+            '<(OBJ_PATH)<(OBJ_SEPARATOR)node_counters.<(OBJ_SUFFIX)',
+            '<(OBJ_PATH)<(OBJ_SEPARATOR)'
+              'node_win32_perfctr_provider.<(OBJ_SUFFIX)',
           ],
         }],
         ['v8_enable_inspector==1', {
@@ -900,10 +1033,21 @@
             }],
             ['OS=="linux"', {
               'libraries': [
-                '<(SHARED_INTERMEDIATE_DIR)/node_dtrace_provider.o',
+                '<(SHARED_INTERMEDIATE_DIR)<(OBJ_SEPARATOR)'
+                  'node_dtrace_provider.<(OBJ_SUFFIX)',
               ]
             }],
           ],
+        }, {
+          'conditions': [
+            [ 'node_use_etw=="true" and OS=="win"', {
+              'libraries': [
+                '<(OBJ_PATH)<(OBJ_SEPARATOR)node_dtrace.<(OBJ_SUFFIX)',
+                '<(OBJ_PATH)<(OBJ_SEPARATOR)'
+                  'node_win32_etw_provider.<(OBJ_SUFFIX)',
+              ],
+            }]
+          ]
         }],
         [ 'OS=="win"', {
           'libraries': [
@@ -914,129 +1058,27 @@
             '<(OBJ_PATH)<(OBJ_SEPARATOR)backtrace_posix.<(OBJ_SUFFIX)',
            ],
         }],
-        [ 'node_shared_zlib=="false"', {
-          'dependencies': [
-            'deps/zlib/zlib.gyp:zlib',
-           ]
-        }],
-        [ 'node_shared_openssl=="false" and node_shared=="false"', {
-          'dependencies': [
-            'deps/openssl/openssl.gyp:openssl'
-          ]
-        }],
-        [ 'node_shared_http_parser=="false"', {
-          'dependencies': [
-            'deps/http_parser/http_parser.gyp:http_parser'
-          ]
-        }],
-        [ 'node_shared_libuv=="false"', {
-          'dependencies': [
-            'deps/uv/uv.gyp:libuv'
-          ]
-        }],
-        [ 'node_shared_nghttp2=="false"', {
-          'dependencies': [
-            'deps/nghttp2/nghttp2.gyp:nghttp2'
-          ],
-          'include_dirs': [
-            'deps/nghttp2/lib/includes'
-          ]
-        }],
-        [ 'node_use_v8_platform=="true"', {
-          'dependencies': [
-            'deps/v8/src/v8.gyp:v8_libplatform',
-          ],
-        }],
         ['OS=="solaris"', {
           'ldflags': [ '-I<(SHARED_INTERMEDIATE_DIR)' ]
-        }],
-        [ 'node_use_openssl=="true"', {
-          'conditions': [
-            [ 'node_shared_openssl=="false"', {
-              'conditions': [
-                # -force_load or --whole-archive are not applicable for
-                # the static library
-                [ 'node_target_type!="static_library"', {
-                  'xcode_settings': {
-                    'OTHER_LDFLAGS': [
-                      '-Wl,-force_load,<(PRODUCT_DIR)/<(OPENSSL_PRODUCT)',
-                    ],
-                  },
-                  'conditions': [
-                    ['OS in "linux freebsd" and node_shared=="false"', {
-                      'ldflags': [
-                        '-Wl,--whole-archive,'
-                            '<(OBJ_DIR)/deps/openssl/'
-                            '<(OPENSSL_PRODUCT)',
-                        '-Wl,--no-whole-archive',
-                      ],
-                    }],
-                  ],
-                }],
-              ],
-            }]]
         }],
       ]
     }
   ], # end targets
 
   'conditions': [
-    [ 'node_target_type=="static_library"', {
+    [ 'OS=="aix" and node_shared=="true"', {
       'targets': [
         {
-          'target_name': 'static_node',
-          'type': 'executable',
+          'target_name': 'node_aix_shared',
+          'type': 'shared_library',
           'product_name': '<(node_core_target_name)',
-          'dependencies': [
-            '<(node_core_target_name)',
-          ],
-          'sources+': [
-            'src/node_main.cc',
-          ],
-          'include_dirs': [
-            'deps/v8/include',
-          ],
-          'xcode_settings': {
-            'OTHER_LDFLAGS': [
-              '-Wl,-force_load,<(PRODUCT_DIR)/<(STATIC_LIB_PREFIX)'
-                  '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
-            ],
-          },
-          'msvs_settings': {
-            'VCLinkerTool': {
-              'AdditionalOptions': [
-                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/'
-                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
-              ],
-            },
-          },
+          'ldflags': [ '--shared' ],
+          'product_extension': '<(shlib_suffix)',
           'conditions': [
-            ['OS in "linux freebsd openbsd solaris android"', {
-              'ldflags': [
-                '-Wl,--whole-archive,<(OBJ_DIR)/<(STATIC_LIB_PREFIX)'
-                    '<(node_core_target_name)<(STATIC_LIB_SUFFIX)',
-                '-Wl,--no-whole-archive',
-              ],
-            }],
-          ],
-         },
-      ],
-    }],
-    ['OS=="aix"', {
-      'targets': [
-        {
-          'target_name': 'node',
-          'conditions': [
-            ['node_shared=="true"', {
-              'type': 'shared_library',
-              'ldflags': ['--shared'],
-              'product_extension': '<(shlib_suffix)',
-            }, {
-              'type': 'executable',
-            }],
             ['target_arch=="ppc64"', {
               'ldflags': [
-                '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread/ppc64'
+                '-Wl,-blibpath:/usr/lib:/lib:'
+                  '/opt/freeware/lib/pthread/ppc64'
               ],
             }],
             ['target_arch=="ppc"', {
@@ -1045,45 +1087,20 @@
               ],
             }]
           ],
-          'dependencies': ['<(node_core_target_name)', 'node_exp'],
-
+          'includes': [
+            'node.gypi'
+          ],
+          'dependencies': [ '<(node_lib_target_name)' ],
           'include_dirs': [
             'src',
             'deps/v8/include',
           ],
-
           'sources': [
-            'src/node_main.cc',
             '<@(library_files)',
-            # node.gyp is added to the project by default.
             'common.gypi',
           ],
-
-          'ldflags': ['-Wl,-bE:<(PRODUCT_DIR)/node.exp', '-Wl,-brtl'],
         },
-        {
-          'target_name': 'node_exp',
-          'type': 'none',
-          'dependencies': [
-            '<(node_core_target_name)',
-          ],
-          'actions': [
-            {
-              'action_name': 'expfile',
-              'inputs': [
-                '<(OBJ_DIR)'
-              ],
-              'outputs': [
-                '<(PRODUCT_DIR)/node.exp'
-              ],
-              'action': [
-                'sh', 'tools/create_expfile.sh',
-                      '<@(_inputs)', '<@(_outputs)'
-              ],
-            }
-          ]
-        }
-      ], # end targets
+      ]
     }], # end aix section
   ], # end conditions block
 }

--- a/test/addons/openssl-binding/binding.gyp
+++ b/test/addons/openssl-binding/binding.gyp
@@ -1,8 +1,4 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
@@ -10,13 +6,6 @@
         ['node_use_openssl=="true"', {
           'sources': ['binding.cc'],
           'include_dirs': ['../../../deps/openssl/openssl/include'],
-          'conditions': [
-            ['OS=="win" and node_target_type=="static_library"', {
-	      'libraries': [
-                '../../../../$(Configuration)/lib/<(OPENSSL_PRODUCT)'
-              ],
-            }],
-          ],
         }]
       ]
     },

--- a/test/addons/zlib-binding/binding.gyp
+++ b/test/addons/zlib-binding/binding.gyp
@@ -1,22 +1,9 @@
 {
-  'includes': ['../../../config.gypi'],
-  'variables': {
-    'node_target_type%': '',
-  },
   'targets': [
     {
       'target_name': 'binding',
       'sources': ['binding.cc'],
       'include_dirs': ['../../../deps/zlib'],
-      'conditions': [
-        ['node_target_type=="static_library"', {
-          'conditions': [
-            ['OS=="win"', {
-	      'libraries': ['../../../../$(Configuration)/lib/zlib.lib'],
-            }],
-          ],
-        }],
-      ],
     },
   ]
 }


### PR DESCRIPTION
Refine the static and shared lib build process in order
to integrate static and shared lib verfication into CI.
When building both static and shared lib, we still build
node executable now and it uses the shared and static lib.

Fixes: https://github.com/nodejs/node/issues/14158

Signed-off-by: Yihong Wang <yh.wang@ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build
