### PR TITLE
_tls_wrap: Migrate the errors to internal/errors #17709

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1505,7 +1505,7 @@ vector for denial-of-service attacks.
 <a id="ERR_TLS_RENEGOTIATION_DISABLED"></a>
 ### ERR_TLS_RENEGOTIATION_DISABLED
 
-An attempt was made to renegotiate TLS on a socket instance with TLS  disabled.
+An attempt was made to renegotiate TLS on a socket instance with TLS disabled.
 
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1505,8 +1505,7 @@ vector for denial-of-service attacks.
 <a id="ERR_TLS_RENEGOTIATION_DISABLED"></a>
 ### ERR_TLS_RENEGOTIATION_DISABLED
 
-This errors is triggered when attempts are made to renegotiate TLS on a socket 
-instance which has TLS  disabled 
+An attempt was made to renegotiate TLS on a socket instance with TLS  disabled.
 
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1502,6 +1502,12 @@ a hostname in the first parameter.
 An excessive amount of TLS renegotiations is detected, which is a potential
 vector for denial-of-service attacks.
 
+<a id="ERR_TLS_RENEGOTIATION_DISABLED"></a>
+### ERR_TLS_RENEGOTIATION_DISABLED
+
+This errors is triggered when attempts are made to renegotiate TLS on a socket 
+instance which has TLS  disabled 
+
 <a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
 ### ERR_TRANSFORM_ALREADY_TRANSFORMING
 

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -70,7 +70,7 @@ function onhandshakestart() {
   }
 
   if (owner[kDisableRenegotiation] && this.handshakes > 0) {
-    const err = new Error('TLS session renegotiation disabled for this socket');
+    const err = new errors.Error('ERR_TLS_RENEGOTIATION_DISABLED');
     owner._emitTLSError(err);
   }
 }

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -70,8 +70,7 @@ function onhandshakestart() {
   }
 
   if (owner[kDisableRenegotiation] && this.handshakes > 0) {
-    const err = new errors.Error('ERR_TLS_RENEGOTIATION_DISABLED');
-    owner._emitTLSError(err);
+    owner._emitTLSError(new errors.Error('ERR_TLS_RENEGOTIATION_DISABLED'));
   }
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -476,6 +476,7 @@ E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
 E('ERR_TLS_REQUIRED_SERVER_NAME',
   '"servername" is required parameter for Server.addContext');
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected');
+E('ERR_TLS_RENEGOTIATION_DISABLED', 'TLS session renegotiation disabled for this socket');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -476,7 +476,6 @@ E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
 E('ERR_TLS_REQUIRED_SERVER_NAME',
   '"servername" is required parameter for Server.addContext');
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected');
-E('ERR_TLS_RENEGOTIATION_DISABLED', 'TLS session renegotiation disabled for this socket');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -474,6 +474,7 @@ E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
 E('ERR_TLS_REQUIRED_SERVER_NAME',
   '"servername" is required parameter for Server.addContext');
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected');
+E('ERR_TLS_RENEGOTIATION_DISABLED', 'TLS session renegotiation disabled for this socket');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -470,11 +470,12 @@ E('ERR_TLS_CERT_ALTNAME_INVALID',
   'Hostname/IP does not match certificate\'s altnames: %s');
 E('ERR_TLS_DH_PARAM_SIZE', 'DH parameter size %s is less than 2048');
 E('ERR_TLS_HANDSHAKE_TIMEOUT', 'TLS handshake timeout');
+E('ERR_TLS_RENEGOTIATION_DISABLED',
+  'TLS session renegotiation disabled for this socket');
 E('ERR_TLS_RENEGOTIATION_FAILED', 'Failed to renegotiate');
 E('ERR_TLS_REQUIRED_SERVER_NAME',
   '"servername" is required parameter for Server.addContext');
 E('ERR_TLS_SESSION_ATTACK', 'TLS session renegotiation attack detected');
-E('ERR_TLS_RENEGOTIATION_DISABLED', 'TLS session renegotiation disabled for this socket');
 E('ERR_TRANSFORM_ALREADY_TRANSFORMING',
   'Calling transform done when still transforming');
 E('ERR_TRANSFORM_WITH_LENGTH_0',

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -18,10 +18,10 @@ const options = {
 const server = tls.Server(options, common.mustCall((socket) => {
   socket.on('error', common.mustCall((err) => {
     common.expectsError({
+      type: Error,
       code: 'ERR_TLS_RENEGOTIATION_DISABLED',
-      message: 'TLS session renegotiation disabled for this socket',
-      type: Error
-    })(error);
+      message: 'TLS session renegotiation disabled for this socket'
+    })(err);
     socket.destroy();
     server.close();
   }));

--- a/test/parallel/test-tls-disable-renegotiation.js
+++ b/test/parallel/test-tls-disable-renegotiation.js
@@ -17,9 +17,11 @@ const options = {
 
 const server = tls.Server(options, common.mustCall((socket) => {
   socket.on('error', common.mustCall((err) => {
-    assert.strictEqual(
-      err.message,
-      'TLS session renegotiation disabled for this socket');
+    common.expectsError({
+      code: 'ERR_TLS_RENEGOTIATION_DISABLED',
+      message: 'TLS session renegotiation disabled for this socket',
+      type: Error
+    })(error);
     socket.destroy();
     server.close();
   }));


### PR DESCRIPTION
Refs: #17709 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
The `doc/api/errors.md` file has been modified to include the `ERR_TLS_RENEGOTIATION_DISABLED` error . 
Also, modified the files `lib/_tls_wrap.js`, `lib/internal/errors.js`, `test/parallel/test-tls-disable-renegotiation.js` so as to add the `ERR_TLS_RENEGOTIATION_DISABLED` error
