### PR TITLE
build,win: replace find-python subroutine with PYTHON variable

### DIFF
--- a/tools/msvs/find_python.cmd
+++ b/tools/msvs/find_python.cmd
@@ -45,7 +45,7 @@ IF NOT EXIST "%p%python.exe" EXIT /B 1
 IF ERRORLEVEL 1 EXIT /B %ERRORLEVEL%
 :: We can wrap it up
 ENDLOCAL & SET pt=%p%& SET need_path_ext=%need_path%
-SET VCBUILD_PYTHON_LOCATION=%pt%python.exe
+SET PYTHON=%pt%python.exe
 IF %need_path_ext%==1 SET Path=%Path%;%pt%
 SET need_path_ext=
 EXIT /B %ERRORLEVEL%

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -165,6 +165,9 @@ if "%target%"=="Clean" echo deleting %~dp0deps\icu
 if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
+call tools\msvs\find_python.cmd
+if errorlevel 1 echo Could not find python2 & goto :exit
+
 call :getnodeversion || exit /b 1
 
 if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
@@ -232,7 +235,8 @@ goto run
 if defined noprojgen goto msbuild
 
 @rem Generate the VS project.
-call :run-python configure %configure_flags%
+echo configure %configure_flags%
+%PYTHON% configure %configure_flags%
 if errorlevel 1 goto create-msvs-files-failed
 if not exist node.sln goto create-msvs-files-failed
 echo Project files generated.
@@ -424,7 +428,7 @@ if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
 :node-check-deopts
-call :run-python tools\test.py --mode=release --check-deopts parallel sequential -J
+%PYTHON% tools\test.py --mode=release --check-deopts parallel sequential -J
 if defined test_node_inspect goto node-test-inspect
 goto node-tests
 
@@ -448,7 +452,8 @@ if defined no_cctest echo Skipping cctest because no-cctest was specified && got
 echo running 'cctest %cctest_args%'
 "%config%\cctest" %cctest_args%
 :run-test-py
-call :run-python tools\test.py %test_args%
+echo running 'python tools\test.py %test_args%'
+%PYTHON% tools\test.py %test_args%
 goto test-v8
 
 :test-v8
@@ -460,7 +465,7 @@ goto lint-cpp
 :lint-cpp
 if not defined lint_cpp goto lint-js
 call :run-lint-cpp src\*.c src\*.cc src\*.h test\addons\*.cc test\addons\*.h test\addons-napi\*.cc test\addons-napi\*.h test\cctest\*.cc test\cctest\*.h test\gc\binding.cc tools\icu\*.cc tools\icu\*.h
-call :run-python tools/check-imports.py
+%PYTHON% tools/check-imports.py
 goto lint-js
 
 :run-lint-cpp
@@ -476,7 +481,7 @@ for /f "tokens=*" %%G in ('dir /b /s /a %*') do (
 ( endlocal
   set cppfilelist=%localcppfilelist%
 )
-call :run-python tools/cpplint.py %cppfilelist% > nul
+%PYTHON% tools/cpplint.py %cppfilelist% > nul
 goto exit
 
 :add-to-list
@@ -537,14 +542,6 @@ echo   vcbuild.bat lint                     : runs the C++ and JavaScript linter
 echo   vcbuild.bat no-cctest                : skip building cctest.exe
 goto exit
 
-:run-python
-call tools\msvs\find_python.cmd
-if errorlevel 1 echo Could not find python2 & goto :exit
-set cmd1="%VCBUILD_PYTHON_LOCATION%" %*
-echo %cmd1%
-%cmd1%
-exit /b %ERRORLEVEL%
-
 :exit
 goto :EOF
 
@@ -557,9 +554,8 @@ rem ***************
 set NODE_VERSION=
 set TAG=
 set FULLVERSION=
-:: Call as subroutine for validation of python
-call :run-python tools\getnodeversion.py > nul
-for /F "tokens=*" %%i in ('"%VCBUILD_PYTHON_LOCATION%" tools\getnodeversion.py') do set NODE_VERSION=%%i
+
+for /F "usebackq tokens=*" %%i in (`%PYTHON% "%~dp0tools\getnodeversion.py"`) do set NODE_VERSION=%%i
 if not defined NODE_VERSION (
   echo Cannot determine current version of Node.js
   exit /b 1


### PR DESCRIPTION
A subroutine does not work as a replacement for the `python` command
since one cannot use a subroutine call in a `for /F` loop.

Similarly to https://github.com/nodejs/node/pull/17298 and https://github.com/nodejs/node/pull/17015, this introduces a maintenance burden: namely, whenever significant changes are introduced in `vcbuild.bat`, one has to make sure `find_python.cmd` is called before the first Python usage. Consequently, I would prefer https://github.com/nodejs/node/pull/17293 to be landed instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build