### PR TITLE
[WIP] fs: add FD object to manage file descriptors

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -291,21 +291,21 @@ explicitly synchronous use libuv's threadpool, which can have surprising and
 negative performance implications for some applications, see the
 [`UV_THREADPOOL_SIZE`][] documentation for more information.
 
-## class: fs.FD
+## class: fs.FileHandle
 <!-- YAML
 added: REPLACEME
 -->
 
-An `fs.FD` object is a wrapper for a numeric file descriptor. Instances of
-`fs.FD` are distinct from numeric file descriptors in that, if the `fs.FD` is
-not explicitly closed using the `fd.close()` method, they will automatically
-close the file descriptor and will emit a process warning, thereby helping to
-prevent memory leaks.
+A `fs.FileHandle` object is a wrapper for a numeric file descriptor. Instances
+of `fs.FileHandle` are distinct from numeric file descriptors in that, if the
+`fs.FileHandle` is not explicitly closed using the `fd.close()` method, they
+will automatically close the file descriptor and will emit a process warning,
+thereby helping to prevent memory leaks.
 
-Instances of the `fs.FD` object are created internally by the `fs.openFD()`
-and `fs.openFDSync()` methods.
+Instances of the `fs.FileHandle` object are created internally by the
+`fs.openFileHandle()` and `fs.openFileHandleSync()` methods.
 
-### fd.close()
+### filehandle.close()
 <!-- YAML
 added: REPLACEME
 -->
@@ -316,18 +316,18 @@ added: REPLACEME
 Closes the file descriptor.
 
 ```js
-const fd = fs.openFDSync('thefile.txt', 'r');
-fd.close()
+const filehandle = fs.openFileHandleSync('thefile.txt', 'r');
+filehandle.close()
   .then(() => console.log('ok'))
   .catch(() => console.log('not ok'));
 ```
 
-### fd.fd
+### filehandle.fd
 <!-- YAML
 added: REPLACEME
 -->
 
-Value: {number} The numeric file descriptor managed by the `FD` object.
+Value: {number} The numeric file descriptor managed by the `FileHandle` object.
 
 ## Class: fs.FSWatcher
 <!-- YAML
@@ -2107,7 +2107,7 @@ through `fs.open()` or `fs.writeFile()`) will fail with `EPERM`. Existing hidden
 files can be opened for writing with the `r+` flag. A call to `fs.ftruncate()`
 can be used to reset the file contents.
 
-## fs.openFD(path, flags[, mode], callback)
+## fs.openFileHandle(path, flags[, mode], callback)
 <!-- YAML
 added: REPLACEME
 -->
@@ -2117,9 +2117,9 @@ added: REPLACEME
 * `mode` {integer} **Default:** `0o666`
 * `callback` {Function}
   * `err` {Error}
