### PR TITLE
test: fix flaky test-http-writable-true-after-close

### DIFF
--- a/test/parallel/test-http-writable-true-after-close.js
+++ b/test/parallel/test-http-writable-true-after-close.js
@@ -12,16 +12,16 @@ let external;
 
 // Proxy server
 const server = createServer(common.mustCall((req, res) => {
+  const listener = common.mustCall(() => {
+    assert.strictEqual(res.writable, true);
+  });
+
+  // on CentOS 5, 'finish' is emitted
+  res.on('finish', listener);
+  // everywhere else, 'close' is emitted
+  res.on('close', listener);
+
   get(`http://127.0.0.1:${internal.address().port}`, common.mustCall((inner) => {
-    const listener = common.mustCall(() => {
-      assert.strictEqual(res.writable, true);
-    });
-
-    // on CentOS 5, 'finish' is emitted
-    res.on('finish', listener);
-    // everywhere else, 'close' is emitted
-    res.on('close', listener);
-
     inner.pipe(res);
   }));
 })).listen(0, () => {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/16321

This will need full stress test CI, coming shortly. (But it did fix it on my macOS.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test