### PR TITLE
src: use AliasedBuffer for TickInfo

### DIFF
--- a/lib/internal/process/next_tick.js
+++ b/lib/internal/process/next_tick.js
@@ -29,7 +29,7 @@ function setupNextTick() {
   ] = process._setupNextTick(_tickCallback);
 
   // *Must* match Environment::TickInfo::Fields in src/env.h.
-  const kScheduled = 0;
+  const kHasScheduled = 0;
 
   const nextTickQueue = {
     head: null,
@@ -40,7 +40,7 @@ function setupNextTick() {
         this.tail.next = entry;
       } else {
         this.head = entry;
-        tickInfo[kScheduled] = 1;
+        tickInfo[kHasScheduled] = 1;
       }
       this.tail = entry;
     },
@@ -50,7 +50,7 @@ function setupNextTick() {
       const ret = this.head.data;
       if (this.head === this.tail) {
         this.head = this.tail = null;
-        tickInfo[kScheduled] = 0;
+        tickInfo[kHasScheduled] = 0;
       } else {
         this.head = this.head.next;
       }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -217,21 +217,15 @@ inline bool Environment::AsyncCallbackScope::in_makecallback() const {
   return env_->makecallback_cntr_ > 1;
 }
 
-inline Environment::TickInfo::TickInfo() {
-  for (int i = 0; i < kFieldsCount; ++i)
-    fields_[i] = 0;
-}
+inline Environment::TickInfo::TickInfo(v8::Isolate* isolate)
+    : fields_(isolate, kFieldsCount) {}
 
-inline uint8_t* Environment::TickInfo::fields() {
+inline AliasedBuffer<uint8_t, v8::Uint8Array>& Environment::TickInfo::fields() {
   return fields_;
 }
 
-inline int Environment::TickInfo::fields_count() const {
-  return kFieldsCount;
-}
-
-inline uint8_t Environment::TickInfo::scheduled() const {
-  return fields_[kScheduled];
+inline bool Environment::TickInfo::has_scheduled() const {
+  return fields_[kHasScheduled] == 1;
 }
 
 inline void Environment::AssignToContext(v8::Local<v8::Context> context,
@@ -269,6 +263,7 @@ inline Environment::Environment(IsolateData* isolate_data,
                                 v8::Local<v8::Context> context)
     : isolate_(context->GetIsolate()),
       isolate_data_(isolate_data),
+      tick_info_(context->GetIsolate()),
       timer_base_(uv_now(isolate_data->event_loop())),
       using_domains_(false),
       printed_error_(false),

--- a/src/env.h
+++ b/src/env.h
@@ -455,20 +455,19 @@ class Environment {
 
   class TickInfo {
    public:
-    inline uint8_t* fields();
-    inline int fields_count() const;
-    inline uint8_t scheduled() const;
+    inline AliasedBuffer<uint8_t, v8::Uint8Array>& fields();
+    inline bool has_scheduled() const;
 
    private:
     friend class Environment;  // So we can call the constructor.
-    inline TickInfo();
+    inline explicit TickInfo(v8::Isolate* isolate);
 
     enum Fields {
-      kScheduled,
+      kHasScheduled,
       kFieldsCount
     };
 
-    uint8_t fields_[kFieldsCount];
+    AliasedBuffer<uint8_t, v8::Uint8Array> fields_;
 
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };


### PR DESCRIPTION
Instead of creating a `v8::ArrayBuffer` in `SetupNextTick`, instead just make `TickInfo` use an `AliasedBuffer`. The reason it wasn't already doing this is that the code there predates the introduction of `AliasedBuffer`.

Also slight clean up around the naming of the "scheduled" flag.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
