### PR TITLE
test: change callback function to arrow function

### DIFF
--- a/test/parallel/test-domain-no-error-handler-abort-on-uncaught-9.js
+++ b/test/parallel/test-domain-no-error-handler-abort-on-uncaught-9.js
@@ -10,8 +10,8 @@ function test() {
   d.on('error', function errorHandler() {
   });
 
-  d.run(function() {
-    d2.run(function() {
+  d.run(() => {
+    d2.run(() => {
       const fs = require('fs');
       fs.exists('/non/existing/file', function onExists() {
         throw new Error('boom!');


### PR DESCRIPTION
Refactored some callback functions to arrow functions
This is practice on code-and-learn for contributing oss.
nodejs/code-and-learn#78

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test