### PR TITLE
http2: add altsvc support

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -821,6 +821,16 @@ that.
 
 Occurs with multiple attempts to shutdown an HTTP/2 session.
 
+<a id="ERR_HTTP2_ALTSVC_INVALID_ORIGIN"></a>
+### ERR_HTTP2_ALTSVC_INVALID_ORIGIN
+
+HTTP/2 ALTSVC frames require a valid origin.
+
+<a id="ERR_HTTP2_ALTSVC_LENGTH"></a>
+### ERR_HTTP2_ALTSVC_LENGTH
+
+HTTP/2 ALTSVC frames are limited to a maximum of 16,382 payload bytes.
+
 <a id="ERR_HTTP2_CONNECT_AUTHORITY"></a>
 ### ERR_HTTP2_CONNECT_AUTHORITY
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -570,8 +570,9 @@ added: REPLACEME
 
 * `alt` {string} A description of the alternative service configuration as
   defined by [RFC 7838][].
-* `originOrStream` {string|number} Either a URL string specifying the origin or
-  the numeric identifier of an active `Http2Stream`.
+* `originOrStream` {number|string|URL|Object} Either a URL string specifying
+  the origin (or an Object with an `origin` property) or the numeric identifier
+  of an active `Http2Stream` as given by the `http2stream.id` property.
 
 Submits an `ALTSVC` frame (as defined by [RFC 7838][]) to the connected client.
 
@@ -603,6 +604,11 @@ a URL and the origin will be derived. For insetance, the origin for the
 HTTP URL `'https://example.org/foo/bar'` is the ASCII string
 `'https://example.org'`. An error will be thrown if either the given string
 cannot be parsed as a URL or if a valid origin cannot be derived.
+
+A `URL` object, or any object with an `origin` property, may be passed as
+`originOrStream`, in which case the value of the `origin` property will be
+used. The value of the `origin` property *must* be a properly serialized
+ASCII origin.
 
 #### Specifying alternative services
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -304,6 +304,10 @@ E('ERR_FS_INVALID_SYMLINK_TYPE',
   'Symlink type must be one of "dir", "file", or "junction". Received "%s"');
 E('ERR_HTTP2_ALREADY_SHUTDOWN',
   'Http2Session is already shutdown or destroyed');
