### PR TITLE
fix: req.headers/req.trailers as Objects

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -739,8 +739,8 @@ req.on('response', (headers) => {
 
 When set, the `options.getTrailers()` function is called immediately after
 queuing the last chunk of payload data to be sent. The callback is passed a
-single object (with a `null` prototype) that the listener may use to specify
-the trailing header fields to send to the peer.
+single object that the listener may use to specify the trailing header fields
+to send to the peer.
 
 *Note*: The HTTP/1 specification forbids trailers from containing HTTP/2
 pseudo-header fields (e.g. `':method'`, `':path'`, etc). An `'error'` event
@@ -1198,8 +1198,8 @@ server.on('stream', (stream) => {
 
 When set, the `options.getTrailers()` function is called immediately after
 queuing the last chunk of payload data to be sent. The callback is passed a
-single object (with a `null` prototype) that the listener may use to specify
-the trailing header fields to send to the peer.
+single object that the listener may use to specify the trailing header fields
+to send to the peer.
 
 ```js
 const http2 = require('http2');
@@ -1272,8 +1272,8 @@ requests.
 
 When set, the `options.getTrailers()` function is called immediately after
 queuing the last chunk of payload data to be sent. The callback is passed a
-single object (with a `null` prototype) that the listener may use to specify
-the trailing header fields to send to the peer.
+single object that the listener may use to specify the trailing header fields
+to send to the peer.
 
 ```js
 const http2 = require('http2');
@@ -1391,8 +1391,8 @@ default behavior is to destroy the stream.
 
 When set, the `options.getTrailers()` function is called immediately after
 queuing the last chunk of payload data to be sent. The callback is passed a
-single object (with a `null` prototype) that the listener may use to specify
-the trailing header fields to send to the peer.
+single object that the listener may use to specify the trailing header fields
+to send to the peer.
 
 ```js
 const http2 = require('http2');
@@ -1967,11 +1967,6 @@ const headers = {
 
 stream.respond(headers);
 ```
-
-*Note*: Header objects passed to callback functions will have a `null`
-prototype. This means that normal JavaScript object methods such as
-`Object.prototype.toString()` and `Object.prototype.hasOwnProperty()` will
-not work.
 
 ```js
 const http2 = require('http2');

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -354,8 +354,8 @@ class Http2ServerResponse extends Stream {
       sendDate: true,
       statusCode: HTTP_STATUS_OK,
     };
-    this[kHeaders] = Object.create(null);
-    this[kTrailers] = Object.create(null);
+    this[kHeaders] = {};
+    this[kTrailers] = {};
     this[kStream] = stream;
     stream[kProxySocket] = null;
     stream[kResponse] = this;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -251,7 +251,7 @@ function onStreamTrailers() {
   const stream = this[kOwner];
   if (stream.destroyed)
     return [];
-  const trailers = Object.create(null);
+  const trailers = {};
   stream[kState].getTrailers.call(stream, trailers);
   const headersList = mapToHeaders(trailers, assertValidPseudoHeaderTrailer);
   if (!Array.isArray(headersList)) {
@@ -1299,7 +1299,7 @@ class ClientHttp2Session extends Http2Session {
     assertIsObject(headers, 'headers');
     assertIsObject(options, 'options');
 
-    headers = Object.assign(Object.create(null), headers);
+    headers = Object.assign({}, headers);
     options = Object.assign({}, options);
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
@@ -1830,7 +1830,7 @@ class Http2Stream extends Duplex {
 
 function processHeaders(headers) {
   assertIsObject(headers, 'headers');
-  headers = Object.assign(Object.create(null), headers);
+  headers = Object.assign({}, headers);
   if (headers[HTTP2_HEADER_STATUS] == null)
     headers[HTTP2_HEADER_STATUS] = HTTP_STATUS_OK;
   headers[HTTP2_HEADER_DATE] = utcDate();
@@ -2043,7 +2043,7 @@ class ServerHttp2Stream extends Http2Stream {
     options.endStream = !!options.endStream;
 
     assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
+    headers = Object.assign({}, headers);
 
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
@@ -2308,7 +2308,7 @@ class ServerHttp2Stream extends Http2Stream {
       throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
 
     assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
+    headers = Object.assign({}, headers);
 
     const session = this[kSession];
     debug(`Http2Stream ${this[kID]} [Http2Session ` +

--- a/test/parallel/test-http2-multiheaders.js
+++ b/test/parallel/test-http2-multiheaders.js
@@ -23,12 +23,9 @@ src['X-FOO'] = 'baz';
 src.constructor = 'foo';
 src.Constructor = 'bar';
 src.CONSTRUCTOR = 'baz';
-// eslint-disable-next-line no-proto
-src['__proto__'] = 'foo';
-src['__PROTO__'] = 'bar';
-src['__Proto__'] = 'baz';
 
 function checkHeaders(headers) {
+  assert(headers instanceof Object);
   assert.deepStrictEqual(headers['accept'],
                          'abc, def, ghijklmnop');
   assert.deepStrictEqual(headers['www-authenticate'],
@@ -37,8 +34,6 @@ function checkHeaders(headers) {
                          'foo, bar, baz');
   assert.deepStrictEqual(headers['x-foo'], 'foo, bar, baz');
   assert.deepStrictEqual(headers['constructor'], 'foo, bar, baz');
-  // eslint-disable-next-line no-proto
-  assert.deepStrictEqual(headers['__proto__'], 'foo, bar, baz');
 }
 
 server.on('stream', common.mustCall((stream, headers) => {


### PR DESCRIPTION
This matches http1 IncomingMessage headers for backwards compatibility.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2