### PR TITLE
build: fix Makefile wrt finding node executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ COVTESTS ?= test-cov
 GTEST_FILTER ?= "*"
 GNUMAKEFLAGS += --no-print-directory
 GCOV ?= gcov
+PWD = $(CURDIR)
 
 ifdef JOBS
   PARALLEL_ARGS = -j $(JOBS)
@@ -609,7 +610,7 @@ out/doc/api/assets/%: doc/api_assets/% out/doc/api/assets
 available-node = \
   if [ -x $(PWD)/$(NODE) ] && [ -e $(PWD)/$(NODE) ]; then \
 		$(PWD)/$(NODE) $(1); \
-	elif [ -x `which node` ] && [ -e `which node` ]; then \
+	elif [ -x `which node` ] && [ -e `which node` ] && [ `which node` ]; then \
 		`which node` $(1); \
 	else \
 		echo "No available node, cannot run \"node $(1)\""; \


### PR DESCRIPTION
Not all shells set `PWD`, so use `CURDIR` instead.

`` `which node` `` may return the empty string, so guard against
that too. Consider:
```
if [ -x `which velociraptor` ] && [ -e `which velociprator` ];\
then echo "run"; else echo "keep calm"; fi;
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
build
