### PR TITLE
src: remove redundant `JSStream::DoAfterWrite`

### DIFF
--- a/lib/internal/wrap_js_stream.js
+++ b/lib/internal/wrap_js_stream.js
@@ -136,7 +136,6 @@ class JSStreamWrap extends Socket {
         if (!self._dequeue(item))
           return;
 
-        handle.doAfterWrite(req);
         handle.finishWrite(req, errCode);
       });
     }
@@ -196,7 +195,6 @@ class JSStreamWrap extends Socket {
 
         const errCode = uv.UV_ECANCELED;
         if (item.type === 'write') {
-          handle.doAfterWrite(req);
           handle.finishWrite(req, errCode);
         } else if (item.type === 'shutdown') {
           handle.finishShutdown(req, errCode);

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -169,17 +169,6 @@ void JSStream::New(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void JSStream::DoAfterWrite(const FunctionCallbackInfo<Value>& args) {
-  JSStream* wrap;
-  CHECK(args[0]->IsObject());
-  WriteWrap* w;
-  ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
-  ASSIGN_OR_RETURN_UNWRAP(&w, args[0].As<Object>());
-
-  w->Done(0);
-}
-
-
 template <class Wrap>
 void JSStream::Finish(const FunctionCallbackInfo<Value>& args) {
   Wrap* w;
@@ -234,7 +223,6 @@ void JSStream::Initialize(Local<Object> target,
 
   AsyncWrap::AddWrapMethods(env, t);
 
-  env->SetProtoMethod(t, "doAfterWrite", DoAfterWrite);
   env->SetProtoMethod(t, "finishWrite", Finish<WriteWrap>);
   env->SetProtoMethod(t, "finishShutdown", Finish<ShutdownWrap>);
   env->SetProtoMethod(t, "readBuffer", ReadBuffer);

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -37,7 +37,6 @@ class JSStream : public AsyncWrap, public StreamBase {
   AsyncWrap* GetAsyncWrap() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void DoAfterWrite(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ReadBuffer(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EmitEOF(const v8::FunctionCallbackInfo<v8::Value>& args);
 


### PR DESCRIPTION
`Finish<WriteWrap>` already does the same thing and is called immediately afterwards anyway.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

src/js_stream