### PR TITLE
test: fix unreliable async-hooks/test-signalwrap

### DIFF
--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -1,7 +1,8 @@
 'use strict';
 const common = require('../common');
 
-if (common.isWindows) return common.skip('no signals in Windows');
+if (common.isWindows)
+  common.skip('no signals in Windows');
 
 const assert = require('assert');
 const initHooks = require('./init-hooks');
@@ -11,6 +12,10 @@ const exec = require('child_process').exec;
 const hooks = initHooks();
 
 hooks.enable();
+
+// Keep the event loop open so process doesn't exit before receiving signals.
+const interval = setInterval(() => {}, 9999);
+
 process.on('SIGUSR2', common.mustCall(onsigusr2, 2));
 
 const as = hooks.activitiesOfTypes('SIGNALWRAP');
@@ -66,6 +71,7 @@ function onsigusr2() {
 }
 
 function onsigusr2Again() {
+  clearInterval(interval);
   setImmediate(() => {
     checkInvocations(
       signal1, { init: 1, before: 2, after: 2, destroy: 1 },


### PR DESCRIPTION
Use an interval to keep the event loop open so the test does not exit
before receiving all signals fom asynchronous `exec()` calls.

Fixes: https://github.com/nodejs/node/issues/14070

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test async_hooks