### PR TITLE
http: remove adapter frame from onParserExecute

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -449,7 +449,7 @@ function socketOnData(server, socket, parser, state, d) {
   onParserExecuteCommon(server, socket, parser, state, ret, d);
 }
 
-function onParserExecute(server, socket, parser, state, ret, d) {
+function onParserExecute(server, socket, parser, state, ret) {
   socket._unrefTimer();
   debug('SERVER socketOnParserExecute %d', ret);
   onParserExecuteCommon(server, socket, parser, state, ret, undefined);


### PR DESCRIPTION
Remove a pointless adapter frame  by fixing up the function's formal
parameter count.  Before:

    frame #0: 0x000033257ea446d5 onParserExecute(...)
    frame #1: 0x000033257ea3b93f <adaptor>
    frame #2: 0x000033257ea41959 <internal>
    frame #3: 0x000033257e9840ff <entry>

After:

    frame #0: 0x00000956287446d5 onParserExecute(...)
    frame #1: 0x0000095628741959 <internal>
    frame #2: 0x00000956286840ff <entry>