### PR TITLE
errors: remove ERR_OUTOFMEMORY

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1332,11 +1332,6 @@ A Node.js API was called in an unsupported manner.
 
 For example: `Buffer.write(string, encoding, offset[, length])`
 
-<a id="ERR_OUTOFMEMORY"></a>
-### ERR_OUTOFMEMORY
-
-An operation caused an out-of-memory condition.
-
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -443,7 +443,6 @@ E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
 E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
-E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_OUT_OF_RANGE', outOfRange);
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');


### PR DESCRIPTION
The error code `ERR_OUTOFMEMORY` was added in e71e71b5138c3dfee080f4215dd957dc7a6cbdaf and is unused ever since 69e6c5a212622ec15b8c2cf904480b6582c6c3a5. Apart from not being used within node core, it is the only error code which does not use underscores to separate words (`ERR_OUTOFMEMORY` vs `ERR_OUT_OF_RANGE`).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
errors