### PR TITLE
build: update lint-cpp on Windows

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -90,6 +90,7 @@ if /i "%1"=="test-v8"       set test_v8=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-intl"  set test_v8_intl=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-benchmarks" set test_v8_benchmarks=1&set custom_v8_test=1&goto arg-ok
 if /i "%1"=="test-v8-all"       set test_v8=1&set test_v8_intl=1&set test_v8_benchmarks=1&set custom_v8_test=1&goto arg-ok
+if /i "%1"=="lint-cpp"      set lint_cpp=1&goto arg-ok
 if /i "%1"=="lint-js"       set lint_js=1&goto arg-ok
 if /i "%1"=="jslint"        set lint_js=1&echo Please use lint-js instead of jslint&goto arg-ok
 if /i "%1"=="lint-js-ci"    set lint_js_ci=1&goto arg-ok
@@ -480,22 +481,22 @@ call :run-python tools/cpplint.py %cppfilelist% > nul
 goto exit
 
 :add-to-list
-echo %1 | findstr /c:"src\node_root_certs.h"
+echo %1 | findstr /c:"src\node_root_certs.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /r /c:"src\\tracing\\trace_event.h"
+echo %1 | findstr /c:"src\tracing\trace_event.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /r /c:"src\\tracing\\trace_event_common.h"
+echo %1 | findstr /c:"src\tracing\trace_event_common.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.h"
+echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.cc"
+echo %1 | findstr /r /c:"test\\addons\\[0-9].*_.*\.cc" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
-echo %1 | findstr /c:"test\\addons-napi\\common.h"
+echo %1 | findstr /c:"test\addons-napi\common.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 
 set "localcppfilelist=%localcppfilelist% %1"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -481,6 +481,7 @@ call :run-python tools/cpplint.py %cppfilelist% > nul
 goto exit
 
 :add-to-list
+@rem Subroutine used to filter items from the cpplint file list
 echo %1 | findstr /c:"src\node_root_certs.h" > nul 2>&1
 if %errorlevel% equ 0 goto exit
 


### PR DESCRIPTION
* Added a `lint-cpp` argument
* Updated `findstr` calls to output to `nul`
* Updated `findstr` calls to only use `/r` when the input is a regex

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes\
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
build