### PR TITLE
test: refactor test-repl-definecommand

### DIFF
--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -35,8 +35,8 @@ r.defineCommand('say2', function() {
 });
 
 inputStream.write('.help\n');
-assert.ok(/\n\.say1     help for say1\n/.test(output),
-          'help for say1 not present');
+assert(/\n\.say1     help for say1\n/.test(output),
+       'help for say1 not present');
 assert(/\n\.say2\n/.test(output), 'help for say2 not present');
 inputStream.write('.say1 node developer\n');
 assert.ok(output.startsWith('hello node developer\n'),

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -23,22 +23,28 @@ r.defineCommand('say1', {
   help: 'help for say1',
   action: function(thing) {
     output = '';
-    this.write(`hello ${thing}`);
+    this.output.write(`hello ${thing}\n`);
     this.displayPrompt();
   }
 });
 
 r.defineCommand('say2', function() {
   output = '';
-  this.write('hello from say2');
+  this.output.write('hello from say2\n');
   this.displayPrompt();
 });
 
 inputStream.write('.help\n');
-assert(/\n\.say1     help for say1\n/.test(output),
-       'help for say1 not present');
+assert.ok(/\n\.say1     help for say1\n/.test(output),
+          'help for say1 not present');
 assert(/\n\.say2\n/.test(output), 'help for say2 not present');
 inputStream.write('.say1 node developer\n');
-assert(/> hello node developer/.test(output), 'say1 outputted incorrectly');
+assert.ok(output.startsWith('hello node developer\n'),
+          `say1 output starts incorrectly: "${output}"`);
+assert.ok(output.includes('> '),
+          `say1 output does not include prompt: "${output}"`);
 inputStream.write('.say2 node developer\n');
-assert(/> hello from say2/.test(output), 'say2 outputted incorrectly');
+assert.ok(output.startsWith('hello from say2\n'),
+          `say2 output starts incorrectly: "${output}"`);
+assert.ok(output.includes('> '),
+          `say2 output does not include prompt: "${output}"`);


### PR DESCRIPTION
The test was writing to both REPL input and output but only checking
output. Sending output to both streams seems like it was an error.

/cc @bmeck 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test repl