### PR TITLE
util: allow wildcards in debuglog()

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -104,6 +104,19 @@ FOO 3245: hello from foo [123]
 where `3245` is the process id.  If it is not run with that
 environment variable set, then it will not print anything.
 
+The `section` supports wildcard also, for example:
+```js
+const util = require('util');
+const debuglog = util.debuglog('foo-bar');
+
+debuglog('hi there, it\'s foo-bar [%d]', 2333);
+```
+
+if it is run with `NODE_DEBUG=foo*` in the environment, then it will output something like:
+```txt
+FOO-BAR 3257: hi there, it's foo-bar [2333]
+```
+
 Multiple comma-separated `section` names may be specified in the `NODE_DEBUG`
 environment variable. For example: `NODE_DEBUG=fs,net,tls`.
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -230,28 +230,21 @@ function format(f) {
   return str;
 }
 
-var debugs = {};
-var debugEnviron;
-
-const regExpSpecialChars = /[|\\{}()[\]^$+?.]/g;
-
-function stringToRegExp(string) {
-  // Escape special chars except wildcard.
-  string = string.replace(regExpSpecialChars, '\\$&');
-  // Transform wildcard to "match anything"
-  string = string.replace(/\*/g, '.*');
-  return new RegExp(`^${string}$`);
+const debugs = {};
+let debugEnvRegex = /^$/;
+if (process.env.NODE_DEBUG) {
+  let debugEnv = process.env.NODE_DEBUG;
+  debugEnv = debugEnv.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+      .replace(/\*/g, '.*')
+      .replace(/,/g, '$|^')
+      .toUpperCase();
+  debugEnvRegex = new RegExp(`^${debugEnv}$`, 'i');
 }
 
 function debuglog(set) {
-  if (debugEnviron === undefined) {
-    debugEnviron = Array.from(new Set(
-      (process.env.NODE_DEBUG || '').split(',').map((s) => s.toUpperCase())));
-    debugEnviron = debugEnviron.map(stringToRegExp);
-  }
   set = set.toUpperCase();
   if (!debugs[set]) {
-    if (debugEnviron.some((name) => name.test(set))) {
+    if (debugEnvRegex.test(set)) {
       var pid = process.pid;
       debugs[set] = function() {
         var msg = exports.format.apply(exports, arguments);

--- a/lib/util.js
+++ b/lib/util.js
@@ -233,14 +233,25 @@ function format(f) {
 var debugs = {};
 var debugEnviron;
 
+const regExpSpecialChars = /[|\\{}()[\]^$+?.]/g;
+
+function stringToRegExp(string) {
+  // Escape special chars except wildcard.
+  string = string.replace(regExpSpecialChars, '\\$&');
+  // Transform wildcard to "match anything"
+  string = string.replace(/\*/g, '.*');
+  return new RegExp(`^${string}$`);
+}
+
 function debuglog(set) {
   if (debugEnviron === undefined) {
-    debugEnviron = new Set(
-      (process.env.NODE_DEBUG || '').split(',').map((s) => s.toUpperCase()));
+    debugEnviron = Array.from(new Set(
+      (process.env.NODE_DEBUG || '').split(',').map((s) => s.toUpperCase())));
+    debugEnviron = debugEnviron.map(stringToRegExp);
   }
   set = set.toUpperCase();
   if (!debugs[set]) {
-    if (debugEnviron.has(set)) {
+    if (debugEnviron.some((name) => name.test(set))) {
       var pid = process.pid;
       debugs[set] = function() {
         var msg = exports.format.apply(exports, arguments);

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -43,6 +43,15 @@ function parent() {
   test('f$oo', true, 'f$oo');
   test('f$oo', false, 'f.oo');
   test('no-bar-at-all', false, 'bar');
+
+  test('test-abc', true, 'test-abc');
+  test('test-a', false, 'test-abc');
+  test('test-*', true, 'test-abc');
+  test('test-*c', true, 'test-abc');
+  test('test-*abc', true, 'test-abc');
+  test('abc-test', true, 'abc-test');
+  test('a*-test', true, 'abc-test');
+  test('*-test', true, 'abc-test');
 }
 
 function test(environ, shouldWrite, section) {


### PR DESCRIPTION
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

**Affected core subsystem(s)**
util

fixes #17605
