### PR TITLE
tls: comment about old-style errors

### DIFF
--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -632,6 +632,8 @@ function onhandshakestart() {
     // state machine and OpenSSL is not re-entrant. We cannot allow the user's
     // callback to destroy the connection right now, it would crash and burn.
     setImmediate(function() {
+      // Old-style error is not being migrated to the newer style
+      // internal/errors.js because _tls_legacy.js has been depreciated.
       var err = new Error('TLS session renegotiation attack detected');
       if (self.cleartext) self.cleartext.emit('error', err);
     });

--- a/lib/_tls_legacy.js
+++ b/lib/_tls_legacy.js
@@ -633,7 +633,7 @@ function onhandshakestart() {
     // callback to destroy the connection right now, it would crash and burn.
     setImmediate(function() {
       // Old-style error is not being migrated to the newer style
-      // internal/errors.js because _tls_legacy.js has been depreciated.
+      // internal/errors.js because _tls_legacy.js has been deprecated.
       var err = new Error('TLS session renegotiation attack detected');
       if (self.cleartext) self.cleartext.emit('error', err);
     });


### PR DESCRIPTION
Old style errors are being migrated to internal/errors.js, however, due to depreciation of _tls_legacy.js, it isn't worth the effort to migrate and potentially force users to update their code for this error change.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)
