### PR TITLE
tls: simplify write mechanism

### DIFF
--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -120,20 +120,18 @@ TLSWrap::~TLSWrap() {
 
 
 void TLSWrap::MakePending() {
-  write_item_queue_.MoveBack(&pending_write_items_);
+  write_callback_scheduled_ = true;
 }
 
 
 bool TLSWrap::InvokeQueued(int status, const char* error_str) {
-  if (pending_write_items_.IsEmpty())
+  if (!write_callback_scheduled_)
     return false;
 
-  // Process old queue
-  WriteItemList queue;
-  pending_write_items_.MoveBack(&queue);
-  while (WriteItem* wi = queue.PopFront()) {
-    wi->w_->Done(status, error_str);
-    delete wi;
+  if (current_write_ != nullptr) {
+    WriteWrap* w = current_write_;
+    current_write_ = nullptr;
+    w->Done(status, error_str);
   }
 
   return true;
@@ -303,7 +301,7 @@ void TLSWrap::EncOut() {
     return;
 
   // Split-off queue
-  if (established_ && !write_item_queue_.IsEmpty())
+  if (established_ && current_write_ != nullptr)
     MakePending();
 
   if (ssl_ == nullptr)
@@ -606,8 +604,9 @@ int TLSWrap::DoWrite(WriteWrap* w,
     }
   }
 
-  // Queue callback to execute it on next tick
-  write_item_queue_.PushBack(new WriteItem(w));
+  // Store the current write wrap
+  CHECK_EQ(current_write_, nullptr);
+  current_write_ = w;
   w->Dispatched();
 
   // Write queued data

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -90,19 +90,6 @@ class TLSWrap : public AsyncWrap,
   // Maximum number of buffers passed to uv_write()
   static const int kSimultaneousBufferCount = 10;
 
-  // Write callback queue's item
-  class WriteItem {
-   public:
-    explicit WriteItem(WriteWrap* w) : w_(w) {
-    }
-    ~WriteItem() {
-      w_ = nullptr;
-    }
-
-    WriteWrap* w_;
-    ListNode<WriteItem> member_;
-  };
-
   TLSWrap(Environment* env,
           Kind kind,
           StreamBase* stream,
@@ -173,9 +160,8 @@ class TLSWrap : public AsyncWrap,
   BIO* enc_out_;
   crypto::NodeBIO* clear_in_;
   size_t write_size_;
-  typedef ListHead<WriteItem, &WriteItem::member_> WriteItemList;
-  WriteItemList write_item_queue_;
-  WriteItemList pending_write_items_;
+  WriteWrap* current_write_ = nullptr;
+  bool write_callback_scheduled_ = false;
   bool started_;
   bool established_;
   bool shutdown_;

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -101,7 +101,6 @@ class TLSWrap : public AsyncWrap,
   void EncOutAfterWrite(WriteWrap* req_wrap, int status);
   bool ClearIn();
   void ClearOut();
-  void MakePending();
   bool InvokeQueued(int status, const char* error_str = nullptr);
 
   inline void Cycle() {
@@ -158,7 +157,7 @@ class TLSWrap : public AsyncWrap,
   StreamBase* stream_;
   BIO* enc_in_;
   BIO* enc_out_;
-  crypto::NodeBIO* clear_in_;
+  std::vector<uv_buf_t> pending_cleartext_input_;
   size_t write_size_;
   WriteWrap* current_write_ = nullptr;
   bool write_callback_scheduled_ = false;

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -100,19 +100,6 @@ ListHead<T, M>::~ListHead() {
 }
 
 template <typename T, ListNode<T> (T::*M)>
-void ListHead<T, M>::MoveBack(ListHead* that) {
-  if (IsEmpty())
-    return;
-  ListNode<T>* to = &that->head_;
-  head_.next_->prev_ = to->prev_;
-  to->prev_->next_ = head_.next_;
-  head_.prev_->next_ = to;
-  to->prev_ = head_.prev_;
-  head_.prev_ = &head_;
-  head_.next_ = &head_;
-}
-
-template <typename T, ListNode<T> (T::*M)>
 void ListHead<T, M>::PushBack(T* element) {
   ListNode<T>* that = &(element->*M);
   head_.prev_->next_ = that;

--- a/src/util.h
+++ b/src/util.h
@@ -181,7 +181,6 @@ class ListHead {
 
   inline ListHead() = default;
   inline ~ListHead();
-  inline void MoveBack(ListHead* that);
   inline void PushBack(T* element);
   inline void PushFront(T* element);
   inline bool IsEmpty() const;


### PR DESCRIPTION
*  tls: refactor write queues away

    The TLS implementation previously had two separate queues for
    WriteWrap instances, one for currently active and one for
    finishing writes (i.e. where the encrypted output is being written
    to the underlying socket).
    
    However, the streams implementation in Node doesn’t allow for
    more than one write to be active at a time; effectively,
    the only possible states were that:
    
    - No write was active.
    - The first write queue had one item, the second one was empty.
    - Only the second write queue had one item, the first one was empty.
    
    To reduce overhead and implementation complexity, remove these
    queues, and instead store a single `WriteWrap` pointer and
    keep track of whether its write callback should be called
    on the next invocation of `InvokeQueued()` or not
    (which is what being in the second queue previously effected).

* tls: remove cleartext input data queue

    The TLS implementation previously kept a separate buffer for
    incoming pieces of data, into which buffers were copied
    before they were up for writing.
    
    This removes this buffer, and replaces it with a simple list
    of `uv_buf_t`s:
    
    - The previous implementation copied all incoming data into
      that buffer, both allocating new storage and wasting time
      with copy operations. Node’s streams/net implementation
      already has to make sure that the allocated memory stays
      fresh until the write is finished, since that is what
      libuv streams rely on anyway.
    - The fact that a separate kind of buffer, `crypto::NodeBIO`
      was used, was confusing: These `BIO` instances are
      only used to communicate with openssl’s streams system
      otherwise, whereas this one was purely for internal
      memory management.
    - The name `clear_in_` was not very helpful.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

tls