### PR TITLE
perf_hooks,http2: add clearEntries to remove http2 entries

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -29,6 +29,14 @@ added: v8.5.0
 The `Performance` provides access to performance metric data. A single
 instance of this class is provided via the `performance` property.
 
+### performance.clearEntries(name)
+<!-- YAML
+added: REPLACEME
+-->
+
+Remove all performance entry objects with `entryType` equal to `name` from the
+Performance Timeline.
+
 ### performance.clearFunctions([name])
 <!-- YAML
 added: v8.5.0
@@ -38,13 +46,6 @@ added: v8.5.0
 
 If `name` is not provided, removes all `PerformanceFunction` objects from the
 Performance Timeline. If `name` is provided, removes entries with `name`.
-
-### performance.clearHttp2()
-<!-- YAML
-added: REPLACEME
--->
-
-Remove all `http2` performance entry objects from the Performance Timeline.
 
 ### performance.clearMarks([name])
 <!-- YAML

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -39,6 +39,13 @@ added: v8.5.0
 If `name` is not provided, removes all `PerformanceFunction` objects from the
 Performance Timeline. If `name` is provided, removes entries with `name`.
 
+### performance.clearHttp2()
+<!-- YAML
+added: REPLACEME
+-->
+
+Remove all `http2` performance entry objects from the Performance Timeline.
+
 ### performance.clearMarks([name])
 <!-- YAML
 added: v8.5.0

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -471,8 +471,8 @@ class Performance extends PerformanceObserverEntryList {
     this[kClearEntry]('function', name);
   }
 
-  clearHttp2() {
-    this[kClearEntry]('http2');
+  clearEntries(name) {
+    this[kClearEntry](name);
   }
 
   timerify(fn) {

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -471,6 +471,10 @@ class Performance extends PerformanceObserverEntryList {
     this[kClearEntry]('function', name);
   }
 
+  clearHttp2() {
+    this[kClearEntry]('http2');
+  }
+
   timerify(fn) {
     if (typeof fn !== 'function') {
       const errors = lazyErrors();

--- a/test/parallel/test-http2-perf_hooks.js
+++ b/test/parallel/test-http2-perf_hooks.js
@@ -46,7 +46,7 @@ const obs = new PerformanceObserver(common.mustCall((items) => {
     default:
       assert.fail('invalid entry name');
   }
-  performance.clearHttp2();
+  performance.clearEntries('http2');
 }, 4));
 obs.observe({ entryTypes: ['http2'] });
 
@@ -103,6 +103,8 @@ server.on('listening', common.mustCall(() => {
 }));
 
 process.on('exit', () => {
+  const entries = performance.getEntries();
   // There shouldn't be any http2 entries left over.
-  assert.strictEqual(performance.getEntries().length, 1);
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(entries[0], performance.nodeTiming);
 });

--- a/test/parallel/test-http2-perf_hooks.js
+++ b/test/parallel/test-http2-perf_hooks.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const h2 = require('http2');
 
-const { PerformanceObserver } = require('perf_hooks');
+const { PerformanceObserver, performance } = require('perf_hooks');
 
 const obs = new PerformanceObserver(common.mustCall((items) => {
   const entry = items.getEntries()[0];
@@ -46,6 +46,7 @@ const obs = new PerformanceObserver(common.mustCall((items) => {
     default:
       assert.fail('invalid entry name');
   }
+  performance.clearHttp2();
 }, 4));
 obs.observe({ entryTypes: ['http2'] });
 
@@ -100,3 +101,8 @@ server.on('listening', common.mustCall(() => {
   }));
 
 }));
+
+process.on('exit', () => {
+  // There shouldn't be any http2 entries left over.
+  assert.strictEqual(performance.getEntries().length, 1);
+});


### PR DESCRIPTION
Add missing clearHttp2 method to `perf_hooks.performance` to
remove the http2 entries from the master timeline to prevent
that from being a memory leak.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2, perf_hooks