### PR TITLE
http: add Object.freeze for status code

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -105,6 +105,7 @@ const STATUS_CODES = {
   510: 'Not Extended',               // RFC 2774
   511: 'Network Authentication Required' // RFC 6585
 };
+Object.freeze(STATUS_CODES);
 
 const kOnExecute = HTTPParser.kOnExecute | 0;
 

--- a/test/parallel/test-http-immutable-status-code.js
+++ b/test/parallel/test-http-immutable-status-code.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+assert(http.STATUS_CODES);
+
+for (const code in http.STATUS_CODES) {
+  const before = http.STATUS_CODES[code];
+  common.expectsError(
+    () => { http.STATUS_CODES[code] = 'foo'; },
+    {
+      type: TypeError,
+      message: `Cannot assign to read only property '${code}' ` +
+               'of object \'#<Object>\''
+    }
+  );
+  assert.strictEqual(before, http.STATUS_CODES[code]);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->
A mutable `http.STATUS_CODES` maybe cause some undefined behavior in userland. This change is to freeze the status codes for robustness.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http