### PR TITLE
test: fix flaky test-resolve-async

### DIFF
--- a/test/addons/callback-scope/test-resolve-async.js
+++ b/test/addons/callback-scope/test-resolve-async.js
@@ -5,9 +5,6 @@ const assert = require('assert');
 const { testResolveAsync } = require(`./build/${common.buildType}/binding`);
 
 let called = false;
-testResolveAsync().then(common.mustCall(() => {
-  called = true;
-}));
+testResolveAsync().then(() => (called = true));
 
-setTimeout(common.mustCall(() => assert(called)),
-           common.platformTimeout(50));
+setTimeout(() => assert(called), common.platformTimeout(50));

--- a/test/addons/callback-scope/test-resolve-async.js
+++ b/test/addons/callback-scope/test-resolve-async.js
@@ -5,6 +5,6 @@ const assert = require('assert');
 const { testResolveAsync } = require(`./build/${common.buildType}/binding`);
 
 let called = false;
-testResolveAsync().then(() => (called = true));
+testResolveAsync().then(() => { called = true; });
 
-setTimeout(() => assert(called), common.platformTimeout(50));
+setTimeout(() => { assert(called); }, common.platformTimeout(50));

--- a/test/addons/callback-scope/test-resolve-async.js
+++ b/test/addons/callback-scope/test-resolve-async.js
@@ -9,5 +9,5 @@ testResolveAsync().then(common.mustCall(() => {
   called = true;
 }));
 
-setTimeout(common.mustCall(() => { assert(called); }),
-           common.platformTimeout(20));
+setTimeout(common.mustCall(() => assert(called)),
+           common.platformTimeout(50));


### PR DESCRIPTION
~~As I understand it, this test doesn't require the `setTimeout` and can do just fine with `setImmediate`.~~ Looks like timeout might be needed after all, let's see if slightly higher setting will do.

This should fix the flakiness seen in https://ci.nodejs.org/job/node-test-commit-linux/15333/nodes=alpine37-container-x64/tapResults/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test
  
  