### PR TITLE
test: remove ambiguous error messages from test_error

### DIFF
--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -83,56 +83,45 @@ common.expectsError(
 
 let error = test_error.createError();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
-assert.strictEqual(error.message, 'error', 'expected message to be "error"');
+assert.strictEqual(error.message, 'error');
 
 error = test_error.createRangeError();
 assert.ok(error instanceof RangeError,
           'expected error to be an instance of RangeError');
 assert.strictEqual(error.message,
-                   'range error',
-                   'expected message to be "range error"');
+                   'range error');
 
 error = test_error.createTypeError();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
 assert.strictEqual(error.message,
-                   'type error',
-                   'expected message to be "type error"');
+                   'type error');
 
 error = test_error.createErrorCode();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
 assert.strictEqual(error.code,
-                   'ERR_TEST_CODE',
-                   'expected code to be "ERR_TEST_CODE"');
+                   'ERR_TEST_CODE');
 assert.strictEqual(error.message,
-                   'Error [error]',
-                   'expected message to be "Error [error]"');
+                   'Error [error]');
 assert.strictEqual(error.name,
-                   'Error [ERR_TEST_CODE]',
-                   'expected name to be "Error [ERR_TEST_CODE]"');
+                   'Error [ERR_TEST_CODE]');
 
 error = test_error.createRangeErrorCode();
 assert.ok(error instanceof RangeError,
           'expected error to be an instance of RangeError');
 assert.strictEqual(error.message,
-                   'RangeError [range error]',
-                   'expected message to be "RangeError [range error]"');
+                   'RangeError [range error]');
 assert.strictEqual(error.code,
-                   'ERR_TEST_CODE',
-                   'expected code to be "ERR_TEST_CODE"');
+                   'ERR_TEST_CODE');
 assert.strictEqual(error.name,
-                   'RangeError [ERR_TEST_CODE]',
-                   'expected name to be "RangeError[ERR_TEST_CODE]"');
+                   'RangeError [ERR_TEST_CODE]');
 
 error = test_error.createTypeErrorCode();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
 assert.strictEqual(error.message,
-                   'TypeError [type error]',
-                   'expected message to be "TypeError [type error]"');
+                   'TypeError [type error]');
 assert.strictEqual(error.code,
-                   'ERR_TEST_CODE',
-                   'expected code to be "ERR_TEST_CODE"');
+                   'ERR_TEST_CODE');
 assert.strictEqual(error.name,
-                   'TypeError [ERR_TEST_CODE]',
-                   'expected name to be "TypeError[ERR_TEST_CODE]"');
+                   'TypeError [ERR_TEST_CODE]');

--- a/test/addons-napi/test_error/test.js
+++ b/test/addons-napi/test_error/test.js
@@ -88,40 +88,29 @@ assert.strictEqual(error.message, 'error');
 error = test_error.createRangeError();
 assert.ok(error instanceof RangeError,
           'expected error to be an instance of RangeError');
-assert.strictEqual(error.message,
-                   'range error');
+assert.strictEqual(error.message, 'range error');
 
 error = test_error.createTypeError();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
-assert.strictEqual(error.message,
-                   'type error');
+assert.strictEqual(error.message, 'type error');
 
 error = test_error.createErrorCode();
 assert.ok(error instanceof Error, 'expected error to be an instance of Error');
-assert.strictEqual(error.code,
-                   'ERR_TEST_CODE');
-assert.strictEqual(error.message,
-                   'Error [error]');
-assert.strictEqual(error.name,
-                   'Error [ERR_TEST_CODE]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.message, 'Error [error]');
+assert.strictEqual(error.name, 'Error [ERR_TEST_CODE]');
 
 error = test_error.createRangeErrorCode();
 assert.ok(error instanceof RangeError,
           'expected error to be an instance of RangeError');
-assert.strictEqual(error.message,
-                   'RangeError [range error]');
-assert.strictEqual(error.code,
-                   'ERR_TEST_CODE');
-assert.strictEqual(error.name,
-                   'RangeError [ERR_TEST_CODE]');
+assert.strictEqual(error.message, 'RangeError [range error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'RangeError [ERR_TEST_CODE]');
 
 error = test_error.createTypeErrorCode();
 assert.ok(error instanceof TypeError,
           'expected error to be an instance of TypeError');
-assert.strictEqual(error.message,
-                   'TypeError [type error]');
-assert.strictEqual(error.code,
-                   'ERR_TEST_CODE');
-assert.strictEqual(error.name,
-                   'TypeError [ERR_TEST_CODE]');
+assert.strictEqual(error.message, 'TypeError [type error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'TypeError [ERR_TEST_CODE]');


### PR DESCRIPTION
I got this project through @Trott on http://nodetodo.org/. Thank you for reviewing it.

Here's a description of the changes:

assert.strictEqual accepts 3 arguments, the last of which allows for
user-specified error message to be thrown when the assertion fails.
Unfortunately, this error message is less helpful than the default when it
is vague. This commit removes vague, user-specified error messages, instead relying on
clearer, default error messages.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
tests
