### PR TITLE
lib, src: use process.config instead of regex

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -75,9 +75,6 @@ const emitDestroyNative = emitHookFactory(destroy_symbol, 'emitDestroyNative');
 const emitPromiseResolveNative =
     emitHookFactory(promise_resolve_symbol, 'emitPromiseResolveNative');
 
-// TODO(refack): move to node-config.cc
-const abort_regex = /^--abort[_-]on[_-]uncaught[_-]exception$/;
-
 // Setup the callbacks that node::AsyncWrap will call when there are hooks to
 // process. They use the same functions as the JS embedder API. These callbacks
 // are setup immediately to prevent async_wrap.setupHooks() from being hijacked
@@ -97,7 +94,7 @@ function fatalError(e) {
     Error.captureStackTrace(o, fatalError);
     process._rawDebug(o.stack);
   }
-  if (process.execArgv.some((e) => abort_regex.test(e))) {
+  if (process.binding('config').shouldAbortOnUncaughtException) {
     process.abort();
   }
   process.exit(1);

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -88,6 +88,9 @@ static void InitConfig(Local<Object> target,
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
 
+  if (env->abort_on_uncaught_exception())
+    READONLY_BOOLEAN_PROPERTY("shouldAbortOnUncaughtException");
+
   READONLY_PROPERTY(target,
                     "bits",
                     Number::New(env->isolate(), 8 * sizeof(intptr_t)));


### PR DESCRIPTION
Is safer to use a `process.binding('config')` defined boolean, than to
regex on `process.execArgv`. Also, this better falls in line with the
conventions of checking flags passed to the executable.

I verified that `test/async-hooks/test-callback-error.js` properly tests this.

First time contributing to the C++ side of Node, please send all the advice 😆 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
lib, src, async_hooks