### PR TITLE
http2: fix kUpdateTimer timer refresh

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1478,7 +1478,7 @@ class Http2Stream extends Duplex {
     if (this.destroyed)
       return;
     if (this[kTimeout])
-      _unrefActive([kTimeout]);
+      _unrefActive(this[kTimeout]);
     if (this[kSession])
       this[kSession][kUpdateTimer]();
   }


### PR DESCRIPTION
Fixes an oversight from 93eb68e6d23c66b85e8f79540500d5d9f0bbc396 😬 

Wasn't caught by a test... @nodejs/http2 anyone have suggestions on how to write a test? Or if you want to write one and push it here that would be fine too.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes _(Unfortunately)_
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2