### PR TITLE
doc: remove duplicate words in API docs

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -623,7 +623,7 @@ pipes between the parent and child. The value is one of the following:
    have an underlying descriptor (file streams do not until the `'open'`
    event has occurred).
 5. Positive integer - The integer value is interpreted as a file descriptor
-   that is is currently open in the parent process. It is shared with the child
+   that is currently open in the parent process. It is shared with the child
    process, similar to how {Stream} objects can be shared.
 6. `null`, `undefined` - Use default value. For stdio fds 0, 1, and 2 (in other
    words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -125,12 +125,12 @@ Creates a new `PerformanceMeasure` entry in the Performance Timeline. A
 `startMark` and `endMark`.
 
 The `startMark` argument may identify any *existing* `PerformanceMark` in the
-the Performance Timeline, or *may* identify any of the timestamp properties
+Performance Timeline, or *may* identify any of the timestamp properties
 provided by the `PerformanceNodeTiming` class. If the named `startMark` does
 not exist, then `startMark` is set to [`timeOrigin`][] by default.
 
 The `endMark` argument must identify any *existing* `PerformanceMark` in the
-the Performance Timeline or any of the timestamp properties provided by the
+Performance Timeline or any of the timestamp properties provided by the
 `PerformanceNodeTiming` class. If the named `endMark` does not exist, an
 error will be thrown.
 


### PR DESCRIPTION
Found using a simple regex.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
doc