### PR TITLE
test: do not open fixture files for writing

### DIFF
--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -34,7 +34,7 @@ const fileTemp = path.join(common.tmpDir, 'a.js');
 common.refreshTmpDir();
 fs.copyFileSync(fileFixture, fileTemp);
 
-fs.open(fileFixture, 'a', 0o777, common.mustCall(function(err, fd) {
+fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {
   assert.ifError(err);
 
   fs.fdatasyncSync(fd);


### PR DESCRIPTION
test-fs-fsync makes a copy of a fixture file, but then doesn't do
anything with it and instead operates on the original fixture file. This
appears to be in error, and this change fixes that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test