### PR TITLE
[6.x] cherry-pick sampling heap profiler fixes from upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 109
+#define V8_PATCH_LEVEL 110
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 5
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 281
-#define V8_PATCH_LEVEL 110
+#define V8_PATCH_LEVEL 111
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/heap/spaces.cc
+++ b/deps/v8/src/heap/spaces.cc
@@ -2382,7 +2382,6 @@ HeapObject* FreeList::Allocate(int size_in_bytes) {
   int new_node_size = 0;
   FreeSpace* new_node = FindNodeFor(size_in_bytes, &new_node_size);
   if (new_node == nullptr) return nullptr;
-  owner_->AllocationStep(new_node->address(), size_in_bytes);
 
   int bytes_left = new_node_size - size_in_bytes;
   DCHECK(bytes_left >= 0);
@@ -2427,6 +2426,8 @@ HeapObject* FreeList::Allocate(int size_in_bytes) {
     owner_->SetTopAndLimit(new_node->address() + size_in_bytes,
                            new_node->address() + new_node_size);
   }
+
+  owner_->AllocationStep(new_node->address(), size_in_bytes);
 
   return new_node;
 }

--- a/deps/v8/src/profiler/sampling-heap-profiler.cc
+++ b/deps/v8/src/profiler/sampling-heap-profiler.cc
@@ -109,6 +109,7 @@ void SamplingHeapProfiler::SampleObject(Address soon_object, size_t size) {
   Sample* sample = new Sample(size, node, loc, this);
   samples_.insert(sample);
   sample->global.SetWeak(sample, OnWeakCallback, WeakCallbackType::kParameter);
+  sample->global.MarkIndependent();
 }
 
 void SamplingHeapProfiler::OnWeakCallback(


### PR DESCRIPTION
The V8 sampling heap profiler has some bugfixes that are available upstream that are not available in Node 6 (V8 5.1). These fix sporadic crashes as seen on https://github.com/GoogleCloudPlatform/cloud-profiler-nodejs/issues/90. The fixes are already present in Node 8.

These are two out of the three CLs in https://bugs.chromium.org/p/v8/issues/detail?id=4959. The third CL is an API change that makes it possible to optionally force a GC at the time the profile is gathered; however it is not essential for fixing the crashes. Even though the API change is likely ABI compatible, I omitted it because it is not essential.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:v8

/cc @nodejs/v8 
CI: https://ci.nodejs.org/job/node-test-pull-request/12071/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1111/