### PR TITLE
doc: replace wrong U+00A0 by common spaces

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -295,7 +295,7 @@ If `msg` is a `String`, then it is automatically converted to a `Buffer`
 with `'utf8'` encoding. With messages that
 contain  multi-byte characters, `offset` and `length` will be calculated with
 respect to [byte length][] and not the character position.
-If `msg` is an array, `offset` and `length` must not be specified.
+If `msg` is an array, `offset` and `length` must not be specified.
 
 The `address` argument is a string. If the value of `address` is a host name,
 DNS will be used to resolve the address of the host.  If `address` is not

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2044,7 +2044,7 @@ the status message for HTTP codes is ignored.
 ### ALPN negotiation
 
 ALPN negotiation allows to support both [HTTPS][] and HTTP/2 over
-the same socket. The `req` and `res` objects can be either HTTP/1 or
+the same socket. The `req` and `res` objects can be either HTTP/1 or
 HTTP/2, and an application **must** restrict itself to the public API of
 [HTTP/1][], and detect if it is possible to use the more advanced
 features of HTTP/2.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -846,7 +846,7 @@ changes:
   * `servername`: {string} Server name for the SNI (Server Name Indication) TLS
     extension.
   * `checkServerIdentity(servername, cert)` {Function} A callback function
-    to be used (instead of the builtin `tls.checkServerIdentity()` function)
+    to be used (instead of the builtin `tls.checkServerIdentity()` function)
     when checking the server's hostname (or the provided `servername` when
     explicitly set) against the certificate. This should return an {Error} if
     verification fails. The method should return `undefined` if the `servername`


### PR DESCRIPTION
##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
doc
