### PR TITLE
lib: combine similar error codes

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1340,7 +1340,7 @@ An operation caused an out-of-memory condition.
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
 
-An input argument value was outside an acceptable range.
+A given value is out of the accepted range.
 
 <a id="ERR_PARSE_HISTORY_DATA"></a>
 ### ERR_PARSE_HISTORY_DATA
@@ -1597,7 +1597,7 @@ entry types were found.
 <a id="ERR_VALUE_OUT_OF_RANGE"></a>
 ### ERR_VALUE_OUT_OF_RANGE
 
-A given value is out of the accepted range.
+Superseded by `ERR_OUT_OF_RANGE`
 
 <a id="ERR_ZLIB_BINDING_CLOSED"></a>
 ### ERR_ZLIB_BINDING_CLOSED

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -650,7 +650,7 @@ exports.execSync = execSync;
 
 function validateTimeout(timeout) {
   if (timeout != null && !(Number.isInteger(timeout) && timeout >= 0)) {
-    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE',
+    throw new errors.RangeError('ERR_OUT_OF_RANGE',
                                 'timeout',
                                 'an unsigned integer',
                                 timeout);
@@ -660,7 +660,7 @@ function validateTimeout(timeout) {
 
 function validateMaxBuffer(maxBuffer) {
   if (maxBuffer != null && !(typeof maxBuffer === 'number' && maxBuffer >= 0)) {
-    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE',
+    throw new errors.RangeError('ERR_OUT_OF_RANGE',
                                 'options.maxBuffer',
                                 'a positive number',
                                 maxBuffer);

--- a/lib/events.js
+++ b/lib/events.js
@@ -56,7 +56,10 @@ Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
     // greater and not a NaN).
     if (typeof arg !== 'number' || arg < 0 || arg !== arg) {
       const errors = lazyErrors();
-      throw new errors.TypeError('ERR_OUT_OF_RANGE', 'defaultMaxListeners');
+      throw new errors.RangeError('ERR_OUT_OF_RANGE',
+                                  'defaultMaxListeners',
+                                  'a non-negative number',
+                                  arg);
     }
     defaultMaxListeners = arg;
   }
@@ -78,7 +81,8 @@ EventEmitter.init = function() {
 EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
   if (typeof n !== 'number' || n < 0 || isNaN(n)) {
     const errors = lazyErrors();
-    throw new errors.TypeError('ERR_OUT_OF_RANGE', 'n');
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'n',
+                                'a non-negative number', n);
   }
   this._maxListeners = n;
   return this;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2353,7 +2353,7 @@ function ReadStream(path, options) {
 
     if (this.start > this.end) {
       const errVal = `{start: ${this.start}, end: ${this.end}}`;
-      throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE',
+      throw new errors.RangeError('ERR_OUT_OF_RANGE',
                                   'start',
                                   '<= "end"',
                                   errVal);
@@ -2511,7 +2511,7 @@ function WriteStream(path, options) {
     }
     if (this.start < 0) {
       const errVal = `{start: ${this.start}}`;
-      throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE',
+      throw new errors.RangeError('ERR_OUT_OF_RANGE',
                                   'start',
                                   '>= 0',
                                   errVal);

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -52,7 +52,10 @@ function _pbkdf2(password, salt, iterations, keylen, digest, callback) {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'iterations', 'number');
 
   if (iterations < 0)
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'iterations');
+    throw new errors.RangeError('ERR_OUT_OF_RANGE',
+                                'iterations',
+                                'a non-negative number',
+                                iterations);
 
   if (typeof keylen !== 'number')
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'keylen', 'number');

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -444,7 +444,7 @@ E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
 E('ERR_OUTOFMEMORY', 'Out of memory');
-E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
+E('ERR_OUT_OF_RANGE', outOfRange);
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');
 E('ERR_SCRIPT_EXECUTION_INTERRUPTED',
@@ -502,9 +502,6 @@ E('ERR_V8BREAKITERATOR', 'Full ICU data not installed. ' +
   'See https://github.com/nodejs/node/wiki/Intl');
 E('ERR_VALID_PERFORMANCE_ENTRY_TYPE',
   'At least one valid performance entry type is required');
-E('ERR_VALUE_OUT_OF_RANGE', (start, end, value) => {
-  return `The value of "${start}" must be ${end}. Received "${value}"`;
-});
 E('ERR_ZLIB_BINDING_CLOSED', 'zlib binding closed');
 E('ERR_ZLIB_INITIALIZATION_FAILED', 'Initialization failed');
 
@@ -615,5 +612,12 @@ function invalidChar(name, field) {
   if (field) {
     msg += ` ["${field}"]`;
   }
+  return msg;
+}
+
+function outOfRange(name, range, value) {
+  let msg = `The value of "${name}" is out of range.`;
+  if (range) msg += ` It must be ${range}.`;
+  if (value !== undefined) msg += ` Received ${value}`;
   return msg;
 }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -851,7 +851,8 @@ class Http2Session extends EventEmitter {
     if (typeof id !== 'number')
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'id', 'number');
     if (id <= 0 || id > kMaxStreams)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE');
+      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'id',
+                                  `> 0 and <= ${kMaxStreams}`, id);
     this[kHandle].setNextStreamID(id);
   }
 

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -115,7 +115,7 @@ function validateTimerDuration(msecs) {
   }
 
   if (msecs < 0 || !isFinite(msecs)) {
-    throw new errors.RangeError('ERR_VALUE_OUT_OF_RANGE', 'msecs',
+    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'msecs',
                                 'a non-negative finite number', msecs);
   }
 

--- a/test/parallel/test-child-process-spawnsync-validation-errors.js
+++ b/test/parallel/test-child-process-spawnsync-validation-errors.js
@@ -15,7 +15,7 @@ if (common.isWindows) {
 }
 
 const invalidRangeError =
-  common.expectsError({ code: 'ERR_VALUE_OUT_OF_RANGE', type: RangeError }, 20);
+  common.expectsError({ code: 'ERR_OUT_OF_RANGE', type: RangeError }, 20);
 
 function pass(option, value) {
   // Run the command with the specified option. Since it's not a real command,

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -70,7 +70,8 @@ common.expectsError(
   {
     code: 'ERR_OUT_OF_RANGE',
     type: RangeError,
-    message: 'The "iterations" argument is out of range'
+    message: 'The value of "iterations" is out of range. ' +
+             'It must be a non-negative number. Received -1'
   }
 );
 
@@ -93,7 +94,7 @@ common.expectsError(
     }, {
       code: 'ERR_OUT_OF_RANGE',
       type: RangeError,
-      message: 'The "keylen" argument is out of range'
+      message: 'The value of "keylen" is out of range.'
     });
 });
 

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -291,7 +291,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "offset" argument is out of range'
+        message: 'The value of "offset" is out of range.'
       }
     );
 
