### PR TITLE
 tools: enable array-callback-return ESLint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -43,6 +43,7 @@ rules:
   # Best Practices
   # http://eslint.org/docs/rules/#best-practices
   accessor-pairs: error
+  array-callback-return: error
   dot-location: [error, property]
   eqeqeq: [error, smart]
   no-fallthrough: error

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -500,9 +500,7 @@ Interface.prototype._tabComplete = function(lastKeypressWasTab) {
       }
 
       // If there is a common prefix to all matches, then apply that portion.
-      var f = completions.filter(function completionFilter(e) {
-        if (e) return e;
-      });
+      var f = completions.filter((e) => e);
       var prefix = commonPrefix(f);
       if (prefix.length > completeOn.length) {
         self._insertString(prefix.slice(completeOn.length));

--- a/test/parallel/test-https-options-boolean-check.js
+++ b/test/parallel/test-https-options-boolean-check.js
@@ -64,7 +64,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [false, [certStr, certStr2]],
   [[{ pem: keyBuff }], false],
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
-].map((params) => {
+].forEach((params) => {
   assert.doesNotThrow(() => {
     https.createServer({
       key: params[0],
@@ -100,7 +100,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[keyStr, keyStr2], [true, false], invalidCertRE],
   [[keyStr, keyStr2], true, invalidCertRE],
   [true, [certBuff, certBuff2], invalidKeyRE]
-].map((params) => {
+].forEach((params) => {
   common.expectsError(() => {
     https.createServer({
       key: params[0],
@@ -123,7 +123,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, caArrBuff],
   [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
-].map((params) => {
+].forEach((params) => {
   assert.doesNotThrow(() => {
     https.createServer({
       key: params[0],
@@ -141,7 +141,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
-].map((params) => {
+].forEach((params) => {
   common.expectsError(() => {
     https.createServer({
       key: params[0],

--- a/test/parallel/test-tls-options-boolean-check.js
+++ b/test/parallel/test-tls-options-boolean-check.js
@@ -64,7 +64,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [false, [certStr, certStr2]],
   [[{ pem: keyBuff }], false],
   [[{ pem: keyBuff }, { pem: keyBuff }], false]
-].map(([key, cert]) => {
+].forEach(([key, cert]) => {
   assert.doesNotThrow(() => {
     tls.createServer({ key, cert });
   });
@@ -97,7 +97,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [[keyStr, keyStr2], [true, false], invalidCertRE],
   [[keyStr, keyStr2], true, invalidCertRE],
   [true, [certBuff, certBuff2], invalidKeyRE]
-].map(([key, cert, message]) => {
+].forEach(([key, cert, message]) => {
   common.expectsError(() => {
     tls.createServer({ key, cert });
   }, {
@@ -117,7 +117,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, caArrBuff],
   [keyBuff, certBuff, caArrDataView],
   [keyBuff, certBuff, false],
-].map(([key, cert, ca]) => {
+].forEach(([key, cert, ca]) => {
   assert.doesNotThrow(() => {
     tls.createServer({ key, cert, ca });
   });
@@ -131,7 +131,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
-].map(([key, cert, ca]) => {
+].forEach(([key, cert, ca]) => {
   common.expectsError(() => {
     tls.createServer({ key, cert, ca });
   }, {
@@ -149,7 +149,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [keyBuff, certBuff, 1],
   [keyBuff, certBuff, true],
   [keyBuff, certBuff, [caCert, true]]
-].map(([key, cert, ca]) => {
+].forEach(([key, cert, ca]) => {
   common.expectsError(() => {
     tls.createServer({ key, cert, ca });
   }, {
@@ -167,7 +167,7 @@ const invalidCertRE = /^The "cert" argument must be one of type string, Buffer, 
   [undefined, undefined, undefined],
   ['', '', ''],
   [0, 0, 0]
-].map(([key, cert, ca]) => {
+].forEach(([key, cert, ca]) => {
   assert.doesNotThrow(() => {
     tls.createSecureContext({ key, cert, ca });
   });


### PR DESCRIPTION
For array methods that depend on a callback (such as `.filter()` or
`.map()`), require a return value from the callback.

First two commits fix a few issues in our code base that would be flagged by this rule.

Third commit enables the rule itself.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools readline test