### PR TITLE
tools: add check for using process.binding crypto

### DIFF
--- a/test/parallel/test-accessor-properties.js
+++ b/test/parallel/test-accessor-properties.js
@@ -2,8 +2,6 @@
 
 const common = require('../common');
 
-if (!common.hasCrypto)
-  common.skip('missing crypto');
 // This tests that the accessor properties do not raise assertions
 // when called with incompatible receivers.
 
@@ -13,9 +11,6 @@ const assert = require('assert');
 // their prototype
 const TTY = process.binding('tty_wrap').TTY;
 const UDP = process.binding('udp_wrap').UDP;
-
-// There are accessor properties in crypto too
-const crypto = process.binding('crypto');
 
 {
   // Should throw instead of raise assertions
@@ -34,15 +29,6 @@ const crypto = process.binding('crypto');
   assert.throws(() => {
     UDP.prototype.fd;
   }, TypeError);
-
-  assert.throws(() => {
-    crypto.SecureContext.prototype._external;
-  }, TypeError);
-
-  assert.throws(() => {
-    crypto.Connection.prototype._external;
-  }, TypeError);
-
 
   // Should not throw for Object.getOwnPropertyDescriptor
   assert.strictEqual(
@@ -65,15 +51,28 @@ const crypto = process.binding('crypto');
     'object'
   );
 
-  assert.strictEqual(
-    typeof Object.getOwnPropertyDescriptor(
-      crypto.SecureContext.prototype, '_external'),
-    'object'
-  );
+  if (common.hasCrypto) { // eslint-disable-line crypto-check
+    // There are accessor properties in crypto too
+    const crypto = process.binding('crypto');
 
-  assert.strictEqual(
-    typeof Object.getOwnPropertyDescriptor(
-      crypto.Connection.prototype, '_external'),
-    'object'
-  );
+    assert.throws(() => {
+      crypto.SecureContext.prototype._external;
+    }, TypeError);
+
+    assert.throws(() => {
+      crypto.Connection.prototype._external;
+    }, TypeError);
+
+    assert.strictEqual(
+      typeof Object.getOwnPropertyDescriptor(
+        crypto.SecureContext.prototype, '_external'),
+      'object'
+    );
+
+    assert.strictEqual(
+      typeof Object.getOwnPropertyDescriptor(
+        crypto.Connection.prototype, '_external'),
+      'object'
+    );
+  }
 }

--- a/test/parallel/test-accessor-properties.js
+++ b/test/parallel/test-accessor-properties.js
@@ -1,7 +1,9 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 // This tests that the accessor properties do not raise assertions
 // when called with incompatible receivers.
 

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -5,6 +5,8 @@
 // to pass to the internal binding layer.
 
 const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 const assert = require('assert');
 const { mapToHeaders } = require('internal/http2/util');
 

--- a/test/parallel/test-http2-util-update-options-buffer.js
+++ b/test/parallel/test-http2-util-update-options-buffer.js
@@ -1,7 +1,9 @@
 // Flags: --expose-internals
 'use strict';
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
 
 // Test coverage for the updateOptionsBuffer method used internally
 // by the http2 implementation.

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -544,7 +544,8 @@ editor.completer('var log = console.l', common.mustCall((error, data) => {
 
   ['Let', 'Const', 'Klass'].forEach((type) => {
     const query = `lexical${type[0]}`;
-    const expected = hasInspector ? [[`lexical${type}`], query] : [];
+    const expected = hasInspector ? [[`lexical${type}`], query] :
+      [[], `lexical${type[0]}`];
     testRepl.complete(query, common.mustCall((error, data) => {
       assert.deepStrictEqual(data, expected);
     }));

--- a/tools/eslint-rules/crypto-check.js
+++ b/tools/eslint-rules/crypto-check.js
@@ -16,13 +16,18 @@ const utils = require('./rules-utils.js');
 const msg = 'Please add a hasCrypto check to allow this test to be skipped ' +
             'when Node is built "--without-ssl".';
 
+const cryptoModules = ['crypto', 'http2'];
+const requireModules = cryptoModules.concat(['tls', 'https']);
+const bindingModules = cryptoModules.concat(['tls_wrap']);
+
 module.exports = function(context) {
   const missingCheckNodes = [];
   const requireNodes = [];
   var hasSkipCall = false;
 
   function testCryptoUsage(node) {
-    if (utils.isRequired(node, ['crypto', 'tls', 'https', 'http2'])) {
+    if (utils.isRequired(node, requireModules) ||
+        utils.isBinding(node, bindingModules)) {
       requireNodes.push(node);
     }
   }

--- a/tools/eslint-rules/rules-utils.js
+++ b/tools/eslint-rules/rules-utils.js
@@ -13,6 +13,18 @@ module.exports.isRequired = function(node, modules) {
 };
 
 /**
+ * Returns true if any of the passed in modules are used in
+ * binding calls.
+ */
+module.exports.isBinding = function(node, modules) {
+  if (node.callee.object) {
+    return node.callee.object.name === 'process' &&
+           node.callee.property.name === 'binding' &&
+           modules.includes(node.arguments[0].value);
+  }
+};
+
+/**
  * Returns true is the node accesses any property in the properties
  * array on the 'common' object.
  */


### PR DESCRIPTION
Currently, when configuring `--without-ssl` any tests that use
`process.binding('crypto')` will not report a lint warning. This is
because the eslint check only generates a warning when using require.

This commit adds a check for using binding in addition to require.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
tools