### PR TITLE
http2: refactor read mechanism

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -279,7 +279,7 @@ function submitRstStream(code) {
 // point, close them. If there is an open fd for file send, close that also.
 // At this point the underlying node::http2:Http2Stream handle is no
 // longer usable so destroy it also.
-function onStreamClose(code, hasData) {
+function onStreamClose(code) {
   const stream = this[kOwner];
   if (stream.destroyed)
     return;
@@ -287,8 +287,7 @@ function onStreamClose(code, hasData) {
   const state = stream[kState];
 
   debug(`Http2Stream ${stream[kID]} [Http2Session ` +
-        `${sessionName(stream[kSession][kType])}]: closed with code ${code}` +
-        ` [has data? ${hasData}]`);
+        `${sessionName(stream[kSession][kType])}]: closed with code ${code}`);
 
   if (!stream.closed) {
     // Clear timeout and remove timeout listeners
@@ -306,13 +305,14 @@ function onStreamClose(code, hasData) {
 
   if (state.fd !== undefined)
     tryClose(state.fd);
-  stream[kMaybeDestroy](null, code, hasData);
+  stream.push(null);
+  stream[kMaybeDestroy](null, code);
 }
 
 // Receives a chunk of data for a given stream and forwards it on
 // to the Http2Stream Duplex for processing.
-function onStreamRead(nread, buf, handle) {
-  const stream = handle[kOwner];
+function onStreamRead(nread, buf) {
+  const stream = this[kOwner];
   if (nread >= 0 && !stream.destroyed) {
     debug(`Http2Stream ${stream[kID]} [Http2Session ` +
           `${sessionName(stream[kSession][kType])}]: receiving data chunk ` +
@@ -320,7 +320,7 @@ function onStreamRead(nread, buf, handle) {
     stream[kUpdateTimer]();
     if (!stream.push(buf)) {
       if (!stream.destroyed)  // we have to check a second time
-        handle.readStop();
+        this.readStop();
     }
     return;
   }
@@ -1431,13 +1431,8 @@ function streamOnResume() {
 }
 
 function streamOnPause() {
-  // if (!this.destroyed && !this.pending)
-  //   this[kHandle].readStop();
-}
-
-function handleFlushData(self) {
   if (!this.destroyed && !this.pending)
-    this[kHandle].flushData();
+    this[kHandle].readStop();
 }
 
 // If the writable side of the Http2Stream is still open, emit the
@@ -1686,11 +1681,10 @@ class Http2Stream extends Duplex {
       this.push(null);
       return;
     }
-    const flushfn = handleFlushData.bind(this);
     if (!this.pending) {
-      flushfn();
+      streamOnResume.call(this);
     } else {
-      this.once('ready', flushfn);
+      this.once('ready', streamOnResume);
     }
   }
 
@@ -1831,10 +1825,10 @@ class Http2Stream extends Duplex {
 
   // The Http2Stream can be destroyed if it has closed and if the readable
   // side has received the final chunk.
-  [kMaybeDestroy](error, code = NGHTTP2_NO_ERROR, hasData = true) {
+  [kMaybeDestroy](error, code = NGHTTP2_NO_ERROR) {
     if (error == null) {
       if (code === NGHTTP2_NO_ERROR &&
-          ((!this._readableState.ended && hasData) ||
+          (!this._readableState.ended ||
           !this._writableState.ended ||
           this._writableState.pendingcb > 0 ||
           !this.closed)) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -303,15 +303,14 @@ MaybeLocal<Object> New(Environment* env, size_t length) {
         data,
         length,
         ArrayBufferCreationMode::kInternalized);
-  Local<Uint8Array> ui = Uint8Array::New(ab, 0, length);
-  Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
-  if (mb.FromMaybe(false))
-    return scope.Escape(ui);
+  MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
-  // Object failed to be created. Clean up resources.
-  free(data);
-  return Local<Object>();
+  if (ui.IsEmpty()) {
+    // Object failed to be created. Clean up resources.
+    free(data);
+  }
+
+  return scope.Escape(ui.FromMaybe(Local<Uint8Array>()));
 }
 
 
@@ -349,15 +348,14 @@ MaybeLocal<Object> Copy(Environment* env, const char* data, size_t length) {
         new_data,
         length,
         ArrayBufferCreationMode::kInternalized);
-  Local<Uint8Array> ui = Uint8Array::New(ab, 0, length);
-  Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
-  if (mb.FromMaybe(false))
-    return scope.Escape(ui);
+  MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
-  // Object failed to be created. Clean up resources.
-  free(new_data);
-  return Local<Object>();
+  if (ui.IsEmpty()) {
+    // Object failed to be created. Clean up resources.
+    free(new_data);
+  }
+
+  return scope.Escape(ui.FromMaybe(Local<Uint8Array>()));
 }
 
 
@@ -392,15 +390,14 @@ MaybeLocal<Object> New(Environment* env,
   // correct.
   if (data == nullptr)
     ab->Neuter();
-  Local<Uint8Array> ui = Uint8Array::New(ab, 0, length);
-  Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
+  MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
-  if (!mb.FromMaybe(false))
+  if (ui.IsEmpty()) {
     return Local<Object>();
+  }
 
   CallbackInfo::New(env->isolate(), ab, callback, data, hint);
-  return scope.Escape(ui);
+  return scope.Escape(ui.ToLocalChecked());
 }
 
 
@@ -415,8 +412,6 @@ MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
 
 
 MaybeLocal<Object> New(Environment* env, char* data, size_t length) {
-  EscapableHandleScope scope(env->isolate());
-
   if (length > 0) {
     CHECK_NE(data, nullptr);
     CHECK(length <= kMaxLength);
@@ -427,12 +422,7 @@ MaybeLocal<Object> New(Environment* env, char* data, size_t length) {
                        data,
                        length,
                        ArrayBufferCreationMode::kInternalized);
-  Local<Uint8Array> ui = Uint8Array::New(ab, 0, length);
-  Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
-  if (mb.FromMaybe(false))
-    return scope.Escape(ui);
-  return Local<Object>();
+  return Buffer::New(env, ab, 0, length).FromMaybe(Local<Object>());
 }
 
 namespace {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -550,12 +550,6 @@ class Http2Stream : public AsyncWrap,
 
   inline void EmitStatistics();
 
-  inline bool HasDataChunks(bool ignore_eos = false);
-
-  inline void AddChunk(const uint8_t* data, size_t len);
-
-  inline void FlushDataChunks();
-
   // Process a Data Chunk
   void OnDataChunk(uv_buf_t* chunk);
 
@@ -740,8 +734,11 @@ class Http2Stream : public AsyncWrap,
   uint32_t current_headers_length_ = 0;  // total number of octets
   std::vector<nghttp2_header> current_headers_;
 
-  // Inbound Data... This is the data received via DATA frames for this stream.
-  std::queue<uv_buf_t> data_chunks_;
+  // This keeps track of the amount of data read from the socket while the
+  // socket was in paused mode. When `ReadStart()` is called (and not before
+  // then), we tell nghttp2 that we consumed that data to get proper
+  // backpressure handling.
+  size_t inbound_consumed_data_while_paused_ = 0;
 
   // Outbound Data... This is the data written by the JS layer that is
   // waiting to be written out to the socket.
@@ -1103,8 +1100,9 @@ class Http2Session : public AsyncWrap {
   // use this to allow timeout tracking during long-lasting writes
   uint32_t chunks_sent_since_last_write_ = 0;
 
-  uv_prepare_t* prep_ = nullptr;
-  char stream_buf_[kAllocBufferSize];
+  char* stream_buf_ = nullptr;
+  size_t stream_buf_size_ = 0;
+  v8::Local<v8::ArrayBuffer> stream_buf_ab_;
 
   size_t max_outstanding_pings_ = DEFAULT_MAX_PINGS;
   std::queue<Http2Ping*> outstanding_pings_;

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -357,6 +357,19 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
 // Mixing operator new and free() is undefined behavior so don't do that.
 v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
 
+inline
+v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
+                                   v8::Local<v8::ArrayBuffer> ab,
+                                   size_t byte_offset,
+                                   size_t length) {
+  v8::Local<v8::Uint8Array> ui = v8::Uint8Array::New(ab, byte_offset, length);
+  v8::Maybe<bool> mb =
+      ui->SetPrototype(env->context(), env->buffer_prototype_object());
+  if (mb.IsNothing())
+    return v8::MaybeLocal<v8::Uint8Array>();
+  return ui;
+}
+
 // Construct a Buffer from a MaybeStackBuffer (and also its subclasses like
 // Utf8Value and TwoByteValue).
 // If |buf| is invalidated, an empty MaybeLocal is returned, and nothing is

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -268,6 +268,17 @@ fail.
 
 If `fn` is not provided, an empty function will be used.
 
+### mustCallAsync([fn][, exact])
+* `fn` [&lt;Function>]
+* `exact` [&lt;Number>] default = 1
+* return [&lt;Function>]
+
+The same as `mustCall()`, except that it is also checked that the Promise
+returned by the function is fulfilled for each invocation of the function.
+
+The return value of the wrapped function is the return value of the original
+function, if necessary wrapped as a promise.
+
 ### mustCallAtLeast([fn][, minimum])
 * `fn` [&lt;Function>] default = () => {}
 * `minimum` [&lt;Number>] default = 1

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -501,6 +501,12 @@ exports.mustCallAtLeast = function(fn, minimum) {
   return _mustCallInner(fn, minimum, 'minimum');
 };
 
+exports.mustCallAsync = function(fn, exact) {
+  return exports.mustCall((...args) => {
+    return Promise.resolve(fn(...args)).then(exports.mustCall((val) => val));
+  }, exact);
+};
+
 function _mustCallInner(fn, criteria = 1, field) {
   if (process._exiting)
     throw new Error('Cannot use common.mustCall*() in process exit handler');

--- a/test/parallel/test-http2-backpressure.js
+++ b/test/parallel/test-http2-backpressure.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Verifies that a full HTTP2 pipeline handles backpressure.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const makeDuplexPair = require('../common/duplexpair');
+
+common.crashOnUnhandledRejection();
+
+{
+  let req;
+  const server = http2.createServer();
+  server.on('stream', common.mustCallAsync(async (stream, headers) => {
+    stream.respond({
+      'content-type': 'text/html',
+      ':status': 200
+    });
+    req._readableState.highWaterMark = 20;
+    stream._writableState.highWaterMark = 20;
+    assert.strictEqual(stream.write('A'.repeat(5)), true);
+    assert.strictEqual(stream.write('A'.repeat(40)), false);
+    assert.strictEqual(await event(req, 'data'), 'A'.repeat(5));
+    assert.strictEqual(await event(req, 'data'), 'A'.repeat(40));
+    await event(stream, 'drain');
+    assert.strictEqual(stream.write('A'.repeat(5)), true);
+    assert.strictEqual(stream.write('A'.repeat(40)), false);
+  }));
+
+  const { clientSide, serverSide } = makeDuplexPair();
+  server.emit('connection', serverSide);
+
+  const client = http2.connect('http://localhost:80', {
+    createConnection: common.mustCall(() => clientSide)
+  });
+
+  req = client.request({ ':path': '/' });
+  req.setEncoding('utf8');
+  req.end();
+}
+
+function event(ee, eventName) {
+  return new Promise((resolve) => {
+    ee.once(eventName, common.mustCall(resolve));
+  });
+}

--- a/test/parallel/test-http2-misbehaving-flow-control-paused.js
+++ b/test/parallel/test-http2-misbehaving-flow-control-paused.js
@@ -56,6 +56,9 @@ let client;
 
 const server = h2.createServer({ settings: { initialWindowSize: 36 } });
 server.on('stream', (stream) => {
+  // Set the high water mark to zero, since otherwise we still accept
+  // reads from the source stream (if we can consume them).
+  stream._readableState.highWaterMark = 0;
   stream.pause();
   stream.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',


### PR DESCRIPTION
~~The first commit is from #18020 to avoid merge conflicts.~~

*  src: introduce internal buffer slice constructor

    Add a C++ variant of `Buffer.from(arrayBuffer, offset, length)`.

* http2: refactor read mechanism

    Refactor the read mechanism to completely avoid copying.

    Instead of copying individual `DATA` frame contents into buffers,
create `ArrayBuffer` instances for all socket reads and emit
slices of those `ArrayBuffer`s to JS.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included (note that the added test passes independently of this change)
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

/cc @nodejs/http2