### PR TITLE
Tab complete paths for `fs` functions in repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -852,6 +852,57 @@ ArrayStream.prototype.resume = function() {};
 ArrayStream.prototype.write = function() {};
 
 const requireRE = /\brequire\s*\(['"](([\w@./-]+\/)?(?:[\w@./-]*))/;
+
+
+const fsTabbableMethods = [
+  'access',
+  'accessSync',
+  'chmod',
+  'chmodSync',
+  'chown',
+  'chownSync',
+  'createReadStream',
+  'createWriteStream',
+  'exists',
+  'existsSync',
+  'lchmod',
+  'lchmodSync',
+  'lchown',
+  'lchownSync',
+  'lstat',
+  'lstatSync',
+  'mkdir',
+  'mkdirSync',
+  'open',
+  'openSync',
+  'readdir',
+  'readdirSync',
+  'readFile',
+  'readFileSync',
+  'readlink',
+  'readlinkSync',
+  'realpath',
+  'realpath',
+  'realpathSync',
+  'realpathSync',
+  'rmdir',
+  'rmdirSync',
+  'stat',
+  'statSync',
+  'symlink',
+  'symlinkSync',
+  'truncate',
+  'truncateSync',
+  'unlink',
+  'unlinkSync',
+  'utimes',
+  'utimesSync',
+].join('|');
+
+const fsRE = new RegExp(
+  `fs\\.(?:${fsTabbableMethods})\\(["'](([\\w@./-]+\\/)?(?:[\\w@./-]*))`
+);
+
 const simpleExpressionRE =
     /(?:[a-zA-Z_$](?:\w|\$)*\.)*[a-zA-Z_$](?:\w|\$)*\.?$/;
 
@@ -948,8 +999,10 @@ function complete(line, callback) {
     }
 
     completionGroupsLoaded();
-  } else if (match = line.match(requireRE)) {
-    // require('...<Tab>')
+  } else if (match = (line.match(requireRE) || line.match(fsRE))) {
+    // require('...<Tab>') and fs.<method>('...<Tab>')
+
+    const isFS = line.match(fsRE);
     const exts = Object.keys(this.context.require.extensions);
     var indexRe = new RegExp('^index(?:' + exts.map(regexpEscape).join('|') +
                              ')$');
@@ -968,7 +1021,7 @@ function complete(line, callback) {
       group = ['../'];
     } else if (/^\.\.?\//.test(completeOn)) {
       paths = [process.cwd()];
-    } else {
+    } else if (!isFS) {
       paths = module.paths.concat(Module.globalPaths);
     }
 
@@ -1014,7 +1067,7 @@ function complete(line, callback) {
       completionGroups.push(group);
     }
 
-    if (!subdir) {
+    if (!subdir && !isFS) {
       completionGroups.push(exports._builtinLibs);
     }
 

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -359,6 +359,139 @@ testMe.complete('var log = console.lo', common.mustCall((error, data) => {
   assert.deepStrictEqual(data, [['console.log'], 'console.lo']);
 }));
 
+// Test tab complete for fs module
+putIn.run(['.clear']);
+
+// does not auto complete empty paths
+testMe.complete('fs.readFileSync("', common.mustCall((error, data) => {
+  assert.strictEqual(error, null);
+  assert.strictEqual(data[0].length, 0);
+}));
+
+// does not complete non-relative paths
+testMe.complete('fs.readFileSync("n', common.mustCall((error, data) => {
+  assert.strictEqual(error, null);
+  assert.strictEqual(data[0].length, 0);
+}));
+
+// does not complete scoped modules paths
+
+testMe.complete('fs.readFileSync("@nodejs', common.mustCall((error, data) => {
+  assert.strictEqual(error, null);
+  assert.strictEqual(data[0].length, 0);
+}));
+
+
+// Test tab completion for fs module paths relative to the current directory
+{
+  putIn.run(['.clear']);
+
+  const cwd = process.cwd();
+  process.chdir(__dirname);
+
+  ['fs.readFileSync(\'.', 'fs.readFileSync(".'].forEach((input) => {
+    testMe.complete(input, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(data.length, 2);
+      assert.strictEqual(data[1], '.');
+      assert.strictEqual(data[0].length, 2);
+      assert.ok(data[0].includes('./'));
+      assert.ok(data[0].includes('../'));
+    }));
+  });
+
+  ['fs.readFileSync(\'..', 'fs.readFileSync("..'].forEach((input) => {
+    testMe.complete(input, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.deepStrictEqual(data, [['../'], '..']);
+    }));
+  });
+
+  const fsTabbableMethods = [
+    'access',
+    'accessSync',
+    'chmod',
+    'chmodSync',
+    'chown',
+    'chownSync',
+    'createReadStream',
+    'createWriteStream',
+    'exists',
+    'existsSync',
+    'lchmod',
+    'lchmodSync',
+    'lchown',
+    'lchownSync',
+    'lstat',
+    'lstatSync',
+    'mkdir',
+    'mkdirSync',
+    'open',
+    'openSync',
+    'readdir',
+    'readdirSync',
+    'readFile',
+    'readFileSync',
+    'readlink',
+    'readlinkSync',
+    'realpath',
+    'realpath',
+    'realpathSync',
+    'realpathSync',
+    'rmdir',
+    'rmdirSync',
+    'stat',
+    'statSync',
+    'symlink',
+    'symlinkSync',
+    'truncate',
+    'truncateSync',
+    'unlink',
+    'unlinkSync',
+    'utimes',
+    'utimesSync',
+  ];
+
+  // test that all tabbable methods allow this featuer
+  fsTabbableMethods.forEach((method) => {
+    testMe.complete(`fs.${method}('..`, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.deepStrictEqual(data, [['../'], '..']);
+    }));
+  });
+
+  ['./', './test-'].forEach((path) => {
+    testMe.complete(`fs.readFileSync('${path}`, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(data.length, 2);
+      assert.strictEqual(data[1], path);
+      assert.ok(data[0].includes('./test-repl-tab-complete'));
+    }));
+  });
+
+  ['../parallel/', '../parallel/test-'].forEach((path) => {
+    testMe.complete(`fs.readFileSync('${path}`, common.mustCall((err, data) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(data.length, 2);
+      assert.strictEqual(data[1], path);
+      assert.ok(data[0].includes('../parallel/test-repl-tab-complete'));
+    }));
+  });
+
+  {
+    const path = '../fixtures/repl-folder-extensions/f';
+    testMe.complete(`fs.readFileSync('${path}`, common.mustCall((err, data) => {
+      assert.ifError(err);
+      assert.strictEqual(data.length, 2);
+      assert.strictEqual(data[1], path);
+      assert.ok(data[0].includes('../fixtures/repl-folder-extensions/foo.js'));
+    }));
+  }
+
+
+  process.chdir(cwd);
+}
+
 // tab completion for defined commands
 putIn.run(['.clear']);
 


### PR DESCRIPTION
Adds autocomplete in `repl` for `fs` methods that lookup file paths. Closes #17764 

1. Tab complete only works for relative paths (this approach made most sense for me)
2. The `fs` module must be explicitly accessed by `fs`.
```javascript
var myFS = require('fs');
myFS.readFile('...<Tab>' // will not work
```

3. I was afraid to refactor the `require('...<Tab>')` completion into a separate function and call it in both the `require` and `fs.<method>`, this would tidy up the code a little. I am willing to refactor it if I get a green light.

4. I have the methods `readlink` and `readlinkSync` in the supported tab complete methods. I am not sure if these make sense to be added, or need a special lookup for only symlinks.


P.S.
Implementing a feature to track all the variables defined for tab completion would benefit the repl tab completion in two folds:
1. the tab completion will be smarter to know which variable refers to the fs module.
2. all definitions (`const` and `let`) will be supported in the tab completion.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
repl