### PR TITLE
doc: remove non-style information from style guide

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -9,9 +9,6 @@
 * The formatting described in `.editorconfig` is preferred.
   * A [plugin][] is available for some editors to automatically apply these
     rules.
-* Mechanical issues, like spelling and grammar, should be identified by tools,
-  insofar as is possible. If not caught by a tool, they should be pointed out by
-  human reviewers.
 * American English spelling is preferred. "Capitalize" vs. "Capitalise",
   "color" vs. "colour", etc.
 * Use [serial commas][].

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -9,6 +9,7 @@
 * The formatting described in `.editorconfig` is preferred.
   * A [plugin][] is available for some editors to automatically apply these
     rules.
+* Changes to documentation should be checked with `make lint-md`.
 * American English spelling is preferred. "Capitalize" vs. "Capitalise",
   "color" vs. "colour", etc.
 * Use [serial commas][].

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -121,6 +121,9 @@ onboarding session.
   avoid stalling the pull request.
   * Note that they are nits when you comment: `Nit: change foo() to bar().`
   * If they are stalling the pull request, fix them yourself on merge.
+* Insofar as possible, issues should be identified by tools rather than human
+  reviewers. If you are leaving comments that could be identified by tools but
+  are not, consider implementing the necessary tooling.
 * Minimum wait for comments time
   * There is a minimum waiting time which we try to respect for non-trivial
       changes, so that people who may have important input in such a distributed

--- a/doc/onboarding.md
+++ b/doc/onboarding.md
@@ -122,8 +122,8 @@ onboarding session.
   * Note that they are nits when you comment: `Nit: change foo() to bar().`
   * If they are stalling the pull request, fix them yourself on merge.
 * Insofar as possible, issues should be identified by tools rather than human
-  reviewers. If you are leaving comments that could be identified by tools but
-  are not, consider implementing the necessary tooling.
+  reviewers. If you are leaving comments about issues that could be identified
+  by tools but are not, consider implementing the necessary tooling.
 * Minimum wait for comments time
   * There is a minimum waiting time which we try to respect for non-trivial
       changes, so that people who may have important input in such a distributed


### PR DESCRIPTION
While I agree that tools should be used insofar as possible, that
information does not belong in the style guide.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc