### PR TITLE
dns, src: add --preserve-dns-order flag with NODE_OPTIONS whitelist

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -24,6 +24,7 @@
 const util = require('util');
 
 const cares = process.binding('cares_wrap');
+const { preserveDnsOrder } = process.binding('config');
 const { isLegalPort } = require('internal/net');
 const { customPromisifyArgs } = require('internal/util');
 const errors = require('internal/errors');
@@ -128,7 +129,7 @@ function lookup(hostname, options, callback) {
   var hints = 0;
   var family = -1;
   var all = false;
-  var verbatim = false;
+  var verbatim = !!preserveDnsOrder;
 
   // Parse arguments
   if (hostname && typeof hostname !== 'string') {
@@ -143,7 +144,10 @@ function lookup(hostname, options, callback) {
     hints = options.hints >>> 0;
     family = options.family >>> 0;
     all = options.all === true;
-    verbatim = options.verbatim === true;
+
+    if (Object.prototype.hasOwnProperty.call(options, 'verbatim')) {
+      verbatim = options.verbatim === true;
+    }
 
     if (hints !== 0 &&
         hints !== cares.AI_ADDRCONFIG &&

--- a/src/node.cc
+++ b/src/node.cc
@@ -258,6 +258,11 @@ std::string config_warning_file;  // NOLINT(runtime/string)
 // that is used by lib/internal/bootstrap_node.js
 bool config_expose_internals = false;
 
+// Set in node.cc by ParseArgs when --preserve-dns-order is used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/dns.js
+bool config_preserve_dns_order = false;
+
 bool v8_initialized = false;
 
 bool linux_at_secure = false;
@@ -3626,6 +3631,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--pending-deprecation",
     "--no-warnings",
     "--napi-modules",
+    "--preserve-dns-order",
     "--expose-http2",   // keep as a non-op through v9.x
     "--experimental-modules",
     "--loader",
@@ -3848,6 +3854,9 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-http2") == 0 ||
                strcmp(arg, "--expose_http2") == 0) {
       // Keep as a non-op through v9.x
+    } else if (strcmp(arg, "--preserve-dns-order") == 0 ||
+               strcmp(arg, "--preserve_dns_order") == 0) {
+      config_preserve_dns_order = true;
     } else if (strcmp(arg, "-") == 0) {
       break;
     } else if (strcmp(arg, "--") == 0) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -88,6 +88,9 @@ static void InitConfig(Local<Object> target,
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
 
+  if (config_preserve_dns_order)
+    READONLY_BOOLEAN_PROPERTY("preserveDnsOrder");
+
   READONLY_PROPERTY(target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -171,6 +171,11 @@ extern bool config_preserve_symlinks;
 // that is used by lib/module.js
 extern bool config_experimental_modules;
 
+// Set in node.cc by ParseArgs when --preserve-dns-order is used.
+// Used in node_config.cc to set a constant on process.binding('config')
+// that is used by lib/dns.js
+extern bool config_preserve_dns_order;
+
 // Set in node.cc by ParseArgs when --loader is used.
 // Used in node_config.cc to set a constant on process.binding('config')
 // that is used by lib/internal/bootstrap_node.js


### PR DESCRIPTION
Added flag with NODE_OPTIONS whitelist to allow preserving lookup order
as retrieved from resolver. Still allows individual lookup requests with verbatim
flag assigned explicitly to override the config flag.

Open for suggestions on how to craft a test for this.
Need discussion for whether this should be added to --help output
I will follow up with commit for documentation changes for dns.lookup(),
but not sure where else might require updating.

Refs: https://github.com/nodejs/node/pull/14731#issuecomment-321513375

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dns, src
