### PR TITLE
assert: fix strict regression

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -316,7 +316,15 @@ assert.ifError = function ifError(err) { if (err) throw err; };
 
 // Expose a strict only variant of assert
 function strict(value, message) {
-  if (!value) innerFail(value, true, message, '==', strict);
+  if (!value) {
+    innerFail({
+      actual: value,
+      expected: true,
+      message,
+      operator: '==',
+      stackStartFn: strict
+    });
+  }
 }
 assert.strict = Object.assign(strict, assert, {
   equal: assert.strictEqual,

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -753,6 +753,14 @@ common.expectsError(
   assert.equal(Object.keys(assert).length, Object.keys(a).length);
   /* eslint-enable no-restricted-properties */
   assert(7);
+  common.expectsError(
+    () => assert(),
+    {
+      code: 'ERR_ASSERTION',
+      type: assert.AssertionError,
+      message: 'undefined == true'
+    }
+  );
 }
 
 common.expectsError(


### PR DESCRIPTION
Using `assert()` or `assert.ok()` resulted in a error since a
refactoring.

Refs: https://github.com/nodejs/node/pull/17582

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
assert