### PR TITLE
async_hooks: use CHECK instead of throwing error

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -343,8 +343,7 @@ static void PromiseHook(PromiseHookType type, Local<Promise> promise,
 static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  if (!args[0]->IsObject())
-    return env->ThrowTypeError("first argument must be an object");
+  CHECK(args[0]->IsObject());
 
   // All of init, before, after, destroy are supplied by async_hooks
   // internally, so this should every only be called once. At which time all


### PR DESCRIPTION
SetupHooks is only available via `process.binding('async_wrap')`, so
there's no reason it shouldn't be called with the appropriate arguments,
since it is an internal-only function. The only place this function is
used is `lib/internal/async_hooks.js`.

cc @jasnell 

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
async_hooks