### PR TITLE
Extract out fs validation functions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -153,6 +153,18 @@ function makeCallback(cb) {
   };
 }
 
+function validateFd(fd) {
+  let err;
+
+  if (!isUint32(fd))
+    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validateFd);
+    throw err;
+  }
+}
+
 // Special case of `makeCallback()` that is specific to async `*stat()` calls as
 // an optimization, since the data passed back to the callback needs to be
 // transformed anyway.
@@ -649,17 +661,14 @@ fs.readFileSync = function(path, options) {
 };
 
 fs.close = function(fd, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
-
+  validateFd(fd);
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.close(fd, req);
 };
 
 fs.closeSync = function(fd) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
 
   const ctx = {};
   binding.close(fd, undefined, ctx);
@@ -720,8 +729,7 @@ fs.openSync = function(path, flags, mode) {
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint8Array(buffer))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
                                ['Buffer', 'Uint8Array']);
@@ -759,8 +767,7 @@ Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
 
 fs.readSync = function(fd, buffer, offset, length, position) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint8Array(buffer))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
                                ['Buffer', 'Uint8Array']);
@@ -794,8 +801,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     callback(err, written || 0, buffer);
   }
 
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
 
   const req = new FSReqWrap();
   req.oncomplete = wrapper;
@@ -839,8 +845,7 @@ Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
 // OR
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (isUint8Array(buffer)) {
     if (position === undefined)
       position = null;
@@ -956,8 +961,7 @@ fs.ftruncate = function(fd, len = 0, callback) {
     callback = len;
     len = 0;
   }
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isInt32(len))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'integer');
   len = Math.max(0, len);
@@ -967,8 +971,7 @@ fs.ftruncate = function(fd, len = 0, callback) {
 };
 
 fs.ftruncateSync = function(fd, len = 0) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isInt32(len))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'integer');
   len = Math.max(0, len);
@@ -1000,30 +1003,26 @@ fs.rmdirSync = function(path) {
 };
 
 fs.fdatasync = function(fd, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fdatasync(fd, req);
 };
 
 fs.fdatasyncSync = function(fd) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   return binding.fdatasync(fd);
 };
 
 fs.fsync = function(fd, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fsync(fd, req);
 };
 
 fs.fsyncSync = function(fd) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   return binding.fsync(fd);
 };
 
@@ -1089,8 +1088,7 @@ fs.readdirSync = function(path, options) {
 };
 
 fs.fstat = function(fd, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   const req = new FSReqWrap();
   req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
@@ -1125,8 +1123,7 @@ fs.stat = function(path, callback) {
 };
 
 fs.fstatSync = function(fd) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   binding.fstat(fd);
   return statsFromValues();
 };
@@ -1336,8 +1333,7 @@ fs.unlinkSync = function(path) {
 
 fs.fchmod = function(fd, mode, callback) {
   mode = modeNum(mode);
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
   if (mode < 0 || mode > 0o777)
@@ -1350,8 +1346,7 @@ fs.fchmod = function(fd, mode, callback) {
 
 fs.fchmodSync = function(fd, mode) {
   mode = modeNum(mode);
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
   if (mode < 0 || mode > 0o777)
@@ -1448,8 +1443,7 @@ if (constants.O_SYMLINK !== undefined) {
 }
 
 fs.fchown = function(fd, uid, gid, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint32(uid))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
   if (!isUint32(gid))
@@ -1461,8 +1455,7 @@ fs.fchown = function(fd, uid, gid, callback) {
 };
 
 fs.fchownSync = function(fd, uid, gid) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   if (!isUint32(uid))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
   if (!isUint32(gid))
@@ -1562,8 +1555,7 @@ fs.utimesSync = function(path, atime, mtime) {
 };
 
 fs.futimes = function(fd, atime, mtime, callback) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
   const req = new FSReqWrap();
@@ -1572,8 +1564,7 @@ fs.futimes = function(fd, atime, mtime, callback) {
 };
 
 fs.futimesSync = function(fd, atime, mtime) {
-  if (!isUint32(fd))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  validateFd(fd);
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
   binding.futimes(fd, atime, mtime);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -189,6 +189,21 @@ function validateOffsetLengthRead(offset, length, bufferLength) {
   }
 }
 
+function validateOffsetLengthWrite(offset, length, byteLength) {
+  let err;
+
+  if (offset > byteLength) {
+    err = new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
+  } else if (offset + length > byteLength || offset + length > kMaxLength) {
+    err = new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+  }
+
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validateOffsetLengthWrite);
+    throw err;
+  }
+}
+
 // Special case of `makeCallback()` that is specific to async `*stat()` calls as
 // an optimization, since the data passed back to the callback needs to be
 // transformed anyway.
@@ -826,11 +841,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
       length = buffer.length - offset;
     if (typeof position !== 'number')
       position = null;
-    const byteLength = buffer.byteLength;
-    if (offset > byteLength)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
-    if (offset + length > byteLength || offset + length > kMaxLength)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+    validateOffsetLengthWrite(offset, length, buffer.byteLength);
     return binding.writeBuffer(fd, buffer, offset, length, position, req);
   }
 
@@ -865,11 +876,7 @@ fs.writeSync = function(fd, buffer, offset, length, position) {
       offset = 0;
     if (typeof length !== 'number')
       length = buffer.length - offset;
-    const byteLength = buffer.byteLength;
-    if (offset > byteLength)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
-    if (offset + length > byteLength || offset + length > kMaxLength)
-      throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+    validateOffsetLengthWrite(offset, length, buffer.byteLength);
     return binding.writeBuffer(fd, buffer, offset, length, position);
   }
   if (typeof buffer !== 'string')

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -165,6 +165,21 @@ function validateFd(fd) {
   }
 }
 
