### PR TITLE
doc: warn about using util.inspect/util.format in prod

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -250,6 +250,11 @@ without any formatting.
 util.format('%% %s'); // '%% %s'
 ```
 
+Please note that `util.format()` is a synchronous method that is mainly
+intended as a debugging tool. Some input values can have a significant
+performance overhead that can block the event loop. Use this function
+with care and never in a hot code path.
+
 ## util.inherits(constructor, superConstructor)
 <!-- YAML
 added: v0.3.0
@@ -461,6 +466,11 @@ console.log(util.inspect(o, { compact: false, depth: 5, breakLength: 80 }));
 // Reducing the `breakLength` will split the "Lorem ipsum" text in smaller
 // chunks.
 ```
+
+Please note that `util.inspect()` is a synchronous method that is mainly
+intended as a debugging tool. Some input values can have a significant
+performance overhead that can block the event loop. Use this function
+with care and never in a hot code path.
 
 ### Customizing `util.inspect` colors
 


### PR DESCRIPTION
Because of the potential performance bottlenecks that may be introduced
by `util.inspect()` and `util.format()` in production code.

Based on real user feedback, it is not obvious that these are intended
to be debugging tools.

/cc @mcollina @lucamaraschi 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc