### PR TITLE
doc: added articles about PR communication in CONTRIBUTING.md

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -116,6 +116,11 @@ oppose the PR, it can be landed. Where there is disagreement among TSC members
 or objections from one or more Collaborators, `semver-major` pull requests
 should be put on the TSC meeting agenda.
 
+#### Helpful resources
+
+* How to respectfully and usefully review code, part [one](https://mtlynch.io/human-code-reviews-1/) and [two](https://mtlynch.io/human-code-reviews-2/)
+* [How to write a positive code review](https://css-tricks.com/code-review-etiquette/)
+
 ### Waiting for Approvals
 
 Before landing pull requests, sufficient time should be left for input

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -828,7 +828,7 @@ The following additional resources may be of assistance:
 * [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
 * [core-validate-commit](https://github.com/evanlucas/core-validate-commit) -
   A utility that ensures commits follow the commit formatting guidelines.
-* How to respectfully and usefully review code part [one](https://mtlynch.io/human-code-reviews-1/) and [two](https://mtlynch.io/human-code-reviews-2/)
+* How to respectfully and usefully review code, part [one](https://mtlynch.io/human-code-reviews-1/) and [two](https://mtlynch.io/human-code-reviews-2/)
 * [How to write a positive code review](https://css-tricks.com/code-review-etiquette/)
 
 <a id="developers-certificate-of-origin"></a>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -828,8 +828,6 @@ The following additional resources may be of assistance:
 * [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
 * [core-validate-commit](https://github.com/evanlucas/core-validate-commit) -
   A utility that ensures commits follow the commit formatting guidelines.
-* How to respectfully and usefully review code, part [one](https://mtlynch.io/human-code-reviews-1/) and [two](https://mtlynch.io/human-code-reviews-2/)
-* [How to write a positive code review](https://css-tricks.com/code-review-etiquette/)
 
 <a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -828,6 +828,8 @@ The following additional resources may be of assistance:
 * [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
 * [core-validate-commit](https://github.com/evanlucas/core-validate-commit) -
   A utility that ensures commits follow the commit formatting guidelines.
+* How to respectfully and usefully review code part [one](https://mtlynch.io/human-code-reviews-1/) and [two](https://mtlynch.io/human-code-reviews-2/)
+* [How to write a positive code review](https://css-tricks.com/code-review-etiquette/)
 
 <a id="developers-certificate-of-origin"></a>
 ## Developer's Certificate of Origin 1.1


### PR DESCRIPTION
Added some references to PR communication articles in
Helpful Ressources inside CONTRIBUTING.md

Fixes: https://github.com/nodejs/node/issues/16359

##### Checklist

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc, meta