+E('ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
+  'HTTP/2 ALTSVC frames require a valid origin');
+E('ERR_HTTP2_ALTSVC_LENGTH',
+  'HTTP/2 ALTSVC frames are limited to 16382 bytes');
 E('ERR_HTTP2_CONNECT_AUTHORITY',
   ':authority header is required for CONNECT requests');
 E('ERR_HTTP2_CONNECT_PATH',

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -32,6 +32,9 @@ const kMaxFrameSize = (2 ** 24) - 1;
 const kMaxInt = (2 ** 32) - 1;
 const kMaxStreams = (2 ** 31) - 1;
 
+// eslint-disable-next-line no-control-regex
+const kQuotedString = /^[\x09\x20-\x5b\x5d-\x7e\x80-\xff]*$/;
+
 const {
   assertIsObject,
   assertValidPseudoHeaderResponse,
@@ -362,6 +365,16 @@ function onFrameError(id, type, code) {
   const emitter = session[kState].streams.get(id) || session;
   emitter[kUpdateTimer]();
   process.nextTick(emit, emitter, 'frameError', type, code, id);
+}
+
+function onAltSvc(stream, origin, alt) {
+  const session = this[kOwner];
+  if (session.destroyed)
+    return;
+  debug(`Http2Session ${sessionName(session[kType])}: altsvc received: ` +
+        `stream: ${stream}, origin: ${origin}, alt: ${alt}`);
+  session[kUpdateTimer]();
+  process.nextTick(emit, session, 'altsvc', alt, origin, stream);
 }
 
 // Receiving a GOAWAY frame from the connected peer is a signal that no
@@ -706,6 +719,7 @@ function setupHandle(socket, type, options) {
   handle.onheaders = onSessionHeaders;
   handle.onframeerror = onFrameError;
   handle.ongoawaydata = onGoawayData;
+  handle.onaltsvc = onAltSvc;
 
   if (typeof options.selectPadding === 'function')
     handle.ongetpadding = onSelectPadding(options.selectPadding);
@@ -1153,6 +1167,42 @@ class ServerHttp2Session extends Http2Session {
 
   get server() {
     return this[kServer];
+  }
+
+  // Submits an altsvc frame to be sent to the client. `stream` is a
+  // numeric Stream ID. origin is a URL string that will be used to get
+  // the origin. alt is a string containing the altsvc details. No fancy
+  // API is provided for that.
+  altsvc(alt, originOrStream) {
+    if (this.destroyed)
+      throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
+
+    let stream = 0;
+    let origin;
+
+    if (typeof originOrStream === 'string') {
+      origin = (new URL(originOrStream)).origin;
+      if (origin.length === 0 || origin === 'null')
+        throw new errors.TypeError('ERR_HTTP2_ALTSVC_INVALID_ORIGIN');
+    } else if (typeof originOrStream === 'number') {
+      if (originOrStream >>> 0 !== originOrStream || originOrStream === 0)
+        throw new errors.RangeError('ERR_OUT_OF_RANGE', 'originOrStream');
+      stream = originOrStream;
+    } else if (originOrStream !== undefined) {
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'originOrStream',
+                                 ['string', 'number']);
+    }
+
+    if (typeof alt !== 'string')
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'alt', 'string');
+    if (!kQuotedString.test(alt))
+      throw new errors.TypeError('ERR_INVALID_CHAR', 'alt');
+
+    // Max length permitted for ALTSVC
+    if ((alt.length + (origin !== undefined ? origin.length : 0)) > 16382)
+      throw new errors.TypeError('ERR_HTTP2_ALTSVC_LENGTH');
+
+    this[kHandle].altsvc(stream, origin || '', alt);
   }
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1182,15 +1182,27 @@ class ServerHttp2Session extends Http2Session {
 
     if (typeof originOrStream === 'string') {
       origin = (new URL(originOrStream)).origin;
-      if (origin.length === 0 || origin === 'null')
+      if (origin === 'null')
         throw new errors.TypeError('ERR_HTTP2_ALTSVC_INVALID_ORIGIN');
     } else if (typeof originOrStream === 'number') {
       if (originOrStream >>> 0 !== originOrStream || originOrStream === 0)
         throw new errors.RangeError('ERR_OUT_OF_RANGE', 'originOrStream');
       stream = originOrStream;
     } else if (originOrStream !== undefined) {
-      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'originOrStream',
-                                 ['string', 'number']);
+      // Allow origin to be passed a URL or object with origin property
+      if (originOrStream !== null && typeof originOrStream === 'object')
+        origin = originOrStream.origin;
+      // Note: if originOrStream is an object with an origin property other
+      // than a URL, then it is possible that origin will be malformed.
+      // We do not verify that here. Users who go that route need to
+      // ensure they are doing the right thing or the payload data will
+      // be invalid.
+      if (typeof origin !== 'string') {
+        throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'originOrStream',
+                                   ['string', 'number', 'URL', 'object']);
+      } else if (origin === 'null' || origin.length === 0) {
+        throw new errors.TypeError('ERR_HTTP2_ALTSVC_INVALID_ORIGIN');
+      }
     }
 
     if (typeof alt !== 'string')

--- a/src/env.h
+++ b/src/env.h
@@ -179,6 +179,7 @@ class ModuleWrap;
   V(netmask_string, "netmask")                                                \
   V(nsname_string, "nsname")                                                  \
   V(ocsp_request_string, "OCSPRequest")                                       \
+  V(onaltsvc_string, "onaltsvc")                                              \
   V(onchange_string, "onchange")                                              \
   V(onclienthello_string, "onclienthello")                                    \
   V(oncomplete_string, "oncomplete")                                          \

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -800,6 +800,11 @@ class Http2Session : public AsyncWrap {
   void Consume(Local<External> external);
   void Unconsume();
   void Goaway(uint32_t code, int32_t lastStreamID, uint8_t* data, size_t len);
+  void AltSvc(int32_t id,
+              uint8_t* origin,
+              size_t origin_len,
+              uint8_t* value,
+              size_t value_len);
 
   bool Ping(v8::Local<v8::Function> function);
 
@@ -877,6 +882,7 @@ class Http2Session : public AsyncWrap {
   static void UpdateChunksSent(const FunctionCallbackInfo<Value>& args);
   static void RefreshState(const FunctionCallbackInfo<Value>& args);
   static void Ping(const FunctionCallbackInfo<Value>& args);
+  static void AltSvc(const FunctionCallbackInfo<Value>& args);
 
   template <get_setting fn>
   static void RefreshSettings(const FunctionCallbackInfo<Value>& args);
@@ -921,6 +927,7 @@ class Http2Session : public AsyncWrap {
   inline void HandlePriorityFrame(const nghttp2_frame* frame);
   inline void HandleSettingsFrame(const nghttp2_frame* frame);
   inline void HandlePingFrame(const nghttp2_frame* frame);
+  inline void HandleAltSvcFrame(const nghttp2_frame* frame);
 
   // nghttp2 callbacks
   static inline int OnBeginHeadersCallback(

--- a/test/parallel/test-http2-altsvc.js
+++ b/test/parallel/test-http2-altsvc.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const http2 = require('http2');
+const Countdown = require('../common/countdown');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.session.altsvc('h2=":8000"', stream.id);
+  stream.respond();
+  stream.end('ok');
+}));
+server.on('session', common.mustCall((session) => {
+  session.altsvc('h2=":8000"', 'https://example.org:8111/this');
+
+  // Won't error, but won't send anything because the stream does not exist
+  session.altsvc('h2=":8000"', 3);
+
+  // Will error because the numeric stream id is out of valid range
+  [0, -1, 1.1, 0xFFFFFFFF + 1, Infinity, -Infinity].forEach((i) => {
+    common.expectsError(
+      () => session.altsvc('h2=":8000"', i),
+      {
+        code: 'ERR_OUT_OF_RANGE',
+        type: RangeError
+      }
+    );
+  });
+
+  // First argument must be a string
+  [0, {}, [], null, Infinity].forEach((i) => {
+    common.expectsError(
+      () => session.altsvc(i),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError
+      }
+    );
+  });
+
+  ['\u0001', 'h2="\uff20"', '👀'].forEach((i) => {
+    common.expectsError(
+      () => session.altsvc(i),
+      {
+        code: 'ERR_INVALID_CHAR',
+        type: TypeError
+      }
+    );
+  });
+
+  [{}, [], true].forEach((i) => {
+    common.expectsError(
+      () => session.altsvc('clear', i),
+      {
+        code: 'ERR_INVALID_ARG_TYPE',
+        type: TypeError
+      }
+    );
+  });
+
+  ['abc:'].forEach((i) => {
+    common.expectsError(
+      () => session.altsvc('h2=":8000', i),
+      {
+        code: 'ERR_HTTP2_ALTSVC_INVALID_ORIGIN',
+        type: TypeError
+      }
+    );
+  });
+
+  // arguments + origin are too long for an ALTSVC frame
+  common.expectsError(
+    () => {
+      session.altsvc('h2=":8000"',
+                     `http://example.${'a'.repeat(17000)}.org:8000`);
+    },
+    {
+      code: 'ERR_HTTP2_ALTSVC_LENGTH',
+      type: TypeError
+    }
+  );
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  const countdown = new Countdown(2, () => {
+    client.close();
+    server.close();
+  });
+
+  client.on('altsvc', common.mustCall((alt, origin, stream) => {
+    assert.strictEqual(alt, 'h2=":8000"');
+    switch (stream) {
+      case 0:
+        assert.strictEqual(origin, 'https://example.org:8111');
+        break;
+      case 1:
+        assert.strictEqual(origin, '');
+        break;
+      default:
+        assert.fail('should not happen');
+    }
+    countdown.dec();
+  }, 2));
+
+  const req = client.request();
+  req.resume();
+  req.on('close', common.mustCall());
+}));


### PR DESCRIPTION
Add support for sending and receiving ALTSVC frames.

As defined by https://tools.ietf.org/html/rfc7838

ping @nodejs/http2
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2
