### PR TITLE
doc: change "less" to "fewer" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,7 +307,7 @@ notes about [commit squashing](#commit-squashing)).
 A good commit message should describe what changed and why.
 
 1. The first line should:
-   - contain a short description of the change (preferably 50 characters or less,
+   - contain a short description of the change (preferably 50 characters or fewer,
      and no more than 72 characters)
    - be entirely in lowercase with the exception of proper nouns, acronyms, and
    the words that refer to code, like function/variable names


### PR DESCRIPTION
Consider the phrase "50 characters or less".
The use of "less" in that phrase is grammatically incorrect.

"Less" and "fewer" are both quantifiers with similar functions.

However, "less" suits mass nouns ("less water", "less salt").
"Fewer" suits countable nouns ("fewer chairs", "fewer doors").

"Character" is a countable noun. Therefore, "fewer" is the appropriate quantifier for it.

I apologize for the pedantry, but it was bothering me 😅 .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc