### PR TITLE
util: improve error message of _errnoException

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1060,7 +1060,7 @@ function _errnoException(err, syscall, original) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err', 'number', err);
   }
   if (err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE', 'err',
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'err',
                                 'a negative integer', err);
   }
   const name = errname(err);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1056,9 +1056,12 @@ function error(...args) {
 }
 
 function _errnoException(err, syscall, original) {
-  if (typeof err !== 'number' || err >= 0 || !Number.isSafeInteger(err)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err',
-                               'negative number');
+  if (typeof err !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'err', 'number', err);
+  }
+  if (err >= 0 || !Number.isSafeInteger(err)) {
+    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE', 'err',
+                                'a negative integer', err);
   }
   const name = errname(err);
   var message = `${syscall} ${name}`;

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -20,12 +20,24 @@ keys.forEach((key) => {
   });
 });
 
-[0, 1, 'test', {}, [], Infinity, -Infinity, NaN].forEach((key) => {
+['test', {}, []].forEach((key) => {
   common.expectsError(
     () => util._errnoException(key),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,
-      message: 'The "err" argument must be of type negative number'
+      message: 'The "err" argument must be of type number. ' +
+               `Received type ${typeof key}`
+    });
+});
+
+[0, 1, Infinity, -Infinity, NaN].forEach((key) => {
+  common.expectsError(
+    () => util._errnoException(key),
+    {
+      code: 'ERR_VALUE_OUT_OF_RANGE',
+      type: RangeError,
+      message: 'The value of "err" must be a negative integer. ' +
+               `Received "${key}"`
     });
 });

--- a/test/parallel/test-uv-errno.js
+++ b/test/parallel/test-uv-errno.js
@@ -35,9 +35,10 @@ keys.forEach((key) => {
   common.expectsError(
     () => util._errnoException(key),
     {
-      code: 'ERR_VALUE_OUT_OF_RANGE',
+      code: 'ERR_OUT_OF_RANGE',
       type: RangeError,
-      message: 'The value of "err" must be a negative integer. ' +
-               `Received "${key}"`
+      message: 'The value of "err" is out of range. ' +
+               'It must be a negative integer. ' +
+               `Received ${key}`
     });
 });


### PR DESCRIPTION
The usage of ERR_INVALID_ARG_TYPE in _errnoException is a little inappropriate. This change is to improve it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
util
