### PR TITLE
doc: improve module.builtinModules documentation

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -841,6 +841,13 @@ added: v9.3.0
 A list of  the names of all modules provided by Node.js. Can be used to verify
 if a module is maintained by a third-party module or not.
 
+Note that `module` in this context isn't the same object that's provided
+by the [module wrapper][]. To access it, require the `Module` module:
+
+```js
+const builtin = require('module').builtinModules;
+```
+
 [`__dirname`]: #modules_dirname
 [`__filename`]: #modules_filename
 [`Error`]: errors.html#errors_class_error
@@ -848,4 +855,5 @@ if a module is maintained by a third-party module or not.
 [`path.dirname()`]: path.html#path_path_dirname_path
 [exports shortcut]: #modules_exports_shortcut
 [module resolution]: #modules_all_together
+[module wrapper]: #modules_the_module_wrapper
 [native addons]: addons.html


### PR DESCRIPTION
In this PR I've kept the original casing of the object `module`, but I think it might be easier to understand if we changed the entire section to use the uppercase version: `Module`. This have two benefits:

1. It matches what's actually exported when requiring "module"
1. It's easier to distinguish from the other `module` object that's available by default to all file modules

That change would instead look like this:

````diff
-### module.builtinModules
+### Module.builtinModules
 <!-- YAML
 added: v9.3.0
 -->

 * {string[]}

 A list of  the names of all modules provided by Node.js. Can be used to verify
 if a module is maintained by a third-party module or not.

+Note that `Module` in this context isn't the same object that's
+available by default inside file modules. To access it you need to
+require the `Module` module:
+
+```js
+const Module = require('module');
+
+const builtin = Module.builtinModules;
+```
+
````

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

- doc