-  * `fd` {[fs.FD][#fs_class_fs_fd]}
+  * `fd` {[fs.FileHandle][#fs_class_fs_filehandle]}
 
-Asynchronous file open that returns an `fs.FD` object. See open(2).
+Asynchronous file open that returns a `fs.FileHandle` object. See open(2).
 
 The `flags` argument can be:
 
@@ -2136,8 +2136,9 @@ An exception occurs if the file does not exist.
   the potentially stale local cache. It has a very real impact on I/O
   performance so using this flag is not recommended unless it is needed.
 
-  Note that this doesn't turn `fs.openFD()` into a synchronous blocking call.
-  If synchronous operation is desired `fs.openFDSync()` should be used.
+  Note that this doesn't turn `fs.openFileHAndle()` into a synchronous blocking
+  call. If synchronous operation is desired `fs.openFileHandleSync()` should be
+  used.
 
 * `'w'` - Open file for writing.
 The file is created (if it does not exist) or truncated (if it exists).
@@ -2162,7 +2163,7 @@ The file is created if it does not exist.
 `mode` sets the file mode (permission and sticky bits), but only if the file was
 created. It defaults to `0o666` (readable and writable).
 
-The callback gets two arguments `(err, fd)`.
+The callback gets two arguments `(err, filehandle)`.
 
 The exclusive flag `'x'` (`O_EXCL` flag in open(2)) ensures that `path` is newly
 created. On POSIX systems, `path` is considered to exist even if it is a symlink
@@ -2178,20 +2179,20 @@ On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
 the end of the file.
 
-*Note*: The behavior of `fs.openFD()` is platform-specific for some flags. As
-such, opening a directory on macOS and Linux with the `'a+'` flag - see example
-below - will return an error. In contrast, on Windows and FreeBSD, a file
-descriptor will be returned.
+*Note*: The behavior of `fs.openFileHandle()` is platform-specific for some
+flags. As such, opening a directory on macOS and Linux with the `'a+'` flag -
+see example below - will return an error. In contrast, on Windows and FreeBSD,
+a file descriptor will be returned.
 
 ```js
 // macOS and Linux
-fs.openFD('<directory>', 'a+', (err, fd) => {
+fs.openFileHandle('<directory>', 'a+', (err, filehandle) => {
   // => [Error: EISDIR: illegal operation on a directory, open <directory>]
 });
 
 // Windows and FreeBSD
-fs.openFD('<directory>', 'a+', (err, fd) => {
-  // => null, <fd>
+fs.openFileHandle('<directory>', 'a+', (err, filehandle) => {
+  // => null, <filehandle>
 });
 ```
 
@@ -2201,11 +2202,11 @@ a colon, Node.js will open a file system stream, as described by
 [this MSDN page][MSDN-Using-Streams].
 
 *Note:* On Windows, opening an existing hidden file using the `w` flag (e.g.
-using `fs.openFD()`) will fail with `EPERM`. Existing hidden
+using `fs.openFileHandle()`) will fail with `EPERM`. Existing hidden
 files can be opened for writing with the `r+` flag. A call to `fs.ftruncate()`
 can be used to reset the file contents.
 
-## fs.openFDSync(path, flags[, mode])
+## fs.openFileHandleSync(path, flags[, mode])
 <!-- YAML
 added: REPLACEME
 -->
@@ -2213,10 +2214,10 @@ added: REPLACEME
 * `path` {string|Buffer|URL}
 * `flags` {string|number}
 * `mode` {integer} **Default:** `0o666`
-* Returns: {[fs.FD][#fs_class_fs_fd]}
+* Returns: {[fs.FileHandle][#fs_class_fs_filehandle]}
 
-Synchronous version of [`fs.openFD()`][]. Returns an `fs.FD` object representing
-the file descriptor.
+Synchronous version of [`fs.openFileHandle()`][]. Returns a `fs.FileHandle`
+object representing the file descriptor.
 
 ## fs.openSync(path, flags[, mode])
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -291,6 +291,44 @@ explicitly synchronous use libuv's threadpool, which can have surprising and
 negative performance implications for some applications, see the
 [`UV_THREADPOOL_SIZE`][] documentation for more information.
 
+## class: fs.FD
+<!-- YAML
+added: REPLACEME
+-->
+
+An `fs.FD` object is a wrapper for a numeric file descriptor. Instances of
+`fs.FD` are distinct from numeric file descriptors in that, if the `fs.FD` is
+not explicitly closed using the `fd.close()` method, they will automatically
+close the file descriptor and will emit a process warning, thereby helping to
+prevent memory leaks.
+
+Instances of the `fs.FD` object are created internally by the `fs.openFD()`
+and `fs.openFDSync()` methods.
+
+### fd.close()
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Promise} A `Promise` that will be resolved once the underlying
+  file descriptor is closed, or will reject if an error occurs while closing.
+
+Closes the file descriptor.
+
+```js
+const fd = fs.openFDSync('thefile.txt', 'r');
+fd.close()
+  .then(() => console.log('ok'))
+  .catch(() => console.log('not ok'));
+```
+
+### fd.fd
+<!-- YAML
+added: REPLACEME
+-->
+
+Value: {number} The numeric file descriptor managed by the `FD` object.
+
 ## Class: fs.FSWatcher
 <!-- YAML
 added: v0.5.8
@@ -2068,6 +2106,117 @@ Functions based on `fs.open()` exhibit this behavior as well. eg.
 through `fs.open()` or `fs.writeFile()`) will fail with `EPERM`. Existing hidden
 files can be opened for writing with the `r+` flag. A call to `fs.ftruncate()`
 can be used to reset the file contents.
+
+## fs.openFD(path, flags[, mode], callback)
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `flags` {string|number}
+* `mode` {integer} **Default:** `0o666`
+* `callback` {Function}
+  * `err` {Error}
+  * `fd` {[fs.FD][#fs_class_fs_fd]}
+
+Asynchronous file open that returns an `fs.FD` object. See open(2).
+
+The `flags` argument can be:
+
+* `'r'` - Open file for reading.
+An exception occurs if the file does not exist.
+
+* `'r+'` - Open file for reading and writing.
+An exception occurs if the file does not exist.
+
+* `'rs+'` - Open file for reading and writing in synchronous mode. Instructs
+  the operating system to bypass the local file system cache.
+
+  This is primarily useful for opening files on NFS mounts as it allows skipping
+  the potentially stale local cache. It has a very real impact on I/O
+  performance so using this flag is not recommended unless it is needed.
+
+  Note that this doesn't turn `fs.openFD()` into a synchronous blocking call.
+  If synchronous operation is desired `fs.openFDSync()` should be used.
+
+* `'w'` - Open file for writing.
+The file is created (if it does not exist) or truncated (if it exists).
+
+* `'wx'` - Like `'w'` but fails if `path` exists.
+
+* `'w+'` - Open file for reading and writing.
+The file is created (if it does not exist) or truncated (if it exists).
+
+* `'wx+'` - Like `'w+'` but fails if `path` exists.
+
+* `'a'` - Open file for appending.
+The file is created if it does not exist.
+
+* `'ax'` - Like `'a'` but fails if `path` exists.
+
+* `'a+'` - Open file for reading and appending.
+The file is created if it does not exist.
+
+* `'ax+'` - Like `'a+'` but fails if `path` exists.
+
+`mode` sets the file mode (permission and sticky bits), but only if the file was
+created. It defaults to `0o666` (readable and writable).
+
+The callback gets two arguments `(err, fd)`.
+
+The exclusive flag `'x'` (`O_EXCL` flag in open(2)) ensures that `path` is newly
+created. On POSIX systems, `path` is considered to exist even if it is a symlink
+to a non-existent file. The exclusive flag may or may not work with network file
+systems.
+
+`flags` can also be a number as documented by open(2); commonly used constants
+are available from `fs.constants`.  On Windows, flags are translated to
+their equivalent ones where applicable, e.g. `O_WRONLY` to `FILE_GENERIC_WRITE`,
+or `O_EXCL|O_CREAT` to `CREATE_NEW`, as accepted by CreateFileW.
+
+On Linux, positional writes don't work when the file is opened in append mode.
+The kernel ignores the position argument and always appends the data to
+the end of the file.
+
+*Note*: The behavior of `fs.openFD()` is platform-specific for some flags. As
+such, opening a directory on macOS and Linux with the `'a+'` flag - see example
+below - will return an error. In contrast, on Windows and FreeBSD, a file
+descriptor will be returned.
+
+```js
+// macOS and Linux
+fs.openFD('<directory>', 'a+', (err, fd) => {
+  // => [Error: EISDIR: illegal operation on a directory, open <directory>]
+});
+
+// Windows and FreeBSD
+fs.openFD('<directory>', 'a+', (err, fd) => {
+  // => null, <fd>
+});
+```
+
+Some characters (`< > : " / \ | ? *`) are reserved under Windows as documented
+by [Naming Files, Paths, and Namespaces][]. Under NTFS, if the filename contains
+a colon, Node.js will open a file system stream, as described by
+[this MSDN page][MSDN-Using-Streams].
+
+*Note:* On Windows, opening an existing hidden file using the `w` flag (e.g.
+using `fs.openFD()`) will fail with `EPERM`. Existing hidden
+files can be opened for writing with the `r+` flag. A call to `fs.ftruncate()`
+can be used to reset the file contents.
+
+## fs.openFDSync(path, flags[, mode])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `flags` {string|number}
+* `mode` {integer} **Default:** `0o666`
+* Returns: {[fs.FD][#fs_class_fs_fd]}
+
+Synchronous version of [`fs.openFD()`][]. Returns an `fs.FD` object representing
+the file descriptor.
 
 ## fs.openSync(path, flags[, mode])
 <!-- YAML

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -768,6 +768,25 @@ fs.open = function(path, flags, mode, callback_) {
                req);
 };
 
+fs.openFD = function(path, flags, mode, callback_) {
+  const callback = makeCallback(arguments[arguments.length - 1]);
+  mode = modeNum(mode, 0o666);
+
+  if (handleError((path = getPathFromURL(path)), callback))
+    return;
+  if (!nullCheck(path, callback)) return;
+  validatePath(path);
+  validateUint32(mode, 'mode');
+
+  const req = new FSReqWrap();
+  req.oncomplete = callback;
+
+  binding.openFD(pathModule.toNamespacedPath(path),
+                 stringToFlags(flags),
+                 mode,
+                 req);
+};
+
 fs.openSync = function(path, flags, mode) {
   mode = modeNum(mode, 0o666);
   handleError((path = getPathFromURL(path)));
@@ -777,6 +796,17 @@ fs.openSync = function(path, flags, mode) {
 
   return binding.open(pathModule.toNamespacedPath(path),
                       stringToFlags(flags), mode);
+};
+
+fs.openFDSync = function(path, flags, mode) {
+  mode = modeNum(mode, 0o666);
+  handleError((path = getPathFromURL(path)));
+  nullCheck(path);
+  validatePath(path);
+  validateUint32(mode, 'mode');
+
+  return binding.openFD(pathModule.toNamespacedPath(path),
+                        stringToFlags(flags), mode);
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -768,7 +768,7 @@ fs.open = function(path, flags, mode, callback_) {
                req);
 };
 
-fs.openFD = function(path, flags, mode, callback_) {
+fs.openFileHandle = function(path, flags, mode, callback_) {
   const callback = makeCallback(arguments[arguments.length - 1]);
   mode = modeNum(mode, 0o666);
 
@@ -781,10 +781,10 @@ fs.openFD = function(path, flags, mode, callback_) {
   const req = new FSReqWrap();
   req.oncomplete = callback;
 
-  binding.openFD(pathModule.toNamespacedPath(path),
-                 stringToFlags(flags),
-                 mode,
-                 req);
+  binding.openFileHandle(pathModule.toNamespacedPath(path),
+                         stringToFlags(flags),
+                         mode,
+                         req);
 };
 
 fs.openSync = function(path, flags, mode) {
@@ -798,15 +798,15 @@ fs.openSync = function(path, flags, mode) {
                       stringToFlags(flags), mode);
 };
 
-fs.openFDSync = function(path, flags, mode) {
+fs.openFileHandleSync = function(path, flags, mode) {
   mode = modeNum(mode, 0o666);
   handleError((path = getPathFromURL(path)));
   nullCheck(path);
   validatePath(path);
   validateUint32(mode, 'mode');
 
-  return binding.openFD(pathModule.toNamespacedPath(path),
-                        stringToFlags(flags), mode);
+  return binding.openFileHandle(pathModule.toNamespacedPath(path),
+                                stringToFlags(flags), mode);
 };
 
 fs.read = function(fd, buffer, offset, length, position, callback) {

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -36,6 +36,7 @@ namespace node {
 #define NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                               \
   V(NONE)                                                                     \
   V(DNSCHANNEL)                                                               \
+  V(FD)                                                                       \
   V(FSEVENTWRAP)                                                              \
   V(FSREQWRAP)                                                                \
   V(GETADDRINFOREQWRAP)                                                       \

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -36,7 +36,8 @@ namespace node {
 #define NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                               \
   V(NONE)                                                                     \
   V(DNSCHANNEL)                                                               \
-  V(FD)                                                                       \
+  V(FILEHANDLE)                                                               \
+  V(FILEHANDLECLOSEREQ)                                                       \
   V(FSEVENTWRAP)                                                              \
   V(FSREQWRAP)                                                                \
   V(GETADDRINFOREQWRAP)                                                       \

--- a/src/env.cc
+++ b/src/env.cc
@@ -280,7 +280,11 @@ void Environment::RunAndClearNativeImmediates() {
     std::vector<NativeImmediateCallback> list;
     native_immediate_callbacks_.swap(list);
     for (const auto& cb : list) {
+      v8::TryCatch try_catch(isolate());
       cb.cb_(this, cb.data_);
+      if (try_catch.HasCaught()) {
+        FatalException(isolate(), try_catch);
+      }
       if (cb.keep_alive_)
         cb.keep_alive_->Reset();
       if (cb.refed_)

--- a/src/env.h
+++ b/src/env.h
@@ -281,6 +281,7 @@ class ModuleWrap;
   V(internal_binding_cache_object, v8::Object)                                \
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
+  V(fd_constructor_template, v8::ObjectTemplate)                              \
   V(host_import_module_dynamically_callback, v8::Function)                    \
   V(http2ping_constructor_template, v8::ObjectTemplate)                       \
   V(http2stream_constructor_template, v8::ObjectTemplate)                     \

--- a/src/env.h
+++ b/src/env.h
@@ -282,6 +282,7 @@ class ModuleWrap;
   V(buffer_prototype_object, v8::Object)                                      \
   V(context, v8::Context)                                                     \
   V(fd_constructor_template, v8::ObjectTemplate)                              \
+  V(fdclose_constructor_template, v8::ObjectTemplate)                         \
   V(host_import_module_dynamically_callback, v8::Function)                    \
   V(http2ping_constructor_template, v8::ObjectTemplate)                       \
   V(http2stream_constructor_template, v8::ObjectTemplate)                     \

--- a/test/parallel/test-fs-fd.js
+++ b/test/parallel/test-fs-fd.js
@@ -8,12 +8,13 @@ const fs = require('fs');
 common.crashOnUnhandledRejection();
 
 {
+  const fdnum = fs.openFileHandleSync(__filename, 'r').fd;
+
   common.expectWarning(
     'Warning',
-    'File descriptor closed on garbage collection'
+    `Closing file descriptor ${fdnum} on garbage collection`
   );
 
-  const fdnum = fs.openFDSync(__filename, 'r').fd;
 
   // No garbage collection should have run by this point so the FD object,
   // and more importantly the file descriptor number itself, it still usable
@@ -33,7 +34,7 @@ common.crashOnUnhandledRejection();
 }
 
 {
-  fs.openFD(__filename, 'r', (err, fd) => {
+  fs.openFileHandle(__filename, 'r', (err, fd) => {
     assert.ifError(err);
     fd.close().then(common.mustCall()).catch(common.mustNotCall());
     gc();  // eslint-disable-line no-undef

--- a/test/parallel/test-fs-fd.js
+++ b/test/parallel/test-fs-fd.js
@@ -1,0 +1,41 @@
+// Flags: --expose-gc --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+common.crashOnUnhandledRejection();
+
+{
+  common.expectWarning(
+    'Warning',
+    'File descriptor closed on garbage collection'
+  );
+
+  const fdnum = fs.openFDSync(__filename, 'r').fd;
+
+  // No garbage collection should have run by this point so the FD object,
+  // and more importantly the file descriptor number itself, it still usable
+  assert.doesNotThrow(() => fs.fstatSync(fdnum));
+
+  // Force a garbage colleciton
+  gc();  // eslint-disable-line no-undef
+
+  // After garbage collection, the file descriptor should be closed.
+  common.expectsError(
+    () => fs.fstatSync(fdnum),
+    {
+      code: 'EBADF',
+      type: Error
+    }
+  );
+}
+
+{
+  fs.openFD(__filename, 'r', (err, fd) => {
+    assert.ifError(err);
+    fd.close().then(common.mustCall()).catch(common.mustNotCall());
+    gc();  // eslint-disable-line no-undef
+  });
+}

--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -35,7 +35,7 @@ common.expectsError(
 );
 
 common.expectsError(
-  () => fs.openFDSync('/path/to/file/that/does/not/exist', 'r'),
+  () => fs.openFileHandleSync('/path/to/file/that/does/not/exist', 'r'),
   {
     code: 'ENOENT',
     type: Error
@@ -52,7 +52,7 @@ fs.open(__filename, 'rs', common.mustCall((err, fd) => {
   assert.strictEqual(typeof fd, 'number');
 }));
 
-fs.openFD(__filename, 'r', common.mustCall((err, fd) => {
+fs.openFileHandle(__filename, 'r', common.mustCall((err, fd) => {
   assert.ifError(err);
   assert.strictEqual(typeof fd, 'object');
   assert.strictEqual(typeof fd.fd, 'number');
@@ -60,7 +60,7 @@ fs.openFD(__filename, 'r', common.mustCall((err, fd) => {
   fd.close().then(common.mustNotCall()).catch(common.mustCall());
 }));
 
-fs.openFD(__filename, 'rs', common.mustCall((err, fd) => {
+fs.openFileHandle(__filename, 'rs', common.mustCall((err, fd) => {
   assert.ifError(err);
   assert.strictEqual(typeof fd, 'object');
   assert.strictEqual(typeof fd.fd, 'number');
@@ -84,14 +84,14 @@ fs.openFD(__filename, 'rs', common.mustCall((err, fd) => {
     }
   );
   common.expectsError(
-    () => fs.openFD(i, 'r', common.mustNotCall()),
+    () => fs.openFileHandle(i, 'r', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError
     }
   );
   common.expectsError(
-    () => fs.openFDSync(i, 'r', common.mustNotCall()),
+    () => fs.openFileHandleSync(i, 'r', common.mustNotCall()),
     {
       code: 'ERR_INVALID_ARG_TYPE',
       type: TypeError

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -165,6 +165,12 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
   testInitialized(new Signal(), 'Signal');
 }
 
+{
+  fs.openFD(__filename, 'r', (err, fd) => {
+    assert.ifError(err);
+    testInitialized(fd, 'FD');
+  });
+}
 
 {
   const binding = process.binding('stream_wrap');

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -7,6 +7,8 @@ const net = require('net');
 const providers = Object.assign({}, process.binding('async_wrap').Providers);
 const fixtures = require('../common/fixtures');
 
+common.crashOnUnhandledRejection();
+
 // Make sure that all Providers are tested.
 {
   const hooks = require('async_hooks').createHook({
@@ -166,9 +168,10 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
 }
 
 {
-  fs.openFD(__filename, 'r', (err, fd) => {
+  fs.openFileHandle(__filename, 'r', (err, fd) => {
     assert.ifError(err);
-    testInitialized(fd, 'FD');
+    testInitialized(fd, 'FileHandle');
+    fd.close().then(common.mustCall()).catch(common.mustNotCall());
   });
 }
 


### PR DESCRIPTION
In preparation for providinng a promisified fs API, introduce a FD wrapper class that automatically closes
the file descriptor on garbage collection, helping to ensure that the fd will not leak.

The promisified fs API will use these objects instead of the numeric file descriptors in order to ensure that fd's are closed appropriately following promise resolve or reject operations.

This was extracted from the WIP fs promises PR: https://github.com/nodejs/node/pull/17739

/cc @addaleax @mcollina 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
fs