### PR TITLE
assert: add error diffs

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -18,6 +18,9 @@ For more information about the used equality comparisons see
 added: REPLACEME
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Added error diffs to the strict mode
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/17002
     description: Added strict mode to the assert module.
 -->
@@ -26,10 +29,40 @@ When using the `strict mode`, any `assert` function will use the equality used i
 the strict function mode. So [`assert.deepEqual()`][] will, for example, work the
 same as [`assert.deepStrictEqual()`][].
 
+On top of that, error messages which involve objects produce an error diff
+instead of displaying both objects. That is not the case for the legacy mode.
+
 It can be accessed using:
 
 ```js
 const assert = require('assert').strict;
+```
+
+Example error diff (the `expected`, `actual`, and `Lines skipped` will be on a
+single row):
+
+```js
+const assert = require('assert').strict;
+
+assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
+```
+
+```diff
+AssertionError [ERR_ASSERTION]: Input A expected to deepStrictEqual input B:
++ expected
+- actual
+... Lines skipped
+
+  [
+    [
+...
+      2,
+-     3
++     '3'
+    ],
+...
+    5
+  ]
 ```
 
 ## Legacy mode

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -65,6 +65,9 @@ AssertionError [ERR_ASSERTION]: Input A expected to deepStrictEqual input B:
   ]
 ```
 
+To deactivate the colors, use the `NODE_DISABLE_COLORS` environment variable.
+Please note that this will also deactivate the colors in the REPL.
+
 ## Legacy mode
 
 > Stability: 0 - Deprecated: Use strict mode instead.

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -121,6 +121,32 @@ added: v0.7.7
 A `number` specifying the number of rows the TTY currently has. This property
 is updated whenever the `'resize'` event is emitted.
 
+### writeStream.getColorDepth([env])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `env` {object} A object containing the environment variables to check.
+  Defaults to `process.env`.
+* Returns: {number}
+
+Returns:
+* 1 for 2,
+* 4 for 16,
+* 8 for 256,
+* 24 for 16,777,216
+colors supported.
+
+Use this to determine what colors the terminal supports. Due to the nature of
+colors in terminals it is possible to either have false positives or false
+negatives. It depends on process information and the environment variables that
+may lie about what terminal is used.
+To enforce a specific behavior without relying on `process.env` it is possible
+to pass in an object with different settings.
+
+Use the `NODE_DISABLE_COLORS` environment variable to enforce this function to
+always return 1.
+
 ## tty.isatty(fd)
 <!-- YAML
 added: v0.5.8

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -48,6 +48,10 @@ const meta = [
 
 const escapeFn = (str) => meta[str.charCodeAt(0)];
 
+const ERR_DIFF_DEACTIVATED = 0;
+const ERR_DIFF_NOT_EQUAL = 1;
+const ERR_DIFF_EQUAL = 2;
+
 // The assert module provides functions that throw
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
@@ -283,7 +287,8 @@ assert.deepStrictEqual = function deepStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'deepStrictEqual',
-      stackStartFn: deepStrictEqual
+      stackStartFn: deepStrictEqual,
+      errorDiff: this === strict ? ERR_DIFF_EQUAL : ERR_DIFF_DEACTIVATED
     });
   }
 };
@@ -296,7 +301,8 @@ function notDeepStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'notDeepStrictEqual',
-      stackStartFn: notDeepStrictEqual
+      stackStartFn: notDeepStrictEqual,
+      errorDiff: this === strict ? ERR_DIFF_NOT_EQUAL : ERR_DIFF_DEACTIVATED
     });
   }
 }
@@ -308,7 +314,8 @@ assert.strictEqual = function strictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'strictEqual',
-      stackStartFn: strictEqual
+      stackStartFn: strictEqual,
+      errorDiff: this === strict ? ERR_DIFF_EQUAL : ERR_DIFF_DEACTIVATED
     });
   }
 };
@@ -320,7 +327,8 @@ assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
       expected,
       message,
       operator: 'notStrictEqual',
-      stackStartFn: notStrictEqual
+      stackStartFn: notStrictEqual,
+      errorDiff: this === strict ? ERR_DIFF_NOT_EQUAL : ERR_DIFF_DEACTIVATED
     });
   }
 };

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -132,22 +132,164 @@ class SystemError extends makeNodeError(Error) {
   }
 }
 
+function createErrDiff(actual, expected, operator) {
+  var other = '';
+  var res = '';
+  var lastPos = 0;
+  var end = '';
+  var skipped = false;
+  const actualLines = util
+    .inspect(actual, { compact: false }).split('\n');
+  const expectedLines = util
+    .inspect(expected, { compact: false }).split('\n');
+  const msg = `Input A expected to ${operator} input B:\n` +
+        '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m';
+  const skippedMsg = ' ... Lines skipped';
+
+  // Remove all ending lines that match (this optimizes the output for
+  // readability by reducing the number of total changed lines).
+  var a = actualLines[actualLines.length - 1];
+  var b = expectedLines[expectedLines.length - 1];
+  var i = 0;
+  while (a === b) {
+    if (i++ < 2) {
+      end = `\n  ${a}${end}`;
+    } else {
+      other = a;
+    }
+    actualLines.pop();
+    expectedLines.pop();
+    a = actualLines[actualLines.length - 1];
+    b = expectedLines[expectedLines.length - 1];
+  }
+  if (i > 3) {
+    end = `\n...${end}`;
+    skipped = true;
+  }
+  if (other !== '') {
+    end = `\n  ${other}${end}`;
+    other = '';
+  }
+
+  const maxLines = Math.max(actualLines.length, expectedLines.length);
+  var printedLines = 0;
+  for (i = 0; i < maxLines; i++) {
+    // Only extra expected lines exist
+    const cur = i - lastPos;
+    if (actualLines.length < i + 1) {
+      if (cur > 1 && i > 2) {
+        if (cur > 4) {
+          res += '\n...';
+          skipped = true;
+        } else if (cur > 3) {
+          res += `\n  ${expectedLines[i - 2]}`;
+          printedLines++;
+        }
+        res += `\n  ${expectedLines[i - 1]}`;
+        printedLines++;
+      }
+      lastPos = i;
+      other += `\n\u001b[32m+\u001b[39m ${expectedLines[i]}`;
+      printedLines++;
+    // Only extra actual lines exist
+    } else if (expectedLines.length < i + 1) {
+      if (cur > 1 && i > 2) {
+        if (cur > 4) {
+          res += '\n...';
+          skipped = true;
+        } else if (cur > 3) {
+          res += `\n  ${actualLines[i - 2]}`;
+          printedLines++;
+        }
+        res += `\n  ${actualLines[i - 1]}`;
+        printedLines++;
+      }
+      lastPos = i;
+      res += `\n\u001b[31m-\u001b[39m ${actualLines[i]}`;
+      printedLines++;
+    // Lines diverge
+    } else if (actualLines[i] !== expectedLines[i]) {
+      if (cur > 1 && i > 2) {
+        if (cur > 4) {
+          res += '\n...';
+          skipped = true;
+        } else if (cur > 3) {
+          res += `\n  ${actualLines[i - 2]}`;
+          printedLines++;
+        }
+        res += `\n  ${actualLines[i - 1]}`;
+        printedLines++;
+      }
+      lastPos = i;
+      res += `\n\u001b[31m-\u001b[39m ${actualLines[i]}`;
+      other += `\n\u001b[32m+\u001b[39m ${expectedLines[i]}`;
+      printedLines += 2;
+    // Lines are identical
+    } else {
+      res += other;
+      other = '';
+      if (cur === 1 || i === 0) {
+        res += `\n  ${actualLines[i]}`;
+        printedLines++;
+      }
+    }
+    // Inspected object to big (Show ~20 rows max)
+    if (printedLines > 20 && i < maxLines - 2) {
+      return `${msg}${skippedMsg}\n${res}\n...${other}\n...`;
+    }
+  }
+  return `${msg}${skipped ? skippedMsg : ''}\n${res}${other}${end}`;
+}
+
 class AssertionError extends Error {
   constructor(options) {
     if (typeof options !== 'object' || options === null) {
       throw new exports.TypeError('ERR_INVALID_ARG_TYPE', 'options', 'Object');
     }
-    var { actual, expected, message, operator, stackStartFn } = options;
+    var {
+      actual,
+      expected,
+      message,
+      operator,
+      stackStartFn,
+      errorDiff = 0
+    } = options;
+
     if (message != null) {
       super(message);
     } else {
+      if (util === null) util = require('util');
+
       if (actual && actual.stack && actual instanceof Error)
         actual = `${actual.name}: ${actual.message}`;
       if (expected && expected.stack && expected instanceof Error)
         expected = `${expected.name}: ${expected.message}`;
-      if (util === null) util = require('util');
-      super(`${util.inspect(actual).slice(0, 128)} ` +
-        `${operator} ${util.inspect(expected).slice(0, 128)}`);
+
+      if (errorDiff === 0) {
+        let res = util.inspect(actual);
+        let other = util.inspect(expected);
+        if (res.length > 128)
+          res = `${res.slice(0, 125)}...`;
+        if (other.length > 128)
+          other = `${other.slice(0, 125)}...`;
+        super(`${res} ${operator} ${other}`);
+      } else if (errorDiff === 1) {
+        // In case the objects are equal but the operator requires unequal, show
+        // the first object and say A equals B
+        const res = util
+          .inspect(actual, { compact: false }).split('\n');
+
+        if (res.length > 20) {
+          res[19] = '...';
+          while (res.length > 20) {
+            res.pop();
+          }
+        }
+        // Only print a single object.
+        super(`Identical input passed to ${operator}:\n${res.join('\n')}`);
+      } else {
+        super(createErrDiff(actual, expected, operator));
+      }
     }
 
     this.generatedMessage = !message;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -14,6 +14,10 @@ const kCode = Symbol('code');
 const kInfo = Symbol('info');
 const messages = new Map();
 
+var green = '';
+var red = '';
+var white = '';
+
 const { errmap } = process.binding('uv');
 const { kMaxLength } = process.binding('buffer');
 const { defineProperty } = Object;
@@ -143,7 +147,7 @@ function createErrDiff(actual, expected, operator) {
   const expectedLines = util
     .inspect(expected, { compact: false }).split('\n');
   const msg = `Input A expected to ${operator} input B:\n` +
-        '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m';
+        `${green}+ expected${white} ${red}- actual${white}`;
   const skippedMsg = ' ... Lines skipped';
 
   // Remove all ending lines that match (this optimizes the output for
@@ -189,7 +193,7 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      other += `\n\u001b[32m+\u001b[39m ${expectedLines[i]}`;
+      other += `\n${green}+${white} ${expectedLines[i]}`;
       printedLines++;
     // Only extra actual lines exist
     } else if (expectedLines.length < i + 1) {
@@ -205,7 +209,7 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      res += `\n\u001b[31m-\u001b[39m ${actualLines[i]}`;
+      res += `\n${red}-${white} ${actualLines[i]}`;
       printedLines++;
     // Lines diverge
     } else if (actualLines[i] !== expectedLines[i]) {
@@ -221,8 +225,8 @@ function createErrDiff(actual, expected, operator) {
         printedLines++;
       }
       lastPos = i;
-      res += `\n\u001b[31m-\u001b[39m ${actualLines[i]}`;
-      other += `\n\u001b[32m+\u001b[39m ${expectedLines[i]}`;
+      res += `\n${red}-${white} ${actualLines[i]}`;
+      other += `\n${green}+${white} ${expectedLines[i]}`;
       printedLines += 2;
     // Lines are identical
     } else {
@@ -258,7 +262,14 @@ class AssertionError extends Error {
     if (message != null) {
       super(message);
     } else {
-      if (util === null) util = require('util');
+      if (util === null) {
+        util = require('util');
+        if (process.stdout.isTTY && process.stdout.getColorDepth() !== 1) {
+          green = '\u001b[32m';
+          white = '\u001b[39m';
+          red = '\u001b[31m';
+        }
+      }
 
       if (actual && actual.stack && actual instanceof Error)
         actual = `${actual.name}: ${actual.message}`;

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -6,7 +6,7 @@ const {
   isHexTable
 } = require('internal/querystring');
 
-const { getConstructorOf } = require('internal/util');
+const { getConstructorOf, removeColors } = require('internal/util');
 const errors = require('internal/errors');
 const querystring = require('querystring');
 
@@ -181,9 +181,8 @@ class URLSearchParams {
     for (var i = 0; i < list.length; i += 2)
       output.push(`${innerInspect(list[i])} => ${innerInspect(list[i + 1])}`);
 
-    var colorRe = /\u001b\[\d\d?m/g;
     var length = output.reduce(
-      (prev, cur) => prev + cur.replace(colorRe, '').length + separator.length,
+      (prev, cur) => prev + removeColors(cur).length + separator.length,
       -separator.length
     );
     if (length > ctx.breakLength) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -17,6 +17,12 @@ const noCrypto = !process.versions.openssl;
 
 const experimentalWarnings = new Set();
 
+const colorRegExp = /\u001b\[\d\d?m/g;
+
+function removeColors(str) {
+  return str.replace(colorRegExp, '');
+}
+
 function isError(e) {
   return objectToString(e) === '[object Error]' || e instanceof Error;
 }
@@ -347,6 +353,7 @@ module.exports = {
   objectToString,
   promisify,
   spliceOne,
+  removeColors,
 
   // Symbol used to customize promisify conversion
   customPromisifyArgs: kCustomPromisifyArgsSymbol,

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -21,11 +21,9 @@
 
 'use strict';
 
-const util = require('util');
+const { inherits, _errnoException, _extend } = require('util');
 const net = require('net');
 const { TTY, isTTY } = process.binding('tty_wrap');
-const { inherits } = util;
-const errnoException = util._errnoException;
 const errors = require('internal/errors');
 const readline = require('readline');
 const { release } = require('os');
@@ -41,7 +39,6 @@ function isatty(fd) {
   return Number.isInteger(fd) && fd >= 0 && isTTY(fd);
 }
 
-
 function ReadStream(fd, options) {
   if (!(this instanceof ReadStream))
     return new ReadStream(fd, options);
@@ -54,7 +51,7 @@ function ReadStream(fd, options) {
     throw new errors.SystemError(ctx);
   }
 
-  options = util._extend({
+  options = _extend({
     highWaterMark: 0,
     readable: true,
     writable: false,
@@ -73,7 +70,6 @@ ReadStream.prototype.setRawMode = function(flag) {
   this._handle.setRawMode(flag);
   this.isRaw = flag;
 };
-
 
 function WriteStream(fd) {
   if (!(this instanceof WriteStream))
@@ -100,15 +96,14 @@ function WriteStream(fd) {
   // Ref: https://github.com/nodejs/node/pull/1771#issuecomment-119351671
   this._handle.setBlocking(true);
 
-  var winSize = new Array(2);
-  var err = this._handle.getWindowSize(winSize);
+  const winSize = new Array(2);
+  const err = this._handle.getWindowSize(winSize);
   if (!err) {
     this.columns = winSize[0];
     this.rows = winSize[1];
   }
 }
 inherits(WriteStream, net.Socket);
-
 
 WriteStream.prototype.isTTY = true;
 
@@ -178,16 +173,15 @@ WriteStream.prototype.getColorDepth = function(env = process.env) {
 };
 
 WriteStream.prototype._refreshSize = function() {
-  var oldCols = this.columns;
-  var oldRows = this.rows;
-  var winSize = new Array(2);
-  var err = this._handle.getWindowSize(winSize);
+  const oldCols = this.columns;
+  const oldRows = this.rows;
+  const winSize = new Array(2);
+  const err = this._handle.getWindowSize(winSize);
   if (err) {
-    this.emit('error', errnoException(err, 'getWindowSize'));
+    this.emit('error', _errnoException(err, 'getWindowSize'));
     return;
   }
-  var newCols = winSize[0];
-  var newRows = winSize[1];
+  const [newCols, newRows] = winSize;
   if (oldCols !== newCols || oldRows !== newRows) {
     this.columns = newCols;
     this.rows = newRows;
@@ -195,8 +189,7 @@ WriteStream.prototype._refreshSize = function() {
   }
 };
 
-
-// backwards-compat
+// Backwards-compat
 WriteStream.prototype.cursorTo = function(x, y) {
   readline.cursorTo(this, x, y);
 };
@@ -212,6 +205,5 @@ WriteStream.prototype.clearScreenDown = function() {
 WriteStream.prototype.getWindowSize = function() {
   return [this.columns, this.rows];
 };
-
 
 module.exports = { isatty, ReadStream, WriteStream };

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -28,6 +28,14 @@ const { inherits } = util;
 const errnoException = util._errnoException;
 const errors = require('internal/errors');
 const readline = require('readline');
+const { release } = require('os');
+
+const OSRelease = release().split('.');
+
+const COLORS_2 = 1;
+const COLORS_16 = 4;
+const COLORS_256 = 8;
+const COLORS_16m = 24;
 
 function isatty(fd) {
   return Number.isInteger(fd) && fd >= 0 && isTTY(fd);
@@ -104,6 +112,70 @@ inherits(WriteStream, net.Socket);
 
 WriteStream.prototype.isTTY = true;
 
+WriteStream.prototype.getColorDepth = function(env = process.env) {
+  if (env.NODE_DISABLE_COLORS || env.TERM === 'dumb' && !env.COLORTERM) {
+    return COLORS_2;
+  }
+
+  if (process.platform === 'win32') {
+    // Windows 10 build 10586 is the first Windows release that supports 256
+    // colors. Windows 10 build 14931 is the first release that supports
+    // 16m/TrueColor.
+    if (+OSRelease[0] >= 10) {
+      const build = +OSRelease[2];
+      if (build >= 14931)
+        return COLORS_16m;
+      if (build >= 10586)
+        return COLORS_256;
+    }
+
+    return COLORS_16;
+  }
+
+  if (env.TMUX) {
+    return COLORS_256;
+  }
+
+  if (env.CI) {
+    if ('TRAVIS' in env || 'CIRCLECI' in env || 'APPVEYOR' in env ||
+      'GITLAB_CI' in env || env.CI_NAME === 'codeship') {
+      return COLORS_256;
+    }
+    return COLORS_2;
+  }
+
+  if ('TEAMCITY_VERSION' in env) {
+    return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ?
+      COLORS_16 : COLORS_2;
+  }
+
+  switch (env.TERM_PROGRAM) {
+    case 'iTerm.app':
+      if (!env.TERM_PROGRAM_VERSION ||
+        /^[0-2]\./.test(env.TERM_PROGRAM_VERSION)) {
+        return COLORS_256;
+      }
+      return COLORS_16m;
+    case 'HyperTerm':
+    case 'Hyper':
+    case 'MacTerm':
+      return COLORS_16m;
+    case 'Apple_Terminal':
+      return COLORS_256;
+  }
+
+  if (env.TERM) {
+    if (/^xterm-256/.test(env.TERM))
+      return COLORS_256;
+    if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(env.TERM))
+      return COLORS_16;
+  }
+
+  if (env.COLORTERM)
+    return COLORS_16;
+
+  return COLORS_2;
+};
 
 WriteStream.prototype._refreshSize = function() {
   var oldCols = this.columns;

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,8 @@ const {
   getIdentificationOf,
   isError,
   promisify,
-  join
+  join,
+  removeColors
 } = require('internal/util');
 
 const inspectDefaultOptions = Object.seal({
@@ -85,7 +86,6 @@ const strEscapeSequencesRegExp = /[\x00-\x1f\x27\x5c]/;
 const strEscapeSequencesReplacer = /[\x00-\x1f\x27\x5c]/g;
 /* eslint-enable */
 const keyStrRegExp = /^[a-zA-Z_][a-zA-Z_0-9]*$/;
-const colorRegExp = /\u001b\[\d\d?m/g;
 const numberRegExp = /^(0|[1-9][0-9]*)$/;
 
 const readableRegExps = {};
@@ -905,7 +905,7 @@ function reduceToSingleString(ctx, output, base, braces, addLn) {
     var length = 0;
     for (; i < output.length && length <= breakLength; i++) {
       if (ctx.colors) {
-        length += output[i].replace(colorRegExp, '').length + 1;
+        length += removeColors(output[i]).length + 1;
       } else {
         length += output[i].length + 1;
       }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -788,10 +788,13 @@ common.expectsError(
   Error.stackTraceLimit = tmpLimit;
 
   // Test error diffs
+  const colors = process.stdout.isTTY && process.stdout.getColorDepth() > 0;
   const start = 'Input A expected to deepStrictEqual input B:';
-  const actExp = '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m';
-  const plus = '\u001b[32m+\u001b[39m';
-  const minus = '\u001b[31m-\u001b[39m';
+  const actExp = colors ?
+    '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m' :
+    '+ expected - actual';
+  const plus = colors ? '\u001b[32m+\u001b[39m' : '+';
+  const minus = colors ? '\u001b[31m-\u001b[39m' : '-';
   let message = [
     start,
     `${actExp} ... Lines skipped`,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -711,7 +711,8 @@ assert.throws(() => {
   assert.strictEqual('A'.repeat(1000), '');
 }, common.expectsError({
   code: 'ERR_ASSERTION',
-  message: new RegExp(`^'${'A'.repeat(127)} strictEqual ''$`) }));
+  message: /^'A{124}\.\.\. strictEqual ''$/
+}));
 
 {
   // bad args to AssertionError constructor should throw TypeError
@@ -752,7 +753,6 @@ common.expectsError(
   assert.equal(assert.notEqual, assert.notStrictEqual);
   assert.equal(assert.notDeepEqual, assert.notDeepStrictEqual);
   assert.equal(Object.keys(assert).length, Object.keys(a).length);
-  /* eslint-enable no-restricted-properties */
   assert(7);
   common.expectsError(
     () => assert(),
@@ -786,6 +786,145 @@ common.expectsError(
     }
   );
   Error.stackTraceLimit = tmpLimit;
+
+  // Test error diffs
+  const start = 'Input A expected to deepStrictEqual input B:';
+  const actExp = '\u001b[32m+ expected\u001b[39m \u001b[31m- actual\u001b[39m';
+  const plus = '\u001b[32m+\u001b[39m';
+  const minus = '\u001b[31m-\u001b[39m';
+  let message = [
+    start,
+    `${actExp} ... Lines skipped`,
+    '',
+    '  [',
+    '    [',
+    '...',
+    '        2,',
+    `${minus}       3`,
+    `${plus}       '3'`,
+    '      ]',
+    '...',
+    '    5',
+    '  ]'].join('\n');
+  assert.throws(
+    () => assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]),
+    { message });
+
+  message = [
+    start,
+    `${actExp} ... Lines skipped`,
+    '',
+    '  [',
+    '    1,',
+    '...',
+    '    0,',
+    `${plus}   1,`,
+    '    1,',
+    '...',
+    '    1',
+    '  ]'
+  ].join('\n');
+  assert.throws(
+    () => assert.deepEqual(
+      [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1]),
+    { message });
+
+  message = [
+    start,
+    `${actExp} ... Lines skipped`,
+    '',
+    '  [',
+    '    1,',
+    '...',
+    '    0,',
+    `${minus}   1,`,
+    '    1,',
+    '...',
+    '    1',
+    '  ]'
+  ].join('\n');
+  assert.throws(
+    () => assert.deepEqual(
+      [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1]),
+    { message });
+
+  message = [
+    start,
+    actExp,
+    '',
+    '  [',
+    '    1,',
+    `${minus}   2,`,
+    `${plus}   1,`,
+    '    1,',
+    '    1,',
+    '    0,',
+    `${minus}   1,`,
+    '    1',
+    '  ]'
+  ].join('\n');
+  assert.throws(
+    () => assert.deepEqual(
+      [1, 2, 1, 1, 0, 1, 1],
+      [1, 1, 1, 1, 0, 1]),
+    { message });
+
+  message = [
+    start,
+    actExp,
+    '',
+    `${minus} [`,
+    `${minus}   1,`,
+    `${minus}   2,`,
+    `${minus}   1`,
+    `${minus} ]`,
+    `${plus} undefined`,
+  ].join('\n');
+  assert.throws(
+    () => assert.deepEqual([1, 2, 1]),
+    { message });
+
+  message = [
+    start,
+    actExp,
+    '',
+    '  [',
+    `${minus}   1,`,
+    '    2,',
+    '    1',
+    '  ]'
+  ].join('\n');
+  assert.throws(
+    () => assert.deepEqual([1, 2, 1], [2, 1]),
+    { message });
+
+  message = `${start}\n` +
+    `${actExp} ... Lines skipped\n` +
+    '\n' +
+    '  [\n' +
+    `${minus}   1,\n`.repeat(10) +
+    '...\n' +
+    `${plus}   2,\n`.repeat(10) +
+    '...';
+  assert.throws(
+    () => assert.deepEqual(Array(12).fill(1), Array(12).fill(2)),
+    { message });
+
+  // notDeepEqual tests
+  message = 'Identical input passed to notDeepStrictEqual:\n[\n  1\n]';
+  assert.throws(
+    () => assert.notDeepEqual([1], [1]),
+    { message });
+
+  message = 'Identical input passed to notDeepStrictEqual:' +
+        `\n[${'\n  1,'.repeat(18)}\n...`;
+  const data = Array(21).fill(1);
+  assert.throws(
+    () => assert.notDeepEqual(data, data),
+    { message });
+  /* eslint-enable no-restricted-properties */
 }
 
 common.expectsError(

--- a/test/parallel/test-tty-get-color-depth.js
+++ b/test/parallel/test-tty-get-color-depth.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert').strict;
+/* eslint-disable no-restricted-properties */
+
+const { WriteStream } = require('tty');
+
+const writeStream = new WriteStream(4);
+
+let depth = writeStream.getColorDepth();
+
+assert.equal(typeof depth, 'number');
+assert(depth >= 1 && depth <= 24);
+
+// If the terminal does not support colors, skip the rest
+if (depth === 1)
+  common.skip();
+
+assert.notEqual(writeStream.getColorDepth({ TERM: 'dumb' }), depth);
+
+// Deactivate colors
+const tmp = process.env.NODE_DISABLE_COLORS;
+process.env.NODE_DISABLE_COLORS = 1;
+
+depth = writeStream.getColorDepth();
+
+assert.equal(depth, 1);
+
+process.env.NODE_DISABLE_COLORS = tmp;

--- a/test/parallel/test-tty-get-color-depth.js
+++ b/test/parallel/test-tty-get-color-depth.js
@@ -3,10 +3,32 @@
 const common = require('../common');
 const assert = require('assert').strict;
 /* eslint-disable no-restricted-properties */
+const { openSync } = require('fs');
+const tty = require('tty');
 
 const { WriteStream } = require('tty');
 
-const writeStream = new WriteStream(4);
+// Do our best to grab a tty fd.
+function getTTYfd() {
+  const ttyFd = [0, 1, 2, 4, 5].find(tty.isatty);
+  if (ttyFd === undefined) {
+    try {
+      return openSync('/dev/tty');
+    } catch (e) {
+      // There aren't any tty fd's available to use.
+      return -1;
+    }
+  }
+  return ttyFd;
+}
+
+const fd = getTTYfd();
+
+// Give up if we did not find a tty
+if (fd === -1)
+  common.skip();
+
+const writeStream = new WriteStream(fd);
 
 let depth = writeStream.getColorDepth();
 


### PR DESCRIPTION
The current assert errors are actually pretty bad when it comes to objects. This implements
a simple way to add diffs as default but only in assert strict mode. It relies on another PR that changes the `util.inspect` output as I use that for the diff. Building the diff differently would likely yield better results but it would also mean more work and this on its own should already be a significant improvement.

So far a few spots are not optimized for performance and I would like to get some general feedback on the solution. I especially do not like the way to distinguish `asserts` `strict mode` and `legacy mode`.
Activating the diff always would mean we have to change all our assert tests and I did not want to do that, besides the fact that some people might partially rely on the message output.

Refs #17576

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert, lib, util, errors