### PR TITLE
[v6.x backport] test: remove hidden use of common.PORT in parallel tests

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -466,7 +466,7 @@ function _mustCallInner(fn, criteria, field) {
 exports.hasMultiLocalhost = function hasMultiLocalhost() {
   const TCP = process.binding('tcp_wrap').TCP;
   const t = new TCP();
-  const ret = t.bind('127.0.0.2', exports.PORT);
+  const ret = t.bind('127.0.0.2', 0);
   t.close();
   return ret === 0;
 };


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/17466

common.hasMultiLocalhost() uses common.PORT under the hood. This is
problematic in parallel tests because another test using port 0 to
get an arbitrary open port may end up getting common.PORT before the
test using common.PORT gets it.

Therefore, change common.PORT to port 0 in common.hasMultiLocalhost().

PR-URL: https://github.com/nodejs/node/pull/17466
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: Jon Moss <me@jonathanmoss.me>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Michael Dawson <michael_dawson@ca.ibm.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test