### PR TITLE
http2: add slowRead detection for stream API

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -994,6 +994,14 @@ send something other than a regular file.
 
 The `Http2Session` closed with a non-zero error code.
 
+<a id="ERR_HTTP2_SLOW_READ"></a>
+### ERR_HTTP2_SLOW_READ
+
+The connected HTTP/2 peer failed to consume sent data fast enough. By default,
+a connected peer has 60 seconds (60000 milliseconds) to consume the queued
+data. This value may be changed using the `slowReadTimeout` when creating a
+new `Http2Session`.
+
 <a id="ERR_HTTP2_SOCKET_BOUND"></a>
 ### ERR_HTTP2_SOCKET_BOUND
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -584,7 +584,6 @@ added: v8.4.0
     and `256` (inclusive).
   * `getTrailers` {Function} Callback function invoked to collect trailer
     headers.
-
 * Returns: {ClientHttp2Stream}
 
 For HTTP/2 Client `Http2Session` instances only, the `http2session.request()`
@@ -739,6 +738,21 @@ send a frame. When invoked, the handler function will receive an integer
 argument identifying the frame type, and an integer argument identifying the
 error code. The `Http2Stream` instance will be destroyed immediately after the
 `'frameError'` event is emitted.
+
+#### Event: `slowRead`
+<!-- YAML
+added: REPLACEME
+-->
+
+The `'slowRead'` event is emitted when a connected peer takes too long to
+consume the queued data. This is typically evidence of a flow control issue
+or a slow read DOS attack. By default, the event will be emitted if the
+queued data is not fully read within 60 seconds, but the timeout may be
+configured using the `slowReadTimeout` option when using either
+`http2.connect()`, `http2.createServer()`, or `http2.createClientServer()`.
+
+If no handler is registered for the `slowRead` event, then the `Http2Stream`
+will be closed with a `FLOW_CONTROL_ERROR` and destroyed.
 
 #### Event: 'timeout'
 <!-- YAML
@@ -1534,6 +1548,9 @@ changes:
     used to determine the padding. See [Using options.selectPadding][].
   * `settings` {[Settings Object][]} The initial settings to send to the
     remote peer upon connection.
+  * `slowReadTimeout` {number} The number of milliseconds the connected peer
+    has to read sent/queued data before the `'slowRead'` event is emitted on
+    the `Http2Stream`. Defaults to `60000`.
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 
@@ -1605,6 +1622,9 @@ changes:
     used to determine the padding. See [Using options.selectPadding][].
   * `settings` {[Settings Object][]} The initial settings to send to the
     remote peer upon connection.
+  * `slowReadTimeout` {number} The number of milliseconds the connected peer
+    has to read sent/queued data before the `'slowRead'` event is emitted on
+    the `Http2Stream`. Defaults to `60000`.
   * ...: Any [`tls.createServer()`][] options can be provided. For
     servers, the identity options (`pfx` or `key`/`cert`) are usually required.
 * `onRequestHandler` {Function} See [Compatibility API][]
@@ -1685,6 +1705,9 @@ changes:
     used to determine the padding. See [Using options.selectPadding][].
   * `settings` {[Settings Object][]} The initial settings to send to the
     remote peer upon connection.
+  * `slowReadTimeout` {number} The number of milliseconds the connected peer
+    has to read sent/queued data before the `'slowRead'` event is emitted on
+    the `Http2Stream`. Defaults to `60000`.
   * `createConnection` {Function} An optional callback that receives the `URL`
     instance passed to `connect` and the `options` object, and returns any
     [`Duplex`][] stream that is to be used as the connection for this session.

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -358,6 +358,7 @@ E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
 E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');
 E('ERR_HTTP2_SESSION_ERROR', 'Session closed with error code %s');
