### PR TITLE
cluster: use rest param & Reflect.apply

### DIFF
--- a/lib/internal/cluster/utils.js
+++ b/lib/internal/cluster/utils.js
@@ -39,6 +39,6 @@ function internal(worker, cb) {
       delete callbacks[message.ack];
     }
 
-    fn.apply(worker, arguments);
+    Reflect.apply(fn, worker, arguments);
   };
 }


### PR DESCRIPTION
Used `Reflect.apply` for performance gain citing similar [change](https://github.com/nodejs/node/pull/17486) in `fs.js` 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
cluster
