### PR TITLE
test: move tmpdir functionality to submodule of common

### DIFF
--- a/benchmark/http/http_server_for_chunky_client.js
+++ b/benchmark/http/http_server_for_chunky_client.js
@@ -2,22 +2,15 @@
 
 const assert = require('assert');
 const http = require('http');
-const fs = require('fs');
 const { fork } = require('child_process');
 const common = require('../common.js');
-const { PIPE, tmpDir } = require('../../test/common');
+const { PIPE } = require('../../test/common');
+const tmpdir = require('../../test/common/tmpdir');
 process.env.PIPE_NAME = PIPE;
 
-try {
-  fs.accessSync(tmpDir, fs.F_OK);
-} catch (e) {
-  fs.mkdirSync(tmpDir);
-}
+tmpdir.refresh();
 
 var server;
-try {
-  fs.unlinkSync(process.env.PIPE_NAME);
-} catch (e) { /* ignore */ }
 
 server = http.createServer(function(req, res) {
   const headers = {

--- a/benchmark/module/module-loader.js
+++ b/benchmark/module/module-loader.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const common = require('../common.js');
 
-const { refreshTmpDir, tmpDir } = require('../../test/common');
-const benchmarkDirectory = path.join(tmpDir, 'nodejs-benchmark-module');
+const tmpdir = require('../../test/common/tmpdir');
+const benchmarkDirectory = path.join(tmpdir.path, 'nodejs-benchmark-module');
 
 const bench = common.createBenchmark(main, {
   thousands: [50],
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
 function main({ thousands, fullPath, useCache }) {
   const n = thousands * 1e3;
 
-  refreshTmpDir();
+  tmpdir.refresh();
   try { fs.mkdirSync(benchmarkDirectory); } catch (e) {}
 
   for (var i = 0; i <= n; i++) {
@@ -35,7 +35,7 @@ function main({ thousands, fullPath, useCache }) {
   else
     measureDir(n, useCache === 'true');
 
-  refreshTmpDir();
+  tmpdir.refresh();
 }
 
 function measureFull(n, useCache) {

--- a/test/addons/load-long-path/test.js
+++ b/test/addons/load-long-path/test.js
@@ -7,12 +7,13 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../../common/tmpdir');
+tmpdir.refresh();
 
 // make a path that is more than 260 chars long.
 // Any given folder cannot have a name longer than 260 characters,
 // so create 10 nested folders each with 30 character long names.
-let addonDestinationDir = path.resolve(common.tmpDir);
+let addonDestinationDir = path.resolve(tmpdir.path);
 
 for (let i = 0; i < 10; i++) {
   addonDestinationDir = path.join(addonDestinationDir, 'x'.repeat(30));

--- a/test/addons/symlinked-module/test.js
+++ b/test/addons/symlinked-module/test.js
@@ -12,10 +12,11 @@ const assert = require('assert');
 // This test should pass in Node.js v4 and v5. This test will pass in Node.js
 // with https://github.com/nodejs/node/pull/5950 reverted.
 
-common.refreshTmpDir();
+const tmpdir = require('../../common/tmpdir');
+tmpdir.refresh();
 
 const addonPath = path.join(__dirname, 'build', common.buildType);
-const addonLink = path.join(common.tmpDir, 'addon');
+const addonLink = path.join(tmpdir.path, 'addon');
 
 try {
   fs.symlinkSync(addonPath, addonLink);

--- a/test/async-hooks/test-graph.pipeconnect.js
+++ b/test/async-hooks/test-graph.pipeconnect.js
@@ -6,7 +6,8 @@ const verifyGraph = require('./verify-graph');
 
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -8,7 +8,8 @@ const { checkInvocations } = require('./hook-checks');
 
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const hooks = initHooks();
 hooks.enable();

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -12,6 +12,7 @@ This directory contains modules used to test the Node.js implementation.
 * [Fixtures module](#fixtures-module)
 * [HTTP2 module](#http2-module)
 * [Internet module](#internet-module)
+* [tmpdir module](#tmpdir-module)
 * [WPT module](#wpt-module)
 
 ## Benchmark Module
@@ -332,11 +333,6 @@ A port number for tests to use if one is needed.
 
 Logs '1..0 # Skipped: ' + `msg`
 
-### refreshTmpDir()
-* return [&lt;String>]
-
-Deletes the testing 'tmp' directory and recreates it.
-
 ### restoreStderr()
 
 Restore the original `process.stderr.write`. Used to restore `stderr` to its
@@ -378,11 +374,6 @@ Platform normalizes the `pwd` command.
 * return [&lt;Object>]
 
 Synchronous version of `spawnPwd`.
-
-### tmpDir
-* [&lt;String>]
-
-The realpath of the 'tmp' directory.
 
 ## Countdown Module
 
@@ -664,6 +655,19 @@ A set of addresses for internet-related tests. All properties are configurable
 via `NODE_TEST_*` environment variables. For example, to configure
 `internet.addresses.INET_HOST`, set the environment
 variable `NODE_TEST_INET_HOST` to a specified host.
+
+## tmpdir Module
+
+The `tmpdir` module supports the use of a temporary directory for testing.
+
+### path
+* [&lt;String>]
+
+The realpath of the testing temporary directory.
+
+### refresh()
+
+Deletes and recreates the testing temporary directory.
 
 ## WPT Module
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -31,15 +31,9 @@ const stream = require('stream');
 const util = require('util');
 const Timer = process.binding('timer_wrap').Timer;
 const { fixturesDir } = require('./fixtures');
-
-const testRoot = process.env.NODE_TEST_DIR ?
-  fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
+const tmpdir = require('./tmpdir');
 
 const noop = () => {};
-
-// Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
-// gets tools to ignore it by default or by simple rules, especially eslint.
-let tmpDirName = '.tmp';
 
 Object.defineProperty(exports, 'PORT', {
   get: () => {
@@ -119,62 +113,6 @@ if (process.env.NODE_TEST_WITH_ASYNC_HOOKS) {
     },
   }).enable();
 }
-
-function rimrafSync(p) {
-  let st;
-  try {
-    st = fs.lstatSync(p);
-  } catch (e) {
-    if (e.code === 'ENOENT')
-      return;
-  }
-
-  try {
-    if (st && st.isDirectory())
-      rmdirSync(p, null);
-    else
-      fs.unlinkSync(p);
-  } catch (e) {
-    if (e.code === 'ENOENT')
-      return;
-    if (e.code === 'EPERM')
-      return rmdirSync(p, e);
-    if (e.code !== 'EISDIR')
-      throw e;
-    rmdirSync(p, e);
-  }
-}
-
-function rmdirSync(p, originalEr) {
-  try {
-    fs.rmdirSync(p);
-  } catch (e) {
-    if (e.code === 'ENOTDIR')
-      throw originalEr;
-    if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
-      const enc = exports.isLinux ? 'buffer' : 'utf8';
-      fs.readdirSync(p, enc).forEach((f) => {
-        if (f instanceof Buffer) {
-          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
-          rimrafSync(buf);
-        } else {
-          rimrafSync(path.join(p, f));
-        }
-      });
-      fs.rmdirSync(p);
-    }
-  }
-}
-
-exports.refreshTmpDir = function() {
-  rimrafSync(exports.tmpDir);
-  fs.mkdirSync(exports.tmpDir);
-};
-
-if (process.env.TEST_THREAD_ID) {
-  tmpDirName += `.${process.env.TEST_THREAD_ID}`;
-}
-exports.tmpDir = path.join(testRoot, tmpDirName);
 
 let opensslCli = null;
 let inFreeBSDJail = null;
@@ -269,7 +207,7 @@ Object.defineProperty(exports, 'hasFipsCrypto', {
 });
 
 {
-  const localRelative = path.relative(process.cwd(), `${exports.tmpDir}/`);
+  const localRelative = path.relative(process.cwd(), `${tmpdir.path}/`);
   const pipePrefix = exports.isWindows ? '\\\\.\\pipe\\' : localRelative;
   const pipeName = `node-test.${process.pid}.sock`;
   exports.PIPE = path.join(pipePrefix, pipeName);

--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -1,0 +1,67 @@
+/* eslint-disable required-modules */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function rimrafSync(p) {
+  let st;
+  try {
+    st = fs.lstatSync(p);
+  } catch (e) {
+    if (e.code === 'ENOENT')
+      return;
+  }
+
+  try {
+    if (st && st.isDirectory())
+      rmdirSync(p, null);
+    else
+      fs.unlinkSync(p);
+  } catch (e) {
+    if (e.code === 'ENOENT')
+      return;
+    if (e.code === 'EPERM')
+      return rmdirSync(p, e);
+    if (e.code !== 'EISDIR')
+      throw e;
+    rmdirSync(p, e);
+  }
+}
+
+function rmdirSync(p, originalEr) {
+  try {
+    fs.rmdirSync(p);
+  } catch (e) {
+    if (e.code === 'ENOTDIR')
+      throw originalEr;
+    if (e.code === 'ENOTEMPTY' || e.code === 'EEXIST' || e.code === 'EPERM') {
+      const enc = process.platform === 'linux' ? 'buffer' : 'utf8';
+      fs.readdirSync(p, enc).forEach((f) => {
+        if (f instanceof Buffer) {
+          const buf = Buffer.concat([Buffer.from(p), Buffer.from(path.sep), f]);
+          rimrafSync(buf);
+        } else {
+          rimrafSync(path.join(p, f));
+        }
+      });
+      fs.rmdirSync(p);
+    }
+  }
+}
+
+const testRoot = process.env.NODE_TEST_DIR ?
+  fs.realpathSync(process.env.NODE_TEST_DIR) : path.resolve(__dirname, '..');
+
+// Using a `.` prefixed name, which is the convention for "hidden" on POSIX,
+// gets tools to ignore it by default or by simple rules, especially eslint.
+let tmpdirName = '.tmp';
+if (process.env.TEST_THREAD_ID) {
+  tmpdirName += `.${process.env.TEST_THREAD_ID}`;
+}
+exports.path = path.join(testRoot, tmpdirName);
+
+exports.refresh = () => {
+  rimrafSync(exports.path);
+  fs.mkdirSync(exports.path);
+};

--- a/test/es-module/test-esm-preserve-symlinks.js
+++ b/test/es-module/test-esm-preserve-symlinks.js
@@ -7,8 +7,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const entry = path.join(tmpDir, 'entry.js');
 const real = path.join(tmpDir, 'real.js');

--- a/test/es-module/test-esm-symlink.js
+++ b/test/es-module/test-esm-symlink.js
@@ -6,8 +6,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const entry = path.join(tmpDir, 'entry.mjs');
 const real = path.join(tmpDir, 'index.mjs');

--- a/test/known_issues/test-cwd-enoent-file.js
+++ b/test/known_issues/test-cwd-enoent-file.js
@@ -17,8 +17,9 @@ const fs = require('fs');
 if (process.argv[2] === 'child') {
   // Do nothing.
 } else {
-  common.refreshTmpDir();
-  const dir = fs.mkdtempSync(`${common.tmpDir}/`);
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const dir = fs.mkdtempSync(`${tmpdir.path}/`);
   process.chdir(dir);
   fs.rmdirSync(dir);
   assert.throws(process.cwd,

--- a/test/known_issues/test-module-deleted-extensions.js
+++ b/test/known_issues/test-module-deleted-extensions.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const file = path.join(common.tmpDir, 'test-extensions.foo.bar');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, 'test-extensions.foo.bar');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(file, '', 'utf8');
 require.extensions['.foo.bar'] = (module, path) => {};
 delete require.extensions['.foo.bar'];
@@ -14,4 +15,4 @@ require.extensions['.bar'] = common.mustCall((module, path) => {
   assert.strictEqual(module.id, file);
   assert.strictEqual(path, file);
 });
-require(path.join(common.tmpDir, 'test-extensions'));
+require(path.join(tmpdir.path, 'test-extensions'));

--- a/test/parallel/test-benchmark-fs.js
+++ b/test/parallel/test-benchmark-fs.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const runBenchmark = require('../common/benchmark');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 runBenchmark('fs', [
   'n=1',
@@ -16,4 +17,4 @@ runBenchmark('fs', [
   'statSyncType=fstatSync',
   'encodingType=buf',
   'filesize=1024'
-], { NODE_TMPDIR: common.tmpDir, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });
+], { NODE_TMPDIR: tmpdir.path, NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/parallel/test-child-process-fork-exec-path.js
+++ b/test/parallel/test-child-process-fork-exec-path.js
@@ -24,9 +24,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const tmpdir = require('../common/tmpdir');
 const msg = { test: 'this' };
 const nodePath = process.execPath;
-const copyPath = path.join(common.tmpDir, 'node-copy.exe');
+const copyPath = path.join(tmpdir.path, 'node-copy.exe');
 
 if (process.env.FORK) {
   assert(process.send);
@@ -34,7 +35,7 @@ if (process.env.FORK) {
   process.send(msg);
   process.exit();
 } else {
-  common.refreshTmpDir();
+  tmpdir.refresh();
   try {
     fs.unlinkSync(copyPath);
   } catch (e) {

--- a/test/parallel/test-cli-node-options-disallowed.js
+++ b/test/parallel/test-cli-node-options-disallowed.js
@@ -8,8 +8,9 @@ if (process.config.variables.node_without_node_options)
 const assert = require('assert');
 const exec = require('child_process').execFile;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 disallow('--version');
 disallow('-v');

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -8,8 +8,9 @@ if (process.config.variables.node_without_node_options)
 const assert = require('assert');
 const exec = require('child_process').execFile;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 expect(`-r ${require.resolve('../fixtures/printA.js')}`, 'A\nB\n');
 expect('--no-deprecation', 'B\n');

--- a/test/parallel/test-cluster-cwd.js
+++ b/test/parallel/test-cluster-cwd.js
@@ -2,19 +2,20 @@
 const common = require('../common');
 const assert = require('assert');
 const cluster = require('cluster');
+const tmpdir = require('../common/tmpdir');
 
 if (cluster.isMaster) {
-  common.refreshTmpDir();
+  tmpdir.refresh();
 
   assert.strictEqual(cluster.settings.cwd, undefined);
   cluster.fork().on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, process.cwd());
   }));
 
-  cluster.setupMaster({ cwd: common.tmpDir });
-  assert.strictEqual(cluster.settings.cwd, common.tmpDir);
+  cluster.setupMaster({ cwd: tmpdir.path });
+  assert.strictEqual(cluster.settings.cwd, tmpdir.path);
   cluster.fork().on('message', common.mustCall((msg) => {
-    assert.strictEqual(msg, common.tmpDir);
+    assert.strictEqual(msg, tmpdir.path);
   }));
 } else {
   process.send(process.cwd());

--- a/test/parallel/test-cluster-eaccess.js
+++ b/test/parallel/test-cluster-eaccess.js
@@ -33,7 +33,8 @@ const net = require('net');
 
 if (cluster.isMaster && process.argv.length !== 3) {
   // cluster.isMaster
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   const PIPE_NAME = common.PIPE;
   const worker = cluster.fork({ PIPE_NAME });
 

--- a/test/parallel/test-cluster-http-pipe.js
+++ b/test/parallel/test-cluster-http-pipe.js
@@ -32,7 +32,8 @@ const cluster = require('cluster');
 const http = require('http');
 
 if (cluster.isMaster) {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   const worker = cluster.fork();
   worker.on('message', common.mustCall((msg) => {
     assert.strictEqual(msg, 'DONE');

--- a/test/parallel/test-cluster-net-listen-relative-path.js
+++ b/test/parallel/test-cluster-net-listen-relative-path.js
@@ -6,6 +6,8 @@ const net = require('net');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 if (common.isWindows)
   common.skip('On Windows named pipes live in their own ' +
               'filesystem and don\'t have a ~100 byte limit');
@@ -20,8 +22,8 @@ assert.strictEqual(path.resolve(socketDir, socketName).length > 100, true,
 
 if (cluster.isMaster) {
   // ensure that the worker exits peacefully
-  common.refreshTmpDir();
-  process.chdir(common.tmpDir);
+  tmpdir.refresh();
+  process.chdir(tmpdir.path);
   fs.mkdirSync(socketDir);
   cluster.fork().on('exit', common.mustCall(function(statusCode) {
     assert.strictEqual(statusCode, 0);

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -297,11 +297,12 @@ common.expectsError(
       padding: crypto.constants.RSA_PKCS1_PSS_PADDING
     });
 
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
-  const sigfile = path.join(common.tmpDir, 's5.sig');
+  const sigfile = path.join(tmpdir.path, 's5.sig');
   fs.writeFileSync(sigfile, s5);
-  const msgfile = path.join(common.tmpDir, 's5.msg');
+  const msgfile = path.join(tmpdir.path, 's5.msg');
   fs.writeFileSync(msgfile, msg);
 
   const cmd =

--- a/test/parallel/test-cwd-enoent-preload.js
+++ b/test/parallel/test-cwd-enoent-preload.js
@@ -8,10 +8,11 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
 const abspathFile = fixtures.path('a.js');
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-cwd-enoent-repl.js
+++ b/test/parallel/test-cwd-enoent-repl.js
@@ -8,8 +8,10 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-cwd-enoent.js
+++ b/test/parallel/test-cwd-enoent.js
@@ -8,8 +8,10 @@ const assert = require('assert');
 const fs = require('fs');
 const spawn = require('child_process').spawn;
 
-const dirname = `${common.tmpDir}/cwd-does-not-exist-${process.pid}`;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
 fs.mkdirSync(dirname);
 process.chdir(dirname);
 fs.rmdirSync(dirname);

--- a/test/parallel/test-file-write-stream.js
+++ b/test/parallel/test-file-write-stream.js
@@ -25,8 +25,9 @@ const assert = require('assert');
 
 const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.tmpDir, 'write.txt');
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+const fn = path.join(tmpdir.path, 'write.txt');
+tmpdir.refresh();
 const file = fs.createWriteStream(fn, {
   highWaterMark: 10
 });

--- a/test/parallel/test-file-write-stream2.js
+++ b/test/parallel/test-file-write-stream2.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
 
-const filepath = path.join(common.tmpDir, 'write.txt');
+
+const filepath = path.join(tmpdir.path, 'write.txt');
 
 const EXPECTED = '012345678910';
 
@@ -58,7 +60,7 @@ function removeTestFile() {
 }
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // drain at 0, return false at 10.
 const file = fs.createWriteStream(filepath, {

--- a/test/parallel/test-file-write-stream3.js
+++ b/test/parallel/test-file-write-stream3.js
@@ -25,8 +25,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
 
-const filepath = path.join(common.tmpDir, 'write_pos.txt');
+
+const filepath = path.join(tmpdir.path, 'write_pos.txt');
 
 
 const cb_expected = 'write open close write open close write open close ';
@@ -51,7 +53,7 @@ process.on('exit', function() {
 });
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 
 function run_test_1() {

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -7,18 +7,20 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+
 const uv = process.binding('uv');
 
-const doesNotExist = path.join(common.tmpDir, '__this_should_not_exist');
-const readOnlyFile = path.join(common.tmpDir, 'read_only_file');
-const readWriteFile = path.join(common.tmpDir, 'read_write_file');
+const tmpdir = require('../common/tmpdir');
+const doesNotExist = path.join(tmpdir.path, '__this_should_not_exist');
+const readOnlyFile = path.join(tmpdir.path, 'read_only_file');
+const readWriteFile = path.join(tmpdir.path, 'read_write_file');
 
 function createFileWithPerms(file, mode) {
   fs.writeFileSync(file, '');
   fs.chmodSync(file, mode);
 }
 
-common.refreshTmpDir();
+tmpdir.refresh();
 createFileWithPerms(readOnlyFile, 0o444);
 createFileWithPerms(readWriteFile, 0o666);
 

--- a/test/parallel/test-fs-append-file-sync.js
+++ b/test/parallel/test-fs-append-file-sync.js
@@ -36,10 +36,11 @@ const data = '南越国是前203年至前111年存在于岭南地区的一个国
              '历经五代君主。南越国是岭南地区的第一个有记载的政权国家，采用封建制和郡县制并存的制度，' +
              '它的建立保证了秦末乱世岭南地区社会秩序的稳定，有效的改善了岭南地区落后的政治、##济现状。\n';
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test that empty file will be created and have content added
-const filename = join(common.tmpDir, 'append-sync.txt');
+const filename = join(tmpdir.path, 'append-sync.txt');
 
 fs.appendFileSync(filename, data);
 
@@ -48,7 +49,7 @@ const fileData = fs.readFileSync(filename);
 assert.strictEqual(Buffer.byteLength(data), fileData.length);
 
 // test that appends data to a non empty file
-const filename2 = join(common.tmpDir, 'append-sync2.txt');
+const filename2 = join(tmpdir.path, 'append-sync2.txt');
 fs.writeFileSync(filename2, currentFileData);
 
 fs.appendFileSync(filename2, data);
@@ -59,7 +60,7 @@ assert.strictEqual(Buffer.byteLength(data) + currentFileData.length,
                    fileData2.length);
 
 // test that appendFileSync accepts buffers
-const filename3 = join(common.tmpDir, 'append-sync3.txt');
+const filename3 = join(tmpdir.path, 'append-sync3.txt');
 fs.writeFileSync(filename3, currentFileData);
 
 const buf = Buffer.from(data, 'utf8');
@@ -70,7 +71,7 @@ const fileData3 = fs.readFileSync(filename3);
 assert.strictEqual(buf.length + currentFileData.length, fileData3.length);
 
 // test that appendFile accepts numbers.
-const filename4 = join(common.tmpDir, 'append-sync4.txt');
+const filename4 = join(tmpdir.path, 'append-sync4.txt');
 fs.writeFileSync(filename4, currentFileData, { mode: m });
 
 fs.appendFileSync(filename4, num, { mode: m });
@@ -87,7 +88,7 @@ assert.strictEqual(Buffer.byteLength(String(num)) + currentFileData.length,
                    fileData4.length);
 
 // test that appendFile accepts file descriptors
-const filename5 = join(common.tmpDir, 'append-sync5.txt');
+const filename5 = join(tmpdir.path, 'append-sync5.txt');
 fs.writeFileSync(filename5, currentFileData);
 
 const filename5fd = fs.openSync(filename5, 'a+', 0o600);

--- a/test/parallel/test-fs-append-file.js
+++ b/test/parallel/test-fs-append-file.js
@@ -25,7 +25,9 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-const filename = join(common.tmpDir, 'append.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = join(tmpdir.path, 'append.txt');
 
 const currentFileData = 'ABCD';
 
@@ -40,7 +42,7 @@ const s = '南越国是前203年至前111年存在于岭南地区的一个国家
 
 let ncallbacks = 0;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // test that empty file will be created and have content added
 fs.appendFile(filename, s, function(e) {
@@ -56,7 +58,7 @@ fs.appendFile(filename, s, function(e) {
 });
 
 // test that appends data to a non empty file
-const filename2 = join(common.tmpDir, 'append2.txt');
+const filename2 = join(tmpdir.path, 'append2.txt');
 fs.writeFileSync(filename2, currentFileData);
 
 fs.appendFile(filename2, s, function(e) {
@@ -73,7 +75,7 @@ fs.appendFile(filename2, s, function(e) {
 });
 
 // test that appendFile accepts buffers
-const filename3 = join(common.tmpDir, 'append3.txt');
+const filename3 = join(tmpdir.path, 'append3.txt');
 fs.writeFileSync(filename3, currentFileData);
 
 const buf = Buffer.from(s, 'utf8');
@@ -91,7 +93,7 @@ fs.appendFile(filename3, buf, function(e) {
 });
 
 // test that appendFile accepts numbers.
-const filename4 = join(common.tmpDir, 'append4.txt');
+const filename4 = join(tmpdir.path, 'append4.txt');
 fs.writeFileSync(filename4, currentFileData);
 
 const m = 0o600;
@@ -115,7 +117,7 @@ fs.appendFile(filename4, n, { mode: m }, function(e) {
 });
 
 // test that appendFile accepts file descriptors
-const filename5 = join(common.tmpDir, 'append5.txt');
+const filename5 = join(tmpdir.path, 'append5.txt');
 fs.writeFileSync(filename5, currentFileData);
 
 fs.open(filename5, 'a+', function(e, fd) {
@@ -146,7 +148,7 @@ fs.open(filename5, 'a+', function(e, fd) {
 
 // test that a missing callback emits a warning, even if the last argument is a
 // function.
-const filename6 = join(common.tmpDir, 'append6.txt');
+const filename6 = join(tmpdir.path, 'append6.txt');
 const warn = 'Calling an asynchronous function without callback is deprecated.';
 common.expectWarning('DeprecationWarning', warn);
 fs.appendFile(filename6, console.log);

--- a/test/parallel/test-fs-buffer.js
+++ b/test/parallel/test-fs-buffer.js
@@ -6,16 +6,17 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 assert.doesNotThrow(() => {
-  fs.access(Buffer.from(common.tmpDir), common.mustCall((err) => {
+  fs.access(Buffer.from(tmpdir.path), common.mustCall((err) => {
     assert.ifError(err);
   }));
 });
 
 assert.doesNotThrow(() => {
-  const buf = Buffer.from(path.join(common.tmpDir, 'a.txt'));
+  const buf = Buffer.from(path.join(tmpdir.path, 'a.txt'));
   fs.open(buf, 'w+', common.mustCall((err, fd) => {
     assert.ifError(err);
     assert(fd);

--- a/test/parallel/test-fs-buffertype-writesync.js
+++ b/test/parallel/test-fs-buffertype-writesync.js
@@ -1,5 +1,5 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 // This test ensures that writeSync does support inputs which
 // are then correctly converted into string buffers.
@@ -8,10 +8,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const filePath = path.join(common.tmpDir, 'test_buffer_type');
+const tmpdir = require('../common/tmpdir');
+
+const filePath = path.join(tmpdir.path, 'test_buffer_type');
 const v = [true, false, 0, 1, Infinity, () => {}, {}, [], undefined, null];
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 v.forEach((value) => {
   const fd = fs.openSync(filePath, 'w');

--- a/test/parallel/test-fs-chmod.js
+++ b/test/parallel/test-fs-chmod.js
@@ -71,10 +71,11 @@ if (common.isWindows) {
   mode_sync = 0o644;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file1 = path.join(common.tmpDir, 'a.js');
-const file2 = path.join(common.tmpDir, 'a1.js');
+const file1 = path.join(tmpdir.path, 'a.js');
+const file2 = path.join(tmpdir.path, 'a1.js');
 
 // Create file1.
 fs.closeSync(fs.openSync(file1, 'w'));
@@ -130,7 +131,7 @@ fs.open(file2, 'w', common.mustCall((err, fd) => {
 
 // lchmod
 if (fs.lchmod) {
-  const link = path.join(common.tmpDir, 'symbolic-link');
+  const link = path.join(tmpdir.path, 'symbolic-link');
 
   fs.symlinkSync(file2, link);
 

--- a/test/parallel/test-fs-copyfile.js
+++ b/test/parallel/test-fs-copyfile.js
@@ -1,11 +1,12 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const src = fixtures.path('a.js');
-const dest = path.join(common.tmpDir, 'copyfile.out');
+const dest = path.join(tmpdir.path, 'copyfile.out');
 const { COPYFILE_EXCL, UV_FS_COPYFILE_EXCL } = fs.constants;
 
 function verify(src, dest) {
@@ -19,7 +20,7 @@ function verify(src, dest) {
   assert.strictEqual(srcStat.size, destStat.size);
 }
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Verify that flags are defined.
 assert.strictEqual(typeof COPYFILE_EXCL, 'number');

--- a/test/parallel/test-fs-fsync.js
+++ b/test/parallel/test-fs-fsync.js
@@ -23,15 +23,16 @@
 const common = require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const fs = require('fs');
 const path = require('path');
 
 const fileFixture = fixtures.path('a.js');
-const fileTemp = path.join(common.tmpDir, 'a.js');
+const fileTemp = path.join(tmpdir.path, 'a.js');
 
 // Copy fixtures to temp.
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.copyFileSync(fileFixture, fileTemp);
 
 fs.open(fileTemp, 'a', 0o777, common.mustCall(function(err, fd) {

--- a/test/parallel/test-fs-link.js
+++ b/test/parallel/test-fs-link.js
@@ -4,11 +4,12 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test creating and reading hard link
-const srcPath = path.join(common.tmpDir, 'hardlink-target.txt');
-const dstPath = path.join(common.tmpDir, 'link1.js');
+const srcPath = path.join(tmpdir.path, 'hardlink-target.txt');
+const dstPath = path.join(tmpdir.path, 'link1.js');
 fs.writeFileSync(srcPath, 'hello world');
 
 function callback(err) {

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -28,12 +28,14 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
+const tmpdir = require('../common/tmpdir');
+
 // make a path that will be at least 260 chars long.
-const fileNameLen = Math.max(260 - common.tmpDir.length - 1, 1);
-const fileName = path.join(common.tmpDir, 'x'.repeat(fileNameLen));
+const fileNameLen = Math.max(260 - tmpdir.path.length - 1, 1);
+const fileName = path.join(tmpdir.path, 'x'.repeat(fileNameLen));
 const fullPath = path.resolve(fileName);
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 console.log({
   filenameLength: fileName.length,

--- a/test/parallel/test-fs-make-callback.js
+++ b/test/parallel/test-fs-make-callback.js
@@ -7,12 +7,13 @@ const callbackThrowValues = [null, true, false, 0, 1, 'foo', /foo/, [], {}];
 const { sep } = require('path');
 const warn = 'Calling an asynchronous function without callback is deprecated.';
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function testMakeCallback(cb) {
   return function() {
     // fs.mkdtemp() calls makeCallback() on its third argument
-    fs.mkdtemp(`${common.tmpDir}${sep}`, {}, cb);
+    fs.mkdtemp(`${tmpdir.path}${sep}`, {}, cb);
   };
 }
 

--- a/test/parallel/test-fs-mkdir-rmdir.js
+++ b/test/parallel/test-fs-mkdir-rmdir.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const d = path.join(common.tmpDir, 'dir');
+const tmpdir = require('../common/tmpdir');
+const d = path.join(tmpdir.path, 'dir');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Make sure the directory does not exist
 assert(!common.fileExists(d));

--- a/test/parallel/test-fs-mkdir.js
+++ b/test/parallel/test-fs-mkdir.js
@@ -24,10 +24,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
-  const pathname = `${common.tmpDir}/test1`;
+  const pathname = `${tmpdir.path}/test1`;
 
   fs.mkdir(pathname, common.mustCall(function(err) {
     assert.strictEqual(err, null);
@@ -36,7 +37,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = `${common.tmpDir}/test2`;
+  const pathname = `${tmpdir.path}/test2`;
 
   fs.mkdir(pathname, 0o777, common.mustCall(function(err) {
     assert.strictEqual(err, null);
@@ -45,7 +46,7 @@ common.refreshTmpDir();
 }
 
 {
-  const pathname = `${common.tmpDir}/test3`;
+  const pathname = `${tmpdir.path}/test3`;
 
   fs.mkdirSync(pathname);
 

--- a/test/parallel/test-fs-mkdtemp.js
+++ b/test/parallel/test-fs-mkdtemp.js
@@ -5,14 +5,15 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const tmpFolder = fs.mkdtempSync(path.join(common.tmpDir, 'foo.'));
+const tmpFolder = fs.mkdtempSync(path.join(tmpdir.path, 'foo.'));
 
 assert.strictEqual(path.basename(tmpFolder).length, 'foo.XXXXXX'.length);
 assert(common.fileExists(tmpFolder));
 
-const utf8 = fs.mkdtempSync(path.join(common.tmpDir, '\u0222abc.'));
+const utf8 = fs.mkdtempSync(path.join(tmpdir.path, '\u0222abc.'));
 assert.strictEqual(Buffer.byteLength(path.basename(utf8)),
                    Buffer.byteLength('\u0222abc.XXXXXX'));
 assert(common.fileExists(utf8));
@@ -23,13 +24,13 @@ function handler(err, folder) {
   assert.strictEqual(this, undefined);
 }
 
-fs.mkdtemp(path.join(common.tmpDir, 'bar.'), common.mustCall(handler));
+fs.mkdtemp(path.join(tmpdir.path, 'bar.'), common.mustCall(handler));
 
 // Same test as above, but making sure that passing an options object doesn't
 // affect the way the callback function is handled.
-fs.mkdtemp(path.join(common.tmpDir, 'bar.'), {}, common.mustCall(handler));
+fs.mkdtemp(path.join(tmpdir.path, 'bar.'), {}, common.mustCall(handler));
 
 // Making sure that not passing a callback doesn't crash, as a default function
 // is passed internally.
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-')));
-assert.doesNotThrow(() => fs.mkdtemp(path.join(common.tmpDir, 'bar-'), {}));
+assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-')));
+assert.doesNotThrow(() => fs.mkdtemp(path.join(tmpdir.path, 'bar-'), {}));

--- a/test/parallel/test-fs-non-number-arguments-throw.js
+++ b/test/parallel/test-fs-non-number-arguments-throw.js
@@ -4,9 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const tempFile = path.join(common.tmpDir, 'fs-non-number-arguments-throw');
+const tmpdir = require('../common/tmpdir');
+const tempFile = path.join(tmpdir.path, 'fs-non-number-arguments-throw');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(tempFile, 'abc\ndef');
 
 // a sanity check when using numbers instead of strings

--- a/test/parallel/test-fs-open-flags.js
+++ b/test/parallel/test-fs-open-flags.js
@@ -84,8 +84,9 @@ common.expectsError(
 );
 
 if (common.isLinux || common.isOSX) {
-  common.refreshTmpDir();
-  const file = path.join(common.tmpDir, 'a.js');
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
+  const file = path.join(tmpdir.path, 'a.js');
   fs.copyFileSync(fixtures.path('a.js'), file);
   fs.open(file, O_DSYNC, common.mustCall(assert.ifError));
 }

--- a/test/parallel/test-fs-open-numeric-flags.js
+++ b/test/parallel/test-fs-open-numeric-flags.js
@@ -1,14 +1,15 @@
 'use strict';
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // O_WRONLY without O_CREAT shall fail with ENOENT
-const pathNE = path.join(common.tmpDir, 'file-should-not-exist');
+const pathNE = path.join(tmpdir.path, 'file-should-not-exist');
 assert.throws(
   () => fs.openSync(pathNE, fs.constants.O_WRONLY),
   (e) => e.code === 'ENOENT'

--- a/test/parallel/test-fs-options-immutable.js
+++ b/test/parallel/test-fs-options-immutable.js
@@ -14,7 +14,8 @@ const path = require('path');
 
 const errHandler = (e) => assert.ifError(e);
 const options = Object.freeze({});
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
   assert.doesNotThrow(() =>
@@ -31,8 +32,8 @@ common.refreshTmpDir();
 }
 
 if (common.canCreateSymLink()) {
-  const sourceFile = path.resolve(common.tmpDir, 'test-readlink');
-  const linkFile = path.resolve(common.tmpDir, 'test-readlink-link');
+  const sourceFile = path.resolve(tmpdir.path, 'test-readlink');
+  const linkFile = path.resolve(tmpdir.path, 'test-readlink-link');
 
   fs.writeFileSync(sourceFile, '');
   fs.symlinkSync(sourceFile, linkFile);
@@ -44,7 +45,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'writeFile');
+  const fileName = path.resolve(tmpdir.path, 'writeFile');
   assert.doesNotThrow(() => fs.writeFileSync(fileName, 'ABCD', options));
   assert.doesNotThrow(() =>
     fs.writeFile(fileName, 'ABCD', options, common.mustCall(errHandler))
@@ -52,7 +53,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'appendFile');
+  const fileName = path.resolve(tmpdir.path, 'appendFile');
   assert.doesNotThrow(() => fs.appendFileSync(fileName, 'ABCD', options));
   assert.doesNotThrow(() =>
     fs.appendFile(fileName, 'ABCD', options, common.mustCall(errHandler))
@@ -82,7 +83,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const tempFileName = path.resolve(common.tmpDir, 'mkdtemp-');
+  const tempFileName = path.resolve(tmpdir.path, 'mkdtemp-');
   assert.doesNotThrow(() => fs.mkdtempSync(tempFileName, options));
   assert.doesNotThrow(() =>
     fs.mkdtemp(tempFileName, options, common.mustCall(errHandler))
@@ -90,7 +91,7 @@ if (common.canCreateSymLink()) {
 }
 
 {
-  const fileName = path.resolve(common.tmpDir, 'streams');
+  const fileName = path.resolve(tmpdir.path, 'streams');
   assert.doesNotThrow(() => {
     fs.WriteStream(fileName, options).once('open', common.mustCall(() => {
       assert.doesNotThrow(() => fs.ReadStream(fileName, options));

--- a/test/parallel/test-fs-promisified.js
+++ b/test/parallel/test-fs-promisified.js
@@ -20,9 +20,10 @@ const exists = promisify(fs.exists);
   }));
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 {
-  const filename = path.join(common.tmpDir, 'write-promise.txt');
+  const filename = path.join(tmpdir.path, 'write-promise.txt');
   const fd = fs.openSync(filename, 'w');
   write(fd, Buffer.from('foobar')).then(common.mustCall((obj) => {
     assert.strictEqual(typeof obj.bytesWritten, 'number');

--- a/test/parallel/test-fs-read-stream-fd.js
+++ b/test/parallel/test-fs-read-stream-fd.js
@@ -20,15 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
-const file = path.join(common.tmpDir, '/read_stream_fd_test.txt');
+const tmpdir = require('../common/tmpdir');
+const file = path.join(tmpdir.path, '/read_stream_fd_test.txt');
 const input = 'hello world';
 
 let output = '';
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(file, input);
 
 const fd = fs.openSync(file, 'r');

--- a/test/parallel/test-fs-readdir-ucs2.js
+++ b/test/parallel/test-fs-readdir-ucs2.js
@@ -8,9 +8,10 @@ const path = require('path');
 const fs = require('fs');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const filename = '\uD83D\uDC04';
-const root = Buffer.from(`${common.tmpDir}${path.sep}`);
+const root = Buffer.from(`${tmpdir.path}${path.sep}`);
 const filebuff = Buffer.from(filename, 'ucs2');
 const fullpath = Buffer.concat([root, filebuff]);
 
@@ -22,7 +23,7 @@ try {
   throw e;
 }
 
-fs.readdir(common.tmpDir, 'ucs2', common.mustCall((err, list) => {
+fs.readdir(tmpdir.path, 'ucs2', common.mustCall((err, list) => {
   assert.ifError(err);
   assert.strictEqual(1, list.length);
   const fn = list[0];

--- a/test/parallel/test-fs-readdir.js
+++ b/test/parallel/test-fs-readdir.js
@@ -4,11 +4,13 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const readdirDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+
+const readdirDir = tmpdir.path;
 const files = ['empty', 'files', 'for', 'just', 'testing'];
 
 // Make sure tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Create the necessary files
 files.forEach(function(currentFile) {

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -18,9 +18,11 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const filename = path.join(common.tmpDir, '/readfile_pipe_large_test.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = path.join(tmpdir.path, '/readfile_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;

--- a/test/parallel/test-fs-readfile-unlink.js
+++ b/test/parallel/test-fs-readfile-unlink.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 
 // Test that unlink succeeds immediately after readFile completes.
 
@@ -28,10 +28,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const fileName = path.resolve(common.tmpDir, 'test.bin');
+const tmpdir = require('../common/tmpdir');
+
+const fileName = path.resolve(tmpdir.path, 'test.bin');
 const buf = Buffer.alloc(512 * 1024, 42);
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.writeFileSync(fileName, buf);
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -15,9 +15,11 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-const filename = path.join(common.tmpDir, '/readfilesync_pipe_large_test.txt');
+const tmpdir = require('../common/tmpdir');
+
+const filename = path.join(tmpdir.path, '/readfilesync_pipe_large_test.txt');
 const dataExpected = 'a'.repeat(999999);
-common.refreshTmpDir();
+tmpdir.refresh();
 fs.writeFileSync(filename, dataExpected);
 
 const exec = require('child_process').exec;

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const assert = require('assert');
 const fs = require('fs');
@@ -31,9 +32,9 @@ let async_completed = 0;
 let async_expected = 0;
 const unlink = [];
 let skipSymlinks = false;
-const tmpDir = common.tmpDir;
+const tmpDir = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 let root = '/';
 let assertEqualPath = assert.strictEqual;
@@ -391,7 +392,8 @@ function test_up_multiple(realpath, realpathSync, cb) {
     common.printSkipMessage('symlink test (no privs)');
     return cb();
   }
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   fs.mkdirSync(tmp('a'), 0o755);
   fs.mkdirSync(tmp('a/b'), 0o755);
   fs.symlinkSync('..', tmp('a/d'), 'dir');

--- a/test/parallel/test-fs-sir-writes-alot.js
+++ b/test/parallel/test-fs-sir-writes-alot.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 const join = require('path').join;
 
-const filename = join(common.tmpDir, 'out.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const filename = join(tmpdir.path, 'out.txt');
+
+tmpdir.refresh();
 
 const fd = fs.openSync(filename, 'w');
 

--- a/test/parallel/test-fs-stream-double-close.js
+++ b/test/parallel/test-fs-stream-double-close.js
@@ -23,15 +23,16 @@
 const common = require('../common');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 test1(fs.createReadStream(__filename));
 test2(fs.createReadStream(__filename));
 test3(fs.createReadStream(__filename));
 
-test1(fs.createWriteStream(`${common.tmpDir}/dummy1`));
-test2(fs.createWriteStream(`${common.tmpDir}/dummy2`));
-test3(fs.createWriteStream(`${common.tmpDir}/dummy3`));
+test1(fs.createWriteStream(`${tmpdir.path}/dummy1`));
+test2(fs.createWriteStream(`${tmpdir.path}/dummy2`));
+test3(fs.createWriteStream(`${tmpdir.path}/dummy3`));
 
 function test1(stream) {
   stream.destroy();

--- a/test/parallel/test-fs-symlink-dir-junction-relative.js
+++ b/test/parallel/test-fs-symlink-dir-junction-relative.js
@@ -28,12 +28,14 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const linkPath1 = path.join(common.tmpDir, 'junction1');
-const linkPath2 = path.join(common.tmpDir, 'junction2');
+const tmpdir = require('../common/tmpdir');
+
+const linkPath1 = path.join(tmpdir.path, 'junction1');
+const linkPath2 = path.join(tmpdir.path, 'junction2');
 const linkTarget = fixtures.fixturesDir;
 const linkData = fixtures.fixturesDir;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Test fs.symlink()
 fs.symlink(linkData, linkPath1, 'junction', common.mustCall(function(err) {

--- a/test/parallel/test-fs-symlink-dir-junction.js
+++ b/test/parallel/test-fs-symlink-dir-junction.js
@@ -26,11 +26,13 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 // test creating and reading symbolic link
 const linkData = fixtures.path('cycles/');
-const linkPath = path.join(common.tmpDir, 'cycles_link');
+const linkPath = path.join(tmpdir.path, 'cycles_link');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.symlink(linkData, linkPath, 'junction', common.mustCall(function(err) {
   assert.ifError(err);

--- a/test/parallel/test-fs-symlink.js
+++ b/test/parallel/test-fs-symlink.js
@@ -32,11 +32,12 @@ const fs = require('fs');
 let linkTime;
 let fileTime;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // test creating and reading symbolic link
 const linkData = fixtures.path('/cycles/root.js');
-const linkPath = path.join(common.tmpDir, 'symlink1.js');
+const linkPath = path.join(tmpdir.path, 'symlink1.js');
 
 fs.symlink(linkData, linkPath, common.mustCall(function(err) {
   assert.ifError(err);

--- a/test/parallel/test-fs-syncwritestream.js
+++ b/test/parallel/test-fs-syncwritestream.js
@@ -21,9 +21,10 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'stdout');
+const filename = path.join(tmpdir.path, 'stdout');
 const stdoutFd = fs.openSync(filename, 'w');
 
 const proc = spawn(process.execPath, [__filename, 'child'], {

--- a/test/parallel/test-fs-truncate-GH-6233.js
+++ b/test/parallel/test-fs-truncate-GH-6233.js
@@ -24,9 +24,11 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-const filename = `${common.tmpDir}/truncate-file.txt`;
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const filename = `${tmpdir.path}/truncate-file.txt`;
+
+tmpdir.refresh();
 
 // Synchronous test.
 {

--- a/test/parallel/test-fs-truncate-fd.js
+++ b/test/parallel/test-fs-truncate-fd.js
@@ -3,8 +3,9 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
+tmpdir.refresh();
 const filename = path.resolve(tmp, 'truncate-file.txt');
 
 fs.writeFileSync(filename, 'hello world', 'utf8');

--- a/test/parallel/test-fs-truncate-sync.js
+++ b/test/parallel/test-fs-truncate-sync.js
@@ -1,11 +1,12 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const filename = path.resolve(tmp, 'truncate-sync-file.txt');
 

--- a/test/parallel/test-fs-truncate.js
+++ b/test/parallel/test-fs-truncate.js
@@ -24,11 +24,12 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const tmp = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+const tmp = tmpdir.path;
 const filename = path.resolve(tmp, 'truncate-file.txt');
 const data = Buffer.alloc(1024 * 16, 'x');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 let stat;
 

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -25,7 +25,8 @@ const assert = require('assert');
 const util = require('util');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 let tests_ok = 0;
 let tests_run = 0;
@@ -73,8 +74,8 @@ function testIt(atime, mtime, callback) {
   // test synchronized code paths, these functions throw on failure
   //
   function syncTests() {
-    fs.utimesSync(common.tmpDir, atime, mtime);
-    expect_ok('utimesSync', common.tmpDir, undefined, atime, mtime);
+    fs.utimesSync(tmpdir.path, atime, mtime);
+    expect_ok('utimesSync', tmpdir.path, undefined, atime, mtime);
     tests_run++;
 
     // some systems don't have futimes
@@ -110,17 +111,17 @@ function testIt(atime, mtime, callback) {
   //
   // test async code paths
   //
-  fs.utimes(common.tmpDir, atime, mtime, common.mustCall(function(err) {
-    expect_ok('utimes', common.tmpDir, err, atime, mtime);
+  fs.utimes(tmpdir.path, atime, mtime, common.mustCall(function(err) {
+    expect_ok('utimes', tmpdir.path, err, atime, mtime);
 
     fs.utimes('foobarbaz', atime, mtime, common.mustCall(function(err) {
       expect_errno('utimes', 'foobarbaz', err, 'ENOENT');
 
       // don't close this fd
       if (common.isWindows) {
-        fd = fs.openSync(common.tmpDir, 'r+');
+        fd = fs.openSync(tmpdir.path, 'r+');
       } else {
-        fd = fs.openSync(common.tmpDir, 'r');
+        fd = fs.openSync(tmpdir.path, 'r');
       }
 
       fs.futimes(fd, atime, mtime, common.mustCall(function(err) {
@@ -145,7 +146,7 @@ function testIt(atime, mtime, callback) {
   tests_run++;
 }
 
-const stats = fs.statSync(common.tmpDir);
+const stats = fs.statSync(tmpdir.path);
 
 // run tests
 const runTest = common.mustCall(testIt, 1);
@@ -174,7 +175,7 @@ process.on('exit', function() {
 
 
 // Ref: https://github.com/nodejs/node/issues/13255
-const path = `${common.tmpDir}/test-utimes-precision`;
+const path = `${tmpdir.path}/test-utimes-precision`;
 fs.writeFileSync(path, '');
 
 // test Y2K38 for all platforms [except 'arm', and 'SunOS']

--- a/test/parallel/test-fs-watch-encoding.js
+++ b/test/parallel/test-fs-watch-encoding.js
@@ -22,10 +22,11 @@ if (common.isAIX)
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const fn = '新建文夹件.txt';
-const a = path.join(common.tmpDir, fn);
+const a = path.join(tmpdir.path, fn);
 
 const watchers = new Set();
 
@@ -42,7 +43,7 @@ function unregisterWatcher(watcher) {
 }
 
 const watcher1 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   { encoding: 'hex' },
   (event, filename) => {
     if (['e696b0e5bbbae69687e5a4b9e4bbb62e747874', null].includes(filename))
@@ -52,7 +53,7 @@ const watcher1 = fs.watch(
 registerWatcher(watcher1);
 
 const watcher2 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   (event, filename) => {
     if ([fn, null].includes(filename))
       done(watcher2);
@@ -61,7 +62,7 @@ const watcher2 = fs.watch(
 registerWatcher(watcher2);
 
 const watcher3 = fs.watch(
-  common.tmpDir,
+  tmpdir.path,
   { encoding: 'buffer' },
   (event, filename) => {
     if (filename instanceof Buffer && filename.toString('utf8') === fn)

--- a/test/parallel/test-fs-watch-recursive.js
+++ b/test/parallel/test-fs-watch-recursive.js
@@ -9,10 +9,12 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const testDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+
+const testDir = tmpdir.path;
 const filenameOne = 'watch.txt';
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const testsubdir = fs.mkdtempSync(testDir + path.sep);
 const relativePathOne = path.join(path.basename(testsubdir), filenameOne);

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -14,7 +14,7 @@ class WatchTestCase {
     this.field = field;
     this.shouldSkip = !shouldInclude;
   }
-  get dirPath() { return join(common.tmpDir, this.dirName); }
+  get dirPath() { return join(tmpdir.path, this.dirName); }
   get filePath() { return join(this.dirPath, this.fileName); }
 }
 
@@ -35,7 +35,8 @@ const cases = [
   )
 ];
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 for (const testCase of cases) {
   if (testCase.shouldSkip) continue;

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -5,6 +5,8 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 // Basic usage tests.
 common.expectsError(
   () => {
@@ -28,7 +30,7 @@ common.expectsError(function() {
   fs.watchFile(new Object(), common.mustNotCall());
 }, { code: 'ERR_INVALID_ARG_TYPE', type: TypeError });
 
-const enoentFile = path.join(common.tmpDir, 'non-existent-file');
+const enoentFile = path.join(tmpdir.path, 'non-existent-file');
 const expectedStatObject = new fs.Stats(
   0,                                        // dev
   0,                                        // mode
@@ -46,7 +48,7 @@ const expectedStatObject = new fs.Stats(
   Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
 );
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // If the file initially didn't exist, and gets created at a later point of
 // time, the callback should be invoked again with proper values in stat object
@@ -80,7 +82,7 @@ watcher.start();  // should not crash
 // Watch events should callback with a filename on supported systems.
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isOSX || common.isWindows) {
-  const dir = path.join(common.tmpDir, 'watch');
+  const dir = path.join(tmpdir.path, 'watch');
 
   fs.mkdir(dir, common.mustCall(function(err) {
     if (err) assert.fail(err);

--- a/test/parallel/test-fs-write-buffer.js
+++ b/test/parallel/test-fs-write-buffer.js
@@ -26,11 +26,12 @@ const path = require('path');
 const fs = require('fs');
 const expected = Buffer.from('hello');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // fs.write with all parameters provided:
 {
-  const filename = path.join(common.tmpDir, 'write1.txt');
+  const filename = path.join(tmpdir.path, 'write1.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -50,7 +51,7 @@ common.refreshTmpDir();
 
 // fs.write with a buffer, without the length parameter:
 {
-  const filename = path.join(common.tmpDir, 'write2.txt');
+  const filename = path.join(tmpdir.path, 'write2.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -70,7 +71,7 @@ common.refreshTmpDir();
 
 // fs.write with a buffer, without the offset and length parameters:
 {
-  const filename = path.join(common.tmpDir, 'write3.txt');
+  const filename = path.join(tmpdir.path, 'write3.txt');
   fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.ifError(err);
 
@@ -90,7 +91,7 @@ common.refreshTmpDir();
 
 // fs.write with the offset passed as undefined followed by the callback:
 {
-  const filename = path.join(common.tmpDir, 'write4.txt');
+  const filename = path.join(tmpdir.path, 'write4.txt');
   fs.open(filename, 'w', 0o644, common.mustCall(function(err, fd) {
     assert.ifError(err);
 
@@ -110,7 +111,7 @@ common.refreshTmpDir();
 
 // fs.write with offset and length passed as undefined followed by the callback:
 {
-  const filename = path.join(common.tmpDir, 'write5.txt');
+  const filename = path.join(tmpdir.path, 'write5.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 
@@ -130,7 +131,7 @@ common.refreshTmpDir();
 
 // fs.write with a Uint8Array, without the offset and length parameters:
 {
-  const filename = path.join(common.tmpDir, 'write6.txt');
+  const filename = path.join(tmpdir.path, 'write6.txt');
   fs.open(filename, 'w', 0o644, common.mustCall((err, fd) => {
     assert.ifError(err);
 

--- a/test/parallel/test-fs-write-file-buffer.js
+++ b/test/parallel/test-fs-write-file-buffer.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const join = require('path').join;
 const util = require('util');
 const fs = require('fs');
@@ -46,9 +46,10 @@ let data = [
 
 data = data.join('\n');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const buf = Buffer.from(data, 'base64');
-fs.writeFileSync(join(common.tmpDir, 'test.jpg'), buf);
+fs.writeFileSync(join(tmpdir.path, 'test.jpg'), buf);
 
 util.log('Done!');

--- a/test/parallel/test-fs-write-file-invalid-path.js
+++ b/test/parallel/test-fs-write-file-invalid-path.js
@@ -8,7 +8,8 @@ const path = require('path');
 if (!common.isWindows)
   common.skip('This test is for Windows only.');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const DATA_VALUE = 'hello';
 
@@ -17,7 +18,7 @@ const DATA_VALUE = 'hello';
 const RESERVED_CHARACTERS = '<>"|?*';
 
 [...RESERVED_CHARACTERS].forEach((ch) => {
-  const pathname = path.join(common.tmpDir, `somefile_${ch}`);
+  const pathname = path.join(tmpdir.path, `somefile_${ch}`);
   assert.throws(
     () => {
       fs.writeFileSync(pathname, DATA_VALUE);
@@ -28,7 +29,7 @@ const RESERVED_CHARACTERS = '<>"|?*';
 
 // Test for ':' (NTFS data streams).
 // Refs: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540537.aspx
-const pathname = path.join(common.tmpDir, 'foo:bar');
+const pathname = path.join(tmpdir.path, 'foo:bar');
 fs.writeFileSync(pathname, DATA_VALUE);
 
 let content = '';

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -46,10 +46,11 @@ if (common.isWindows) {
   mode = 0o755;
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // Test writeFileSync
-const file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
+const file1 = path.join(tmpdir.path, 'testWriteFileSync.txt');
 
 fs.writeFileSync(file1, '123', { mode });
 
@@ -59,7 +60,7 @@ assert.strictEqual(content, '123');
 assert.strictEqual(fs.statSync(file1).mode & 0o777, mode);
 
 // Test appendFileSync
-const file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
+const file2 = path.join(tmpdir.path, 'testAppendFileSync.txt');
 
 fs.appendFileSync(file2, 'abc', { mode });
 
@@ -69,7 +70,7 @@ assert.strictEqual(content, 'abc');
 assert.strictEqual(fs.statSync(file2).mode & mode, mode);
 
 // Test writeFileSync with file descriptor
-const file3 = path.join(common.tmpDir, 'testWriteFileSyncFd.txt');
+const file3 = path.join(tmpdir.path, 'testWriteFileSyncFd.txt');
 
 const fd = fs.openSync(file3, 'w+', mode);
 fs.writeFileSync(fd, '123');

--- a/test/parallel/test-fs-write-file-uint8array.js
+++ b/test/parallel/test-fs-write-file-uint8array.js
@@ -4,9 +4,10 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = join(common.tmpDir, 'test.txt');
+const filename = join(tmpdir.path, 'test.txt');
 
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
           '广西两省区的大部份地区，福建省、湖南、贵州、云南的一小部份地区和越南的北部。' +

--- a/test/parallel/test-fs-write-file.js
+++ b/test/parallel/test-fs-write-file.js
@@ -25,9 +25,10 @@ const assert = require('assert');
 const fs = require('fs');
 const join = require('path').join;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = join(common.tmpDir, 'test.txt');
+const filename = join(tmpdir.path, 'test.txt');
 
 const n = 220;
 const s = '南越国是前203年至前111年存在于岭南地区的一个国家，国都位于番禺，疆域包括今天中国的广东、' +
@@ -48,7 +49,7 @@ fs.writeFile(filename, s, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts buffers
-const filename2 = join(common.tmpDir, 'test2.txt');
+const filename2 = join(tmpdir.path, 'test2.txt');
 const buf = Buffer.from(s, 'utf8');
 
 fs.writeFile(filename2, buf, common.mustCall(function(e) {
@@ -62,7 +63,7 @@ fs.writeFile(filename2, buf, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts numbers.
-const filename3 = join(common.tmpDir, 'test3.txt');
+const filename3 = join(tmpdir.path, 'test3.txt');
 
 const m = 0o600;
 fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
@@ -82,7 +83,7 @@ fs.writeFile(filename3, n, { mode: m }, common.mustCall(function(e) {
 }));
 
 // test that writeFile accepts file descriptors
-const filename4 = join(common.tmpDir, 'test4.txt');
+const filename4 = join(tmpdir.path, 'test4.txt');
 
 fs.open(filename4, 'w+', common.mustCall(function(e, fd) {
   assert.ifError(e);

--- a/test/parallel/test-fs-write-stream-autoclose-option.js
+++ b/test/parallel/test-fs-write-stream-autoclose-option.js
@@ -4,8 +4,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write-autoclose-opt1.txt');
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+
+const file = path.join(tmpdir.path, 'write-autoclose-opt1.txt');
+tmpdir.refresh();
 let stream = fs.createWriteStream(file, { flags: 'w+', autoClose: false });
 stream.write('Test1');
 stream.end();

--- a/test/parallel/test-fs-write-stream-change-open.js
+++ b/test/parallel/test-fs-write-stream-change-open.js
@@ -20,14 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const file = path.join(tmpdir.path, 'write.txt');
+
+tmpdir.refresh();
 
 const stream = fs.WriteStream(file);
 const _fs_close = fs.close;

--- a/test/parallel/test-fs-write-stream-close-without-callback.js
+++ b/test/parallel/test-fs-write-stream-close-without-callback.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const s = fs.createWriteStream(path.join(common.tmpDir, 'nocallback'));
+const s = fs.createWriteStream(path.join(tmpdir.path, 'nocallback'));
 
 s.end('hello world');
 s.close();

--- a/test/parallel/test-fs-write-stream-double-close.js
+++ b/test/parallel/test-fs-write-stream-double-close.js
@@ -5,17 +5,18 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
-  const s = fs.createWriteStream(path.join(common.tmpDir, 'rw'));
+  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw'));
 
   s.close(common.mustCall());
   s.close(common.mustCall());
 }
 
 {
-  const s = fs.createWriteStream(path.join(common.tmpDir, 'rw2'));
+  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw2'));
 
   let emits = 0;
   s.on('close', () => {
@@ -36,7 +37,7 @@ common.refreshTmpDir();
 }
 
 {
-  const s = fs.createWriteStream(path.join(common.tmpDir, 'rw'), {
+  const s = fs.createWriteStream(path.join(tmpdir.path, 'rw'), {
     autoClose: false
   });
 

--- a/test/parallel/test-fs-write-stream-encoding.js
+++ b/test/parallel/test-fs-write-stream-encoding.js
@@ -1,17 +1,18 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
+const tmpdir = require('../common/tmpdir');
 const firstEncoding = 'base64';
 const secondEncoding = 'latin1';
 
 const examplePath = fixtures.path('x.txt');
-const dummyPath = path.join(common.tmpDir, 'x.txt');
+const dummyPath = path.join(tmpdir.path, 'x.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const exampleReadStream = fs.createReadStream(examplePath, {
   encoding: firstEncoding

--- a/test/parallel/test-fs-write-stream-end.js
+++ b/test/parallel/test-fs-write-stream-end.js
@@ -25,17 +25,18 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 {
-  const file = path.join(common.tmpDir, 'write-end-test0.txt');
+  const file = path.join(tmpdir.path, 'write-end-test0.txt');
   const stream = fs.createWriteStream(file);
   stream.end();
   stream.on('close', common.mustCall());
 }
 
 {
-  const file = path.join(common.tmpDir, 'write-end-test1.txt');
+  const file = path.join(tmpdir.path, 'write-end-test1.txt');
   const stream = fs.createWriteStream(file);
   stream.end('a\n', 'utf8');
   stream.on('close', common.mustCall(function() {

--- a/test/parallel/test-fs-write-stream-err.js
+++ b/test/parallel/test-fs-write-stream-err.js
@@ -24,9 +24,10 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const stream = fs.createWriteStream(`${common.tmpDir}/out`, {
+const stream = fs.createWriteStream(`${tmpdir.path}/out`, {
   highWaterMark: 10
 });
 const err = new Error('BAM');

--- a/test/parallel/test-fs-write-stream-throw-type-error.js
+++ b/test/parallel/test-fs-write-stream-throw-type-error.js
@@ -4,9 +4,11 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-const example = path.join(common.tmpDir, 'dummy');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const example = path.join(tmpdir.path, 'dummy');
+
+tmpdir.refresh();
 
 assert.doesNotThrow(() => {
   fs.createWriteStream(example, undefined);

--- a/test/parallel/test-fs-write-stream.js
+++ b/test/parallel/test-fs-write-stream.js
@@ -25,9 +25,11 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const file = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
 
-common.refreshTmpDir();
+const file = path.join(tmpdir.path, 'write.txt');
+
+tmpdir.refresh();
 
 {
   const stream = fs.WriteStream(file);

--- a/test/parallel/test-fs-write-string-coerce.js
+++ b/test/parallel/test-fs-write-string-coerce.js
@@ -4,9 +4,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const fn = path.join(common.tmpDir, 'write-string-coerce.txt');
+const fn = path.join(tmpdir.path, 'write-string-coerce.txt');
 const data = true;
 const expected = String(data);
 

--- a/test/parallel/test-fs-write-sync.js
+++ b/test/parallel/test-fs-write-sync.js
@@ -20,13 +20,14 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const filename = path.join(common.tmpDir, 'write.txt');
+const tmpdir = require('../common/tmpdir');
+const filename = path.join(tmpdir.path, 'write.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // fs.writeSync with all parameters provided:
 {

--- a/test/parallel/test-fs-write.js
+++ b/test/parallel/test-fs-write.js
@@ -25,16 +25,18 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const fn = path.join(common.tmpDir, 'write.txt');
-const fn2 = path.join(common.tmpDir, 'write2.txt');
-const fn3 = path.join(common.tmpDir, 'write3.txt');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const fn = path.join(tmpdir.path, 'write.txt');
+const fn2 = path.join(tmpdir.path, 'write2.txt');
+const fn3 = path.join(tmpdir.path, 'write3.txt');
 const expected = 'ümlaut.';
 const constants = fs.constants;
 
 /* eslint-disable no-undef */
 common.allowGlobals(externalizeString, isOneByteString, x);
-
-common.refreshTmpDir();
 
 {
   const expected = 'ümlaut eins';  // Must be a unique string.
@@ -75,6 +77,7 @@ common.refreshTmpDir();
   fs.closeSync(fd);
   assert.strictEqual(expected, fs.readFileSync(fn, 'utf8'));
 }
+/* eslint-enable no-undef */
 
 fs.open(fn, 'w', 0o644, common.mustCall(function(err, fd) {
   assert.ifError(err);

--- a/test/parallel/test-http-agent-getname.js
+++ b/test/parallel/test-http-agent-getname.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const http = require('http');
 const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
 
 const agent = new http.Agent();
 
@@ -33,7 +35,7 @@ assert.strictEqual(
 );
 
 // unix socket
-const socketPath = path.join(common.tmpDir, 'foo', 'bar');
+const socketPath = path.join(tmpdir.path, 'foo', 'bar');
 assert.strictEqual(
   agent.getName({
     socketPath

--- a/test/parallel/test-http-chunk-problem.js
+++ b/test/parallel/test-http-chunk-problem.js
@@ -37,7 +37,9 @@ if (process.argv[2] === 'shasum') {
 const http = require('http');
 const cp = require('child_process');
 
-const filename = require('path').join(common.tmpDir, 'big');
+const tmpdir = require('../common/tmpdir');
+
+const filename = require('path').join(tmpdir.path, 'big');
 let server;
 
 function executeRequest(cb) {
@@ -59,7 +61,7 @@ function executeRequest(cb) {
 }
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 const ddcmd = common.ddCommand(filename, 10240);
 

--- a/test/parallel/test-http-client-abort-keep-alive-queued-unix-socket.js
+++ b/test/parallel/test-http-client-abort-keep-alive-queued-unix-socket.js
@@ -16,7 +16,8 @@ class Agent extends http.Agent {
 const server = http.createServer((req, res) => res.end());
 
 const socketPath = common.PIPE;
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(socketPath, common.mustCall(() => {
   const agent = new Agent({

--- a/test/parallel/test-http-client-abort-unix-socket.js
+++ b/test/parallel/test-http-client-abort-unix-socket.js
@@ -12,7 +12,8 @@ class Agent extends http.Agent {
   }
 }
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(() => {
   const req = http.get({

--- a/test/parallel/test-http-client-pipe-end.js
+++ b/test/parallel/test-http-client-pipe-end.js
@@ -34,7 +34,8 @@ const server = http.createServer(function(req, res) {
   });
 });
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, function() {
   const req = http.request({

--- a/test/parallel/test-http-client-response-domain.js
+++ b/test/parallel/test-http-client-response-domain.js
@@ -27,7 +27,8 @@ const domain = require('domain');
 
 let d;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // first fire up a simple HTTP server
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-http-get-pipeline-problem.js
+++ b/test/parallel/test-http-get-pipeline-problem.js
@@ -32,7 +32,8 @@ const Countdown = require('../common/countdown');
 
 http.globalAgent.maxSockets = 1;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const image = fixtures.readSync('/person.jpg');
 
@@ -68,7 +69,7 @@ server.listen(0, function() {
 
       http.get(opts, function(res) {
         console.error(`recv ${x}`);
-        const s = fs.createWriteStream(`${common.tmpDir}/${x}.jpg`);
+        const s = fs.createWriteStream(`${tmpdir.path}/${x}.jpg`);
         res.pipe(s);
 
         s.on('finish', function() {
@@ -85,13 +86,13 @@ server.listen(0, function() {
 
 function checkFiles() {
   // Should see 1.jpg, 2.jpg, ..., 100.jpg in tmpDir
-  const files = fs.readdirSync(common.tmpDir);
+  const files = fs.readdirSync(tmpdir.path);
   assert(total <= files.length);
 
   for (let i = 0; i < total; i++) {
     const fn = `${i}.jpg`;
     assert.ok(files.includes(fn), `couldn't find '${fn}'`);
-    const stat = fs.statSync(`${common.tmpDir}/${fn}`);
+    const stat = fs.statSync(`${tmpdir.path}/${fn}`);
     assert.strictEqual(
       image.length, stat.size,
       `size doesn't match on '${fn}'. Got ${stat.size} bytes`);

--- a/test/parallel/test-http-pipe-fs.js
+++ b/test/parallel/test-http-pipe-fs.js
@@ -29,9 +29,10 @@ const NUMBER_OF_STREAMS = 2;
 
 const countdown = new Countdown(NUMBER_OF_STREAMS, () => server.close());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file = path.join(common.tmpDir, 'http-pipe-fs-test.txt');
+const file = path.join(tmpdir.path, 'http-pipe-fs-test.txt');
 
 const server = http.createServer(common.mustCall(function(req, res) {
   const stream = fs.createWriteStream(file);

--- a/test/parallel/test-http-unix-socket-keep-alive.js
+++ b/test/parallel/test-http-unix-socket-keep-alive.js
@@ -5,7 +5,8 @@ const http = require('http');
 
 const server = http.createServer((req, res) => res.end());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(() =>
   asyncLoop(makeKeepAliveRequest, 10, common.mustCall(() =>

--- a/test/parallel/test-http-unix-socket.js
+++ b/test/parallel/test-http-unix-socket.js
@@ -34,7 +34,8 @@ const server = http.createServer(function(req, res) {
   res.end();
 });
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(function() {
 

--- a/test/parallel/test-http2-compat-serverrequest-pipe.js
+++ b/test/parallel/test-http2-compat-serverrequest-pipe.js
@@ -11,9 +11,10 @@ const path = require('path');
 
 // piping should work as expected with createWriteStream
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const loc = fixtures.path('url-tests.js');
-const fn = path.join(common.tmpDir, 'http2-url-tests.js');
+const fn = path.join(tmpdir.path, 'http2-url-tests.js');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-http2-pipe.js
+++ b/test/parallel/test-http2-pipe.js
@@ -11,9 +11,10 @@ const path = require('path');
 
 // piping should work as expected with createWriteStream
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 const loc = fixtures.path('url-tests.js');
-const fn = path.join(common.tmpDir, 'http2-url-tests.js');
+const fn = path.join(tmpdir.path, 'http2-url-tests.js');
 
 const server = http2.createServer();
 

--- a/test/parallel/test-https-unix-socket-self-signed.js
+++ b/test/parallel/test-https-unix-socket-self-signed.js
@@ -4,7 +4,8 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const fixtures = require('../common/fixtures');
 const https = require('https');

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -7,9 +7,10 @@ const fs = require('fs');
 const path = require('path');
 const SyncWriteStream = require('internal/fs').SyncWriteStream;
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'sync-write-stream.txt');
+const filename = path.join(tmpdir.path, 'sync-write-stream.txt');
 
 // Verify constructing the instance with default options.
 {

--- a/test/parallel/test-module-circular-symlinks.js
+++ b/test/parallel/test-module-circular-symlinks.js
@@ -29,8 +29,9 @@ const fs = require('fs');
 //         └── node_modules
 //         └── moduleA -> {tmpDir}/node_modules/moduleA
 
-common.refreshTmpDir();
-const tmpDir = common.tmpDir;
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
 
 const node_modules = path.join(tmpDir, 'node_modules');
 const moduleA = path.join(node_modules, 'moduleA');

--- a/test/parallel/test-module-loading-globalpaths.js
+++ b/test/parallel/test-module-loading-globalpaths.js
@@ -10,10 +10,11 @@ const pkgName = 'foo';
 if (process.argv[2] === 'child') {
   console.log(require(pkgName).string);
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
   // Copy node binary into a test $PREFIX directory.
-  const prefixPath = path.join(common.tmpDir, 'install');
+  const prefixPath = path.join(tmpdir.path, 'install');
   fs.mkdirSync(prefixPath);
   let testExecPath;
   if (common.isWindows) {
@@ -43,7 +44,7 @@ if (process.argv[2] === 'child') {
   delete env['NODE_PATH'];
 
   // Test empty global path.
-  const noPkgHomeDir = path.join(common.tmpDir, 'home-no-pkg');
+  const noPkgHomeDir = path.join(tmpdir.path, 'home-no-pkg');
   fs.mkdirSync(noPkgHomeDir);
   env['HOME'] = env['USERPROFILE'] = noPkgHomeDir;
   assert.throws(

--- a/test/parallel/test-module-symlinked-peer-modules.js
+++ b/test/parallel/test-module-symlinked-peer-modules.js
@@ -13,9 +13,10 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const tmpDir = common.tmpDir;
+const tmpDir = tmpdir.path;
 
 // Creates the following structure
 // {tmpDir}

--- a/test/parallel/test-net-connect-options-fd.js
+++ b/test/parallel/test-net-connect-options-fd.js
@@ -8,7 +8,8 @@ const net = require('net');
 const path = require('path');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function testClients(getSocketOpt, getConnectOpt, getConnectCb) {
   const cloneOptions = (index) =>

--- a/test/parallel/test-net-connect-options-path.js
+++ b/test/parallel/test-net-connect-options-path.js
@@ -5,7 +5,8 @@ const net = require('net');
 // This file tests the option handling of net.connect,
 // net.createConnect, and new Socket().connect
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const CLIENT_VARIANTS = 12;
 

--- a/test/parallel/test-net-pingpong.js
+++ b/test/parallel/test-net-pingpong.js
@@ -128,7 +128,8 @@ function pingPongTest(port, host) {
 }
 
 /* All are run at once, so run on different ports */
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 pingPongTest(common.PIPE);
 pingPongTest(0);
 pingPongTest(0, 'localhost');

--- a/test/parallel/test-net-pipe-connect-errors.js
+++ b/test/parallel/test-net-pipe-connect-errors.js
@@ -36,12 +36,13 @@ if (common.isWindows) {
   // file instead
   emptyTxt = fixtures.path('empty.txt');
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
   // Keep the file name very short so that we don't exceed the 108 char limit
   // on CI for a POSIX socket. Even though this isn't actually a socket file,
   // the error will be different from the one we are expecting if we exceed the
   // limit.
-  emptyTxt = `${common.tmpDir}0.txt`;
+  emptyTxt = `${tmpdir.path}0.txt`;
 
   function cleanup() {
     try {

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -8,7 +8,8 @@ const { getSystemErrorName } = require('util');
 const { TCP, constants: TCPConstants } = process.binding('tcp_wrap');
 const { Pipe, constants: PipeConstants } = process.binding('pipe_wrap');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function closeServer() {
   return common.mustCall(function() {

--- a/test/parallel/test-net-server-listen-path.js
+++ b/test/parallel/test-net-server-listen-path.js
@@ -3,7 +3,8 @@
 const common = require('../common');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function closeServer() {
   return common.mustCall(function() {

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -9,10 +9,11 @@ const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
 
-common.refreshTmpDir();
-const npmSandbox = path.join(common.tmpDir, 'npm-sandbox');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const npmSandbox = path.join(tmpdir.path, 'npm-sandbox');
 fs.mkdirSync(npmSandbox);
-const installDir = path.join(common.tmpDir, 'install-dir');
+const installDir = path.join(tmpdir.path, 'install-dir');
 fs.mkdirSync(installDir);
 
 const npmPath = path.join(

--- a/test/parallel/test-pipe-address.js
+++ b/test/parallel/test-pipe-address.js
@@ -4,7 +4,8 @@ const assert = require('assert');
 const net = require('net');
 const server = net.createServer(common.mustNotCall());
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 server.listen(common.PIPE, common.mustCall(function() {
   assert.strictEqual(server.address(), common.PIPE);

--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -27,9 +27,10 @@ const http = require('http');
 const path = require('path');
 const cp = require('child_process');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir || '/tmp', 'big');
+const filename = path.join(tmpdir.path || '/tmp', 'big');
 let count = 0;
 
 const server = http.createServer(function(req, res) {

--- a/test/parallel/test-pipe-stream.js
+++ b/test/parallel/test-pipe-stream.js
@@ -3,7 +3,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 function test(clazz, cb) {
   let have_ping = false;

--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -4,7 +4,8 @@ const net = require('net');
 
 // This test should end immediately after `unref` is called
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const s = net.Server();
 s.listen(common.PIPE);

--- a/test/parallel/test-pipe-writev.js
+++ b/test/parallel/test-pipe-writev.js
@@ -7,7 +7,8 @@ if (common.isWindows)
 const assert = require('assert');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = net.createServer((connection) => {
   connection.on('error', (err) => {

--- a/test/parallel/test-process-chdir.js
+++ b/test/parallel/test-process-chdir.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+
+const tmpdir = require('../common/tmpdir');
 
 process.chdir('..');
 assert.notStrictEqual(process.cwd(), __dirname);
@@ -18,10 +20,10 @@ if (process.versions.icu) {
   // ICU is unavailable, use characters that can't be decomposed
   dirName = 'weird \ud83d\udc04 characters \ud83d\udc05';
 }
-const dir = path.resolve(common.tmpDir, dirName);
+const dir = path.resolve(tmpdir.path, dirName);
 
 // Make sure that the tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.mkdirSync(dir);
 process.chdir(dir);
@@ -29,7 +31,7 @@ assert.strictEqual(process.cwd().normalize(), dir.normalize());
 
 process.chdir('..');
 assert.strictEqual(process.cwd().normalize(),
-                   path.resolve(common.tmpDir).normalize());
+                   path.resolve(tmpdir.path).normalize());
 
 const errMessage = /^TypeError: Bad argument\.$/;
 assert.throws(function() { process.chdir({}); },

--- a/test/parallel/test-process-execpath.js
+++ b/test/parallel/test-process-execpath.js
@@ -14,9 +14,10 @@ if (process.argv[2] === 'child') {
   // The console.log() output is part of the test here.
   console.log(process.execPath);
 } else {
-  common.refreshTmpDir();
+  const tmpdir = require('../common/tmpdir');
+  tmpdir.refresh();
 
-  const symlinkedNode = path.join(common.tmpDir, 'symlinked-node');
+  const symlinkedNode = path.join(tmpdir.path, 'symlinked-node');
   fs.symlinkSync(process.execPath, symlinkedNode);
 
   const proc = child_process.spawnSync(symlinkedNode, [__filename, 'child']);

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -12,10 +12,11 @@ const fork = require('child_process').fork;
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const warnmod = require.resolve(fixtures.path('warnings.js'));
-const warnpath = path.join(common.tmpDir, 'warnings.txt');
+const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { env: Object.assign({}, process.env,
                                    { NODE_REDIRECT_WARNINGS: warnpath }) })

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -12,10 +12,11 @@ const fork = require('child_process').fork;
 const path = require('path');
 const assert = require('assert');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const warnmod = fixtures.path('warnings.js');
-const warnpath = path.join(common.tmpDir, 'warnings.txt');
+const warnpath = path.join(tmpdir.path, 'warnings.txt');
 
 fork(warnmod, { execArgv: [`--redirect-warnings=${warnpath}`] })
   .on('exit', common.mustCall(() => {

--- a/test/parallel/test-regress-GH-3739.js
+++ b/test/parallel/test-regress-GH-3739.js
@@ -5,10 +5,12 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-let dir = path.resolve(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+
+let dir = path.resolve(tmpdir.path);
 
 // Make sure that the tmp directory is clean
-common.refreshTmpDir();
+tmpdir.refresh();
 
 // Make a long path.
 for (let i = 0; i < 50; i++) {

--- a/test/parallel/test-repl-history-perm.js
+++ b/test/parallel/test-repl-history-perm.js
@@ -31,8 +31,9 @@ stream._write = function(c, e, cb) {
 };
 stream.readable = stream.writable = true;
 
-common.refreshTmpDir();
-const replHistoryPath = path.join(common.tmpDir, '.node_repl_history');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const replHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 
 const checkResults = common.mustCall(function(err, r) {
   assert.ifError(err);

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -11,11 +11,12 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // Mock os.homedir()
 os.homedir = function() {
-  return common.tmpDir;
+  return tmpdir.path;
 };
 
 // Create an input stream specialized for testing an array of actions
@@ -55,16 +56,16 @@ const CLEAR = { ctrl: true, name: 'u' };
 
 // File paths
 const historyFixturePath = fixtures.path('.node_repl_history');
-const historyPath = path.join(common.tmpDir, '.fixture_copy_repl_history');
-const historyPathFail = path.join(common.tmpDir, '.node_repl\u0000_history');
+const historyPath = path.join(tmpdir.path, '.fixture_copy_repl_history');
+const historyPathFail = path.join(tmpdir.path, '.node_repl\u0000_history');
 const oldHistoryPathObj = fixtures.path('old-repl-history-file-obj.json');
 const oldHistoryPathFaulty = fixtures.path('old-repl-history-file-faulty.json');
 const oldHistoryPath = fixtures.path('old-repl-history-file.json');
 const enoentHistoryPath = fixtures.path('enoent-repl-history-file.json');
 const emptyHistoryPath = fixtures.path('.empty-repl-history-file');
-const defaultHistoryPath = path.join(common.tmpDir, '.node_repl_history');
+const defaultHistoryPath = path.join(tmpdir.path, '.node_repl_history');
 const emptyHiddenHistoryPath = fixtures.path('.empty-hidden-repl-history-file');
-const devNullHistoryPath = path.join(common.tmpDir,
+const devNullHistoryPath = path.join(tmpdir.path,
                                      '.dev-null-repl-history-file');
 // Common message bits
 const prompt = '> ';

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -25,7 +25,8 @@ const assert = require('assert');
 const join = require('path').join;
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const repl = require('repl');
 
@@ -39,7 +40,7 @@ const testFile = [
   'var top = function() {',
   'var inner = {one:1};'
 ];
-const saveFileName = join(common.tmpDir, 'test.save.js');
+const saveFileName = join(tmpdir.path, 'test.save.js');
 
 // input some data
 putIn.run(testFile);
@@ -91,7 +92,7 @@ testMe.complete('inner.o', function(error, data) {
 // clear the REPL
 putIn.run(['.clear']);
 
-let loadFile = join(common.tmpDir, 'file.does.not.exist');
+let loadFile = join(tmpdir.path, 'file.does.not.exist');
 
 // should not break
 putIn.write = function(data) {
@@ -103,7 +104,7 @@ putIn.write = function(data) {
 putIn.run([`.load ${loadFile}`]);
 
 // throw error on loading directory
-loadFile = common.tmpDir;
+loadFile = tmpdir.path;
 putIn.write = function(data) {
   assert.strictEqual(data, `Failed to load:${loadFile} is not a valid file\n`);
   putIn.write = () => {};
@@ -115,7 +116,7 @@ putIn.run(['.clear']);
 
 // NUL (\0) is disallowed in filenames in UNIX-like operating systems and
 // Windows so we can use that to test failed saves
-const invalidFileName = join(common.tmpDir, '\0\0\0\0\0');
+const invalidFileName = join(tmpdir.path, '\0\0\0\0\0');
 
 // should not break
 putIn.write = function(data) {

--- a/test/parallel/test-require-long-path.js
+++ b/test/parallel/test-require-long-path.js
@@ -6,15 +6,17 @@ if (!common.isWindows)
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 // make a path that is more than 260 chars long.
-const dirNameLen = Math.max(260 - common.tmpDir.length, 1);
-const dirName = path.join(common.tmpDir, 'x'.repeat(dirNameLen));
+const dirNameLen = Math.max(260 - tmpdir.path.length, 1);
+const dirName = path.join(tmpdir.path, 'x'.repeat(dirNameLen));
 const fullDirPath = path.resolve(dirName);
 
 const indexFile = path.join(fullDirPath, 'index.js');
 const otherFile = path.join(fullDirPath, 'other.js');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 fs.mkdirSync(fullDirPath);
 fs.writeFileSync(indexFile, 'require("./other");');
@@ -23,4 +25,4 @@ fs.writeFileSync(otherFile, '');
 require(indexFile);
 require(otherFile);
 
-common.refreshTmpDir();
+tmpdir.refresh();

--- a/test/parallel/test-require-symlink.js
+++ b/test/parallel/test-require-symlink.js
@@ -14,12 +14,13 @@ const process = require('process');
 // Setup: Copy fixtures to tmp directory.
 
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const dirName = 'module-require-symlink';
 const fixtureSource = fixtures.path(dirName);
-const tmpDirTarget = path.join(common.tmpDir, dirName);
+const tmpDirTarget = path.join(tmpdir.path, dirName);
 
 // Copy fixtureSource to linkTarget recursively.
-common.refreshTmpDir();
+tmpdir.refresh();
 
 function copyDir(source, target) {
   fs.mkdirSync(target);
@@ -40,7 +41,7 @@ copyDir(fixtureSource, tmpDirTarget);
 // Move to tmp dir and do everything with relative paths there so that the test
 // doesn't incorrectly fail due to a symlink somewhere else in the absolute
 // path.
-process.chdir(common.tmpDir);
+process.chdir(tmpdir.path);
 
 const linkDir = path.join(dirName,
                           'node_modules',

--- a/test/parallel/test-require-unicode.js
+++ b/test/parallel/test-require-unicode.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const dirname = path.join(common.tmpDir, '\u4e2d\u6587\u76ee\u5f55');
+const dirname = path.join(tmpdir.path, '\u4e2d\u6587\u76ee\u5f55');
 fs.mkdirSync(dirname);
 fs.writeFileSync(path.join(dirname, 'file.js'), 'module.exports = 42;');
 fs.writeFileSync(path.join(dirname, 'package.json'),

--- a/test/parallel/test-stdin-from-file.js
+++ b/test/parallel/test-stdin-from-file.js
@@ -1,13 +1,14 @@
 'use strict';
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const { join } = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 
 const stdoutScript = fixtures.path('echo-close-check.js');
-const tmpFile = join(common.tmpDir, 'stdin.txt');
+const tmpFile = join(tmpdir.path, 'stdin.txt');
 
 const cmd = `"${process.argv[0]}" "${stdoutScript}" < "${tmpFile}"`;
 
@@ -24,7 +25,7 @@ const string = 'abc\nümlaut.\nsomething else\n' +
                '有效的改善了岭南地区落后的政治、##济现状。\n';
 
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 console.log(`${cmd}\n\n`);
 

--- a/test/parallel/test-stdout-to-file.js
+++ b/test/parallel/test-stdout-to-file.js
@@ -5,12 +5,13 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const scriptString = fixtures.path('print-chars.js');
 const scriptBuffer = fixtures.path('print-chars-from-buffer.js');
-const tmpFile = path.join(common.tmpDir, 'stdout.txt');
+const tmpFile = path.join(tmpdir.path, 'stdout.txt');
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 function test(size, useBuffer, cb) {
   const cmd = `"${process.argv[0]}" "${

--- a/test/parallel/test-tls-connect-pipe.js
+++ b/test/parallel/test-tls-connect-pipe.js
@@ -33,7 +33,8 @@ const options = {
   cert: fixtures.readKey('agent1-cert.pem')
 };
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = tls.Server(options, common.mustCall(function(socket) {
   server.close();

--- a/test/parallel/test-tls-net-connect-prefer-path.js
+++ b/test/parallel/test-tls-net-connect-prefer-path.js
@@ -8,7 +8,8 @@ const fixtures = require('../common/fixtures');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const tls = require('tls');
 const net = require('net');

--- a/test/parallel/test-tls-wrap-econnreset-pipe.js
+++ b/test/parallel/test-tls-wrap-econnreset-pipe.js
@@ -8,7 +8,8 @@ const assert = require('assert');
 const tls = require('tls');
 const net = require('net');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const server = net.createServer((c) => {
   c.end();

--- a/test/parallel/test-trace-events-all.js
+++ b/test/parallel/test-trace-events-all.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled', '-e', CODE ]);

--- a/test/parallel/test-trace-events-async-hooks.js
+++ b/test/parallel/test-trace-events-async-hooks.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-binding.js
+++ b/test/parallel/test-trace-events-binding.js
@@ -20,8 +20,9 @@ const CODE = `
 `;
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-category-used.js
+++ b/test/parallel/test-trace-events-category-used.js
@@ -7,8 +7,9 @@ const CODE = `console.log(
   process.binding("trace_events").categoryGroupEnabled("custom")
 );`;
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const procEnabled = cp.spawn(
   process.execPath,

--- a/test/parallel/test-trace-events-none.js
+++ b/test/parallel/test-trace-events-none.js
@@ -7,8 +7,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc_no_categories = cp.spawn(
   process.execPath,

--- a/test/parallel/test-trace-events-process-exit.js
+++ b/test/parallel/test-trace-events-process-exit.js
@@ -4,10 +4,12 @@ const assert = require('assert');
 const cp = require('child_process');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-trace-events-v8.js
+++ b/test/parallel/test-trace-events-v8.js
@@ -8,8 +8,9 @@ const CODE =
   'setTimeout(() => { for (var i = 0; i < 100000; i++) { "test" + i } }, 1)';
 const FILE_NAME = 'node_trace.1.log';
 
-common.refreshTmpDir();
-process.chdir(common.tmpDir);
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+process.chdir(tmpdir.path);
 
 const proc = cp.spawn(process.execPath,
                       [ '--trace-events-enabled',

--- a/test/parallel/test-zlib-from-gzip.js
+++ b/test/parallel/test-zlib-from-gzip.js
@@ -29,7 +29,8 @@ const zlib = require('zlib');
 const path = require('path');
 const fixtures = require('../common/fixtures');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 const gunzip = zlib.createGunzip();
 
@@ -37,7 +38,7 @@ const fs = require('fs');
 
 const fixture = fixtures.path('person.jpg.gz');
 const unzippedFixture = fixtures.path('person.jpg');
-const outputFile = path.resolve(common.tmpDir, 'person.jpg');
+const outputFile = path.resolve(tmpdir.path, 'person.jpg');
 const expect = fs.readFileSync(unzippedFixture);
 const inp = fs.createReadStream(fixture);
 const out = fs.createWriteStream(outputFile);

--- a/test/pummel/test-fs-largefile.js
+++ b/test/pummel/test-fs-largefile.js
@@ -20,15 +20,16 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filepath = path.join(common.tmpDir, 'large.txt');
+const filepath = path.join(tmpdir.path, 'large.txt');
 const fd = fs.openSync(filepath, 'w+');
 const offset = 5 * 1024 * 1024 * 1024; // 5GB
 const message = 'Large File';

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -25,7 +25,9 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-const FILENAME = path.join(common.tmpDir, 'watch-me');
+const tmpdir = require('../common/tmpdir');
+
+const FILENAME = path.join(tmpdir.path, 'watch-me');
 const TIMEOUT = 1300;
 
 let nevents = 0;

--- a/test/pummel/test-fs-watch-file.js
+++ b/test/pummel/test-fs-watch-file.js
@@ -25,12 +25,14 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
+const tmpdir = require('../common/tmpdir');
+
 let watchSeenOne = 0;
 let watchSeenTwo = 0;
 let watchSeenThree = 0;
 let watchSeenFour = 0;
 
-const testDir = common.tmpDir;
+const testDir = tmpdir.path;
 
 const filenameOne = 'watch.txt';
 const filepathOne = path.join(testDir, filenameOne);

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -24,7 +24,9 @@ const common = require('../common');
 const path = require('path');
 const fs = require('fs');
 
-const testDir = common.tmpDir;
+const tmpdir = require('tmpdir');
+
+const testDir = tmpdir.path;
 const testsubdir = path.join(testDir, 'testsubdir');
 const filepath = path.join(testsubdir, 'watch.txt');
 

--- a/test/pummel/test-regress-GH-814.js
+++ b/test/pummel/test-regress-GH-814.js
@@ -22,8 +22,10 @@
 'use strict';
 // Flags: --expose_gc
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
+
+const tmpdir = require('../common/tmpdir');
 
 function newBuffer(size, value) {
   const buffer = Buffer.allocUnsafe(size);
@@ -36,7 +38,7 @@ function newBuffer(size, value) {
 }
 
 const fs = require('fs');
-const testFileName = require('path').join(common.tmpDir, 'GH-814_testFile.txt');
+const testFileName = require('path').join(tmpdir.path, 'GH-814_testFile.txt');
 const testFileFD = fs.openSync(testFileName, 'w');
 console.log(testFileName);
 

--- a/test/pummel/test-regress-GH-814_2.js
+++ b/test/pummel/test-regress-GH-814_2.js
@@ -22,11 +22,12 @@
 'use strict';
 // Flags: --expose_gc
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const fs = require('fs');
-const testFileName = require('path').join(common.tmpDir, 'GH-814_test.txt');
+const tmpdir = require('../common/tmpdir');
+const testFileName = require('path').join(tmpdir.path, 'GH-814_test.txt');
 const testFD = fs.openSync(testFileName, 'w');
 console.error(`${testFileName}\n`);
 

--- a/test/pummel/test-tls-session-timeout.js
+++ b/test/pummel/test-tls-session-timeout.js
@@ -28,6 +28,8 @@ if (!common.opensslCli)
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const tmpdir = require('../common/tmpdir');
+
 doTest();
 
 // This test consists of three TLS requests --
@@ -65,7 +67,7 @@ function doTest() {
 
   const sessionFileName = (function() {
     const ticketFileName = 'tls-session-ticket.txt';
-    const tmpPath = join(common.tmpDir, ticketFileName);
+    const tmpPath = join(tmpdir.path, ticketFileName);
     fs.writeFileSync(tmpPath, fixtures.readSync(ticketFileName));
     return tmpPath;
   }());

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 const { getSystemErrorName } = require('util');
 
 // Make sure that all Providers are tested.
@@ -139,7 +140,7 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 }
 
 {
-  common.refreshTmpDir();
+  tmpdir.refresh();
 
   const server = net.createServer(common.mustCall((socket) => {
     server.close();

--- a/test/sequential/test-fs-readfile-tostring-fail.js
+++ b/test/sequential/test-fs-readfile-tostring-fail.js
@@ -13,9 +13,10 @@ const kStringMaxLength = process.binding('buffer').kStringMaxLength;
 if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const file = path.join(common.tmpDir, 'toobig.txt');
+const file = path.join(tmpdir.path, 'toobig.txt');
 const stream = fs.createWriteStream(file, {
   flags: 'a'
 });

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -26,14 +26,16 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
+const tmpdir = require('../common/tmpdir');
+
 const expectFilePath = common.isWindows ||
                        common.isLinux ||
                        common.isOSX ||
                        common.isAIX;
 
-const testDir = common.tmpDir;
+const testDir = tmpdir.path;
 
-common.refreshTmpDir();
+tmpdir.refresh();
 
 {
   const filepath = path.join(testDir, 'watch.txt');

--- a/test/sequential/test-http2-timeout-large-write-file.js
+++ b/test/sequential/test-http2-timeout-large-write-file.js
@@ -8,7 +8,8 @@ const fs = require('fs');
 const http2 = require('http2');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
 // This test assesses whether long-running writes can complete
 // or timeout because the session or stream are not aware that the
@@ -29,7 +30,7 @@ let offsetTimeout = common.platformTimeout(100);
 let didReceiveData = false;
 
 const content = Buffer.alloc(writeSize, 0x44);
-const filepath = path.join(common.tmpDir, 'http2-large-write.tmp');
+const filepath = path.join(tmpdir.path, 'http2-large-write.tmp');
 fs.writeFileSync(filepath, content, 'binary');
 const fd = fs.openSync(filepath, 'r');
 

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -242,7 +242,8 @@ try {
 
   assert.deepStrictEqual(children, {
     'common/index.js': {
-      'common/fixtures.js': {}
+      'common/fixtures.js': {},
+      'common/tmpdir.js': {}
     },
     'fixtures/not-main-module.js': {},
     'fixtures/a.js': {

--- a/test/sequential/test-regress-GH-4027.js
+++ b/test/sequential/test-regress-GH-4027.js
@@ -25,9 +25,10 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const filename = path.join(common.tmpDir, 'watched');
+const filename = path.join(tmpdir.path, 'watched');
 fs.writeFileSync(filename, 'quis custodiet ipsos custodes');
 
 fs.watchFile(filename, { interval: 50 }, common.mustCall(function(curr, prev) {

--- a/test/tick-processor/tick-processor-base.js
+++ b/test/tick-processor/tick-processor-base.js
@@ -1,12 +1,13 @@
 'use strict';
-const common = require('../common');
+require('../common');
 const fs = require('fs');
 const cp = require('child_process');
 const path = require('path');
 
-common.refreshTmpDir();
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
 
-const LOG_FILE = path.join(common.tmpDir, 'tick-processor.log');
+const LOG_FILE = path.join(tmpdir.path, 'tick-processor.log');
 const RETRY_TIMEOUT = 150;
 
 function runTest(test) {


### PR DESCRIPTION
Move tmpdir functionality to its own module (common/tmpdir).

(Trying to move to focused small modules and reduce unwieldy monoliths. Not sure how this will be received...)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test