### PR TITLE
tests: fix test-require-deps-deprecation for already installed deps

### DIFF
--- a/test/parallel/test-require-deps-deprecation.js
+++ b/test/parallel/test-require-deps-deprecation.js
@@ -39,6 +39,15 @@ for (const m of deprecatedModules) {
   } catch (err) {}
 }
 
+// Instead of checking require, check that resolve isn't pointing toward
+// /node/deps, as user might already have node installed with acorn in
+// require.resolve range
 for (const m of deps) {
-  assert.throws(() => { require(m); }, /^Error: Cannot find module/);
+  let path;
+  try {
+    path = require.resolve(m);
+  } catch (err) {
+    continue;
+  }
+  assert.notStrictEqual(path, m);
 }

--- a/test/parallel/test-require-deps-deprecation.js
+++ b/test/parallel/test-require-deps-deprecation.js
@@ -39,14 +39,16 @@ for (const m of deprecatedModules) {
   } catch (err) {}
 }
 
-// Instead of checking require, check that resolve isn't pointing toward
-// /node/deps, as user might already have node installed with acorn in
-// require.resolve range
+// Instead of checking require, check that resolve isn't pointing toward a
+// built-in module, as user might already have node installed with acorn in
+// require.resolve range.
+// Ref: https://github.com/nodejs/node/issues/17148
 for (const m of deps) {
   let path;
   try {
     path = require.resolve(m);
   } catch (err) {
+    assert.ok(err.toString().startsWith('Error: Cannot find module '));
     continue;
   }
   assert.notStrictEqual(path, m);


### PR DESCRIPTION
Merry christmas!

Test test-require-deps-deprecation.js was failing when user already had node
installed with acorn in require.resolve range.
Modified test to acknowledge the possibility and throw only if acorn is
found in the deps directory.

Fixes: https://github.com/nodejs/node/issues/17148
Refs: https://github.com/nodejs/node/issues/17148#issuecomment-346167296

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
test
