### PR TITLE
timers: remove domain enter and exit

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -256,15 +256,7 @@ function listOnTimeout() {
       continue;
     }
 
-    var domain = timer.domain;
-    if (domain) {
-      domain.enter();
-    }
-
     tryOnTimeout(timer, list);
-
-    if (domain)
-      domain.exit();
   }
 
   // If `L.peek(list)` returned nothing, the list was either empty or we have
@@ -641,30 +633,21 @@ var immediateQueue = new ImmediateList();
 function processImmediate() {
   var immediate = immediateQueue.head;
   var tail = immediateQueue.tail;
-  var domain;
 
   // Clear the linked list early in case new `setImmediate()` calls occur while
   // immediate callbacks are executed
   immediateQueue.head = immediateQueue.tail = null;
 
   while (immediate !== null) {
-    domain = immediate.domain;
-
     if (!immediate._onImmediate) {
       immediate = immediate._idleNext;
       continue;
     }
 
-    if (domain)
-      domain.enter();
-
     // Save next in case `clearImmediate(immediate)` is called from callback
     var next = immediate._idleNext;
 
     tryOnImmediate(immediate, tail);
-
-    if (domain)
-      domain.exit();
 
     // If `clearImmediate(immediate)` wasn't called from the callback, use the
     // `immediate`'s next item


### PR DESCRIPTION
With domains implemented over `AsyncHook`, it's no longer necessary to explicitly enter and exit the domain.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
timers