### PR TITLE
repl: fix coloring of `process.versions`

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1093,10 +1093,6 @@ function _exceptionWithHostPort(err,
   return ex;
 }
 
-// process.versions needs a custom function as some values are lazy-evaluated.
-process.versions[inspect.custom] =
-  () => exports.format(JSON.parse(JSON.stringify(process.versions)));
-
 function callbackifyOnRejected(reason, cb) {
   // `!reason` guard inspired by bluebird (Ref: https://goo.gl/t5IS6M).
   // Because `null` is a special error value in callbacks which means "no error


### PR DESCRIPTION
Remove the custom formatter that was added in commit 4fb27d4 ("intl: Add
more versions from ICU").  It's not necessary anymore (and may not have
been necessary at all) and prevents proper coloring in the REPL.

Fixes: https://github.com/nodejs/node/issues/17086