### PR TITLE
doc: fs doc improvements

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -820,10 +820,10 @@ the method will return `undefined`.
 
 ```js
 try {
-  fs.accessSyc('etc/passwd', fs.constants.R_OK | fs.constants.W_OK);
+  fs.accessSync('etc/passwd', fs.constants.R_OK | fs.constants.W_OK);
   console.log('can read/write');
 } catch (err) {
-  console.log('no access!');
+  console.error('no access!');
 }
 ```
 
@@ -871,8 +871,8 @@ fs.appendFile('message.txt', 'data to append', 'utf8', callback);
 ```
 
 The `file` may be specified as a numeric file descriptor that has been opened
-for appending (using `fs.open()` or `fs.openSync()`. It is important to note
-that the file descriptor will not be closed automatically.
+for appending (using `fs.open()` or `fs.openSync()`). The file descriptor will
+not be closed automatically.
 
 ```js
 fs.open('message.txt', 'a', (err, fd) => {
@@ -926,15 +926,15 @@ fs.appendFileSync('message.txt', 'data to append', 'utf8');
 ```
 
 The `file` may be specified as a numeric file descriptor that has been opened
-for appending (using `fs.open()` or `fs.openSync()`. It is important to note
-that the file descriptor will not be closed automatically.
+for appending (using `fs.open()` or `fs.openSync()`). The file descriptor will
+not be closed automatically.
 
 ```js
 let fd;
 
 try {
   fd = fs.openSync('message.txt', 'a');
-  fs.appendFile(fd, 'data to append', 'utf8');
+  fs.appendFileSync(fd, 'data to append', 'utf8');
 } catch (err) {
   /* Handle the error */
 } finally {
@@ -988,7 +988,7 @@ constants:
 An easier method of constructing the `mode` is to use a sequence of three
 octal digits (e.g. `765`). The left-most digit (`7` in the example), specifies
 the permissions for the file owner. The middle digit (`6` in the example),
-specifies permissions for the group. The right most digit (`5` in the example),
+specifies permissions for the group. The right-most digit (`5` in the example),
 specifies the permissions for others.
 
 | Number  |       Description        |

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3457,7 +3457,6 @@ The following constants are meant for use with the [`fs.Stats`][] object's
 [`fs.FSWatcher`]: #fs_class_fs_fswatcher
 [`fs.Stats`]: #fs_class_fs_stats
 [`fs.access()`]: #fs_fs_access_path_mode_callback
-[`fs.appendFile()`]: fs.html#fs_fs_appendfile_file_data_options_callback
 [`fs.chmod()`]: #fs_fs_chmod_path_mode_callback
 [`fs.chown()`]: #fs_fs_chown_path_uid_gid_callback
 [`fs.exists()`]: fs.html#fs_fs_exists_path_callback


### PR DESCRIPTION
Some fs doc improvements

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc