### PR TITLE
perf_hooks: add warning when too many entries in the timeline

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -137,6 +137,8 @@ Performance Timeline. This limit is not strictly enforced, but a process
 warning will be emitted if the number of entries in the timeline exceeds
 this limit.
 
+Defaults to 150.
+
 ### performance.measure(name, startMark, endMark)
 <!-- YAML
 added: v8.5.0

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -125,6 +125,18 @@ Creates a new `PerformanceMark` entry in the Performance Timeline. A
 `performanceEntry.duration` is always `0`. Performance marks are used
 to mark specific significant moments in the Performance Timeline.
 
+### performance.maxBufferSize
+<!-- YAML
+added: REPLACEME
+-->
+
+Value: {number}
+
+The maximum number of Performance Entry items that should be added to the
+Performance Timeline. This limit is not strictly enforced, but a process
+warning will be emitted if the number of entries in the timeline exceeds
+this limit.
+
 ### performance.measure(name, startMark, endMark)
 <!-- YAML
 added: v8.5.0

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -125,7 +125,7 @@ Creates a new `PerformanceMark` entry in the Performance Timeline. A
 `performanceEntry.duration` is always `0`. Performance marks are used
 to mark specific significant moments in the Performance Timeline.
 
-### performance.maxBufferSize
+### performance.maxEntries
 <!-- YAML
 added: REPLACEME
 -->

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -53,6 +53,9 @@ const kClearEntry = Symbol('clear-entry');
 const kGetEntries = Symbol('get-entries');
 const kIndex = Symbol('index');
 const kMarks = Symbol('marks');
+const kCount = Symbol('count');
+const kMaxCount = Symbol('max-count');
+const kDefaultMaxCount = 150;
 
 observerCounts[NODE_PERFORMANCE_ENTRY_TYPE_MARK] = 1;
 observerCounts[NODE_PERFORMANCE_ENTRY_TYPE_MEASURE] = 1;
