### PR TITLE
process: fix coverage generation

### DIFF
--- a/lib/internal/process/write-coverage.js
+++ b/lib/internal/process/write-coverage.js
@@ -1,5 +1,4 @@
 'use strict';
-const process = require('process');
 const path = require('path');
 const { mkdirSync, writeFileSync } = require('fs');
 


### PR DESCRIPTION
e8a26e783e2e33514d44d8b2725d5f048e1314ce added `process` to the
internal module wrapper. This broke the utility used to write
coverage information due to a SyntaxError that `process` had
already been declared.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process