### PR TITLE
src: remove unused function

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -154,10 +154,6 @@ void NewFSReqWrap(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-inline bool IsInt64(double x) {
-  return x == static_cast<double>(static_cast<int64_t>(x));
-}
-
 void After(uv_fs_t *req) {
   FSReqWrap* req_wrap = static_cast<FSReqWrap*>(req->data);
   CHECK_EQ(req_wrap->req(), req);


### PR DESCRIPTION
The function `IsInt64()` in `src/node_file.cc` is no longer used. This commit removes it.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
src