### PR TITLE
doc: improve security section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,20 +169,19 @@ officially supported platforms.
 
 ## Security
 
-All security bugs in Node.js are taken seriously and should be reported by
-emailing security@nodejs.org. This will be delivered to a subset of the project
-team who handle security issues. Please don't disclose security bugs
-publicly until they have been handled by the security team.
+Security flaws in Node.js should be reported by emailing security@nodejs.org.
+Please do not disclose security bugs publicly until they have been handled by
+the security team.
 
-Your email will be acknowledged within 24 hours, and you’ll receive a more
+Your email will be acknowledged within 24 hours, and you will receive a more
 detailed response to your email within 48 hours indicating the next steps in
 handling your report.
 
 There are no hard and fast rules to determine if a bug is worth reporting as
-a security issue. The general rule is any issue worth reporting
-must allow an attacker to compromise the confidentiality, integrity
-or availability of the Node.js application or its system for which the attacker
-does not already have the capability.
+a security issue. The general rule is an issue worth reporting should allow an
+attacker to compromise the confidentiality, integrity, or availability of the
+Node.js application or its system for which the attacker does not already have
+the capability.
 
 To illustrate the point, here are some examples of past issues and what the
 Security Response Team thinks of them. When in doubt, however, please do send


### PR DESCRIPTION
* Remove fluff text and get to the point: Report security flaws to
  security@nodejs.org. Please do not disclose security flaws publicly
  until they have been handled by the security team.
* Fix somewhat confusing paragraph that says there are no "hard
  and fast rules" but then uses _must_ in the context of a "general
  rule". Easiest solution seems to be to change _must_ to _should_.
* Minor style change (_you will_ instead of _you'll_)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc
  