### PR TITLE
test: use shorthand properties in tests

### DIFF
--- a/test/fixtures/tls-connect.js
+++ b/test/fixtures/tls-connect.js
@@ -44,10 +44,7 @@ exports.connect = function connect(options, callback) {
 
   const server = {};
   const client = {};
-  const pair = {
-    server: server,
-    client: client,
-  };
+  const pair = { server, client };
 
   tls.createServer(options.server, function(conn) {
     server.conn = conn;

--- a/test/internet/test-tls-reuse-host-from-socket.js
+++ b/test/internet/test-tls-reuse-host-from-socket.js
@@ -30,7 +30,7 @@ const tls = require('tls');
 const net = require('net');
 
 const socket = net.connect(443, 'www.example.org', common.mustCall(() => {
-  const secureSocket = tls.connect({ socket: socket }, common.mustCall(() => {
+  const secureSocket = tls.connect({ socket }, common.mustCall(() => {
     secureSocket.destroy();
     console.log('ok');
   }));

--- a/test/parallel/test-child-process-env.js
+++ b/test/parallel/test-child-process-env.js
@@ -35,10 +35,10 @@ Object.setPrototypeOf(env, {
 let child;
 if (common.isWindows) {
   child = spawn('cmd.exe', ['/c', 'set'],
-                Object.assign({}, process.env, { env: env }));
+                Object.assign({}, process.env, { env }));
 } else {
   child = spawn('/usr/bin/env', [],
-                Object.assign({}, process.env, { env: env }));
+                Object.assign({}, process.env, { env }));
 }
 
 

--- a/test/parallel/test-cluster-dgram-1.js
+++ b/test/parallel/test-cluster-dgram-1.js
@@ -102,7 +102,7 @@ function worker() {
 
     // Every 10 messages, notify the master.
     if (received === PACKETS_PER_WORKER) {
-      process.send({ received: received });
+      process.send({ received });
       socket.close();
     }
   }, PACKETS_PER_WORKER));

--- a/test/parallel/test-cluster-worker-no-exit.js
+++ b/test/parallel/test-cluster-worker-no-exit.js
@@ -60,7 +60,7 @@ if (cluster.isMaster) {
 
     worker = cluster.fork()
       .on('online', function() {
-        this.send({ port: port });
+        this.send({ port });
       });
   });
   process.on('exit', function() {

--- a/test/parallel/test-fs-realpath-buffer-encoding.js
+++ b/test/parallel/test-fs-realpath-buffer-encoding.js
@@ -21,13 +21,13 @@ for (encoding in expected) {
   const expected_value = expected[encoding];
   let result;
 
-  result = fs.realpathSync(string_dir, { encoding: encoding });
+  result = fs.realpathSync(string_dir, { encoding });
   assert.strictEqual(result, expected_value);
 
   result = fs.realpathSync(string_dir, encoding);
   assert.strictEqual(result, expected_value);
 
-  result = fs.realpathSync(buffer_dir, { encoding: encoding });
+  result = fs.realpathSync(buffer_dir, { encoding });
   assert.strictEqual(result, expected_value);
 
   result = fs.realpathSync(buffer_dir, encoding);
@@ -53,7 +53,7 @@ for (encoding in expected) {
 
   fs.realpath(
     string_dir,
-    { encoding: encoding },
+    { encoding },
     common.mustCall((err, res) => {
       assert.ifError(err);
       assert.strictEqual(res, expected_value);
@@ -65,7 +65,7 @@ for (encoding in expected) {
   }));
   fs.realpath(
     buffer_dir,
-    { encoding: encoding },
+    { encoding },
     common.mustCall((err, res) => {
       assert.ifError(err);
       assert.strictEqual(res, expected_value);

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -51,7 +51,7 @@ common.refreshTmpDir();
 // Test writeFileSync
 const file1 = path.join(common.tmpDir, 'testWriteFileSync.txt');
 
-fs.writeFileSync(file1, '123', { mode: mode });
+fs.writeFileSync(file1, '123', { mode });
 
 content = fs.readFileSync(file1, { encoding: 'utf8' });
 assert.strictEqual(content, '123');
@@ -61,7 +61,7 @@ assert.strictEqual(fs.statSync(file1).mode & 0o777, mode);
 // Test appendFileSync
 const file2 = path.join(common.tmpDir, 'testAppendFileSync.txt');
 
-fs.appendFileSync(file2, 'abc', { mode: mode });
+fs.appendFileSync(file2, 'abc', { mode });
 
 content = fs.readFileSync(file2, { encoding: 'utf8' });
 assert.strictEqual(content, 'abc');

--- a/test/parallel/test-http-client-read-in-error.js
+++ b/test/parallel/test-http-client-read-in-error.js
@@ -34,7 +34,7 @@ class Agent extends http.Agent {
 const agent = new Agent();
 
 http.request({
-  agent: agent
+  agent
 }).once('error', function() {
   console.log('ignore');
 });

--- a/test/parallel/test-http-pipeline-flood.js
+++ b/test/parallel/test-http-pipeline-flood.js
@@ -66,7 +66,7 @@ function child() {
   const net = require('net');
 
   const port = +process.argv[3];
-  const conn = net.connect({ port: port });
+  const conn = net.connect({ port });
 
   let req = `GET / HTTP/1.1\r\nHost: localhost:${port}\r\nAccept: */*\r\n\r\n`;
 

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -22,8 +22,8 @@ const URL = url.URL;
       [`http://localhost:${port}`],
       [new URL(`http://localhost:${port}`)],
       [url.parse(`http://localhost:${port}`)],
-      [{ port: port }, { protocol: 'http:' }],
-      [{ port: port, hostname: '127.0.0.1' }, { protocol: 'http:' }]
+      [{ port }, { protocol: 'http:' }],
+      [{ port, hostname: '127.0.0.1' }, { protocol: 'http:' }]
     ];
 
     const serverClose = new Countdown(items.length + 1,

--- a/test/parallel/test-https-agent-create-connection.js
+++ b/test/parallel/test-https-agent-create-connection.js
@@ -51,10 +51,7 @@ function createServer() {
       port: port,
       host: host,
       rejectUnauthorized: false,
-      _agentKey: agent.getName({
-        port: port,
-        host: host,
-      }),
+      _agentKey: agent.getName({ port, host })
     };
 
     const socket = agent.createConnection(options);
@@ -70,10 +67,7 @@ function createServer() {
     const host = 'localhost';
     const options = {
       rejectUnauthorized: false,
-      _agentKey: agent.getName({
-        port: port,
-        host: host,
-      }),
+      _agentKey: agent.getName({ port, host })
     };
     const socket = agent.createConnection(port, options);
     checkRequest(socket, server);
@@ -88,10 +82,7 @@ function createServer() {
     const host = 'localhost';
     const options = {
       rejectUnauthorized: false,
-      _agentKey: agent.getName({
-        port: port,
-        host: host,
-      }),
+      _agentKey: agent.getName({ port, host })
     };
     const socket = agent.createConnection(port, host, options);
     checkRequest(socket, server);

--- a/test/parallel/test-https-strict.js
+++ b/test/parallel/test-https-strict.js
@@ -112,11 +112,7 @@ function listening() {
 
 function makeReq(path, port, error, host, ca) {
   pending++;
-  const options = {
-    port: port,
-    path: path,
-    ca: ca
-  };
+  const options = { port, path, ca };
 
   if (!ca) {
     options.agent = agent0;
@@ -134,7 +130,7 @@ function makeReq(path, port, error, host, ca) {
   }
 
   if (host) {
-    options.headers = { host: host };
+    options.headers = { host };
   }
   const req = https.get(options);
   const server = port === server1.address().port ? server1 :

--- a/test/parallel/test-https-truncate.js
+++ b/test/parallel/test-https-truncate.js
@@ -38,7 +38,7 @@ const data = Buffer.alloc(1024 * 32 + 1);
 httpsTest();
 
 function httpsTest() {
-  const sopt = { key: key, cert: cert };
+  const sopt = { key, cert };
 
   const server = https.createServer(sopt, function(req, res) {
     res.setHeader('content-length', data.length);

--- a/test/parallel/test-net-connect-options-port.js
+++ b/test/parallel/test-net-connect-options-port.js
@@ -60,7 +60,7 @@ const net = require('net');
 {
   // connect({hint}, cb) and connect({hint})
   const hints = (dns.ADDRCONFIG | dns.V4MAPPED) + 42;
-  const hintOptBlocks = doConnect([{ hints: hints }],
+  const hintOptBlocks = doConnect([{ hints }],
                                   () => common.mustNotCall());
   for (const block of hintOptBlocks) {
     common.expectsError(block, {

--- a/test/parallel/test-net-server-listen-handle.js
+++ b/test/parallel/test-net-server-listen-handle.js
@@ -144,7 +144,7 @@ if (!common.isWindows) {  // Windows doesn't support {fd: <n>}
   // Test invalid fd
   const fd = fs.openSync(__filename, 'r');
   net.createServer()
-    .listen({ fd: fd }, common.mustNotCall())
+    .listen({ fd }, common.mustNotCall())
     .on('error', common.mustCall(function(err) {
       assert.strictEqual(String(err), 'Error: listen EINVAL');
       this.close();

--- a/test/parallel/test-net-server-listen-options.js
+++ b/test/parallel/test-net-server-listen-options.js
@@ -17,7 +17,7 @@ function close() { this.close(); }
     .on('listening', common.mustCall(close));
 }
 
-// Test listen(port, cb) and listen({port: port}, cb) combinations
+// Test listen(port, cb) and listen({ port }, cb) combinations
 const listenOnPort = [
   (port, cb) => net.createServer().listen({ port }, cb),
   (port, cb) => net.createServer().listen(port, cb)

--- a/test/parallel/test-stream2-readable-wrap.js
+++ b/test/parallel/test-stream2-readable-wrap.js
@@ -29,8 +29,7 @@ const EE = require('events').EventEmitter;
 function runTest(highWaterMark, objectMode, produce) {
 
   const old = new EE();
-  const r = new Readable({ highWaterMark: highWaterMark,
-                           objectMode: objectMode });
+  const r = new Readable({ highWaterMark, objectMode });
   assert.strictEqual(r, r.wrap(old));
 
   r.on('end', common.mustCall());
@@ -63,7 +62,7 @@ function runTest(highWaterMark, objectMode, produce) {
   }
 
   const w = new Writable({ highWaterMark: highWaterMark * 2,
-                           objectMode: objectMode });
+                           objectMode });
   const written = [];
   w._write = function(chunk, encoding, cb) {
     written.push(chunk);

--- a/test/parallel/test-tls-cert-regression.js
+++ b/test/parallel/test-tls-cert-regression.js
@@ -68,8 +68,8 @@ sPWhSOb9VQjMXekI4Y2l8fqAVTS2Fn6+8jkVKxXBywSVCw==
 
 function test(cert, key, cb) {
   const server = tls.createServer({
-    cert: cert,
-    key: key
+    cert,
+    key
   }).listen(0, function() {
     server.close(cb);
   });

--- a/test/parallel/test-tls-connect-no-host.js
+++ b/test/parallel/test-tls-connect-no-host.js
@@ -16,8 +16,8 @@ const key = fixtures.readSync('test_key.pem');
 // tls.connect(options) with no options.host should accept a cert with
 //   CN:'localhost'
 tls.createServer({
-  key: key,
-  cert: cert
+  key,
+  cert
 }).listen(0, function() {
   const socket = tls.connect({
     port: this.address().port,

--- a/test/parallel/test-tls-ecdh-multiple.js
+++ b/test/parallel/test-tls-ecdh-multiple.js
@@ -74,7 +74,7 @@ process.on('exit', function() {
     unsupportedCurves.push('brainpoolP256r1');
 
   unsupportedCurves.forEach((ecdhCurve) => {
-    assert.throws(() => tls.createServer({ ecdhCurve: ecdhCurve }),
+    assert.throws(() => tls.createServer({ ecdhCurve }),
                   /Error: Failed to set ECDH curve/);
   });
 });

--- a/test/parallel/test-tls-env-extra-ca.js
+++ b/test/parallel/test-tls-env-extra-ca.js
@@ -38,7 +38,7 @@ const server = tls.createServer(options, common.mustCall(function(s) {
     NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'ca1-cert.pem')
   });
 
-  fork(__filename, { env: env }).on('exit', common.mustCall(function(status) {
+  fork(__filename, { env }).on('exit', common.mustCall(function(status) {
     assert.strictEqual(status, 0, 'client did not succeed in connecting');
   }));
 }));

--- a/test/parallel/test-tls-friendly-error-message.js
+++ b/test/parallel/test-tls-friendly-error-message.js
@@ -31,7 +31,7 @@ const tls = require('tls');
 const key = fixtures.readKey('agent1-key.pem');
 const cert = fixtures.readKey('agent1-cert.pem');
 
-tls.createServer({ key: key, cert: cert }, common.mustCall(function(conn) {
+tls.createServer({ key, cert }, common.mustCall(function(conn) {
   conn.end();
   this.close();
 })).listen(0, common.mustCall(function() {

--- a/test/parallel/test-tls-no-sslv3.js
+++ b/test/parallel/test-tls-no-sslv3.js
@@ -13,7 +13,7 @@ const fixtures = require('../common/fixtures');
 
 const cert = fixtures.readSync('test_cert.pem');
 const key = fixtures.readSync('test_key.pem');
-const server = tls.createServer({ cert: cert, key: key }, common.mustNotCall());
+const server = tls.createServer({ cert, key }, common.mustNotCall());
 const errors = [];
 let stderr = '';
 

--- a/test/parallel/test-tls-over-http-tunnel.js
+++ b/test/parallel/test-tls-over-http-tunnel.js
@@ -35,10 +35,7 @@ let gotRequest = false;
 const key = fixtures.readKey('agent1-key.pem');
 const cert = fixtures.readKey('agent1-cert.pem');
 
-const options = {
-  key: key,
-  cert: cert
-};
+const options = { key, cert };
 
 const server = https.createServer(options, function(req, res) {
   console.log('SERVER: got request');

--- a/test/parallel/test-tls-securepair-server.js
+++ b/test/parallel/test-tls-securepair-server.js
@@ -42,7 +42,7 @@ function log(a) {
 
 const server = net.createServer(common.mustCall(function(socket) {
   log(`connection fd=${socket.fd}`);
-  const sslcontext = tls.createSecureContext({ key: key, cert: cert });
+  const sslcontext = tls.createSecureContext({ key, cert });
   sslcontext.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
   const pair = tls.createSecurePair(sslcontext, true);

--- a/test/parallel/test-tls-session-cache.js
+++ b/test/parallel/test-tls-session-cache.js
@@ -71,10 +71,7 @@ function doTest(testOptions, callback) {
     // Emulate asynchronous store
     setTimeout(function() {
       assert.ok(!session);
-      session = {
-        id: id,
-        data: data
-      };
+      session = { id, data };
       cb();
     }, 1000);
   });

--- a/test/parallel/test-tls-starttls-server.js
+++ b/test/parallel/test-tls-starttls-server.js
@@ -21,10 +21,7 @@ const server = net.createServer(common.mustCall((s) => {
     isServer: true,
     server: server,
 
-    secureContext: tls.createSecureContext({
-      key: key,
-      cert: cert
-    }),
+    secureContext: tls.createSecureContext({ key, cert }),
 
     SNICallback: common.mustCall((hostname, callback) => {
       assert.strictEqual(hostname, 'test.test');

--- a/test/parallel/test-tls-zero-clear-in.js
+++ b/test/parallel/test-tls-zero-clear-in.js
@@ -32,8 +32,8 @@ const cert = fixtures.readSync('test_cert.pem');
 const key = fixtures.readSync('test_key.pem');
 
 const server = tls.createServer({
-  cert: cert,
-  key: key
+  cert,
+  key
 }, function(c) {
   // Nop
   setTimeout(function() {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -149,7 +149,7 @@ for (const showHidden of [true, false]) {
 // Now do the same checks but from a different context
 for (const showHidden of [true, false]) {
   const ab = vm.runInNewContext('new ArrayBuffer(4)');
-  const dv = vm.runInNewContext('new DataView(ab, 1, 2)', { ab: ab });
+  const dv = vm.runInNewContext('new DataView(ab, 1, 2)', { ab });
   assert.strictEqual(
     util.inspect(ab, showHidden),
     'ArrayBuffer { byteLength: 4 }'

--- a/test/parallel/test-vm-access-process-env.js
+++ b/test/parallel/test-vm-access-process-env.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const vm = require('vm');
 
 assert.doesNotThrow(function() {
-  const context = vm.createContext({ process: process });
+  const context = vm.createContext({ process });
   const result = vm.runInContext('process.env["PATH"]', context);
   assert.notStrictEqual(undefined, result);
 });

--- a/test/parallel/test-vm-context.js
+++ b/test/parallel/test-vm-context.js
@@ -81,7 +81,7 @@ const contextifiedSandboxErrorMsg =
 script = vm.createScript('const assert = require(\'assert\'); assert.throws(' +
                          'function() { throw "hello world"; }, /hello/);',
                          'some.js');
-script.runInNewContext({ require: require });
+script.runInNewContext({ require });
 
 // Issue GH-7529
 script = vm.createScript('delete b');

--- a/test/parallel/test-vm-function-declaration.js
+++ b/test/parallel/test-vm-function-declaration.js
@@ -24,7 +24,7 @@ require('../common');
 const assert = require('assert');
 
 const vm = require('vm');
-const o = vm.createContext({ console: console });
+const o = vm.createContext({ console });
 
 // Function declaration and expression should both be copied to the
 // sandboxed context.

--- a/test/parallel/test-vm-global-define-property.js
+++ b/test/parallel/test-vm-global-define-property.js
@@ -36,7 +36,7 @@ const code =
     'f;\n';
 
 const x = {};
-const o = vm.createContext({ console: console, x: x });
+const o = vm.createContext({ console, x });
 
 const res = vm.runInContext(code, o, 'test');
 

--- a/test/parallel/test-vm-harmony-symbols.js
+++ b/test/parallel/test-vm-harmony-symbols.js
@@ -31,7 +31,7 @@ assert.strictEqual(typeof sandbox.Symbol, 'function');
 assert.notStrictEqual(sandbox.Symbol, Symbol);
 
 // Unless we copy the Symbol constructor explicitly, of course.
-sandbox = { Symbol: Symbol };
+sandbox = { Symbol };
 vm.runInNewContext('this.Symbol = Symbol', sandbox);
 assert.strictEqual(typeof sandbox.Symbol, 'function');
 assert.strictEqual(sandbox.Symbol, Symbol);

--- a/test/parallel/test-vm-new-script-new-context.js
+++ b/test/parallel/test-vm-new-script-new-context.js
@@ -91,7 +91,7 @@ const Script = require('vm').Script;
 {
   const script = new Script('f.a = 2');
   const f = { a: 1 };
-  script.runInNewContext({ f: f });
+  script.runInNewContext({ f });
   assert.strictEqual(f.a, 2);
 
   assert.throws(() => {

--- a/test/parallel/test-vm-proxies.js
+++ b/test/parallel/test-vm-proxies.js
@@ -12,7 +12,7 @@ assert.strictEqual(typeof sandbox.Proxy, 'function');
 assert.notStrictEqual(sandbox.Proxy, Proxy);
 
 // Unless we copy the Proxy object explicitly, of course.
-sandbox = { Proxy: Proxy };
+sandbox = { Proxy };
 vm.runInNewContext('this.Proxy = Proxy', sandbox);
 assert.strictEqual(typeof sandbox.Proxy, 'function');
 assert.strictEqual(sandbox.Proxy, Proxy);

--- a/test/parallel/test-vm-run-in-new-context.js
+++ b/test/parallel/test-vm-run-in-new-context.js
@@ -65,7 +65,7 @@ assert.strictEqual(global.foo, 100);
 
 // Modify an object by reference
 const f = { a: 1 };
-vm.runInNewContext('f.a = 2', { f: f });
+vm.runInNewContext('f.a = 2', { f });
 assert.strictEqual(f.a, 2);
 
 // Use function in context without referencing context

--- a/test/parallel/test-vm-timeout.js
+++ b/test/parallel/test-vm-timeout.js
@@ -47,7 +47,7 @@ assert.throws(function() {
   const context = {
     log: console.log,
     runInVM: function(timeout) {
-      vm.runInNewContext('while(true) {}', context, { timeout: timeout });
+      vm.runInNewContext('while(true) {}', context, { timeout });
     }
   };
   vm.runInNewContext('runInVM(10)', context, { timeout: 10000 });
@@ -58,7 +58,7 @@ assert.throws(function() {
 assert.throws(function() {
   const context = {
     runInVM: function(timeout) {
-      vm.runInNewContext('while(true) {}', context, { timeout: timeout });
+      vm.runInNewContext('while(true) {}', context, { timeout });
     }
   };
   vm.runInNewContext('runInVM(10000)', context, { timeout: 100 });
@@ -69,9 +69,7 @@ assert.throws(function() {
 assert.throws(function() {
   const context = {
     runInVM: function(timeout) {
-      vm.runInNewContext('throw new Error(\'foobar\')', context, {
-        timeout: timeout
-      });
+      vm.runInNewContext('throw new Error(\'foobar\')', context, { timeout });
     }
   };
   vm.runInNewContext('runInVM(10000)', context, { timeout: 100000 });

--- a/test/parallel/test-zlib.js
+++ b/test/parallel/test-zlib.js
@@ -191,10 +191,7 @@ testKeys.forEach(common.mustCall((file) => {
               zlibPairs.forEach(common.mustCall((pair) => {
                 const Def = pair[0];
                 const Inf = pair[1];
-                const opts = { level: level,
-                               windowBits: windowBits,
-                               memLevel: memLevel,
-                               strategy: strategy };
+                const opts = { level, windowBits, memLevel, strategy };
 
                 const def = new Def(opts);
                 const inf = new Inf(opts);

--- a/test/pummel/test-tls-securepair-client.js
+++ b/test/pummel/test-tls-securepair-client.js
@@ -117,7 +117,7 @@ function test(keyfn, certfn, check, next) {
   function startClient() {
     const s = new net.Stream();
 
-    const sslcontext = tls.createSecureContext({ key: key, cert: cert });
+    const sslcontext = tls.createSecureContext({ key, cert });
     sslcontext.context.setCiphers('RC4-SHA:AES128-SHA:AES256-SHA');
 
     const pair = tls.createSecurePair(sslcontext, false);


### PR DESCRIPTION
This updates the tests to use shorthand property declarations when *all* properties can be converted to the shortened notation (with two exceptions).

`{ a: a, b: b, ... }` becomes `{ a, b }`, but `{ a: a, b: c, ... }` remains `{ a: a, b: c, ... }`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test