### PR TITLE
[8.x] deps: V8: backport 14ac02c from upstream

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 6
 #define V8_MINOR_VERSION 1
 #define V8_BUILD_NUMBER 534
-#define V8_PATCH_LEVEL 48
+#define V8_PATCH_LEVEL 49
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/profiler/profiler-listener.cc
+++ b/deps/v8/src/profiler/profiler-listener.cc
@@ -16,11 +16,7 @@ namespace internal {
 ProfilerListener::ProfilerListener(Isolate* isolate)
     : function_and_resource_names_(isolate->heap()) {}
 
-ProfilerListener::~ProfilerListener() {
-  for (auto code_entry : code_entries_) {
-    delete code_entry;
-  }
-}
+ProfilerListener::~ProfilerListener() = default;
 
 void ProfilerListener::CallbackEvent(Name* name, Address entry_point) {
   CodeEventsContainer evt_rec(CodeEventRecord::CODE_CREATION);
@@ -286,19 +282,23 @@ CodeEntry* ProfilerListener::NewCodeEntry(
     CodeEventListener::LogEventsAndTags tag, const char* name,
     const char* name_prefix, const char* resource_name, int line_number,
     int column_number, JITLineInfoTable* line_info, Address instruction_start) {
-  CodeEntry* code_entry =
-      new CodeEntry(tag, name, name_prefix, resource_name, line_number,
-                    column_number, line_info, instruction_start);
-  code_entries_.push_back(code_entry);
-  return code_entry;
+  std::unique_ptr<CodeEntry> code_entry = base::make_unique<CodeEntry>(
+      tag, name, name_prefix, resource_name, line_number, column_number,
+      line_info, instruction_start);
+  CodeEntry* raw_code_entry = code_entry.get();
+  code_entries_.push_back(std::move(code_entry));
+  return raw_code_entry;
 }
 
 void ProfilerListener::AddObserver(CodeEventObserver* observer) {
   base::LockGuard<base::Mutex> guard(&mutex_);
-  if (std::find(observers_.begin(), observers_.end(), observer) !=
-      observers_.end())
-    return;
-  observers_.push_back(observer);
+  if (observers_.empty()) {
+    code_entries_.clear();
+  }
+  if (std::find(observers_.begin(), observers_.end(), observer) ==
+      observers_.end()) {
+    observers_.push_back(observer);
+  }
 }
 
 void ProfilerListener::RemoveObserver(CodeEventObserver* observer) {

--- a/deps/v8/src/profiler/profiler-listener.cc
+++ b/deps/v8/src/profiler/profiler-listener.cc
@@ -4,6 +4,7 @@
 
 #include "src/profiler/profiler-listener.h"
 
+#include "src/base/template-utils.h"
 #include "src/deoptimizer.h"
 #include "src/objects-inl.h"
 #include "src/profiler/cpu-profiler.h"

--- a/deps/v8/src/profiler/profiler-listener.h
+++ b/deps/v8/src/profiler/profiler-listener.h
@@ -74,6 +74,7 @@ class ProfilerListener : public CodeEventListener {
   const char* GetFunctionName(const char* name) {
     return function_and_resource_names_.GetFunctionName(name);
   }
+  size_t entries_count_for_test() const { return code_entries_.size(); }
 
  private:
   void RecordInliningInfo(CodeEntry* entry, AbstractCode* abstract_code);
@@ -87,7 +88,7 @@ class ProfilerListener : public CodeEventListener {
   }
 
   StringsStorage function_and_resource_names_;
-  std::vector<CodeEntry*> code_entries_;
+  std::vector<std::unique_ptr<CodeEntry>> code_entries_;
   std::vector<CodeEventObserver*> observers_;
   base::Mutex mutex_;
 

--- a/deps/v8/test/cctest/test-cpu-profiler.cc
+++ b/deps/v8/test/cctest/test-cpu-profiler.cc
@@ -2192,3 +2192,31 @@ TEST(TracingCpuProfiler) {
 
   i::V8::SetPlatformForTesting(old_platform);
 }
+
+TEST(CodeEntriesMemoryLeak) {
+  v8::HandleScope scope(CcTest::isolate());
+  v8::Local<v8::Context> env = CcTest::NewContext(PROFILER_EXTENSION);
+  v8::Context::Scope context_scope(env);
+
+  std::string source = "function start() {}\n";
+  for (int i = 0; i < 1000; ++i) {
+    source += "function foo" + std::to_string(i) + "() { return " +
+              std::to_string(i) +
+              "; }\n"
+              "foo" +
+              std::to_string(i) + "();\n";
+  }
+  CompileRun(source.c_str());
+  v8::Local<v8::Function> function = GetFunction(env, "start");
+
+  ProfilerHelper helper(env);
+
+  for (int j = 0; j < 100; ++j) {
+    v8::CpuProfile* profile = helper.Run(function, nullptr, 0);
+    profile->Delete();
+  }
+  ProfilerListener* profiler_listener =
+      CcTest::i_isolate()->logger()->profiler_listener();
+
+  CHECK_GE(10000ul, profiler_listener->entries_count_for_test());
+}


### PR DESCRIPTION
This is the Node.js 8.x (V8 6.1) specific backport of #17512. Additional fixup was needed to make the patch work with V8 6.1.

/cc @gibfahn @MylesBorins 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps:v8

CI: https://ci.nodejs.org/job/node-test-pull-request/12085/
V8-CI: https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/1113/