### PR TITLE
tools: fix man pages linking regex

### DIFF
--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -419,12 +419,12 @@ function linkManPages(text) {
     /(^|\s)([a-z.]+)\((\d)([a-z]?)\)/gm,
     (match, beginning, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
-      const displayAs = `${beginning}${name}(${number}${optionalCharacter})`;
+      const displayAs = `${name}(${number}${optionalCharacter})`;
       if (BSD_ONLY_SYSCALLS.has(name)) {
-        return `<a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
+        return `${beginning}<a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
           `&sektion=${number}">${displayAs}</a>`;
       } else {
-        return `<a href="http://man7.org/linux/man-pages/man${number}` +
+        return `${beginning}<a href="http://man7.org/linux/man-pages/man${number}` +
           `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
       }
     });

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -416,7 +416,7 @@ const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 // '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
 function linkManPages(text) {
   return text.replace(
-    /\b([a-z.]+)\((\d)([a-z]?)\)/gm,
+    / ([a-z.]+)\((\d)([a-z]?)\)/gm,
     (match, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
       const displayAs = `${name}(${number}${optionalCharacter})`;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -416,10 +416,10 @@ const BSD_ONLY_SYSCALLS = new Set(['lchmod']);
 // '<a href="http://man7.org/linux/man-pages/man2/open.2.html">open(2)</a>'
 function linkManPages(text) {
   return text.replace(
-    / ([a-z.]+)\((\d)([a-z]?)\)/gm,
-    (match, name, number, optionalCharacter) => {
+    /(^|\s)([a-z.]+)\((\d)([a-z]?)\)/gm,
+    (match, beginning, name, number, optionalCharacter) => {
       // name consists of lowercase letters, number is a single digit
-      const displayAs = `${name}(${number}${optionalCharacter})`;
+      const displayAs = `${beginning}${name}(${number}${optionalCharacter})`;
       if (BSD_ONLY_SYSCALLS.has(name)) {
         return ` <a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
           `&sektion=${number}">${displayAs}</a>`;

--- a/tools/doc/html.js
+++ b/tools/doc/html.js
@@ -421,10 +421,10 @@ function linkManPages(text) {
       // name consists of lowercase letters, number is a single digit
       const displayAs = `${beginning}${name}(${number}${optionalCharacter})`;
       if (BSD_ONLY_SYSCALLS.has(name)) {
-        return ` <a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
+        return `<a href="https://www.freebsd.org/cgi/man.cgi?query=${name}` +
           `&sektion=${number}">${displayAs}</a>`;
       } else {
-        return ` <a href="http://man7.org/linux/man-pages/man${number}` +
+        return `<a href="http://man7.org/linux/man-pages/man${number}` +
           `/${name}.${number}${optionalCharacter}.html">${displayAs}</a>`;
       }
     });


### PR DESCRIPTION
The change to word boundary was breaking many doc pages. This reverts the word boundary back to space.

Fixes: https://github.com/nodejs/node/issues/17637
Fixes: https://github.com/nodejs/node/issues/17694
Refs: https://github.com/nodejs/node/pull/17479

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tools, doc
