### PR TITLE
lib: minor optimizations

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -21,8 +21,6 @@
 
 'use strict';
 
-var spliceOne;
-
 function EventEmitter() {
   EventEmitter.init.call(this);
 }
@@ -292,9 +290,7 @@ EventEmitter.prototype.removeListener =
         if (position === 0)
           list.shift();
         else {
-          if (spliceOne === undefined)
-            spliceOne = require('internal/util').spliceOne;
-          spliceOne(list, position);
+          list.splice(position, 1);
         }
 
         if (list.length === 1)

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -224,8 +224,11 @@ function getIdentificationOf(obj) {
       const desc = Object.getOwnPropertyDescriptor(obj, 'constructor');
       if (desc !== undefined &&
           typeof desc.value === 'function' &&
-          desc.value.name !== '')
+          desc.value.name !== '') {
         constructor = desc.value.name;
+        if (tag !== undefined)
+          break;
+      }
     }
 
     if (tag === undefined) {
@@ -238,11 +241,10 @@ function getIdentificationOf(obj) {
           if (typeof tag !== 'string')
             tag = undefined;
         }
+        if (constructor !== undefined)
+          break;
       }
     }
-
-    if (constructor !== undefined && tag !== undefined)
-      break;
 
     obj = Object.getPrototypeOf(obj);
   }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -323,13 +323,6 @@ function join(output, separator) {
   return str;
 }
 
-// About 1.5x faster than the two-arg version of Array#splice().
-function spliceOne(list, index) {
-  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-    list[i] = list[k];
-  list.pop();
-}
-
 module.exports = {
   assertCrypto,
   cachedResult,
@@ -346,7 +339,6 @@ module.exports = {
   normalizeEncoding,
   objectToString,
   promisify,
-  spliceOne,
 
   // Symbol used to customize promisify conversion
   customPromisifyArgs: kCustomPromisifyArgsSymbol,

--- a/lib/url.js
+++ b/lib/url.js
@@ -28,8 +28,6 @@ const { hexTable } = require('internal/querystring');
 
 const errors = require('internal/errors');
 
-const { spliceOne } = require('internal/util');
-
 // WHATWG URL implementation provided by internal/url
 const {
   URL,
@@ -871,12 +869,12 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   for (var i = srcPath.length - 1; i >= 0; i--) {
     last = srcPath[i];
     if (last === '.') {
-      spliceOne(srcPath, i);
+      srcPath.splice(i, 1);
     } else if (last === '..') {
-      spliceOne(srcPath, i);
+      srcPath.splice(i, 1);
       up++;
-    } else if (up) {
-      spliceOne(srcPath, i);
+    } else if (up !== 0) {
+      srcPath.splice(i, 1);
       up--;
     }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -436,12 +436,15 @@ function formatValue(ctx, value, recurseTimes, ln) {
 
   const { constructor, tag } = getIdentificationOf(value);
   var prefix = '';
-  if (constructor && tag && constructor !== tag)
-    prefix = `${constructor} [${tag}] `;
-  else if (constructor)
-    prefix = `${constructor} `;
-  else if (tag)
+  if (constructor !== undefined) {
+    if (tag !== undefined && constructor !== tag) {
+      prefix = `${constructor} [${tag}] `;
+    } else {
+      prefix = `${constructor} `;
+    }
+  } else if (tag !== undefined) {
     prefix = `[${tag}] `;
+  }
 
   var base = '';
   var formatter = formatObject;


### PR DESCRIPTION
First commit
```
lib: remove internal spliceOne 

Benchmarking the function in V8 6.3 shows that the native splice is
definitely faster than the current implementation.
```
I benchmarked this with the following benchmark that I do not want to include as I do not see a real point in testing something removed.

```js
'use strict';

const n = 1e4;

const data = Array(n).fill(0).map((_, i) =>
  (Math.random() > 0.33 ? i : {}));
const copy = JSON.parse(JSON.stringify(data));

var i = 0;

function spliceOne(list, index) {
  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
    list[i] = list[k];
  list.pop();
}

const randomAccess = [];
for (i = 0; i < n; i++) {
  randomAccess[i] = Math.floor(Math.random() * (n - i));
}

console.time('splice');
for (i = 0; i < n; i++) {
  data.splice(randomAccess[i], 1);
}
console.timeEnd('splice');


console.time('spliceOne');
for (i = 0; i < n; i++) {
  spliceOne(copy, randomAccess[i]);
}
console.timeEnd('spliceOne');
```
The outcome is similar to

```
splice: 22.399ms
spliceOne: 52.952ms
```

Second commit
```
util: optimize code paths

Just a minor refactoring of a few statements to have more ideal
code paths.
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib, util