### PR TITLE
tls: fix SNICallback without .server option

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -506,9 +506,8 @@ TLSSocket.prototype._init = function(socket, wrap) {
   if (process.features.tls_sni &&
       options.isServer &&
       options.SNICallback &&
-      options.server &&
       (options.SNICallback !== SNICallback ||
-       options.server._contexts.length)) {
+       (options.server && options.server._contexts.length))) {
     assert(typeof options.SNICallback === 'function');
     this._SNICallback = options.SNICallback;
     ssl.enableCertCb();

--- a/test/parallel/test-tls-socket-snicallback-without-server.js
+++ b/test/parallel/test-tls-socket-snicallback-without-server.js
@@ -12,13 +12,8 @@ const tls = require('tls');
 const fixtures = require('../common/fixtures');
 const makeDuplexPair = require('../common/duplexpair');
 
-const sslcontext = tls.createSecureContext({
-  cert: fixtures.readSync('test_cert.pem'),
-  key: fixtures.readSync('test_key.pem')
-});
-
 const { clientSide, serverSide } = makeDuplexPair();
-const tlsSocket = new tls.TLSSocket(serverSide, {
+new tls.TLSSocket(serverSide, {
   isServer: true,
   SNICallback: common.mustCall((servername, cb) => {
     assert.strictEqual('www.google.com', servername);

--- a/test/parallel/test-tls-socket-snicallback-without-server.js
+++ b/test/parallel/test-tls-socket-snicallback-without-server.js
@@ -16,7 +16,7 @@ const { clientSide, serverSide } = makeDuplexPair();
 new tls.TLSSocket(serverSide, {
   isServer: true,
   SNICallback: common.mustCall((servername, cb) => {
-    assert.strictEqual('www.google.com', servername);
+    assert.strictEqual(servername, 'www.google.com');
   })
 });
 

--- a/test/parallel/test-tls-socket-snicallback-without-server.js
+++ b/test/parallel/test-tls-socket-snicallback-without-server.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// This is based on test-tls-securepair-fiftharg.js
+// for the deprecated `tls.createSecurePair()` variant.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const makeDuplexPair = require('../common/duplexpair');
+
+const sslcontext = tls.createSecureContext({
+  cert: fixtures.readSync('test_cert.pem'),
+  key: fixtures.readSync('test_key.pem')
+});
+
+const { clientSide, serverSide } = makeDuplexPair();
+const tlsSocket = new tls.TLSSocket(serverSide, {
+  isServer: true,
+  SNICallback: common.mustCall((servername, cb) => {
+    assert.strictEqual('www.google.com', servername);
+  })
+});
+
+// captured traffic from browser's request to https://www.google.com
+const sslHello = fixtures.readSync('google_ssl_hello.bin');
+
+clientSide.write(sslHello);


### PR DESCRIPTION
`options.server` only needs to be set when its contents are actually being inspected.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tls