@@ -300,7 +300,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "offset" argument is out of range'
+        message: 'The value of "offset" is out of range.'
       }
     );
 
@@ -309,7 +309,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "offset" argument is out of range'
+        message: 'The value of "offset" is out of range.'
       }
     );
 
@@ -318,7 +318,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "offset" argument is out of range'
+        message: 'The value of "offset" is out of range.'
       }
     );
 
@@ -421,7 +421,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "size" argument is out of range'
+        message: 'The value of "size" is out of range.'
       }
     );
 
@@ -430,7 +430,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "size" argument is out of range'
+        message: 'The value of "size" is out of range.'
       }
     );
 
@@ -439,7 +439,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "size" argument is out of range'
+        message: 'The value of "size" is out of range.'
       }
     );
 
@@ -448,7 +448,7 @@ process.setMaxListeners(256);
       {
         code: 'ERR_OUT_OF_RANGE',
         type: RangeError,
-        message: 'The "size" argument is out of range'
+        message: 'The value of "size" is out of range.'
       }
     );
 

--- a/test/parallel/test-event-emitter-max-listeners.js
+++ b/test/parallel/test-event-emitter-max-listeners.js
@@ -36,8 +36,9 @@ for (const obj of throwsObjs) {
     () => e.setMaxListeners(obj),
     {
       code: 'ERR_OUT_OF_RANGE',
-      type: TypeError,
-      message: 'The "n" argument is out of range'
+      type: RangeError,
+      message: 'The value of "n" is out of range. ' +
+               `It must be a non-negative number. Received ${obj}`
     }
   );
 
