### PR TITLE
async_hooks: update defaultTriggerAsyncIdScope for perf

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -452,8 +452,8 @@ Socket.prototype.send = function(buffer,
   const afterDns = (ex, ip) => {
     defaultTriggerAsyncIdScope(
       this[async_id_symbol],
-      [ex, this, ip, list, address, port, callback],
-      doSend
+      doSend,
+      ex, this, ip, list, address, port, callback
     );
   };
 

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -260,7 +260,7 @@ function getDefaultTriggerAsyncId() {
 }
 
 
-function defaultTriggerAsyncIdScope(triggerAsyncId, opaque, block) {
+function defaultTriggerAsyncIdScope(triggerAsyncId, block, ...args) {
   // CHECK(Number.isSafeInteger(triggerAsyncId))
   // CHECK(triggerAsyncId > 0)
   const oldDefaultTriggerAsyncId = async_id_fields[kDefaultTriggerAsyncId];
@@ -268,7 +268,7 @@ function defaultTriggerAsyncIdScope(triggerAsyncId, opaque, block) {
 
   var ret;
   try {
-    ret = Reflect.apply(block, null, opaque);
+    ret = Reflect.apply(block, null, args);
   } finally {
     async_id_fields[kDefaultTriggerAsyncId] = oldDefaultTriggerAsyncId;
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -317,7 +317,7 @@ function onSocketFinish() {
     return this.destroy();
 
   var err = defaultTriggerAsyncIdScope(
-    this[async_id_symbol], [this, afterShutdown], shutdownSocket
+    this[async_id_symbol], shutdownSocket, this, afterShutdown
   );
 
   if (err)
@@ -1043,7 +1043,7 @@ Socket.prototype.connect = function(...args) {
                                  path);
     }
     defaultTriggerAsyncIdScope(
-      this[async_id_symbol], [this, path], internalConnect
+      this[async_id_symbol], internalConnect, this, path
     );
   } else {
     lookupAndConnect(this, options);
@@ -1089,8 +1089,8 @@ function lookupAndConnect(self, options) {
       if (self.connecting)
         defaultTriggerAsyncIdScope(
           self[async_id_symbol],
-          [self, host, port, addressType, localAddress, localPort],
-          internalConnect
+          internalConnect,
+          self, host, port, addressType, localAddress, localPort
         );
     });
     return;
@@ -1118,7 +1118,7 @@ function lookupAndConnect(self, options) {
   debug('connect: dns options', dnsopts);
   self._host = host;
   var lookup = options.lookup || dns.lookup;
-  defaultTriggerAsyncIdScope(self[async_id_symbol], [], function() {
+  defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
     lookup(host, dnsopts, function emitLookup(err, ip, addressType) {
       self.emit('lookup', err, ip, addressType, host);
 
@@ -1140,8 +1140,8 @@ function lookupAndConnect(self, options) {
         self._unrefTimer();
         defaultTriggerAsyncIdScope(
           self[async_id_symbol],
-          [self, ip, port, addressType, localAddress, localPort],
-          internalConnect
+          internalConnect,
+          self, ip, port, addressType, localAddress, localPort
         );
       }
     });


### PR DESCRIPTION
The existing version of `defaultTriggerAsyncIdScope` creates an `Array` for the callback's arguments which is highly inefficient. Instead, use rest syntax and allow V8 to do that work for us. This yields roughly 2x performance for this particular function.

CI: https://ci.nodejs.org/job/node-test-pull-request/12416/

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
async_hooks, dgram, net
  
  