### PR TITLE
doc: update pushStream docs to use err first

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1174,14 +1174,16 @@ added: v8.4.0
 * Returns: {undefined}
 
 Initiates a push stream. The callback is invoked with the new `Http2Stream`
-instance created for the push stream.
+instance created for the push stream passed as the second argument, or an
+`Error` passed as the first argument.
 
 ```js
 const http2 = require('http2');
 const server = http2.createServer();
 server.on('stream', (stream) => {
   stream.respond({ ':status': 200 });
-  stream.pushStream({ ':path': '/' }, (pushStream) => {
+  stream.pushStream({ ':path': '/' }, (err, pushStream) => {
+    if (err) throw err;
     pushStream.respond({ ':status': 200 });
     pushStream.end('some pushed data');
   });

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1015,7 +1015,7 @@ const { NGHTTP2_CANCEL } = http2.constants;
 const req = client.request({ ':path': '/' });
 
 // Cancel the stream if there's no activity after 5 seconds
-req.setTimeout(5000, () => req.rstStream(NGHTTP2_CANCEL));
+req.setTimeout(5000, () => req.close(NGHTTP2_CANCEL));
 ```
 
 #### http2stream.state


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/17406#issuecomment-356661798

/cc @mcollina 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2, doc