### PR TITLE
stream,net: slightly more consistent typechecking

### DIFF
--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -249,9 +249,7 @@ function validChunk(stream, state, chunk, cb) {
 
   if (chunk === null) {
     er = new errors.TypeError('ERR_STREAM_NULL_VALUES');
-  } else if (typeof chunk !== 'string' &&
-             chunk !== undefined &&
-             !state.objectMode) {
+  } else if (typeof chunk !== 'string' && !state.objectMode) {
     er = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'chunk',
                               ['string', 'Buffer']);
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -701,17 +701,6 @@ protoGetter('localPort', function localPort() {
 });
 
 
-Socket.prototype.write = function(chunk, encoding, cb) {
-  if (typeof chunk !== 'string' && !(chunk instanceof Buffer)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
-                               'chunk',
-                               ['string', 'Buffer'],
-                               chunk);
-  }
-  return stream.Duplex.prototype.write.apply(this, arguments);
-};
-
-
 Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
   // If we are still connecting, then buffer this for later.
   // The Writable logic will buffer up any more writes while


### PR DESCRIPTION
* stream: remove `undefined` check

  `validChunk` allowed `undefined` as a chunk in object mode; however,
  this was redundant, since:

  - `validChunk()` is only used by `.write()`
  - If the `validChunk()` check passes for `undefined`, `.write()`
    calls `writeOrBuffer()`
  - If `writeOrBuffer()` does not receive a Buffer, it calls
    `decodeChunk()`
    - `decodeChunk()` ignores `undefined` because it checks
      `typeof chunk === 'string'`
    - After that call, `chunk.length` is accessed, which throws an
      error if `chunk` is `undefined`.

  This “fixes” a bug in the sense that `state.pendingcb` is no longer
  incremented for write attempts that fail like this.

* net: remove Socket.prototype.write

  This is superfluous now that typechecking in `net` and
  `stream` are aligned.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (`test-net-connect-buffer` checks the error for `undefined`)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

net, stream