### PR TITLE
doc: add change info for async_hooks.executionAsyncId()

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -470,6 +470,14 @@ init for PROMISE with id 6, trigger id: 5  # the Promise returned by then()
 
 #### `async_hooks.executionAsyncId()`
 
+<!-- YAML
+added: v8.1.0
+changes:
+  - version: v8.2.0
+    pr-url: https://github.com/nodejs/node/pull/13490
+    description: Renamed from currentId
+-->
+
 * Returns: {number} The `asyncId` of the current execution context. Useful to
   track when something calls.
 


### PR DESCRIPTION
Add meta information to async_hooks documentation informing that
executionAsyncId was renamed from currentId at Node.js 8.2.0.

Not sure if maybe it'd be more correct to show it as "added" rather than "changed" at 8.2.0. Thoughts, @nodejs/documentation ?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
