### PR TITLE
assert: fix .throws and .doesNotThrow stack frames

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -242,7 +242,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         expected,
         operator: 'throws',
         message: `Missing expected exception${details}`,
-        stackStartFn: innerThrows
+        stackStartFn: assert.throws
       });
     }
     if (expected && expectedException(actual, expected) === false) {
@@ -256,7 +256,7 @@ function innerThrows(shouldThrow, block, expected, message) {
         expected,
         operator: 'doesNotThrow',
         message: `Got unwanted exception${details}\n${actual.message}`,
-        stackStartFn: innerThrows
+        stackStartFn: assert.doesNotThrow
       });
     }
     throw actual;

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -634,6 +634,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
   } catch (e) {
     threw = true;
     assert.strictEqual(e.message, 'Missing expected exception.');
+    assert.ok(!e.stack.includes('throws'), e.stack);
   }
   assert.ok(threw);
 }
@@ -678,6 +679,7 @@ try {
     threw = true;
     assert.ok(e.message.includes(rangeError.message));
     assert.ok(e instanceof assert.AssertionError);
+    assert.ok(!e.stack.includes('doesNotThrow'), e.stack);
   }
   assert.ok(threw);
 }

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -476,33 +476,21 @@ common.expectsError(
   }
 );
 
-{
-  let threw = false;
-  try {
-    assert.doesNotThrow(makeBlock(thrower, Error), 'user message');
-  } catch (e) {
-    threw = true;
-    common.expectsError({
-      code: 'ERR_ASSERTION',
-      message: /Got unwanted exception: user message\n\[object Object\]/
-    })(e);
+common.expectsError(
+  () => assert.doesNotThrow(makeBlock(thrower, Error), 'user message'),
+  {
+    code: 'ERR_ASSERTION',
+    message: /Got unwanted exception: user message\n\[object Object\]/
   }
-  assert.ok(threw);
-}
+);
 
-{
-  let threw = false;
-  try {
-    assert.doesNotThrow(makeBlock(thrower, Error));
-  } catch (e) {
-    threw = true;
-    common.expectsError({
-      code: 'ERR_ASSERTION',
-      message: /Got unwanted exception\.\n\[object Object\]/
-    })(e);
+common.expectsError(
+  () => assert.doesNotThrow(makeBlock(thrower, Error)),
+  {
+    code: 'ERR_ASSERTION',
+    message: /Got unwanted exception\.\n\[object Object\]/
   }
-  assert.ok(threw);
-}
+);
 
 // make sure that validating using constructor really works
 {
@@ -691,21 +679,15 @@ try {
   }
 
   const testBlockTypeError = (method, block) => {
-    let threw = true;
-
-    try {
-      method(block);
-      threw = false;
-    } catch (e) {
-      common.expectsError({
+    common.expectsError(
+      () => method(block),
+      {
         code: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         message: 'The "block" argument must be of type Function. Received ' +
-                 `type ${typeName(block)}`
-      })(e);
-    }
-
-    assert.ok(threw);
+                `type ${typeName(block)}`
+      }
+    );
   };
 
   testBlockTypeError(assert.throws, 'string');


### PR DESCRIPTION
All assert functions suppress their own function name from showing up in the stack trace.
That was not the case with `throws` and `doesNotThrow`.

On top of that I refactored two `common.expectsError` cases that were less than ideal. I can open a new PR for that if that is requested, but I stumbled upon those when looking for a good place to add a new test, so I thought it would be fine to include it in this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert, test