@@ -250,10 +253,17 @@ const nodeTiming = new PerformanceNodeTiming();
 // Maintains a list of entries as a linked list stored in insertion order.
 class PerformanceObserverEntryList {
   constructor() {
-    Object.defineProperty(this, kEntries, {
-      writable: true,
-      enumerable: false,
-      value: {}
+    Object.defineProperties(this, {
+      [kEntries]: {
+        writable: true,
+        enumerable: false,
+        value: {}
+      },
+      [kCount]: {
+        writable: true,
+        enumerable: false,
+        value: 0
+      }
     });
     L.init(this[kEntries]);
   }
@@ -261,7 +271,12 @@ class PerformanceObserverEntryList {
   [kInsertEntry](entry) {
     const item = { entry };
     L.append(this[kEntries], item);
+    this[kCount]++;
     this[kIndexEntry](item);
+  }
+
+  get length() {
+    return this[kCount];
   }
 
   [kIndexEntry](entry) {
@@ -384,7 +399,20 @@ class Performance extends PerformanceObserverEntryList {
     this[kIndex] = {
       [kMarks]: new Set()
     };
+    this[kMaxCount] = kDefaultMaxCount;
     this[kInsertEntry](nodeTiming);
+  }
+
+  set maxBufferSize(val) {
+    if (typeof val !== 'number' || val >>> 0 !== val) {
+      const errors = lazyErrors();
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'val', 'number');
+    }
+    this[kMaxCount] = Math.max(1, val >>> 0);
+  }
+
+  get maxBufferSize() {
+    return this[kMaxCount];
   }
 
   [kIndexEntry](item) {
@@ -397,6 +425,17 @@ class Performance extends PerformanceObserverEntryList {
     }
     const entry = item.entry;
     L.append(items, { entry, item });
+    const count = this[kCount];
+    if (count > this[kMaxCount]) {
+      const text = count === 1 ? 'is 1 entry' : `are ${count} entries`;
+      process.emitWarning('Possible perf_hooks memory leak detected. ' +
+                          `There ${text} in the ` +
+                          'Performance Timeline. Use the clear methods ' +
+                          'to remove entries that are no longer needed or ' +
+                          'set performance.maxBufferSize equal to a higher ' +
+                          'value (currently the maxBufferSize is ' +
+                          `${this[kMaxCount]}).`);
+    }
   }
 
   [kClearEntry](type, name) {
@@ -411,10 +450,12 @@ class Performance extends PerformanceObserverEntryList {
         if (entry.name === `${name}`) {
           L.remove(item); // remove from the index
           L.remove(item.item); // remove from the master
+          this[kCount]--;
         }
       } else {
         L.remove(item); // remove from the index
         L.remove(item.item); // remove from the master
+        this[kCount]--;
       }
       item = next;
     }

--- a/lib/perf_hooks.js
+++ b/lib/perf_hooks.js
@@ -403,7 +403,7 @@ class Performance extends PerformanceObserverEntryList {
     this[kInsertEntry](nodeTiming);
   }
 
-  set maxBufferSize(val) {
+  set maxEntries(val) {
     if (typeof val !== 'number' || val >>> 0 !== val) {
       const errors = lazyErrors();
       throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'val', 'number');
@@ -411,7 +411,7 @@ class Performance extends PerformanceObserverEntryList {
     this[kMaxCount] = Math.max(1, val >>> 0);
   }
 
-  get maxBufferSize() {
+  get maxEntries() {
     return this[kMaxCount];
   }
 
@@ -432,8 +432,8 @@ class Performance extends PerformanceObserverEntryList {
                           `There ${text} in the ` +
                           'Performance Timeline. Use the clear methods ' +
                           'to remove entries that are no longer needed or ' +
-                          'set performance.maxBufferSize equal to a higher ' +
-                          'value (currently the maxBufferSize is ' +
+                          'set performance.maxEntries equal to a higher ' +
+                          'value (currently the maxEntries is ' +
                           `${this[kMaxCount]}).`);
     }
   }

--- a/test/parallel/test-performance-warning.js
+++ b/test/parallel/test-performance-warning.js
@@ -6,13 +6,13 @@ const { performance } = require('perf_hooks');
 const assert = require('assert');
 
 assert.strictEqual(performance.length, 1);
-assert.strictEqual(performance.maxBufferSize, 150);
+assert.strictEqual(performance.maxEntries, 150);
 
-performance.maxBufferSize = 1;
+performance.maxEntries = 1;
 
 [-1, 0xffffffff + 1, '', null, undefined, Infinity].forEach((i) => {
   common.expectsError(
-    () => performance.maxBufferSize = i,
+    () => performance.maxEntries = i,
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
@@ -23,7 +23,7 @@ performance.maxBufferSize = 1;
 common.expectWarning('Warning', [
   'Possible perf_hooks memory leak detected. There are 2 entries in the ' +
   'Performance Timeline. Use the clear methods to remove entries that are no ' +
-  'longer needed or set performance.maxBufferSize equal to a higher value ' +
-  '(currently the maxBufferSize is 1).']);
+  'longer needed or set performance.maxEntries equal to a higher value ' +
+  '(currently the maxEntries is 1).']);
 
 performance.mark('test');

--- a/test/parallel/test-performance-warning.js
+++ b/test/parallel/test-performance-warning.js
@@ -1,0 +1,29 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+const { performance } = require('perf_hooks');
+const assert = require('assert');
+
+assert.strictEqual(performance.length, 1);
+assert.strictEqual(performance.maxBufferSize, 150);
+
+performance.maxBufferSize = 1;
+
+[-1, 0xffffffff + 1, '', null, undefined, Infinity].forEach((i) => {
+  common.expectsError(
+    () => performance.maxBufferSize = i,
+    {
+      code: 'ERR_INVALID_ARG_TYPE',
+      type: TypeError
+    }
+  );
+});
+
+common.expectWarning('Warning', [
+  'Possible perf_hooks memory leak detected. There are 2 entries in the ' +
+  'Performance Timeline. Use the clear methods to remove entries that are no ' +
+  'longer needed or set performance.maxBufferSize equal to a higher value ' +
+  '(currently the maxBufferSize is 1).']);
+
+performance.mark('test');


### PR DESCRIPTION
Due to quirks in how the performance API is defined, there is a non-zero risk of memory leaks. Add an upper limit and emit a warning if it is reached.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
perf_hooks
