### PR TITLE
build: allow x86_64 as a dest_cpu alias for x64

### DIFF
--- a/configure
+++ b/configure
@@ -61,7 +61,7 @@ parser = optparse.OptionParser()
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
             'android', 'aix', 'cloudabi')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
-              'ppc64', 'x32','x64', 'x86', 's390', 's390x')
+              'ppc64', 'x32','x64', 'x86', 'x86_64', 's390', 's390x')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')
 valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
 valid_mips_arch = ('loongson', 'r1', 'r2', 'r6', 'rx')
@@ -861,6 +861,9 @@ def configure_node(o):
   # the Makefile resets this to x86 afterward
   if target_arch == 'x86':
     target_arch = 'ia32'
+  # x86_64 is common across linuxes, allow it as an alias for x64
+  if target_arch == 'x86_64':
+    target_arch = 'x64'
   o['variables']['host_arch'] = host_arch
   o['variables']['target_arch'] = target_arch
   o['variables']['node_byteorder'] = sys.byteorder


### PR DESCRIPTION
`x86_64` is a standard for Linux in many places so when we (in Build) want to match `--dest-cpu` to the platform arch we have to do some rewriting, manual or scripted. This change introduces `x86_64` as a possible alias for `x64` in _configure_. It trickles down from _configure_ as `x64` so it's only a simple alias at the top level.

@nodejs/build 