### PR TITLE
deps: update nghttp2 to 1.29.0

### DIFF
--- a/deps/nghttp2/lib/CMakeLists.txt
+++ b/deps/nghttp2/lib/CMakeLists.txt
@@ -44,6 +44,10 @@ set_target_properties(nghttp2 PROPERTIES
   VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
   C_VISIBILITY_PRESET hidden
 )
+target_include_directories(nghttp2 INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}/includes"
+    "${CMAKE_CURRENT_SOURCE_DIR}/includes"
+    )
 
 if(HAVE_CUNIT)
   # Static library (for unittests because of symbol visibility)

--- a/deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
+++ b/deps/nghttp2/lib/includes/nghttp2/nghttp2ver.h
@@ -29,7 +29,7 @@
  * @macro
  * Version number of the nghttp2 library release
  */
-#define NGHTTP2_VERSION "1.25.0"
+#define NGHTTP2_VERSION "1.29.0"
 
 /**
  * @macro
@@ -37,6 +37,6 @@
  * release. This is a 24 bit number with 8 bits for major number, 8 bits
  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
  */
-#define NGHTTP2_VERSION_NUM 0x011900
+#define NGHTTP2_VERSION_NUM 0x011d00
 
 #endif /* NGHTTP2VER_H */

--- a/deps/nghttp2/lib/nghttp2_buf.h
+++ b/deps/nghttp2/lib/nghttp2_buf.h
@@ -398,7 +398,7 @@ int nghttp2_bufs_advance(nghttp2_bufs *bufs);
 void nghttp2_bufs_seek_last_present(nghttp2_bufs *bufs);
 
 /*
- * Returns nonzero if bufs->cur->next is not emtpy.
+ * Returns nonzero if bufs->cur->next is not empty.
  */
 int nghttp2_bufs_next_present(nghttp2_bufs *bufs);
 

--- a/deps/nghttp2/lib/nghttp2_callbacks.c
+++ b/deps/nghttp2/lib/nghttp2_callbacks.c
@@ -168,3 +168,8 @@ void nghttp2_session_callbacks_set_error_callback(
     nghttp2_session_callbacks *cbs, nghttp2_error_callback error_callback) {
   cbs->error_callback = error_callback;
 }
+
+void nghttp2_session_callbacks_set_error_callback2(
+    nghttp2_session_callbacks *cbs, nghttp2_error_callback2 error_callback2) {
+  cbs->error_callback2 = error_callback2;
+}

--- a/deps/nghttp2/lib/nghttp2_callbacks.h
+++ b/deps/nghttp2/lib/nghttp2_callbacks.h
@@ -119,6 +119,7 @@ struct nghttp2_session_callbacks {
   nghttp2_unpack_extension_callback unpack_extension_callback;
   nghttp2_on_extension_chunk_recv_callback on_extension_chunk_recv_callback;
   nghttp2_error_callback error_callback;
+  nghttp2_error_callback2 error_callback2;
 };
 
 #endif /* NGHTTP2_CALLBACKS_H */

--- a/deps/nghttp2/lib/nghttp2_frame.h
+++ b/deps/nghttp2/lib/nghttp2_frame.h
@@ -70,7 +70,9 @@
 #define NGHTTP2_MAX_PADLEN 256
 
 /* Union of extension frame payload */
-typedef union { nghttp2_ext_altsvc altsvc; } nghttp2_ext_frame_payload;
+typedef union {
+  nghttp2_ext_altsvc altsvc;
+} nghttp2_ext_frame_payload;
 
 void nghttp2_frame_pack_frame_hd(uint8_t *buf, const nghttp2_frame_hd *hd);
 

