### PR TITLE
readline,test: update references to archived repository

### DIFF
--- a/lib/readline.js
+++ b/lib/readline.js
@@ -760,7 +760,8 @@ Interface.prototype._ttyWrite = function(s, key) {
   key = key || {};
   this._previousKey = key;
 
-  // Ignore escape key - Fixes #2876
+  // Ignore escape key, fixes
+  // https://github.com/nodejs/node-v0.x-archive/issues/2876.
   if (key.name === 'escape') return;
 
   if (key.ctrl && key.shift) {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -601,7 +601,7 @@ testAssertionMessage({ a: undefined, b: null }, '{ a: undefined, b: null }');
 testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
                      '{ a: NaN, b: Infinity, c: -Infinity }');
 
-// #2893
+// https://github.com/nodejs/node-v0.x-archive/issues/2893
 {
   let threw = false;
   try {
@@ -617,7 +617,7 @@ testAssertionMessage({ a: NaN, b: Infinity, c: -Infinity },
   assert.ok(threw);
 }
 
-// #5292
+// https://github.com/nodejs/node-v0.x-archive/issues/5292
 try {
   assert.strictEqual(1, 2);
 } catch (e) {

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -636,7 +636,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  // #1210 Test UTF-8 string includes null character
+  // https://github.com/nodejs/node-v0.x-archive/pull/1210
+  // Test UTF-8 string includes null character
   let buf = Buffer.from('\0');
   assert.strictEqual(buf.length, 1);
   buf = Buffer.from('\0\0');
@@ -660,7 +661,8 @@ assert.strictEqual('<Buffer 81 a3 66 6f 6f a3 62 61 72>', x.inspect());
 }
 
 {
-  // #243 Test write() with maxLength
+  // https://github.com/nodejs/node-v0.x-archive/issues/243
+  // Test write() with maxLength
   const buf = Buffer.allocUnsafe(4);
   buf.fill(0xFF);
   assert.strictEqual(buf.write('abcd', 1, 2, 'utf8'), 2);
@@ -886,7 +888,8 @@ assert.throws(() => Buffer.allocUnsafe(8).writeFloatLE(0.0, -1), RangeError);
   assert.strictEqual(buf.readIntBE(0, 5), -0x0012000000);
 }
 
-// Regression test for #5482: should throw but not assert in C++ land.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
+// should throw but not assert in C++ land.
 common.expectsError(
   () => Buffer.from('', 'buffer'),
   {
@@ -896,8 +899,9 @@ common.expectsError(
   }
 );
 
-// Regression test for #6111. Constructing a buffer from another buffer
-// should a) work, and b) not corrupt the source buffer.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/6111.
+// Constructing a buffer from another buffer should a) work, and b) not corrupt
+// the source buffer.
 {
   const a = [...Array(128).keys()]; // [0, 1, 2, 3, ... 126, 127]
   const b = Buffer.from(a);

--- a/test/parallel/test-cluster-worker-init.js
+++ b/test/parallel/test-cluster-worker-init.js
@@ -42,7 +42,7 @@ if (cluster.isMaster) {
     worker.send(msg);
   });
 } else {
-  // GH #7998
+  // https://github.com/nodejs/node-v0.x-archive/issues/7998
   cluster.worker.on('message', (message) => {
     process.send(message === msg);
   });

--- a/test/parallel/test-crypto-binary-default.js
+++ b/test/parallel/test-crypto-binary-default.js
@@ -414,7 +414,8 @@ fileStream.on('close', common.mustCall(function() {
   );
 }));
 
-// Issue #2227: unknown digest method should throw an error.
+// Unknown digest method should throw an error:
+// https://github.com/nodejs/node-v0.x-archive/issues/2227
 assert.throws(function() {
   crypto.createHash('xyzzy');
 }, /^Error: Digest method not supported$/);

--- a/test/parallel/test-crypto-cipher-decipher.js
+++ b/test/parallel/test-crypto-cipher-decipher.js
@@ -145,7 +145,8 @@ testCipher2(Buffer.from('0123456789abcdef'));
     });
 }
 
-// Base64 padding regression test, see #4837.
+// Base64 padding regression test, see
+// https://github.com/nodejs/node-v0.x-archive/issues/4837.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');
   const s = c.update('test', 'utf8', 'base64') + c.final('base64');
@@ -153,7 +154,7 @@ testCipher2(Buffer.from('0123456789abcdef'));
 }
 
 // Calling Cipher.final() or Decipher.final() twice should error but
-// not assert. See #4886.
+// not assert. See https://github.com/nodejs/node-v0.x-archive/issues/4886.
 {
   const c = crypto.createCipher('aes-256-cbc', 'secret');
   try { c.final('xxx'); } catch (e) { /* Ignore. */ }
@@ -165,14 +166,16 @@ testCipher2(Buffer.from('0123456789abcdef'));
   try { d.final('xxx'); } catch (e) { /* Ignore. */ }
 }
 
-// Regression test for #5482: string to Cipher#update() should not assert.
+// Regression test for https://github.com/nodejs/node-v0.x-archive/issues/5482:
+// string to Cipher#update() should not assert.
 {
   const c = crypto.createCipher('aes192', '0123456789abcdef');
   c.update('update');
   c.final();
 }
 
-// #5655 regression tests, 'utf-8' and 'utf8' are identical.
+// https://github.com/nodejs/node-v0.x-archive/issues/5655 regression tests,
+// 'utf-8' and 'utf8' are identical.
 {
   let c = crypto.createCipher('aes192', '0123456789abcdef');
   c.update('update', '');  // Defaults to "utf8".

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -105,7 +105,8 @@ fileStream.on('close', common.mustCall(function() {
                      'Test SHA1 of sample.png');
 }));
 
