### PR TITLE
test: replace assert.equal with assert.strictEqual

### DIFF
--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -15,7 +15,7 @@ targetURL.pathname = absolutePath;
 function expectErrorProperty(result, propertyKey, value) {
   Promise.resolve(result)
     .catch(common.mustCall(error => {
-      assert.equal(error[propertyKey], value);
+      assert.strictEqual(error[propertyKey], value);
     }));
 }
 
@@ -51,7 +51,7 @@ function expectOkNamespace(result) {
 function expectFsNamespace(result) {
   Promise.resolve(result)
     .then(common.mustCall(ns => {
-      assert.equal(typeof ns.default.writeFile, 'function');
+      assert.strictEqual(typeof ns.default.writeFile, 'function');
     }));
 }
 

--- a/test/fixtures/es-module-loaders/loader-shared-dep.mjs
+++ b/test/fixtures/es-module-loaders/loader-shared-dep.mjs
@@ -2,6 +2,6 @@ import dep from './loader-dep.js';
 import assert from 'assert';
 
 export function resolve(specifier, base, defaultResolve) {
-  assert.equal(dep.format, 'esm');
+  assert.strictEqual(dep.format, 'esm');
   return defaultResolve(specifier, base);
 }

--- a/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+++ b/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
@@ -12,7 +12,7 @@ export async function resolve (specifier, base, defaultResolve) {
     await defaultResolve(specifier, base);
   }
   catch (e) {
-    assert.equal(e.code, 'MODULE_NOT_FOUND');
+    assert.strictEqual(e.code, 'MODULE_NOT_FOUND');
     return {
       format: 'builtin',
       url: 'fs'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Overview
Replaced `assert.equal` with `assert.strictEqual` as pointed out in https://github.com/nodejs/code-and-learn/issues/58#issuecomment-258660372.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test