### PR TITLE
fs: migrate fs_event_wrap to internal/errors

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1664,6 +1664,8 @@ fs.appendFileSync = function(path, data, options) {
 function FSWatcher() {
   EventEmitter.call(this);
 
+  this._initialized = false;
+
   var self = this;
   this._handle = new FSEvent();
   this._handle.owner = this;
@@ -1689,6 +1691,13 @@ FSWatcher.prototype.start = function(filename,
                                      encoding) {
   handleError((filename = getPathFromURL(filename)));
   nullCheck(filename);
+
+  if (this._initialized) {
+    return;
+  }
+
+  validatePath(filename, 'filename');
+
   var err = this._handle.start(pathModule.toNamespacedPath(filename),
                                persistent,
                                recursive,
@@ -1698,10 +1707,13 @@ FSWatcher.prototype.start = function(filename,
     const error = errnoException(err, `watch ${filename}`);
     error.filename = filename;
     throw error;
+  } else {
+    this._initialized = true;
   }
 };
 
 FSWatcher.prototype.close = function() {
+  this._initialized = false;
   this._handle.close();
 };
 

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -114,13 +114,10 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
   if (wrap->initialized_)
     return args.GetReturnValue().Set(0);
 
-  static const char kErrMsg[] = "filename must be a string or Buffer";
-  if (args.Length() < 1)
-    return env->ThrowTypeError(kErrMsg);
+  CHECK_GE(args.Length(), 4);
 
   BufferValue path(env->isolate(), args[0]);
-  if (*path == nullptr)
-    return env->ThrowTypeError(kErrMsg);
+  CHECK_NE(*path, nullptr);
 
   unsigned int flags = 0;
   if (args[2]->IsTrue())

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -114,6 +114,22 @@ tmpdir.refresh();
 
 }
 
+{
+  const msg = 'The "filename" argument must be one of type' +
+    ' string, Buffer, or URL';
+
+  [false, 1, [], {}, null, undefined].forEach((i) => {
+    common.expectsError(
+      () => fs.watch(i, common.mustNotCall()),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError,
+        message: msg
+      }
+    );
+  });
+}
+
 // https://github.com/joyent/node/issues/2293 - non-persistent watcher should
 // not block the event loop
 {


### PR DESCRIPTION
Migrates `fs_event_wrap.cc` to internal/errors style.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

fs