### PR TITLE
Add a test about socketOnDrain where needPause is false

### DIFF
--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -1,0 +1,47 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const http = require('http');
+
+let requestReceived = 0;
+
+const server = http.createServer(function(req, res) {
+  const id = ++requestReceived;
+  const enoughToDrain = req.connection.writableHighWaterMark;
+  const body = 'x'.repeat(enoughToDrain);
+
+  if (id === 1) {
+    // Case of needParse = false
+    req.connection.once('pause', common.mustCall(() => {
+      assert(req.connection._paused, '_paused must be true because it exceeds' +
+                                     'hightWaterMark by second request');
+    }));
+    res.write(body);
+  } else {
+    // Case of needParse = true
+    const resume = req.connection.parser.resume.bind(req.connection.parser);
+    req.connection.parser.resume = common.mustCall((...args) => {
+      const paused = req.connection._paused;
+      assert(!paused, '_paused must be false because it become false by ' +
+                      'socketOnDrain when outgoingData falls below ' +
+                      'hightWaterMark');
+      return resume(...args);
+    });
+    assert(!res.write(body), 'res.write must be fail because it will exceed ' +
+                             'hightWaterMark on this call');
+  }
+  res.end();
+}).on('listening', () => {
+  const c = net.createConnection(server.address().port, () => {
+    c.write('GET / HTTP/1.1\r\n\r\n');
+    c.write('GET / HTTP/1.1\r\n\r\n');
+    c.end();
+  });
+
+  c.on('data', () => {});
+  c.on('end', () => {
+    server.close();
+  });
+})
+.listen(0);

--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -4,6 +4,11 @@ const assert = require('assert');
 const net = require('net');
 const http = require('http');
 
+// These test cases to check socketOnDrain where needPause becomes false.
+// When send large response enough to exceed highWaterMark, it expect the socket
+// to be paused and res.write would be failed.
+// And it should be resumed when outgoingData falls below highWaterMark.
+
 let requestReceived = 0;
 
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -28,8 +28,8 @@ const server = http.createServer(function(req, res) {
                       'highWaterMark');
       return resume(...args);
     });
-    assert(!res.write(body), 'res.write must be fail because it will exceed ' +
-                             'highWaterMark on this call');
+    assert(!res.write(body), 'res.write must return false because it will ' +
+                             'exceed highWaterMark on this call');
   }
   res.end();
 }).on('listening', () => {

--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -17,7 +17,6 @@ const server = http.createServer(function(req, res) {
       assert(req.connection._paused, '_paused must be true because it exceeds' +
                                      'highWaterMark by second request');
     }));
-    res.write(body);
   } else {
     // Case of needParse = true
     const resume = req.connection.parser.resume.bind(req.connection.parser);
@@ -28,9 +27,9 @@ const server = http.createServer(function(req, res) {
                       'highWaterMark');
       return resume(...args);
     });
-    assert(!res.write(body), 'res.write must return false because it will ' +
-                             'exceed highWaterMark on this call');
   }
+  assert(!res.write(body), 'res.write must return false because it will ' +
+                           'exceed highWaterMark on this call');
   res.end();
 }).on('listening', () => {
   const c = net.createConnection(server.address().port, () => {

--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -43,5 +43,6 @@ const server = http.createServer(function(req, res) {
   c.on('end', () => {
     server.close();
   });
-})
-.listen(0);
+});
+
+server.listen(0);

--- a/test/parallel/test-http-hightwatermark.js
+++ b/test/parallel/test-http-hightwatermark.js
@@ -15,7 +15,7 @@ const server = http.createServer(function(req, res) {
     // Case of needParse = false
     req.connection.once('pause', common.mustCall(() => {
       assert(req.connection._paused, '_paused must be true because it exceeds' +
-                                     'hightWaterMark by second request');
+                                     'highWaterMark by second request');
     }));
     res.write(body);
   } else {
@@ -25,11 +25,11 @@ const server = http.createServer(function(req, res) {
       const paused = req.connection._paused;
       assert(!paused, '_paused must be false because it become false by ' +
                       'socketOnDrain when outgoingData falls below ' +
-                      'hightWaterMark');
+                      'highWaterMark');
       return resume(...args);
     });
     assert(!res.write(body), 'res.write must be fail because it will exceed ' +
-                             'hightWaterMark on this call');
+                             'highWaterMark on this call');
   }
   res.end();
 }).on('listening', () => {


### PR DESCRIPTION
This PR closes #17051

@mcollina Would you please review my changes ?

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
