### PR TITLE
doc: add C++ style comments to the style guide

### DIFF
--- a/CPP_STYLE_GUIDE.md
+++ b/CPP_STYLE_GUIDE.md
@@ -4,6 +4,7 @@
 
 * [Formatting](#formatting)
   * [Left-leaning (C++ style) asterisks for pointer declarations](#left-leaning-c-style-asterisks-for-pointer-declarations)
+  * [C++ style comments](#c-style-comments)
   * [2 spaces of indentation for blocks or bodies of conditionals](#2-spaces-of-indentation-for-blocks-or-bodies-of-conditionals)
   * [4 spaces of indentation for statement continuations](#4-spaces-of-indentation-for-statement-continuations)
   * [Align function arguments vertically](#align-function-arguments-vertically)
@@ -32,6 +33,26 @@ these rules:
 ## Left-leaning (C++ style) asterisks for pointer declarations
 
 `char* buffer;` instead of `char *buffer;`
+
+## C++ style comments
+
+Use C++ style comments (`//`) for both single-line and multi-line comments.
+Comments should also start with uppercase and finish with a dot.
+
+Examples:
+
+```c++
+// A single-line comment.
+
+// Multi-line comments
+// should also use C++
+// style comments.
+```
+
+The codebase may contain old C style comments (`/* */`) from before this was the
+preferred style. Feel free to update old comments to the preferred style when
+working on code in the immediate vicinity or when changing/improving those
+comments.
 
 ## 2 spaces of indentation for blocks or bodies of conditionals
 


### PR DESCRIPTION
Adds instructions on how to format C++ comments to the C++ style guide, as `cpplint.py` doesn't complain about C-style comments on the code and C++ style comments are the encouraged format.

There's a lot of C-style comments on the current code, and because of that new contributors may think C-style comments are the encouraged format for multi-line comments.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

doc