### PR TITLE
dns: add basic perf_hooks support

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -646,6 +646,25 @@ processing that happens on libuv's threadpool that [`dns.lookup()`][] can have.
 They do not use the same set of configuration files than what [`dns.lookup()`][]
 uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 
+## Monitoring DNS Performance
+
+The [Performance Observer][] API may be used to monitor the duration of DNS
+operations:
+
+```js
+const dns = require('dns');
+const { PerformanceObserver, performance } = require('perf_hooks');
+
+const obs = new PerformanceObserver((items) => {
+  const entry = items.getEntries()[0];
+  console.log(entry.name); // example.org
+  console.log(entry.entryType); // dns
+  console.log(entry.startTime);
+  console.log(entry.duration);
+  performance.clearDNS(); // Always clear to prevent memory leaks
+});
+```
+
 [`Error`]: errors.html#errors_class_error
 [`UV_THREADPOOL_SIZE`]: cli.html#cli_uv_threadpool_size_size
 [`dgram.createSocket()`]: dgram.html#dgram_dgram_createsocket_options_callback
@@ -669,5 +688,6 @@ uses. For instance, _they do not use the configuration from `/etc/hosts`_.
 [`util.promisify()`]: util.html#util_util_promisify_original
 [DNS error codes]: #dns_error_codes
 [Implementation considerations section]: #dns_implementation_considerations
+[Performance Observer]: perf_hooks.html
 [rfc5952]: https://tools.ietf.org/html/rfc5952#section-6
 [supported `getaddrinfo` flags]: #dns_supported_getaddrinfo_flags

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -254,8 +254,8 @@ added: v8.5.0
 
 * {string}
 
-The type of the performance entry. Current it may be one of: `'node'`, `'mark'`,
-`'measure'`, `'gc'`, or `'function'`.
+The type of the performance entry. Currently it may be one of: `'node'`,
+`'mark'`, `'measure'`, `'gc'`, `'function'`, `'http2'`, or `'dns'`.
 
 ### performanceEntry.kind
 <!-- YAML

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -19,6 +19,7 @@ const {
   NODE_PERFORMANCE_ENTRY_TYPE_GC,
   NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION,
   NODE_PERFORMANCE_ENTRY_TYPE_HTTP2,
+  NODE_PERFORMANCE_ENTRY_TYPE_DNS,
 
   NODE_PERFORMANCE_MILESTONE_NODE_START,
   NODE_PERFORMANCE_MILESTONE_V8_START,
@@ -63,7 +64,8 @@ const observerableTypes = [
   'measure',
   'gc',
   'function',
-  'http2'
+  'http2',
+  'dns'
 ];
 
 const IDX_STREAM_STATS_ID = 0;
@@ -579,6 +581,7 @@ function mapTypes(i) {
     case 'gc': return NODE_PERFORMANCE_ENTRY_TYPE_GC;
     case 'function': return NODE_PERFORMANCE_ENTRY_TYPE_FUNCTION;
     case 'http2': return NODE_PERFORMANCE_ENTRY_TYPE_HTTP2;
+    case 'dns': return NODE_PERFORMANCE_ENTRY_TYPE_DNS;
   }
 }
 

--- a/src/node_perf_common.h
+++ b/src/node_perf_common.h
@@ -39,7 +39,8 @@ extern uint64_t performance_v8_start;
   V(MEASURE, "measure")                                                       \
   V(GC, "gc")                                                                 \
   V(FUNCTION, "function")                                                     \
-  V(HTTP2, "http2")
+  V(HTTP2, "http2")                                                           \
+  V(DNS, "dns")
 
 enum PerformanceMilestone {
 #define V(name, _) NODE_PERFORMANCE_MILESTONE_##name,

--- a/test/parallel/test-dns-perf_hooks.js
+++ b/test/parallel/test-dns-perf_hooks.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const dns = require('dns');
+const dnstools = require('../common/dns');
+const dgram = require('dgram');
+const Countdown = require('../common/countdown');
+
+const { PerformanceObserver, performance } = require('perf_hooks');
+
+const obs = new PerformanceObserver(common.mustCall((items) => {
+  const entry = items.getEntries()[0];
+  assert.strictEqual(entry.name, 'example.org');
+  assert.strictEqual(entry.entryType, 'dns');
+  assert.strictEqual(typeof entry.startTime, 'number');
+  assert.strictEqual(typeof entry.duration, 'number');
+  performance.clearDNS();
+}, 3));
+obs.observe({ entryTypes: ['dns'] });
+
+const answers = [
+  { type: 'A', address: '1.2.3.4', ttl: 123 },
+  { type: 'AAAA', address: '::42', ttl: 123 }
+];
+
+const server = dgram.createSocket('udp4');
+
+const countdown = new Countdown(3, () => server.close());
+
+server.on('message', common.mustCall((msg, { address, port }) => {
+  const parsed = dnstools.parseDNSPacket(msg);
+  const domain = parsed.questions[0].domain;
+
+  server.send(dnstools.writeDNSPacket({
+    id: parsed.id,
+    questions: parsed.questions,
+    answers: answers.map((answer) => Object.assign({ domain }, answer)),
+  }), port, address);
+}, 3));
+
+server.bind(0, common.mustCall(() => {
+  const address = server.address();
+  dns.setServers([`127.0.0.1:${address.port}`]);
+
+  dns.resolveAny('example.org', common.mustCall(() => countdown.dec()));
+  dns.resolve4('example.org', common.mustCall(() => countdown.dec()));
+  dns.resolve6('example.org', common.mustCall(() => countdown.dec()));
+}));


### PR DESCRIPTION
emit simple perf_hooks timings for dns operations.

```js
const { PerformanceObserver, performance } = require('perf_hooks');
const obs = new PerformanceObserver((items) => {
  const entry = items.getEntries()[0];
  console.log(entry.name, entry.duration);
  performance.clearDNS();
});
obs.observe({ entryTypes: ['dns'] });

dns.resolveAny('example.org', console.log);
```

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
dns, perf_hooks