### PR TITLE
(v9.x backport) errors: remove ERR_OUTOFMEMORY

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1284,11 +1284,6 @@ A Node.js API was called in an unsupported manner.
 
 For example: `Buffer.write(string, encoding, offset[, length])`
 
-<a id="ERR_OUTOFMEMORY"></a>
-### ERR_OUTOFMEMORY
-
-An operation caused an out-of-memory condition.
-
 <a id="ERR_OUT_OF_RANGE"></a>
 ### ERR_OUT_OF_RANGE
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -319,7 +319,6 @@ E('ERR_NAPI_CONS_PROTOTYPE_OBJECT', 'Constructor.prototype must be an object');
 E('ERR_NO_CRYPTO', 'Node.js is not compiled with OpenSSL crypto support');
 E('ERR_NO_ICU', '%s is not supported on Node.js compiled without ICU');
 E('ERR_NO_LONGER_SUPPORTED', '%s is no longer supported');
-E('ERR_OUTOFMEMORY', 'Out of memory');
 E('ERR_OUT_OF_RANGE', 'The "%s" argument is out of range');
 E('ERR_PARSE_HISTORY_DATA', 'Could not parse history data in %s');
 E('ERR_REQUIRE_ESM', 'Must use import to load ES Module: %s');


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/17877 to v9.x.