### PR TITLE
benchmark: fix timeout bug in write-stream-throughput

### DIFF
--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -41,10 +41,6 @@ function main(conf) {
   var started = false;
   var ending = false;
   var ended = false;
-  setTimeout(function() {
-    ending = true;
-    f.end();
-  }, dur * 1000);
 
   var f = fs.createWriteStream(filename);
   f.on('drain', write);
@@ -66,6 +62,10 @@ function main(conf) {
 
     if (!started) {
       started = true;
+      setTimeout(function() {
+        ending = true;
+        f.end();
+      }, dur * 1000);
       bench.start();
     }
 


### PR DESCRIPTION
Currently it's possible for this benchmark to call `bench.end()` before `bench.start()`. Fix this to resolve some occasional CI flakiness.

Fixes: https://github.com/nodejs/node/issues/17901

CI: https://ci.nodejs.org/job/node-test-pull-request/12388/
Stress test CI: https://ci.nodejs.org/job/node-stress-single-test/1600/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
benchmark
  