### PR TITLE
Add tests to improve internal/crypto/pbkdf2.js coverage

### DIFF
--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -65,6 +65,15 @@ common.expectsError(
   }
 );
 
+common.expectsError(
+  () => crypto.pbkdf2Sync('password', 'salt', -1, 20, null),
+  {
+    code: 'ERR_OUT_OF_RANGE',
+    type: RangeError,
+    message: 'The "iterations" argument is out of range'
+  }
+);
+
 [Infinity, -Infinity, NaN, -1, 4073741824, INT_MAX + 1].forEach((i) => {
   common.expectsError(
     () => {

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -74,6 +74,17 @@ common.expectsError(
   }
 );
 
+['str', null, undefined, [], {}].forEach((i) => {
+  common.expectsError(
+    () => {
+      crypto.pbkdf2Sync('password', 'salt', 1, i, 'sha256');
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError,
+      message: 'The "keylen" argument must be of type number'
+    });
+});
+
 [Infinity, -Infinity, NaN, -1, 4073741824, INT_MAX + 1].forEach((i) => {
   common.expectsError(
     () => {

--- a/test/parallel/test-crypto-pbkdf2.js
+++ b/test/parallel/test-crypto-pbkdf2.js
@@ -74,10 +74,10 @@ common.expectsError(
   }
 );
 
-['str', null, undefined, [], {}].forEach((i) => {
+['str', null, undefined, [], {}].forEach((notNumber) => {
   common.expectsError(
     () => {
-      crypto.pbkdf2Sync('password', 'salt', 1, i, 'sha256');
+      crypto.pbkdf2Sync('password', 'salt', 1, notNumber, 'sha256');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError,


### PR DESCRIPTION
I added these tests

- Add a test of _pbkdf2 where keylen is not a number
- Add a test of _pbkdf2 where iterations < 0

Current coverage is here: https://coverage.nodejs.org/coverage-1fa59b4c7e575ca7/root/internal/crypto/diffiehellman.js.html

I cannot write a test where PBKDF2 returns -1.
I think it is coverage blockers so I create an issue (#17731).

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test