### PR TITLE
http2: use aliased buffer for perf stats, add stats

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3003,23 +3003,35 @@ The `name` property of the `PerformanceEntry` will be equal to either
 If `name` is equal to `Http2Stream`, the `PerformanceEntry` will contain the
 following additional properties:
 
+* `bytesRead` {number} The number of DATA frame bytes received for this
+  `Http2Stream`.
+* `bytesWritten` {number} The number of DATA frame bytes sent for this
+  `Http2Stream`.
+* `id` {number} The identifier of the associated `Http2Stream`
 * `timeToFirstByte` {number} The number of milliseconds elapsed between the
   `PerformanceEntry` `startTime` and the reception of the first `DATA` frame.
+* `timeToFirstByteSent` {number} The number of milliseconds elapsed between
+  the `PerformanceEntry` `startTime` and sending of the first `DATA` frame.
 * `timeToFirstHeader` {number} The number of milliseconds elapsed between the
   `PerformanceEntry` `startTime` and the reception of the first header.
 
 If `name` is equal to `Http2Session`, the `PerformanceEntry` will contain the
 following additional properties:
 
+* `bytesRead` {number} The number of bytes received for this `Http2Session`.
+* `bytesWritten` {number} The number of bytes sent for this `Http2Session`.
+* `framesReceived` {number} The number of HTTP/2 frames received by the
+  `Http2Session`.
+* `framesSent` {number} The number of HTTP/2 frames sent by the `Http2Session`.
+* `maxConcurrentStreams` {number} The maximum number of streams concurrently
+  open during the lifetime of the `Http2Session`.
 * `pingRTT` {number} The number of milliseconds elapsed since the transmission
   of a `PING` frame and the reception of its acknowledgment. Only present if
   a `PING` frame has been sent on the `Http2Session`.
-* `streamCount` {number} The number of `Http2Stream` instances processed by
-  the `Http2Session`.
 * `streamAverageDuration` {number} The average duration (in milliseconds) for
   all `Http2Stream` instances.
-* `framesReceived` {number} The number of HTTP/2 frames received by the
-  `Http2Session`.
+* `streamCount` {number} The number of `Http2Stream` instances processed by
+  the `Http2Session`.
 * `type` {string} Either `'server'` or `'client'` to identify the type of
   `Http2Session`.
 

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -36,8 +36,6 @@ const {
   NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END
 } = constants;
 
-const { sessionStats, streamStats } = process.binding('http2');
-
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 const { inherits } = require('util');
@@ -85,9 +83,14 @@ const IDX_SESSION_STATS_DATA_SENT = 6;
 const IDX_SESSION_STATS_DATA_RECEIVED = 7;
 const IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS = 8;
 
