### PR TITLE
http: add rawPacket in err of `clientError` event

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -765,6 +765,11 @@ object, so any HTTP response sent, including response headers and payload,
 *must* be written directly to the `socket` object. Care must be taken to
 ensure the response is a properly formatted HTTP response message.
 
+> `err` is an instance of `Error` with two extra columns:
+>
+> + `bytesParsed`: the bytes count of request packet that Node.js may parse correctly;
+> + `rawPacket`: the raw packet of current request.
+
 ### Event: 'close'
 <!-- YAML
 added: v0.1.4

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -734,7 +734,7 @@ changes:
     description: The default action of calling `.destroy()` on the `socket`
                  will no longer take place if there are listeners attached
                  for `clientError`.
-  - version: VERSION
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/17672
     description: The rawPacket is the current buffer that just parsed. Adding
                  this buffer to the error object of clientError event is to make

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -734,6 +734,11 @@ changes:
     description: The default action of calling `.destroy()` on the `socket`
                  will no longer take place if there are listeners attached
                  for `clientError`.
+  - version: VERSION
+    pr-url: https://github.com/nodejs/node/pull/17672
+    description: The rawPacket is the current buffer that just parsed. Adding
+                 this buffer to the error object of clientError event is to make
+                 it possible that developers can log the broken packet.
 -->
 
 * `exception` {Error}

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -765,10 +765,10 @@ object, so any HTTP response sent, including response headers and payload,
 *must* be written directly to the `socket` object. Care must be taken to
 ensure the response is a properly formatted HTTP response message.
 
-> `err` is an instance of `Error` with two extra columns:
->
-> + `bytesParsed`: the bytes count of request packet that Node.js may parse correctly;
-> + `rawPacket`: the raw packet of current request.
+`err` is an instance of `Error` with two extra columns:
+
++ `bytesParsed`: the bytes count of request packet that Node.js may have parsed correctly;
++ `rawPacket`: the raw packet of current request.
 
 ### Event: 'close'
 <!-- YAML

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -772,7 +772,8 @@ ensure the response is a properly formatted HTTP response message.
 
 `err` is an instance of `Error` with two extra columns:
 
-+ `bytesParsed`: the bytes count of request packet that Node.js may have parsed correctly;
++ `bytesParsed`: the bytes count of request packet that Node.js may have parsed
+  correctly;
 + `rawPacket`: the raw packet of current request.
 
 ### Event: 'close'

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -476,6 +476,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   resetSocketTimeout(server, socket, state);
 
   if (ret instanceof Error) {
+    ret.rawPacket = d || parser.getCurrentBuffer();
     debug('parse error', ret);
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -475,8 +475,11 @@ function socketOnError(e) {
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   resetSocketTimeout(server, socket, state);
 
+  if (!d)
+    d = parser.getCurrentBuffer();
+
   if (ret instanceof Error) {
-    ret.rawPacket = d || parser.getCurrentBuffer();
+    ret.rawPacket = d;
     debug('parse error', ret);
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
@@ -484,9 +487,6 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     var bytesParsed = ret;
     var req = parser.incoming;
     debug('SERVER upgrade or connect', req.method);
-
-    if (!d)
-      d = parser.getCurrentBuffer();
 
     socket.removeListener('data', state.onData);
     socket.removeListener('end', state.onEnd);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -475,12 +475,8 @@ function socketOnError(e) {
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   resetSocketTimeout(server, socket, state);
 
-  if (!d) {
-    d = parser.getCurrentBuffer();
-  }
-
   if (ret instanceof Error) {
-    ret.rawPacket = d;
+    ret.rawPacket = d || parser.getCurrentBuffer();
     debug('parse error', ret);
     socketOnError.call(socket, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
@@ -488,6 +484,9 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     var bytesParsed = ret;
     var req = parser.incoming;
     debug('SERVER upgrade or connect', req.method);
+
+    if (!d)
+      d = parser.getCurrentBuffer();
 
     socket.removeListener('data', state.onData);
     socket.removeListener('end', state.onEnd);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -475,8 +475,9 @@ function socketOnError(e) {
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   resetSocketTimeout(server, socket, state);
 
-  if (!d)
+  if (!d) {
     d = parser.getCurrentBuffer();
+  }
 
   if (ret instanceof Error) {
     ret.rawPacket = d;

--- a/test/parallel/test-http-server-client-error.js
+++ b/test/parallel/test-http-server-client-error.js
@@ -10,6 +10,12 @@ const server = http.createServer(common.mustCall(function(req, res) {
 }));
 
 server.on('clientError', common.mustCall(function(err, socket) {
+  assert.strictEqual(err instanceof Error, true);
+  assert.strictEqual(err.code, 'HPE_INVALID_METHOD');
+  assert.strictEqual(err.bytesParsed, 1);
+  assert.strictEqual(err.message, 'Parse Error');
+  assert.strictEqual(err.rawPacket.toString(), 'Oopsie-doopsie\r\n');
+
   socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
 
   server.close();


### PR DESCRIPTION
The `rawPacket` is the current buffer that just parsed. Adding this
buffer to the error object of `clientError` event is to make it possible
that developers can log the broken packet.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http