### PR TITLE
test: fix flaky test-http-pipeline-flood

### DIFF
--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -56,9 +56,9 @@ function parent() {
       server.close();
     }));
 
-    server.setTimeout(200, common.mustCall(function() {
+    server.setTimeout(200, common.mustCallAtLeast(function() {
       child.kill();
-    }));
+    }, 1));
   });
 }
 


### PR DESCRIPTION
This fixes one of the issues with this test (the repeated timeout, for which there's no real reason to validate that it only occurs exactly once). Haven't been able to reproduce the other one so perhaps there was a bug that was fixed in the meantime or something. Not sure.

Refs: https://github.com/nodejs/node/issues/16317

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
  