### PR TITLE
net: remove ADDRCONFIG DNS hint on Windows

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1091,7 +1091,10 @@ function lookupAndConnect(self, options) {
     hints: options.hints || 0
   };
 
-  if (dnsopts.family !== 4 && dnsopts.family !== 6 && dnsopts.hints === 0) {
+  if (process.platform !== 'win32' &&
+      dnsopts.family !== 4 &&
+      dnsopts.family !== 6 &&
+      dnsopts.hints === 0) {
     dnsopts.hints = dns.ADDRCONFIG;
   }
 


### PR DESCRIPTION
On Windows setting `ADDRCONFIG` causes localhost resolution to fail if there are no network connections. This removes that flag on Windows.

Fixes: https://github.com/nodejs/node/issues/17641

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
net
