### PR TITLE
napi: fixed memory leak in napi_async_init()/napi_async_destroy()

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -2770,6 +2770,8 @@ napi_status napi_async_destroy(napi_env env,
       reinterpret_cast<node::async_context*>(async_context);
   node::EmitAsyncDestroy(isolate, *node_async_context);
 
+  delete node_async_context;
+
   return napi_clear_last_error(env);
 }
 


### PR DESCRIPTION
This patch fixes memory leak related to async_context not being freed in napi_async_destroy() after being allocated in napi_async_init()

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

napi_async_init()/napi_async_destroy() in src/node_api.cc
