### PR TITLE
perf_hooks: fix scheduling regression

### DIFF
--- a/test/parallel/test-performance-gc.js
+++ b/test/parallel/test-performance-gc.js
@@ -51,3 +51,13 @@ const kinds = [
   // Keep the event loop alive to witness the GC async callback happen.
   setImmediate(() => setImmediate(() => 0));
 }
+
+// GC should not keep the event loop alive
+{
+  let didCall = false;
+  process.on('beforeExit', () => {
+    assert(!didCall);
+    didCall = true;
+    global.gc();
+  });
+}


### PR DESCRIPTION
Scheduling a `PerformanceGCCallback` should not keep the event loop alive but due to the recent switch to using the native `SetImmediate` method, it does. Go back to using `uv_async_t` and add a regression test.

The reason this was uncovered by the `http2` binding is that it takes just long enough to do the GC on all the string constants that it creates that this race condition was triggered. (I finally uncovered this when the problem went away simply by commenting out `HTTP_KNOWN_HEADERS(STRING_CONSTANT)` in `node::http2::Initialize`.)

Refs: https://github.com/nodejs/node/pull/18020
Fixes: https://github.com/nodejs/node/issues/18047

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
perf_hooks, src
  
  