### PR TITLE
lib, test: migrate _http_outgoing.js's remaining errors to internal/errors.js

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -629,7 +629,7 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
 
 function write_(msg, chunk, encoding, callback, fromEnd) {
   if (msg.finished) {
-    var err = new Error('write after end');
+    const err = new errors.Error('ERR_STREAM_WRITE_AFTER_END');
     nextTick(msg.socket && msg.socket[async_id_symbol],
              writeAfterEndNT.bind(msg),
              err,
@@ -880,7 +880,7 @@ OutgoingMessage.prototype.flush = internalUtil.deprecate(function() {
 
 OutgoingMessage.prototype.pipe = function pipe() {
   // OutgoingMessage should be write-only. Piping from it is disabled.
-  this.emit('error', new Error('Cannot pipe, not readable'));
+  this.emit('error', new errors.Error('ERR_STREAM_CANNOT_PIPE'));
 };
 
 module.exports = {

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -25,11 +25,9 @@ const assert = require('assert');
 const http = require('http');
 
 const server = http.Server(common.mustCall(function(req, res) {
-  res.on('error', common.mustCall(function onResError(err) {
-    common.expectsError({
-      code: 'ERR_STREAM_WRITE_AFTER_END',
-      type: Error
-    })(err);
+  res.on('error', common.expectsError({
+    code: 'ERR_STREAM_WRITE_AFTER_END',
+    type: Error
   }));
 
   res.write('This should write.');

--- a/test/parallel/test-http-res-write-after-end.js
+++ b/test/parallel/test-http-res-write-after-end.js
@@ -26,7 +26,10 @@ const http = require('http');
 
 const server = http.Server(common.mustCall(function(req, res) {
   res.on('error', common.mustCall(function onResError(err) {
-    assert.strictEqual(err.message, 'write after end');
+    common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      type: Error
+    })(err);
   }));
 
   res.write('This should write.');

--- a/test/parallel/test-http-server-write-after-end.js
+++ b/test/parallel/test-http-server-write-after-end.js
@@ -2,7 +2,6 @@
 
 const common = require('../common');
 const http = require('http');
-const assert = require('assert');
 
 // Fix for https://github.com/nodejs/node/issues/14368
 
@@ -10,7 +9,10 @@ const server = http.createServer(handle);
 
 function handle(req, res) {
   res.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.message, 'write after end');
+    common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      type: Error
+    })(err);
     server.close();
   }));
 

--- a/test/parallel/test-outgoing-message-pipe.js
+++ b/test/parallel/test-outgoing-message-pipe.js
@@ -1,16 +1,14 @@
 'use strict';
-const assert = require('assert');
 const common = require('../common');
 const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 
 // Verify that an error is thrown upon a call to `OutgoingMessage.pipe`.
 
 const outgoingMessage = new OutgoingMessage();
-assert.throws(
-  common.mustCall(() => { outgoingMessage.pipe(outgoingMessage); }),
-  common.expectsError({
+common.expectsError(
+  () => { outgoingMessage.pipe(outgoingMessage); },
+  {
     code: 'ERR_STREAM_CANNOT_PIPE',
     type: Error
-  }),
-  'OutgoingMessage.pipe should throw an error'
+  }
 );

--- a/test/parallel/test-outgoing-message-pipe.js
+++ b/test/parallel/test-outgoing-message-pipe.js
@@ -8,8 +8,9 @@ const OutgoingMessage = require('_http_outgoing').OutgoingMessage;
 const outgoingMessage = new OutgoingMessage();
 assert.throws(
   common.mustCall(() => { outgoingMessage.pipe(outgoingMessage); }),
-  (err) => {
-    return ((err instanceof Error) && /Cannot pipe, not readable/.test(err));
-  },
+  common.expectsError({
+    code: 'ERR_STREAM_CANNOT_PIPE',
+    type: Error
+  }),
   'OutgoingMessage.pipe should throw an error'
 );

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -16,11 +16,9 @@ const server = http.createServer(common.mustCall(function(req, res) {
   process.nextTick(common.mustCall(() => {
     res.end();
     myStream.emit('data', 'some data');
-    res.on('error', common.mustCall(function(err) {
-      common.expectsError({
-        code: 'ERR_STREAM_WRITE_AFTER_END',
-        type: Error
-      })(err);
+    res.on('error', common.expectsError({
+      code: 'ERR_STREAM_WRITE_AFTER_END',
+      type: Error
     }));
 
     process.nextTick(common.mustCall(() => server.close()));

--- a/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
+++ b/test/parallel/test-pipe-outgoing-message-data-emitted-after-ended.js
@@ -1,7 +1,6 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
-const assert = require('assert');
 const stream = require('stream');
 
 // Verify that when piping a stream to an `OutgoingMessage` (or a type that
@@ -18,7 +17,10 @@ const server = http.createServer(common.mustCall(function(req, res) {
     res.end();
     myStream.emit('data', 'some data');
     res.on('error', common.mustCall(function(err) {
-      assert.strictEqual(err.message, 'write after end');
+      common.expectsError({
+        code: 'ERR_STREAM_WRITE_AFTER_END',
+        type: Error
+      })(err);
     }));
 
     process.nextTick(common.mustCall(() => server.close()));


### PR DESCRIPTION
cc @jasnell @joyeecheung 

A couple of `lib/_http_outgoing.js`'s errors were still in the "old style":
`throw new Error(<some message here>)`.

This PR migrates those 2 old style errors to the "new style": `internal/errors.js`'s error-system.

In the future, changes to these errors' messages won't break semver-major status. With the old style, changes to these errors' messages broke semver-major status. It was inconvenient.

This PR also adapts `_http_outgoing.js`'s tests accordingly.

Refs: https://github.com/nodejs/node/issues/17709
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib, test