+let sessionStats;
+let streamStats;
+
 function collectHttp2Stats(entry) {
   switch (entry.name) {
     case 'Http2Stream':
+      if (streamStats === undefined)
+        streamStats = process.binding('http2').streamStats;
       entry.id =
         streamStats[IDX_STREAM_STATS_ID] >>> 0;
       entry.timeToFirstByte =
@@ -102,6 +105,8 @@ function collectHttp2Stats(entry) {
         streamStats[IDX_STREAM_STATS_RECEIVEDBYTES];
       break;
     case 'Http2Session':
+      if (sessionStats === undefined)
+        sessionStats = process.binding('http2').sessionStats;
       entry.type =
         sessionStats[IDX_SESSION_STATS_TYPE] >>> 0 === 0 ? 'server' : 'client';
       entry.pingRTT =

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -36,6 +36,8 @@ const {
   NODE_PERFORMANCE_MILESTONE_PRELOAD_MODULE_LOAD_END
 } = constants;
 
+const { sessionStats, streamStats } = process.binding('http2');
+
 const L = require('internal/linkedlist');
 const kInspect = require('internal/util').customInspectSymbol;
 const { inherits } = require('util');
@@ -65,6 +67,63 @@ const observerableTypes = [
   'function',
   'http2'
 ];
+
+const IDX_STREAM_STATS_ID = 0;
+const IDX_STREAM_STATS_TIMETOFIRSTBYTE = 1;
+const IDX_STREAM_STATS_TIMETOFIRSTHEADER = 2;
+const IDX_STREAM_STATS_TIMETOFIRSTBYTESENT = 3;
+const IDX_STREAM_STATS_SENTBYTES = 4;
+const IDX_STREAM_STATS_RECEIVEDBYTES = 5;
+
+const IDX_SESSION_STATS_TYPE = 0;
+const IDX_SESSION_STATS_PINGRTT = 1;
+const IDX_SESSION_STATS_FRAMESRECEIVED = 2;
+const IDX_SESSION_STATS_FRAMESSENT = 3;
+const IDX_SESSION_STATS_STREAMCOUNT = 4;
+const IDX_SESSION_STATS_STREAMAVERAGEDURATION = 5;
+const IDX_SESSION_STATS_DATA_SENT = 6;
+const IDX_SESSION_STATS_DATA_RECEIVED = 7;
+const IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS = 8;
+
+function collectHttp2Stats(entry) {
+  switch (entry.name) {
+    case 'Http2Stream':
+      entry.id =
+        streamStats[IDX_STREAM_STATS_ID] >>> 0;
+      entry.timeToFirstByte =
+        streamStats[IDX_STREAM_STATS_TIMETOFIRSTBYTE];
+      entry.timeToFirstHeader =
+        streamStats[IDX_STREAM_STATS_TIMETOFIRSTHEADER];
+      entry.timeToFirstByteSent =
+        streamStats[IDX_STREAM_STATS_TIMETOFIRSTBYTESENT];
+      entry.bytesWritten =
+        streamStats[IDX_STREAM_STATS_SENTBYTES];
+      entry.bytesRead =
+        streamStats[IDX_STREAM_STATS_RECEIVEDBYTES];
+      break;
+    case 'Http2Session':
+      entry.type =
+        sessionStats[IDX_SESSION_STATS_TYPE] >>> 0 === 0 ? 'server' : 'client';
+      entry.pingRTT =
+        sessionStats[IDX_SESSION_STATS_PINGRTT];
+      entry.framesReceived =
+        sessionStats[IDX_SESSION_STATS_FRAMESRECEIVED];
+      entry.framesSent =
+        sessionStats[IDX_SESSION_STATS_FRAMESSENT];
+      entry.streamCount =
+        sessionStats[IDX_SESSION_STATS_STREAMCOUNT];
+      entry.streamAverageDuration =
+        sessionStats[IDX_SESSION_STATS_STREAMAVERAGEDURATION];
+      entry.bytesWritten =
+        sessionStats[IDX_SESSION_STATS_DATA_SENT];
+      entry.bytesRead =
+        sessionStats[IDX_SESSION_STATS_DATA_RECEIVED];
+      entry.maxConcurrentStreams =
+        sessionStats[IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS];
+      break;
+  }
+}
+
 
 let errors;
 function lazyErrors() {
@@ -467,6 +526,10 @@ function doNotify() {
 // Set up the callback used to receive PerformanceObserver notifications
 function observersCallback(entry) {
   const type = mapTypes(entry.entryType);
+
+  if (type === NODE_PERFORMANCE_ENTRY_TYPE_HTTP2)
+    collectHttp2Stats(entry);
+
   performance[kInsertEntry](entry);
   const list = getObserversList(type);
 

--- a/src/node_http2_state.h
+++ b/src/node_http2_state.h
@@ -61,6 +61,29 @@ namespace http2 {
     PADDING_BUF_FIELD_COUNT
   };
 
+  enum Http2StreamStatisticsIndex {
+    IDX_STREAM_STATS_ID,
+    IDX_STREAM_STATS_TIMETOFIRSTBYTE,
+    IDX_STREAM_STATS_TIMETOFIRSTHEADER,
+    IDX_STREAM_STATS_TIMETOFIRSTBYTESENT,
+    IDX_STREAM_STATS_SENTBYTES,
+    IDX_STREAM_STATS_RECEIVEDBYTES,
+    IDX_STREAM_STATS_COUNT
+  };
+
+  enum Http2SessionStatisticsIndex {
+    IDX_SESSION_STATS_TYPE,
+    IDX_SESSION_STATS_PINGRTT,
+    IDX_SESSION_STATS_FRAMESRECEIVED,
+    IDX_SESSION_STATS_FRAMESSENT,
+    IDX_SESSION_STATS_STREAMCOUNT,
+    IDX_SESSION_STATS_STREAMAVERAGEDURATION,
+    IDX_SESSION_STATS_DATA_SENT,
+    IDX_SESSION_STATS_DATA_RECEIVED,
+    IDX_SESSION_STATS_MAX_CONCURRENT_STREAMS,
+    IDX_SESSION_STATS_COUNT
+  };
+
 class http2_state {
  public:
   explicit http2_state(v8::Isolate* isolate) :
@@ -76,6 +99,16 @@ class http2_state {
       isolate,
       offsetof(http2_state_internal, stream_state_buffer),
       IDX_STREAM_STATE_COUNT,
+      root_buffer),
+    stream_stats_buffer(
+      isolate,
+      offsetof(http2_state_internal, stream_stats_buffer),
+      IDX_STREAM_STATS_COUNT,
+      root_buffer),
+    session_stats_buffer(
+      isolate,
+      offsetof(http2_state_internal, session_stats_buffer),
+      IDX_SESSION_STATS_COUNT,
       root_buffer),
     padding_buffer(
       isolate,
@@ -97,6 +130,8 @@ class http2_state {
   AliasedBuffer<uint8_t, v8::Uint8Array> root_buffer;
   AliasedBuffer<double, v8::Float64Array> session_state_buffer;
   AliasedBuffer<double, v8::Float64Array> stream_state_buffer;
+  AliasedBuffer<double, v8::Float64Array> stream_stats_buffer;
+  AliasedBuffer<double, v8::Float64Array> session_stats_buffer;
   AliasedBuffer<uint32_t, v8::Uint32Array> padding_buffer;
   AliasedBuffer<uint32_t, v8::Uint32Array> options_buffer;
   AliasedBuffer<uint32_t, v8::Uint32Array> settings_buffer;
@@ -106,6 +141,8 @@ class http2_state {
     // doubles first so that they are always sizeof(double)-aligned
     double session_state_buffer[IDX_SESSION_STATE_COUNT];
     double stream_state_buffer[IDX_STREAM_STATE_COUNT];
+    double stream_stats_buffer[IDX_STREAM_STATS_COUNT];
+    double session_stats_buffer[IDX_SESSION_STATS_COUNT];
     uint32_t padding_buffer[PADDING_BUF_FIELD_COUNT];
     uint32_t options_buffer[IDX_OPTIONS_FLAGS + 1];
     uint32_t settings_buffer[IDX_SETTINGS_COUNT + 1];

--- a/test/parallel/test-http2-perf_hooks.js
+++ b/test/parallel/test-http2-perf_hooks.js
@@ -8,7 +8,7 @@ const h2 = require('http2');
 
 const { PerformanceObserver } = require('perf_hooks');
 
-const obs = new PerformanceObserver((items) => {
+const obs = new PerformanceObserver(common.mustCall((items) => {
   const entry = items.getEntries()[0];
   assert.strictEqual(entry.entryType, 'http2');
   assert.strictEqual(typeof entry.startTime, 'number');
@@ -19,6 +19,10 @@ const obs = new PerformanceObserver((items) => {
       assert.strictEqual(typeof entry.streamAverageDuration, 'number');
       assert.strictEqual(typeof entry.streamCount, 'number');
       assert.strictEqual(typeof entry.framesReceived, 'number');
+      assert.strictEqual(typeof entry.framesSent, 'number');
+      assert.strictEqual(typeof entry.bytesWritten, 'number');
+      assert.strictEqual(typeof entry.bytesRead, 'number');
+      assert.strictEqual(typeof entry.maxConcurrentStreams, 'number');
       switch (entry.type) {
         case 'server':
           assert.strictEqual(entry.streamCount, 1);
@@ -34,12 +38,15 @@ const obs = new PerformanceObserver((items) => {
       break;
     case 'Http2Stream':
       assert.strictEqual(typeof entry.timeToFirstByte, 'number');
+      assert.strictEqual(typeof entry.timeToFirstByteSent, 'number');
       assert.strictEqual(typeof entry.timeToFirstHeader, 'number');
+      assert.strictEqual(typeof entry.bytesWritten, 'number');
+      assert.strictEqual(typeof entry.bytesRead, 'number');
       break;
     default:
       assert.fail('invalid entry name');
   }
-});
+}, 4));
 obs.observe({ entryTypes: ['http2'] });
 
 const body =


### PR DESCRIPTION
Add an aliased buffer for session and stream statistics, add a few more useful metrics

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2