### PR TITLE
http2: implement ref() and unref() on sessions

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -423,69 +423,6 @@ added: v8.4.0
 A prototype-less object describing the current remote settings of this
 `Http2Session`. The remote settings are set by the *connected* HTTP/2 peer.
 
-#### http2session.request(headers[, options])
-<!-- YAML
-added: v8.4.0
--->
-
-* `headers` {[Headers Object][]}
-* `options` {Object}
-  * `endStream` {boolean} `true` if the `Http2Stream` *writable* side should
-    be closed initially, such as when sending a `GET` request that should not
-    expect a payload body.
-  * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
-    the created stream is made the sole direct dependency of the parent, with
-    all other existing dependents made a dependent of the newly created stream.
-    **Default:** `false`
-  * `parent` {number} Specifies the numeric identifier of a stream the newly
-    created stream is dependent on.
-  * `weight` {number} Specifies the relative dependency of a stream in relation
-    to other streams with the same `parent`. The value is a number between `1`
-    and `256` (inclusive).
-  * `getTrailers` {Function} Callback function invoked to collect trailer
-    headers.
-
-* Returns: {ClientHttp2Stream}
-
-For HTTP/2 Client `Http2Session` instances only, the `http2session.request()`
-creates and returns an `Http2Stream` instance that can be used to send an
-HTTP/2 request to the connected server.
-
-This method is only available if `http2session.type` is equal to
-`http2.constants.NGHTTP2_SESSION_CLIENT`.
-
-```js
-const http2 = require('http2');
-const clientSession = http2.connect('https://localhost:1234');
-const {
-  HTTP2_HEADER_PATH,
-  HTTP2_HEADER_STATUS
-} = http2.constants;
-
-const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
-req.on('response', (headers) => {
-  console.log(headers[HTTP2_HEADER_STATUS]);
-  req.on('data', (chunk) => { /** .. **/ });
-  req.on('end', () => { /** .. **/ });
-});
-```
-
-When set, the `options.getTrailers()` function is called immediately after
-queuing the last chunk of payload data to be sent. The callback is passed a
-single object (with a `null` prototype) that the listener may used to specify
-the trailing header fields to send to the peer.
-
-*Note*: The HTTP/1 specification forbids trailers from containing HTTP/2
-"pseudo-header" fields (e.g. `':method'`, `':path'`, etc). An `'error'` event
-will be emitted if the `getTrailers` callback attempts to set such header
-fields.
-
-The the `:method` and `:path` pseudoheaders are not specified within `headers`,
-they respectively default to:
-
-* `:method` = `'GET'`
-* `:path` = `/`
-
 #### http2session.setTimeout(msecs, callback)
 <!-- YAML
 added: v8.4.0
@@ -604,6 +541,90 @@ The `http2session.type` will be equal to
 `http2.constants.NGHTTP2_SESSION_SERVER` if this `Http2Session` instance is a
 server, and `http2.constants.NGHTTP2_SESSION_CLIENT` if the instance is a
 client.
+
+### Class: ClientHttp2Session
+<!-- YAML
+added: v8.4.0
+-->
+
+#### clienthttp2session.ref()
+<!-- YAML
+added: ??? (TODO)
+-->
+
+Calls [`ref()`][`net.Socket.prototype.ref`] on this `ClientHttp2Session`
+instance's underlying [`net.Socket`].
+
+#### clienthttp2session.request(headers[, options])
+<!-- YAML
+added: v8.4.0
+-->
+
+* `headers` {[Headers Object][]}
+* `options` {Object}
+  * `endStream` {boolean} `true` if the `Http2Stream` *writable* side should
+    be closed initially, such as when sending a `GET` request that should not
+    expect a payload body.
+  * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
+    the created stream is made the sole direct dependency of the parent, with
+    all other existing dependents made a dependent of the newly created stream.
+    **Default:** `false`
+  * `parent` {number} Specifies the numeric identifier of a stream the newly
+    created stream is dependent on.
+  * `weight` {number} Specifies the relative dependency of a stream in relation
+    to other streams with the same `parent`. The value is a number between `1`
+    and `256` (inclusive).
+  * `getTrailers` {Function} Callback function invoked to collect trailer
+    headers.
+
+* Returns: {ClientHttp2Stream}
+
+For HTTP/2 Client `Http2Session` instances only, the `http2session.request()`
+creates and returns an `Http2Stream` instance that can be used to send an
+HTTP/2 request to the connected server.
+
+This method is only available if `http2session.type` is equal to
+`http2.constants.NGHTTP2_SESSION_CLIENT`.
+
+```js
+const http2 = require('http2');
+const clientSession = http2.connect('https://localhost:1234');
+const {
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS
+} = http2.constants;
+
+const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
+req.on('response', (headers) => {
+  console.log(headers[HTTP2_HEADER_STATUS]);
+  req.on('data', (chunk) => { /** .. **/ });
+  req.on('end', () => { /** .. **/ });
+});
+```
+
+When set, the `options.getTrailers()` function is called immediately after
+queuing the last chunk of payload data to be sent. The callback is passed a
+single object (with a `null` prototype) that the listener may used to specify
+the trailing header fields to send to the peer.
+
+*Note*: The HTTP/1 specification forbids trailers from containing HTTP/2
+"pseudo-header" fields (e.g. `':method'`, `':path'`, etc). An `'error'` event
+will be emitted if the `getTrailers` callback attempts to set such header
+fields.
+
+The the `:method` and `:path` pseudoheaders are not specified within `headers`,
+they respectively default to:
+
+* `:method` = `'GET'`
+* `:path` = `/`
+
+#### clienthttp2session.unref()
+<!-- YAML
+added: ??? (TODO)
+-->
+
+Calls [`unref()`][`net.Socket.prototype.unref`] on this `ClientHttp2Session`
+instance's underlying [`net.Socket`].
 
 ### Class: Http2Stream
 <!-- YAML
