### PR TITLE
build,win: restore vcbuild TAG functionality

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -158,7 +158,6 @@ if defined link_module      set configure_flags=%configure_flags% %link_module%
 if defined i18n_arg         set configure_flags=%configure_flags% --with-intl=%i18n_arg%
 if defined config_flags     set configure_flags=%configure_flags% %config_flags%
 if defined target_arch      set configure_flags=%configure_flags% --dest-cpu=%target_arch%
-if defined TAG              set configure_flags=%configure_flags% --tag=%TAG%
 
 if not exist "%~dp0deps\icu" goto no-depsicu
 if "%target%"=="Clean" echo deleting %~dp0deps\icu
@@ -166,6 +165,8 @@ if "%target%"=="Clean" rmdir /S /Q %~dp0deps\icu
 :no-depsicu
 
 call :getnodeversion || exit /b 1
+
+if defined TAG set configure_flags=%configure_flags% --tag=%TAG%
 
 if "%target%"=="Clean" rmdir /Q /S "%~dp0%config%\node-v%FULLVERSION%-win-%target_arch%" > nul 2> nul
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/17299
Ref: https://github.com/nodejs/abi-stable-node/issues/289

/cc @refack @digitalinfinity @mhdawson 

Would someone mind testing this on a Windows machine please?

something like this (off the top of my head, I don't have a Windows machine to tinker with right at this moment):

```
set DISTTYPE=nightly
set DATESTRING=20180108
set COMMIT=abc123
vcbuild.bat build x64
```