+function validateOffsetLengthRead(offset, length, bufferLength) {
+  let err;
+
+  if (offset < 0 || offset >= bufferLength) {
+    err = new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
+  } else if (length < 0 || offset + length > bufferLength) {
+    err = new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+  }
+
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validateOffsetLengthRead);
+    throw err;
+  }
+}
+
 // Special case of `makeCallback()` that is specific to async `*stat()` calls as
 // an optimization, since the data passed back to the callback needs to be
 // transformed anyway.
@@ -743,11 +758,7 @@ fs.read = function(fd, buffer, offset, length, position, callback) {
     });
   }
 
-  if (offset < 0 || offset >= buffer.length)
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
-
-  if (length < 0 || offset + length > buffer.length)
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+  validateOffsetLengthRead(offset, length, buffer.length);
 
   if (!isUint32(position))
     position = -1;
@@ -779,11 +790,7 @@ fs.readSync = function(fd, buffer, offset, length, position) {
     return 0;
   }
 
-  if (offset < 0 || offset >= buffer.length)
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'offset');
-
-  if (length < 0 || offset + length > buffer.length)
-    throw new errors.RangeError('ERR_OUT_OF_RANGE', 'length');
+  validateOffsetLengthRead(offset, length, buffer.length);
 
   if (!isUint32(position))
     position = -1;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -162,14 +162,14 @@ function validateBuffer(buffer) {
   }
 }
 
-function validateFd(fd) {
+function validateLen(len) {
   let err;
 
-  if (!isUint32(fd))
-    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'fd', 'integer');
+  if (!isInt32(len))
+    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'integer');
 
   if (err !== undefined) {
-    Error.captureStackTrace(err, validateFd);
+    Error.captureStackTrace(err, validateLen);
     throw err;
   }
 }
@@ -218,6 +218,18 @@ function validatePath(path, propName) {
 
   if (err !== undefined) {
     Error.captureStackTrace(err, validatePath);
+    throw err;
+  }
+}
+
+function validateUint32(value, propName) {
+  let err;
+
+  if (!isUint32(value))
+    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', propName, 'integer');
+
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validateUint32);
     throw err;
   }
 }
@@ -708,14 +720,14 @@ fs.readFileSync = function(path, options) {
 };
 
 fs.close = function(fd, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.close(fd, req);
 };
 
 fs.closeSync = function(fd) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
 
   const ctx = {};
   binding.close(fd, undefined, ctx);
@@ -742,9 +754,7 @@ fs.open = function(path, flags, mode, callback_) {
     return;
   if (!nullCheck(path, callback)) return;
   validatePath(path);
-
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -760,16 +770,14 @@ fs.openSync = function(path, flags, mode) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
   validatePath(path);
-
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
 
   return binding.open(pathModule.toNamespacedPath(path),
                       stringToFlags(flags), mode);
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   validateBuffer(buffer);
 
   offset |= 0;
@@ -801,7 +809,7 @@ Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
                       { value: ['bytesRead', 'buffer'], enumerable: false });
 
 fs.readSync = function(fd, buffer, offset, length, position) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   validateBuffer(buffer);
 
   offset |= 0;
@@ -829,7 +837,7 @@ fs.write = function(fd, buffer, offset, length, position, callback) {
     callback(err, written || 0, buffer);
   }
 
