### PR TITLE
doc: value choice for imitating the old behavior of http.Server.keepAliveTimeout

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -919,7 +919,7 @@ timeout has fired, it will reset the regular inactivity timeout, i.e.,
 [`server.timeout`][].
 
 A value of `0` will disable the keep-alive timeout behavior on incoming connections.
-A value of `0` makes the http server behave similarly to earlier Node.js versions,
+A value of `0` makes the http server behave similarly to Node.js versions prior to 8.0.0,
 which did not have a keep-alive timeout.
 
 *Note*: The socket timeout logic is set up on connection, so changing this

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -900,7 +900,7 @@ added: v0.9.12
 The number of milliseconds of inactivity before a socket is presumed
 to have timed out.
 
-A value of 0 will disable the timeout behavior on incoming connections.
+A value of `0` will disable the timeout behavior on incoming connections.
 
 *Note*: The socket timeout logic is set up on connection, so changing this
 value only affects new connections to the server, not any existing connections.
@@ -918,7 +918,9 @@ will be destroyed. If the server receives new data before the keep-alive
 timeout has fired, it will reset the regular inactivity timeout, i.e.,
 [`server.timeout`][].
 
-A value of 0 will disable the keep-alive timeout behavior on incoming connections.
+A value of `0` will disable the keep-alive timeout behavior on incoming connections.
+A value of `0` makes the http server behave similarly to earlier Node.js versions,
+which did not have a keep-alive timeout.
 
 *Note*: The socket timeout logic is set up on connection, so changing this
 value only affects new connections to the server, not any existing connections.


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

Documenting the best way to imitate the old behavior saves time for people
migrating from older versions.
(E.g. for unexpected ECONNRESET)

It isn't immediately obvious if earlier nodejs versions behaved the same
way as nodejs 8 does with keepAliveTimeout = 0.
From 0aa7ef595084bca35f76cb38e28a0efc7a3128a3, it seems like they behave
the same way.

Related to issues such as #13391 that show up when migrating to node 8



##### Affected core subsystem(s)
doc