### PR TITLE
n-api: expose n-api version in process.versions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3032,6 +3032,12 @@ void SetupProcessObject(Environment* env,
                     "nghttp2",
                     FIXED_ONE_BYTE_STRING(env->isolate(), NGHTTP2_VERSION));
 
+  const char node_napi_version[] = NODE_STRINGIFY(NAPI_VERSION);
+  READONLY_PROPERTY(
+      versions,
+      "napi",
+      FIXED_ONE_BYTE_STRING(env->isolate(), node_napi_version));
+
   // process._promiseRejectEvent
   Local<Object> promiseRejectEvent = Object::New(env->isolate());
   READONLY_DONT_ENUM_PROPERTY(process,

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -18,8 +18,6 @@
 #include "node_api.h"
 #include "node_internals.h"
 
-#define NAPI_VERSION  2
-
 static
 napi_status napi_set_last_error(napi_env env, napi_status error_code,
                                 uint32_t engine_error_code = 0,

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -109,4 +109,7 @@
  */
 #define NODE_MODULE_VERSION 60
 
+// the NAPI_VERSION provided by this version of the runtime
+#define NAPI_VERSION  2
+
 #endif  // SRC_NODE_VERSION_H_

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const expected_keys = ['ares', 'http_parser', 'modules', 'node',
-                       'uv', 'v8', 'zlib', 'nghttp2'];
+                       'uv', 'v8', 'zlib', 'nghttp2', 'napi'];
 
 if (common.hasCrypto) {
   expected_keys.push('openssl');


### PR DESCRIPTION
Expose n-api version in process.versions so that it is
available for use in javascript by external modules
like node-pre-gyp. It was previously accessible through
a functon available in the N-API.

##### Checklist
- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] tests and/or benchmarks are included
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
n-api, core