### PR TITLE
Fix AttributeError: __exit__ on Python 2.6

### DIFF
--- a/tools/configure.d/nodedownload.py
+++ b/tools/configure.d/nodedownload.py
@@ -60,7 +60,7 @@ def unpack(packedfile, parent_path):
             icuzip.extractall(parent_path)
             return parent_path
     elif tarfile.is_tarfile(packedfile):
-        with tarfile.TarFile.open(packedfile, 'r') as icuzip:
+        with contextlib.closing(tarfile.TarFile.open(packedfile, 'r')) as icuzip:
             print ' Extracting tarfile: %s' % packedfile
             icuzip.extractall(parent_path)
             return parent_path


### PR DESCRIPTION
Error occurs while dealing with Tar archives

To reproduce run `./configure --with-intl=full-icu --with-icu-source=icu4c-60_1-src.tgz`


##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
