### PR TITLE
doc: removed extra explanation in api/buffer.md

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1047,13 +1047,11 @@ changes:
 * `targetStart` {integer} The offset within `target` at which to begin
   comparison. **Default:** `0`
 * `targetEnd` {integer} The offset with `target` at which to end comparison
-  (not inclusive). Ignored when `targetStart` is `undefined`.
-  **Default:** `target.length`
+  (not inclusive). **Default:** `target.length`
 * `sourceStart` {integer} The offset within `buf` at which to begin comparison.
-  Ignored when `targetStart` is `undefined`. **Default:** `0`
+  **Default:** `0`
 * `sourceEnd` {integer} The offset within `buf` at which to end comparison
-  (not inclusive). Ignored when `targetStart` is `undefined`.
-  **Default:** [`buf.length`]
+  (not inclusive). **Default:** [`buf.length`]
 * Returns: {integer}
 
 Compares `buf` with `target` and returns a number indicating whether `buf`
@@ -1123,9 +1121,9 @@ added: v0.1.90
 * `targetStart` {integer} The offset within `target` at which to begin
   copying to. **Default:** `0`
 * `sourceStart` {integer} The offset within `buf` at which to begin copying from.
-  Ignored when `targetStart` is `undefined`. **Default:** `0`
+  **Default:** `0`
 * `sourceEnd` {integer} The offset within `buf` at which to stop copying (not
-  inclusive). Ignored when `sourceStart` is `undefined`. **Default:** [`buf.length`]
+  inclusive). **Default:** [`buf.length`]
 * Returns: {integer} The number of bytes copied.
 
 Copies data from a region of `buf` to a region in `target` even if the `target`


### PR DESCRIPTION
Closes : #17618

##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc/api/buffer