### PR TITLE
http2: keep session objects alive during Http2Scope 

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -174,7 +174,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_HEADER_TABLE_SIZE)) {
     uint32_t val = buffer[IDX_SETTINGS_HEADER_TABLE_SIZE];
-    DEBUG_HTTP2SESSION2(session, "setting header table size: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting header table size: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_HEADER_TABLE_SIZE;
     entries_[n].value = val;
     n++;
@@ -182,7 +182,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_MAX_CONCURRENT_STREAMS)) {
     uint32_t val = buffer[IDX_SETTINGS_MAX_CONCURRENT_STREAMS];
-    DEBUG_HTTP2SESSION2(session, "setting max concurrent streams: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting max concurrent streams: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
     entries_[n].value = val;
     n++;
@@ -190,7 +190,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_MAX_FRAME_SIZE)) {
     uint32_t val = buffer[IDX_SETTINGS_MAX_FRAME_SIZE];
-    DEBUG_HTTP2SESSION2(session, "setting max frame size: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting max frame size: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_MAX_FRAME_SIZE;
     entries_[n].value = val;
     n++;
@@ -198,7 +198,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_INITIAL_WINDOW_SIZE)) {
     uint32_t val = buffer[IDX_SETTINGS_INITIAL_WINDOW_SIZE];
-    DEBUG_HTTP2SESSION2(session, "setting initial window size: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting initial window size: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
     entries_[n].value = val;
     n++;
@@ -206,7 +206,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_MAX_HEADER_LIST_SIZE)) {
     uint32_t val = buffer[IDX_SETTINGS_MAX_HEADER_LIST_SIZE];
-    DEBUG_HTTP2SESSION2(session, "setting max header list size: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting max header list size: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE;
     entries_[n].value = val;
     n++;
@@ -214,7 +214,7 @@ void Http2Session::Http2Settings::Init() {
 
   if (flags & (1 << IDX_SETTINGS_ENABLE_PUSH)) {
     uint32_t val = buffer[IDX_SETTINGS_ENABLE_PUSH];
-    DEBUG_HTTP2SESSION2(session, "setting enable push: %d\n", val);
+    DEBUG_HTTP2SESSION2(session_, "setting enable push: %d\n", val);
     entries_[n].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
     entries_[n].value = val;
     n++;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -72,7 +72,7 @@ Http2Scope::Http2Scope(Http2Session* session) {
   session->flags_ |= SESSION_STATE_HAS_SCOPE;
   session_ = session;
 
-  // Always keep the session object alive for at least as long as the
+  // Always keep the session object alive for at least as long as
   // this scope is active.
   session_handle_ = session->object();
   CHECK(!session_handle_.IsEmpty());

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -445,6 +445,7 @@ class Http2Scope {
 
  private:
   Http2Session* session_ = nullptr;
+  Local<Object> session_handle_;
 };
 
 // The Http2Options class is used to parse the options object passed in to


### PR DESCRIPTION
Keep a local handle as a reference to the JS `Http2Session`
object so that it will not be garbage collected
when inside an `Http2Scope`, because the presence of the
latter usually indicates that further actions on
the session object are expected.

Strictly speaking, storing the `session_handle_` as a
property on the scope object is not necessary, but
this is not very costly and makes the code more
obviously correct.

Fixes: #17840

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

@nodejs/http2