### PR TITLE
build: remove duplicate async-hooks and known_issues test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,11 +218,9 @@ test: all ## Default test target. Runs default tests, linters, and builds docs.
 	$(MAKE) -s lint
 	$(MAKE) -s cctest
 	$(PYTHON) tools/test.py --mode=release -J \
-		$(CI_ASYNC_HOOKS) \
 		$(CI_JS_SUITES) \
 		$(CI_NATIVE_SUITES) \
-		$(CI_DOC) \
-		known_issues
+		$(CI_DOC)
 
 # For a quick test, does not run linter or build doc
 test-only: all
@@ -230,10 +228,8 @@ test-only: all
 	$(MAKE) build-addons-napi
 	$(MAKE) cctest
 	$(PYTHON) tools/test.py --mode=release -J \
-		$(CI_ASYNC_HOOKS) \
 		$(CI_JS_SUITES) \
-		$(CI_NATIVE_SUITES) \
-		known_issues
+		$(CI_NATIVE_SUITES)
 
 test-cov: all
 	$(MAKE) build-addons
@@ -386,7 +382,6 @@ test-all-valgrind: test-build
 	$(PYTHON) tools/test.py --mode=debug,release --valgrind
 
 CI_NATIVE_SUITES ?= addons addons-napi
-CI_ASYNC_HOOKS := async-hooks
 CI_JS_SUITES ?= default
 CI_DOC := doctool
 
@@ -401,7 +396,7 @@ test-ci-native: | test/addons/.buildstamp test/addons-napi/.buildstamp
 test-ci-js: | clear-stalled
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
-		$(TEST_CI_ARGS) $(CI_ASYNC_HOOKS) $(CI_JS_SUITES) known_issues
+		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 	# Clean up any leftover processes, error if found.
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \
@@ -414,8 +409,7 @@ test-ci: | clear-stalled build-addons build-addons-napi doc-only
 	out/Release/cctest --gtest_output=tap:cctest.tap
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
 		--mode=release --flaky-tests=$(FLAKY_TESTS) \
-		$(TEST_CI_ARGS) $(CI_ASYNC_HOOKS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) \
-		$(CI_DOC) known_issues
+		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	# Clean up any leftover processes, error if found.
 	ps awwx | grep Release/node | grep -v grep | cat
 	@PS_OUT=`ps awwx | grep Release/node | grep -v grep | awk '{print $$1}'`; \

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -44,7 +44,7 @@ set enable_static=
 set build_addons_napi=
 set test_node_inspect=
 set test_check_deopts=
-set js_test_suites=default async-hooks known_issues
+set js_test_suites=default
 set v8_test_options=
 set v8_build_options=
 set "common_test_suites=%js_test_suites% doctool addons addons-napi&set build_addons=1&set build_addons_napi=1"


### PR DESCRIPTION
The `default` test suite in `test.py` includes `async-hooks` and
`known_issues`. Our current setup results in those test suites being run
twice during each CI run. Remove the duplication.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build test