### PR TITLE
benchmark: make temp file path configurable

### DIFF
--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -3,7 +3,7 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname,
+const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
                               `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 const assert = require('assert');

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -5,7 +5,7 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname,
+const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
                               `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -3,7 +3,7 @@
 
 const path = require('path');
 const common = require('../common.js');
-const filename = path.resolve(__dirname,
+const filename = path.resolve(process.env.NODE_TMPDIR || __dirname,
                               `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -1,12 +1,12 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('fs', [
   'n=1',
   'size=1',
-  'dur=1',
+  'dur=0.1',
   'len=1024',
   'concurrent=1',
   'pathType=relative',
@@ -14,4 +14,4 @@ runBenchmark('fs', [
   'statSyncType=fstatSync',
   'encodingType=buf',
   'filesize=1024'
-]);
+], { NODE_TMPDIR: common.tmpDir });


### PR DESCRIPTION
In three fs benchmarks, a temp file is created in the source tree. For
tests, allow the location to be configurable so it gets written to the
test temp directory instead.

Additionally, shave about a second off the test running time by setting
`dur` to `0.1` instead of `1`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark test fs