### PR TITLE
Add tests to improve internal/crypto/diffiehellman.js coverage

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -22,6 +22,13 @@ assert.strictEqual(secret2.toString('base64'), secret1);
 assert.strictEqual(dh1.verifyError, 0);
 assert.strictEqual(dh2.verifyError, 0);
 
+{
+  const DiffieHellman = crypto.DiffieHellman;
+  const dh = DiffieHellman(p1, 'buffer');
+  assert(dh instanceof DiffieHellman, 'DiffieHellman is expected to return a ' +
+                                      'new instance when called without `new`');
+}
+
 [
   [0x1, 0x2],
   () => { },

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -31,17 +31,17 @@ assert.strictEqual(dh2.verifyError, 0);
 
 {
   const DiffieHellmanGroup = crypto.DiffieHellmanGroup;
-  const dh = DiffieHellmanGroup('modp5');
-  assert(dh instanceof DiffieHellmanGroup, 'DiffieHellmanGroup is expected to' +
-                                           ' return a new instance when ' +
-                                           'called without `new`');
+  const dhg = DiffieHellmanGroup('modp5');
+  assert(dhg instanceof DiffieHellmanGroup, 'DiffieHellmanGroup is expected ' +
+                                            'to return a new instance when ' +
+                                            'called without `new`');
 }
 
 {
   const ECDH = crypto.ECDH;
-  const dh = ECDH('prime256v1');
-  assert(dh instanceof ECDH, 'ECDH is expected to return a new instance when ' +
-                             'called without `new`');
+  const ecdh = ECDH('prime256v1');
+  assert(ecdh instanceof ECDH, 'ECDH is expected to return a new instance ' +
+                               'when called without `new`');
 }
 
 [

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -37,6 +37,13 @@ assert.strictEqual(dh2.verifyError, 0);
                                            'called without `new`');
 }
 
+{
+  const ECDH = crypto.ECDH;
+  const dh = ECDH('prime256v1');
+  assert(dh instanceof ECDH, 'ECDH is expected to return a new instance when ' +
+                             'called without `new`');
+}
+
 [
   [0x1, 0x2],
   () => { },

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -29,6 +29,14 @@ assert.strictEqual(dh2.verifyError, 0);
                                       'new instance when called without `new`');
 }
 
+{
+  const DiffieHellmanGroup = crypto.DiffieHellmanGroup;
+  const dh = DiffieHellmanGroup('modp5');
+  assert(dh instanceof DiffieHellmanGroup, 'DiffieHellmanGroup is expected to' +
+                                           ' return a new instance when ' +
+                                           'called without `new`');
+}
+
 [
   [0x1, 0x2],
   () => { },


### PR DESCRIPTION
I added these tests

- Call crypto.ECDH without new keyword
- Call crypto.DiffieHellmanGroup without new keyword
- Call crypto.DiffieHellman without new keyword

Current coverage is here: https://coverage.nodejs.org/coverage-1fa59b4c7e575ca7/root/internal/crypto/diffiehellman.js.html

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test