### PR TITLE
deps: cherry-pick 0c35b72 from upstream V8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -27,7 +27,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.5',
+    'v8_embedder_string': '-node.6',
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,

--- a/deps/v8/src/api.cc
+++ b/deps/v8/src/api.cc
@@ -2230,9 +2230,8 @@ Location Module::GetModuleRequestLocation(int i) const {
 
 Local<Value> Module::GetModuleNamespace() {
   Utils::ApiCheck(
-      GetStatus() == kEvaluated, "v8::Module::GetModuleNamespace",
-      "v8::Module::GetModuleNamespace can only be used on a module with "
-      "status kEvaluated");
+      GetStatus() >= kInstantiated, "v8::Module::GetModuleNamespace",
+      "v8::Module::GetModuleNamespace must be used on an instantiated module");
   i::Handle<i::Module> self = Utils::OpenHandle(this);
   i::Handle<i::JSModuleNamespace> module_namespace =
       i::Module::GetModuleNamespace(self);


### PR DESCRIPTION
cherry pick a fix for v8::Module::GetModuleNamespace for #17560 

Original commit message:

    [api,modules] Allow GetModuleNamespace on unevaluated modules.

    Bug: v8:7217
    Cq-Include-Trybots: master.tryserver.chromium.linux:linux_chromium_rel_ng
    Change-Id: I97b067254355eb91e12b92eba92631cbc3ce8000
    Reviewed-on: https://chromium-review.googlesource.com/839280
    Commit-Queue: Georg Neis <neis@chromium.org>
    Reviewed-by: Adam Klein <adamk@chromium.org>
    Cr-Commit-Position: refs/heads/master@{#50395}

Refs: https://github.com/v8/v8/commit/0c35b7252aaeedf4871a78935075808439726853

##### Checklist
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
deps/v8
  
  