### PR TITLE
[v8.x backport] test,doc: do not indicate that non-functions "return" values

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -42,12 +42,14 @@ A stream to push an array into a REPL
 
 Blocks for `time` amount of time.
 
-### canCreateSymLink
-API to indicate whether the current running process can create
-symlinks. On Windows, this returns false if the process running
-doesn't have privileges to create symlinks (specifically
-[SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)).
-On non-Windows platforms, this currently returns true.
+### canCreateSymLink()
+* return [&lt;Boolean>]
+
+Checks whether the current running process can create symlinks. On Windows, this
+returns `false` if the process running doesn't have privileges to create
+symlinks
+([SeCreateSymbolicLinkPrivilege](https://msdn.microsoft.com/en-us/library/windows/desktop/bb530716(v=vs.85).aspx)).
+On non-Windows platforms, this always returns `true`.
 
 ### crashOnUnhandledRejection()
 
@@ -62,9 +64,9 @@ failures.
 Platform normalizes the `dd` command
 
 ### enoughTestMem
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Check if there is more than 1gb of total memory.
+Indicates if there is more than 1gb of total memory.
 
 ### expectsError([fn, ]settings[, exact])
 * `fn` [&lt;Function>] a function that should throw.
@@ -137,39 +139,39 @@ Returns an instance of all possible `ArrayBufferView`s of the provided Buffer.
 Returns the file name and line number for the provided Function.
 
 ### globalCheck
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Turn this off if the test should not check for global leaks.
+Set to `false` if the test should not check for global leaks.
 
 ### hasCrypto
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks for 'openssl'.
+Indicates whether OpenSSL is available.
 
 ### hasFipsCrypto
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks `hasCrypto` and `crypto` with fips.
+Indicates `hasCrypto` and `crypto` with fips.
 
 ### hasIntl
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks if [internationalization] is supported.
+Indicates if [internationalization] is supported.
 
 ### hasSmallICU
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks `hasIntl` and `small-icu` is supported.
+Indicates `hasIntl` and `small-icu` are supported.
 
 ### hasIPv6
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks whether `IPv6` is supported on this platform.
+Indicates whether `IPv6` is supported on this platform.
 
 ### hasMultiLocalhost
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks if there are multiple localhosts available.
+Indicates if there are multiple localhosts available.
 
 ### hijackStderr(listener)
 * `listener` [&lt;Function>]: a listener with a single parameter
@@ -190,12 +192,12 @@ be passed to `listener`. What's more, `process.stdout.writeTimes` is a count of
 the number of calls.
 
 ### inFreeBSDJail
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Checks whether free BSD Jail is true or false.
 
 ### isAIX
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Advanced Interactive eXecutive (AIX).
 
@@ -206,54 +208,54 @@ Platform check for Advanced Interactive eXecutive (AIX).
 Attempts to 'kill' `pid`
 
 ### isFreeBSD
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Free BSD.
 
 ### isLinux
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Linux.
 
 ### isLinuxPPCBE
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Linux on PowerPC.
 
 ### isOSX
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for macOS.
 
 ### isSunOS
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for SunOS.
 
 ### isWindows
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Windows.
 
 ### isWOW64
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
 Platform check for Windows 32-bit on Windows 64-bit.
 
-### leakedGlobals
+### leakedGlobals()
 * return [&lt;Array>]
 
-Checks whether any globals are not on the `knownGlobals` list.
+Indicates whether any globals are not on the `knownGlobals` list.
 
 ### localhostIPv4
-* return [&lt;String>]
+* [&lt;String>]
 
-Gets IP of localhost
+IP of `localhost`.
 
 ### localIPv6Hosts
-* return [&lt;Array>]
+* [&lt;Array>]
 
-Array of IPV6 hosts.
+Array of IPV6 representations for `localhost`.
 
 ### mustCall([fn][, exact])
 * `fn` [&lt;Function>] default = () => {}
@@ -294,9 +296,9 @@ the exit code and/or signal name of a node process that aborted, `false`
 otherwise.
 
 ### opensslCli
-* return [&lt;Boolean>]
+* [&lt;Boolean>]
 
-Checks whether 'opensslCli' is supported.
+Indicates whether 'opensslCli' is supported.
 
 ### platformTimeout(ms)
 * `ms` [&lt;Number>]
@@ -305,14 +307,14 @@ Checks whether 'opensslCli' is supported.
 Platform normalizes timeout.
 
 ### PIPE
-* return [&lt;String>]
+* [&lt;String>]
 
-Path to the test sock.
+Path to the test socket.
 
 ### PORT
-* return [&lt;Number>] default = `12346`
+* [&lt;Number>]
 
-Port tests are running on.
+A port number for tests to use if one is needed.
 
 ### printSkipMessage(msg)
 * `msg` [&lt;String>]
@@ -335,12 +337,12 @@ Restore the original `process.stdout.write`. Used to restore `stdout` to its
 original state after calling [`common.hijackStdOut()`][].
 
 ### rootDir
-* return [&lt;String>]
+* [&lt;String>]
 
 Path to the 'root' directory. either `/` or `c:\\` (windows)
 
 ### projectDir
-* return [&lt;String>]
+* [&lt;String>]
 
 Path to the project directory.
 
@@ -372,7 +374,7 @@ Platform normalizes the `pwd` command.
 Synchronous version of `spawnPwd`.
 
 ### tmpDir
-* return [&lt;String>]
+* [&lt;String>]
 
 The realpath of the 'tmp' directory.
 


### PR DESCRIPTION
Update documentation for test `common` module so that properties that
are not functions do not specify a return type and functions that do
return values specify the type.

PR-URL: https://github.com/nodejs/node/pull/17267
Reviewed-By: Vse Mozhet Byt <vsemozhetbyt@gmail.com>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test doc