### PR TITLE
doc: change eventName type annotations

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -175,7 +175,7 @@ added and `'removeListener'` when existing listeners are removed.
 added: v0.1.26
 -->
 
-* `eventName` {any} The name of the event being listened for
+* `eventName` {string|symbol} The name of the event being listened for
 * `listener` {Function} The event handler function
 
 The `EventEmitter` instance will emit its own `'newListener'` event *before*
@@ -219,7 +219,7 @@ changes:
                  now yields the original listener function.
 -->
 
-* `eventName` {any} The event name
+* `eventName` {string|symbol} The event name
 * `listener` {Function} The event handler function
 
 The `'removeListener'` event is emitted *after* the `listener` is removed.
@@ -287,7 +287,7 @@ Its `name` property is set to `'MaxListenersExceededWarning'`.
 <!-- YAML
 added: v0.1.26
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 - `listener` {Function}
 
 Alias for `emitter.on(eventName, listener)`.
@@ -296,7 +296,7 @@ Alias for `emitter.on(eventName, listener)`.
 <!-- YAML
 added: v0.1.26
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 - `...args` {any}
 
 Synchronously calls each of the listeners registered for the event named
@@ -340,7 +340,7 @@ set by [`emitter.setMaxListeners(n)`][] or defaults to
 added: v3.2.0
 -->
 
-* `eventName` {any} The name of the event being listened for
+* `eventName` {string|symbol} The name of the event being listened for
 
 Returns the number of listeners listening to the event named `eventName`.
 
@@ -353,7 +353,7 @@ changes:
     description: For listeners attached using `.once()` this returns the
                  original listeners instead of wrapper functions now.
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -370,7 +370,7 @@ console.log(util.inspect(server.listeners('connection')));
 added: v0.1.101
 -->
 
-* `eventName` {any} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds the `listener` function to the end of the listeners array for the
@@ -406,7 +406,7 @@ myEE.emit('foo');
 added: v0.3.0
 -->
 
-* `eventName` {any} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds a **one-time** `listener` function for the event named `eventName`. The
@@ -439,7 +439,7 @@ myEE.emit('foo');
 added: v6.0.0
 -->
 
-* `eventName` {any} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds the `listener` function to the *beginning* of the listeners array for the
@@ -461,7 +461,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 added: v6.0.0
 -->
 
-* `eventName` {any} The name of the event.
+* `eventName` {string|symbol} The name of the event.
 * `listener` {Function} The callback function
 
 Adds a **one-time** `listener` function for the event named `eventName` to the
@@ -480,7 +480,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 <!-- YAML
 added: v0.1.26
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 
 Removes all listeners, or those of the specified `eventName`.
 
@@ -494,7 +494,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 <!-- YAML
 added: v0.1.26
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 - `listener` {Function}
 
 Removes the specified `listener` from the listener array for the event named

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -578,7 +578,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 <!-- YAML
 added: REPLACEME
 -->
-- `eventName` {any}
+- `eventName` {string|symbol}
 
 Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once`).


### PR DESCRIPTION
Change type annotations for eventName in events API doc from {any} to
{string|symbol} to be consistent with doc changes made in #17440.

Fixes: https://github.com/nodejs/node/issues/17657

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
