### PR TITLE
test: make test-tls-invoke-queued use public API

### DIFF
--- a/test/parallel/test-tls-invoke-queued.js
+++ b/test/parallel/test-tls-invoke-queued.js
@@ -36,12 +36,12 @@ const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')
 }, common.mustCall(function(c) {
-  c._write('hello ', null, common.mustCall(function() {
-    c._write('world!', null, common.mustCall(function() {
+  c.write('hello ', null, common.mustCall(function() {
+    c.write('world!', null, common.mustCall(function() {
       c.destroy();
     }));
     // Data on next _write() will be written but callback will not be invoked
-    c._write(' gosh', null, common.mustNotCall());
+    c.write(' gosh', null, common.mustNotCall());
   }));
 
   server.close();


### PR DESCRIPTION
`parallel/test-tls-invoke-queued` previously used the internal
`_write()` API to hook into the internals more directly, but this
invalidates the general assumption made by streams APIs that
only a single write is active at a time, and which is enforced through the public API.

~~I *might* want for this to wait a bit before landing – not because it’s a tricky change, but to make sure other upcoming changes pass independently of this PR.~~

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

test/tls