### PR TITLE
test: do not open fixture files for writing

### DIFF
--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -22,10 +22,12 @@
 // Flags: --expose_internals
 'use strict';
 const common = require('../common');
-const fixtures = require('../common/fixtures');
-const assert = require('assert');
 
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 
 const O_APPEND = fs.constants.O_APPEND || 0;
 const O_CREAT = fs.constants.O_CREAT || 0;
@@ -81,8 +83,9 @@ common.expectsError(
   { code: 'ERR_INVALID_OPT_VALUE', type: TypeError }
 );
 
-if (common.isLinux) {
-  const file = fixtures.path('a.js');
-
+if (common.isLinux || common.isOSX) {
+  common.refreshTmpDir();
+  const file = path.join(common.tmpDir, 'a.js');
+  fs.copyFileSync(fixtures.path('a.js'), file);
   fs.open(file, O_DSYNC, common.mustCall(assert.ifError));
 }


### PR DESCRIPTION
Use temp directory for open with `O_DSYNC` (which indicates a write may
occur) rather than `fixtures` directory. Additionally, test can be run
on macOS so allow that in addition to Linux.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test fs