### PR TITLE
test: fix flaky test-pipe-unref

### DIFF
--- a/test/parallel/test-pipe-unref.js
+++ b/test/parallel/test-pipe-unref.js
@@ -2,10 +2,10 @@
 const common = require('../common');
 const net = require('net');
 
+// This test should end immediately after `unref` is called
+
 common.refreshTmpDir();
 
 const s = net.Server();
 s.listen(common.PIPE);
 s.unref();
-
-setTimeout(common.mustNotCall(), 1000).unref();


### PR DESCRIPTION
This test doesn't need to use an arbitrary `setTimeout`, it should just end naturally (if working as intended) or timeout as per default for all tests.

Fixes: https://github.com/nodejs/node/issues/16875

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test