### PR TITLE
test: fix flaky test-http-highwatermark

### DIFF
--- a/test/parallel/test-http-highwatermark.js
+++ b/test/parallel/test-http-highwatermark.js
@@ -14,7 +14,7 @@ let requestReceived = 0;
 const server = http.createServer(function(req, res) {
   const id = ++requestReceived;
   const enoughToDrain = req.connection.writableHighWaterMark;
-  const body = 'x'.repeat(enoughToDrain);
+  const body = 'x'.repeat(enoughToDrain * 100);
 
   if (id === 1) {
     // Case of needParse = false
@@ -39,11 +39,11 @@ const server = http.createServer(function(req, res) {
 }).on('listening', () => {
   const c = net.createConnection(server.address().port, () => {
     c.write('GET / HTTP/1.1\r\n\r\n');
-    c.write('GET / HTTP/1.1\r\n\r\n');
+    c.write('GET / HTTP/1.1\r\n\r\n',
+            () => setImmediate(() => c.on('data', () => {})));
     c.end();
   });
 
-  c.on('data', () => {});
   c.on('end', () => {
     server.close();
   });

--- a/test/parallel/test-http-highwatermark.js
+++ b/test/parallel/test-http-highwatermark.js
@@ -40,7 +40,7 @@ const server = http.createServer(function(req, res) {
   const c = net.createConnection(server.address().port, () => {
     c.write('GET / HTTP/1.1\r\n\r\n');
     c.write('GET / HTTP/1.1\r\n\r\n',
-            () => setImmediate(() => c.on('data', () => {})));
+            () => setImmediate(() => c.resume()));
     c.end();
   });
 


### PR DESCRIPTION
The current version of the test is dependent on the requests coming in before the data is successfully sent & read. Make `write` size much larger and delay the `read` on the other side a bit to get rid of the flakiness.

Fixes: https://github.com/nodejs/node/issues/17857

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test