### PR TITLE
[v6.x backport] crypto: remove BIO_set_shutdown

### DIFF
--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -51,8 +51,6 @@ void NodeBIO::AssignEnvironment(Environment* env) {
 int NodeBIO::New(BIO* bio) {
   bio->ptr = new NodeBIO();
 
-  // XXX Why am I doing it?!
-  bio->shutdown = 1;
   bio->init = 1;
   bio->num = -1;
 


### PR DESCRIPTION
I've not been able to find any reason for calling
BIO_set_shutdown(bio, 1). This is done by default for the following
versions of OpenSSL:

https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/crypto/bio/bio_lib.c#L26
https://github.com/openssl/openssl/blob/OpenSSL_1_0_1/crypto/bio/bio_lib.c#L90
https://github.com/openssl/openssl/blob/OpenSSL_1_0_2/crypto/bio/bio_lib.c#L88
https://github.com/openssl/openssl/blob/OpenSSL_1_0_0/crypto/bio/bio_lib.c#L90

This commit removes the call and the comment.

PR-URL: https://github.com/nodejs/node/pull/17542
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src