### PR TITLE
test: simplify loadDHParam in TLS test

### DIFF
--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -6,7 +6,6 @@ const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
 const tls = require('tls');
-const fs = require('fs');
 
 const key = fixtures.readKey('agent2-key.pem');
 const cert = fixtures.readKey('agent2-cert.pem');
@@ -15,9 +14,7 @@ let ntests = 0;
 let nsuccess = 0;
 
 function loadDHParam(n) {
-  let path = fixtures.fixturesDir;
-  if (n !== 'error') path += '/keys';
-  return fs.readFileSync(`${path}/dh${n}.pem`);
+  return fixtures.readKey(`dh${n}.pem`);
 }
 
 const cipherlist = {

--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -14,10 +14,7 @@ let nsuccess = 0;
 let nerror = 0;
 
 function loadDHParam(n) {
-  const params = [`dh${n}.pem`];
-  if (n !== 'error')
-    params.unshift('keys');
-  return fixtures.readSync(params);
+  return fixtures.readKey(`dh${n}.pem`);
 }
 
 function test(size, err, next) {


### PR DESCRIPTION
Neither of these tests seems to use the `error` value.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test