### PR TITLE
 async_hooks: use typed array stack as fast path 

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -26,7 +26,7 @@ const async_wrap = process.binding('async_wrap');
  * It has a fixed size, so if that is exceeded, calls to the native
  * side are used instead in pushAsyncIds() and popAsyncIds().
  */
-const { async_hook_fields, async_id_fields, async_ids_fast_stack } = async_wrap;
+const { async_hook_fields, async_id_fields } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a std::stack on
 // Environment::AsyncHooks::ids_stack_ tracks the resource responsible for the
 // current execution stack. This is unwound as each resource exits. In the case
@@ -68,7 +68,7 @@ const active_hooks = {
 const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
         kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
         kDefaultTriggerAsyncId, kStackLength,
-        kFastStackCapacity } = async_wrap.constants;
+        kStackCapacity } = async_wrap.constants;
 
 // Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
@@ -342,11 +342,11 @@ function emitDestroyScript(asyncId) {
 // This is the equivalent of the native push_async_ids() call.
 function pushAsyncIds(asyncId, triggerAsyncId) {
   const stackLength = async_hook_fields[kStackLength];
-  if (stackLength >= kFastStackCapacity)
+  if (stackLength >= async_hook_fields[kStackCapacity])
     return pushAsyncIds_(asyncId, triggerAsyncId);
   const offset = stackLength;
-  async_ids_fast_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
-  async_ids_fast_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
+  async_wrap.async_ids_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
+  async_wrap.async_ids_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
   async_hook_fields[kStackLength]++;
   async_id_fields[kExecutionAsyncId] = asyncId;
   async_id_fields[kTriggerAsyncId] = triggerAsyncId;
@@ -358,15 +358,15 @@ function popAsyncIds(asyncId) {
   if (async_hook_fields[kStackLength] === 0) return false;
   const stackLength = async_hook_fields[kStackLength];
 
-  if (stackLength > kFastStackCapacity ||
-        (async_hook_fields[kCheck] > 0 &&
-         async_id_fields[kExecutionAsyncId] !== asyncId)) {
+  if (async_hook_fields[kCheck] > 0 &&
+      async_id_fields[kExecutionAsyncId] !== asyncId) {
+    // Do the same thing as the native code (i.e. crash hard).
     return popAsyncIds_(asyncId);
   }
 
   const offset = stackLength - 1;
-  async_id_fields[kExecutionAsyncId] = async_ids_fast_stack[2 * offset];
-  async_id_fields[kTriggerAsyncId] = async_ids_fast_stack[2 * offset + 1];
+  async_id_fields[kExecutionAsyncId] = async_wrap.async_ids_stack[2 * offset];
+  async_id_fields[kTriggerAsyncId] = async_wrap.async_ids_stack[2 * offset + 1];
   async_hook_fields[kStackLength] = offset;
   return offset > 0;
 }

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -67,8 +67,7 @@ const active_hooks = {
 // for a given step, that step can bail out early.
 const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
         kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
-        kDefaultTriggerAsyncId, kStackLength,
-        kStackCapacity } = async_wrap.constants;
+        kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
 // Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
@@ -341,10 +340,9 @@ function emitDestroyScript(asyncId) {
 
 // This is the equivalent of the native push_async_ids() call.
 function pushAsyncIds(asyncId, triggerAsyncId) {
-  const stackLength = async_hook_fields[kStackLength];
-  if (stackLength >= async_hook_fields[kStackCapacity])
+  const offset = async_hook_fields[kStackLength];
+  if (offset * 2 >= async_wrap.async_ids_stack.length)
     return pushAsyncIds_(asyncId, triggerAsyncId);
-  const offset = stackLength;
   async_wrap.async_ids_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
   async_wrap.async_ids_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
   async_hook_fields[kStackLength]++;

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -19,14 +19,20 @@ const async_wrap = process.binding('async_wrap');
  *    retrieving the triggerAsyncId value is passing directly to the
  *    constructor -> value set in kDefaultTriggerAsyncId -> executionAsyncId of
  *    the current resource.
+ *
+ * async_ids_fast_stack is a Float64Array that contains part of the async ID
+ * stack. Each pushAsyncIds() call adds two doubles to it, and each
+ * popAsyncIds() call removes two doubles from it.
+ * It has a fixed size, so if that is exceeded, calls to the native
+ * side are used instead in pushAsyncIds() and popAsyncIds().
  */
-const { async_hook_fields, async_id_fields } = async_wrap;
+const { async_hook_fields, async_id_fields, async_ids_fast_stack } = async_wrap;
 // Store the pair executionAsyncId and triggerAsyncId in a std::stack on
 // Environment::AsyncHooks::ids_stack_ tracks the resource responsible for the
 // current execution stack. This is unwound as each resource exits. In the case
 // of a fatal exception this stack is emptied after calling each hook's after()
 // callback.
-const { pushAsyncIds, popAsyncIds } = async_wrap;
+const { pushAsyncIds: pushAsyncIds_, popAsyncIds: popAsyncIds_ } = async_wrap;
 // For performance reasons, only track Proimses when a hook is enabled.
 const { enablePromiseHook, disablePromiseHook } = async_wrap;
 // Properties in active_hooks are used to keep track of the set of hooks being
@@ -60,8 +66,9 @@ const active_hooks = {
 // async execution. These are tracked so if the user didn't include callbacks
 // for a given step, that step can bail out early.
 const { kInit, kBefore, kAfter, kDestroy, kPromiseResolve,
-        kCheck, kExecutionAsyncId, kAsyncIdCounter,
-        kDefaultTriggerAsyncId } = async_wrap.constants;
+        kCheck, kExecutionAsyncId, kAsyncIdCounter, kTriggerAsyncId,
+        kDefaultTriggerAsyncId, kStackLength,
+        kFastStackCapacity } = async_wrap.constants;
 
 // Used in AsyncHook and AsyncResource.
 const init_symbol = Symbol('init');
@@ -329,6 +336,39 @@ function emitDestroyScript(asyncId) {
   if (async_hook_fields[kDestroy] === 0 || asyncId <= 0)
     return;
   async_wrap.queueDestroyAsyncId(asyncId);
+}
+
+
+// This is the equivalent of the native push_async_ids() call.
+function pushAsyncIds(asyncId, triggerAsyncId) {
+  const stackLength = async_hook_fields[kStackLength];
+  if (stackLength >= kFastStackCapacity)
+    return pushAsyncIds_(asyncId, triggerAsyncId);
+  const offset = stackLength;
+  async_ids_fast_stack[offset * 2] = async_id_fields[kExecutionAsyncId];
+  async_ids_fast_stack[offset * 2 + 1] = async_id_fields[kTriggerAsyncId];
+  async_hook_fields[kStackLength]++;
+  async_id_fields[kExecutionAsyncId] = asyncId;
+  async_id_fields[kTriggerAsyncId] = triggerAsyncId;
+}
+
+
+// This is the equivalent of the native pop_async_ids() call.
+function popAsyncIds(asyncId) {
+  if (async_hook_fields[kStackLength] === 0) return false;
+  const stackLength = async_hook_fields[kStackLength];
+
+  if (stackLength > kFastStackCapacity ||
+        (async_hook_fields[kCheck] > 0 &&
+         async_id_fields[kExecutionAsyncId] !== asyncId)) {
+    return popAsyncIds_(asyncId);
+  }
+
+  const offset = stackLength - 1;
+  async_id_fields[kExecutionAsyncId] = async_ids_fast_stack[2 * offset];
+  async_id_fields[kTriggerAsyncId] = async_ids_fast_stack[2 * offset + 1];
+  async_hook_fields[kStackLength] = offset;
+  return offset > 0;
 }
 
 

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -367,9 +367,9 @@
     // Arrays containing hook flags and ids for async_hook calls.
     const { async_hook_fields, async_id_fields } = async_wrap;
     // Internal functions needed to manipulate the stack.
-    const { clearAsyncIdStack, asyncIdStackSize } = async_wrap;
+    const { clearAsyncIdStack } = async_wrap;
     const { kAfter, kExecutionAsyncId,
-            kDefaultTriggerAsyncId } = async_wrap.constants;
+            kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
     process._fatalException = function(er) {
       var caught;
@@ -407,7 +407,7 @@
           do {
             NativeModule.require('internal/async_hooks').emitAfter(
               async_id_fields[kExecutionAsyncId]);
-          } while (asyncIdStackSize() > 0);
+          } while (async_hook_fields[kStackLength] > 0);
         // Or completely empty the id stack.
         } else {
           clearAsyncIdStack();

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -207,6 +207,10 @@ class AliasedBuffer {
     return GetValue(index);
   }
 
+  size_t Length() const {
+    return count_;
+  }
+
  private:
   v8::Isolate* isolate_;
   size_t count_;

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -95,6 +95,21 @@ class AliasedBuffer {
     js_array_.Reset();
   }
 
+  AliasedBuffer& operator=(AliasedBuffer&& that) {
+    this->~AliasedBuffer();
+    isolate_ = that.isolate_;
+    count_ = that.count_;
+    byte_offset_ = that.byte_offset_;
+    buffer_ = that.buffer_;
+    free_buffer_ = that.free_buffer_;
+
+    js_array_.Reset(isolate_, that.js_array_.Get(isolate_));
+
+    that.buffer_ = nullptr;
+    that.js_array_.Reset();
+    return *this;
+  }
+
   /**
    * Helper class that is returned from operator[] to support assignment into
    * a specified location.
@@ -193,7 +208,7 @@ class AliasedBuffer {
   }
 
  private:
-  v8::Isolate* const isolate_;
+  v8::Isolate* isolate_;
   size_t count_;
   size_t byte_offset_;
   NativeT* buffer_;

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -111,9 +111,15 @@ class AliasedBuffer {
           index_(that.index_) {
     }
 
-    inline Reference& operator=(const NativeT &val) {
+    template <typename T>
+    inline Reference& operator=(const T& val) {
       aliased_buffer_->SetValue(index_, val);
       return *this;
+    }
+
+    // This is not caught by the template operator= above.
+    inline Reference& operator=(const Reference& val) {
+      return *this = static_cast<NativeT>(val);
     }
 
     operator NativeT() const {

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -543,10 +543,9 @@ void AsyncWrap::Initialize(Local<Object> target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());
 
-  FORCE_SET_TARGET_FIELD(target,
-                         "async_ids_fast_stack",
-                         env->async_hooks()->async_ids_fast_stack()
-                            .GetJSArray());
+  target->Set(context,
+              env->async_ids_stack_string(),
+              env->async_hooks()->async_ids_stack().GetJSArray()).FromJust();
 
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \
@@ -565,7 +564,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
   SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
   SET_HOOKS_CONSTANT(kStackLength);
-  SET_HOOKS_CONSTANT(kFastStackCapacity);
+  SET_HOOKS_CONSTANT(kStackCapacity);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);
 
@@ -595,6 +594,7 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->set_async_hooks_after_function(Local<Function>());
   env->set_async_hooks_destroy_function(Local<Function>());
   env->set_async_hooks_promise_resolve_function(Local<Function>());
+  env->set_async_hooks_binding(target);
 }
 
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -564,7 +564,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
   SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
   SET_HOOKS_CONSTANT(kStackLength);
-  SET_HOOKS_CONSTANT(kStackCapacity);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);
 

--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -468,13 +468,6 @@ void AsyncWrap::PopAsyncIds(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void AsyncWrap::AsyncIdStackSize(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  args.GetReturnValue().Set(
-      static_cast<double>(env->async_hooks()->stack_size()));
-}
-
-
 void AsyncWrap::ClearAsyncIdStack(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   env->async_hooks()->clear_async_id_stack();
@@ -513,7 +506,6 @@ void AsyncWrap::Initialize(Local<Object> target,
   env->SetMethod(target, "setupHooks", SetupHooks);
   env->SetMethod(target, "pushAsyncIds", PushAsyncIds);
   env->SetMethod(target, "popAsyncIds", PopAsyncIds);
-  env->SetMethod(target, "asyncIdStackSize", AsyncIdStackSize);
   env->SetMethod(target, "clearAsyncIdStack", ClearAsyncIdStack);
   env->SetMethod(target, "queueDestroyAsyncId", QueueDestroyAsyncId);
   env->SetMethod(target, "enablePromiseHook", EnablePromiseHook);
@@ -551,6 +543,11 @@ void AsyncWrap::Initialize(Local<Object> target,
                          "async_id_fields",
                          env->async_hooks()->async_id_fields().GetJSArray());
 
+  FORCE_SET_TARGET_FIELD(target,
+                         "async_ids_fast_stack",
+                         env->async_hooks()->async_ids_fast_stack()
+                            .GetJSArray());
+
   Local<Object> constants = Object::New(isolate);
 #define SET_HOOKS_CONSTANT(name)                                              \
   FORCE_SET_TARGET_FIELD(                                                     \
@@ -567,6 +564,8 @@ void AsyncWrap::Initialize(Local<Object> target,
   SET_HOOKS_CONSTANT(kTriggerAsyncId);
   SET_HOOKS_CONSTANT(kAsyncIdCounter);
   SET_HOOKS_CONSTANT(kDefaultTriggerAsyncId);
+  SET_HOOKS_CONSTANT(kStackLength);
+  SET_HOOKS_CONSTANT(kFastStackCapacity);
 #undef SET_HOOKS_CONSTANT
   FORCE_SET_TARGET_FIELD(target, "constants", constants);
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -122,7 +122,6 @@ class AsyncWrap : public BaseObject {
   static void GetAsyncId(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PushAsyncIds(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void PopAsyncIds(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void AsyncIdStackSize(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ClearAsyncIdStack(
     const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AsyncReset(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -66,9 +66,6 @@ inline Environment::AsyncHooks::AsyncHooks()
   // and flag changes won't be included.
   fields_[kCheck] = 1;
 
-  // async_ids_stack_ was initialized to store 16 async_context structs.
-  fields_[kStackCapacity] = 16;
-
   // kDefaultTriggerAsyncId should be -1, this indicates that there is no
   // specified default value and it should fallback to the executionAsyncId.
   // 0 is not used as the magic value, because that indicates a missing context
@@ -133,7 +130,7 @@ inline void Environment::AsyncHooks::push_async_ids(double async_id,
   }
 
   uint32_t offset = fields_[kStackLength];
-  if (offset >= fields_[kStackCapacity])
+  if (offset * 2 >= async_ids_stack_.Length())
     grow_async_ids_stack();
   async_ids_stack_[2 * offset] = async_id_fields_[kExecutionAsyncId];
   async_ids_stack_[2 * offset + 1] = async_id_fields_[kTriggerAsyncId];
@@ -168,7 +165,6 @@ inline bool Environment::AsyncHooks::pop_async_id(double async_id) {
   }
 
   uint32_t offset = fields_[kStackLength] - 1;
-  CHECK_LT(offset, fields_[kStackCapacity]);
   async_id_fields_[kExecutionAsyncId] = async_ids_stack_[2 * offset];
   async_id_fields_[kTriggerAsyncId] = async_ids_stack_[2 * offset + 1];
   fields_[kStackLength] = offset;

--- a/src/env.cc
+++ b/src/env.cc
@@ -405,7 +405,7 @@ void Environment::CollectUVExceptionInfo(v8::Local<v8::Value> object,
 
 
 void Environment::AsyncHooks::grow_async_ids_stack() {
-  const uint32_t old_capacity = fields_[kStackCapacity];
+  const uint32_t old_capacity = async_ids_stack_.Length() / 2;
   const uint32_t new_capacity = old_capacity * 1.5;
   AliasedBuffer<double, v8::Float64Array> new_buffer(
       env()->isolate(), new_capacity * 2);
@@ -413,7 +413,6 @@ void Environment::AsyncHooks::grow_async_ids_stack() {
   for (uint32_t i = 0; i < old_capacity * 2; ++i)
     new_buffer[i] = async_ids_stack_[i];
   async_ids_stack_ = std::move(new_buffer);
-  fields_[kStackCapacity] = new_capacity;
 
   env()->async_hooks_binding()->Set(
       env()->context(),

--- a/src/env.cc
+++ b/src/env.cc
@@ -403,4 +403,22 @@ void Environment::CollectUVExceptionInfo(v8::Local<v8::Value> object,
                              syscall, message, path, dest);
 }
 
+
+void Environment::AsyncHooks::grow_async_ids_stack() {
+  const uint32_t old_capacity = fields_[kStackCapacity];
+  const uint32_t new_capacity = old_capacity * 1.5;
+  AliasedBuffer<double, v8::Float64Array> new_buffer(
+      env()->isolate(), new_capacity * 2);
+
+  for (uint32_t i = 0; i < old_capacity * 2; ++i)
+    new_buffer[i] = async_ids_stack_[i];
+  async_ids_stack_ = std::move(new_buffer);
+  fields_[kStackCapacity] = new_capacity;
+
+  env()->async_hooks_binding()->Set(
+      env()->context(),
+      env()->async_ids_stack_string(),
+      async_ids_stack_.GetJSArray()).FromJust();
+}
+
 }  // namespace node

--- a/src/env.h
+++ b/src/env.h
@@ -41,7 +41,6 @@
 #include <map>
 #include <stdint.h>
 #include <vector>
-#include <stack>
 #include <unordered_map>
 
 struct nghttp2_rcbuf;
@@ -372,7 +371,6 @@ class Environment {
       kTotals,
       kCheck,
       kStackLength,
-      kStackCapacity,
       kFieldsCount,
     };
 

--- a/src/env.h
+++ b/src/env.h
@@ -313,11 +313,6 @@ class ModuleWrap;
 
 class Environment;
 
-struct node_async_ids {
-  double async_id;
-  double trigger_async_id;
-};
-
 class IsolateData {
  public:
   IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
@@ -424,7 +419,7 @@ class Environment {
     // Used by provider_string().
     v8::Isolate* isolate_;
     // Stores the ids of the current execution context stack.
-    std::stack<struct node_async_ids> async_ids_stack_;
+    std::stack<async_context> async_ids_stack_;
     // Attached to a Uint32Array that tracks the number of active hooks for
     // each type.
     AliasedBuffer<uint32_t, v8::Uint32Array> fields_;

--- a/src/env.h
+++ b/src/env.h
@@ -369,6 +369,7 @@ class Environment {
       kPromiseResolve,
       kTotals,
       kCheck,
+      kStackLength,
       kFieldsCount,
     };
 
@@ -380,10 +381,15 @@ class Environment {
       kUidFieldsCount,
     };
 
+    enum FastStackFields {
+      kFastStackCapacity = 64
+    };
+
     AsyncHooks() = delete;
 
     inline AliasedBuffer<uint32_t, v8::Uint32Array>& fields();
     inline AliasedBuffer<double, v8::Float64Array>& async_id_fields();
+    inline AliasedBuffer<double, v8::Float64Array>& async_ids_fast_stack();
 
     inline v8::Local<v8::String> provider_string(int idx);
 
@@ -391,7 +397,6 @@ class Environment {
 
     inline void push_async_ids(double async_id, double trigger_async_id);
     inline bool pop_async_id(double async_id);
-    inline size_t stack_size();
     inline void clear_async_id_stack();  // Used in fatal exceptions.
 
     // Used to set the kDefaultTriggerAsyncId in a scope. This is instead of
@@ -420,6 +425,9 @@ class Environment {
     v8::Isolate* isolate_;
     // Stores the ids of the current execution context stack.
     std::stack<async_context> async_ids_stack_;
+    // Stores the ids of the current execution context stack with limited
+    // capacity, but with the benefit of much faster access from JS.
+    AliasedBuffer<double, v8::Float64Array> async_ids_fast_stack_;
     // Attached to a Uint32Array that tracks the number of active hooks for
     // each type.
     AliasedBuffer<uint32_t, v8::Uint32Array> fields_;

--- a/test/parallel/test-async-hooks-recursive-stack.js
+++ b/test/parallel/test-async-hooks-recursive-stack.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const async_hooks = require('async_hooks');
+
+// This test verifies that the async ID stack can grow indefinitely.
+
+function recurse(n) {
+  const a = new async_hooks.AsyncResource('foobar');
+  a.emitBefore();
+  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  if (n >= 0)
+    recurse(n - 1);
+  assert.strictEqual(a.asyncId(), async_hooks.executionAsyncId());
+  assert.strictEqual(a.triggerAsyncId(), async_hooks.triggerAsyncId());
+  a.emitAfter();
+}
+
+recurse(1000);


### PR DESCRIPTION
- Communicate the current async stack length through a
  typed array field rather than a native binding method
- Add a new fixed-size `async_ids_fast_stack` typed array
  that contains the async ID stack up to a fixed limit.
  This increases performance noticeably, since most of the time
  the async ID stack will not be more than a handful of
  levels deep.
- Make the JS `pushAsyncIds()` and `popAsyncIds()` functions
  do the same thing as the native ones if the fast path
  is applicable.

Benchmarks:

    $ ./node benchmark/compare.js --new ./node --old ./node-master --runs 10 --filter next-tick process | Rscript benchmark/compare.R
    [00:03:25|% 100| 6/6 files | 20/20 runs | 1/1 configs]: Done
                                                   improvement confidence      p.value
     process/next-tick-breadth-args.js millions=4     19.72 %        *** 3.013913e-06
     process/next-tick-breadth.js millions=4          27.33 %        *** 5.847983e-11
     process/next-tick-depth-args.js millions=12      40.08 %        *** 1.237127e-13
     process/next-tick-depth.js millions=12           77.27 %        *** 1.413290e-11
     process/next-tick-exec-args.js millions=5        13.58 %        *** 1.245180e-07
     process/next-tick-exec.js millions=5             16.80 %        *** 2.961386e-07

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

async_hooks