### PR TITLE
test: remove literals that obscure assert messages

### DIFF
--- a/test/addons-napi/test_buffer/test.js
+++ b/test/addons-napi/test_buffer/test.js
@@ -9,14 +9,13 @@ assert.strictEqual(binding.newBuffer().toString(), binding.theText);
 assert.strictEqual(binding.newExternalBuffer().toString(), binding.theText);
 console.log('gc1');
 global.gc();
-assert.strictEqual(binding.getDeleterCallCount(), 1, 'deleter was not called');
+assert.strictEqual(binding.getDeleterCallCount(), 1);
 assert.strictEqual(binding.copyBuffer().toString(), binding.theText);
 
 let buffer = binding.staticBuffer();
-assert.strictEqual(binding.bufferHasInstance(buffer), true,
-                   'buffer type checking fails');
+assert.strictEqual(binding.bufferHasInstance(buffer), true);
 assert.strictEqual(binding.bufferInfo(buffer), true);
 buffer = null;
 global.gc();
 console.log('gc2');
-assert.strictEqual(binding.getDeleterCallCount(), 2, 'deleter was not called');
+assert.strictEqual(binding.getDeleterCallCount(), 2);


### PR DESCRIPTION
Remove string literals as messages to `assert.strictEqual()`. They can
be misleading here (where perhaps the reason an assertino failed isn't
that the deleter wasn't called but rather was called too many times.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test buffer