-// Issue #2227: unknown digest method should throw an error.
+// Issue https://github.com/nodejs/node-v0.x-archive/issues/2227: unknown digest
+// method should throw an error.
 assert.throws(function() {
   crypto.createHash('xyzzy');
 }, /Digest method not supported/);

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -476,8 +476,9 @@ process.setMaxListeners(256);
   }
 }
 
-// #5126, "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData()
-// length exceeds max acceptable value"
+// https://github.com/nodejs/node-v0.x-archive/issues/5126,
+// "FATAL ERROR: v8::Object::SetIndexedPropertiesToExternalArrayData() length
+// exceeds max acceptable value"
 common.expectsError(
   () => crypto.randomBytes((-1 >>> 0) + 1),
   {

--- a/test/parallel/test-crypto.js
+++ b/test/parallel/test-crypto.js
@@ -162,8 +162,8 @@ testImmutability(tls.getCiphers);
 testImmutability(crypto.getHashes);
 testImmutability(crypto.getCurves);
 
-// Regression tests for #5725: hex input that's not a power of two should
-// throw, not assert in C++ land.
+// Regression tests for https://github.com/nodejs/node-v0.x-archive/pull/5725:
+// hex input that's not a power of two should throw, not assert in C++ land.
 assert.throws(function() {
   crypto.createCipher('aes192', 'test').update('0', 'hex');
 }, (err) => {

--- a/test/parallel/test-dgram-ref.js
+++ b/test/parallel/test-dgram-ref.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 const dgram = require('dgram');
 
-// should not hang, see #1282
+// should not hang, see https://github.com/nodejs/node-v0.x-archive/issues/1282
 dgram.createSocket('udp4');
 dgram.createSocket('udp6');
 

--- a/test/parallel/test-dns-regress-7070.js
+++ b/test/parallel/test-dns-regress-7070.js
@@ -23,7 +23,8 @@
 const common = require('../common');
 const dns = require('dns');
 
-// Should not raise assertion error. Issue #7070
+// Should not raise assertion error.
+// Issue https://github.com/nodejs/node-v0.x-archive/issues/7070
 common.expectsError(() => dns.resolveNs([]), // bad name
                     {
                       code: 'ERR_INVALID_ARG_TYPE',

--- a/test/parallel/test-timers-unref.js
+++ b/test/parallel/test-timers-unref.js
@@ -71,7 +71,8 @@ const check_unref = setInterval(() => {
     setInterval(() => timeout.unref(), SHORT_TIME);
 }
 
-// Should not assert on args.Holder()->InternalFieldCount() > 0. See #4261.
+// Should not assert on args.Holder()->InternalFieldCount() > 0.
+// See https://github.com/nodejs/node-v0.x-archive/issues/4261.
 {
   const t = setInterval(() => {}, 1);
   process.nextTick(t.unref.bind({}));

--- a/test/parallel/test-tls-set-encoding.js
+++ b/test/parallel/test-tls-set-encoding.js
@@ -63,7 +63,7 @@ server.listen(0, function() {
   client.on('close', function() {
     // readyState is deprecated but we want to make
     // sure this isn't triggering an assert in lib/net.js
-    // See issue #1069.
+    // See https://github.com/nodejs/node-v0.x-archive/issues/1069.
     assert.strictEqual('closed', client.readyState);
 
     // Confirming the buffer string is encoded in ASCII

--- a/test/sequential/test-child-process-execsync.js
+++ b/test/sequential/test-child-process-execsync.js
@@ -93,7 +93,8 @@ ret = execFileSync(process.execPath, args, { encoding: 'utf8' });
 
 assert.strictEqual(ret, `${msg}\n`);
 
-// Verify that the cwd option works - GH #7824
+// Verify that the cwd option works.
+// See https://github.com/nodejs/node-v0.x-archive/issues/7824.
 {
   const cwd = common.rootDir;
   const cmd = common.isWindows ? 'echo %cd%' : 'pwd';
@@ -102,7 +103,8 @@ assert.strictEqual(ret, `${msg}\n`);
   assert.strictEqual(response.toString().trim(), cwd);
 }
 
-// Verify that stderr is not accessed when stdio = 'ignore' - GH #7966
+// Verify that stderr is not accessed when stdio = 'ignore'.
+// See https://github.com/nodejs/node-v0.x-archive/issues/7966.
 {
   assert.throws(function() {
     execSync('exit -1', { stdio: 'ignore' });

--- a/test/sequential/test-module-loading.js
+++ b/test/sequential/test-module-loading.js
@@ -214,7 +214,8 @@ try {
 }
 
 {
-  // #1357 Loading JSON files with require()
+  // Loading JSON files with require()
+  // See https://github.com/nodejs/node-v0.x-archive/issues/1357.
   const json = require('../fixtures/packages/main/package.json');
   assert.deepStrictEqual(json, {
     name: 'package-name',
@@ -329,7 +330,8 @@ process.on('exit', function() {
 });
 
 
-// #1440 Loading files with a byte order marker.
+// Loading files with a byte order marker.
+// See https://github.com/nodejs/node-v0.x-archive/issues/1440.
 assert.strictEqual(require('../fixtures/utf8-bom.js'), 42);
 assert.strictEqual(require('../fixtures/utf8-bom.json'), 42);
 


### PR DESCRIPTION
References to issues / PRs from the old repository (https://github.com/nodejs/node-v0.x-archive) are misleading without the full URL. Updated references within the test directory accordingly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
readline, test