### PR TITLE
[v6.x backport] src: guard bundled_ca/openssl_ca with HAVE_OPENSSL

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3878,8 +3878,10 @@ static void ParseArgs(int* argc,
   const char** new_exec_argv = new const char*[nargs];
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
+#if HAVE_OPENSSL
   bool use_bundled_ca = false;
   bool use_openssl_ca = false;
+#endif  // HAVE_INSPECTOR
 
   for (unsigned int i = 0; i < nargs; ++i) {
     new_exec_argv[i] = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -3878,6 +3878,8 @@ static void ParseArgs(int* argc,
   const char** new_exec_argv = new const char*[nargs];
   const char** new_v8_argv = new const char*[nargs];
   const char** new_argv = new const char*[nargs];
+  bool use_bundled_ca = false;
+  bool use_openssl_ca = false;
 
   for (unsigned int i = 0; i < nargs; ++i) {
     new_exec_argv[i] = nullptr;
@@ -3983,7 +3985,9 @@ static void ParseArgs(int* argc,
       default_cipher_list = arg + 18;
     } else if (strncmp(arg, "--use-openssl-ca", 16) == 0) {
       ssl_openssl_cert_store = true;
+      use_openssl_ca = true;
     } else if (strncmp(arg, "--use-bundled-ca", 16) == 0) {
+      use_bundled_ca = true;
       ssl_openssl_cert_store = false;
 #if NODE_FIPS_MODE
     } else if (strcmp(arg, "--enable-fips") == 0) {
@@ -4017,6 +4021,16 @@ static void ParseArgs(int* argc,
     new_exec_argc += args_consumed;
     index += args_consumed;
   }
+
+#if HAVE_OPENSSL
+  if (use_openssl_ca && use_bundled_ca) {
+    fprintf(stderr,
+            "%s: either --use-openssl-ca or --use-bundled-ca can be used, "
+            "not both\n",
+            argv[0]);
+    exit(9);
+  }
+#endif
 
   // Copy remaining arguments.
   const unsigned int args_left = nargs - index;

--- a/test/parallel/test-openssl-ca-options.js
+++ b/test/parallel/test-openssl-ca-options.js
@@ -1,0 +1,30 @@
+'use strict';
+// This test checks the usage of --use-bundled-ca and --use-openssl-ca arguments
+// to verify that both are not used at the same time.
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const os = require('os');
+const childProcess = require('child_process');
+const result = childProcess.spawnSync(
+  process.execPath,
+  [ '--use-bundled-ca', '--use-openssl-ca', '-p', 'process.version' ],
+  { encoding: 'utf8' }
+);
+
+assert.strictEqual(result.stderr, `${process.execPath
+}: either --use-openssl-ca or --use-bundled-ca can be used, not both${os.EOL}`
+);
+assert.strictEqual(result.status, 9);
+
+const useBundledCA = childProcess.spawnSync(process.execPath, [
+  '--use-bundled-ca',
+  '-p', 'process.version']);
+assert.strictEqual(useBundledCA.status, 0);
+
+const useOpenSSLCA = childProcess.spawnSync(process.execPath, [
+  '--use-openssl-ca',
+  '-p', 'process.version']);
+assert.strictEqual(useOpenSSLCA.status, 0);


### PR DESCRIPTION
This is a backport of the following PRs:
* https://github.com/nodejs/node/pull/12302
* https://github.com/nodejs/node/pull/12087

Please note that there was a previous [PR](https://github.com/nodejs/node/pull/14834) for backporting this, but was closed as noted in this [comment](https://github.com/nodejs/node/pull/14834#issuecomment-330672326).

@MylesBorins I'm not sure if this should land due to your comment above. Could you take a look and let me know what you think?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src