### PR TITLE
crypto: assign deprecation code for setAuthTag/GCM

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -807,6 +807,18 @@ Importing assert directly is not recommended as the exposed functions will use
 loose equality checks. Use `require('assert').strict` instead. The API is the
 same as the legacy assert but it will always use strict equality checks.
 
+<a id="DEP00XX"></a>
+### DEP00XX: Invalid GCM authentication tag lengths
+
+Type: Runtime
+
+Node.js supports all GCM authentication tag lengths which are accepted by
+OpenSSL when calling [`decipher.setAuthTag()`][]. This behavior will change in
+a future version at which point only authentication tag lengths of 128, 120,
+112, 104, 96, 64 and 32 bits will be allowed. Authentication tags whose length
+is not included in this list will be considered invalid in compliance with
+[NIST SP 800-38D][].
+
 [`Buffer.allocUnsafeSlow(size)`]: buffer.html#buffer_class_method_buffer_allocunsafeslow_size
 [`Buffer.from(array)`]: buffer.html#buffer_class_method_buffer_from_array
 [`Buffer.from(buffer)`]: buffer.html#buffer_class_method_buffer_from_buffer
@@ -821,6 +833,7 @@ same as the legacy assert but it will always use strict equality checks.
 [`console.log()`]: console.html#console_console_log_data_args
 [`crypto.createCredentials()`]: crypto.html#crypto_crypto_createcredentials_details
 [`crypto.pbkdf2()`]: crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+[`decipher.setAuthTag()`]: crypto.html#crypto_decipher_setauthtag_buffer
 [`domain`]: domain.html
 [`ecdh.setPublicKey()`]: crypto.html#crypto_ecdh_setpublickey_publickey_encoding
 [`emitter.listenerCount(eventName)`]: events.html#events_emitter_listenercount_eventname
@@ -871,4 +884,5 @@ same as the legacy assert but it will always use strict equality checks.
 [alloc_unsafe_size]: buffer.html#buffer_class_method_buffer_allocunsafe_size
 [from_arraybuffer]: buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length
 [from_string_encoding]: buffer.html#buffer_class_method_buffer_from_string_encoding
+[NIST SP 800-38D]: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [`REPLServer.clearBufferedCommand()`]: repl.html#repl_replserver_clearbufferedcommand

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -815,7 +815,7 @@ Type: Runtime
 Node.js supports all GCM authentication tag lengths which are accepted by
 OpenSSL when calling [`decipher.setAuthTag()`][]. This behavior will change in
 a future version at which point only authentication tag lengths of 128, 120,
-112, 104, 96, 64 and 32 bits will be allowed. Authentication tags whose length
+112, 104, 96, 64, and 32 bits will be allowed. Authentication tags whose length
 is not included in this list will be considered invalid in compliance with
 [NIST SP 800-38D][].
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -3786,10 +3786,11 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   // Restrict GCM tag lengths according to NIST 800-38d, page 9.
   unsigned int tag_len = Buffer::Length(args[0]);
   if (tag_len > 16 || (tag_len < 12 && tag_len != 8 && tag_len != 4)) {
-    ProcessEmitWarning(cipher->env(),
-        "Permitting authentication tag lengths of %u bytes is deprecated. "
-        "Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.",
-        tag_len);
+    char msg[125];
+    snprintf(msg, sizeof(msg),
+             "Permitting authentication tag lengths of %u bytes is deprecated. "
+             "Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.", tag_len);
+    ProcessEmitDeprecationWarning(cipher->env(), msg, "DEP00XX");
   }
 
   // Note: we don't use std::max() here to work around a header conflict.

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -335,13 +335,17 @@ const errMessages = {
 
 const ciphers = crypto.getCiphers();
 
-common.expectWarning('Warning', (common.hasFipsCrypto ? [] : [
-  'Use Cipheriv for counter mode of aes-192-gcm'
-]).concat(
-  [0, 1, 2, 6, 9, 10, 11, 17]
+const expectedWarnings = common.hasFipsCrypto ?
+  [] : ['Use Cipheriv for counter mode of aes-192-gcm'];
+
+const expectedDeprecationWarnings = [0, 1, 2, 6, 9, 10, 11, 17]
   .map((i) => `Permitting authentication tag lengths of ${i} bytes is ` +
-            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.')
-));
+            'deprecated. Valid GCM tag lengths are 4, 8, 12, 13, 14, 15, 16.');
+
+common.expectWarning({
+  Warning: expectedWarnings,
+  DeprecationWarning: expectedDeprecationWarnings
+});
 
 for (const test of TEST_CASES) {
   if (!ciphers.includes(test.algo)) {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/17566 added a warning when invalid GCM tag lengths are used. As a preparation for https://github.com/nodejs/node/pull/17825, assign a deprecation code before moving it to end-of-life.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
crypto