@@ -1669,9 +1690,9 @@ changes:
     [`Duplex`][] stream that is to be used as the connection for this session.
   * ...: Any [`net.connect()`][] or [`tls.connect()`][] options can be provided.
 * `listener` {Function}
-* Returns {Http2Session}
+* Returns {ClientHttp2Session}
 
-Returns a HTTP/2 client `Http2Session` instance.
+Returns a `ClientHttp2Session` instance.
 
 ```js
 const http2 = require('http2');
@@ -2806,6 +2827,8 @@ if the stream is closed.
 [`http2.createServer()`]: #http2_http2_createserver_options_onrequesthandler
 [`http2stream.pushStream()`]: #http2_http2stream_pushstream_headers_options_callback
 [`net.Socket`]: net.html#net_class_net_socket
+[`net.Socket.prototype.ref`]: net.html#net_socket_ref
+[`net.Socket.prototype.unref`]: net.html#net_socket_unref
 [`net.connect()`]: net.html#net_net_connect
 [`request.socket.getPeerCertificate()`]: tls.html#tls_tlssocket_getpeercertificate_detailed
 [`response.end()`]: #http2_response_end_data_encoding_callback

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -549,7 +549,7 @@ added: v8.4.0
 
 #### clienthttp2session.ref()
 <!-- YAML
-added: ??? (TODO)
+added: REPLACEME
 -->
 
 Calls [`ref()`][`net.Socket.prototype.ref`] on this `ClientHttp2Session`
@@ -620,7 +620,7 @@ they respectively default to:
 
 #### clienthttp2session.unref()
 <!-- YAML
-added: ??? (TODO)
+added: REPLACEME
 -->
 
 Calls [`unref()`][`net.Socket.prototype.unref`] on this `ClientHttp2Session`

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -413,6 +413,14 @@ session.ping(Buffer.from('abcdefgh'), (err, duration, payload) => {
 If the `payload` argument is not specified, the default payload will be the
 64-bit timestamp (little endian) marking the start of the `PING` duration.
 
+#### http2session.ref()
+<!-- YAML
+added: REPLACEME
+-->
+
+Calls [`ref()`][`net.Socket.prototype.ref`] on this `Http2Session`
+instance's underlying [`net.Socket`].
+
 #### http2session.remoteSettings
 <!-- YAML
 added: v8.4.0
@@ -542,18 +550,18 @@ The `http2session.type` will be equal to
 server, and `http2.constants.NGHTTP2_SESSION_CLIENT` if the instance is a
 client.
 
-### Class: ClientHttp2Session
-<!-- YAML
-added: v8.4.0
--->
-
-#### clienthttp2session.ref()
+#### http2session.unref()
 <!-- YAML
 added: REPLACEME
 -->
 
-Calls [`ref()`][`net.Socket.prototype.ref`] on this `ClientHttp2Session`
+Calls [`unref()`][`net.Socket.prototype.unref`] on this `Http2Session`
 instance's underlying [`net.Socket`].
+
+### Class: ClientHttp2Session
+<!-- YAML
+added: v8.4.0
+-->
 
 #### clienthttp2session.request(headers[, options])
 <!-- YAML
@@ -612,19 +620,11 @@ the trailing header fields to send to the peer.
 will be emitted if the `getTrailers` callback attempts to set such header
 fields.
 
-The the `:method` and `:path` pseudoheaders are not specified within `headers`,
+The `:method` and `:path` pseudoheaders are not specified within `headers`,
 they respectively default to:
 
 * `:method` = `'GET'`
 * `:path` = `/`
-
-#### clienthttp2session.unref()
-<!-- YAML
-added: REPLACEME
--->
-
-Calls [`unref()`][`net.Socket.prototype.unref`] on this `ClientHttp2Session`
-instance's underlying [`net.Socket`].
 
 ### Class: Http2Stream
 <!-- YAML

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1225,13 +1225,19 @@ class ClientHttp2Session extends Http2Session {
 
   ref() {
     if (this[kSocket]) {
-      this[kSocket].ref();
+      assert(this[kSocket]._handle);
+      if (typeof this[kSocket]._handle.ref === 'function') {
+        this[kSocket].ref();
+      }
     }
   }
 
   unref() {
     if (this[kSocket]) {
-      this[kSocket].unref();
+      assert(this[kSocket]._handle);
+      if (typeof this[kSocket]._handle.unref === 'function') {
+        this[kSocket].unref();
+      }
     }
   }
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1222,6 +1222,18 @@ class ClientHttp2Session extends Http2Session {
     }
     return stream;
   }
+
+  ref() {
+    if (this[kSocket]) {
+      this[kSocket].ref();
+    }
+  }
+
+  unref() {
+    if (this[kSocket]) {
+      this[kSocket].unref();
+    }
+  }
 }
 
 function createWriteReq(req, handle, data, encoding) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1122,19 +1122,13 @@ class Http2Session extends EventEmitter {
 
   ref() {
     if (this[kSocket]) {
-      assert(this[kSocket]._handle);
-      if (typeof this[kSocket]._handle.ref === 'function') {
-        this[kSocket].ref();
-      }
+      this[kSocket].ref();
     }
   }
 
   unref() {
     if (this[kSocket]) {
-      assert(this[kSocket]._handle);
-      if (typeof this[kSocket]._handle.unref === 'function') {
-        this[kSocket].unref();
-      }
+      this[kSocket].unref();
     }
   }
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1119,6 +1119,24 @@ class Http2Session extends EventEmitter {
 
     process.nextTick(emit, this, 'timeout');
   }
+
+  ref() {
+    if (this[kSocket]) {
+      assert(this[kSocket]._handle);
+      if (typeof this[kSocket]._handle.ref === 'function') {
+        this[kSocket].ref();
+      }
+    }
+  }
+
+  unref() {
+    if (this[kSocket]) {
+      assert(this[kSocket]._handle);
+      if (typeof this[kSocket]._handle.unref === 'function') {
+        this[kSocket].unref();
+      }
+    }
+  }
 }
 
 // ServerHttp2Session instances should never have to wait for the socket
@@ -1221,24 +1239,6 @@ class ClientHttp2Session extends Http2Session {
       onConnect();
     }
     return stream;
-  }
-
-  ref() {
-    if (this[kSocket]) {
-      assert(this[kSocket]._handle);
-      if (typeof this[kSocket]._handle.ref === 'function') {
-        this[kSocket].ref();
-      }
-    }
-  }
-
-  unref() {
-    if (this[kSocket]) {
-      assert(this[kSocket]._handle);
-      if (typeof this[kSocket]._handle.unref === 'function') {
-        this[kSocket].unref();
-      }
-    }
   }
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -1140,7 +1140,9 @@ Socket.prototype.ref = function() {
     return this;
   }
 
-  this._handle.ref();
+  if (typeof this._handle.ref === 'function') {
+    this._handle.ref();
+  }
 
   return this;
 };
@@ -1152,7 +1154,9 @@ Socket.prototype.unref = function() {
     return this;
   }
 
-  this._handle.unref();
+  if (typeof this._handle.unref === 'function') {
+    this._handle.unref();
+  }
 
   return this;
 };

--- a/test/parallel/test-http2-client-session-ref.js
+++ b/test/parallel/test-http2-client-session-ref.js
@@ -1,0 +1,29 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+const { kSocket } = require('internal/http2/util');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+function isActiveHandle(h) {
+  return process._getActiveHandles().indexOf(h) !== -1;
+}
+
+const server = http2.createServer();
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  assert.ok(isActiveHandle(client[kSocket]));
+  client.unref();
+  assert.ok(!isActiveHandle(client[kSocket]));
+  client.ref();
+  assert.ok(isActiveHandle(client[kSocket]));
+  client.destroy();
+  assert.ok(!isActiveHandle(client[kSocket]));
+  assert.doesNotThrow(client.unref.bind(client));
+  assert.doesNotThrow(client.ref.bind(client));
+  server.close();
+}));

--- a/test/parallel/test-http2-session-unref.js
+++ b/test/parallel/test-http2-session-unref.js
@@ -6,16 +6,10 @@
 // (2) Doesn't crash
 
 const common = require('../common');
-const { kSocket } = require('internal/http2/util');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const assert = require('assert');
 const http2 = require('http2');
 const { PassThrough } = require('stream');
-
-function isActiveHandle(h) {
-  return process._getActiveHandles().indexOf(h) !== -1;
-}
 
 const server = http2.createServer();
 


### PR DESCRIPTION
Fixes #16617

This is my stab at adding `ref` and `unref` on `ClientHttp2Session` instances. It seems mostly straightforward, but there were a few questions I had in mind about this code change:

- Should `ClientHttp2Session` instances be `unref`d by default?
- Should these be available on `ServerHttp2Session` objects as well? (my thought is no)
- Should calling `ref`/`unref` be a no-op after the session has been destroyed, or could it return an error?

I saw [this comment](https://github.com/nodejs/node/issues/16617#issuecomment-340571382) made by @addaleax about `uv_prepare_t`, but I don't really understand it. To me, this code change seems sufficient, but maybe I'm missing something.

Also, I updated the docs to separate `ClientHttp2Session` from `Http2Session`... which seemed to make sense considering that this distinction is present even in the codebase.

##### Checklist
- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
##### Affected core subsystem(s)
http2
