### PR TITLE
[8.x backport] test: remove common.fixturesDir 

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -124,11 +124,6 @@ Returns a new promise that will propagate `promise` resolution or rejection if
 that happens within the `timeoutMs` timespan, or rejects with `error` as
 a reason otherwise.
 
-### fixturesDir
-* return [&lt;String>]
-
-Path to the 'fixtures' directory.
-
 ### getArrayBufferViews(buf)
 * `buf` [&lt;Buffer>]
 * return [&lt;ArrayBufferView&#91;&#93;>]

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -36,8 +36,6 @@ const testRoot = process.env.NODE_TEST_DIR ?
 
 const noop = () => {};
 
-exports.fixturesDir = fixturesDir;
-
 // Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
 // gets tools to ignore it by default or by simple rules, especially eslint.
 let tmpDirName = '.tmp';
@@ -314,7 +312,7 @@ exports.childShouldThrowAndAbort = function() {
 
 exports.ddCommand = function(filename, kilobytes) {
   if (exports.isWindows) {
-    const p = path.resolve(exports.fixturesDir, 'create-file.js');
+    const p = path.resolve(fixturesDir, 'create-file.js');
     return `"${process.argv[0]}" "${p}" "${filename}" ${kilobytes * 1024}`;
   } else {
     return `dd if=/dev/zero of="${filename}" bs=1024 count=${kilobytes}`;

--- a/test/parallel/test-tls-interleave.js
+++ b/test/parallel/test-tls-interleave.js
@@ -26,15 +26,13 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-
 const tls = require('tls');
 
-const fs = require('fs');
+const fixtures = require('../common/fixtures');
 
-const dir = common.fixturesDir;
-const options = { key: fs.readFileSync(`${dir}/test_key.pem`),
-                  cert: fs.readFileSync(`${dir}/test_cert.pem`),
-                  ca: [ fs.readFileSync(`${dir}/test_ca.pem`) ] };
+const options = { key: fixtures.readSync('test_key.pem'),
+                  cert: fixtures.readSync('test_cert.pem'),
+                  ca: [ fixtures.readSync('test_ca.pem') ] };
 
 const writes = [
   'some server data',

--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -26,14 +26,15 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
-const fs = require('fs');
 const tls = require('tls');
+
+const fixtures = require('../common/fixtures');
 
 let received = '';
 
 const server = tls.createServer({
-  key: fs.readFileSync(`${common.fixturesDir}/keys/agent1-key.pem`),
-  cert: fs.readFileSync(`${common.fixturesDir}/keys/agent1-cert.pem`)
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 }, common.mustCall(function(c) {
   c._write('hello ', null, common.mustCall(function() {
     c._write('world!', null, common.mustCall(function() {


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/17400

Remove common.fixturesDir. All tests now use the the common/fixtures
module instead.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test doc