### PR TITLE
http2: simplify onSelectPadding

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -354,10 +354,7 @@ function onSelectPadding(fn) {
     const frameLen = paddingBuffer[PADDING_BUF_FRAME_LENGTH];
     const maxFramePayloadLen = paddingBuffer[PADDING_BUF_MAX_PAYLOAD_LENGTH];
     paddingBuffer[PADDING_BUF_RETURN_VALUE] =
-        Math.min(maxFramePayloadLen,
-                 Math.max(frameLen,
-                          fn(frameLen,
-                             maxFramePayloadLen) | 0));
+        fn(frameLen, maxFramePayloadLen) >>> 0;
   };
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -353,8 +353,7 @@ function onSelectPadding(fn) {
   return function getPadding() {
     const frameLen = paddingBuffer[PADDING_BUF_FRAME_LENGTH];
     const maxFramePayloadLen = paddingBuffer[PADDING_BUF_MAX_PAYLOAD_LENGTH];
-    paddingBuffer[PADDING_BUF_RETURN_VALUE] =
-        fn(frameLen, maxFramePayloadLen) >>> 0;
+    paddingBuffer[PADDING_BUF_RETURN_VALUE] = fn(frameLen, maxFramePayloadLen);
   };
 }
 


### PR DESCRIPTION
`OnCallbackPadding` on the native side already clamps
the return value into the right range, so there’s not need
to also do that on the JS side.

~~Also, use `>>> 0` instead of `| 0` to get an uint32, since
the communication with C++ land happens through an Uint32Array.~~

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2

CI: https://ci.nodejs.org/job/node-test-commit/14901/