### PR TITLE
test: improve flaky test-listen-fd-ebadf.js

### DIFF
--- a/test/parallel/test-listen-fd-ebadf.js
+++ b/test/parallel/test-listen-fd-ebadf.js
@@ -21,12 +21,24 @@
 
 'use strict';
 const common = require('../common');
+
 const assert = require('assert');
+const fs = require('fs');
 const net = require('net');
 
 net.createServer(common.mustNotCall()).listen({ fd: 2 })
   .on('error', common.mustCall(onError));
-net.createServer(common.mustNotCall()).listen({ fd: 42 })
+
+let invalidFd = 2;
+
+// Get first known bad file descriptor.
+try {
+  while (fs.fstatSync(++invalidFd));
+} catch (e) {
+  // do nothing; we now have an invalid fd
+}
+
+net.createServer(common.mustNotCall()).listen({ fd: invalidFd })
   .on('error', common.mustCall(onError));
 
 function onError(ex) {


### PR DESCRIPTION
Find an invalid file descriptor rather than assuming 42 will be invalid.

Fixes: https://github.com/nodejs/node/issues/17762

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test net