### PR TITLE
http: convert utcDate to use setTimeout

### DIFF
--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -1,20 +1,21 @@
 'use strict';
 
-const timers = require('timers');
+const { setUnrefTimeout } = require('internal/timers');
 
 var dateCache;
 function utcDate() {
   if (!dateCache) {
     const d = new Date();
     dateCache = d.toUTCString();
-    timers.enroll(utcDate, 1000 - d.getMilliseconds());
-    timers._unrefActive(utcDate);
+
+    setUnrefTimeout(timeout, 1000 - d.getMilliseconds());
   }
   return dateCache;
 }
-utcDate._onTimeout = function() {
+
+function timeout() {
   dateCache = undefined;
-};
+}
 
 function ondrain() {
   if (this._httpMessage) this._httpMessage.emit('drain');


### PR DESCRIPTION
A sort-of follow-up to https://github.com/nodejs/node/pull/17704, this
removes the last internal use of `enroll()`.

Edit - CI: https://ci.nodejs.org/job/node-test-pull-request/12243/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http