### PR TITLE
test: fix flaky test-benchmark-fs

### DIFF
--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -3,6 +3,8 @@
 const common = require('../common');
 const runBenchmark = require('../common/benchmark');
 
+common.refreshTmpDir();
+
 runBenchmark('fs', [
   'n=1',
   'size=1',


### PR DESCRIPTION
test-benchmark-fs uses common.tmpDir without first insuring it exists by
calling common.refreshTmpDir(). Add that function call.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test