### PR TITLE
trace_events: stop tracing agent in process.exit()

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -2029,7 +2029,9 @@ static void WaitForInspectorDisconnect(Environment* env) {
 
 static void Exit(const FunctionCallbackInfo<Value>& args) {
   WaitForInspectorDisconnect(Environment::GetCurrent(args));
-  v8_platform.StopTracingAgent();
+  if (trace_enabled) {
+    v8_platform.StopTracingAgent();
+  }
   exit(args[0]->Int32Value());
 }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2029,6 +2029,7 @@ static void WaitForInspectorDisconnect(Environment* env) {
 
 static void Exit(const FunctionCallbackInfo<Value>& args) {
   WaitForInspectorDisconnect(Environment::GetCurrent(args));
+  v8_platform.StopTracingAgent();
   exit(args[0]->Int32Value());
 }
 

--- a/test/parallel/test-trace-events-process-exit.js
+++ b/test/parallel/test-trace-events-process-exit.js
@@ -1,0 +1,22 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+
+const FILE_NAME = 'node_trace.1.log';
+
+common.refreshTmpDir();
+process.chdir(common.tmpDir);
+
+const proc = cp.spawn(process.execPath,
+                      [ '--trace-events-enabled',
+                        '-e', 'process.exit()' ]);
+
+proc.once('exit', common.mustCall(() => {
+  assert(common.fileExists(FILE_NAME));
+  fs.readFile(FILE_NAME, common.mustCall((err, data) => {
+    const traces = JSON.parse(data.toString()).traceEvents;
+    assert(traces.length > 0);
+  }));
+}));


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
trace_events
