### PR TITLE
fs: fix options.end of fs.ReadStream()

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2236,7 +2236,7 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = (typeof this.fd !== 'number' && options.start === undefined) ?
+  this.start = typeof this.fd !== 'number' && options.start === undefined ?
     0 : options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2236,7 +2236,8 @@ function ReadStream(path, options) {
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
-  this.start = options.start;
+  this.start = (typeof this.fd !== 'number' && options.start === undefined) ?
+    0 : options.start;
   this.end = options.end;
   this.autoClose = options.autoClose === undefined ? true : options.autoClose;
   this.pos = undefined;

--- a/test/parallel/test-fs-read-stream.js
+++ b/test/parallel/test-fs-read-stream.js
@@ -165,6 +165,20 @@ common.expectsError(
 }
 
 {
+  // Verify that end works when start is not specified.
+  const stream = new fs.createReadStream(rangeFile, { end: 1 });
+  stream.data = '';
+
+  stream.on('data', function(chunk) {
+    stream.data += chunk;
+  });
+
+  stream.on('end', common.mustCall(function() {
+    assert.strictEqual('xy', stream.data);
+  }));
+}
+
+{
   // pause and then resume immediately.
   const pauseRes = fs.createReadStream(rangeFile);
   pauseRes.pause();

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
+require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
@@ -68,16 +68,3 @@ w.on('results', function(res) {
 });
 
 r.pipe(w);
-
-{
-  // Verify that end works when start is not specified.
-  const end = 3;
-  const r = new FSReadable(file, { end });
-  const w = new TestWriter();
-
-  w.on('results', common.mustCall((res) => {
-    assert.strictEqual(w.length, end + 1);
-  }));
-
-  r.pipe(w);
-}

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 
@@ -69,15 +69,15 @@ w.on('results', function(res) {
 
 r.pipe(w);
 
-const optionsEnd = 3;
-const optionsEndExpectLength = optionsEnd + 1;
-const rOfEnd = new FSReadable(file, {
-  end: optionsEnd,
-});
-const wOfEnd = new TestWriter();
+{
+  // Verify that end works when start is not specified.
+  const end = 3;
+  const r = new FSReadable(file, { end });
+  const w = new TestWriter();
 
-wOfEnd.on('results', function(res) {
-  assert.strictEqual(wOfEnd.length, optionsEndExpectLength);
-});
+  w.on('results', common.mustCall((res) => {
+    assert.strictEqual(w.length, end + 1);
+  }));
 
-rOfEnd.pipe(wOfEnd);
+  r.pipe(w);
+}

--- a/test/sequential/test-stream2-fs.js
+++ b/test/sequential/test-stream2-fs.js
@@ -68,3 +68,16 @@ w.on('results', function(res) {
 });
 
 r.pipe(w);
+
+const optionsEnd = 3;
+const optionsEndExpectLength = optionsEnd + 1;
+const rOfEnd = new FSReadable(file, {
+  end: optionsEnd,
+});
+const wOfEnd = new TestWriter();
+
+wOfEnd.on('results', function(res) {
+  assert.strictEqual(wOfEnd.length, optionsEndExpectLength);
+});
+
+rOfEnd.pipe(wOfEnd);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/18116

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

options.end of fs.ReadStream does not work when options.start is undefined.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
fs