### PR TITLE
path: fix path.normalize not correctly normalizing relative paths

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -29,17 +29,6 @@ function assertPath(path) {
   }
 }
 
-function findLastSlashIndex(path, isWin32) {
-  var i = path.length - 1;
-  for (; i >= 0; i--) {
-    const charCode = path.charCodeAt(i);
-    if ((!isWin32 && charCode === 47/*/*/) ||
-        (isWin32 && charCode === 92/*\*/))
-      break;
-  }
-  return i;
-}
-
 // Resolves . and .. elements in a path with directory names
 function normalizeStringWin32(path, allowAboveRoot) {
   var res = '';
@@ -62,15 +51,14 @@ function normalizeStringWin32(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== 46/*.*/ ||
             res.charCodeAt(res.length - 2) !== 46/*.*/) {
           if (res.length > 2) {
-            const lastSlashIndex = findLastSlashIndex(res, true);
+            const lastSlashIndex = res.lastIndexOf('\\');
             if (lastSlashIndex !== res.length - 1) {
               if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
                 res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 -
-                                    findLastSlashIndex(res, true);
+                lastSegmentLength = res.length - 1 - res.lastIndexOf('\\');
               }
               lastSlash = i;
               dots = 0;
@@ -131,14 +119,14 @@ function normalizeStringPosix(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== 46/*.*/ ||
             res.charCodeAt(res.length - 2) !== 46/*.*/) {
           if (res.length > 2) {
-            const lastSlashIndex = findLastSlashIndex(res);
+            const lastSlashIndex = res.lastIndexOf('/');
             if (lastSlashIndex !== res.length - 1) {
               if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
                 res = res.slice(0, lastSlashIndex);
-                lastSegmentLength = res.length - 1 - findLastSlashIndex(res);
+                lastSegmentLength = res.length - 1 - res.lastIndexOf('/');
               }
               lastSlash = i;
               dots = 0;

--- a/lib/path.js
+++ b/lib/path.js
@@ -29,6 +29,17 @@ function assertPath(path) {
   }
 }
 
+function findLastSlashIndex(path, isWin32) {
+  var i = path.length - 1;
+  for (; i >= 0; i--) {
+    const charCode = path.charCodeAt(i);
+    if ((!isWin32 && charCode === 47/*/*/) ||
+        (isWin32 && charCode === 92/*\*/))
+      break;
+  }
+  return i;
+}
+
 // Resolves . and .. elements in a path with directory names
 function normalizeStringWin32(path, allowAboveRoot) {
   var res = '';
@@ -51,19 +62,15 @@ function normalizeStringWin32(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== 46/*.*/ ||
             res.charCodeAt(res.length - 2) !== 46/*.*/) {
           if (res.length > 2) {
-            const start = res.length - 1;
-            var j = start;
-            for (; j >= 0; --j) {
-              if (res.charCodeAt(j) === 92/*\*/)
-                break;
-            }
-            if (j !== start) {
-              if (j === -1) {
+            const lastSlashIndex = findLastSlashIndex(res, true);
+            if (lastSlashIndex !== res.length - 1) {
+              if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
-                res = res.slice(0, j);
-                lastSegmentLength = j;
+                res = res.slice(0, lastSlashIndex);
+                lastSegmentLength = res.length - 1 -
+                                    findLastSlashIndex(res, true);
               }
               lastSlash = i;
               dots = 0;
@@ -124,19 +131,14 @@ function normalizeStringPosix(path, allowAboveRoot) {
             res.charCodeAt(res.length - 1) !== 46/*.*/ ||
             res.charCodeAt(res.length - 2) !== 46/*.*/) {
           if (res.length > 2) {
-            const start = res.length - 1;
-            var j = start;
-            for (; j >= 0; --j) {
-              if (res.charCodeAt(j) === 47/*/*/)
-                break;
-            }
-            if (j !== start) {
-              if (j === -1) {
+            const lastSlashIndex = findLastSlashIndex(res);
+            if (lastSlashIndex !== res.length - 1) {
+              if (lastSlashIndex === -1) {
                 res = '';
                 lastSegmentLength = 0;
               } else {
-                res = res.slice(0, j);
-                lastSegmentLength = j;
+                res = res.slice(0, lastSlashIndex);
+                lastSegmentLength = res.length - 1 - findLastSlashIndex(res);
               }
               lastSlash = i;
               dots = 0;

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -27,6 +27,18 @@ assert.strictEqual(path.win32.normalize('..\\foo..\\..\\..\\bar'),
                    '..\\..\\bar');
 assert.strictEqual(path.win32.normalize('..\\...\\..\\.\\...\\..\\..\\bar'),
                    '..\\..\\bar');
+assert.strictEqual(path.win32.normalize('../../../foo/../../../bar'),
+                   '..\\..\\..\\..\\..\\bar');
+assert.strictEqual(path.win32.normalize('../../../foo/../../../bar/../../'),
+                   '..\\..\\..\\..\\..\\..\\');
+assert.strictEqual(
+  path.win32.normalize('../foobar/barfoo/foo/../../../bar/../../'),
+  '..\\..\\'
+);
+assert.strictEqual(
+  path.win32.normalize('../.../../foobar/../../../bar/../../baz'),
+  '..\\..\\..\\..\\baz'
+);
 
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
                    'fixtures/b/c.js');
@@ -44,3 +56,15 @@ assert.strictEqual(path.posix.normalize('bar/foo..'), 'bar/foo..');
 assert.strictEqual(path.posix.normalize('../foo../../../bar'), '../../bar');
 assert.strictEqual(path.posix.normalize('../.../.././.../../../bar'),
                    '../../bar');
+assert.strictEqual(path.posix.normalize('../../../foo/../../../bar'),
+                   '../../../../../bar');
+assert.strictEqual(path.posix.normalize('../../../foo/../../../bar/../../'),
+                   '../../../../../../');
+assert.strictEqual(
+  path.posix.normalize('../foobar/barfoo/foo/../../../bar/../../'),
+  '../../'
+);
+assert.strictEqual(
+  path.posix.normalize('../.../../foobar/../../../bar/../../baz'),
+  '../../../../baz'
+);


### PR DESCRIPTION
After slicing, the `lastSegmentLength` should be calculated again.
It should be `(res.length - 1 - lastSlashIndex)`, instead of value `j`.

Tests for it is also added.

Fixes: https://github.com/nodejs/node/issues/17928

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
path
  