-  validateFd(fd);
+  validateUint32(fd, 'fd');
 
   const req = new FSReqWrap();
   req.oncomplete = wrapper;
@@ -869,7 +877,7 @@ Object.defineProperty(fs.write, internalUtil.customPromisifyArgs,
 // OR
 //  fs.writeSync(fd, string[, position[, encoding]]);
 fs.writeSync = function(fd, buffer, offset, length, position) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   if (isUint8Array(buffer)) {
     if (position === undefined)
       position = null;
@@ -968,9 +976,8 @@ fs.ftruncate = function(fd, len = 0, callback) {
     callback = len;
     len = 0;
   }
-  validateFd(fd);
-  if (!isInt32(len))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'integer');
+  validateUint32(fd, 'fd');
+  validateLen(len);
   len = Math.max(0, len);
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
@@ -978,9 +985,8 @@ fs.ftruncate = function(fd, len = 0, callback) {
 };
 
 fs.ftruncateSync = function(fd, len = 0) {
-  validateFd(fd);
-  if (!isInt32(len))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'len', 'integer');
+  validateUint32(fd, 'fd');
+  validateLen(len);
   len = Math.max(0, len);
   return binding.ftruncate(fd, len);
 };
@@ -1004,26 +1010,26 @@ fs.rmdirSync = function(path) {
 };
 
 fs.fdatasync = function(fd, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fdatasync(fd, req);
 };
 
 fs.fdatasyncSync = function(fd) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   return binding.fdatasync(fd);
 };
 
 fs.fsync = function(fd, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
   binding.fsync(fd, req);
 };
 
 fs.fsyncSync = function(fd) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   return binding.fsync(fd);
 };
 
