### PR TITLE
fs: fix fs.readFile, fs.exists{Sync} regression caused by assertions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -389,6 +389,9 @@ fs.readFile = function(path, options, callback) {
       req.oncomplete(null, path);
     });
     return;
+  } else if (typeof path !== 'string' && !(path instanceof Buffer)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
   }
 
   binding.open(pathModule.toNamespacedPath(path),

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -340,6 +340,10 @@ fs.accessSync = function(path, mode) {
 fs.exists = function(path, callback) {
   if (handleError((path = getPathFromURL(path)), cb))
     return;
+  if (typeof path !== 'string' && !(path instanceof Buffer)) {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'path',
+                               ['string', 'Buffer', 'URL']);
+  }
   if (!nullCheck(path, cb)) return;
   var req = new FSReqWrap();
   req.oncomplete = cb;
@@ -361,6 +365,9 @@ Object.defineProperty(fs.exists, internalUtil.promisify.custom, {
 fs.existsSync = function(path) {
   try {
     handleError((path = getPathFromURL(path)));
+    if (typeof path !== 'string' && !(path instanceof Buffer)) {
+      return false;
+    }
     nullCheck(path);
     binding.stat(pathModule.toNamespacedPath(path));
     return true;

--- a/test/parallel/test-fs-exists.js
+++ b/test/parallel/test-fs-exists.js
@@ -42,3 +42,14 @@ fs.exists(new URL('https://foo'), common.mustCall(function(y) {
 
 assert(fs.existsSync(f));
 assert(!fs.existsSync(`${f}-NO`));
+
+common.expectsError(
+  () => { fs.exists(() => {}); },
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "path" argument must be one of type string, Buffer, or URL',
+    type: TypeError
+  }
+);
+
+assert(!fs.existsSync());

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const fs = require('fs');
 
 // Test that fs.readFile fails correctly on a non-existent file.
 
@@ -54,3 +55,12 @@ test({ NODE_DEBUG: 'fs' }, common.mustCall((data) => {
   assert(/EISDIR/.test(data));
   assert(/test-fs-readfile-error/.test(data));
 }));
+
+common.expectsError(
+  () => { fs.readFile(() => {}); },
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "path" argument must be one of type string, Buffer, or URL',
+    type: TypeError
+  }
+);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs

Refs: https://github.com/nodejs/node/pull/17667

https://github.com/nodejs/node/pull/17667 didn't include the path validation of these methods in JS land, so passing undefined as paths to them would go straight to assertions, which caused CITGM regression https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1165/ . This PR fixes that by adding those validations back.
