### PR TITLE
test: refactor test-tls-securepair-fiftharg

### DIFF
--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -15,7 +15,7 @@ const sslcontext = tls.createSecureContext({
 
 const pair = tls.createSecurePair(sslcontext, true, false, false, {
   SNICallback: common.mustCall((servername, cb) => {
-    assert.strictEqual('www.google.com', servername);
+    assert.strictEqual(servername, 'www.google.com');
   })
 });
 

--- a/test/parallel/test-tls-securepair-fiftharg.js
+++ b/test/parallel/test-tls-securepair-fiftharg.js
@@ -13,10 +13,9 @@ const sslcontext = tls.createSecureContext({
   key: fixtures.readSync('test_key.pem')
 });
 
-let catchedServername;
 const pair = tls.createSecurePair(sslcontext, true, false, false, {
-  SNICallback: common.mustCall(function(servername, cb) {
-    catchedServername = servername;
+  SNICallback: common.mustCall((servername, cb) => {
+    assert.strictEqual('www.google.com', servername);
   })
 });
 
@@ -24,7 +23,3 @@ const pair = tls.createSecurePair(sslcontext, true, false, false, {
 const sslHello = fixtures.readSync('google_ssl_hello.bin');
 
 pair.encrypted.write(sslHello);
-
-process.on('exit', function() {
-  assert.strictEqual('www.google.com', catchedServername);
-});


### PR DESCRIPTION
Assert the server name directly in the `SNICallback`, since `common.mustCall()` already guarantees that the callback is called exactly once, making `process.on('exit')` unnecessary.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/tls