### PR TITLE
test: remove unused disposed_ variable

### DIFF
--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -186,7 +186,6 @@ class TestInspectorDelegate : public InspectorSocket::Delegate {
 
   void process(inspector_handshake_event event, const std::string& path);
 
-  bool disposed_ = false;
   delegate_fn handshake_delegate_;
   InspectorSocket::Pointer socket_;
   std::string ws_key_;


### PR DESCRIPTION
Currently building test_inspector_socket.cc generates the following
warning:
```console
../test/cctest/test_inspector_socket.cc:189:8: warning:
private field 'disposed_' is not used [-Wunused-private-field]
  bool disposed_ = false;
       ^

1 warning generated.
```
This commit removes this variable.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test