### PR TITLE
doc: fix typos in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,9 +199,8 @@ functional guidelines of the Node.js project.
 
 ## Pull Requests
 
-Pull Requests are the way in which concrete changes are made to the code,
-documentation, dependencies, and tools contained with the `nodejs/node`
-repository.
+Pull Requests are the way concrete changes are made to the code, documentation,
+dependencies, and tools contained in the `nodejs/node` repository.
 
 There are two fundamental components of the Pull Request process: one concrete
 and technical, and one more process oriented. The concrete and technical


### PR DESCRIPTION
Remove incorrect usage of "in which". The sentence is better and shorter
without it anyway. Replace incorrect "with" with "in".

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc