### PR TITLE
fs: encapsulate FSReqWrap more

### DIFF
--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -112,9 +112,8 @@ if (common.hasCrypto) { // eslint-disable-line crypto-check
   const req = new FSReqWrap();
   req.oncomplete = () => { };
 
-  testUninitialized(req, 'FSReqWrap');
-  binding.access(path.toNamespacedPath('../'), fs.F_OK, req);
   testInitialized(req, 'FSReqWrap');
+  binding.access(path.toNamespacedPath('../'), fs.F_OK, req);
 
   const StatWatcher = binding.StatWatcher;
   testInitialized(new StatWatcher(), 'StatWatcher');


### PR DESCRIPTION
In further preparation for the Promises enabled fs API, further encapsulate FSReqWrap details.

This is another bit of code extracted from the WIP fs promises PR: https://github.com/nodejs/node/pull/17739. Pulling this out in order to make the eventual fs promises PR easier to review.

/cc @addaleax @mcollina 

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