@@ -1036,8 +1042,7 @@ fs.mkdir = function(path, mode, callback) {
 
   validatePath(path);
   mode = modeNum(mode, 0o777);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1049,8 +1054,7 @@ fs.mkdirSync = function(path, mode) {
   nullCheck(path);
   validatePath(path);
   mode = modeNum(mode, 0o777);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
   return binding.mkdir(pathModule.toNamespacedPath(path), mode);
 };
 
@@ -1077,7 +1081,7 @@ fs.readdirSync = function(path, options) {
 };
 
 fs.fstat = function(fd, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   const req = new FSReqWrap();
   req.oncomplete = makeStatsCallback(callback);
   binding.fstat(fd, req);
@@ -1106,7 +1110,7 @@ fs.stat = function(path, callback) {
 };
 
 fs.fstatSync = function(fd) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   binding.fstat(fd);
   return statsFromValues();
 };
@@ -1273,9 +1277,8 @@ fs.unlinkSync = function(path) {
 
 fs.fchmod = function(fd, mode, callback) {
   mode = modeNum(mode);
-  validateFd(fd);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(fd, 'fd');
+  validateUint32(mode, 'mode');
   if (mode < 0 || mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
 
@@ -1286,9 +1289,8 @@ fs.fchmod = function(fd, mode, callback) {
 
 fs.fchmodSync = function(fd, mode) {
   mode = modeNum(mode);
-  validateFd(fd);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(fd, 'fd');
+  validateUint32(mode, 'mode');
   if (mode < 0 || mode > 0o777)
     throw new errors.RangeError('ERR_OUT_OF_RANGE', 'mode');
   return binding.fchmod(fd, mode);
@@ -1340,8 +1342,7 @@ fs.chmod = function(path, mode, callback) {
 
   validatePath(path);
   mode = modeNum(mode);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1353,8 +1354,7 @@ fs.chmodSync = function(path, mode) {
   nullCheck(path);
   validatePath(path);
   mode = modeNum(mode);
-  if (!isUint32(mode))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
+  validateUint32(mode, 'mode');
   return binding.chmod(pathModule.toNamespacedPath(path), mode);
 };
 
@@ -1377,11 +1377,9 @@ if (constants.O_SYMLINK !== undefined) {
 }
 
 fs.fchown = function(fd, uid, gid, callback) {
-  validateFd(fd);
-  if (!isUint32(uid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
-  if (!isUint32(gid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  validateUint32(fd, 'fd');
+  validateUint32(uid, 'uid');
+  validateUint32(gid, 'gid');
 
   const req = new FSReqWrap();
   req.oncomplete = makeCallback(callback);
@@ -1389,11 +1387,9 @@ fs.fchown = function(fd, uid, gid, callback) {
 };
 
 fs.fchownSync = function(fd, uid, gid) {
-  validateFd(fd);
-  if (!isUint32(uid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
-  if (!isUint32(gid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  validateUint32(fd, 'fd');
+  validateUint32(uid, 'uid');
+  validateUint32(gid, 'gid');
 
   return binding.fchown(fd, uid, gid);
 };
@@ -1405,10 +1401,8 @@ fs.chown = function(path, uid, gid, callback) {
   if (!nullCheck(path, callback)) return;
 
   validatePath(path);
-  if (!isUint32(uid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
-  if (!isUint32(gid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  validateUint32(uid, 'uid');
+  validateUint32(gid, 'gid');
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1419,10 +1413,8 @@ fs.chownSync = function(path, uid, gid) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
   validatePath(path);
-  if (!isUint32(uid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
-  if (!isUint32(gid))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'gid', 'integer');
+  validateUint32(uid, 'uid');
+  validateUint32(gid, 'gid');
   return binding.chown(pathModule.toNamespacedPath(path), uid, gid);
 };
 
@@ -1477,7 +1469,7 @@ fs.utimesSync = function(path, atime, mtime) {
 };
 
 fs.futimes = function(fd, atime, mtime, callback) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
   const req = new FSReqWrap();
@@ -1486,7 +1478,7 @@ fs.futimes = function(fd, atime, mtime, callback) {
 };
 
 fs.futimesSync = function(fd, atime, mtime) {
-  validateFd(fd);
+  validateUint32(fd, 'fd');
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
   binding.futimes(fd, atime, mtime);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -153,6 +153,15 @@ function makeCallback(cb) {
   };
 }
 
+function validateBuffer(buffer) {
+  if (!isUint8Array(buffer)) {
+    const err = new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
+                                     ['Buffer', 'Uint8Array']);
+    Error.captureStackTrace(err, validateBuffer);
+    throw err;
+  }
+}
+
 function validateFd(fd) {
   let err;
 
@@ -745,9 +754,7 @@ fs.openSync = function(path, flags, mode) {
 
 fs.read = function(fd, buffer, offset, length, position, callback) {
   validateFd(fd);
-  if (!isUint8Array(buffer))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
-                               ['Buffer', 'Uint8Array']);
+  validateBuffer(buffer);
 
   offset |= 0;
   length |= 0;
@@ -779,9 +786,7 @@ Object.defineProperty(fs.read, internalUtil.customPromisifyArgs,
 
 fs.readSync = function(fd, buffer, offset, length, position) {
   validateFd(fd);
-  if (!isUint8Array(buffer))
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'buffer',
-                               ['Buffer', 'Uint8Array']);
+  validateBuffer(buffer);
 
   offset |= 0;
   length |= 0;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -204,6 +204,24 @@ function validateOffsetLengthWrite(offset, length, byteLength) {
   }
 }
 
+function validatePath(path, propName) {
+  let err;
+
+  if (propName === undefined) {
+    propName = 'path';
+  }
+
+  if (typeof path !== 'string' && !isUint8Array(path)) {
+    err = new errors.TypeError('ERR_INVALID_ARG_TYPE', propName,
+                               ['string', 'Buffer', 'URL']);
+  }
+
+  if (err !== undefined) {
+    Error.captureStackTrace(err, validatePath);
+    throw err;
+  }
+}
+
 // Special case of `makeCallback()` that is specific to async `*stat()` calls as
 // an optimization, since the data passed back to the callback needs to be
 // transformed anyway.
@@ -351,10 +369,7 @@ fs.access = function(path, mode, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
 
-  if (typeof path !== 'string' && !(path instanceof Buffer)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
 
   if (!nullCheck(path, callback))
     return;
@@ -367,12 +382,7 @@ fs.access = function(path, mode, callback) {
 
 fs.accessSync = function(path, mode) {
   handleError((path = getPathFromURL(path)));
-
-  if (typeof path !== 'string' && !(path instanceof Buffer)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
-
+  validatePath(path);
   nullCheck(path);
 
   if (mode === undefined)
@@ -391,10 +401,7 @@ fs.accessSync = function(path, mode) {
 fs.exists = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), cb))
     return;
-  if (typeof path !== 'string' && !(path instanceof Buffer)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   if (!nullCheck(path, cb)) return;
   var req = new FSReqWrap();
   req.oncomplete = cb;
@@ -416,7 +423,9 @@ Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
 fs.existsSync = function(path) {
   try {
     handleError((path = getPathFromURL(path)));
-    if (typeof path !== 'string' && !(path instanceof Buffer)) {
+    try {
+      validatePath(path);
+    } catch (e) {
       return false;
     }
     nullCheck(path);
@@ -447,10 +456,9 @@ fs.readFile = function(path, options, callback) {
       req.oncomplete(null, path);
     });
     return;
-  } else if (typeof path !== 'string' && !(path instanceof Buffer)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
   }
+
+  validatePath(path);
 
   binding.open(pathModule.toNamespacedPath(path),
                stringToFlags(options.flag || 'r'),
@@ -733,11 +741,7 @@ fs.open = function(path, flags, mode, callback_) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
 
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -755,10 +759,7 @@ fs.openSync = function(path, flags, mode) {
   mode = modeNum(mode, 0o666);
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
 
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -896,15 +897,8 @@ fs.rename = function(oldPath, newPath, callback) {
 
   if (!nullCheck(oldPath, callback)) return;
   if (!nullCheck(newPath, callback)) return;
-
-  if (typeof oldPath !== 'string' && !isUint8Array(oldPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof newPath !== 'string' && !isUint8Array(newPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(oldPath, 'oldPath');
+  validatePath(newPath, 'newPath');
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.rename(pathModule.toNamespacedPath(oldPath),
@@ -917,14 +911,8 @@ fs.renameSync = function(oldPath, newPath) {
   handleError((newPath = getPathFromURL(newPath)));
   nullCheck(oldPath);
   nullCheck(newPath);
-  if (typeof oldPath !== 'string' && !isUint8Array(oldPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof newPath !== 'string' && !isUint8Array(newPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(oldPath, 'oldPath');
+  validatePath(newPath, 'newPath');
   return binding.rename(pathModule.toNamespacedPath(oldPath),
                         pathModule.toNamespacedPath(newPath));
 };
@@ -1002,10 +990,7 @@ fs.rmdir = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.rmdir(pathModule.toNamespacedPath(path), req);
@@ -1014,10 +999,7 @@ fs.rmdir = function(path, callback) {
 fs.rmdirSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   return binding.rmdir(pathModule.toNamespacedPath(path));
 };
 
@@ -1052,10 +1034,7 @@ fs.mkdir = function(path, mode, callback) {
     return;
   if (!nullCheck(path, callback)) return;
 
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   mode = modeNum(mode, 0o777);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -1068,10 +1047,7 @@ fs.mkdir = function(path, mode, callback) {
 fs.mkdirSync = function(path, mode) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   mode = modeNum(mode, 0o777);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -1085,10 +1061,7 @@ fs.readdir = function(path, options, callback) {
     return;
   if (!nullCheck(path, callback)) return;
 
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1099,10 +1072,7 @@ fs.readdirSync = function(path, options) {
   options = getOptions(options, {});
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   return binding.readdir(pathModule.toNamespacedPath(path), options.encoding);
 };
 
@@ -1118,10 +1088,7 @@ fs.lstat = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.lstat(pathModule.toNamespacedPath(path), req);
@@ -1132,10 +1099,7 @@ fs.stat = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.stat(pathModule.toNamespacedPath(path), req);
@@ -1150,10 +1114,7 @@ fs.fstatSync = function(fd) {
 fs.lstatSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   binding.lstat(pathModule.toNamespacedPath(path));
   return statsFromValues();
 };
@@ -1161,10 +1122,7 @@ fs.lstatSync = function(path) {
 fs.statSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   binding.stat(pathModule.toNamespacedPath(path));
   return statsFromValues();
 };
@@ -1175,10 +1133,7 @@ fs.readlink = function(path, options, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path, 'oldPath');
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.readlink(pathModule.toNamespacedPath(path), options.encoding, req);
@@ -1188,10 +1143,7 @@ fs.readlinkSync = function(path, options) {
   options = getOptions(options, {});
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'oldPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path, 'oldPath');
   return binding.readlink(pathModule.toNamespacedPath(path), options.encoding);
 };
 
@@ -1243,15 +1195,8 @@ fs.symlink = function(target, path, type_, callback_) {
 
   if (!nullCheck(target, callback)) return;
   if (!nullCheck(path, callback)) return;
-
-  if (typeof target !== 'string' && !isUint8Array(target)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(target, 'target');
+  validatePath(path);
 
   const flags = stringToSymlinkType(type);
   const req = new FSReqWrap();
@@ -1267,14 +1212,8 @@ fs.symlinkSync = function(target, path, type) {
   nullCheck(target);
   nullCheck(path);
 
-  if (typeof target !== 'string' && !isUint8Array(target)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'target',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(target, 'target');
+  validatePath(path);
   const flags = stringToSymlinkType(type);
   return binding.symlink(preprocessSymlinkDestination(target, type, path),
                          pathModule.toNamespacedPath(path), flags);
@@ -1292,14 +1231,8 @@ fs.link = function(existingPath, newPath, callback) {
   if (!nullCheck(existingPath, callback)) return;
   if (!nullCheck(newPath, callback)) return;
 
-  if (typeof existingPath !== 'string' && !isUint8Array(existingPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'existingPath',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof newPath !== 'string' && !isUint8Array(newPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(existingPath, 'existingPath');
+  validatePath(newPath, 'newPath');
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1314,14 +1247,8 @@ fs.linkSync = function(existingPath, newPath) {
   handleError((newPath = getPathFromURL(newPath)));
   nullCheck(existingPath);
   nullCheck(newPath);
-  if (typeof existingPath !== 'string' && !isUint8Array(existingPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'existingPath',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof newPath !== 'string' && !isUint8Array(newPath)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'newPath',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(existingPath, 'existingPath');
+  validatePath(newPath, 'newPath');
   return binding.link(pathModule.toNamespacedPath(existingPath),
                       pathModule.toNamespacedPath(newPath));
 };
@@ -1331,10 +1258,7 @@ fs.unlink = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), callback))
     return;
   if (!nullCheck(path, callback)) return;
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   const req = new FSReqWrap();
   req.oncomplete = callback;
   binding.unlink(pathModule.toNamespacedPath(path), req);
@@ -1343,10 +1267,7 @@ fs.unlink = function(path, callback) {
 fs.unlinkSync = function(path) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   return binding.unlink(pathModule.toNamespacedPath(path));
 };
 
@@ -1417,10 +1338,7 @@ fs.chmod = function(path, mode, callback) {
     return;
   if (!nullCheck(path, callback)) return;
 
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   mode = modeNum(mode);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -1433,10 +1351,7 @@ fs.chmod = function(path, mode, callback) {
 fs.chmodSync = function(path, mode) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   mode = modeNum(mode);
   if (!isUint32(mode))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'mode', 'integer');
@@ -1489,10 +1404,7 @@ fs.chown = function(path, uid, gid, callback) {
     return;
   if (!nullCheck(path, callback)) return;
 
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   if (!isUint32(uid))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
   if (!isUint32(gid))
@@ -1506,10 +1418,7 @@ fs.chown = function(path, uid, gid, callback) {
 fs.chownSync = function(path, uid, gid) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   if (!isUint32(uid))
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'uid', 'integer');
   if (!isUint32(gid))
@@ -1548,10 +1457,7 @@ fs.utimes = function(path, atime, mtime, callback) {
     return;
   if (!nullCheck(path, callback)) return;
 
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
 
   const req = new FSReqWrap();
   req.oncomplete = callback;
@@ -1564,10 +1470,7 @@ fs.utimes = function(path, atime, mtime, callback) {
 fs.utimesSync = function(path, atime, mtime) {
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
-  if (typeof path !== 'string' && !isUint8Array(path)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(path);
   binding.utimes(pathModule.toNamespacedPath(path),
                  toUnixTimestamp(atime),
                  toUnixTimestamp(mtime));
@@ -2279,14 +2182,8 @@ fs.copyFile = function(src, dest, flags, callback) {
   if (!nullCheck(dest, callback))
     return;
 
-  if (typeof src !== 'string' && !isUint8Array(src)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof dest !== 'string' && !isUint8Array(dest)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(src, 'src');
+  validatePath(dest, 'dest');
 
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);
@@ -2306,14 +2203,8 @@ fs.copyFileSync = function(src, dest, flags) {
   handleError(dest);
   nullCheck(dest);
 
-  if (typeof src !== 'string' && !isUint8Array(src)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'src',
-                               ['string', 'Buffer', 'URL']);
-  }
-  if (typeof dest !== 'string' && !isUint8Array(dest)) {
-    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'dest',
-                               ['string', 'Buffer', 'URL']);
-  }
+  validatePath(src, 'src');
+  validatePath(dest, 'dest');
 
   src = pathModule._makeLong(src);
   dest = pathModule._makeLong(dest);


### PR DESCRIPTION
Many different validations are repeated within `fs.js`, so I extracted them out to separate functions to try and DRY up the code and avoid duplicating them.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs