### PR TITLE
lib: enable dot-notation eslint rule

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -1,4 +1,6 @@
 rules:
+  dot-notation: error
+
   # Custom rules in tools/eslint-rules
   require-buffer: error
   buffer-constructor: error

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -68,7 +68,7 @@ class Session extends EventEmitter {
     const id = this[nextIdSymbol]++;
     const message = { id, method };
     if (params) {
-      message['params'] = params;
+      message.params = params;
     }
     if (callback) {
       this[messageCallbacksSymbol].set(id, callback);

--- a/lib/module.js
+++ b/lib/module.js
@@ -729,7 +729,7 @@ Module._initPaths = function() {
     paths.unshift(path.resolve(homeDir, '.node_modules'));
   }
 
-  var nodePath = process.env['NODE_PATH'];
+  var nodePath = process.env.NODE_PATH;
   if (nodePath) {
     paths = nodePath.split(path.delimiter).filter(function(path) {
       return !!path;


### PR DESCRIPTION
There are currently only two instances of property access using square brackets (`foo['bar']`) within the `lib` folder. Fix those and enable an eslint rule to prefer dot notation (`foo.bar`).

Eventually this could be enabled across the project but currently this would cause too much churn (152 instances would need to be changed, mostly within `test`).

Refs: https://eslint.org/docs/rules/dot-notation

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
lib