### PR TITLE
src: rename `On*` -> `Emit*` for stream callbacks

### DIFF
--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -201,14 +201,14 @@ void JSStream::ReadBuffer(const FunctionCallbackInfo<Value>& args) {
   do {
     uv_buf_t buf;
     ssize_t avail = len;
-    wrap->OnAlloc(len, &buf);
+    wrap->EmitAlloc(len, &buf);
     if (static_cast<ssize_t>(buf.len) < avail)
       avail = buf.len;
 
     memcpy(buf.base, data, avail);
     data += avail;
     len -= avail;
-    wrap->OnRead(avail, &buf);
+    wrap->EmitRead(avail, &buf);
   } while (len != 0);
 }
 
@@ -217,7 +217,7 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
   JSStream* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
 
-  wrap->OnRead(UV_EOF, nullptr);
+  wrap->EmitRead(UV_EOF, nullptr);
 }
 
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -402,7 +402,7 @@ void StreamBase::AfterWrite(WriteWrap* req_wrap, int status) {
   // Unref handle property
   Local<Object> req_wrap_obj = req_wrap->object();
   req_wrap_obj->Delete(env->context(), env->handle_string()).FromJust();
-  OnAfterWrite(req_wrap, status);
+  EmitAfterWrite(req_wrap, status);
 
   Local<Value> argv[] = {
     Integer::New(env->isolate(), status),

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -166,19 +166,19 @@ class StreamResource {
   virtual void ClearError();
 
   // Events
-  inline void OnAfterWrite(WriteWrap* w, int status) {
+  inline void EmitAfterWrite(WriteWrap* w, int status) {
     if (!after_write_cb_.is_empty())
       after_write_cb_.fn(w, status, after_write_cb_.ctx);
   }
 
-  inline void OnAlloc(size_t size, uv_buf_t* buf) {
+  inline void EmitAlloc(size_t size, uv_buf_t* buf) {
     if (!alloc_cb_.is_empty())
       alloc_cb_.fn(size, buf, alloc_cb_.ctx);
   }
 
-  inline void OnRead(ssize_t nread,
-                     const uv_buf_t* buf,
-                     uv_handle_type pending = UV_UNKNOWN_HANDLE) {
+  inline void EmitRead(ssize_t nread,
+                       const uv_buf_t* buf,
+                       uv_handle_type pending = UV_UNKNOWN_HANDLE) {
     if (nread > 0)
       bytes_read_ += static_cast<uint64_t>(nread);
     if (!read_cb_.is_empty())

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -165,7 +165,7 @@ void LibuvStreamWrap::OnAlloc(uv_handle_t* handle,
 
   CHECK_EQ(wrap->stream(), reinterpret_cast<uv_stream_t*>(handle));
 
-  return static_cast<StreamBase*>(wrap)->OnAlloc(suggested_size, buf);
+  return wrap->EmitAlloc(suggested_size, buf);
 }
 
 
@@ -263,7 +263,7 @@ void LibuvStreamWrap::OnRead(uv_stream_t* handle,
     }
   }
 
-  static_cast<StreamBase*>(wrap)->OnRead(nread, buf, type);
+  wrap->EmitRead(nread, buf, type);
 }
 
 

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -230,11 +230,11 @@ void TLSWrap::Receive(const FunctionCallbackInfo<Value>& args) {
 
   // Copy given buffer entirely or partiall if handle becomes closed
   while (len > 0 && wrap->IsAlive() && !wrap->IsClosing()) {
-    wrap->stream_->OnAlloc(len, &buf);
+    wrap->stream_->EmitAlloc(len, &buf);
     size_t copy = buf.len > len ? len : buf.len;
     memcpy(buf.base, data, copy);
     buf.len = copy;
-    wrap->stream_->OnRead(buf.len, &buf);
+    wrap->stream_->EmitRead(buf.len, &buf);
 
     data += copy;
     len -= copy;
@@ -443,11 +443,11 @@ void TLSWrap::ClearOut() {
       int avail = read;
 
       uv_buf_t buf;
-      OnAlloc(avail, &buf);
+      EmitAlloc(avail, &buf);
       if (static_cast<int>(buf.len) < avail)
         avail = buf.len;
       memcpy(buf.base, current, avail);
-      OnRead(avail, &buf);
+      EmitRead(avail, &buf);
 
       // Caveat emptor: OnRead() calls into JS land which can result in
       // the SSL context object being destroyed.  We have to carefully
@@ -463,7 +463,7 @@ void TLSWrap::ClearOut() {
   int flags = SSL_get_shutdown(ssl_);
   if (!eof_ && flags & SSL_RECEIVED_SHUTDOWN) {
     eof_ = true;
-    OnRead(UV_EOF, nullptr);
+    EmitRead(UV_EOF, nullptr);
   }
 
   // We need to check whether an error occurred or the connection was
@@ -739,13 +739,13 @@ void TLSWrap::DoRead(ssize_t nread,
       eof_ = true;
     }
 
-    OnRead(nread, nullptr);
+    EmitRead(nread, nullptr);
     return;
   }
 
   // Only client connections can receive data
   if (ssl_ == nullptr) {
-    OnRead(UV_EPROTO, nullptr);
+    EmitRead(UV_EPROTO, nullptr);
     return;
   }
 


### PR DESCRIPTION
This should make these function calls a lot more intuitive for people who are more accustomed to Node’s EventEmitter API.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes 
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/stream_base