@@ -45,8 +46,9 @@ for (const obj of throwsObjs) {
     () => events.defaultMaxListeners = obj,
     {
       code: 'ERR_OUT_OF_RANGE',
-      type: TypeError,
-      message: 'The "defaultMaxListeners" argument is out of range'
+      type: RangeError,
+      message: 'The value of "defaultMaxListeners" is out of range. ' +
+               `It must be a non-negative number. Received ${obj}`
     }
   );
 }

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -180,8 +180,9 @@ const run_test_4 = common.mustCall(function() {
     fs.createWriteStream(filepath, { start: -5, flags: 'r+' });
   };
   const err = {
-    code: 'ERR_VALUE_OUT_OF_RANGE',
-    message: 'The value of "start" must be >= 0. Received "{start: -5}"',
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "start" is out of range. ' +
+             'It must be >= 0. Received {start: -5}',
     type: RangeError
   };
   common.expectsError(block, err);

--- a/test/parallel/test-fs-read-stream-inherit.js
+++ b/test/parallel/test-fs-read-stream-inherit.js
@@ -110,14 +110,15 @@ const rangeFile = fixtures.path('x.txt');
 
 {
   const message =
-    'The value of "start" must be <= "end". Received "{start: 10, end: 2}"';
+    'The value of "start" is out of range. It must be <= "end". ' +
+    'Received {start: 10, end: 2}';
 
   common.expectsError(
     () => {
       fs.createReadStream(rangeFile, Object.create({ start: 10, end: 2 }));
     },
     {
-      code: 'ERR_VALUE_OUT_OF_RANGE',
+      code: 'ERR_OUT_OF_RANGE',
       message,
       type: RangeError
     });

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -145,9 +145,9 @@ common.expectsError(
     fs.createReadStream(rangeFile, { start: 10, end: 2 });
   },
   {
-    code: 'ERR_VALUE_OUT_OF_RANGE',
-    message:
-      'The value of "start" must be <= "end". Received "{start: 10, end: 2}"',
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "start" is out of range. It must be <= "end". ' +
+             'Received {start: 10, end: 2}',
     type: RangeError
   });
 

--- a/test/parallel/test-internal-errors.js
+++ b/test/parallel/test-internal-errors.js
@@ -281,8 +281,18 @@ assert.strictEqual(
 );
 
 assert.strictEqual(
-  errors.message('ERR_VALUE_OUT_OF_RANGE', ['A', 'some values', 'B']),
-  'The value of "A" must be some values. Received "B"'
+  errors.message('ERR_OUT_OF_RANGE', ['A']),
+  'The value of "A" is out of range.'
+);
+
+assert.strictEqual(
+  errors.message('ERR_OUT_OF_RANGE', ['A', 'some values']),
+  'The value of "A" is out of range. It must be some values.'
+);
+
+assert.strictEqual(
+  errors.message('ERR_OUT_OF_RANGE', ['A', 'some values', 'B']),
+  'The value of "A" is out of range. It must be some values. Received B'
 );
 
 assert.strictEqual(

--- a/test/parallel/test-timers-enroll-invalid-msecs.js
+++ b/test/parallel/test-timers-enroll-invalid-msecs.js
@@ -27,10 +27,11 @@ const timers = require('timers');
   common.expectsError(
     () => timers.enroll({}, val),
     {
-      code: 'ERR_VALUE_OUT_OF_RANGE',
+      code: 'ERR_OUT_OF_RANGE',
       type: RangeError,
-      message: 'The value of "msecs" must be a non-negative ' +
-               `finite number. Received "${val}"`
+      message: 'The value of "msecs" is out of range. ' +
+               'It must be a non-negative finite number. ' +
+               `Received ${val}`
     }
   );
 });


### PR DESCRIPTION
There two similar error codes in lib: `ERR_VALUE_OUT_OF_RANGE` and `ERR_OUT_OF_RANGE`. This change is to:
* reduce them into `ERR_VALUE_OUT_OF_RANGE`
* make some error messages more detailed

Fix: https://github.com/nodejs/node/issues/17603

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
