### PR TITLE
[v6.x backport] test: fix truncation of argv

### DIFF
--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -34,8 +34,8 @@ struct Argv {
     snprintf(argv_[0], prog_len, "%s", prog);
     snprintf(argv_[0] + prog_len, arg1_len, "%s", arg1);
     snprintf(argv_[0] + prog_len + arg1_len, arg2_len, "%s", arg2);
-    argv_[1] = argv_[0] + prog_len + 1;
-    argv_[2] = argv_[0] + prog_len + arg1_len + 1;
+    argv_[1] = argv_[0] + prog_len;
+    argv_[2] = argv_[0] + prog_len + arg1_len;
   }
 
   ~Argv() {


### PR DESCRIPTION
Currently argv_[1] and argv_[2] are getting truncated by one character
because of an incorrect addition of one to account for the null
character. I only noticed this when working on #12087, but that fix
will probably not get included in favor of a JavaScript test so I'm
adding this separate commit for it.

Refs: https://github.com/nodejs/node/pull/12087
PR-URL: https://github.com/nodejs/node/pull/12110
Reviewed-By: Richard Lau <riclau@uk.ibm.com>
Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Gibson Fahnestock <gibfahn@gmail.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test