--- a/deps/nghttp2/lib/nghttp2_hd.h
+++ b/deps/nghttp2/lib/nghttp2_hd.h
@@ -211,7 +211,9 @@ typedef struct {
 
 #define HD_MAP_SIZE 128
 
-typedef struct { nghttp2_hd_entry *table[HD_MAP_SIZE]; } nghttp2_hd_map;
+typedef struct {
+  nghttp2_hd_entry *table[HD_MAP_SIZE];
+} nghttp2_hd_map;
 
 struct nghttp2_hd_deflater {
   nghttp2_hd_context ctx;
@@ -313,7 +315,7 @@ void nghttp2_hd_deflate_free(nghttp2_hd_deflater *deflater);
  *
  * This function expands |bufs| as necessary to store the result. If
  * buffers is full and the process still requires more space, this
- * funtion fails and returns NGHTTP2_ERR_HEADER_COMP.
+ * function fails and returns NGHTTP2_ERR_HEADER_COMP.
  *
  * After this function returns, it is safe to delete the |nva|.
  *

--- a/deps/nghttp2/lib/nghttp2_helper.c
+++ b/deps/nghttp2/lib/nghttp2_helper.c
@@ -322,6 +322,9 @@ const char *nghttp2_strerror(int error_code) {
     return "Internal error";
   case NGHTTP2_ERR_CANCEL:
     return "Cancel";
+  case NGHTTP2_ERR_SETTINGS_EXPECTED:
+    return "When a local endpoint expects to receive SETTINGS frame, it "
+           "receives an other type of frame";
   case NGHTTP2_ERR_NOMEM:
     return "Out of memory";
   case NGHTTP2_ERR_CALLBACK_FAILURE:

--- a/deps/nghttp2/lib/nghttp2_outbound_item.h
+++ b/deps/nghttp2/lib/nghttp2_outbound_item.h
@@ -112,7 +112,7 @@ struct nghttp2_outbound_item {
   nghttp2_ext_frame_payload ext_frame_payload;
   nghttp2_aux_data aux_data;
   /* The priority used in priority comparion.  Smaller is served
-     ealier.  For PING, SETTINGS and non-DATA frames (excluding
+     earlier.  For PING, SETTINGS and non-DATA frames (excluding
      response HEADERS frame) have dedicated cycle value defined above.
      For DATA frame, cycle is computed by taking into account of
      effective weight and frame payload length previously sent, so

--- a/deps/nghttp2/lib/nghttp2_pq.h
+++ b/deps/nghttp2/lib/nghttp2_pq.h
@@ -35,7 +35,9 @@
 
 /* Implementation of priority queue */
 
-typedef struct { size_t index; } nghttp2_pq_entry;
+typedef struct {
+  size_t index;
+} nghttp2_pq_entry;
 
 typedef struct {
   /* The pointer to the pointer to the item stored */
@@ -71,7 +73,7 @@ void nghttp2_pq_free(nghttp2_pq *pq);
 /*
  * Adds |item| to the priority queue |pq|.
  *
- * This function returns 0 if it succeds, or one of the following
+ * This function returns 0 if it succeeds, or one of the following
  * negative error codes:
  *
  * NGHTTP2_ERR_NOMEM

--- a/deps/nghttp2/lib/nghttp2_queue.h
+++ b/deps/nghttp2/lib/nghttp2_queue.h
@@ -36,7 +36,9 @@ typedef struct nghttp2_queue_cell {
   struct nghttp2_queue_cell *next;
 } nghttp2_queue_cell;
 
-typedef struct { nghttp2_queue_cell *front, *back; } nghttp2_queue;
+typedef struct {
+  nghttp2_queue_cell *front, *back;
+} nghttp2_queue;
 
 void nghttp2_queue_init(nghttp2_queue *queue);
 void nghttp2_queue_free(nghttp2_queue *queue);

--- a/deps/nghttp2/lib/nghttp2_session.h
+++ b/deps/nghttp2/lib/nghttp2_session.h
@@ -319,7 +319,7 @@ struct nghttp2_session {
   uint8_t pending_enable_push;
   /* Nonzero if the session is server side. */
   uint8_t server;
-  /* Flags indicating GOAWAY is sent and/or recieved. The flags are
+  /* Flags indicating GOAWAY is sent and/or received. The flags are
      composed by bitwise OR-ing nghttp2_goaway_flag. */
   uint8_t goaway_flags;
   /* This flag is used to reduce excessive queuing of WINDOW_UPDATE to
@@ -722,7 +722,7 @@ int nghttp2_session_on_goaway_received(nghttp2_session *session,
                                        nghttp2_frame *frame);
 
 /*
- * Called when WINDOW_UPDATE is recieved, assuming |frame| is properly
+ * Called when WINDOW_UPDATE is received, assuming |frame| is properly
  * initialized.
  *
  * This function returns 0 if it succeeds, or one of the following
@@ -737,7 +737,7 @@ int nghttp2_session_on_window_update_received(nghttp2_session *session,
                                               nghttp2_frame *frame);
 
 /*
- * Called when ALTSVC is recieved, assuming |frame| is properly
+ * Called when ALTSVC is received, assuming |frame| is properly
  * initialized.
  *
  * This function returns 0 if it succeeds, or one of the following

--- a/deps/nghttp2/lib/nghttp2_stream.c
+++ b/deps/nghttp2/lib/nghttp2_stream.c
@@ -366,8 +366,9 @@ static void check_queued(nghttp2_stream *stream) {
         }
       }
       if (queued == 0) {
-        fprintf(stderr, "stream(%p)=%d, stream->queued == 1, and "
-                        "!stream_active(), but no descendants is queued\n",
+        fprintf(stderr,
+                "stream(%p)=%d, stream->queued == 1, and "
+                "!stream_active(), but no descendants is queued\n",
                 stream, stream->stream_id);
         assert(0);
       }
@@ -378,9 +379,10 @@ static void check_queued(nghttp2_stream *stream) {
     }
   } else {
     if (stream_active(stream) || !nghttp2_pq_empty(&stream->obq)) {
-      fprintf(stderr, "stream(%p) = %d, stream->queued == 0, but "
-                      "stream_active(stream) == %d and "
-                      "nghttp2_pq_size(&stream->obq) = %zu\n",
+      fprintf(stderr,
+              "stream(%p) = %d, stream->queued == 0, but "
+              "stream_active(stream) == %d and "
+              "nghttp2_pq_size(&stream->obq) = %zu\n",
               stream, stream->stream_id, stream_active(stream),
               nghttp2_pq_size(&stream->obq));
       assert(0);


### PR DESCRIPTION
Update nghttp2 to 1.29.0

Significant changes since last update:
* lib: Use NGHTTP2_REFUSED_STREAM for streams which are closed by GOAWAY
* lib: Add nghttp2_error_callback2 (will be using this soon)

Refs: https://github.com/nodejs/node/issues/17746

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
deps, nghttp2