### PR TITLE
test: coverage for internal util.emitExperimentalWarning

### DIFF
--- a/test/parallel/test-util-emit-experimental-warning.js
+++ b/test/parallel/test-util-emit-experimental-warning.js
@@ -1,0 +1,17 @@
+'use strict';
+// Flags: --expose-internals
+const common = require('../common');
+const assert = require('assert');
+const { emitExperimentalWarning } = require('internal/util');
+
+// This test ensures that the emitExperimentalWarning in internal/util emits a
+// warning when passed an unsupported feature and that it simply returns
+// when passed the same feature multiple times.
+
+process.on('warning', common.mustCall((warning) => {
+  assert(/is an experimental feature/.test(warning.message));
+}, 2));
+
+emitExperimentalWarning('feature1');
+emitExperimentalWarning('feature1'); // should not warn
+emitExperimentalWarning('feature2');


### PR DESCRIPTION
Added [missing](https://coverage.nodejs.org/coverage-06e1b0386196f8f8/root/internal/util.js.html) coverage for method `emitExperimentalWarning` in `internal/utils.js`.
##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
