### PR TITLE
process: do not directly schedule _tickCallback in _fatalException

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -362,6 +362,8 @@
     }
   }
 
+  function noop() {}
+
   function setupProcessFatal() {
     const async_wrap = process.binding('async_wrap');
     // Arrays containing hook flags and ids for async_hook calls.
@@ -372,23 +374,15 @@
             kDefaultTriggerAsyncId, kStackLength } = async_wrap.constants;
 
     process._fatalException = function(er) {
-      var caught;
-
       // It's possible that kDefaultTriggerAsyncId was set for a constructor
       // call that threw and was never cleared. So clear it now.
       async_id_fields[kDefaultTriggerAsyncId] = -1;
 
       if (exceptionHandlerState.captureFn !== null) {
         exceptionHandlerState.captureFn(er);
-        caught = true;
-      }
-
-      if (!caught)
-        caught = process.emit('uncaughtException', er);
-
-      // If someone handled it, then great.  otherwise, die in C++ land
-      // since that means that we'll exit the process, emit the 'exit' event
-      if (!caught) {
+      } else if (!process.emit('uncaughtException', er)) {
+        // If someone handled it, then great.  otherwise, die in C++ land
+        // since that means that we'll exit the process, emit the 'exit' event
         try {
           if (!process._exiting) {
             process._exiting = true;
@@ -397,24 +391,25 @@
         } catch (er) {
           // nothing to be done about it at this point.
         }
-
-      } else {
-        // If we handled an error, then make sure any ticks get processed
-        NativeModule.require('timers').setImmediate(process._tickCallback);
-
-        // Emit the after() hooks now that the exception has been handled.
-        if (async_hook_fields[kAfter] > 0) {
-          do {
-            NativeModule.require('internal/async_hooks').emitAfter(
-              async_id_fields[kExecutionAsyncId]);
-          } while (async_hook_fields[kStackLength] > 0);
-        // Or completely empty the id stack.
-        } else {
-          clearAsyncIdStack();
-        }
+        return false;
       }
 
-      return caught;
+      // If we handled an error, then make sure any ticks get processed
+      // by ensuring that the next Immediate cycle isn't empty
+      NativeModule.require('timers').setImmediate(noop);
+
+      // Emit the after() hooks now that the exception has been handled.
+      if (async_hook_fields[kAfter] > 0) {
+        const { emitAfter } = NativeModule.require('internal/async_hooks');
+        do {
+          emitAfter(async_id_fields[kExecutionAsyncId]);
+        } while (async_hook_fields[kStackLength] > 0);
+      // Or completely empty the id stack.
+      } else {
+        clearAsyncIdStack();
+      }
+
+      return true;
     };
   }
 

--- a/test/parallel/test-process-fatal-exception-tick.js
+++ b/test/parallel/test-process-fatal-exception-tick.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// If a process encounters an uncaughtException, it should schedule
+// processing of nextTicks on the next Immediates cycle but not
+// before all Immediates are handled
+
+let stage = 0;
+
+process.once('uncaughtException', common.expectsError({
+  type: Error,
+  message: 'caughtException'
+}));
+
+setImmediate(() => {
+  stage++;
+  process.nextTick(() => assert.strictEqual(stage, 2));
+});
+const now = Date.now();
+setTimeout(() => setImmediate(() => stage++), 1);
+while (now + 10 >= Date.now());
+throw new Error('caughtException');


### PR DESCRIPTION
When a process encounters a `_fatalException` that is caught, it should schedule execution of `nextTicks` but not in an arbitrary place of the next `Immediates` queue. Instead, add a no-op function to the queue that will ensure `processImmediate` runs, which will then ensure that `nextTicks` are processed at the end.

The current behaviour is counter-intuitive and can have completely unforeseen consequences because it allows for a `_tickCallback` to be scheduled anywhere within the `setImmediate` queue, which breaks the one basic rule of `nextTick` — that it runs when all the current operations complete.

CI: https://ci.nodejs.org/job/node-test-pull-request/12279/
CitGM: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1165/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
process, test