### PR TITLE
tools: non-Ascii linter for /lib only

### DIFF
--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -6,3 +6,4 @@ rules:
   buffer-constructor: error
   no-let-in-for-declaration: error
   lowercase-name-for-primitive: error
+  non-ascii-character: error

--- a/lib/console.js
+++ b/lib/console.js
@@ -84,7 +84,7 @@ function createWriteErrorHandler(stream) {
       // If there was an error, it will be emitted on `stream` as
       // an `error` event. Adding a `once` listener will keep that error
       // from becoming an uncaught exception, but since the handler is
-      // removed after the event, non-console.* writes won’t be affected.
+      // removed after the event, non-console.* writes won't be affected.
       // we are only adding noop if there is no one else listening for 'error'
       if (stream.listenerCount('error') === 0) {
         stream.on('error', noop);
@@ -125,7 +125,7 @@ function write(ignoreErrors, stream, string, errorhandler, groupIndent) {
     // even in edge cases such as low stack space.
     if (e.message === MAX_STACK_MESSAGE && e.name === 'RangeError')
       throw e;
-    // Sorry, there’s no proper way to pass along the error here.
+    // Sorry, there's no proper way to pass along the error here.
   } finally {
     stream.removeListener('error', noop);
   }

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1885,7 +1885,7 @@ function processRespondWithFD(self, fd, headers, offset = 0, length = -1,
     return;
   }
   // exact length of the file doesn't matter here, since the
-  // stream is closing anyway — just use 1 to signify that
+  // stream is closing anyway - just use 1 to signify that
   // a write does exist
   trackWriteState(self, 1);
 }

--- a/lib/internal/test/unicode.js
+++ b/lib/internal/test/unicode.js
@@ -3,4 +3,4 @@
 // This module exists entirely for regression testing purposes.
 // See `test/parallel/test-internal-unicode.js`.
 
-module.exports = '✓';
+module.exports = '✓'; // eslint-disable-line

--- a/lib/internal/test/unicode.js
+++ b/lib/internal/test/unicode.js
@@ -3,4 +3,6 @@
 // This module exists entirely for regression testing purposes.
 // See `test/parallel/test-internal-unicode.js`.
 
-module.exports = '✓'; // eslint-disable-line
+/* eslint-disable non-ascii-character */
+module.exports = '✓';
+/* eslint-enable non-ascii-character */

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -45,7 +45,7 @@ try {
   try {
     Stream._isUint8Array = process.binding('util').isUint8Array;
   } catch (e) {
-    // This throws for Node < 4.2.0 because there’s no util binding and
+    // This throws for Node < 4.2.0 because there's no util binding and
     // returns undefined for Node < 7.4.0.
   }
 }

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -97,6 +97,7 @@ const Timeout = timerInternals.Timeout;
 // TimerWrap C++ handle, which makes the call after the duration to process the
 // list it is attached to.
 //
+// eslint-disable non-ascii-character
 //
 // ╔════ > Object Map
 // ║
@@ -118,6 +119,7 @@ const Timeout = timerInternals.Timeout;
 // ║
 // ╚════ > Linked List
 //
+// eslint-enable non-ascii-character
 //
 // With this, virtually constant-time insertion (append), removal, and timeout
 // is possible in the JavaScript layer. Any one list of timers is able to be

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -97,7 +97,7 @@ const Timeout = timerInternals.Timeout;
 // TimerWrap C++ handle, which makes the call after the duration to process the
 // list it is attached to.
 //
-// eslint-disable non-ascii-character
+/* eslint-disable non-ascii-character */
 //
 // ╔════ > Object Map
 // ║
@@ -119,7 +119,7 @@ const Timeout = timerInternals.Timeout;
 // ║
 // ╚════ > Linked List
 //
-// eslint-enable non-ascii-character
+/* eslint-enable non-ascii-character */
 //
 // With this, virtually constant-time insertion (append), removal, and timeout
 // is possible in the JavaScript layer. Any one list of timers is able to be

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -374,7 +374,7 @@ Zlib.prototype.flush = function flush(kind, callback) {
     this._scheduledFlushFlag = maxFlush(kind, this._scheduledFlushFlag);
 
     // If a callback was passed, always register a new `drain` + flush handler,
-    // mostly because that’s simpler and flush callbacks piling up is a rare
+    // mostly because that's simpler and flush callbacks piling up is a rare
     // thing anyway.
     if (!alreadyHadFlushScheduled || callback) {
       const drainHandler = () => this.flush(this._scheduledFlushFlag, callback);

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -26,13 +26,14 @@ const suggestions = {
 
 module.exports = (context) => {
 
-  const reportIfError = (node, text) => {
+  const reportIfError = (node, sourceCode) => {
 
-    const matches = text.match(nonAsciiRegexPattern);
+    const matches = sourceCode.text.match(nonAsciiRegexPattern);
 
     if (!matches) return;
 
     const offendingCharacter = matches[0];
+    const offendingCharacterPosition = matches.index;
     const suggestion = suggestions[offendingCharacter];
 
     let message = `Non-ASCII character '${offendingCharacter}' detected.`;
@@ -44,6 +45,7 @@ module.exports = (context) => {
     context.report({
       node,
       message,
+      loc: sourceCode.getLocFromIndex(offendingCharacterPosition),
       fix: (fixer) => {
         return fixer.replaceText(
           node,
@@ -54,6 +56,6 @@ module.exports = (context) => {
   };
 
   return {
-    Program: (node) => reportIfError(node, context.getSourceCode().text)
+    Program: (node) => reportIfError(node, context.getSourceCode())
   };
 };

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -1,0 +1,57 @@
+/**
+ * @fileOverview Any non-ASCII characters in lib/ will increase the size
+ *               of the compiled node binary. This linter rule ensures that
+ *               any such character is reported.
+ * @author Sarat Addepalli <sarat.addepalli@gmail.com>
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const nonAsciiSelector = 'Literal[value=/[^\n\x20-\x7e]/]';
+const nonAsciiRegexPattern = new RegExp(/[^\n\x20-\x7e]/);
+const suggestions = {
+  '’': '\'',
+  '‛': '\'',
+  '‘': '\'',
+  '“': '"',
+  '‟': '"',
+  '”': '"',
+  '«': '"',
+  '»': '"',
+  '—': '-'
+};
+
+module.exports = (context) => {
+
+  const reportError = (node) => {
+
+    const nodeValue = node.value;
+    const offendingCharacter = nodeValue.match(nonAsciiRegexPattern)[0];
+    const suggestion = suggestions[offendingCharacter];
+
+    let message = `Non-ASCII character '${offendingCharacter}' detected.`;
+
+    message = suggestion ?
+      `${message} Consider replacing with: ${suggestion}` :
+      message;
+
+    context.report({
+      node,
+      message,
+      fix: (fixer) => {
+        return fixer.replaceText(
+          node,
+          suggestion ? `${suggestion}` : ''
+        );
+      }
+    });
+  };
+
+  return {
+    [nonAsciiSelector]: (node) => reportError(node, context)
+  };
+};

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -11,7 +11,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const nonAsciiRegexPattern = new RegExp(/[^\r\n\x20-\x7e]/);
+const nonAsciiRegexPattern = /[^\r\n\x20-\x7e]/;
 const suggestions = {
   '’': '\'',
   '‛': '\'',
@@ -26,10 +26,9 @@ const suggestions = {
 
 module.exports = (context) => {
 
-  const reportIfError = (node, token) => {
+  const reportIfError = (node, text) => {
 
-    const { value } = token;
-    const matches = value.match(nonAsciiRegexPattern);
+    const matches = text.match(nonAsciiRegexPattern);
 
     if (!matches) return;
 
@@ -55,13 +54,6 @@ module.exports = (context) => {
   };
 
   return {
-    Program: (node) => {
-      const source = context.getSourceCode();
-      const sourceTokens = source.getTokens(node);
-      const commentTokens = source.getAllComments();
-      const tokens = sourceTokens.concat(commentTokens);
-
-      tokens.forEach((token) => reportIfError(node, token));
-    }
+    Program: (node) => reportIfError(node, context.getSourceCode().text)
   };
 };


### PR DESCRIPTION
Non-ASCII characters in /lib get compiled into the node binary,
and may bloat the binary size unnecessarily. A linter rule may
help prevent this.

Fixes: #11209

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md

- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
`eslint`
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
