### PR TITLE
stream: check type and range of highWaterMark

### DIFF
--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -31,6 +31,7 @@ const util = require('util');
 const debug = util.debuglog('stream');
 const BufferList = require('internal/streams/BufferList');
 const destroyImpl = require('internal/streams/destroy');
+const { getHighWaterMark } = require('internal/streams/state');
 const errors = require('internal/errors');
 var StringDecoder;
 
@@ -75,19 +76,7 @@ function ReadableState(options, stream) {
 
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
-  var hwm = options.highWaterMark;
-  var readableHwm = options.readableHighWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-
-  if (hwm || hwm === 0)
-    this.highWaterMark = hwm;
-  else if (isDuplex && (readableHwm || readableHwm === 0))
-    this.highWaterMark = readableHwm;
-  else
-    this.highWaterMark = defaultHwm;
-
-  // cast to ints.
-  this.highWaterMark = Math.floor(this.highWaterMark);
+  this.highWaterMark = getHighWaterMark(this, options, isDuplex);
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -76,7 +76,8 @@ function ReadableState(options, stream) {
 
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
-  this.highWaterMark = getHighWaterMark(this, options, isDuplex);
+  this.highWaterMark = getHighWaterMark(this, options, 'readableHighWaterMark',
+                                        isDuplex);
 
   // A linked list is used to store data chunks instead of an array because the
   // linked list can remove elements from the beginning faster than

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -33,6 +33,7 @@ const internalUtil = require('internal/util');
 const Stream = require('stream');
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
+const { getHighWaterMark } = require('internal/streams/state');
 const errors = require('internal/errors');
 
 util.inherits(Writable, Stream);
@@ -59,19 +60,7 @@ function WritableState(options, stream) {
   // the point at which write() starts returning false
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
-  var hwm = options.highWaterMark;
-  var writableHwm = options.writableHighWaterMark;
-  var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-
-  if (hwm || hwm === 0)
-    this.highWaterMark = hwm;
-  else if (isDuplex && (writableHwm || writableHwm === 0))
-    this.highWaterMark = writableHwm;
-  else
-    this.highWaterMark = defaultHwm;
-
-  // cast to ints.
-  this.highWaterMark = Math.floor(this.highWaterMark);
+  this.highWaterMark = getHighWaterMark(this, options, isDuplex);
 
   // if _final has been called
   this.finalCalled = false;

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -60,7 +60,8 @@ function WritableState(options, stream) {
   // the point at which write() starts returning false
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
-  this.highWaterMark = getHighWaterMark(this, options, isDuplex);
+  this.highWaterMark = getHighWaterMark(this, options, 'writableHighWaterMark',
+                                        isDuplex);
 
   // if _final has been called
   this.finalCalled = false;

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -9,19 +9,11 @@ function getHighWaterMarkFromProperty(hwm, name) {
   return Math.floor(hwm);
 }
 
-function getHighWaterMark(state, options, isDuplex) {
+function getHighWaterMark(state, options, duplexKey, isDuplex) {
   if (options.highWaterMark != null) {
     return getHighWaterMarkFromProperty(options.highWaterMark, 'highWaterMark');
-  } else if (isDuplex) {
-    if (state instanceof stream.Readable.ReadableState) {
-      if (options.readableHighWaterMark != null) {
-        return getHighWaterMarkFromProperty(options.readableHighWaterMark,
-                                            'readableHighWaterMark');
-      }
-    } else if (options.writableHighWaterMark != null) {
-      return getHighWaterMarkFromProperty(options.writableHighWaterMark,
-                                          'writableHighWaterMark');
-    }
+  } else if (isDuplex && options[duplexKey] != null) {
+    return getHighWaterMarkFromProperty(options[duplexKey], duplexKey);
   }
 
   // Default value

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -4,23 +4,21 @@ const stream = require('stream');
 const errors = require('internal/errors');
 
 function getHighWaterMarkFromProperty(hwm, name) {
-  if (typeof hwm !== 'number' || hwm < 0)
+  if (typeof hwm !== 'number' || !(hwm >= 0))
     throw new errors.TypeError('ERR_INVALID_OPT_VALUE', name, hwm);
   return Math.floor(hwm);
 }
 
 function getHighWaterMark(state, options, isDuplex) {
-  if (options.highWaterMark != null && !Number.isNaN(options.highWaterMark)) {
+  if (options.highWaterMark != null) {
     return getHighWaterMarkFromProperty(options.highWaterMark, 'highWaterMark');
   } else if (isDuplex) {
     if (state instanceof stream.Readable.ReadableState) {
-      if (options.readableHighWaterMark != null &&
-          !Number.isNaN(options.readableHighWaterMark)) {
+      if (options.readableHighWaterMark != null) {
         return getHighWaterMarkFromProperty(options.readableHighWaterMark,
                                             'readableHighWaterMark');
       }
-    } else if (options.writableHighWaterMark != null &&
-               !Number.isNaN(options.writableHighWaterMark)) {
+    } else if (options.writableHighWaterMark != null) {
       return getHighWaterMarkFromProperty(options.writableHighWaterMark,
                                           'writableHighWaterMark');
     }

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const stream = require('stream');
+const errors = require('internal/errors');
+
+function getHighWaterMarkFromProperty(hwm, name) {
+  if (typeof hwm !== 'number' || hwm < 0)
+    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', name, hwm);
+  return Math.floor(hwm);
+}
+
+function getHighWaterMark(state, options, isDuplex) {
+  if (options.highWaterMark != null && !Number.isNaN(options.highWaterMark)) {
+    return getHighWaterMarkFromProperty(options.highWaterMark, 'highWaterMark');
+  } else if (isDuplex) {
+    if (state instanceof stream.Readable.ReadableState) {
+      if (options.readableHighWaterMark != null &&
+          !Number.isNaN(options.readableHighWaterMark)) {
+        return getHighWaterMarkFromProperty(options.readableHighWaterMark,
+                                            'readableHighWaterMark');
+      }
+    } else if (options.writableHighWaterMark != null &&
+               !Number.isNaN(options.writableHighWaterMark)) {
+      return getHighWaterMarkFromProperty(options.writableHighWaterMark,
+                                          'writableHighWaterMark');
+    }
+  }
+
+  // Default value
+  return state.objectMode ? 16 : 16 * 1024;
+}
+
+module.exports = {
+  getHighWaterMark
+};

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -3,17 +3,19 @@
 const stream = require('stream');
 const errors = require('internal/errors');
 
-function getHighWaterMarkFromProperty(hwm, name) {
-  if (typeof hwm !== 'number' || !(hwm >= 0))
-    throw new errors.TypeError('ERR_INVALID_OPT_VALUE', name, hwm);
-  return Math.floor(hwm);
-}
-
 function getHighWaterMark(state, options, duplexKey, isDuplex) {
-  if (options.highWaterMark != null) {
-    return getHighWaterMarkFromProperty(options.highWaterMark, 'highWaterMark');
-  } else if (isDuplex && options[duplexKey] != null) {
-    return getHighWaterMarkFromProperty(options[duplexKey], duplexKey);
+  let hwm = options.highWaterMark;
+  if (hwm != null) {
+    if (typeof hwm !== 'number' || !(hwm >= 0))
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE', 'highWaterMark', hwm);
+    return Math.floor(hwm);
+  } else if (isDuplex) {
+    hwm = options[duplexKey];
+    if (hwm != null) {
+      if (typeof hwm !== 'number' || !(hwm >= 0))
+        throw new errors.TypeError('ERR_INVALID_OPT_VALUE', duplexKey, hwm);
+      return Math.floor(hwm);
+    }
   }
 
   // Default value

--- a/lib/internal/streams/state.js
+++ b/lib/internal/streams/state.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const stream = require('stream');
 const errors = require('internal/errors');
 
 function getHighWaterMark(state, options, duplexKey, isDuplex) {

--- a/node.gyp
+++ b/node.gyp
@@ -141,6 +141,7 @@
       'lib/internal/streams/BufferList.js',
       'lib/internal/streams/legacy.js',
       'lib/internal/streams/destroy.js',
+      'lib/internal/streams/state.js',
       'lib/internal/wrap_js_stream.js',
       'deps/v8/tools/splaytree.js',
       'deps/v8/tools/codemap.js',

--- a/test/parallel/test-stream-transform-split-highwatermark.js
+++ b/test/parallel/test-stream-transform-split-highwatermark.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const { Transform, Readable, Writable } = require('stream');
@@ -54,13 +54,32 @@ testTransform(0, 0, {
   writableHighWaterMark: 777,
 });
 
-// test undefined, null, NaN
-[undefined, null, NaN].forEach((v) => {
+// test undefined, null
+[undefined, null].forEach((v) => {
   testTransform(DEFAULT, DEFAULT, { readableHighWaterMark: v });
   testTransform(DEFAULT, DEFAULT, { writableHighWaterMark: v });
   testTransform(666, DEFAULT, { highWaterMark: v, readableHighWaterMark: 666 });
   testTransform(DEFAULT, 777, { highWaterMark: v, writableHighWaterMark: 777 });
 });
+
+// test NaN
+{
+  common.expectsError(() => {
+    new Transform({ readableHighWaterMark: NaN });
+  }, {
+    type: TypeError,
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: 'The value "NaN" is invalid for option "readableHighWaterMark"'
+  });
+
+  common.expectsError(() => {
+    new Transform({ writableHighWaterMark: NaN });
+  }, {
+    type: TypeError,
+    code: 'ERR_INVALID_OPT_VALUE',
+    message: 'The value "NaN" is invalid for option "writableHighWaterMark"'
+  });
+}
 
 // test non Duplex streams ignore the options
 {

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -1,8 +1,9 @@
 'use strict';
-require('../common');
+const common = require('../common');
 
 // This test ensures that the stream implementation correctly handles values
-// for highWaterMark which exceed the range of signed 32 bit integers.
+// for highWaterMark which exceed the range of signed 32 bit integers and
+// rejects invalid values.
 
 const assert = require('assert');
 const stream = require('stream');
@@ -16,3 +17,15 @@ assert.strictEqual(readable._readableState.highWaterMark, ovfl);
 
 const writable = stream.Writable({ highWaterMark: ovfl });
 assert.strictEqual(writable._writableState.highWaterMark, ovfl);
+
+for (const invalidHwm of [true, false, '5', {}, -5]) {
+  for (const type of [stream.Readable, stream.Writable]) {
+    common.expectsError(() => {
+      type({ highWaterMark: invalidHwm });
+    }, {
+      type: TypeError,
+      code: 'ERR_INVALID_OPT_VALUE',
+      message: `The value "${invalidHwm}" is invalid for option "highWaterMark"`
+    });
+  }
+}

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -18,7 +18,7 @@ assert.strictEqual(readable._readableState.highWaterMark, ovfl);
 const writable = stream.Writable({ highWaterMark: ovfl });
 assert.strictEqual(writable._writableState.highWaterMark, ovfl);
 
-for (const invalidHwm of [true, false, '5', {}, -5]) {
+for (const invalidHwm of [true, false, '5', {}, -5, NaN]) {
   for (const type of [stream.Readable, stream.Writable]) {
     common.expectsError(() => {
       type({ highWaterMark: invalidHwm });


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/13065.

Stream constructors should throw when an invalid `highWaterMark` option is given.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
stream