### PR TITLE
assert: async parameter for assert.throws() and assert.doesNotThrow()

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -243,21 +243,21 @@ function expectedException(actual, expected, msg) {
   return expected.call({}, actual) === true;
 }
 
-function getActual(block) {
+async function getActual(block) {
   if (typeof block !== 'function') {
     throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'block', 'Function',
                                block);
   }
   try {
-    block();
+    await block();
   } catch (e) {
     return e;
   }
 }
 
 // Expected to throw an error.
-assert.throws = function throws(block, error, message) {
-  const actual = getActual(block);
+assert.throws = async function throws(block, error, message) {
+  const actual = await getActual(block);
 
   if (typeof error === 'string') {
     if (arguments.length === 3)
@@ -289,8 +289,8 @@ assert.throws = function throws(block, error, message) {
   }
 };
 
-assert.doesNotThrow = function doesNotThrow(block, error, message) {
-  const actual = getActual(block);
+assert.doesNotThrow = async function doesNotThrow(block, error, message) {
+  const actual = await getActual(block);
   if (actual === undefined)
     return;
 

--- a/test/parallel/test-assert-async.js
+++ b/test/parallel/test-assert-async.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const promisify = require('util').promisify;
+const wait = promisify(setTimeout);
+
+// Ensure async support for assert.throws() and assert.doesNotThrow()
+/* eslint-disable prefer-common-expectserror */
+
+assert.throws(
+  async () => { assert.fail(); },
+  common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'Failed',
+    operator: undefined,
+    actual: undefined,
+    expected: undefined
+  })
+);
+
+assert.throws(
+  async () => {
+    await wait(common.platformTimeout(10));
+    assert.fail();
+  },
+  common.expectsError({
+    code: 'ERR_ASSERTION',
+    type: assert.AssertionError,
+    message: 'Failed',
+    operator: undefined,
+    actual: undefined,
+    expected: undefined
+  })
+);
+
+assert.doesNotThrow(async () => {});
+
+assert.doesNotThrow(async () => {
+  await wait(common.platformTimeout(10));
+  assert.fail();
+});


### PR DESCRIPTION
_Hello community!
It's my first PR, I hope I didn't missed important stuff. 
Documentation isn't included yet as I'd like to get feedback on this new feature first._

The first parameter of `assert.throws()` and `assert.doesNotThrow()` can be an async function.

Benefit is to make tests way more easier to read.
Validating error behaviour with promise-based code used to look like this:
```javascript
it('should report database option errors', () => {
  transferData({}, '')
    .then(() => {
      throw new Error('it should have failed');
    }, err => {
      assert(err.message.includes('"host" is required'));
    });
);
```

Now, thanks to async/await support, it looks like this:
```javascript
it('should report database option errors', async () => {
  try {
    await transferData({}, '');
    throw new Error('it should have failed');
  } catch (err) {
    assert(err.message.includes('"host" is required'));
  }
});
```

With native async support, it can now be written like this:
```javascript
it('should report database option errors', async () =>
  assert.throws(async () => transferData({}, ''), /^Error: "host" is required/)
);
```

However, it may be considered as a breaking change: `assert.throws()` used to return nothing, while now, due to its async nature, it returns a Promise.


##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
assert