+E('ERR_HTTP2_SLOW_READ', 'Connected peer failed to read data fast enough');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
 E('ERR_HTTP2_STATUS_101',

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -86,6 +86,7 @@ const kType = Symbol('type');
 const kUpdateTimer = Symbol('update-timer');
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
+const kDefaultSlowReadTimeout = 60 * 1000;  // Is 60 seconds too much?
 
 const {
   paddingBuffer,
@@ -99,6 +100,7 @@ const {
   NGHTTP2_REFUSED_STREAM,
   NGHTTP2_DEFAULT_WEIGHT,
   NGHTTP2_FLAG_END_STREAM,
+  NGHTTP2_FLOW_CONTROL_ERROR,
   NGHTTP2_HCAT_PUSH_RESPONSE,
   NGHTTP2_HCAT_RESPONSE,
   NGHTTP2_INTERNAL_ERROR,
@@ -791,7 +793,8 @@ class Http2Session extends EventEmitter {
       streams: new Map(),
       pendingStreams: new Set(),
       pendingAck: 0,
-      writeQueueSize: 0
+      writeQueueSize: 0,
+      slowReadTimeout: options.slowReadTimeout || kDefaultSlowReadTimeout
     };
 
     this[kType] = type;
@@ -1278,6 +1281,10 @@ function afterDoStreamWrite(status, handle, req) {
   const stream = handle[kOwner];
   const session = stream[kSession];
 
+  // Clear the slowReadTimeout
+  clearTimeout(req.timeout);
+  req.timeout = undefined;
+
   stream[kUpdateTimer]();
 
   const { bytes } = req;
@@ -1324,6 +1331,14 @@ function abort(stream) {
       !(stream._writableState.ended || stream._writableState.ending)) {
     process.nextTick(emit, stream, 'aborted');
     stream[kState].flags |= STREAM_FLAGS_ABORTED;
+  }
+}
+
+function onSlowRead(stream) {
+  if (!stream.emit('slowRead')) {
+    const err = new errors.Error('ERR_HTTP2_SLOW_READ');
+    stream.close(NGHTTP2_FLOW_CONTROL_ERROR);
+    stream.destroy(err);
   }
 }
 
@@ -1492,6 +1507,8 @@ class Http2Stream extends Duplex {
 
     const handle = this[kHandle];
     const req = new WriteWrap();
+    req.timeout = setTimeout(onSlowRead.bind(req, this),
+                             this.session[kState].slowReadTimeout);
     req.stream = this[kID];
     req.handle = handle;
     req.callback = cb;
@@ -1529,6 +1546,8 @@ class Http2Stream extends Duplex {
 
     const handle = this[kHandle];
     const req = new WriteWrap();
+    req.timeout = setTimeout(onSlowRead.bind(req, this),
+                             this.session[kState].slowReadTimeout);
     req.stream = this[kID];
     req.handle = handle;
     req.callback = cb;
@@ -2235,7 +2254,7 @@ function handleHeaderContinue(headers) {
     this.emit('continue');
 }
 
-const setTimeout = {
+const setTimeoutProp = {
   configurable: true,
   enumerable: true,
   writable: true,
@@ -2269,8 +2288,8 @@ const setTimeout = {
     return this;
   }
 };
-Object.defineProperty(Http2Stream.prototype, 'setTimeout', setTimeout);
-Object.defineProperty(Http2Session.prototype, 'setTimeout', setTimeout);
+Object.defineProperty(Http2Stream.prototype, 'setTimeout', setTimeoutProp);
+Object.defineProperty(Http2Session.prototype, 'setTimeout', setTimeoutProp);
 
 
 // When the socket emits an error, destroy the associated Http2Session and
@@ -2348,6 +2367,13 @@ function initializeOptions(options) {
   assertIsObject(options, 'options');
   options = Object.assign({}, options);
   options.allowHalfOpen = true;
+  if (options.slowReadTimeout === undefined)
+    options.slowReadTimeout = kDefaultSlowReadTimeout;
+  if (typeof options.slowReadTimeout !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                               'options.slowReadTimeout',
+                               'number');
+  }
   assertIsObject(options.settings, 'options.settings');
   options.settings = Object.assign({}, options.settings);
   return options;
@@ -2441,6 +2467,15 @@ function connect(authority, options, listener) {
 
   assertIsObject(options, 'options');
   options = Object.assign({}, options);
+
+  options.allowHalfOpen = true;
+  if (options.slowReadTimeout === undefined)
+    options.slowReadTimeout = kDefaultSlowReadTimeout;
+  if (typeof options.slowReadTimeout !== 'number') {
+    throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                               'options.slowReadTimeout',
+                               'number');
+  }
 
   if (typeof authority === 'string')
     authority = new URL(authority);

--- a/test/sequential/test-http2-slowread.js
+++ b/test/sequential/test-http2-slowread.js
@@ -1,0 +1,80 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http2 = require('http2');
+const {
+  NGHTTP2_FLOW_CONTROL_ERROR
+} = http2.constants;
+
+
+const largeChunk = Buffer.alloc(0xFFFFFF);
+
+{
+  const server = http2.createServer({ slowReadTimeout: 1000 });
+
+  server.on('stream', (stream) => {
+    stream.on('error', common.expectsError({
+      code: 'ERR_HTTP2_SLOW_READ',
+      type: Error,
+      message: 'Connected peer failed to read data fast enough'
+    }));
+    stream.respond();
+    stream.end(largeChunk);
+  });
+
+  server.listen(0, common.mustCall(() => {
+    // Evil client creates a slow-read scenario, forcing our server to only
+    // send one byte at a time.
+    const client = http2.connect(`http://localhost:${server.address().port}`,
+                                 { settings: { initialWindowSize: 1 } });
+
+    const req = client.request();
+
+    req.resume();
+    req.on('close', () => {
+      client.close();
+      server.close();
+    });
+
+    req.on('error', common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      type: Error,
+      message: `Stream closed with error code ${NGHTTP2_FLOW_CONTROL_ERROR}`
+    }));
+  }));
+}
+
+
+{
+  const server = http2.createServer({ slowReadTimeout: 1000 });
+
+  server.on('stream', (stream) => {
+    // Handle the slow read event ourselves
+    stream.on('error', common.mustNotCall());
+    stream.on('slowRead', common.mustCall(() => {
+      // Close without an error
+      stream.close();
+    }));
+    stream.respond();
+    stream.end(largeChunk);
+  });
+
+  server.listen(0, common.mustCall(() => {
+    // Evil client creates a slow-read scenario, forcing our server to only
+    // send one byte at a time.
+    const client = http2.connect(`http://localhost:${server.address().port}`,
+                                 { settings: { initialWindowSize: 1 } });
+
+    const req = client.request();
+
+    req.resume();
+    req.on('close', () => {
+      client.close();
+      server.close();
+    });
+
+    req.on('close', common.mustCall());
+    req.on('error', common.mustNotCall());
+  }));
+}


### PR DESCRIPTION
Add mechanism for detecting and handling slow reads.

Ping @nodejs/http2 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2