### PR TITLE
Remove uncommon functions from common module

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -340,11 +340,6 @@ original state after calling [`common.hijackStdOut()`][].
 
 Path to the 'root' directory. either `/` or `c:\\` (windows)
 
-### projectDir
-* [&lt;String>]
-
-Path to the project directory.
-
 ### skip(msg)
 * `msg` [&lt;String>]
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -851,12 +851,3 @@ exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
 exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');
 exports.restoreStderr = restoreWritable.bind(null, 'stderr');
-
-let fd = 2;
-exports.firstInvalidFD = function firstInvalidFD() {
-  // Get first known bad file descriptor.
-  try {
-    while (fs.fstatSync(++fd));
-  } catch (e) {}
-  return fd;
-};

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -823,23 +823,6 @@ exports.crashOnUnhandledRejection = function() {
              (err) => process.nextTick(() => { throw err; }));
 };
 
-exports.getTTYfd = function getTTYfd() {
-  const tty = require('tty');
-  let tty_fd = 0;
-  if (!tty.isatty(tty_fd)) tty_fd++;
-  else if (!tty.isatty(tty_fd)) tty_fd++;
-  else if (!tty.isatty(tty_fd)) tty_fd++;
-  else {
-    try {
-      tty_fd = fs.openSync('/dev/tty');
-    } catch (e) {
-      // There aren't any tty fd's available to use.
-      return -1;
-    }
-  }
-  return tty_fd;
-};
-
 // Hijack stdout and stderr
 const stdWrite = {};
 function hijackStdWritable(name, listener) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -69,7 +69,6 @@ exports.enoughTestCpu = Array.isArray(cpus) &&
                         (cpus.length > 1 || cpus[0].speed > 999);
 
 exports.rootDir = exports.isWindows ? 'c:\\' : '/';
-exports.projectDir = path.resolve(__dirname, '..', '..');
 
 exports.buildType = process.config.target_defaults.default_configuration;
 

--- a/test/doctool/test-make-doc.js
+++ b/test/doctool/test-make-doc.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const apiPath = path.resolve(common.projectDir, 'out', 'doc', 'api');
+const apiPath = path.resolve(__dirname, '..', '..', 'out', 'doc', 'api');
 const docs = fs.readdirSync(apiPath);
 assert.ok(docs.includes('_toc.html'));
 

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -247,7 +247,24 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 
 {
   // Do our best to grab a tty fd.
-  const tty_fd = common.getTTYfd();
+  function getTTYfd() {
+    const tty = require('tty');
+    let tty_fd = 0;
+    if (!tty.isatty(tty_fd)) tty_fd++;
+    else if (!tty.isatty(tty_fd)) tty_fd++;
+    else if (!tty.isatty(tty_fd)) tty_fd++;
+    else {
+      try {
+        tty_fd = fs.openSync('/dev/tty');
+      } catch (e) {
+        // There aren't any tty fd's available to use.
+        return -1;
+      }
+    }
+    return tty_fd;
+  }
+
+  const tty_fd = getTTYfd();
   if (tty_fd >= 0) {
     const tty_wrap = process.binding('tty_wrap');
     // fd may still be invalid, so guard against it.

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -249,28 +249,25 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
   // Do our best to grab a tty fd.
   function getTTYfd() {
     const tty = require('tty');
-    let tty_fd = 0;
-    if (!tty.isatty(tty_fd)) tty_fd++;
-    else if (!tty.isatty(tty_fd)) tty_fd++;
-    else if (!tty.isatty(tty_fd)) tty_fd++;
-    else {
+    let ttyFd = [0, 1, 2].find(tty.isatty);
+    if (ttyFd === undefined) {
       try {
-        tty_fd = fs.openSync('/dev/tty');
+        ttyFd = fs.openSync('/dev/tty');
       } catch (e) {
         // There aren't any tty fd's available to use.
         return -1;
       }
     }
-    return tty_fd;
+    return ttyFd;
   }
 
-  const tty_fd = getTTYfd();
-  if (tty_fd >= 0) {
+  const ttyFd = getTTYfd();
+  if (ttyFd >= 0) {
     const tty_wrap = process.binding('tty_wrap');
     // fd may still be invalid, so guard against it.
     const handle = (() => {
       try {
-        return new tty_wrap.TTY(tty_fd, false);
+        return new tty_wrap.TTY(ttyFd, false);
       } catch (e) {
         return null;
       }


### PR DESCRIPTION
In an effort to make the `common` module slightly less of a monolith and junk drawer, and to reduce the needed parsing/loading of some function from around 2000 times per test run to just 1, this PR removes functions that are only used once.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test